### PR TITLE
feat: add approval hooks for gating dangerous tool operations

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -12,7 +12,12 @@ from typing import AsyncGenerator, List, Optional
 
 from agents.main_agent.core import ModelConfig, SystemPromptBuilder, AgentFactory
 from agents.main_agent.session import SessionFactory
-from agents.main_agent.session.hooks import StopHook
+from agents.main_agent.session.hooks import (
+    StopHook,
+    EmailApprovalHook,
+    ExternalWriteApprovalHook,
+    DangerousToolApprovalHook,
+)
 from agents.main_agent.tools import (
     create_default_registry,
     ToolFilter,
@@ -180,12 +185,23 @@ class BaseAgent(ABC):
         """
         Create agent hooks.
 
+        Includes:
+        - StopHook: Always enabled, cancels tool execution on user stop
+        - Approval hooks: Gate dangerous operations for user confirmation
+
         Returns:
             list: List of initialized hooks
         """
         hooks = []
-        stop_hook = StopHook(self.session_manager)
-        hooks.append(stop_hook)
+
+        # Always-on: session cancellation
+        hooks.append(StopHook(self.session_manager))
+
+        # Approval gates for dangerous operations
+        hooks.append(EmailApprovalHook())
+        hooks.append(ExternalWriteApprovalHook())
+        hooks.append(DangerousToolApprovalHook())
+
         return hooks
 
     def _build_filtered_tools(self) -> List:

--- a/backend/src/agents/main_agent/session/hooks/__init__.py
+++ b/backend/src/agents/main_agent/session/hooks/__init__.py
@@ -1,9 +1,19 @@
 """Hooks for Main Agent"""
 
 from agents.main_agent.session.hooks.stop import StopHook
+from agents.main_agent.session.hooks.tool_approval import (
+    ToolApprovalHook,
+    EmailApprovalHook,
+    ExternalWriteApprovalHook,
+    DangerousToolApprovalHook,
+)
 
 __all__ = [
     "StopHook",
+    "ToolApprovalHook",
+    "EmailApprovalHook",
+    "ExternalWriteApprovalHook",
+    "DangerousToolApprovalHook",
 ]
 
 

--- a/backend/src/agents/main_agent/session/hooks/tool_approval.py
+++ b/backend/src/agents/main_agent/session/hooks/tool_approval.py
@@ -1,0 +1,90 @@
+"""
+Tool approval hooks for gating dangerous operations.
+
+These hooks intercept tool calls before execution and can request
+user confirmation for operations that modify external systems.
+
+Based on the approval hook pattern from:
+https://github.com/aws-samples/sample-strands-agent-with-agentcore
+"""
+
+import logging
+from typing import Any, Set
+
+from strands.hooks import HookProvider, HookRegistry, BeforeToolCallEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ToolApprovalHook(HookProvider):
+    """
+    Base approval hook that gates specified tool names.
+
+    Subclasses define which tool names require approval and what
+    message to show the user. The hook sets the approval_required
+    flag on the event, which the streaming layer can surface to
+    the client for user confirmation.
+    """
+
+    # Subclasses override these
+    tool_names: Set[str] = set()
+    approval_message: str = "This operation requires approval."
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeToolCallEvent, self.check_approval)
+
+    def check_approval(self, event: BeforeToolCallEvent) -> None:
+        """Check if the tool call requires user approval."""
+        tool_name = event.tool_use.get("name", "")
+        if tool_name in self.tool_names:
+            logger.info(f"Tool approval required: {tool_name}")
+            # The approval_required attribute signals the streaming layer
+            # to elicit user confirmation before proceeding
+            event.tool_use["_approval_required"] = True
+            event.tool_use["_approval_message"] = self.approval_message
+
+
+class EmailApprovalHook(ToolApprovalHook):
+    """Gate bulk email operations (send, delete, forward)."""
+
+    tool_names = {
+        "send_email",
+        "send_bulk_email",
+        "delete_emails",
+        "forward_email",
+    }
+    approval_message = (
+        "This tool will perform an email operation. "
+        "Please confirm you want to proceed."
+    )
+
+
+class ExternalWriteApprovalHook(ToolApprovalHook):
+    """Gate operations that write to external systems (GitHub, APIs, etc.)."""
+
+    tool_names = {
+        "create_pull_request",
+        "merge_pull_request",
+        "create_issue",
+        "push_code",
+        "deploy",
+        "delete_repository",
+    }
+    approval_message = (
+        "This tool will modify an external system. "
+        "Please confirm you want to proceed."
+    )
+
+
+class DangerousToolApprovalHook(ToolApprovalHook):
+    """Gate tools with irreversible side effects."""
+
+    tool_names = {
+        "delete_file",
+        "drop_table",
+        "execute_sql",
+    }
+    approval_message = (
+        "This tool performs an irreversible operation. "
+        "Please confirm you want to proceed."
+    )

