### PR TITLE
fix:  Fix admin guard to use backend RBAC instead of hard-coded JWT roles

### DIFF
--- a/backend/src/apis/app_api/users/models.py
+++ b/backend/src/apis/app_api/users/models.py
@@ -1,6 +1,6 @@
 """User search models for sharing functionality."""
 
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel, Field, ConfigDict
 
 
@@ -18,3 +18,14 @@ class UserSearchResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     users: List[UserSearchResult] = Field(..., description="List of matching users")
+
+
+class UserPermissionsResponse(BaseModel):
+    """Response model for user effective permissions resolved from AppRoles."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    app_roles: List[str] = Field(..., alias="appRoles", description="Resolved application roles")
+    tools: List[str] = Field(..., description="Accessible tool IDs")
+    models: List[str] = Field(..., description="Accessible model IDs")
+    quota_tier: Optional[str] = Field(None, alias="quotaTier", description="Assigned quota tier")
+    resolved_at: str = Field(..., alias="resolvedAt", description="ISO timestamp of resolution")

--- a/backend/src/apis/app_api/users/routes.py
+++ b/backend/src/apis/app_api/users/routes.py
@@ -6,9 +6,10 @@ import logging
 
 from apis.shared.auth.dependencies import get_current_user
 from apis.shared.auth.models import User
+from apis.shared.rbac.service import get_app_role_service
 from apis.shared.users.repository import UserRepository
 from apis.shared.users.models import UserProfile, UserListItem, UserStatus
-from .models import UserSearchResult, UserSearchResponse
+from .models import UserSearchResult, UserSearchResponse, UserPermissionsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,35 @@ router = APIRouter(prefix="/users", tags=["users"])
 def get_user_repository() -> UserRepository:
     """Get user repository instance."""
     return UserRepository()
+
+
+@router.get("/me/permissions", response_model=UserPermissionsResponse)
+async def get_my_permissions(
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Get the current user's effective permissions resolved from AppRoles.
+
+    Any authenticated user can query their own permissions. Resolves JWT roles
+    to AppRoles via the RBAC system and returns merged effective permissions.
+    """
+    logger.info(f"GET /users/me/permissions - User: {current_user.user_id}")
+    try:
+        service = get_app_role_service()
+        permissions = await service.resolve_user_permissions(current_user)
+        return UserPermissionsResponse(
+            app_roles=permissions.app_roles,
+            tools=permissions.tools,
+            models=permissions.models,
+            quota_tier=permissions.quota_tier,
+            resolved_at=permissions.resolved_at,
+        )
+    except Exception as e:
+        logger.error(f"Failed to resolve permissions for {current_user.user_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to resolve user permissions"
+        )
 
 
 @router.get("/search", response_model=UserSearchResponse)

