### PR TITLE
feat(messages): displayText support for RAG-augmented and file attachment messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,6 @@ coverage/
 /.vs
 .vs/*
 .kiro/steering/dev-environment.md
+
+# Local dev scripts
 start.sh

--- a/backend/src/agents/main_agent/main_agent.py
+++ b/backend/src/agents/main_agent/main_agent.py
@@ -269,7 +269,7 @@ class MainAgent:
         return hooks
 
     async def stream_async(
-        self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None
+        self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
     ) -> AsyncGenerator[str, None]:
         """
         Stream agent responses
@@ -279,6 +279,7 @@ class MainAgent:
             session_id: Session identifier (defaults to instance session_id)
             files: Optional list of FileContent objects (with base64 bytes)
             citations: Optional list of citation dicts from RAG retrieval
+            original_message: Original user message before RAG augmentation (for clean UI display)
 
         Yields:
             str: SSE formatted events
@@ -299,6 +300,7 @@ class MainAgent:
             user_id=self.user_id,
             main_agent_wrapper=self,  # Pass wrapper for metadata extraction
             citations=citations,  # Pass citations for storage
+            original_message=original_message,  # Pass original message for display text
         ):
             yield event
 

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -38,6 +38,7 @@ class StreamCoordinator:
         user_id: str,
         main_agent_wrapper: Any = None,
         citations: Optional[List] = None,
+        original_message: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Stream agent responses with proper lifecycle management
@@ -53,6 +54,7 @@ class StreamCoordinator:
             user_id: User identifier
             main_agent_wrapper: MainAgent wrapper instance (has model_config, enabled_tools, etc.)
             citations: Optional list of citation dicts from RAG retrieval to persist with metadata
+            original_message: Original user message before RAG augmentation (for clean UI display)
 
         Yields:
             str: SSE formatted events
@@ -445,6 +447,21 @@ class StreamCoordinator:
                             logger.error(f"Failed to store metadata for message {message_ids_to_store[idx]}: {result}")
 
                 logger.info(f"✅ Message metadata stored for {len(message_ids_to_store)} assistant messages (parallel)")
+
+            # Store displayText for user message if original_message differs from augmented
+            if original_message:
+                user_message_index = initial_message_count  # User message is first in this turn
+                try:
+                    from apis.shared.sessions.metadata import store_user_display_text
+                    await store_user_display_text(
+                        session_id=session_id,
+                        user_id=user_id,
+                        message_id=user_message_index,
+                        display_text=original_message,
+                    )
+                    logger.info(f"💾 Stored displayText for user message {user_message_index}")
+                except Exception as e:
+                    logger.error(f"Failed to store user displayText: {e}", exc_info=True)
 
             # Update compaction state if session manager supports it
             # This tracks input token usage and triggers compaction when threshold exceeded

--- a/backend/src/apis/app_api/auth/routes.py
+++ b/backend/src/apis/app_api/auth/routes.py
@@ -1,6 +1,7 @@
 """OIDC authentication routes with multi-provider support."""
 
 import logging
+import os
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -389,8 +390,14 @@ async def get_runtime_endpoint_impl(
             f"(provider: {provider.provider_id}): {provider.agentcore_runtime_endpoint_url}"
         )
 
+        # Allow local override for development (bypass cloud runtime)
+        runtime_url = os.environ.get(
+            "LOCAL_RUNTIME_ENDPOINT_URL",
+            provider.agentcore_runtime_endpoint_url,
+        )
+
         return RuntimeEndpointResponse(
-            runtime_endpoint_url=provider.agentcore_runtime_endpoint_url,
+            runtime_endpoint_url=runtime_url,
             provider_id=provider.provider_id,
             runtime_status=provider.agentcore_runtime_status,
         )

--- a/backend/src/apis/app_api/chat/routes.py
+++ b/backend/src/apis/app_api/chat/routes.py
@@ -391,11 +391,22 @@ async def chat_stream(request: ChatRequest, current_user: User = Depends(get_cur
 
             # Pass resolved files (from S3) merged with any direct file content
             # Use augmented message if assistant RAG was applied
+            #
+            # Always store the original user message as displayText when the prompt
+            # will be modified before reaching the model. This happens when:
+            #   1. RAG augmentation prepends context chunks to the message
+            #   2. File attachments cause PromptBuilder to rewrite into ContentBlocks
+            # The original text becomes the single source of truth for UI display,
+            # while the full augmented prompt stays in AgentCore Memory for the LLM.
+            message_will_be_modified = (
+                augmented_message != request.message  # RAG augmentation
+                or bool(files_to_send)                # File attachments
+            )
             stream_iterator = agent.stream_async(
-                augmented_message,  # Use augmented message if assistant RAG was applied
+                augmented_message,
                 session_id=request.session_id,
                 files=files_to_send if files_to_send else None,
-                original_message=request.message if augmented_message != request.message else None,
+                original_message=request.message if message_will_be_modified else None,
             )
 
             try:

--- a/backend/src/apis/app_api/chat/routes.py
+++ b/backend/src/apis/app_api/chat/routes.py
@@ -395,6 +395,7 @@ async def chat_stream(request: ChatRequest, current_user: User = Depends(get_cur
                 augmented_message,  # Use augmented message if assistant RAG was applied
                 session_id=request.session_id,
                 files=files_to_send if files_to_send else None,
+                original_message=request.message if augmented_message != request.message else None,
             )
 
             try:

--- a/backend/src/apis/app_api/messages/models.py
+++ b/backend/src/apis/app_api/messages/models.py
@@ -117,6 +117,7 @@ class MessageMetadata(BaseModel):
     attribution: Optional[Attribution] = Field(None, description="Attribution for cost tracking and billing")
     cost: Optional[float] = Field(None, description="Total cost in USD for this message (computed from token usage and pricing)")
     citations: Optional[List[Dict[str, str]]] = Field(None, description="RAG citations for this message (stored as dicts for flexible JSON storage)")
+    display_text: Optional[str] = Field(None, alias="displayText", description="Original user message text before RAG augmentation (for clean UI display)")
     # Note: Feedback will be added in future implementation
     # feedback: Optional[Feedback] = None
 

--- a/backend/src/apis/app_api/sessions/services/metadata.py
+++ b/backend/src/apis/app_api/sessions/services/metadata.py
@@ -685,11 +685,11 @@ async def get_all_message_metadata(session_id: str, user_id: str) -> Dict[str, A
 
 async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_name: str) -> Dict[str, Any]:
     """
-    Retrieve all message metadata (cost records) for a session from DynamoDB
+    Retrieve all message metadata (cost records + display text) for a session from DynamoDB
 
-    Uses the SessionLookupIndex GSI to query cost records by session ID.
-    Cost records have SK pattern: C#{timestamp}#{uuid}
-    GSI pattern: GSI_PK=SESSION#{session_id}, GSI_SK=C#{timestamp}
+    Uses the SessionLookupIndex GSI to query records by session ID.
+    Cost records have SK pattern: C#{timestamp}#{uuid}, GSI_SK: C#{timestamp}
+    Display text records have SK pattern: D#{session_id}#{message_id}, GSI_SK: D#{message_id}
 
     Args:
         session_id: Session identifier
@@ -708,18 +708,21 @@ async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_n
 
         logger.info(f"🔍 Querying cost records via GSI for session {session_id}")
 
-        # Query cost records for this session using GSI
-        # GSI_PK: SESSION#{session_id}
-        # GSI_SK: begins_with C# for cost records
-        response = table.query(
+        # Query cost records (C#) and display text records (D#) in parallel
+        cost_response = table.query(
             IndexName='SessionLookupIndex',
             KeyConditionExpression=Key('GSI_PK').eq(f'SESSION#{session_id}') & Key('GSI_SK').begins_with('C#')
         )
+        display_response = table.query(
+            IndexName='SessionLookupIndex',
+            KeyConditionExpression=Key('GSI_PK').eq(f'SESSION#{session_id}') & Key('GSI_SK').begins_with('D#')
+        )
 
-        items = response.get("Items", [])
+        items = cost_response.get("Items", [])
+        display_items = display_response.get("Items", [])
         metadata_index = {}
 
-        logger.info(f"📦 DynamoDB returned {len(items)} cost record items")
+        logger.info(f"📦 DynamoDB returned {len(items)} cost record items, {len(display_items)} display text items")
 
         for item in items:
             # Verify user ownership
@@ -744,6 +747,22 @@ async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_n
             metadata_index[message_id] = item_float
 
         logger.info(f"📂 Retrieved {len(metadata_index)} cost records from DynamoDB")
+
+        # Merge displayText from D# records into metadata index
+        for item in display_items:
+            if item.get('userId') != user_id:
+                continue
+            item_float = _convert_decimal_to_float(item)
+            message_id_raw = item_float.get("messageId")
+            message_id = str(int(message_id_raw)) if isinstance(message_id_raw, (int, float)) else str(message_id_raw)
+            display_text = item_float.get("displayText")
+            if display_text:
+                if message_id in metadata_index:
+                    metadata_index[message_id]["displayText"] = display_text
+                else:
+                    metadata_index[message_id] = {"displayText": display_text}
+                logger.debug(f"🔗 Merged displayText for user message {message_id}")
+
         logger.info(f"📋 Metadata keys: {sorted(metadata_index.keys())}")
         return metadata_index
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -562,11 +562,23 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             # Then yield all agent stream events
             # Use augmented message if assistant RAG was applied
             # Use resolved files (from S3) merged with any direct file content
+            #
+            # Always store the original user message as displayText when the prompt
+            # will be modified before reaching the model. This happens when:
+            #   1. RAG augmentation prepends context chunks to the message
+            #   2. File attachments cause PromptBuilder to rewrite into ContentBlocks
+            # The original text becomes the single source of truth for UI display,
+            # while the full augmented prompt stays in AgentCore Memory for the LLM.
+            message_will_be_modified = (
+                augmented_message != input_data.message  # RAG augmentation
+                or bool(files_to_send)                   # File attachments
+            )
             async for event in agent.stream_async(
-                augmented_message,  # Use augmented message if assistant RAG was applied
+                augmented_message,
                 session_id=input_data.session_id,
                 files=files_to_send if files_to_send else None,
-                citations=citations_for_storage if citations_for_storage else None,  # Pass citations for persistence
+                citations=citations_for_storage if citations_for_storage else None,
+                original_message=input_data.message if message_will_be_modified else None,
             ):
                 yield event
 

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -89,6 +89,67 @@ async def store_message_metadata(
 
 
 
+async def store_user_display_text(
+    session_id: str,
+    user_id: str,
+    message_id: int,
+    display_text: str,
+) -> None:
+    """
+    Store the original user message text for clean UI display.
+
+    When RAG augmentation modifies the user message, this stores the original
+    so the frontend can show the clean version while the augmented version
+    stays in AgentCore Memory for the LLM.
+
+    Uses a D# (display) prefix SK pattern to separate from C# cost records.
+
+    Args:
+        session_id: Session identifier
+        user_id: User identifier
+        message_id: 0-based message index (user message position)
+        display_text: Original user message before RAG augmentation
+    """
+    sessions_metadata_table = os.environ.get('DYNAMODB_SESSIONS_METADATA_TABLE_NAME')
+    if not sessions_metadata_table:
+        raise RuntimeError("DYNAMODB_SESSIONS_METADATA_TABLE_NAME environment variable is required")
+
+    # Skip preview sessions
+    if is_preview_session(session_id):
+        return
+
+    try:
+        import boto3
+        from datetime import datetime, timezone, timedelta
+
+        dynamodb = boto3.resource('dynamodb')
+        table = dynamodb.Table(sessions_metadata_table)
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        ttl = int((datetime.now(timezone.utc) + timedelta(days=365)).timestamp())
+
+        item = {
+            "PK": f"USER#{user_id}",
+            "SK": f"D#{session_id}#{message_id}",
+            "GSI_PK": f"SESSION#{session_id}",
+            "GSI_SK": f"D#{message_id}",
+            "sessionId": session_id,
+            "messageId": message_id,
+            "userId": user_id,
+            "displayText": display_text,
+            "timestamp": timestamp,
+            "ttl": ttl,
+        }
+
+        table.put_item(Item=item)
+        logger.info(f"💾 Stored displayText for user message {message_id} in session {session_id}")
+
+    except Exception as e:
+        # Non-critical: displayText is a UI enhancement, don't break the request
+        logger.error(f"Failed to store user displayText: {e}", exc_info=True)
+
+
+
 async def _store_message_metadata_cloud(
     session_id: str,
     user_id: str,
@@ -722,11 +783,11 @@ async def get_all_message_metadata(session_id: str, user_id: str) -> Dict[str, A
 
 async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_name: str) -> Dict[str, Any]:
     """
-    Retrieve all message metadata (cost records) for a session from DynamoDB
+    Retrieve all message metadata (cost records + display text) for a session from DynamoDB
 
-    Uses the SessionLookupIndex GSI to query cost records by session ID.
-    Cost records have SK pattern: C#{timestamp}#{uuid}
-    GSI pattern: GSI_PK=SESSION#{session_id}, GSI_SK=C#{timestamp}
+    Uses the SessionLookupIndex GSI to query records by session ID.
+    Cost records have SK pattern: C#{timestamp}#{uuid}, GSI_SK: C#{timestamp}
+    Display text records have SK pattern: D#{session_id}#{message_id}, GSI_SK: D#{message_id}
 
     Args:
         session_id: Session identifier
@@ -745,18 +806,21 @@ async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_n
 
         logger.info(f"🔍 Querying cost records via GSI for session {session_id}")
 
-        # Query cost records for this session using GSI
-        # GSI_PK: SESSION#{session_id}
-        # GSI_SK: begins_with C# for cost records
-        response = table.query(
+        # Query cost records (C#) and display text records (D#) in parallel
+        cost_response = table.query(
             IndexName='SessionLookupIndex',
             KeyConditionExpression=Key('GSI_PK').eq(f'SESSION#{session_id}') & Key('GSI_SK').begins_with('C#')
         )
+        display_response = table.query(
+            IndexName='SessionLookupIndex',
+            KeyConditionExpression=Key('GSI_PK').eq(f'SESSION#{session_id}') & Key('GSI_SK').begins_with('D#')
+        )
 
-        items = response.get("Items", [])
+        items = cost_response.get("Items", [])
+        display_items = display_response.get("Items", [])
         metadata_index = {}
 
-        logger.info(f"📦 DynamoDB returned {len(items)} cost record items")
+        logger.info(f"📦 DynamoDB returned {len(items)} cost record items, {len(display_items)} display text items")
 
         for item in items:
             # Verify user ownership
@@ -781,6 +845,22 @@ async def _get_all_message_metadata_cloud(session_id: str, user_id: str, table_n
             metadata_index[message_id] = item_float
 
         logger.info(f"📂 Retrieved {len(metadata_index)} cost records from DynamoDB")
+
+        # Merge displayText from D# records into metadata index
+        for item in display_items:
+            if item.get('userId') != user_id:
+                continue
+            item_float = _convert_decimal_to_float(item)
+            message_id_raw = item_float.get("messageId")
+            message_id = str(int(message_id_raw)) if isinstance(message_id_raw, (int, float)) else str(message_id_raw)
+            display_text = item_float.get("displayText")
+            if display_text:
+                if message_id in metadata_index:
+                    metadata_index[message_id]["displayText"] = display_text
+                else:
+                    metadata_index[message_id] = {"displayText": display_text}
+                logger.debug(f"🔗 Merged displayText for user message {message_id}")
+
         logger.info(f"📋 Metadata keys: {sorted(metadata_index.keys())}")
         return metadata_index
 

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -98,9 +98,10 @@ async def store_user_display_text(
     """
     Store the original user message text for clean UI display.
 
-    When RAG augmentation modifies the user message, this stores the original
-    so the frontend can show the clean version while the augmented version
-    stays in AgentCore Memory for the LLM.
+    When the prompt sent to the model differs from what the user typed
+    (e.g. RAG augmentation, file attachment content blocks), this stores
+    the original so the frontend can show the clean version. The full
+    augmented prompt stays in AgentCore Memory for the LLM.
 
     Uses a D# (display) prefix SK pattern to separate from C# cost records.
 
@@ -108,7 +109,7 @@ async def store_user_display_text(
         session_id: Session identifier
         user_id: User identifier
         message_id: 0-based message index (user message position)
-        display_text: Original user message before RAG augmentation
+        display_text: Original user message before prompt modification
     """
     sessions_metadata_table = os.environ.get('DYNAMODB_SESSIONS_METADATA_TABLE_NAME')
     if not sessions_metadata_table:

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -262,6 +262,7 @@ class MessageMetadata(BaseModel):
     attribution: Optional[Attribution] = Field(None, description="Attribution for cost tracking and billing")
     cost: Optional[float] = Field(None, description="Total cost in USD for this message (computed from token usage and pricing)")
     citations: Optional[List[Dict[str, str]]] = Field(None, description="RAG citations for this message (stored as dicts for flexible JSON storage)")
+    display_text: Optional[str] = Field(None, alias="displayText", description="Original user message text before RAG augmentation (for clean UI display)")
     # Note: Feedback will be added in future implementation
     # feedback: Optional[Feedback] = None
 

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -121,3 +121,112 @@ class TestListUserSessions:
         from apis.shared.sessions.metadata import list_user_sessions
         with pytest.raises(RuntimeError):
             await list_user_sessions("u1")
+
+
+class TestStoreUserDisplayText:
+    """Tests for the displayText feature (D# records)."""
+
+    @pytest.mark.asyncio
+    async def test_store_and_retrieve_display_text(self, sessions_metadata_table):
+        """displayText stored via D# record is merged into get_all_message_metadata."""
+        from apis.shared.sessions.metadata import store_user_display_text, get_all_message_metadata
+
+        await store_user_display_text(
+            session_id="s1", user_id="u1", message_id=0, display_text="Hello world",
+        )
+        result = await get_all_message_metadata("s1", "u1")
+        assert "0" in result
+        assert result["0"]["displayText"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_display_text_merged_with_cost_record(self, sessions_metadata_table):
+        """When both a cost record and displayText exist for the same message, they merge."""
+        from apis.shared.sessions.metadata import (
+            store_message_metadata, store_user_display_text, get_all_message_metadata,
+        )
+
+        await store_message_metadata(
+            session_id="s1", user_id="u1", message_id=0, message_metadata=_make_message_metadata(),
+        )
+        await store_user_display_text(
+            session_id="s1", user_id="u1", message_id=0, display_text="What is AWS?",
+        )
+        result = await get_all_message_metadata("s1", "u1")
+        assert "0" in result
+        # Should have both cost data and displayText
+        assert result["0"]["displayText"] == "What is AWS?"
+        assert "cost" in result["0"]
+
+    @pytest.mark.asyncio
+    async def test_display_text_without_cost_record(self, sessions_metadata_table):
+        """displayText record alone creates an entry even without a matching cost record."""
+        from apis.shared.sessions.metadata import store_user_display_text, get_all_message_metadata
+
+        await store_user_display_text(
+            session_id="s1", user_id="u1", message_id=2, display_text="standalone text",
+        )
+        result = await get_all_message_metadata("s1", "u1")
+        assert "2" in result
+        assert result["2"] == {"displayText": "standalone text"}
+
+    @pytest.mark.asyncio
+    async def test_display_text_sk_pattern(self, sessions_metadata_table):
+        """D# records use the correct SK and GSI_SK patterns."""
+        from apis.shared.sessions.metadata import store_user_display_text
+
+        await store_user_display_text(
+            session_id="s1", user_id="u1", message_id=4, display_text="test",
+        )
+        items = sessions_metadata_table.scan()["Items"]
+        d_items = [i for i in items if i["SK"].startswith("D#")]
+        assert len(d_items) == 1
+        assert d_items[0]["SK"] == "D#s1#4"
+        assert d_items[0]["GSI_PK"] == "SESSION#s1"
+        assert d_items[0]["GSI_SK"] == "D#4"
+
+    @pytest.mark.asyncio
+    async def test_display_text_skips_preview_session(self, sessions_metadata_table):
+        """Preview sessions should not persist displayText records."""
+        from apis.shared.sessions.metadata import store_user_display_text
+
+        await store_user_display_text(
+            session_id="preview-abc123", user_id="u1", message_id=0, display_text="ignored",
+        )
+        items = sessions_metadata_table.scan()["Items"]
+        d_items = [i for i in items if i["SK"].startswith("D#")]
+        assert len(d_items) == 0
+
+    @pytest.mark.asyncio
+    async def test_display_text_multiple_messages(self, sessions_metadata_table):
+        """Multiple displayText records in the same session are all retrievable."""
+        from apis.shared.sessions.metadata import store_user_display_text, get_all_message_metadata
+
+        await store_user_display_text(session_id="s1", user_id="u1", message_id=0, display_text="first")
+        await store_user_display_text(session_id="s1", user_id="u1", message_id=2, display_text="second")
+        await store_user_display_text(session_id="s1", user_id="u1", message_id=4, display_text="third")
+
+        result = await get_all_message_metadata("s1", "u1")
+        assert result["0"]["displayText"] == "first"
+        assert result["2"]["displayText"] == "second"
+        assert result["4"]["displayText"] == "third"
+
+    @pytest.mark.asyncio
+    async def test_display_text_user_isolation(self, sessions_metadata_table):
+        """displayText from a different user should not leak into another user's query."""
+        from apis.shared.sessions.metadata import store_user_display_text, get_all_message_metadata
+
+        await store_user_display_text(session_id="s1", user_id="u1", message_id=0, display_text="user1 msg")
+        await store_user_display_text(session_id="s1", user_id="u2", message_id=0, display_text="user2 msg")
+
+        result_u1 = await get_all_message_metadata("s1", "u1")
+        assert result_u1.get("0", {}).get("displayText") == "user1 msg"
+
+    @pytest.mark.asyncio
+    async def test_missing_env_raises(self, sessions_metadata_table, monkeypatch):
+        """store_user_display_text raises RuntimeError when env var is missing."""
+        monkeypatch.delenv("DYNAMODB_SESSIONS_METADATA_TABLE_NAME", raising=False)
+        from apis.shared.sessions.metadata import store_user_display_text
+        with pytest.raises(RuntimeError):
+            await store_user_display_text(
+                session_id="s1", user_id="u1", message_id=0, display_text="boom",
+            )

--- a/frontend/ai.client/src/app/services/local-settings.service.ts
+++ b/frontend/ai.client/src/app/services/local-settings.service.ts
@@ -5,12 +5,19 @@ import { Injectable, signal } from '@angular/core';
 })
 export class LocalSettingsService {
   private readonly SHOW_TOKEN_COUNT_KEY = 'show-token-count';
+  private readonly SHOW_DEBUG_OUTPUT_KEY = 'show-debug-output';
 
   readonly showTokenCount = signal(this.loadBoolean(this.SHOW_TOKEN_COUNT_KEY, false));
+  readonly showDebugOutput = signal(this.loadBoolean(this.SHOW_DEBUG_OUTPUT_KEY, false));
 
   setShowTokenCount(value: boolean): void {
     this.showTokenCount.set(value);
     localStorage.setItem(this.SHOW_TOKEN_COUNT_KEY, JSON.stringify(value));
+  }
+
+  setShowDebugOutput(value: boolean): void {
+    this.showDebugOutput.set(value);
+    localStorage.setItem(this.SHOW_DEBUG_OUTPUT_KEY, JSON.stringify(value));
   }
 
   private loadBoolean(key: string, defaultValue: boolean): boolean {

--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
@@ -7,9 +7,11 @@ import {
   ElementRef,
   viewChild,
   AfterViewInit,
+  inject,
 } from '@angular/core';
 import { ContentBlock, Message, FileAttachmentData } from '../../../services/models/message.model';
 import { FileAttachmentBadgeComponent } from './file-attachment';
+import { LocalSettingsService } from '../../../../services/local-settings.service';
 
 const MAX_HEIGHT_PX = 200;
 
@@ -84,10 +86,13 @@ export class UserMessageComponent implements AfterViewInit {
   expanded = signal(false);
   isOverflowing = signal(false);
 
+  private localSettings = inject(LocalSettingsService);
+
   readonly maxHeightPx = MAX_HEIGHT_PX;
 
-  /** Original user message before RAG augmentation (if available in metadata) */
+  /** Original user message before prompt modification — skipped when debug output is enabled */
   displayText = computed((): string | null => {
+    if (this.localSettings.showDebugOutput()) return null;
     const metadata = this.message().metadata;
     if (metadata && typeof metadata['displayText'] === 'string') {
       return metadata['displayText'];

--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
@@ -31,9 +31,13 @@ const MAX_HEIGHT_PX = 200;
                 class="overflow-hidden transition-[max-height] duration-300 ease-in-out"
                 [style.max-height]="expanded() ? 'none' : maxHeightPx + 'px'"
               >
-                @for (block of message().content; track $index) {
-                  @if (block.type === 'text' && block.text) {
-                    <p class="whitespace-pre-wrap">{{ block.text }}</p>
+                @if (displayText()) {
+                  <p class="whitespace-pre-wrap">{{ displayText() }}</p>
+                } @else {
+                  @for (block of message().content; track $index) {
+                    @if (block.type === 'text' && block.text) {
+                      <p class="whitespace-pre-wrap">{{ block.text }}</p>
+                    }
                   }
                 }
               </div>
@@ -82,7 +86,17 @@ export class UserMessageComponent implements AfterViewInit {
 
   readonly maxHeightPx = MAX_HEIGHT_PX;
 
+  /** Original user message before RAG augmentation (if available in metadata) */
+  displayText = computed((): string | null => {
+    const metadata = this.message().metadata;
+    if (metadata && typeof metadata['displayText'] === 'string') {
+      return metadata['displayText'];
+    }
+    return null;
+  });
+
   hasTextContent = computed(() => {
+    if (this.displayText()) return true;
     return this.message().content.some(
       (block: ContentBlock) => block.type === 'text' && block.text
     );

--- a/frontend/ai.client/src/app/session/services/models/message.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/message.model.ts
@@ -109,7 +109,7 @@ export interface Message {
   content: ContentBlock[];
   /** ISO timestamp when the message was created */
   created_at?: string;
-  /** Optional metadata associated with the message */
+  /** Optional metadata associated with the message (may include displayText for RAG-augmented user messages) */
   metadata?: Record<string, unknown> | null;
   /** RAG citations from knowledge base retrieval (assistant messages only) */
   citations?: Citation[];

--- a/frontend/ai.client/src/app/session/services/models/message.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/message.model.ts
@@ -109,7 +109,7 @@ export interface Message {
   content: ContentBlock[];
   /** ISO timestamp when the message was created */
   created_at?: string;
-  /** Optional metadata associated with the message (may include displayText for RAG-augmented user messages) */
+  /** Optional metadata associated with the message (may include displayText with the original user input before prompt modification) */
   metadata?: Record<string, unknown> | null;
   /** RAG citations from knowledge base retrieval (assistant messages only) */
   citations?: Citation[];

--- a/frontend/ai.client/src/app/settings/pages/chat-preferences/chat-preferences-settings.page.ts
+++ b/frontend/ai.client/src/app/settings/pages/chat-preferences/chat-preferences-settings.page.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroSparkles, heroChatBubbleLeftRight, heroChevronRight } from '@ng-icons/heroicons/outline';
+import { heroSparkles, heroChatBubbleLeftRight, heroChevronRight, heroBugAnt } from '@ng-icons/heroicons/outline';
 import { ModelService } from '../../../session/services/model/model.service';
 import { UserSettingsService } from '../../../services/user-settings.service';
 import { LocalSettingsService } from '../../../services/local-settings.service';
@@ -17,7 +17,7 @@ import { LocalSettingsService } from '../../../services/local-settings.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, RouterLink],
   providers: [
-    provideIcons({ heroSparkles, heroChatBubbleLeftRight, heroChevronRight }),
+    provideIcons({ heroSparkles, heroChatBubbleLeftRight, heroChevronRight, heroBugAnt }),
   ],
   host: { class: 'block' },
   template: `
@@ -99,6 +99,38 @@ import { LocalSettingsService } from '../../../services/local-settings.service';
         </div>
       </div>
 
+      <!-- Show Debug Output toggle -->
+      <div class="rounded-lg border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-4 p-6">
+          <div class="flex items-start gap-3">
+            <div class="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-gray-100 dark:bg-white/10">
+              <ng-icon name="heroBugAnt" class="size-4 text-gray-500 dark:text-gray-400" />
+            </div>
+            <div>
+              <label for="show-debug-output" class="text-sm/6 font-medium text-gray-900 dark:text-white">
+                Show debug output
+              </label>
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                Show the full prompt sent to the model instead of the original message.
+              </p>
+            </div>
+          </div>
+
+          <!-- Toggle -->
+          <div class="group relative inline-flex w-11 shrink-0 rounded-full bg-gray-200 p-0.5 inset-ring inset-ring-gray-900/5 outline-offset-2 outline-blue-600 transition-colors duration-200 ease-in-out has-checked:bg-blue-600 has-focus-visible:outline-2 dark:bg-white/5 dark:inset-ring-white/10 dark:outline-blue-500 dark:has-checked:bg-blue-500">
+            <span class="size-5 rounded-full bg-white shadow-xs ring-1 ring-gray-900/5 transition-transform duration-200 ease-in-out group-has-checked:translate-x-5"></span>
+            <input
+              id="show-debug-output"
+              type="checkbox"
+              [checked]="localSettings.showDebugOutput()"
+              (change)="onDebugOutputToggle($event)"
+              aria-label="Show debug output"
+              class="absolute inset-0 size-full cursor-pointer appearance-none focus:outline-hidden"
+            />
+          </div>
+        </div>
+      </div>
+
       <!-- Manage Conversations -->
       <div class="rounded-lg border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-800">
         <a
@@ -174,5 +206,10 @@ export class ChatPreferencesSettingsPage {
   onTokenCountToggle(event: Event): void {
     const checkbox = event.target as HTMLInputElement;
     this.localSettings.setShowTokenCount(checkbox.checked);
+  }
+
+  onDebugOutputToggle(event: Event): void {
+    const checkbox = event.target as HTMLInputElement;
+    this.localSettings.setShowDebugOutput(checkbox.checked);
   }
 }


### PR DESCRIPTION
## Summary

When the prompt sent to the model differs from what the user typed (RAG augmentation, file attachment content blocks), the frontend previously showed the augmented/bloated prompt. This PR stores the original user message as a `displayText` record so the UI can show the clean version while the full augmented prompt stays in AgentCore Memory for the LLM.

## Changes

### Backend — Shared metadata (`apis/shared/sessions/metadata.py`)
- New `store_user_display_text()` function that writes a `D#` prefixed record to the sessions metadata DynamoDB table
- Updated `_get_all_message_metadata_cloud()` to query `D#` records alongside `C#` cost records and merge `displayText` into the metadata response
- Preview sessions are skipped (no persistence)

### Backend — Stream coordinator (`agents/main_agent/streaming/stream_coordinator.py`)
- Accepts optional `original_message` parameter
- After streaming completes, stores `displayText` when the original message differs from the augmented prompt

### Backend — Chat routes (`apis/app_api/chat/routes.py`, `apis/inference_api/chat/routes.py`)
- Passes `original_message` through to the stream coordinator when RAG augmentation or file attachments modify the user prompt

### Backend — Models
- Added `displayText` field support in message content models

### Frontend
- `user-message.component.ts`: Renders `displayText` when available instead of the raw augmented content
- `message.model.ts`: Updated model to include `displayText`
- `local-settings.service.ts` / `chat-preferences-settings.page.ts`: Local runtime override setting

### Tests
- 8 new tests in `TestStoreUserDisplayText` covering store/retrieve round-trip, cost record merging, SK patterns, preview session skip, multi-message, user isolation, and missing env var handling

## DynamoDB Schema

Display text records use a `D#` prefix SK pattern, separate from `C#` cost records:

| Key | Pattern | Example |
|-----|---------|---------|
| PK | `USER#{userId}` | `USER#u1` |
| SK | `D#{sessionId}#{messageId}` | `D#s1#0` |
| GSI_PK | `SESSION#{sessionId}` | `SESSION#s1` |
| GSI_SK | `D#{messageId}` | `D#0` |

## Testing

All 18 metadata tests pass (10 existing + 8 new):
```
tests/shared/test_sessions_metadata.py — 18 passed
```