--- a/backend/tests/agents/main_agent/session/test_tool_approval.py
+++ b/backend/tests/agents/main_agent/session/test_tool_approval.py
@@ -1,0 +1,106 @@
+"""Tests for tool approval hooks."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from agents.main_agent.session.hooks.tool_approval import (
+    ToolApprovalHook,
+    EmailApprovalHook,
+    ExternalWriteApprovalHook,
+    DangerousToolApprovalHook,
+)
+
+
+def _make_event(tool_name: str):
+    """Create a mock BeforeToolCallEvent."""
+    event = MagicMock()
+    event.tool_use = {"name": tool_name}
+    return event
+
+
+class TestEmailApprovalHook:
+    """Req AH-1: Email operations require approval."""
+
+    def test_send_email_flagged(self):
+        hook = EmailApprovalHook()
+        event = _make_event("send_email")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_delete_emails_flagged(self):
+        hook = EmailApprovalHook()
+        event = _make_event("delete_emails")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_read_email_not_flagged(self):
+        hook = EmailApprovalHook()
+        event = _make_event("read_email")
+        hook.check_approval(event)
+        assert "_approval_required" not in event.tool_use
+
+    def test_approval_message_set(self):
+        hook = EmailApprovalHook()
+        event = _make_event("send_email")
+        hook.check_approval(event)
+        assert "email operation" in event.tool_use["_approval_message"]
+
+
+class TestExternalWriteApprovalHook:
+    """Req AH-2: External system writes require approval."""
+
+    def test_create_pr_flagged(self):
+        hook = ExternalWriteApprovalHook()
+        event = _make_event("create_pull_request")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_deploy_flagged(self):
+        hook = ExternalWriteApprovalHook()
+        event = _make_event("deploy")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_list_repos_not_flagged(self):
+        hook = ExternalWriteApprovalHook()
+        event = _make_event("list_repositories")
+        hook.check_approval(event)
+        assert "_approval_required" not in event.tool_use
+
+
+class TestDangerousToolApprovalHook:
+    """Req AH-3: Irreversible operations require approval."""
+
+    def test_delete_file_flagged(self):
+        hook = DangerousToolApprovalHook()
+        event = _make_event("delete_file")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_execute_sql_flagged(self):
+        hook = DangerousToolApprovalHook()
+        event = _make_event("execute_sql")
+        hook.check_approval(event)
+        assert event.tool_use.get("_approval_required") is True
+
+    def test_calculator_not_flagged(self):
+        hook = DangerousToolApprovalHook()
+        event = _make_event("calculator")
+        hook.check_approval(event)
+        assert "_approval_required" not in event.tool_use
+
+
+class TestToolApprovalHookBase:
+    """Req AH-4: Base hook class behavior."""
+
+    def test_empty_tool_names_flags_nothing(self):
+        hook = ToolApprovalHook()
+        event = _make_event("anything")
+        hook.check_approval(event)
+        assert "_approval_required" not in event.tool_use
+
+    def test_register_hooks_adds_callback(self):
+        hook = EmailApprovalHook()
+        registry = MagicMock()
+        hook.register_hooks(registry)
+        registry.add_callback.assert_called_once()


### PR DESCRIPTION
## Summary
- Implement three approval hook categories using Strands `BeforeToolCallEvent`:
  - **EmailApprovalHook:** Gates `send_email`, `delete_emails`, `forward_email`, etc.
  - **ExternalWriteApprovalHook:** Gates `create_pull_request`, `deploy`, `push_code`, etc.
  - **DangerousToolApprovalHook:** Gates `delete_file`, `drop_table`, `execute_sql`, etc.
- Hooks set `_approval_required`/`_approval_message` on the `tool_use` dict for the streaming layer to surface to the client
- All hooks registered in `BaseAgent._create_hooks()` — inherited by all agent types

## Details
Based on the approval hook pattern from [sample-strands-agent-with-agentcore](https://github.com/aws-samples/sample-strands-agent-with-agentcore). Tool name sets are configurable per hook subclass.

**Files changed:** 4 (2 new, 2 modified)

## Test plan
- [x] 618/618 tests pass (606 existing + 12 new approval hook tests)
- [ ] Verify email operations are flagged for approval
- [ ] Verify external writes are flagged for approval
- [ ] Verify safe tools (calculator, read_email) are NOT flagged

> **Note:** PR 6 of 6 (final) — depends on #143
> Merge order: 1→2→3→4→5→**6**
> After merging all 6, the full agent architecture refactor is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)