--- a/frontend/ai.client/src/app/auth/admin.guard.spec.ts
+++ b/frontend/ai.client/src/app/auth/admin.guard.spec.ts
@@ -13,7 +13,8 @@ describe('adminGuard', () => {
     refreshAccessToken: ReturnType<typeof vi.fn>;
   };
   let userService: {
-    hasAnyRole: ReturnType<typeof vi.fn>;
+    isAdmin: ReturnType<typeof vi.fn>;
+    ensurePermissionsLoaded: ReturnType<typeof vi.fn>;
     refreshUser: ReturnType<typeof vi.fn>;
     getUser: ReturnType<typeof vi.fn>;
   };
@@ -30,7 +31,8 @@ describe('adminGuard', () => {
     };
 
     userService = {
-      hasAnyRole: vi.fn(),
+      isAdmin: vi.fn(),
+      ensurePermissionsLoaded: vi.fn().mockResolvedValue(undefined),
       refreshUser: vi.fn(),
       getUser: vi.fn().mockReturnValue({ roles: [] }),
     };
@@ -56,38 +58,31 @@ describe('adminGuard', () => {
 
   /**
    * Validates: Requirements 13.6
-   * Authenticated user with admin role returns true
+   * Authenticated user with system_admin AppRole returns true
    */
-  it('should return true when user is authenticated and has Admin role', async () => {
+  it('should return true when user is authenticated and has system_admin AppRole', async () => {
     authService.isAuthenticated.mockReturnValue(true);
-    userService.hasAnyRole.mockReturnValue(true);
+    userService.isAdmin.mockReturnValue(true);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 
     expect(result).toBe(true);
+    expect(userService.ensurePermissionsLoaded).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalled();
-  });
-
-  it('should return true when user is authenticated and has SuperAdmin role', async () => {
-    authService.isAuthenticated.mockReturnValue(true);
-    userService.hasAnyRole.mockReturnValue(true);
-
-    const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
-
-    expect(result).toBe(true);
   });
 
   /**
    * Validates: Requirements 13.7
-   * Authenticated user without admin roles redirects to /
+   * Authenticated user without system_admin AppRole redirects to /
    */
-  it('should redirect to / when user is authenticated but lacks admin roles', async () => {
+  it('should redirect to / when user is authenticated but lacks system_admin AppRole', async () => {
     authService.isAuthenticated.mockReturnValue(true);
-    userService.hasAnyRole.mockReturnValue(false);
+    userService.isAdmin.mockReturnValue(false);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 
     expect(result).toBe(false);
+    expect(userService.ensurePermissionsLoaded).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalledWith(['/']);
   });
 
@@ -127,32 +122,33 @@ describe('adminGuard', () => {
 
   /**
    * Validates: Requirements 13.6
-   * Expired token + successful refresh + admin role returns true
+   * Expired token + successful refresh + system_admin AppRole returns true
    */
-  it('should return true when token refresh succeeds and user has admin role', async () => {
+  it('should return true when token refresh succeeds and user has system_admin AppRole', async () => {
     authService.isAuthenticated.mockReturnValue(false);
     authService.getAccessToken.mockReturnValue('expired-token');
     authService.isTokenExpired.mockReturnValue(true);
     authService.refreshAccessToken.mockResolvedValue({});
-    userService.hasAnyRole.mockReturnValue(true);
+    userService.isAdmin.mockReturnValue(true);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 
     expect(result).toBe(true);
     expect(authService.refreshAccessToken).toHaveBeenCalled();
     expect(userService.refreshUser).toHaveBeenCalled();
+    expect(userService.ensurePermissionsLoaded).toHaveBeenCalled();
   });
 
   /**
    * Validates: Requirements 13.7
-   * Expired token + successful refresh + no admin role redirects to /
+   * Expired token + successful refresh + no system_admin AppRole redirects to /
    */
-  it('should redirect to / when token refresh succeeds but user lacks admin role', async () => {
+  it('should redirect to / when token refresh succeeds but user lacks system_admin AppRole', async () => {
     authService.isAuthenticated.mockReturnValue(false);
     authService.getAccessToken.mockReturnValue('expired-token');
     authService.isTokenExpired.mockReturnValue(true);
     authService.refreshAccessToken.mockResolvedValue({});
-    userService.hasAnyRole.mockReturnValue(false);
+    userService.isAdmin.mockReturnValue(false);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 

--- a/frontend/ai.client/src/app/auth/admin.guard.ts
+++ b/frontend/ai.client/src/app/auth/admin.guard.ts
@@ -4,17 +4,15 @@ import { AuthService } from './auth.service';
 import { UserService } from './user.service';
 
 /**
- * Route guard that protects admin routes requiring specific roles.
+ * Route guard that protects admin routes using backend RBAC resolution.
  *
- * Checks if the user is authenticated and has one of the required admin roles:
- * - Admin
- * - SuperAdmin
- * - DotNetDevelopers
+ * Checks if the user is authenticated and has the `system_admin` AppRole
+ * (resolved from the backend RBAC system, not raw JWT roles).
  *
  * If not authenticated, redirects to /auth/login.
- * If authenticated but lacks required role, redirects to home page.
+ * If authenticated but lacks system_admin AppRole, redirects to home page.
  *
- * @returns True if user is authenticated and has required role, false otherwise
+ * @returns True if user is authenticated and has system_admin AppRole, false otherwise
  */
 export const adminGuard: CanActivateFn = async (route, state) => {
   const authService = inject(AuthService);
@@ -45,13 +43,12 @@ export const adminGuard: CanActivateFn = async (route, state) => {
     }
   }
 
-  // User is authenticated, check for admin roles
-  const requiredRoles = ['Admin', 'SuperAdmin', 'DotNetDevelopers'];
-  const hasRequiredRole = userService.hasAnyRole(requiredRoles);
+  // Ensure permissions are resolved from backend RBAC before checking
+  await userService.ensurePermissionsLoaded();
 
-  if (!hasRequiredRole) {
-    // User doesn't have required role, redirect to home
-    console.warn('User lacks required admin role:', userService.getUser()?.roles);
+  // Check for system_admin AppRole (resolved from backend RBAC, not raw JWT roles)
+  if (!userService.isAdmin()) {
+    console.warn('User lacks system_admin AppRole:', userService.getUser()?.roles);
     router.navigate(['/']);
     return false;
   }

--- a/frontend/ai.client/src/app/auth/callback/callback.service.ts
+++ b/frontend/ai.client/src/app/auth/callback/callback.service.ts
@@ -67,6 +67,9 @@ export class CallbackService {
       // Refresh user data from new token
       this.userService.refreshUser();
 
+      // Ensure resolved permissions are available before navigating
+      await this.userService.ensurePermissionsLoaded();
+
       // Enable sessions loading now that user is authenticated
       this.sessionService.enableSessionsLoading();
 

--- a/frontend/ai.client/src/app/auth/user.model.ts
+++ b/frontend/ai.client/src/app/auth/user.model.ts
@@ -13,6 +13,18 @@ export interface User {
 }
 
 /**
+ * Effective permissions resolved from the backend AppRole RBAC system.
+ * Returned by GET /users/me/permissions.
+ */
+export interface UserPermissions {
+  appRoles: string[];
+  tools: string[];
+  models: string[];
+  quotaTier: string | null;
+  resolvedAt: string;
+}
+
+/**
  * Decoded JWT payload structure.
  * Uses an index signature to support dynamic claim names
  * from any OIDC provider.

--- a/frontend/ai.client/src/app/auth/user.service.ts
+++ b/frontend/ai.client/src/app/auth/user.service.ts
@@ -1,6 +1,9 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { AuthService } from './auth.service';
-import { User, JWTPayload } from './user.model';
+import { ConfigService } from '../services/config.service';
+import { User, JWTPayload, UserPermissions } from './user.model';
 
 /**
  * Service for managing current user information decoded from JWT tokens.
@@ -11,15 +14,31 @@ import { User, JWTPayload } from './user.model';
 })
 export class UserService {
   private authService = inject(AuthService);
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
 
   /**
    * Current user signal. Null if not authenticated or token cannot be decoded.
    */
   readonly currentUser = signal<User | null>(null);
 
+  /** Application roles resolved from the backend RBAC system. */
+  readonly appRoles = signal<string[]>([]);
+
+  /** Whether the current user has the system_admin AppRole. */
+  readonly isAdmin = computed(() => this.appRoles().includes('system_admin'));
+
+  /** Promise for the in-flight permissions fetch, used to avoid duplicate requests. */
+  private _permissionsPromise: Promise<void> | null = null;
+
   constructor() {
     // Initialize user from current token or set anonymous user if auth disabled
     this.refreshUser();
+
+    // If user has a token on page load, fetch permissions from backend
+    if (this.authService.getAccessToken()) {
+      this._permissionsPromise = this.fetchPermissions();
+    }
 
     if (typeof window !== 'undefined') {
       // Listen for storage events to sync when tokens change in other tabs/windows
@@ -32,10 +51,13 @@ export class UserService {
       // Listen for custom events to sync when tokens change in same tab
       window.addEventListener('token-stored', () => {
         this.refreshUser();
+        this._permissionsPromise = this.fetchPermissions();
       });
 
       window.addEventListener('token-cleared', () => {
         this.currentUser.set(null);
+        this.appRoles.set([]);
+        this._permissionsPromise = null;
       });
     }
   }
@@ -167,6 +189,44 @@ export class UserService {
     const user = this.currentUser();
     if (!user) return false;
     return roles.some(role => user.roles.includes(role));
+  }
+
+  /**
+   * Fetch permissions from the backend RBAC system.
+   * Updates the appRoles signal with resolved application roles.
+   */
+  async fetchPermissions(): Promise<void> {
+    try {
+      const url = `${this.config.appApiUrl()}/users/me/permissions`;
+      const permissions = await firstValueFrom(
+        this.http.get<UserPermissions>(url)
+      );
+      this.appRoles.set(permissions.appRoles);
+    } catch (error) {
+      console.error('Failed to fetch user permissions:', error);
+      this.appRoles.set([]);
+    }
+  }
+
+  /**
+   * Ensure permissions have been loaded. Awaits any in-flight fetch
+   * or starts a new one if needed. Used by guards to handle direct navigation.
+   */
+  async ensurePermissionsLoaded(): Promise<void> {
+    if (this._permissionsPromise) {
+      await this._permissionsPromise;
+    } else if (this.authService.getAccessToken()) {
+      this._permissionsPromise = this.fetchPermissions();
+      await this._permissionsPromise;
+    }
+  }
+
+  /**
+   * Check if user has a specific AppRole.
+   * @param role AppRole to check (e.g., 'system_admin')
+   */
+  hasAppRole(role: string): boolean {
+    return this.appRoles().includes(role);
   }
 
   /**

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -34,11 +34,8 @@ export class Sidenav {
     return session.title || 'Untitled Session';
   });
 
-  // Check if user has admin roles
-  protected isAdmin = computed(() => {
-    const requiredRoles = ['Admin', 'SuperAdmin', 'DotNetDevelopers'];
-    return this.userService.hasAnyRole(requiredRoles);
-  });
+  // Check if user has system_admin AppRole (resolved from backend RBAC)
+  protected isAdmin = this.userService.isAdmin;
 
   newSession() {
     this.sidenavService.close();


### PR DESCRIPTION
## Summary
- Adds `GET /users/me/permissions` backend endpoint that resolves JWT roles to AppRoles via the existing RBAC system (`AppRoleService`)
- Replaces hard-coded `['Admin', 'SuperAdmin', 'DotNetDevelopers']` checks in the frontend admin guard and sidenav with the backend-resolved `system_admin` AppRole
- Frontend `UserService` now fetches and caches resolved AppRoles after login and on page load, exposing an `isAdmin` computed signal

Closes #21

## Changes

**Backend (2 files):**
- `users/models.py` — Added `UserPermissionsResponse` Pydantic model
- `users/routes.py` — Added `GET /users/me/permissions` endpoint (any authenticated user, calls `AppRoleService.resolve_user_permissions()`)

**Frontend (6 files):**
- `user.model.ts` — Added `UserPermissions` interface
- `user.service.ts` — Added `appRoles` signal, `isAdmin` computed, `fetchPermissions()`, `ensurePermissionsLoaded()`, `hasAppRole()`
- `callback.service.ts` — Awaits permissions resolution after login before navigating
- `admin.guard.ts` — Uses `userService.isAdmin()` instead of hard-coded role list
- `sidenav.ts` — Uses `userService.isAdmin` signal instead of hard-coded role list
- `admin.guard.spec.ts` — Updated test mocks to match new interface

## Design decisions
- **Fail-closed**: If the permissions fetch fails, `appRoles` stays empty → admin access denied
- **No duplicate requests**: `ensurePermissionsLoaded()` reuses in-flight promises
- **Direct navigation handled**: Guard awaits permission resolution before checking
- **Existing `hasRole()`/`hasAnyRole()` preserved**: Still useful for non-admin JWT role checks
- **Backend `require_admin` not changed**: Migrating 40+ admin endpoints from `require_admin` to `require_system_admin` is a separate, larger task

## Test plan
- [ ] Verify Angular build compiles (confirmed ✅)
- [ ] Login with a user whose JWT role maps to `system_admin` AppRole → admin nav visible, admin routes accessible
- [ ] Login with a user whose JWT role does NOT map → admin nav hidden, admin routes redirect to `/`
- [ ] Direct-navigate to `/admin` while logged in as admin → works (ensurePermissionsLoaded flow)
- [ ] Direct-navigate to `/admin` as non-admin → redirects to `/`