### PR TITLE
chore(deps): optimize Dependabot config for develop branch workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,96 @@
 version: 2
 updates:
-  # Monitor pip lock files for known vulnerabilities
+  # ── Python backend ──
   - package-ecosystem: "pip"
     directory: "/backend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/Boise"
     open-pull-requests-limit: 10
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
       - "security"
+      - "backend"
+    groups:
+      # Group minor/patch updates to reduce PR noise
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns: ["*"]
 
-  # Monitor npm dependencies
+  # ── Frontend npm ──
   - package-ecosystem: "npm"
     directory: "/frontend/ai.client"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+      time: "09:00"
+      timezone: "America/Boise"
+    open-pull-requests-limit: 10
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
+      - "frontend"
+    groups:
+      angular:
+        patterns: ["@angular*"]
+        update-types: ["minor", "patch"]
+      frontend-minor-patch:
+        exclude-patterns: ["@angular*"]
+        update-types: ["minor", "patch"]
 
+  # ── Infrastructure CDK ──
   - package-ecosystem: "npm"
     directory: "/infrastructure"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/Boise"
     open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
+      - "infrastructure"
+    groups:
+      aws-cdk:
+        patterns: ["aws-cdk*", "@aws-cdk*"]
+        update-types: ["minor", "patch"]
+      infra-minor-patch:
+        exclude-patterns: ["aws-cdk*", "@aws-cdk*"]
+        update-types: ["minor", "patch"]
 
-  # Monitor GitHub Actions for updates
+  # ── GitHub Actions ──
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/Boise"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns: ["*"]


### PR DESCRIPTION
- Target all version update PRs to develop branch
- Group minor/patch updates to reduce PR noise (Angular, AWS CDK, etc.)
- Use increase-if-necessary versioning strategy for stable constraints
- Standardize commit messages with chore(deps) prefix
- Add ecosystem-specific labels (backend, frontend, infrastructure, ci)
- Consistent Monday 9 AM Mountain Time schedule across all ecosystems
- Bump open-pull-requests-limit to 10 for frontend/backend