### PR TITLE
feat: add VoiceAgent with BidiAgent for speech-to-speech interaction

### DIFF
--- a/backend/src/agents/main_agent/__init__.py
+++ b/backend/src/agents/main_agent/__init__.py
@@ -32,6 +32,12 @@ from .base_agent import BaseAgent
 from .chat_agent import ChatAgent
 from .skill_agent import SkillAgent
 from .agent_types import create_agent, register_agent_type, get_available_types
+
+# VoiceAgent is optional (requires strands-agents[bidi])
+try:
+    from .voice_agent import VoiceAgent
+except ImportError:
+    VoiceAgent = None
 from .core import ModelConfig, SystemPromptBuilder
 from .session import SessionFactory
 from .tools import ToolRegistry, ToolFilter, GatewayIntegration, create_default_registry

--- a/backend/src/agents/main_agent/agent_types.py
+++ b/backend/src/agents/main_agent/agent_types.py
@@ -58,5 +58,12 @@ def _register_defaults():
     register_agent_type("chat", ChatAgent)
     register_agent_type("skill", SkillAgent)
 
+    # Voice agent is optional (requires strands-agents[bidi])
+    try:
+        from agents.main_agent.voice_agent import VoiceAgent
+        register_agent_type("voice", VoiceAgent)
+    except Exception:
+        pass
+
 
 _register_defaults()

--- a/backend/src/agents/main_agent/config/constants.py
+++ b/backend/src/agents/main_agent/config/constants.py
@@ -56,6 +56,11 @@ class EnvVars:
     SESSION_ID = "SESSION_ID"
     USER_ID = "USER_ID"
 
+    # --- Voice Agent ---
+    NOVA_SONIC_MODEL_ID = "NOVA_SONIC_MODEL_ID"
+    NOVA_SONIC_VOICE = "NOVA_SONIC_VOICE"
+    NOVA_SONIC_MAX_MESSAGES = "NOVA_SONIC_MAX_MESSAGES"
+
 
 class Defaults:
     """Default values for configuration parameters.
@@ -99,6 +104,14 @@ class Defaults:
 
     # --- Gateway ---
     GATEWAY_MCP_ENABLED = True
+
+    # --- Voice Agent ---
+    NOVA_SONIC_MODEL_ID = "amazon.nova-2-sonic-v1:0"
+    NOVA_SONIC_VOICE = "tiffany"
+    NOVA_SONIC_INPUT_RATE = 16000
+    NOVA_SONIC_OUTPUT_RATE = 16000
+    NOVA_SONIC_MAX_MESSAGES = 20
+    VOICE_AGENT_ID = "voice"
 
 
 class Prefixes:

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -1,0 +1,222 @@
+"""
+Voice Agent — Bidirectional speech-to-speech agent using Nova Sonic.
+
+Extends BaseAgent with BidiAgent (Strands bidirectional agent) for
+real-time voice interaction. Shares session history with text ChatAgent
+for voice-text continuity.
+
+Requires: strands-agents[bidi] extra for BidiAgent and BidiNovaSonicModel.
+
+Based on the voice agent pattern from:
+https://github.com/aws-samples/sample-strands-agent-with-agentcore
+"""
+
+import logging
+import os
+import sys
+import types
+from typing import Any, AsyncGenerator, List, Optional
+
+from agents.main_agent.base_agent import BaseAgent
+from agents.main_agent.config.constants import EnvVars, Defaults
+
+logger = logging.getLogger(__name__)
+
+# Optional imports — BidiAgent requires the strands bidi extra
+try:
+    from strands.agent.bidi import BidiAgent
+    from strands.models.bidi_nova_sonic import BidiNovaSonicModel
+    BIDI_AVAILABLE = True
+except ImportError:
+    BIDI_AVAILABLE = False
+    logger.info("BidiAgent not available — install strands-agents[bidi] for voice support")
+
+
+# Mock PyAudio to avoid dependency — browser uses Web Audio API
+if "pyaudio" not in sys.modules:
+    _fake_pyaudio = types.ModuleType("pyaudio")
+    _fake_pyaudio.PyAudio = type("PyAudio", (), {})
+    sys.modules["pyaudio"] = _fake_pyaudio
+
+
+class VoiceAgent(BaseAgent):
+    """
+    Bidirectional voice agent using AWS Nova Sonic 2.
+
+    Provides:
+    - Real-time speech-to-speech via BidiNovaSonicModel
+    - Voice-text continuity (loads previous text chat history)
+    - Separate agent_id ("voice") to avoid session state conflicts
+    - Configurable voice, sample rate, and model via environment variables
+
+    Usage:
+        agent = VoiceAgent(session_id="sess-123", enabled_tools=[...])
+        await agent.start()
+        await agent.send_audio(audio_base64, sample_rate=16000)
+        async for event in agent.stream_async(""):
+            # BidiOutputEvent, BidiAudioStreamEvent, etc.
+    """
+
+    def __init__(self, voice: Optional[str] = None, **kwargs):
+        """
+        Initialize voice agent.
+
+        Args:
+            voice: Voice name override ("matthew", "tiffany", "amy").
+                   Defaults to NOVA_SONIC_VOICE env var or "tiffany".
+            **kwargs: All BaseAgent constructor args
+        """
+        self._voice = voice or os.environ.get(
+            EnvVars.NOVA_SONIC_VOICE, Defaults.NOVA_SONIC_VOICE
+        )
+        self._bidi_agent: Any = None
+        super().__init__(**kwargs)
+
+    def _create_agent(self) -> None:
+        """Create BidiAgent with Nova Sonic model and shared tools."""
+        if not BIDI_AVAILABLE:
+            raise RuntimeError(
+                "Voice agent requires BidiAgent. "
+                "Install with: uv sync --extra bidi"
+            )
+
+        try:
+            tools = self._build_filtered_tools()
+
+            # Configure Nova Sonic 2 model
+            model_id = os.environ.get(
+                EnvVars.NOVA_SONIC_MODEL_ID, Defaults.NOVA_SONIC_MODEL_ID
+            )
+
+            model = BidiNovaSonicModel(
+                model_id=model_id,
+                provider_config={
+                    "audio": {
+                        "voice": self._voice,
+                        "input_rate": Defaults.NOVA_SONIC_INPUT_RATE,
+                        "output_rate": Defaults.NOVA_SONIC_OUTPUT_RATE,
+                        "channels": 1,
+                        "format": "pcm",
+                    },
+                },
+                client_config={"region": os.environ.get(EnvVars.AWS_REGION, Defaults.AWS_REGION)},
+            )
+
+            # Build voice-specific system prompt
+            voice_prompt = self._build_voice_system_prompt()
+
+            # Load text history for voice-text continuity
+            initial_messages = self._load_text_history()
+
+            # Create BidiAgent with separate agent_id
+            self._bidi_agent = BidiAgent(
+                model=model,
+                tools=tools,
+                system_prompt=voice_prompt,
+                agent_id=Defaults.VOICE_AGENT_ID,
+                session_manager=self.session_manager,
+                messages=initial_messages,
+            )
+
+            # Also store as self.agent for BaseAgent compatibility
+            self.agent = self._bidi_agent
+
+            logger.info(
+                f"VoiceAgent created: model={model_id}, voice={self._voice}, "
+                f"tools={len(tools)}, history_messages={len(initial_messages)}"
+            )
+
+        except Exception as e:
+            logger.error(f"Error creating voice agent: {e}")
+            raise
+
+    def _build_voice_system_prompt(self) -> str:
+        """Build system prompt optimized for voice interaction."""
+        base = self.system_prompt if isinstance(self.system_prompt, str) else ""
+        voice_addendum = (
+            "\n\n## Voice Interaction Guidelines\n"
+            "- Keep responses concise and conversational\n"
+            "- Avoid long lists or complex formatting (the user is listening)\n"
+            "- Use natural speech patterns\n"
+            "- Confirm understanding before taking actions\n"
+        )
+        return base + voice_addendum
+
+    def _load_text_history(self) -> list:
+        """
+        Load recent text chat history for voice-text continuity.
+
+        Reads messages from the text agent's session to provide context
+        for the voice conversation.
+        """
+        max_messages = int(os.environ.get(
+            EnvVars.NOVA_SONIC_MAX_MESSAGES, str(Defaults.NOVA_SONIC_MAX_MESSAGES)
+        ))
+
+        try:
+            if hasattr(self.session_manager, "list_messages"):
+                messages = self.session_manager.list_messages()
+                if messages and len(messages) > max_messages:
+                    messages = messages[-max_messages:]
+                return messages or []
+        except Exception as e:
+            logger.warning(f"Could not load text history: {e}")
+
+        return []
+
+    async def start(self) -> None:
+        """Start the bidirectional voice connection."""
+        if self._bidi_agent and hasattr(self._bidi_agent, "start"):
+            await self._bidi_agent.start()
+
+    async def send_audio(self, audio_base64: str, sample_rate: int = 16000) -> None:
+        """
+        Send audio data to the voice agent.
+
+        Args:
+            audio_base64: Base64-encoded PCM audio
+            sample_rate: Audio sample rate (default 16kHz)
+        """
+        if self._bidi_agent and hasattr(self._bidi_agent, "send_audio"):
+            await self._bidi_agent.send_audio(audio_base64, sample_rate)
+
+    async def send_text(self, text: str) -> None:
+        """
+        Send text input to the voice agent (fallback from audio).
+
+        Args:
+            text: Text message to send
+        """
+        if self._bidi_agent and hasattr(self._bidi_agent, "send_text"):
+            await self._bidi_agent.send_text(text)
+
+    async def stream_async(
+        self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
+    ) -> AsyncGenerator[str, None]:
+        """
+        Stream voice agent events.
+
+        For voice agents, events include audio stream data, text transcriptions,
+        and tool use events.
+
+        Args:
+            message: Text message (may be empty for audio-only)
+            session_id: Session identifier
+            files: Not used for voice
+            citations: Not used for voice
+            original_message: Not used for voice
+
+        Yields:
+            str: SSE formatted events
+        """
+        if not self._bidi_agent:
+            self._create_agent()
+
+        if hasattr(self._bidi_agent, "stream_async"):
+            async for event in self._bidi_agent.stream_async(message):
+                yield str(event)
+
+    async def stop(self) -> None:
+        """Stop the bidirectional voice connection."""
+        if self._bidi_agent and hasattr(self._bidi_agent, "stop"):
+            await self._bidi_agent.stop()

--- a/backend/tests/agents/main_agent/test_voice_agent.py
+++ b/backend/tests/agents/main_agent/test_voice_agent.py
@@ -1,0 +1,140 @@
+"""Tests for VoiceAgent — module-level and class-level behavior."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agents.main_agent.config.constants import Defaults, EnvVars
+from agents.main_agent.base_agent import BaseAgent
+
+
+class TestVoiceAgentImport:
+    """Req VA-1: VoiceAgent is importable and conditionally available."""
+
+    def test_voice_agent_module_importable(self):
+        # The module itself should always be importable
+        import agents.main_agent.voice_agent as va
+        assert hasattr(va, "VoiceAgent")
+        assert hasattr(va, "BIDI_AVAILABLE")
+
+    def test_voice_agent_is_base_agent_subclass(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+        assert issubclass(VoiceAgent, BaseAgent)
+
+
+class TestVoiceConstants:
+    """Req VA-2: Voice configuration constants."""
+
+    def test_default_voice(self):
+        assert Defaults.NOVA_SONIC_VOICE == "tiffany"
+
+    def test_default_model_id(self):
+        assert Defaults.NOVA_SONIC_MODEL_ID == "amazon.nova-2-sonic-v1:0"
+
+    def test_default_sample_rates(self):
+        assert Defaults.NOVA_SONIC_INPUT_RATE == 16000
+        assert Defaults.NOVA_SONIC_OUTPUT_RATE == 16000
+
+    def test_default_max_messages(self):
+        assert Defaults.NOVA_SONIC_MAX_MESSAGES == 20
+
+    def test_voice_agent_id(self):
+        assert Defaults.VOICE_AGENT_ID == "voice"
+
+    def test_env_var_names(self):
+        assert EnvVars.NOVA_SONIC_MODEL_ID == "NOVA_SONIC_MODEL_ID"
+        assert EnvVars.NOVA_SONIC_VOICE == "NOVA_SONIC_VOICE"
+        assert EnvVars.NOVA_SONIC_MAX_MESSAGES == "NOVA_SONIC_MAX_MESSAGES"
+
+
+class TestVoiceAgentRegistration:
+    """Req VA-3: VoiceAgent factory registration."""
+
+    def test_voice_type_in_available_if_bidi_installed(self):
+        from agents.main_agent.voice_agent import BIDI_AVAILABLE
+        from agents.main_agent.agent_types import get_available_types
+
+        if BIDI_AVAILABLE:
+            assert "voice" in get_available_types()
+
+    def test_chat_and_skill_always_available(self):
+        from agents.main_agent.agent_types import get_available_types
+        types = get_available_types()
+        assert "chat" in types
+        assert "skill" in types
+
+
+class TestVoiceAgentTextHistory:
+    """Req VA-4: Voice-text continuity."""
+
+    def test_load_text_history_respects_max(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+
+        # Create a mock session manager with lots of messages
+        mock_session = MagicMock()
+        mock_session.list_messages.return_value = list(range(50))
+
+        agent = VoiceAgent.__new__(VoiceAgent)
+        agent.session_manager = mock_session
+
+        # Patch the env var for max messages
+        with patch.dict("os.environ", {EnvVars.NOVA_SONIC_MAX_MESSAGES: "10"}):
+            messages = agent._load_text_history()
+
+        assert len(messages) == 10
+
+    def test_load_text_history_handles_empty(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+
+        mock_session = MagicMock()
+        mock_session.list_messages.return_value = []
+
+        agent = VoiceAgent.__new__(VoiceAgent)
+        agent.session_manager = mock_session
+
+        messages = agent._load_text_history()
+        assert messages == []
+
+    def test_load_text_history_handles_error(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+
+        mock_session = MagicMock()
+        mock_session.list_messages.side_effect = RuntimeError("connection failed")
+
+        agent = VoiceAgent.__new__(VoiceAgent)
+        agent.session_manager = mock_session
+
+        messages = agent._load_text_history()
+        assert messages == []
+
+
+class TestVoiceSystemPrompt:
+    """Req VA-5: Voice-optimized system prompt."""
+
+    def test_voice_prompt_adds_guidelines(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+
+        agent = VoiceAgent.__new__(VoiceAgent)
+        agent.system_prompt = "You are a helpful assistant."
+
+        prompt = agent._build_voice_system_prompt()
+        assert "Voice Interaction Guidelines" in prompt
+        assert "concise and conversational" in prompt
+
+    def test_voice_prompt_preserves_base(self):
+        from agents.main_agent.voice_agent import VoiceAgent
+
+        agent = VoiceAgent.__new__(VoiceAgent)
+        agent.system_prompt = "Base prompt here."
+
+        prompt = agent._build_voice_system_prompt()
+        assert "Base prompt here." in prompt
+
+
+class TestPyAudioMock:
+    """Req VA-6: PyAudio mock is in place."""
+
+    def test_pyaudio_in_sys_modules(self):
+        import sys
+        # After importing voice_agent, pyaudio should be mocked
+        import agents.main_agent.voice_agent  # noqa: F401
+        assert "pyaudio" in sys.modules


### PR DESCRIPTION
## Summary
- Implement `VoiceAgent(BaseAgent)` for bidirectional voice using AWS Nova Sonic 2
- `BidiNovaSonicModel` with configurable voice, sample rate, and model via env vars
- Voice-text continuity: loads previous text chat history from shared session
- Separate `agent_id` ("voice") prevents session state conflicts with text agent
- Voice-optimized system prompt with conversational guidelines
- PyAudio mock for server-side (browser handles audio via Web Audio API)
- Conditional registration — only available when `strands-agents[bidi]` is installed

## Details
Add voice-related constants to `config/constants.py` (`NOVA_SONIC_MODEL_ID`, `NOVA_SONIC_VOICE`, etc.). Register `"voice"` type in agent factory.

Entirely additive — no existing code paths affected.

**Files changed:** 5 (2 new, 3 modified)

## Test plan
- [x] 606/606 tests pass (590 existing + 16 new voice tests)
- [ ] Verify VoiceAgent is importable and a BaseAgent subclass
- [ ] Verify voice-text history loading respects max message limit
- [ ] Verify voice system prompt includes conversational guidelines

> **Note:** PR 5 of 6 — depends on #142
> Merge order: 1→2→3→4→**5**→6

🤖 Generated with [Claude Code](https://claude.com/claude-code)