### PR TITLE
feat: add WebSocket voice route and bidi dependency for VoiceAgent

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,11 @@ agentcore = [
     "google-genai==1.70.0",  # For Google Gemini models
 ]
 
+# Voice/BidiAgent dependencies (Nova Sonic speech-to-speech)
+bidi = [
+    "strands-agents[bidi]==1.34.1",
+]
+
 # Document ingestion pipeline dependencies (for Lambda deployment)
 # NOTE: For document ingestion dependencies, see:
 #   backend/src/apis/app_api/documents/ingestion/requirements.txt
@@ -71,7 +76,7 @@ dev = [
 
 # All dependencies (convenience)
 all = [
-    "agentcore-stack[agentcore,dev]",
+    "agentcore-stack[agentcore,bidi,dev]",
 ]
 
 [tool.setuptools]

--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -211,6 +211,23 @@ DEFAULT_MODELS: list[dict[str, Any]] = [
         "supportsCaching": True,
         "isDefault": False,
     },
+    {
+        "modelId": "amazon.nova-2-sonic-v1:0",
+        "modelName": "Nova 2 Sonic",
+        "provider": "bedrock",
+        "providerName": "Amazon",
+        "inputModalities": ["TEXT", "SPEECH"],
+        "outputModalities": ["TEXT", "SPEECH"],
+        "maxInputTokens": 200000,
+        "maxOutputTokens": 4096,
+        "inputPricePerMillionTokens": Decimal("3.00"),
+        "outputPricePerMillionTokens": Decimal("12.00"),
+        "cacheWritePricePerMillionTokens": Decimal("0"),
+        "cacheReadPricePerMillionTokens": Decimal("0"),
+        "isReasoningModel": False,
+        "supportsCaching": False,
+        "isDefault": False,
+    },
 ]
 
 

--- a/backend/scripts/test_voice_client.py
+++ b/backend/scripts/test_voice_client.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Minimal WebSocket test client for the voice endpoint.
+
+Usage:
+    # With a real JWT token (from Cognito):
+    python scripts/test_voice_client.py --token "eyJhbGc..."
+
+    # With a fake token for local testing (requires no auth verification):
+    python scripts/test_voice_client.py --fake-token
+
+    # Send a text message instead of audio (simpler test):
+    python scripts/test_voice_client.py --fake-token --text "Hello, what can you help me with?"
+
+Prerequisites:
+    pip install websockets
+    # Server must be running: cd src/apis/inference_api && uv run python main.py
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+try:
+    import websockets
+except ImportError:
+    print("Install websockets: pip install websockets")
+    sys.exit(1)
+
+try:
+    import jwt as pyjwt
+except ImportError:
+    pyjwt = None
+
+
+def make_fake_token() -> str:
+    """Create a fake JWT token for local testing."""
+    if pyjwt is None:
+        print("pyjwt not available for fake token generation, using placeholder")
+        return "fake.token.placeholder"
+    return pyjwt.encode(
+        {"sub": "test-user-001", "email": "test@example.com", "name": "Test User"},
+        "test-secret",
+        algorithm="HS256",
+    )
+
+
+async def run_client(url: str, token: str, text_message: str = None):
+    """Connect to voice WebSocket and exchange messages."""
+    print(f"Connecting to {url}")
+
+    async with websockets.connect(url) as ws:
+        print("Connected!")
+
+        # Send config message
+        config = {
+            "type": "config",
+            "session_id": "voice-test-001",
+            "auth_token": token,
+        }
+        await ws.send(json.dumps(config))
+        print(f"Sent config: {json.dumps(config, indent=2)}")
+
+        # Read connection confirmation
+        response = await asyncio.wait_for(ws.recv(), timeout=15.0)
+        print(f"Received: {response}")
+
+        if text_message:
+            # Send a text message (simpler than audio for testing)
+            msg = {"type": "bidi_text_input", "text": text_message}
+            await ws.send(json.dumps(msg))
+            print(f"Sent text: {text_message}")
+
+            # Read responses for a few seconds
+            print("\nListening for responses (10s timeout)...")
+            try:
+                while True:
+                    response = await asyncio.wait_for(ws.recv(), timeout=10.0)
+                    try:
+                        parsed = json.loads(response)
+                        print(f"  Event: {json.dumps(parsed, indent=2)[:200]}")
+                    except json.JSONDecodeError:
+                        print(f"  Raw: {response[:200]}")
+            except asyncio.TimeoutError:
+                print("No more responses (timeout)")
+        else:
+            # Just test ping/pong
+            await ws.send(json.dumps({"type": "ping"}))
+            response = await asyncio.wait_for(ws.recv(), timeout=5.0)
+            print(f"Ping response: {response}")
+
+        # Send stop
+        await ws.send(json.dumps({"type": "stop"}))
+        print("Sent stop signal")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test voice WebSocket endpoint")
+    parser.add_argument("--url", default="ws://localhost:8001/voice/stream", help="WebSocket URL")
+    parser.add_argument("--token", help="JWT bearer token")
+    parser.add_argument("--fake-token", action="store_true", help="Generate a fake JWT for local testing")
+    parser.add_argument("--text", help="Send a text message instead of audio")
+    args = parser.parse_args()
+
+    token = args.token
+    if args.fake_token:
+        token = make_fake_token()
+    if not token:
+        print("Error: Provide --token or --fake-token")
+        sys.exit(1)
+
+    url = f"{args.url}?session_id=voice-test-001&token={token}"
+
+    try:
+        asyncio.run(run_client(url, token, args.text))
+    except ConnectionRefusedError:
+        print(f"Connection refused. Is the server running at {args.url}?")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\nInterrupted")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -229,11 +229,11 @@ class StreamCoordinator:
                             usage_for_cost = accumulated_metadata.get("usage", {})
                             logger.info(f"💰 Cost calculation: model_id={model_id}, usage={usage_for_cost}")
                             try:
-                                cost = await self._calculate_streaming_cost(model_id=model_id, usage=usage_for_cost)
-                                if cost is not None:
-                                    final_metadata["cost"] = cost
+                                cost_result = await self._calculate_streaming_cost(model_id=model_id, usage=usage_for_cost)
+                                if cost_result is not None:
+                                    final_metadata["cost"] = cost_result
                                     logger.info(
-                                        f"💰 Calculated streaming cost: ${cost:.6f} for {usage_for_cost.get('inputTokens', 0)} input, {usage_for_cost.get('outputTokens', 0)} output tokens"
+                                        f"💰 Calculated streaming cost: ${cost_result['total']:.6f} (input=${cost_result['inputCost']:.6f}, output=${cost_result['outputCost']:.6f}) for {usage_for_cost.get('inputTokens', 0)} input, {usage_for_cost.get('outputTokens', 0)} output tokens"
                                     )
                             except Exception as cost_error:
                                 logger.warning(f"Failed to calculate streaming cost: {cost_error}")
@@ -625,15 +625,16 @@ class StreamCoordinator:
 
     def _get_initial_message_count(self, session_manager: Any) -> int:
         """
-        Get the initial message count from session manager BEFORE streaming starts.
+        Get the GLOBAL initial message count BEFORE streaming starts.
 
-        This is a key optimization that eliminates post-stream AgentCore Memory queries.
-        By capturing the message count at the start of streaming, we can calculate
-        the indices of new messages without querying the database after streaming.
+        Returns the total number of messages across ALL agents (default + voice)
+        in the session, because metadata retrieval in get_messages_from_cloud()
+        uses global enumerate indices across all agents' messages.
 
-        The count is obtained from:
-        1. TurnBasedSessionManager.message_count (initialized from AgentCore Memory at session start)
-        2. Fallback to 0 if no count is available
+        The agent-specific message_count (from TurnBasedSessionManager) only
+        counts messages for the "default" agent, which causes index mismatches
+        in mixed voice+text sessions.  We prefer list_messages() which returns
+        ALL messages regardless of agent_id.
 
         Args:
             session_manager: Session manager instance
@@ -641,58 +642,55 @@ class StreamCoordinator:
         Returns:
             int: Number of messages that existed before this stream started (0 if unknown)
         """
-        # For TurnBasedSessionManager (cloud mode): use the pre-initialized message_count
-        # This was queried from AgentCore Memory when the session manager was created
+        # Prefer list_messages() for global count — it returns ALL messages
+        # regardless of agent_id, matching how get_messages_from_cloud() retrieves them.
+        session_id = self._resolve_session_id(session_manager)
+        if session_id:
+            lister = self._resolve_list_messages(session_manager)
+            if lister:
+                try:
+                    messages = lister(session_id, "default")
+                    count = len(messages) if messages else 0
+                    logger.info(f"Using global list_messages count: {count}")
+                    return count
+                except Exception as e:
+                    logger.warning(f"Failed to get global message count: {e}")
+
+        # Fallback to agent-specific message_count (may undercount in mixed sessions)
         if hasattr(session_manager, "message_count"):
             count = session_manager.message_count
-            logger.debug(f"Using TurnBasedSessionManager.message_count: {count}")
+            logger.debug(f"Fallback to TurnBasedSessionManager.message_count: {count}")
             return count
 
-        # Check wrapped session managers
         if hasattr(session_manager, "base_manager"):
             base_manager = session_manager.base_manager
-
-            # Check if base manager has message_count
             if hasattr(base_manager, "message_count"):
                 count = base_manager.message_count
-                logger.debug(f"Using base_manager.message_count: {count}")
+                logger.debug(f"Fallback to base_manager.message_count: {count}")
                 return count
 
-            # Try list_messages if available
-            if hasattr(base_manager, "list_messages"):
-                try:
-                    # Get session_id from config or session_manager
-                    session_id = None
-                    if hasattr(base_manager, "config"):
-                        session_id = base_manager.config.session_id
-                    elif hasattr(base_manager, "session_id"):
-                        session_id = base_manager.session_id
-                    elif hasattr(session_manager, "session_id"):
-                        session_id = session_manager.session_id
-
-                    if session_id:
-                        messages = base_manager.list_messages(session_id, "default")
-                        count = len(messages) if messages else 0
-                        logger.debug(f"Using base_manager.list_messages count: {count}")
-                        return count
-                except Exception as e:
-                    logger.warning(f"Failed to get message count from base_manager: {e}")
-
-        # Direct session manager with list_messages
-        if hasattr(session_manager, "list_messages"):
-            try:
-                session_id = getattr(session_manager, "session_id", None)
-                if session_id:
-                    messages = session_manager.list_messages(session_id, "default")
-                    count = len(messages) if messages else 0
-                    logger.debug(f"Using session_manager.list_messages count: {count}")
-                    return count
-            except Exception as e:
-                logger.warning(f"Failed to get message count from session_manager: {e}")
-
-        # Fallback: no count available (assume new session)
         logger.warning("Could not determine initial message count, defaulting to 0")
         return 0
+
+    @staticmethod
+    def _resolve_session_id(session_manager: Any) -> Optional[str]:
+        """Extract session_id from a session manager."""
+        for mgr in (session_manager, getattr(session_manager, "base_manager", None)):
+            if mgr is None:
+                continue
+            if hasattr(mgr, "config") and hasattr(mgr.config, "session_id"):
+                return mgr.config.session_id
+            if hasattr(mgr, "session_id"):
+                return mgr.session_id
+        return None
+
+    @staticmethod
+    def _resolve_list_messages(session_manager: Any) -> Optional[callable]:
+        """Find list_messages callable on a session manager."""
+        for mgr in (session_manager, getattr(session_manager, "base_manager", None)):
+            if mgr and hasattr(mgr, "list_messages"):
+                return mgr.list_messages
+        return None
 
     def _get_latest_message_id(self, session_manager: Any) -> Optional[int]:
         """
@@ -908,7 +906,9 @@ class StreamCoordinator:
 
                 # Calculate cost if we have both usage and pricing
                 if token_usage and pricing_snapshot:
-                    cost = self._calculate_message_cost(usage=accumulated_metadata.get("usage", {}), pricing=pricing_snapshot)
+                    cost_result = self._calculate_message_cost(usage=accumulated_metadata.get("usage", {}), pricing=pricing_snapshot)
+                    if cost_result is not None:
+                        cost = cost_result
 
             # Create Attribution for cost tracking foundation
             attribution = Attribution(
@@ -1012,7 +1012,7 @@ class StreamCoordinator:
             logger.error(f"Failed to get pricing snapshot for {model_id}: {e}")
             return None
 
-    def _calculate_message_cost(self, usage: Dict[str, Any], pricing: Optional[Dict[str, Any]]) -> Optional[float]:
+    def _calculate_message_cost(self, usage: Dict[str, Any], pricing: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """
         Calculate message cost from usage and pricing
 
@@ -1021,7 +1021,7 @@ class StreamCoordinator:
             pricing: Pricing snapshot (PricingSnapshot model)
 
         Returns:
-            Total cost in USD or None if pricing unavailable
+            Dict with total cost and breakdown, or None if pricing unavailable
         """
         if not pricing:
             return None
@@ -1035,14 +1035,20 @@ class StreamCoordinator:
             else:
                 pricing_dict = pricing
 
-            total_cost, _ = CostCalculator.calculate_message_cost(usage, pricing_dict)
-            return total_cost
+            total_cost, breakdown = CostCalculator.calculate_message_cost(usage, pricing_dict)
+            return {
+                "total": total_cost,
+                "inputCost": breakdown.input_cost,
+                "outputCost": breakdown.output_cost,
+                "cacheReadCost": breakdown.cache_read_cost,
+                "cacheWriteCost": breakdown.cache_write_cost,
+            }
 
         except Exception as e:
             logger.error(f"Failed to calculate message cost: {e}")
             return None
 
-    async def _calculate_streaming_cost(self, model_id: str, usage: Dict[str, Any]) -> Optional[float]:
+    async def _calculate_streaming_cost(self, model_id: str, usage: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
         Calculate cost for streaming response to send to client in real-time.
 
@@ -1055,7 +1061,7 @@ class StreamCoordinator:
             usage: Token usage dict from streaming
 
         Returns:
-            Total cost in USD or None if pricing unavailable
+            Dict with total cost and breakdown, or None if pricing unavailable
         """
         if not usage:
             return None

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -159,12 +159,17 @@ class VoiceAgent(BaseAgent):
             if hasattr(self.session_manager, "list_messages"):
                 # AgentCoreMemorySessionManager.list_messages requires session_id and agent_id
                 # Use "default" to read the text chat agent's history
-                messages = self.session_manager.list_messages(
+                session_messages = self.session_manager.list_messages(
                     session_id=self.session_id,
                     agent_id="default",
                     limit=max_messages,
                 )
-                return messages or []
+                if not session_messages:
+                    return []
+
+                # Convert SessionMessage objects to plain dicts for BidiAgent
+                # Nova Sonic expects {"role": "user"|"assistant", "content": [...]}
+                return [msg.to_dict() for msg in session_messages]
         except Exception as e:
             logger.warning(f"Could not load text history: {e}")
 

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -198,29 +198,28 @@ class VoiceAgent(BaseAgent):
 
     async def stream_async(
         self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[dict, None]:
         """
-        Stream voice agent events.
+        Stream voice agent events via BidiAgent.receive().
 
-        For voice agents, events include audio stream data, text transcriptions,
-        and tool use events.
+        Yields typed event dicts (BidiAudioStreamEvent, BidiTranscriptStreamEvent,
+        BidiResponseCompleteEvent, etc.) from the Nova Sonic bidirectional stream.
 
-        Args:
-            message: Text message (may be empty for audio-only)
-            session_id: Session identifier
-            files: Not used for voice
-            citations: Not used for voice
-            original_message: Not used for voice
+        The BidiAgent uses receive() as its event source — not stream_async().
+        Audio and text input are sent separately via send_audio()/send_text().
 
         Yields:
-            str: SSE formatted events
+            dict: Event dictionaries with 'type' field indicating event kind
         """
         if not self._bidi_agent:
             self._create_agent()
 
-        if hasattr(self._bidi_agent, "stream_async"):
-            async for event in self._bidi_agent.stream_async(message):
-                yield str(event)
+        async for event in self._bidi_agent.receive():
+            # Events have as_dict() for serialization
+            if hasattr(event, "as_dict"):
+                yield event.as_dict()
+            else:
+                yield {"type": "unknown", "data": str(event)}
 
     async def stop(self) -> None:
         """Stop the bidirectional voice connection.

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -74,7 +74,6 @@ class VoiceAgent(BaseAgent):
         # Nova Sonic bidi_usage events report CUMULATIVE token counts (not deltas).
         # _accumulated_usage stores the latest cumulative snapshot from the stream.
         self._accumulated_usage: dict = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
-        self._current_turn_usage: dict = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
         self._per_turn_usage: List[dict] = []  # Snapshot of usage per completed turn
         self._turn_count: int = 0  # Completed turns (bidi_response_complete)
         self._response_start_count: int = 0  # Started turns (bidi_response_start)

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -167,9 +167,10 @@ class VoiceAgent(BaseAgent):
                 if not session_messages:
                     return []
 
-                # Convert SessionMessage objects to plain dicts for BidiAgent
-                # Nova Sonic expects {"role": "user"|"assistant", "content": [...]}
-                return [msg.to_dict() for msg in session_messages]
+                # Convert SessionMessage objects to plain message dicts for BidiAgent
+                # to_message() returns {"role": "user"|"assistant", "content": [...]}
+                # (to_dict() wraps it in metadata — Nova Sonic needs the inner message)
+                return [msg.to_message() for msg in session_messages]
         except Exception as e:
             logger.warning(f"Could not load text history: {e}")
 

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -147,8 +147,9 @@ class VoiceAgent(BaseAgent):
         """
         Load recent text chat history for voice-text continuity.
 
-        Reads messages from the text agent's session to provide context
-        for the voice conversation.
+        Reads messages from the text (default) agent's session to provide
+        context for the voice conversation. Uses agent_id="default" to
+        read from the text chat agent's history.
         """
         max_messages = int(os.environ.get(
             EnvVars.NOVA_SONIC_MAX_MESSAGES, str(Defaults.NOVA_SONIC_MAX_MESSAGES)
@@ -156,9 +157,13 @@ class VoiceAgent(BaseAgent):
 
         try:
             if hasattr(self.session_manager, "list_messages"):
-                messages = self.session_manager.list_messages()
-                if messages and len(messages) > max_messages:
-                    messages = messages[-max_messages:]
+                # AgentCoreMemorySessionManager.list_messages requires session_id and agent_id
+                # Use "default" to read the text chat agent's history
+                messages = self.session_manager.list_messages(
+                    session_id=self.session_id,
+                    agent_id="default",
+                    limit=max_messages,
+                )
                 return messages or []
         except Exception as e:
             logger.warning(f"Could not load text history: {e}")

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -257,14 +257,19 @@ class VoiceAgent(BaseAgent):
         dicts via as_dict(). This is the primary event source for the voice
         WebSocket route.
 
-        Intercepts bidi_usage events to accumulate token counts and
-        bidi_response_complete events to track turn count.
+        Intercepts bidi_usage events to accumulate token counts, calculate
+        real-time cost, and enrich the event with a cost breakdown before
+        forwarding to the client.
 
         Yields:
             dict: Event dictionaries suitable for JSON serialization
         """
         if not self._bidi_agent:
             raise RuntimeError("Voice agent not started")
+
+        # Lazy-loaded pricing for real-time cost calculation
+        pricing_dict: Optional[dict] = None
+        pricing_loaded = False
 
         async for event in self._bidi_agent.receive():
             if hasattr(event, "as_dict"):
@@ -276,7 +281,6 @@ class VoiceAgent(BaseAgent):
 
             # Log non-audio event types for debugging (skip audio to avoid noise)
             if event_type not in ("bidi_audio_stream",):
-                # Log extra detail for events that might carry usage data
                 if any(k in event_dict for k in ("usage", "inputTokens", "outputTokens", "totalTokens")):
                     logger.info(f"Voice event: type={event_type}, keys={list(event_dict.keys())}")
                 else:
@@ -296,6 +300,32 @@ class VoiceAgent(BaseAgent):
                     self._accumulated_usage[key] = usage.get(key, self._accumulated_usage[key])
                 logger.info(f"Voice bidi_usage snapshot: {usage}")
                 logger.info(f"Voice usage current: {self._accumulated_usage}")
+
+                # Calculate real-time cost and enrich the event for the client.
+                # Pricing is fetched once and cached for the session lifetime.
+                if not pricing_loaded:
+                    pricing_loaded = True
+                    try:
+                        from apis.app_api.costs.pricing_config import get_model_pricing
+                        pricing_dict = await get_model_pricing(self.voice_model_id)
+                    except Exception as e:
+                        logger.debug(f"Voice pricing unavailable: {e}")
+
+                if pricing_dict and self._accumulated_usage.get("totalTokens", 0) > 0:
+                    try:
+                        from apis.app_api.costs.calculator import CostCalculator
+                        total_cost, breakdown = CostCalculator.calculate_message_cost(
+                            self._accumulated_usage, pricing_dict
+                        )
+                        event_dict["cost"] = {
+                            "total": total_cost,
+                            "inputCost": breakdown.input_cost,
+                            "outputCost": breakdown.output_cost,
+                            "cacheReadCost": breakdown.cache_read_cost,
+                            "cacheWriteCost": breakdown.cache_write_cost,
+                        }
+                    except Exception as e:
+                        logger.debug(f"Voice cost calculation error: {e}")
 
             # Track completed assistant turns and snapshot cumulative usage at turn boundary
             if event_type == "bidi_response_complete":

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -178,54 +178,77 @@ class VoiceAgent(BaseAgent):
 
     async def start(self) -> None:
         """Start the bidirectional voice connection."""
-        if self._bidi_agent and hasattr(self._bidi_agent, "start"):
-            await self._bidi_agent.start()
+        if not self._bidi_agent:
+            self._create_agent()
+        await self._bidi_agent.start()
 
     async def send_audio(self, audio_base64: str, sample_rate: int = 16000) -> None:
         """
-        Send audio data to the voice agent.
+        Send audio data to the voice agent via BidiAgent.send().
 
         Args:
             audio_base64: Base64-encoded PCM audio
             sample_rate: Audio sample rate (default 16kHz)
         """
-        if self._bidi_agent and hasattr(self._bidi_agent, "send_audio"):
-            await self._bidi_agent.send_audio(audio_base64, sample_rate)
+        if not self._bidi_agent:
+            raise RuntimeError("Voice agent not started")
+
+        await self._bidi_agent.send({
+            "type": "bidi_audio_input",
+            "audio": audio_base64,
+            "format": "pcm",
+            "sample_rate": sample_rate,
+            "channels": 1,
+        })
 
     async def send_text(self, text: str) -> None:
         """
-        Send text input to the voice agent (fallback from audio).
+        Send text input to the voice agent via BidiAgent.send().
 
         Args:
             text: Text message to send
         """
-        if self._bidi_agent and hasattr(self._bidi_agent, "send_text"):
-            await self._bidi_agent.send_text(text)
+        if not self._bidi_agent:
+            raise RuntimeError("Voice agent not started")
 
-    async def stream_async(
-        self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
-    ) -> AsyncGenerator[dict, None]:
+        await self._bidi_agent.send({
+            "type": "bidi_text_input",
+            "text": text,
+            "role": "user",
+        })
+
+    async def receive_events(self) -> AsyncGenerator[dict, None]:
         """
-        Stream voice agent events via BidiAgent.receive().
+        Receive and transform events from BidiAgent for WebSocket transmission.
 
-        Yields typed event dicts (BidiAudioStreamEvent, BidiTranscriptStreamEvent,
-        BidiResponseCompleteEvent, etc.) from the Nova Sonic bidirectional stream.
-
-        The BidiAgent uses receive() as its event source — not stream_async().
-        Audio and text input are sent separately via send_audio()/send_text().
+        Wraps BidiAgent.receive() and converts typed event objects to plain
+        dicts via as_dict(). This is the primary event source for the voice
+        WebSocket route.
 
         Yields:
-            dict: Event dictionaries with 'type' field indicating event kind
+            dict: Event dictionaries suitable for JSON serialization
         """
         if not self._bidi_agent:
-            self._create_agent()
+            raise RuntimeError("Voice agent not started")
 
         async for event in self._bidi_agent.receive():
-            # Events have as_dict() for serialization
             if hasattr(event, "as_dict"):
                 yield event.as_dict()
             else:
                 yield {"type": "unknown", "data": str(event)}
+
+    async def stream_async(
+        self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
+    ) -> AsyncGenerator[str, None]:
+        """
+        BaseAgent interface compatibility — not used for voice mode.
+
+        Voice mode uses start() + send_audio()/send_text() + receive_events() + stop()
+        instead of the request-response stream_async() pattern.
+        """
+        logger.warning("stream_async() called on VoiceAgent — use receive_events() instead")
+        return
+        yield  # Make this a generator
 
     async def stop(self) -> None:
         """Stop the bidirectional voice connection.

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 
 # Optional imports — BidiAgent requires the strands bidi extra
 try:
-    from strands.agent.bidi import BidiAgent
-    from strands.models.bidi_nova_sonic import BidiNovaSonicModel
+    from strands.experimental.bidi import BidiAgent
+    from strands.experimental.bidi.models.nova_sonic import BidiNovaSonicModel
     BIDI_AVAILABLE = True
 except ImportError:
     BIDI_AVAILABLE = False

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -11,6 +11,7 @@ Based on the voice agent pattern from:
 https://github.com/aws-samples/sample-strands-agent-with-agentcore
 """
 
+import asyncio
 import logging
 import os
 import sys
@@ -217,6 +218,16 @@ class VoiceAgent(BaseAgent):
                 yield str(event)
 
     async def stop(self) -> None:
-        """Stop the bidirectional voice connection."""
+        """Stop the bidirectional voice connection.
+
+        Handles CancelledError from the BidiAgent's internal stream teardown
+        gracefully — the Nova Sonic SDK may cancel pending futures during
+        shutdown, which is expected and not an error.
+        """
         if self._bidi_agent and hasattr(self._bidi_agent, "stop"):
-            await self._bidi_agent.stop()
+            try:
+                await self._bidi_agent.stop()
+            except asyncio.CancelledError:
+                logger.debug("BidiAgent stop cancelled (expected during teardown)")
+            except Exception as e:
+                logger.warning(f"Error during BidiAgent stop: {e}")

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -71,6 +71,13 @@ class VoiceAgent(BaseAgent):
             EnvVars.NOVA_SONIC_VOICE, Defaults.NOVA_SONIC_VOICE
         )
         self._bidi_agent: Any = None
+        # Nova Sonic bidi_usage events report CUMULATIVE token counts (not deltas).
+        # _accumulated_usage stores the latest cumulative snapshot from the stream.
+        self._accumulated_usage: dict = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+        self._current_turn_usage: dict = {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}
+        self._per_turn_usage: List[dict] = []  # Snapshot of usage per completed turn
+        self._turn_count: int = 0  # Completed turns (bidi_response_complete)
+        self._response_start_count: int = 0  # Started turns (bidi_response_start)
         super().__init__(**kwargs)
 
     def _create_agent(self) -> None:
@@ -217,6 +224,31 @@ class VoiceAgent(BaseAgent):
             "role": "user",
         })
 
+    @property
+    def accumulated_usage(self) -> dict:
+        """Token usage accumulated across all voice turns."""
+        return self._accumulated_usage
+
+    @property
+    def turn_count(self) -> int:
+        """Number of completed assistant response turns."""
+        return self._turn_count
+
+    @property
+    def response_start_count(self) -> int:
+        """Number of started assistant responses (may exceed turn_count if interrupted)."""
+        return self._response_start_count
+
+    @property
+    def per_turn_usage(self) -> List[dict]:
+        """Token usage snapshots for each completed turn."""
+        return self._per_turn_usage
+
+    @property
+    def voice_model_id(self) -> str:
+        """Nova Sonic model ID used by this agent."""
+        return os.environ.get(EnvVars.NOVA_SONIC_MODEL_ID, Defaults.NOVA_SONIC_MODEL_ID)
+
     async def receive_events(self) -> AsyncGenerator[dict, None]:
         """
         Receive and transform events from BidiAgent for WebSocket transmission.
@@ -224,6 +256,9 @@ class VoiceAgent(BaseAgent):
         Wraps BidiAgent.receive() and converts typed event objects to plain
         dicts via as_dict(). This is the primary event source for the voice
         WebSocket route.
+
+        Intercepts bidi_usage events to accumulate token counts and
+        bidi_response_complete events to track turn count.
 
         Yields:
             dict: Event dictionaries suitable for JSON serialization
@@ -233,9 +268,42 @@ class VoiceAgent(BaseAgent):
 
         async for event in self._bidi_agent.receive():
             if hasattr(event, "as_dict"):
-                yield event.as_dict()
+                event_dict = event.as_dict()
             else:
-                yield {"type": "unknown", "data": str(event)}
+                event_dict = {"type": "unknown", "data": str(event)}
+
+            event_type = event_dict.get("type", "")
+
+            # Log non-audio event types for debugging (skip audio to avoid noise)
+            if event_type not in ("bidi_audio_stream",):
+                # Log extra detail for events that might carry usage data
+                if any(k in event_dict for k in ("usage", "inputTokens", "outputTokens", "totalTokens")):
+                    logger.info(f"Voice event: type={event_type}, keys={list(event_dict.keys())}")
+                else:
+                    logger.info(f"Voice event: type={event_type}")
+
+            # Track started turns (bidi_response_start)
+            if event_type == "bidi_response_start":
+                self._response_start_count += 1
+                logger.info(f"Voice response started (count={self._response_start_count})")
+
+            # Update cumulative token usage from bidi_usage events.
+            # Nova Sonic reports CUMULATIVE totals in each event (not deltas),
+            # so we replace rather than sum.
+            if event_type == "bidi_usage":
+                usage = event_dict.get("usage", event_dict)
+                for key in ("inputTokens", "outputTokens", "totalTokens"):
+                    self._accumulated_usage[key] = usage.get(key, self._accumulated_usage[key])
+                logger.info(f"Voice bidi_usage snapshot: {usage}")
+                logger.info(f"Voice usage current: {self._accumulated_usage}")
+
+            # Track completed assistant turns and snapshot cumulative usage at turn boundary
+            if event_type == "bidi_response_complete":
+                self._per_turn_usage.append(self._accumulated_usage.copy())
+                self._turn_count += 1
+                logger.info(f"Voice turn {self._turn_count} complete, cumulative usage: {self._accumulated_usage}")
+
+            yield event_dict
 
     async def stream_async(
         self, message: str, session_id: Optional[str] = None, files: Optional[List] = None, citations: Optional[List] = None, original_message: Optional[str] = None
@@ -249,6 +317,39 @@ class VoiceAgent(BaseAgent):
         logger.warning("stream_async() called on VoiceAgent — use receive_events() instead")
         return
         yield  # Make this a generator
+
+    async def drain_remaining_events(self, timeout: float = 3.0) -> None:
+        """Drain remaining events from BidiAgent to capture final usage data.
+
+        After stop() is called, the BidiAgent may still have queued events
+        (especially bidi_usage) that were not consumed because the
+        _send_to_client task was cancelled on client disconnect. This method
+        consumes those remaining events with a timeout to ensure accumulated
+        usage totals are complete before finalization.
+        """
+        if not self._bidi_agent:
+            return
+        try:
+            async with asyncio.timeout(timeout):
+                async for event in self._bidi_agent.receive():
+                    if hasattr(event, "as_dict"):
+                        event_dict = event.as_dict()
+                    else:
+                        continue
+                    event_type = event_dict.get("type", "")
+                    if event_type == "bidi_usage":
+                        usage = event_dict.get("usage", event_dict)
+                        for key in ("inputTokens", "outputTokens", "totalTokens"):
+                            self._accumulated_usage[key] = usage.get(key, self._accumulated_usage[key])
+                        logger.info(f"Drained bidi_usage: {usage}, current: {self._accumulated_usage}")
+                    elif event_type == "bidi_response_complete":
+                        self._per_turn_usage.append(self._accumulated_usage.copy())
+                        self._turn_count += 1
+                        logger.info(f"Drained turn {self._turn_count} complete")
+        except (TimeoutError, asyncio.CancelledError, StopAsyncIteration):
+            pass
+        except Exception as e:
+            logger.debug(f"Event drain ended: {e}")
 
     async def stop(self) -> None:
         """Stop the bidirectional voice connection.
@@ -264,3 +365,4 @@ class VoiceAgent(BaseAgent):
                 logger.debug("BidiAgent stop cancelled (expected during teardown)")
             except Exception as e:
                 logger.warning(f"Error during BidiAgent stop: {e}")
+        logger.info(f"Voice agent stopped. Final accumulated_usage: {self._accumulated_usage}")

--- a/backend/src/apis/app_api/costs/aggregator.py
+++ b/backend/src/apis/app_api/costs/aggregator.py
@@ -167,8 +167,12 @@ class CostAggregator:
         model_stats = {}
 
         for message in messages:
-            # Extract cost and tokens
-            cost = float(message.get("cost", 0.0))
+            # Extract cost and tokens (cost may be a float or a breakdown dict)
+            raw_cost = message.get("cost", 0.0)
+            if isinstance(raw_cost, dict):
+                cost = float(raw_cost.get("total", 0.0))
+            else:
+                cost = float(raw_cost or 0.0)
             total_cost += cost
 
             input_tokens = message.get("inputTokens", 0)

--- a/backend/src/apis/app_api/messages/models.py
+++ b/backend/src/apis/app_api/messages/models.py
@@ -1,6 +1,6 @@
 """Messages API models"""
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -115,7 +115,7 @@ class MessageMetadata(BaseModel):
     token_usage: Optional[TokenUsage] = Field(None, alias="tokenUsage", description="Token usage statistics")
     model_info: Optional[ModelInfo] = Field(None, alias="modelInfo", description="Model information for cost tracking")
     attribution: Optional[Attribution] = Field(None, description="Attribution for cost tracking and billing")
-    cost: Optional[float] = Field(None, description="Total cost in USD for this message (computed from token usage and pricing)")
+    cost: Optional[Union[float, Dict[str, float]]] = Field(None, description="Cost for this message — either a total float (legacy) or a breakdown dict with total, inputCost, outputCost, cacheReadCost, cacheWriteCost")
     citations: Optional[List[Dict[str, str]]] = Field(None, description="RAG citations for this message (stored as dicts for flexible JSON storage)")
     display_text: Optional[str] = Field(None, alias="displayText", description="Original user message text before RAG augmentation (for clean UI display)")
     # Note: Feedback will be added in future implementation

--- a/backend/src/apis/app_api/sessions/services/metadata.py
+++ b/backend/src/apis/app_api/sessions/services/metadata.py
@@ -224,8 +224,12 @@ async def _update_cost_summary_async(
         import asyncio
         from datetime import datetime
 
-        # Extract cost and usage from metadata
-        cost = message_metadata.cost or 0.0
+        # Extract cost from metadata — may be a float (legacy) or a breakdown dict
+        raw_cost = message_metadata.cost
+        if isinstance(raw_cost, dict):
+            cost = raw_cost.get("total", 0.0)
+        else:
+            cost = raw_cost or 0.0
         token_usage = message_metadata.token_usage
 
         usage_delta = {}

--- a/backend/src/apis/app_api/sessions/services/metadata.py
+++ b/backend/src/apis/app_api/sessions/services/metadata.py
@@ -11,7 +11,7 @@ import logging
 import json
 import os
 import base64
-from typing import Optional, Tuple, Any, Dict
+from typing import Optional, Tuple, Any, Dict, Union
 from decimal import Decimal
 
 from apis.shared.sessions.models import MessageMetadata, SessionMetadata
@@ -54,7 +54,7 @@ def _convert_decimal_to_float(obj: Any) -> Any:
 async def store_message_metadata(
     session_id: str,
     user_id: str,
-    message_id: int,
+    message_id: Union[int, str],
     message_metadata: MessageMetadata
 ) -> None:
     """
@@ -65,7 +65,7 @@ async def store_message_metadata(
     Args:
         session_id: Session identifier
         user_id: User identifier
-        message_id: Message number (1, 2, 3, ...)
+        message_id: Message index or namespaced key (e.g. 1 for default, "voice:1" for voice)
         message_metadata: MessageMetadata object to store
 
     Note:
@@ -88,7 +88,7 @@ async def store_message_metadata(
 async def _store_message_metadata_cloud(
     session_id: str,
     user_id: str,
-    message_id: int,
+    message_id: Union[int, str],
     message_metadata: MessageMetadata,
     table_name: str
 ) -> None:

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -242,12 +242,12 @@ async def _send_to_client(
 ) -> None:
     """Stream events from voice agent to client.
 
-    VoiceAgent.stream_async() yields dicts from BidiAgent.receive() — each dict
+    VoiceAgent.receive_events() yields dicts from BidiAgent.receive() — each dict
     has a 'type' field (e.g. 'bidi_audio_stream', 'bidi_transcript_stream',
     'bidi_response_complete', etc.).
     """
     try:
-        async for event in voice_agent.stream_async(""):
+        async for event in voice_agent.receive_events():
             try:
                 if isinstance(event, dict):
                     await websocket.send_json(event)

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -24,9 +24,13 @@ import json
 import jwt
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from apis.shared.sessions.metadata import get_session_metadata, store_session_metadata
+from apis.shared.sessions.models import SessionMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +77,192 @@ def _extract_user_from_token(token: str) -> Optional[Dict[str, str]]:
         return None
 
 
+async def _ensure_session_metadata(session_id: str, user_id: str) -> None:
+    """Create session metadata entry if one doesn't already exist.
+
+    This makes the voice session visible in the conversations side nav.
+    If the session started as a text chat, existing metadata is preserved.
+    """
+    try:
+        existing = await get_session_metadata(session_id, user_id)
+        if existing:
+            logger.debug(f"Session metadata already exists for {session_id}")
+            return
+
+        now = datetime.now(timezone.utc).isoformat()
+        metadata = SessionMetadata(
+            session_id=session_id,
+            user_id=user_id,
+            title="Voice Conversation",
+            status="active",
+            created_at=now,
+            last_message_at=now,
+            message_count=0,
+            starred=False,
+            tags=[],
+            preferences=None,
+        )
+        await store_session_metadata(session_id=session_id, user_id=user_id, session_metadata=metadata)
+        logger.info(f"Created session metadata for voice session {session_id}")
+    except Exception as e:
+        logger.error(f"Failed to create session metadata for {session_id}: {e}", exc_info=True)
+
+
+async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: Any) -> None:
+    """Update session metadata and store cost/token data after voice session ends.
+
+    Called in the finally block of voice_stream to persist usage metrics.
+    """
+    # Use response_start_count as fallback when turns are interrupted before completion
+    completed_turns = getattr(voice_agent, "turn_count", 0)
+    started_turns = getattr(voice_agent, "response_start_count", 0)
+    effective_turns = max(completed_turns, started_turns)
+
+    logger.info(
+        f"Finalizing voice session {session_id}: "
+        f"completed_turns={completed_turns}, started_turns={started_turns}, "
+        f"effective_turns={effective_turns}, "
+        f"accumulated_usage={getattr(voice_agent, 'accumulated_usage', 'N/A')}, "
+        f"per_turn_usage_count={len(getattr(voice_agent, 'per_turn_usage', []))}"
+    )
+    try:
+        # Update session metadata with final turn count
+        existing = await get_session_metadata(session_id, user_id)
+        if existing:
+            now = datetime.now(timezone.utc).isoformat()
+            updated = SessionMetadata(
+                session_id=session_id,
+                user_id=user_id,
+                title=existing.title,
+                status=existing.status,
+                created_at=existing.created_at,
+                last_message_at=now,
+                message_count=existing.message_count + effective_turns,
+                starred=existing.starred,
+                tags=existing.tags,
+                preferences=existing.preferences,
+            )
+            await store_session_metadata(session_id=session_id, user_id=user_id, session_metadata=updated)
+            logger.info(f"Updated voice session metadata: turns={effective_turns}, session={session_id}")
+    except Exception as e:
+        logger.error(f"Failed to update session metadata for {session_id}: {e}", exc_info=True)
+
+    # Store metadata for each assistant message in the voice session.
+    # BidiAgent may split responses into multiple messages, so we can't assume
+    # a strict user/assistant alternating pattern. Instead, read the actual messages
+    # from AgentCore Memory and find which indices are assistant messages.
+    try:
+        import asyncio
+        from agents.main_agent.config.constants import Defaults
+
+        accumulated_usage = getattr(voice_agent, "accumulated_usage", {})
+        has_usage = (accumulated_usage.get("inputTokens", 0) + accumulated_usage.get("outputTokens", 0)) > 0
+
+        if not has_usage:
+            logger.info(f"No voice usage to record metadata for session {session_id}")
+            return
+
+        from apis.app_api.messages.models import Attribution, MessageMetadata, ModelInfo, TokenUsage
+        from apis.app_api.sessions.services.metadata import store_message_metadata
+
+        model_id = getattr(voice_agent, "voice_model_id", "amazon.nova-2-sonic-v1:0")
+        model_info = ModelInfo(
+            model_id=model_id,
+            model_name="Nova Sonic 2",
+            provider="bedrock",
+        )
+
+        # Read actual messages from AgentCore Memory to find assistant indices
+        assistant_indices = []
+        try:
+            session_manager = voice_agent.session_manager
+            if hasattr(session_manager, "list_messages"):
+                messages = await asyncio.to_thread(
+                    session_manager.list_messages,
+                    session_id,
+                    Defaults.VOICE_AGENT_ID,
+                )
+                for idx, msg in enumerate(messages or []):
+                    inner = getattr(msg, "message", msg)
+                    role = inner.get("role") if isinstance(inner, dict) else getattr(inner, "role", None)
+                    if role == "assistant":
+                        assistant_indices.append(idx)
+                logger.info(f"Voice session messages: {len(messages or [])} total, assistant at indices {assistant_indices}")
+        except Exception as msg_err:
+            logger.warning(f"Could not read voice messages for metadata: {msg_err}")
+
+        if not assistant_indices:
+            # Fallback: store a single record at index 1 (most common position)
+            assistant_indices = [1]
+            logger.info("No assistant messages found, using fallback index [1]")
+
+        # Get pricing
+        pricing = None
+        try:
+            from apis.app_api.costs.calculator import CostCalculator
+            from apis.app_api.costs.pricing_config import get_model_pricing
+
+            pricing = await get_model_pricing(model_id)
+        except Exception as cost_err:
+            logger.debug(f"Cost calculation unavailable for voice: {cost_err}")
+
+        # Store cumulative session usage on the LAST assistant message only.
+        # Nova Sonic reports cumulative totals for the whole connection, so
+        # splitting across messages would be misleading. The last message
+        # carries the full session cost; earlier messages get no badge.
+        last_idx = assistant_indices[-1]
+        input_tokens = accumulated_usage.get("inputTokens", 0)
+        output_tokens = accumulated_usage.get("outputTokens", 0)
+        total_tokens = input_tokens + output_tokens
+
+        token_usage = TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+        )
+
+        attribution = Attribution(
+            user_id=user_id,
+            session_id=session_id,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
+        cost = None
+        if pricing and total_tokens > 0:
+            try:
+                total_cost, breakdown = CostCalculator.calculate_message_cost(accumulated_usage, pricing)
+                cost = {
+                    "total": total_cost,
+                    "inputCost": breakdown.input_cost,
+                    "outputCost": breakdown.output_cost,
+                    "cacheReadCost": breakdown.cache_read_cost,
+                    "cacheWriteCost": breakdown.cache_write_cost,
+                }
+            except Exception:
+                pass
+
+        message_metadata = MessageMetadata(
+            token_usage=token_usage,
+            model_info=model_info,
+            attribution=attribution,
+            cost=cost,
+        )
+
+        await store_message_metadata(
+            session_id=session_id,
+            user_id=user_id,
+            message_id=f"voice:{last_idx}",
+            message_metadata=message_metadata,
+        )
+
+        logger.info(
+            f"Stored voice metadata on last assistant message (index {last_idx}), "
+            f"usage={accumulated_usage}, session={session_id}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to store voice cost metadata for {session_id}: {e}", exc_info=True)
+
+
 @router.websocket("/voice/stream")
 async def voice_stream(websocket: WebSocket):
     """
@@ -87,6 +277,7 @@ async def voice_stream(websocket: WebSocket):
     token = websocket.query_params.get("token", "")
     enabled_tools_raw = websocket.query_params.get("enabled_tools", "")
     voice_agent = None
+    user_id = None
 
     try:
         # Parse enabled tools
@@ -149,6 +340,9 @@ async def voice_stream(websocket: WebSocket):
         # Start the voice agent
         await voice_agent.start()
 
+        # Create session metadata so voice sessions appear in the side nav
+        await _ensure_session_metadata(session_id, user_id)
+
         # Run bidirectional communication
         receive_task = asyncio.create_task(
             _receive_from_client(websocket, voice_agent, session_id)
@@ -189,11 +383,23 @@ async def voice_stream(websocket: WebSocket):
     finally:
         # Cleanup — catch BaseException since CancelledError escapes Exception in 3.12
         _active_sessions.pop(session_id, None)
-        if voice_agent:
+        if voice_agent and user_id:
+            # 1. Stop BidiAgent first — flushes stream, emits final events including usage
             try:
                 await voice_agent.stop()
             except BaseException as e:
-                logger.debug(f"Voice agent stop during cleanup: {type(e).__name__}: {e}")
+                logger.debug(f"Voice agent stop: {type(e).__name__}: {e}")
+            # 2. Drain any remaining queued events (captures final bidi_usage
+            #    that weren't consumed because _send_to_client was cancelled)
+            try:
+                await voice_agent.drain_remaining_events(timeout=3.0)
+            except BaseException as e:
+                logger.debug(f"Voice event drain: {type(e).__name__}: {e}")
+            # 3. NOW finalize with complete accumulated usage data
+            try:
+                await _finalize_voice_session(session_id, user_id, voice_agent)
+            except BaseException as e:
+                logger.debug(f"Voice session finalization error: {type(e).__name__}: {e}")
         try:
             await websocket.close()
         except BaseException:

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -187,16 +187,16 @@ async def voice_stream(websocket: WebSocket):
         except Exception:
             pass
     finally:
-        # Cleanup
+        # Cleanup — catch BaseException since CancelledError escapes Exception in 3.12
         _active_sessions.pop(session_id, None)
         if voice_agent:
             try:
                 await voice_agent.stop()
-            except Exception as e:
-                logger.error(f"Error stopping voice agent: {e}")
+            except BaseException as e:
+                logger.debug(f"Voice agent stop during cleanup: {type(e).__name__}: {e}")
         try:
             await websocket.close()
-        except Exception:
+        except BaseException:
             pass
         logger.info(f"Voice session cleaned up: {session_id}")
 

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -1,0 +1,298 @@
+"""
+WebSocket voice route for bidirectional speech-to-speech interaction.
+
+Exposes VoiceAgent via WebSocket for real-time audio streaming with
+AWS Nova Sonic 2. Adapted from the sample-strands-agent-with-agentcore
+voice router pattern.
+
+Protocol:
+    Client → Server:
+        {"type": "config", "session_id": "...", "auth_token": "...", ...}  (first message)
+        {"type": "bidi_audio_input", "audio": "<base64>", "sample_rate": 16000}
+        {"type": "bidi_text_input", "text": "..."}
+        {"type": "ping"}
+        {"type": "stop"}
+
+    Server → Client:
+        {"type": "bidi_connection_start", "connection_id": "...", "status": "connected"}
+        {"type": "bidi_error", "message": "..."}
+        Agent stream events (audio, transcripts, tool use, etc.)
+"""
+
+import asyncio
+import json
+import jwt
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["voice"])
+
+# Track active voice sessions for debugging
+_active_sessions: Dict[str, Any] = {}
+
+# Lazy import to avoid loading bidi deps at module level
+_VoiceAgentClass = None
+
+
+def _get_voice_agent_class():
+    """Lazily import VoiceAgent to avoid import errors when bidi not installed."""
+    global _VoiceAgentClass
+    if _VoiceAgentClass is None:
+        from agents.main_agent.voice_agent import VoiceAgent
+        _VoiceAgentClass = VoiceAgent
+    return _VoiceAgentClass
+
+
+def _extract_user_from_token(token: str) -> Optional[Dict[str, str]]:
+    """
+    Extract user claims from JWT token (trusted — no signature verification).
+
+    Same pattern as get_current_user_trusted in auth/dependencies.py.
+    WebSocket connections can't use Depends() so we handle auth manually.
+    """
+    if not token:
+        return None
+
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+        user_id = payload.get("sub")
+        if not user_id:
+            return None
+        return {
+            "user_id": str(user_id),
+            "email": payload.get("email") or payload.get("preferred_username") or "",
+            "raw_token": token,
+        }
+    except jwt.DecodeError as e:
+        logger.warning(f"Failed to decode voice auth token: {e}")
+        return None
+
+
+@router.websocket("/voice/stream")
+async def voice_stream(websocket: WebSocket):
+    """
+    Bidirectional voice streaming endpoint.
+
+    Query params:
+        session_id: Session identifier (optional, auto-generated if missing)
+        token: JWT bearer token for authentication
+        enabled_tools: JSON array of tool IDs (optional)
+    """
+    session_id = websocket.query_params.get("session_id") or str(uuid.uuid4())
+    token = websocket.query_params.get("token", "")
+    enabled_tools_raw = websocket.query_params.get("enabled_tools", "")
+    voice_agent = None
+
+    try:
+        # Parse enabled tools
+        enabled_tools = None
+        if enabled_tools_raw:
+            try:
+                enabled_tools = json.loads(enabled_tools_raw)
+            except json.JSONDecodeError:
+                logger.warning(f"Invalid enabled_tools JSON: {enabled_tools_raw}")
+
+        # Authenticate
+        user_info = _extract_user_from_token(token)
+        if not user_info:
+            await websocket.close(code=4001, reason="Authentication required")
+            return
+
+        user_id = user_info["user_id"]
+        auth_token = user_info["raw_token"]
+
+        # Accept the WebSocket connection
+        await websocket.accept()
+        logger.info(f"Voice WebSocket connected: session={session_id}, user={user_id}")
+
+        # Wait for initial config message (supplements query params)
+        try:
+            first_msg = await asyncio.wait_for(
+                websocket.receive_json(), timeout=10.0
+            )
+            if first_msg.get("type") == "config":
+                # Config can override session params
+                session_id = first_msg.get("session_id", session_id)
+                if first_msg.get("auth_token"):
+                    auth_token = first_msg["auth_token"]
+                if first_msg.get("enabled_tools"):
+                    enabled_tools = first_msg["enabled_tools"]
+                logger.info(f"Voice config received: session={session_id}")
+        except asyncio.TimeoutError:
+            logger.warning("No config message received within 10s, using query params")
+        except Exception as e:
+            logger.warning(f"Error reading config message: {e}")
+
+        # Create VoiceAgent
+        VoiceAgent = _get_voice_agent_class()
+        voice_agent = VoiceAgent(
+            session_id=session_id,
+            user_id=user_id,
+            auth_token=auth_token,
+            enabled_tools=enabled_tools,
+        )
+
+        _active_sessions[session_id] = voice_agent
+
+        # Send connection confirmation
+        await websocket.send_json({
+            "type": "bidi_connection_start",
+            "connection_id": session_id,
+            "status": "connected",
+        })
+
+        # Start the voice agent
+        await voice_agent.start()
+
+        # Run bidirectional communication
+        receive_task = asyncio.create_task(
+            _receive_from_client(websocket, voice_agent, session_id)
+        )
+        send_task = asyncio.create_task(
+            _send_to_client(websocket, voice_agent, session_id)
+        )
+
+        done, pending = await asyncio.wait(
+            [receive_task, send_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # Cancel pending tasks
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Check for task exceptions
+        for task in done:
+            if task.exception():
+                logger.error(f"Voice task error: {task.exception()}")
+
+    except WebSocketDisconnect:
+        logger.info(f"Voice WebSocket disconnected: session={session_id}")
+    except Exception as e:
+        logger.error(f"Voice stream error: {e}", exc_info=True)
+        try:
+            await websocket.send_json({
+                "type": "bidi_error",
+                "message": str(e),
+            })
+        except Exception:
+            pass
+    finally:
+        # Cleanup
+        _active_sessions.pop(session_id, None)
+        if voice_agent:
+            try:
+                await voice_agent.stop()
+            except Exception as e:
+                logger.error(f"Error stopping voice agent: {e}")
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+        logger.info(f"Voice session cleaned up: {session_id}")
+
+
+async def _receive_from_client(
+    websocket: WebSocket, voice_agent: Any, session_id: str
+) -> None:
+    """Receive messages from client and dispatch to voice agent."""
+    try:
+        while True:
+            msg = await websocket.receive_json()
+            msg_type = msg.get("type", "")
+
+            if msg_type == "bidi_audio_input":
+                audio = msg.get("audio", "")
+                sample_rate = msg.get("sample_rate", 16000)
+                await voice_agent.send_audio(audio, sample_rate)
+
+            elif msg_type == "bidi_text_input":
+                text = msg.get("text", "")
+                if text:
+                    await voice_agent.send_text(text)
+
+            elif msg_type == "ping":
+                await websocket.send_json({"type": "pong"})
+
+            elif msg_type == "stop":
+                logger.info(f"Client requested stop: session={session_id}")
+                break
+
+            else:
+                logger.debug(f"Unknown message type: {msg_type}")
+
+    except WebSocketDisconnect:
+        logger.info(f"Client disconnected (receive): session={session_id}")
+    except asyncio.CancelledError:
+        logger.debug(f"Receive task cancelled: session={session_id}")
+        raise
+
+
+async def _send_to_client(
+    websocket: WebSocket, voice_agent: Any, session_id: str
+) -> None:
+    """Stream events from voice agent to client."""
+    try:
+        async for event in voice_agent.stream_async(""):
+            try:
+                if isinstance(event, str):
+                    # Try to parse as JSON for structured events
+                    try:
+                        parsed = json.loads(event)
+                        await websocket.send_json(parsed)
+                    except json.JSONDecodeError:
+                        await websocket.send_json({
+                            "type": "bidi_text",
+                            "content": event,
+                        })
+                elif isinstance(event, dict):
+                    await websocket.send_json(event)
+                else:
+                    await websocket.send_json({
+                        "type": "bidi_event",
+                        "data": str(event),
+                    })
+            except Exception as e:
+                logger.warning(f"Error sending event to client: {e}")
+
+    except asyncio.CancelledError:
+        logger.debug(f"Send task cancelled: session={session_id}")
+        raise
+    except Exception as e:
+        logger.error(f"Error in send_to_client: {e}")
+
+
+# --- Debug endpoints ---
+
+@router.get("/voice/sessions")
+async def list_voice_sessions():
+    """List active voice sessions (for debugging)."""
+    return {
+        "active_sessions": list(_active_sessions.keys()),
+        "count": len(_active_sessions),
+    }
+
+
+@router.delete("/voice/sessions/{session_id}")
+async def stop_voice_session(session_id: str):
+    """Force-stop a voice session (for debugging)."""
+    agent = _active_sessions.get(session_id)
+    if not agent:
+        return {"status": "not_found", "session_id": session_id}
+
+    try:
+        await agent.stop()
+    except Exception as e:
+        logger.error(f"Error force-stopping session {session_id}: {e}")
+
+    _active_sessions.pop(session_id, None)
+    return {"status": "stopped", "session_id": session_id}

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -34,6 +34,11 @@ from apis.shared.sessions.models import SessionMetadata
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_log(value: str) -> str:
+    """Strip newlines and carriage returns to prevent log injection."""
+    return str(value).replace("\n", "").replace("\r", "")
+
 router = APIRouter(tags=["voice"])
 
 # Track active voice sessions for debugging
@@ -86,7 +91,7 @@ async def _ensure_session_metadata(session_id: str, user_id: str) -> None:
     try:
         existing = await get_session_metadata(session_id, user_id)
         if existing:
-            logger.debug(f"Session metadata already exists for {session_id}")
+            logger.debug(f"Session metadata already exists for {_sanitize_log(session_id)}")
             return
 
         now = datetime.now(timezone.utc).isoformat()
@@ -103,9 +108,9 @@ async def _ensure_session_metadata(session_id: str, user_id: str) -> None:
             preferences=None,
         )
         await store_session_metadata(session_id=session_id, user_id=user_id, session_metadata=metadata)
-        logger.info(f"Created session metadata for voice session {session_id}")
+        logger.info(f"Created session metadata for voice session {_sanitize_log(session_id)}")
     except Exception as e:
-        logger.error(f"Failed to create session metadata for {session_id}: {e}", exc_info=True)
+        logger.error(f"Failed to create session metadata for {_sanitize_log(session_id)}: {e}", exc_info=True)
 
 
 async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: Any) -> None:
@@ -119,7 +124,7 @@ async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: An
     effective_turns = max(completed_turns, started_turns)
 
     logger.info(
-        f"Finalizing voice session {session_id}: "
+        f"Finalizing voice session {_sanitize_log(session_id)}: "
         f"completed_turns={completed_turns}, started_turns={started_turns}, "
         f"effective_turns={effective_turns}, "
         f"accumulated_usage={getattr(voice_agent, 'accumulated_usage', 'N/A')}, "
@@ -143,9 +148,9 @@ async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: An
                 preferences=existing.preferences,
             )
             await store_session_metadata(session_id=session_id, user_id=user_id, session_metadata=updated)
-            logger.info(f"Updated voice session metadata: turns={effective_turns}, session={session_id}")
+            logger.info(f"Updated voice session metadata: turns={effective_turns}, session={_sanitize_log(session_id)}")
     except Exception as e:
-        logger.error(f"Failed to update session metadata for {session_id}: {e}", exc_info=True)
+        logger.error(f"Failed to update session metadata for {_sanitize_log(session_id)}: {e}", exc_info=True)
 
     # Store metadata for each assistant message in the voice session.
     # BidiAgent may split responses into multiple messages, so we can't assume
@@ -159,7 +164,7 @@ async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: An
         has_usage = (accumulated_usage.get("inputTokens", 0) + accumulated_usage.get("outputTokens", 0)) > 0
 
         if not has_usage:
-            logger.info(f"No voice usage to record metadata for session {session_id}")
+            logger.info(f"No voice usage to record metadata for session {_sanitize_log(session_id)}")
             return
 
         from apis.app_api.messages.models import Attribution, MessageMetadata, ModelInfo, TokenUsage
@@ -257,10 +262,10 @@ async def _finalize_voice_session(session_id: str, user_id: str, voice_agent: An
 
         logger.info(
             f"Stored voice metadata on last assistant message (index {last_idx}), "
-            f"usage={accumulated_usage}, session={session_id}"
+            f"usage={accumulated_usage}, session={_sanitize_log(session_id)}"
         )
     except Exception as e:
-        logger.error(f"Failed to store voice cost metadata for {session_id}: {e}", exc_info=True)
+        logger.error(f"Failed to store voice cost metadata for {_sanitize_log(session_id)}: {e}", exc_info=True)
 
 
 @router.websocket("/voice/stream")
@@ -286,7 +291,7 @@ async def voice_stream(websocket: WebSocket):
             try:
                 enabled_tools = json.loads(enabled_tools_raw)
             except json.JSONDecodeError:
-                logger.warning(f"Invalid enabled_tools JSON: {enabled_tools_raw}")
+                logger.warning(f"Invalid enabled_tools JSON: {_sanitize_log(enabled_tools_raw)}")
 
         # Authenticate
         user_info = _extract_user_from_token(token)
@@ -299,7 +304,7 @@ async def voice_stream(websocket: WebSocket):
 
         # Accept the WebSocket connection
         await websocket.accept()
-        logger.info(f"Voice WebSocket connected: session={session_id}, user={user_id}")
+        logger.info(f"Voice WebSocket connected: session={_sanitize_log(session_id)}, user={_sanitize_log(user_id)}")
 
         # Wait for initial config message (supplements query params)
         try:
@@ -313,7 +318,7 @@ async def voice_stream(websocket: WebSocket):
                     auth_token = first_msg["auth_token"]
                 if first_msg.get("enabled_tools"):
                     enabled_tools = first_msg["enabled_tools"]
-                logger.info(f"Voice config received: session={session_id}")
+                logger.info(f"Voice config received: session={_sanitize_log(session_id)}")
         except asyncio.TimeoutError:
             logger.warning("No config message received within 10s, using query params")
         except Exception as e:
@@ -370,7 +375,7 @@ async def voice_stream(websocket: WebSocket):
                 logger.error(f"Voice task error: {task.exception()}")
 
     except WebSocketDisconnect:
-        logger.info(f"Voice WebSocket disconnected: session={session_id}")
+        logger.info(f"Voice WebSocket disconnected: session={_sanitize_log(session_id)}")
     except Exception as e:
         logger.error(f"Voice stream error: {e}", exc_info=True)
         try:
@@ -404,7 +409,7 @@ async def voice_stream(websocket: WebSocket):
             await websocket.close()
         except BaseException:
             pass
-        logger.info(f"Voice session cleaned up: {session_id}")
+        logger.info(f"Voice session cleaned up: {_sanitize_log(session_id)}")
 
 
 async def _receive_from_client(
@@ -430,16 +435,16 @@ async def _receive_from_client(
                 await websocket.send_json({"type": "pong"})
 
             elif msg_type == "stop":
-                logger.info(f"Client requested stop: session={session_id}")
+                logger.info(f"Client requested stop: session={_sanitize_log(session_id)}")
                 break
 
             else:
-                logger.debug(f"Unknown message type: {msg_type}")
+                logger.debug(f"Unknown message type: {_sanitize_log(msg_type)}")
 
     except WebSocketDisconnect:
-        logger.info(f"Client disconnected (receive): session={session_id}")
+        logger.info(f"Client disconnected (receive): session={_sanitize_log(session_id)}")
     except asyncio.CancelledError:
-        logger.debug(f"Receive task cancelled: session={session_id}")
+        logger.debug(f"Receive task cancelled: session={_sanitize_log(session_id)}")
         raise
 
 
@@ -463,13 +468,13 @@ async def _send_to_client(
                         "data": str(event),
                     })
             except WebSocketDisconnect:
-                logger.info(f"Client disconnected during send: session={session_id}")
+                logger.info(f"Client disconnected during send: session={_sanitize_log(session_id)}")
                 return
             except Exception as e:
                 logger.warning(f"Error sending event to client: {e}")
 
     except asyncio.CancelledError:
-        logger.debug(f"Send task cancelled: session={session_id}")
+        logger.debug(f"Send task cancelled: session={_sanitize_log(session_id)}")
         raise
     except Exception as e:
         logger.error(f"Error in send_to_client: {e}")
@@ -496,7 +501,7 @@ async def stop_voice_session(session_id: str):
     try:
         await agent.stop()
     except Exception as e:
-        logger.error(f"Error force-stopping session {session_id}: {e}")
+        logger.error(f"Error force-stopping session {_sanitize_log(session_id)}: {e}")
 
     _active_sessions.pop(session_id, None)
     return {"status": "stopped", "session_id": session_id}

--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -240,27 +240,25 @@ async def _receive_from_client(
 async def _send_to_client(
     websocket: WebSocket, voice_agent: Any, session_id: str
 ) -> None:
-    """Stream events from voice agent to client."""
+    """Stream events from voice agent to client.
+
+    VoiceAgent.stream_async() yields dicts from BidiAgent.receive() — each dict
+    has a 'type' field (e.g. 'bidi_audio_stream', 'bidi_transcript_stream',
+    'bidi_response_complete', etc.).
+    """
     try:
         async for event in voice_agent.stream_async(""):
             try:
-                if isinstance(event, str):
-                    # Try to parse as JSON for structured events
-                    try:
-                        parsed = json.loads(event)
-                        await websocket.send_json(parsed)
-                    except json.JSONDecodeError:
-                        await websocket.send_json({
-                            "type": "bidi_text",
-                            "content": event,
-                        })
-                elif isinstance(event, dict):
+                if isinstance(event, dict):
                     await websocket.send_json(event)
                 else:
                     await websocket.send_json({
                         "type": "bidi_event",
                         "data": str(event),
                     })
+            except WebSocketDisconnect:
+                logger.info(f"Client disconnected during send: session={session_id}")
+                return
             except Exception as e:
                 logger.warning(f"Error sending event to client: {e}")
 

--- a/backend/src/apis/inference_api/main.py
+++ b/backend/src/apis/inference_api/main.py
@@ -131,10 +131,12 @@ app.add_middleware(
 #from health.health import router as health_router
 from apis.inference_api.chat.routes import router as agentcore_router
 from apis.inference_api.chat.converse_routes import router as converse_router
+from apis.inference_api.chat.voice_routes import router as voice_router
 # Include routers
 #app.include_router(health_router)
 app.include_router(agentcore_router)  # AgentCore Runtime endpoints: /ping, /invocations
 app.include_router(converse_router)  # API-key authenticated converse endpoint
+app.include_router(voice_router)  # WebSocket voice streaming endpoint
 
 # Mount static file directories for serving generated content
 # These are created by tools (visualization, code interpreter, etc.)

--- a/backend/src/apis/shared/sessions/messages.py
+++ b/backend/src/apis/shared/sessions/messages.py
@@ -395,7 +395,14 @@ async def get_messages_from_cloud(
         import asyncio
 
         async def fetch_messages():
-            """Fetch messages from AgentCore Memory (runs in thread pool since it's sync)"""
+            """Fetch messages from AgentCore Memory.
+
+            Note: AgentCore Memory's list_events API does not filter by
+            agent_id — it returns ALL messages for the session regardless
+            of which agent stored them.  A single fetch with any agent_id
+            is sufficient; fetching twice (e.g. "default" + "voice") would
+            return identical results and cause duplication.
+            """
             return await asyncio.to_thread(session_manager.list_messages, session_id, "default")
 
         async def fetch_metadata():
@@ -404,40 +411,40 @@ async def get_messages_from_cloud(
 
             return await get_all_message_metadata(session_id, user_id)
 
-        # Run both fetches in parallel
-        messages_raw, metadata_index = await asyncio.gather(fetch_messages(), fetch_metadata())
+        # Run fetches in parallel
+        messages_raw, metadata_index = await asyncio.gather(
+            fetch_messages(), fetch_metadata()
+        )
 
-        logger.info(f"AgentCore Memory returned {len(messages_raw) if messages_raw else 0} raw messages")
+        messages_raw = list(messages_raw or [])
+
+        logger.info(f"AgentCore Memory returned {len(messages_raw)} raw messages")
         logger.info(f"Metadata index contains {len(metadata_index)} entries")
         logger.info(f"🔑 Metadata index keys: {sorted(metadata_index.keys())}")
 
         # Convert to our Message model
         messages = []
-        if messages_raw:
-            # DO NOT SORT - AgentCore Memory returns messages in chronological order
-            # The enumerated index matches the stored sequence number (message_id)
-            for idx, msg in enumerate(messages_raw):
-                try:
-                    # Metadata join: use index as message_id (0-based sequence)
-                    metadata = metadata_index.get(str(idx))
+        for idx, msg in enumerate(messages_raw):
+            try:
+                # Look up metadata: try plain index first (text chat),
+                # then "voice:<idx>" prefix (voice chat metadata).
+                metadata = metadata_index.get(str(idx))
+                if metadata is None:
+                    metadata = metadata_index.get(f"voice:{idx}")
 
-                    # Determine message role for logging
-                    # Cost metadata only exists for assistant messages (LLM API calls)
-                    msg_role = _get_message_role(msg)
+                msg_role = _get_message_role(msg)
 
-                    if metadata:
-                        logger.debug(f"🔗 Joined metadata for message {idx} ({msg_role})")
-                    elif msg_role == "user":
-                        # User messages don't have cost metadata - this is expected
-                        logger.debug(f"📝 User message {idx} - no cost metadata (expected)")
-                    else:
-                        # Assistant message without metadata is unexpected
-                        logger.warning(f"⚠️ No metadata found for assistant message {idx}")
+                if metadata:
+                    logger.debug(f"🔗 Joined metadata for message {idx} ({msg_role})")
+                elif msg_role == "user":
+                    logger.debug(f"📝 User message {idx} - no cost metadata (expected)")
+                else:
+                    logger.warning(f"⚠️ No metadata found for assistant message {idx}")
 
-                    messages.append(_convert_message(msg, metadata=metadata))
-                except Exception as e:
-                    logger.error(f"Error converting message {idx}: {e}", exc_info=True)
-                    continue
+                messages.append(_convert_message(msg, metadata=metadata))
+            except Exception as e:
+                logger.error(f"Error converting message {idx}: {e}", exc_info=True)
+                continue
 
         logger.info(f"Retrieved {len(messages)} messages from AgentCore Memory with metadata")
 

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -6,7 +6,7 @@ This module contains all session-related data models including:
 - Session preferences and configuration
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -260,7 +260,7 @@ class MessageMetadata(BaseModel):
     token_usage: Optional[TokenUsage] = Field(None, alias="tokenUsage", description="Token usage statistics")
     model_info: Optional[ModelInfo] = Field(None, alias="modelInfo", description="Model information for cost tracking")
     attribution: Optional[Attribution] = Field(None, description="Attribution for cost tracking and billing")
-    cost: Optional[float] = Field(None, description="Total cost in USD for this message (computed from token usage and pricing)")
+    cost: Optional[Union[float, Dict[str, float]]] = Field(None, description="Cost for this message — either a total float (legacy) or a breakdown dict with total, inputCost, outputCost, cacheReadCost, cacheWriteCost")
     citations: Optional[List[Dict[str, str]]] = Field(None, description="RAG citations for this message (stored as dicts for flexible JSON storage)")
     display_text: Optional[str] = Field(None, alias="displayText", description="Original user message text before RAG augmentation (for clean UI display)")
     # Note: Feedback will be added in future implementation

--- a/backend/tests/agents/main_agent/test_voice_agent.py
+++ b/backend/tests/agents/main_agent/test_voice_agent.py
@@ -66,20 +66,25 @@ class TestVoiceAgentRegistration:
 class TestVoiceAgentTextHistory:
     """Req VA-4: Voice-text continuity."""
 
-    def test_load_text_history_respects_max(self):
+    def test_load_text_history_passes_limit(self):
         from agents.main_agent.voice_agent import VoiceAgent
 
-        # Create a mock session manager with lots of messages
         mock_session = MagicMock()
-        mock_session.list_messages.return_value = list(range(50))
+        mock_session.list_messages.return_value = list(range(10))
 
         agent = VoiceAgent.__new__(VoiceAgent)
         agent.session_manager = mock_session
+        agent.session_id = "test-session"
 
-        # Patch the env var for max messages
         with patch.dict("os.environ", {EnvVars.NOVA_SONIC_MAX_MESSAGES: "10"}):
             messages = agent._load_text_history()
 
+        # Verify limit is passed to list_messages
+        mock_session.list_messages.assert_called_once_with(
+            session_id="test-session",
+            agent_id="default",
+            limit=10,
+        )
         assert len(messages) == 10
 
     def test_load_text_history_handles_empty(self):
@@ -90,6 +95,7 @@ class TestVoiceAgentTextHistory:
 
         agent = VoiceAgent.__new__(VoiceAgent)
         agent.session_manager = mock_session
+        agent.session_id = "test-session"
 
         messages = agent._load_text_history()
         assert messages == []
@@ -102,6 +108,7 @@ class TestVoiceAgentTextHistory:
 
         agent = VoiceAgent.__new__(VoiceAgent)
         agent.session_manager = mock_session
+        agent.session_id = "test-session"
 
         messages = agent._load_text_history()
         assert messages == []

--- a/backend/tests/agents/main_agent/test_voice_agent.py
+++ b/backend/tests/agents/main_agent/test_voice_agent.py
@@ -69,8 +69,15 @@ class TestVoiceAgentTextHistory:
     def test_load_text_history_passes_limit(self):
         from agents.main_agent.voice_agent import VoiceAgent
 
+        # Mock SessionMessage objects with to_dict()
+        mock_msgs = []
+        for i in range(10):
+            m = MagicMock()
+            m.to_dict.return_value = {"role": "user", "content": [{"text": f"msg {i}"}]}
+            mock_msgs.append(m)
+
         mock_session = MagicMock()
-        mock_session.list_messages.return_value = list(range(10))
+        mock_session.list_messages.return_value = mock_msgs
 
         agent = VoiceAgent.__new__(VoiceAgent)
         agent.session_manager = mock_session
@@ -85,7 +92,9 @@ class TestVoiceAgentTextHistory:
             agent_id="default",
             limit=10,
         )
+        # Messages are converted to dicts via to_dict()
         assert len(messages) == 10
+        assert messages[0]["role"] == "user"
 
     def test_load_text_history_handles_empty(self):
         from agents.main_agent.voice_agent import VoiceAgent

--- a/backend/tests/agents/main_agent/test_voice_agent.py
+++ b/backend/tests/agents/main_agent/test_voice_agent.py
@@ -69,11 +69,11 @@ class TestVoiceAgentTextHistory:
     def test_load_text_history_passes_limit(self):
         from agents.main_agent.voice_agent import VoiceAgent
 
-        # Mock SessionMessage objects with to_dict()
+        # Mock SessionMessage objects with to_message()
         mock_msgs = []
         for i in range(10):
             m = MagicMock()
-            m.to_dict.return_value = {"role": "user", "content": [{"text": f"msg {i}"}]}
+            m.to_message.return_value = {"role": "user", "content": [{"text": f"msg {i}"}]}
             mock_msgs.append(m)
 
         mock_session = MagicMock()

--- a/backend/tests/agents/main_agent/test_voice_routes.py
+++ b/backend/tests/agents/main_agent/test_voice_routes.py
@@ -1,0 +1,117 @@
+"""Tests for voice WebSocket route — auth, message dispatch, debug endpoints."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from apis.inference_api.chat.voice_routes import (
+    _extract_user_from_token,
+    _active_sessions,
+    router,
+)
+
+
+class TestExtractUserFromToken:
+    """Req VR-1: JWT token extraction for WebSocket auth."""
+
+    def test_valid_token_extracts_user_id(self):
+        import jwt as pyjwt
+        token = pyjwt.encode({"sub": "user-123", "email": "test@example.com"}, "secret")
+        result = _extract_user_from_token(token)
+        assert result is not None
+        assert result["user_id"] == "user-123"
+        assert result["email"] == "test@example.com"
+        assert result["raw_token"] == token
+
+    def test_missing_sub_returns_none(self):
+        import jwt as pyjwt
+        token = pyjwt.encode({"email": "no-sub@example.com"}, "secret")
+        result = _extract_user_from_token(token)
+        assert result is None
+
+    def test_empty_token_returns_none(self):
+        assert _extract_user_from_token("") is None
+
+    def test_none_token_returns_none(self):
+        assert _extract_user_from_token(None) is None
+
+    def test_malformed_token_returns_none(self):
+        result = _extract_user_from_token("not.a.valid.jwt.token.at.all")
+        assert result is None
+
+    def test_preferred_username_fallback(self):
+        import jwt as pyjwt
+        token = pyjwt.encode({"sub": "user-456", "preferred_username": "jdoe"}, "secret")
+        result = _extract_user_from_token(token)
+        assert result["email"] == "jdoe"
+
+
+class TestActiveSessionsManagement:
+    """Req VR-2: Active session tracking."""
+
+    def test_sessions_dict_exists(self):
+        assert isinstance(_active_sessions, dict)
+
+    def test_sessions_can_be_added_and_removed(self):
+        _active_sessions["test-session"] = MagicMock()
+        assert "test-session" in _active_sessions
+        del _active_sessions["test-session"]
+        assert "test-session" not in _active_sessions
+
+
+class TestVoiceAgentLazyImport:
+    """Req VR-3: Lazy VoiceAgent import."""
+
+    def test_get_voice_agent_class_returns_class(self):
+        from apis.inference_api.chat.voice_routes import _get_voice_agent_class
+        cls = _get_voice_agent_class()
+        assert cls is not None
+        assert cls.__name__ == "VoiceAgent"
+
+    def test_get_voice_agent_class_caches(self):
+        from apis.inference_api.chat.voice_routes import _get_voice_agent_class
+        cls1 = _get_voice_agent_class()
+        cls2 = _get_voice_agent_class()
+        assert cls1 is cls2
+
+
+class TestDebugEndpoints:
+    """Req VR-4: Debug endpoint behavior."""
+
+    @pytest.fixture(autouse=True)
+    def clean_sessions(self):
+        """Ensure clean session state for each test."""
+        _active_sessions.clear()
+        yield
+        _active_sessions.clear()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_empty(self):
+        from apis.inference_api.chat.voice_routes import list_voice_sessions
+        result = await list_voice_sessions()
+        assert result["count"] == 0
+        assert result["active_sessions"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_with_entries(self):
+        from apis.inference_api.chat.voice_routes import list_voice_sessions
+        _active_sessions["sess-1"] = MagicMock()
+        _active_sessions["sess-2"] = MagicMock()
+        result = await list_voice_sessions()
+        assert result["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_session_not_found(self):
+        from apis.inference_api.chat.voice_routes import stop_voice_session
+        result = await stop_voice_session("nonexistent")
+        assert result["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_stop_session_calls_stop(self):
+        from apis.inference_api.chat.voice_routes import stop_voice_session
+        mock_agent = AsyncMock()
+        _active_sessions["sess-stop"] = mock_agent
+        result = await stop_voice_session("sess-stop")
+        assert result["status"] == "stopped"
+        mock_agent.stop.assert_called_once()
+        assert "sess-stop" not in _active_sessions

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,10 +1,11 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -48,10 +49,13 @@ all = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "strands-agents" },
+    { name = "strands-agents", extra = ["bidi"] },
     { name = "strands-agents-tools" },
     { name = "tiktoken" },
     { name = "types-aiofiles" },
+]
+bidi = [
+    { name = "strands-agents", extra = ["bidi"] },
 ]
 dev = [
     { name = "black" },
@@ -69,7 +73,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentcore-stack", extras = ["agentcore", "dev"], marker = "extra == 'all'" },
+    { name = "agentcore-stack", extras = ["agentcore", "bidi", "dev"], marker = "extra == 'all'" },
     { name = "aiofiles", specifier = "==25.1.0" },
     { name = "authlib", specifier = "==1.6.9" },
     { name = "aws-opentelemetry-distro", marker = "extra == 'agentcore'", specifier = "==0.16.0" },
@@ -93,12 +97,13 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.9" },
     { name = "starlette", specifier = "==1.0.0" },
     { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.34.1" },
+    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.34.1" },
     { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.3.0" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20251011" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.44.0" },
 ]
-provides-extras = ["agentcore", "dev", "all"]
+provides-extras = ["agentcore", "bidi", "dev", "all"]
 
 [[package]]
 name = "aiofiles"
@@ -406,6 +411,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/b2/455c0bfcbd772dafd4c9e93c4b713e36790abf9ccbca9b8e661968b29798/aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2", size = 10096, upload-time = "2020-05-27T23:10:34.742Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/11/5dc8be418e1d54bed15eaf3a7461797e5ebb9e6a34869ad750561f35fa5b/aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977", size = 6838, upload-time = "2020-05-27T23:10:33.658Z" },
+]
+
+[[package]]
+name = "aws-sdk-bedrock-runtime"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smithy-aws-core", extra = ["eventstream", "json"], marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-http", extra = ["awscrt"], marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ff/c5396e82ab39a30cebd08c875250e72c1116f57c8c1f3e0dda1c1db9b177/aws_sdk_bedrock_runtime-0.5.0.tar.gz", hash = "sha256:cc0af7330bda9e398ad9ebf39c021a59dbc28c616a6c9c7765c355773b2402f4", size = 159805, upload-time = "2026-04-07T19:24:24.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/1c/b6f1b10435beee0c6289e2ce5e736bbd30555ce9b5898bd9f98f982827ad/aws_sdk_bedrock_runtime-0.5.0-py3-none-any.whl", hash = "sha256:87a002ba4d070e32e4343858c3aacc2cf040beed7f03c93e2b984e78a4f4ceb6", size = 84911, upload-time = "2026-04-07T19:24:25.49Z" },
+]
+
+[[package]]
+name = "aws-sdk-signers"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/1e/e93f5b7711bb9c3b97a4d5486ee3a74db412a66bf6160977bb69f0434830/aws_sdk_signers-0.2.0.tar.gz", hash = "sha256:3b23fb02ababb9e768fc102ab7584e344be8d65324ef3c33df4b8cad6cee26e7", size = 18069, upload-time = "2026-04-07T19:24:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/f3/cb2cd5177bb6c21d339b96079ece8e30ffe9954540494bae73a6498677ac/aws_sdk_signers-0.2.0-py3-none-any.whl", hash = "sha256:e770dcc390e18093840ef4ce1ac70fc419fe6ac8737809ffce9a9fab56d8ac2d", size = 21621, upload-time = "2026-04-07T19:24:08.57Z" },
+]
+
+[[package]]
+name = "awscrt"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/4d/c2aece4af7b5537c855548f53ee077d01216a1a4adbf0fd24f23dbac52bf/awscrt-0.32.0.tar.gz", hash = "sha256:92e749fce6c61da8db1af0baa6b7e96f7acf8a5574760b3d7880d190cedee8a0", size = 36832208, upload-time = "2026-03-27T01:19:18.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/9f/ded80b31ea4e30be66cf8dd35ecb0bce3e5a2fee39542bd877d7c2f2c2e4/awscrt-0.32.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:211cee3a5335bbc96405afdbdebf9c17bf16f3a299e9d8b661d5c904634ade43", size = 3391016, upload-time = "2026-03-27T01:17:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8e/81ad2ad2c90faba849f106f4ee8c2f00741b1137225e965ba2be4b36fd9d/awscrt-0.32.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:693f40a004270dfc7e0f92f7d36ef5fb8e40de686fa87a0603ade74a479bbf40", size = 3930641, upload-time = "2026-03-27T01:18:01.454Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/09/193d7da3033e0c2f283f0c1a017a6e0918c91e0f57c3e4a18314ba7c97ad/awscrt-0.32.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3b3014bd320ce95a3698f8b00312a06accc6222505ace4e6cbb524aa10ab8654", size = 4217980, upload-time = "2026-03-27T01:18:02.909Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fa/63fc0f4573bf29135fde0b5a168c8d2c003344a342e7a342ab6e13ded795/awscrt-0.32.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:43ea8a3bb994259b1c2cb6fc400374cc6c84a2b235eada3370d5f012420427dd", size = 3861043, upload-time = "2026-03-27T01:18:04.424Z" },
+    { url = "https://files.pythonhosted.org/packages/95/57/e64e365c9112cbe4b04982effb22d62d57728513555c9516879598ebfea9/awscrt-0.32.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7cec6175c9616840a599050a0e6157846b509e7b3a7f2ab9f8e9a64bcb342e68", size = 4101797, upload-time = "2026-03-27T01:18:05.758Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2f/2a3decaa3111c47fbec0a051767838741b52c61e37c215cb9c905d74ed5b/awscrt-0.32.0-cp310-cp310-win32.whl", hash = "sha256:0a585e9089140f55a8452c2f1aefe17712d39eff5413c1c0c7aa393e749fd5b7", size = 4041085, upload-time = "2026-03-27T01:18:07.28Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/72f38c224bd38e383b1e08713c655c0756a41c6d0e7e59616e7d47b6ec35/awscrt-0.32.0-cp310-cp310-win_amd64.whl", hash = "sha256:d4423dbdb75ed37bbd9697a672bfd75a02a7354ac9b818fa2d38059726171928", size = 4204956, upload-time = "2026-03-27T01:18:08.947Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/74/1e63af11b71ca90e6bcc70affea6400078d4cf6605f0593fe0a91a1daeb5/awscrt-0.32.0-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:4ca7040b279cf6014c06de93be7a29a164c9c92469eb79c70143853873e81949", size = 3391226, upload-time = "2026-03-27T01:18:10.231Z" },
+    { url = "https://files.pythonhosted.org/packages/43/62/d1383a31d32b9963a3a646d926f77a46d88cee1a86536186ad0ac0c44aea/awscrt-0.32.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15a96559710e559bc4131b7af55b93c0c79505d4b9c4c4511b3b825bbb4f82a9", size = 3889898, upload-time = "2026-03-27T01:18:11.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/37c25e283ed4ebe21117fb183c1dbcd947d72fb770f05f9f1e8c2b63541e/awscrt-0.32.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11a8cf1902c35ad784ceedbe2d5b44956a34bb2b7c3c818511ce93bdb21bc386", size = 4178874, upload-time = "2026-03-27T01:18:13.128Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/23/6dbefd6efbe0914c73f633ea6702aa4701425337f4e0c1059ec99aedde23/awscrt-0.32.0-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f1eea556144c2999e105966bbe97a0460d10d656e331bc2c875f15ece3315c3b", size = 3800811, upload-time = "2026-03-27T01:18:14.848Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2e/0af9a203fea97504e0bd11261b12422ff555745699c176dee1767f09c9f6/awscrt-0.32.0-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:d7ef6f0e728c1b7a0a4b771d4c677a00bc1bf377b8b2dd59a1dd626b920efc3b", size = 4039356, upload-time = "2026-03-27T01:18:16.684Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/6371dc9dc7b4a8dfafe7ed1b4f30500cc22e239413a6fdcaab72f8b80b8e/awscrt-0.32.0-cp311-abi3-win32.whl", hash = "sha256:8cee2fea902452a36f67f9d79e6eb406d4359854dad6df439b3c671f07059763", size = 4039614, upload-time = "2026-03-27T01:18:17.979Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c2/0bd9346f22ced5f11dac7039876ea2824cc3e268b6b681e2a8a29b1e8701/awscrt-0.32.0-cp311-abi3-win_amd64.whl", hash = "sha256:8213ee3b3c1adb5364a48a87420cde4426688f0438a88f6381595586be7ffc17", size = 4201989, upload-time = "2026-03-27T01:18:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/67/2093978f8496dad5e90d77c3f59f07d3f040e32eda60f3592f1b45d48d65/awscrt-0.32.0-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:d1efd89302eeee14878ca2067de6525c85d4973cd4473bc537e8807ecca660d3", size = 3390414, upload-time = "2026-03-27T01:18:21.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4d/c2f8a732fef457ce58e7d798b2775deea16a3a840d8a9dd43bb21b80ec63/awscrt-0.32.0-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e36af2cfec50b0a2d270921217245c36f6722b9aae756394ca050dee535883", size = 3881094, upload-time = "2026-03-27T01:18:22.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/be/3cd7ad30fbc65eed95c1df2d50f9f1facb82335137f1842ec4e2152d3a51/awscrt-0.32.0-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a94d7c85486908adf07693519b3a8ec7c61b86cc0901fed266ff2239babef6ce", size = 4172552, upload-time = "2026-03-27T01:18:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/af/e299192ae380cb688ff505aa9145a9b4e9c31bf12275d67074bfd6aff899/awscrt-0.32.0-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:68e36b744ed8089be80a2f7c8ed9bd46573f00870d1429707c1c847f3dc99a6f", size = 3791182, upload-time = "2026-03-27T01:18:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/ffa769df6417720a4f9bddd9f8cc077f671d0a970d88d2c80e0e06eb0890/awscrt-0.32.0-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b1a9f3952f382feee264614e727d78e7fa12bad138a025e832affc84780fdc89", size = 4035286, upload-time = "2026-03-27T01:18:26.444Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/cf80de14e9735750af9c4d11173150da997b8333ca6e68dc4850b6768a7c/awscrt-0.32.0-cp313-abi3-win32.whl", hash = "sha256:56c418ac23102e34ad95ea68ad5527ce534b7c79bb3ec3b908b647d90ee3ce41", size = 4034631, upload-time = "2026-03-27T01:18:28.247Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d6/d95df41f0e3a9434a750a33fbe465c8638212a46ec469f301511fd4791f7/awscrt-0.32.0-cp313-abi3-win_amd64.whl", hash = "sha256:7a3a464b0c23d1c2cca23b210035da203b1ead7cafcda2cebb87af3de20cc2b2", size = 4197293, upload-time = "2026-03-27T01:18:29.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/aa/5d85dc363c2269a205d33305e13b07298beaf582f653f10f6fc70531dc29/awscrt-0.32.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:f61cc36f645444d4e27cdf2c8fc5d3fdca77de35f341ad0e6c65f6c097ef5afd", size = 3401086, upload-time = "2026-03-27T01:18:31.388Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9e/fac5cab0cd7a94a4978daade9ef6d77c3b1037f470476d16ae822b54c97e/awscrt-0.32.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c51510e2171a3cab33612b98333a4baca391ed76a1185e9f6ec5433196e646af", size = 4006884, upload-time = "2026-03-27T01:18:32.696Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cc/abd847148100a62616abaa5bdf9731686646e2a6f73e44bb63a718d6fd1e/awscrt-0.32.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f22723fc84ec31ed13591105083bea57fcbb7a9b20600dcfda8b5c28fa8047f8", size = 4293086, upload-time = "2026-03-27T01:18:34.092Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8e/05572eaab9ff7a0a40f17c084d61389602c5018c7f4b7bb7ad9e58b4bea9/awscrt-0.32.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:4bc6492b7622cbad46d65492fb12239d946e890797c5da6c30a878a04c694623", size = 3934220, upload-time = "2026-03-27T01:18:35.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/4d/6e2dc94c69b32aadf037e5057f550d8e1bf3271573e5e95cc8934499a579/awscrt-0.32.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:dd6df896ae0650977de05c8e83fc5f3f7472b4d8de7744560526c13a63da8fd0", size = 4168581, upload-time = "2026-03-27T01:18:36.885Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4d/099e4fc39839ff130716713401d36ed9fa8b78feb5dcbf273e1e1aa71dd2/awscrt-0.32.0-cp313-cp313t-win32.whl", hash = "sha256:5fb05ab256b90c2d39386702d20419159b605a1f0e95d0fade715ccc9a76856a", size = 4091134, upload-time = "2026-03-27T01:18:38.532Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a6/e0c63b8b73424f91a9fab52f100f412864ddd47e01ce84a6aeae35a12b7b/awscrt-0.32.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c1c69543cdeab10f7fcbd3f238996ee1ed73fb8f88dd9701fffc872d73bd256d", size = 4247510, upload-time = "2026-03-27T01:18:40.02Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/64/e7d5eac410e305b5d62da268d4c486dd003b065b3119031679a6cf242861/awscrt-0.32.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f82a7969c025875fa419fc6349c8013bc88359ce264cb6c2399d03f42fbae0e3", size = 3401104, upload-time = "2026-03-27T01:18:41.354Z" },
+    { url = "https://files.pythonhosted.org/packages/27/36/20d11e4b2a32337b712f1aa683a7d4bed777d1bfdff5d7803c7b952556c2/awscrt-0.32.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:877e6061448abc91b1926f3f8c73808ce2a170a404065ba185a407fbfd2eb8e7", size = 4007601, upload-time = "2026-03-27T01:18:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/d1d21aaa4c3affc82ff3b4ae75bad10d80234ea01d8d239a578efa23646b/awscrt-0.32.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83427cf90f1606a34dbbe29b1544f945899b3abdb8608a57f004c6f459fd1fd", size = 4293839, upload-time = "2026-03-27T01:18:44.628Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2b/bb17205da426d175991ca9f9a5873c8c50a0620ec12c299ee3d80941552a/awscrt-0.32.0-cp314-cp314t-win32.whl", hash = "sha256:de44db7677361a05a1cdce9a1c29b6628542094599cb33105b99b97b4b9580ea", size = 4171775, upload-time = "2026-03-27T01:18:46.184Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2c/65ac451a08b57d9d66c8ffc2cbdf3c32e7da84d0a1887bdf6a3da4877585/awscrt-0.32.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7b9eb088e4e17539d3c5ec8f40f04363fabb807f9d509653d2443056d22b3506", size = 4347754, upload-time = "2026-03-27T01:18:47.641Z" },
 ]
 
 [[package]]
@@ -1336,6 +1405,97 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "ijson"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/57/60d1a6a512f2f0508d0bc8b4f1cc5616fd3196619b66bd6a01f9155a1292/ijson-3.5.0.tar.gz", hash = "sha256:94688760720e3f5212731b3cb8d30267f9a045fb38fb3870254e7b9504246f31", size = 68658, upload-time = "2026-02-24T03:58:30.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/32/21c1b47a1afb7319944d0b9685c0997a9d574a77b030c82f6a1ac2cef4eb/ijson-3.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ea8dcac10d86adaeead454bc25c97b68d0bda573d5fd6f86f5e21cf8f7906f88", size = 88935, upload-time = "2026-02-24T03:56:40.591Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/6ac7ebbb3cd767c87cdcbb950a6754afd1c0977756347bfe03eb8e5b866d/ijson-3.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:92b0495bbb2150bbf14fc5d98fb6d76bcd1c526605a172709e602e6fedc96495", size = 60567, upload-time = "2026-02-24T03:56:41.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/98/1140de9ae872468a8bc2e87c171228e25e58b1eb696b7fb430f7590fea44/ijson-3.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7af0c4c8943be8b09a4e57bdc1da6001dae7b36526d4154fe5c8224738d0921f", size = 60620, upload-time = "2026-02-24T03:56:42.764Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e1/67dfe0774e4c7ca6ec8702e280e8764d356f3db54358999818cda6df7679/ijson-3.5.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:45887d5e84ff0d2b138c926cebd9071830733968afe8d9d12080b3c178c7f918", size = 126558, upload-time = "2026-02-24T03:56:43.922Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ef/23d614fc773d428caeb6e197218b7e32adcc668ff5b98777039149571208/ijson-3.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a70b575be8e57a28c80e90ed349ad3a851c3478524c70e36e07d6092ecd12c9", size = 133091, upload-time = "2026-02-24T03:56:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/80/99727603cd8a1d32edafa4392f4056b2420bf48c15afd34481c68a2d4435/ijson-3.5.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2adeecd45830bfd5580ca79a584154713aabef0b9607e16249133df5d2859813", size = 130249, upload-time = "2026-02-24T03:56:46.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/3a3d623ca80768e834be8a834ef05960e3b9e79af1a911704ff10c9e8792/ijson-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d873e72889e7fc5962ab58909f1adff338d7c2f49e450e5b5fe844eff8155a14", size = 133501, upload-time = "2026-02-24T03:56:47.54Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f6/df2c14ad340834eccee379046f155e4b66a16ddafd445429dee7b3323614/ijson-3.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9a88c559456a79708592234d697645d92b599718f4cbbeaa6515f83ac63ca0ae", size = 128438, upload-time = "2026-02-24T03:56:48.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7e/9ff5b8b5fee113f5607bc4149b707382a898eeb545153189b075e5ec8d59/ijson-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cf83f58ad50dc0d39a2105cb26d4f359b38f42cef68b913170d4d47d97d97ba5", size = 131116, upload-time = "2026-02-24T03:56:49.737Z" },
+    { url = "https://files.pythonhosted.org/packages/64/20/954ce0d440d7cf72a3d8361b14406f9cdbf624b1625c10f8488857c769d6/ijson-3.5.0-cp310-cp310-win32.whl", hash = "sha256:aec4580a7712a19b1f95cd41bed260fc6a31266d37ef941827772a4c199e8143", size = 52724, upload-time = "2026-02-24T03:56:50.932Z" },
+    { url = "https://files.pythonhosted.org/packages/24/33/ece87d60502c6115642cbabeb8c122fa982212b392bc4f4ff5aab8e02dac/ijson-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:9a9c4c70501e23e8eb1675330686d1598eebfa14b6f0dbc8f00c2e081cc628fa", size = 55125, upload-time = "2026-02-24T03:56:51.942Z" },
+    { url = "https://files.pythonhosted.org/packages/65/da/644343198abca5e0f6e2486063f8d8f3c443ca0ef5e5c890e51ef6032e33/ijson-3.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5616311404b858d32740b7ad8b9a799c62165f5ecb85d0a8ed16c21665a90533", size = 88964, upload-time = "2026-02-24T03:56:53.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/63/8621190aa2baf96156dfd4c632b6aa9f1464411e50b98750c09acc0505ea/ijson-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e9733f94029dd41702d573ef64752e2556e72aea14623d6dbb7a44ca1ccf30fd", size = 60582, upload-time = "2026-02-24T03:56:54.261Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/6a3f041fdd17dacff33b7d7d3ba3df6dca48740108340c6042f974b2ad20/ijson-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db8398c6721b98412a4f618da8022550c8b9c5d9214040646071b5deb4d4a393", size = 60632, upload-time = "2026-02-24T03:56:55.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/68/474541998abbdecfd46a744536878335de89aceb9f085bff1aaf35575ceb/ijson-3.5.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c061314845c08163b1784b6076ea5f075372461a32e6916f4e5f211fd4130b64", size = 131988, upload-time = "2026-02-24T03:56:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/e05ff8b72a44fe9d192f41c5dcbc35cfa87efc280cdbfe539ffaf4a7535e/ijson-3.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1111a1c5ac79119c5d6e836f900c1a53844b50a18af38311baa6bb61e2645aca", size = 138669, upload-time = "2026-02-24T03:56:57.555Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b5/955a83b031102c7a602e2c06d03aff0a0e584212f09edb94ccc754d203ac/ijson-3.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e74aff8c681c24002b61b1822f9511d4c384f324f7dbc08c78538e01fdc9fcb", size = 135093, upload-time = "2026-02-24T03:56:59.267Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f2/30250cfcb4d2766669b31f6732689aab2bb91de426a15a3ebe482df7ee48/ijson-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:739a7229b1b0cc5f7e2785a6e7a5fc915e850d3fed9588d0e89a09f88a417253", size = 138715, upload-time = "2026-02-24T03:57:00.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/05/785a145d7e75e04e04480d59b6323cd4b1d9013a6cd8643fa635fbc93490/ijson-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ef88712160360cab3ca6471a4e5418243f8b267cf1fe1620879d1b5558babc71", size = 133194, upload-time = "2026-02-24T03:57:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/eb/80d6f8a748dead4034cea0939494a67d10ccf88d6413bf6e860393139676/ijson-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ca0d1b6b5f8166a6248f4309497585fb8553b04bc8179a0260fad636cfdb798", size = 135588, upload-time = "2026-02-24T03:57:03.131Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a8/bbc21f9400ebdbca48fab272593e0d1f875691be1e927d264d90d48b8c47/ijson-3.5.0-cp311-cp311-win32.whl", hash = "sha256:966039cf9047c7967febf7b9a52ec6f38f5464a4c7fbb5565e0224b7376fefff", size = 52721, upload-time = "2026-02-24T03:57:04.365Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2e/4e8c0208b8f920ee80c88c956f93e78318f2cfb646455353b182738b490c/ijson-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:6bad6a1634cb7c9f3f4c7e52325283b35b565f5b6cc27d42660c6912ce883422", size = 55121, upload-time = "2026-02-24T03:57:05.498Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/17/9c63c7688025f3a8c47ea717b8306649c8c7244e49e20a2be4e3515dc75c/ijson-3.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1ebefbe149a6106cc848a3eaf536af51a9b5ccc9082de801389f152dba6ab755", size = 88536, upload-time = "2026-02-24T03:57:06.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/dd/e15c2400244c117b06585452ebc63ae254f5a6964f712306afd1422daae0/ijson-3.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:19e30d9f00f82e64de689c0b8651b9cfed879c184b139d7e1ea5030cec401c21", size = 60499, upload-time = "2026-02-24T03:57:09.155Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a9/bf4fe3538a0c965f16b406f180a06105b875da83f0743e36246be64ef550/ijson-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a04a33ee78a6f27b9b8528c1ca3c207b1df3b8b867a4cf2fcc4109986f35c227", size = 60330, upload-time = "2026-02-24T03:57:10.574Z" },
+    { url = "https://files.pythonhosted.org/packages/31/76/6f91bdb019dd978fce1bc5ea1cd620cfc096d258126c91db2c03a20a7f34/ijson-3.5.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d48dc2984af02eb3c56edfb3f13b3f62f2f3e4fe36f058c8cfc75d93adf4fed", size = 138977, upload-time = "2026-02-24T03:57:11.932Z" },
+    { url = "https://files.pythonhosted.org/packages/11/be/bbc983059e48a54b0121ee60042979faed7674490bbe7b2c41560db3f436/ijson-3.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1e73a44844d9adbca9cf2c4132cd875933e83f3d4b23881fcaf82be83644c7d", size = 149785, upload-time = "2026-02-24T03:57:13.255Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/2fee58f9024a3449aee83edfa7167fb5ccd7e1af2557300e28531bb68e16/ijson-3.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7389a56b8562a19948bdf1d7bae3a2edc8c7f86fb59834dcb1c4c722818e645a", size = 149729, upload-time = "2026-02-24T03:57:14.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/56/f1706761fcc096c9d414b3dcd000b1e6e5c24364c21cfba429837f98ee8d/ijson-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3176f23f8ebec83f374ed0c3b4e5a0c4db7ede54c005864efebbed46da123608", size = 150697, upload-time = "2026-02-24T03:57:15.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6e/ee0d9c875a0193b632b3e9ccd1b22a50685fb510256ad57ba483b6529f77/ijson-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6babd88e508630c6ef86c9bebaaf13bb2fb8ec1d8f8868773a03c20253f599bc", size = 142873, upload-time = "2026-02-24T03:57:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bf/f9d4399d0e6e3fd615035290a71e97c843f17f329b43638c0a01cf112d73/ijson-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dc1b3836b174b6db2fa8319f1926fb5445abd195dc963368092103f8579cb8ed", size = 151583, upload-time = "2026-02-24T03:57:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/a7254a065933c0e2ffd3586f46187d84830d3d7b6f41cfa5901820a4f87d/ijson-3.5.0-cp312-cp312-win32.whl", hash = "sha256:6673de9395fb9893c1c79a43becd8c8fbee0a250be6ea324bfd1487bb5e9ee4c", size = 53079, upload-time = "2026-02-24T03:57:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7b/2edca79b359fc9f95d774616867a03ecccdf333797baf5b3eea79733918c/ijson-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f4f7fabd653459dcb004175235f310435959b1bb5dfa8878578391c6cc9ad944", size = 55500, upload-time = "2026-02-24T03:57:20.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/d67e764a712c3590627480643a3b51efcc3afa4ef3cb54ee4c989073c97e/ijson-3.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e9cedc10e40dd6023c351ed8bfc7dcfce58204f15c321c3c1546b9c7b12562a4", size = 88544, upload-time = "2026-02-24T03:57:21.293Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/39/f1c299371686153fa3cf5c0736b96247a87a1bee1b7145e6d21f359c505a/ijson-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3647649f782ee06c97490b43680371186651f3f69bebe64c6083ee7615d185e5", size = 60495, upload-time = "2026-02-24T03:57:22.501Z" },
+    { url = "https://files.pythonhosted.org/packages/16/94/b1438e204d75e01541bebe3e668fe3e68612d210e9931ae1611062dd0a56/ijson-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90e74be1dce05fce73451c62d1118671f78f47c9f6be3991c82b91063bf01fc9", size = 60325, upload-time = "2026-02-24T03:57:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e2/4aa9c116fa86cc8b0f574f3c3a47409edc1cd4face05d0e589a5a176b05d/ijson-3.5.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:78e9ad73e7be2dd80627504bd5cbf512348c55ce2c06e362ed7683b5220e8568", size = 138774, upload-time = "2026-02-24T03:57:24.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d2/738b88752a70c3be1505faa4dcd7110668c2712e582a6a36488ed1e295d4/ijson-3.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9577449313cc94be89a4fe4b3e716c65f09cc19636d5a6b2861c4e80dddebd58", size = 149820, upload-time = "2026-02-24T03:57:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/0b3ab9f393ca8f72ea03bc896ba9fdc987e90ae08cdb51c32a4ee0c14d5e/ijson-3.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e4c1178fb50aff5f5701a30a5152ead82a14e189ce0f6102fa1b5f10b2f54ff", size = 149747, upload-time = "2026-02-24T03:57:27.308Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a3/b0037119f75131b78cb00acc2657b1a9d0435475f1f2c5f8f5a170b66b9c/ijson-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0eb402ab026ffb37a918d75af2b7260fe6cfbce13232cc83728a714dd30bd81d", size = 151027, upload-time = "2026-02-24T03:57:28.522Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a0/cb344de1862bf09d8f769c9d25c944078c87dd59a1b496feec5ad96309a4/ijson-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5b08ee08355f9f729612a8eb9bf69cc14f9310c3b2a487c6f1c3c65d85216ec4", size = 142996, upload-time = "2026-02-24T03:57:29.774Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/32/a8ffd67182e02ea61f70f62daf43ded4fa8a830a2520a851d2782460aba8/ijson-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bda62b6d48442903e7bf56152108afb7f0f1293c2b9bef2f2c369defea76ab18", size = 152068, upload-time = "2026-02-24T03:57:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/3578df8e75d446aab0ae92e27f641341f586b85e1988536adebc65300cb4/ijson-3.5.0-cp313-cp313-win32.whl", hash = "sha256:8d073d9b13574cfa11083cc7267c238b7a6ed563c2661e79192da4a25f09c82c", size = 53065, upload-time = "2026-02-24T03:57:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a2/f7cdaf5896710da3e69e982e44f015a83d168aa0f3a89b6f074b5426779d/ijson-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:2419f9e32e0968a876b04d8f26aeac042abd16f582810b576936bbc4c6015069", size = 55499, upload-time = "2026-02-24T03:57:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/13e2492d17e19a2084523e18716dc2809159f2287fd2700c735f311e76c4/ijson-3.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4d4b0cd676b8c842f7648c1a783448fac5cd3b98289abd83711b3e275e143524", size = 93019, upload-time = "2026-02-24T03:57:33.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/92/483fc97ece0c3f1cecabf48f6a7a36e89d19369eec462faaeaa34c788992/ijson-3.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:252dec3680a48bb82d475e36b4ae1b3a9d7eb690b951bb98a76c5fe519e30188", size = 62714, upload-time = "2026-02-24T03:57:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/793fe020a0fe9d9eed4c285cf4a5cfdb0a935708b3bde0d72f35c794b513/ijson-3.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:aa1b5dca97d323931fde2501172337384c958914d81a9dac7f00f0d4bfc76bc7", size = 62460, upload-time = "2026-02-24T03:57:35.874Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/f1a2690aa8d4df1f4e262b385e65a933ffdc250b091531bac9a449c19e16/ijson-3.5.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7a5ec7fd86d606094bba6f6f8f87494897102fa4584ef653f3005c51a784c320", size = 199273, upload-time = "2026-02-24T03:57:37.07Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a2/f1346d5299e79b988ab472dc773d5381ec2d57c23cb2f1af3ede4a810e62/ijson-3.5.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:009f41443e1521847701c6d87fa3923c0b1961be3c7e7de90947c8cb92ea7c44", size = 216884, upload-time = "2026-02-24T03:57:38.346Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3c/8b637e869be87799e6c2c3c275a30a546f086b1aed77e2b7f11512168c5a/ijson-3.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4c3651d1f9fe2839a93fdf8fd1d5ca3a54975349894249f3b1b572bcc4bd577", size = 207306, upload-time = "2026-02-24T03:57:39.718Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/18b1c1df6951ca056782d7580ec40cea4ff9a27a0947d92640d1cc8c4ae3/ijson-3.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:945b7abcfcfeae2cde17d8d900870f03536494245dda7ad4f8d056faa303256c", size = 211364, upload-time = "2026-02-24T03:57:40.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/e795812e82851574a9dba8a53fde045378f531ef14110c6fb55dbd23b443/ijson-3.5.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0574b0a841ff97495c13e9d7260fbf3d85358b061f540c52a123db9dbbaa2ed6", size = 200608, upload-time = "2026-02-24T03:57:42.272Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cd/013c85b4749b57a4cb4c2670014d1b32b8db4ab1a7be92ea7aeb5d7fe7b5/ijson-3.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f969ffb2b89c5cdf686652d7fb66252bc72126fa54d416317411497276056a18", size = 205127, upload-time = "2026-02-24T03:57:43.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7c/faf643733e3ab677f180018f6a855c4ef70b7c46540987424c563c959e42/ijson-3.5.0-cp313-cp313t-win32.whl", hash = "sha256:59d3f9f46deed1332ad669518b8099920512a78bda64c1f021fcd2aff2b36693", size = 55282, upload-time = "2026-02-24T03:57:44.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/22/94ddb47c24b491377aca06cd8fc9202cad6ab50619842457d2beefde21ea/ijson-3.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c2839fa233746d8aad3b8cd2354e441613f5df66d721d59da4a09394bd1db2b", size = 58016, upload-time = "2026-02-24T03:57:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/93/0868efe753dc1df80cc405cf0c1f2527a6991643607c741bff8dcb899b3b/ijson-3.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:25a5a6b2045c90bb83061df27cfa43572afa43ba9408611d7bfe237c20a731a9", size = 89094, upload-time = "2026-02-24T03:57:46.115Z" },
+    { url = "https://files.pythonhosted.org/packages/24/94/fd5a832a0df52ef5e4e740f14ac8640725d61034a1b0c561e8b5fb424706/ijson-3.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8976c54c0b864bc82b951bae06567566ac77ef63b90a773a69cd73aab47f4f4f", size = 60715, upload-time = "2026-02-24T03:57:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/1b9a90af5732491f9eec751ee211b86b11011e1158c555c06576d52c3919/ijson-3.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:859eb2038f7f1b0664df4241957694cc35e6295992d71c98659b22c69b3cbc10", size = 60638, upload-time = "2026-02-24T03:57:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6f/2c551ea980fe56f68710a8d5389cfbd015fc45aaafd17c3c52c346db6aa1/ijson-3.5.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c911aa02991c7c0d3639b6619b93a93210ff1e7f58bf7225d613abea10adc78e", size = 140667, upload-time = "2026-02-24T03:57:49.314Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/27b887879ba6a5bc29766e3c5af4942638c952220fd63e1e442674f7883a/ijson-3.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:903cbdc350173605220edc19796fbea9b2203c8b3951fb7335abfa8ed37afda8", size = 149850, upload-time = "2026-02-24T03:57:50.329Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/23e10e1bc04bf31193b21e2960dce14b17dbd5d0c62204e8401c59d62c08/ijson-3.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4549d96ded5b8efa71639b2160235415f6bdb8c83367615e2dbabcb72755c33", size = 149206, upload-time = "2026-02-24T03:57:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/90/e552f6495063b235cf7fa2c592f6597c057077195e517b842a0374fd470c/ijson-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6b2dcf6349e6042d83f3f8c39ce84823cf7577eba25bac5aae5e39bbbbbe9c1c", size = 150438, upload-time = "2026-02-24T03:57:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/18/45bf8f297c41b42a1c231d261141097babd953d2c28a07be57ae4c3a1a02/ijson-3.5.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e44af39e6f8a17e5627dcd89715d8279bf3474153ff99aae031a936e5c5572e5", size = 144369, upload-time = "2026-02-24T03:57:53.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/deb9772bb2c0cead7ad64f00c3598eec9072bdf511818e70e2c512eeabbe/ijson-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9260332304b7e7828db56d43f08fc970a3ab741bf84ff10189361ea1b60c395b", size = 151352, upload-time = "2026-02-24T03:57:54.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/51/67f4d80cd58ad7eab0cd1af5fe28b961886338956b2f88c0979e21914346/ijson-3.5.0-cp314-cp314-win32.whl", hash = "sha256:63bc8121bb422f6969ced270173a3fa692c29d4ae30c860a2309941abd81012a", size = 53610, upload-time = "2026-02-24T03:57:55.655Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d3/263672ea22983ba3940f1534316dbc9200952c1c2a2332d7a664e4eaa7ae/ijson-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:01b6dad72b7b7df225ef970d334556dfad46c696a2c6767fb5d9ed8889728bca", size = 56301, upload-time = "2026-02-24T03:57:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d9/86f7fac35e0835faa188085ae0579e813493d5261ce056484015ad533445/ijson-3.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ea4b676ec98e374c1df400a47929859e4fa1239274339024df4716e802aa7e4", size = 93069, upload-time = "2026-02-24T03:57:57.849Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/e7366ed9c6e60228d35baf4404bac01a126e7775ea8ce57f560125ed190a/ijson-3.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:014586eec043e23c80be9a923c56c3a0920a0f1f7d17478ce7bc20ba443968ef", size = 62767, upload-time = "2026-02-24T03:57:58.758Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/3e703e8cc4b3ada79f13b28070b51d9550c578f76d1968657905857b2ddd/ijson-3.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5b8b886b0248652d437f66e7c5ac318bbdcb2c7137a7e5327a68ca00b286f5f", size = 62467, upload-time = "2026-02-24T03:58:00.261Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/0c91af32c1ee8a957fdac2e051b5780756d05fd34e4b60d94a08d51bac1d/ijson-3.5.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:498fd46ae2349297e43acf97cdc421e711dbd7198418677259393d2acdc62d78", size = 200447, upload-time = "2026-02-24T03:58:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/80/796ea0e391b7e2d45c5b1b451734bba03f81c2984cf955ea5eaa6c4920ad/ijson-3.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a51b4f9b81f12793731cf226266d1de2112c3c04ba4a04117ad4e466897e05", size = 217820, upload-time = "2026-02-24T03:58:02.598Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/52b6613fdda4078c62eb5b4fe3efc724ddc55a4ad524c93de51830107aa3/ijson-3.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9636c710dc4ac4a281baa266a64f323b4cc165cec26836af702c44328b59a515", size = 208310, upload-time = "2026-02-24T03:58:04.759Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ad/8b3105a78774fd4a65e534a21d975ef3a77e189489fe3029ebcaeba5e243/ijson-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f7168a39e8211107666d71b25693fd1b2bac0b33735ef744114c403c6cac21e1", size = 211843, upload-time = "2026-02-24T03:58:05.836Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/a2739f6072d6e1160581bc3ed32da614c8cced023dcd519d9c5fa66e0425/ijson-3.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8696454245415bc617ab03b0dc3ae4c86987df5dc6a90bad378fe72c5409d89e", size = 200906, upload-time = "2026-02-24T03:58:07.788Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5e/e06c2de3c3d4a9cfb655c1ad08a68fb72838d271072cdd3196576ac4431a/ijson-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c21bfb61f71f191565885bf1bc29e0a186292d866b4880637b833848360bdc1b", size = 205495, upload-time = "2026-02-24T03:58:09.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/11/778201eb2e202ddd76b36b0fb29bf3d8e3c167389d8aa883c62524e49f47/ijson-3.5.0-cp314-cp314t-win32.whl", hash = "sha256:a2619460d6795b70d0155e5bf016200ac8a63ab5397aa33588bb02b6c21759e6", size = 56280, upload-time = "2026-02-24T03:58:10.116Z" },
+    { url = "https://files.pythonhosted.org/packages/23/28/96711503245339084c8086b892c47415895eba49782d6cc52d9f4ee50301/ijson-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4f24b78d4ef028d17eb57ad1b16c0aed4a17bdd9badbf232dc5d9305b7e13854", size = 58965, upload-time = "2026-02-24T03:58:11.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3b/d31ecfa63a218978617446159f3d77aab2417a5bd2885c425b176353ff78/ijson-3.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d64c624da0e9d692d6eb0ff63a79656b59d76bf80773a17c5b0f835e4e8ef627", size = 57715, upload-time = "2026-02-24T03:58:24.545Z" },
+    { url = "https://files.pythonhosted.org/packages/30/51/b170e646d378e8cccf9637c05edb5419b00c2c4df64b0258c3af5355608e/ijson-3.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:876f7df73b7e0d6474f9caa729b9cdbfc8e76de9075a4887dfd689e29e85c4ca", size = 57205, upload-time = "2026-02-24T03:58:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/83/44dbd0231b0a8c6c14d27473d10c4e27dfbce7d5d9a833c79e3e6c33eb40/ijson-3.5.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e7dbff2c8d9027809b0cde663df44f3210da10ea377121d42896fb6ee405dd31", size = 71229, upload-time = "2026-02-24T03:58:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/cf84048b7c6cec888826e696a31f45bee7ebcac15e532b6be1fc4c2c9608/ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4217a1edc278660679e1197c83a1a2a2d367792bfbb2a3279577f4b59b93730d", size = 71217, upload-time = "2026-02-24T03:58:28.021Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0a/e34c729a87ff67dc6540f6bcc896626158e691d433ab57db0086d73decd2/ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04f0fc740311388ee745ba55a12292b722d6f52000b11acbb913982ba5fbdf87", size = 68618, upload-time = "2026-02-24T03:58:28.918Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0f/e849d072f2e0afe49627de3995fc9dae54b4c804c70c0840f928d95c10e1/ijson-3.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fdeee6957f92e0c114f65c55cf8fe7eabb80cfacab64eea6864060913173f66d", size = 55369, upload-time = "2026-02-24T03:58:29.839Z" },
 ]
 
 [[package]]
@@ -4035,6 +4195,79 @@ wheels = [
 ]
 
 [[package]]
+name = "smithy-aws-core"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-sdk-signers", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-http", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/a5/abc799cb5263136c94838b8acc987b4c423c08a048ba63d5ebb934b5dde9/smithy_aws_core-0.5.0.tar.gz", hash = "sha256:8f6c758f986657de6e4e182d28cfd5761789478f1b12275b5686789728488f08", size = 15475, upload-time = "2026-04-07T19:24:19.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/3f/878740067fb1ee8f5d551eed016b69dafa9a8eb3c968a637986cdd528a41/smithy_aws_core-0.5.0-py3-none-any.whl", hash = "sha256:08a4d2b5b71fb09f06f43405c82c4c5b466011c3dde1b4ae578e240a383473a0", size = 24802, upload-time = "2026-04-07T19:24:18.596Z" },
+]
+
+[package.optional-dependencies]
+eventstream = [
+    { name = "smithy-aws-event-stream", marker = "python_full_version >= '3.12'" },
+]
+json = [
+    { name = "smithy-json", marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
+name = "smithy-aws-event-stream"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/3f/c1544c3336122571b371eea2dd0dc2542112f172029f06bb43e4c09c128e/smithy_aws_event_stream-0.2.1.tar.gz", hash = "sha256:ae67ea3e582f2c2c556e302e57bc90a19b9b5847bcc8520e89396bcafc26235f", size = 12334, upload-time = "2025-12-30T23:23:27.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/80/b52689e3dc39d478f7ba69ca18be2e762b3866efe4ae5312d69059f9fe01/smithy_aws_event_stream-0.2.1-py3-none-any.whl", hash = "sha256:31d1089306732b4f35e1c6be2e8c2a3f7524c72c59aa2fd1dcba77b97bef4bc3", size = 15569, upload-time = "2025-12-30T23:23:26.411Z" },
+]
+
+[[package]]
+name = "smithy-core"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/9c/d4eb7fb59f377b712477a468132ad483179c7877064a16110d6f2109c309/smithy_core-0.4.0.tar.gz", hash = "sha256:eee8bfdcb1f1453c1f20d8b6214fac579b57a7c585ee2f503c404c93d274bb9a", size = 50880, upload-time = "2026-04-07T19:24:11.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/25/56488440a801f462db96500ef3d543bf860c4319e77c36d09900a8c27587/smithy_core-0.4.0-py3-none-any.whl", hash = "sha256:50b99e7debecadc6a29a483717ac707ac0480d948f87793b73c26a6b37b03cc5", size = 65010, upload-time = "2026-04-07T19:24:10.874Z" },
+]
+
+[[package]]
+name = "smithy-http"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/b4/7422f8c06ab8bd70e6b04e8cd570fb16bc5068bc21066f318bee2b8e8e29/smithy_http-0.4.0.tar.gz", hash = "sha256:212b233d55f9006cbf4b8df7a42e17b841d4cfbe9b25d9afe2ad903e364fc79c", size = 29021, upload-time = "2026-04-07T19:24:14.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/cd/953eb19e4683f76dac97b9ac30656955d4420211dc1464f5de2faa065fe1/smithy_http-0.4.0-py3-none-any.whl", hash = "sha256:ae381d8bee199d1604ae1a983e59e0b8f51b3bf3561587be9381f4c62818ff72", size = 40536, upload-time = "2026-04-07T19:24:13.075Z" },
+]
+
+[package.optional-dependencies]
+awscrt = [
+    { name = "awscrt", marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
+name = "smithy-json"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ijson", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-core", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/50/5ea5bdb003e2d89afa6dfa8702208f2e61db56b4261656435aa15e176f55/smithy_json-0.2.2.tar.gz", hash = "sha256:e40f154455ebceb0552ef37310c5d0c297c6e6690087396adacf06fb170f59de", size = 7644, upload-time = "2026-04-07T19:24:15.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/bd/761ae4148699ec2a20ff975379aa439a6123420d102bc23a356dd64667d9/smithy_json-0.2.2-py3-none-any.whl", hash = "sha256:4c7be8532f4ae0429a8a6676adf41e40941893ce7d491bc7faa50590077f97da", size = 10177, upload-time = "2026-04-07T19:24:15.846Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4107,6 +4340,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/22/f958d52a794e508a31ace8b8cbba0379226a98fac9826f3b757f95912b70/strands_agents-1.34.1.tar.gz", hash = "sha256:d1ff614dc364ce54348c24b011bbef6c466a0dd33e19996bd1a4ec4aab846cb1", size = 796829, upload-time = "2026-04-01T20:37:29.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/eb/b0db0fb9ae691d3ed0ac9f9604b60f9154671baf4c61853c0b6607e2a91e/strands_agents-1.34.1-py3-none-any.whl", hash = "sha256:edc5ccd4fbc64bf203ced282083ed011953f628cf8f060e1c88e6a2fd8429f3a", size = 393990, upload-time = "2026-04-01T20:37:27.906Z" },
+]
+
+[package.optional-dependencies]
+bidi = [
+    { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12'" },
+    { name = "smithy-aws-core", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]

--- a/frontend/ai.client/public/audio/pcm-capture.worklet.js
+++ b/frontend/ai.client/public/audio/pcm-capture.worklet.js
@@ -1,0 +1,17 @@
+/**
+ * AudioWorklet processor that captures PCM samples from the microphone
+ * and forwards them to the main thread via MessagePort.
+ *
+ * Registered as 'pcm-capture' and used by AudioRecorderService.
+ */
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0] && input[0].length > 0) {
+      this.port.postMessage(new Float32Array(input[0]));
+    }
+    return true;
+  }
+}
+
+registerProcessor('pcm-capture', PcmCaptureProcessor);

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -46,7 +46,7 @@ export class ModelFormPage implements OnInit {
 
   // Available options for multi-select fields
   readonly availableProviders = AVAILABLE_PROVIDERS;
-  readonly availableModalities = ['TEXT', 'IMAGE', 'VIDEO', 'AUDIO', 'EMBEDDING'];
+  readonly availableModalities = ['TEXT', 'IMAGE', 'VIDEO', 'AUDIO', 'SPEECH', 'EMBEDDING'];
 
   // AppRoles from the API (reactive resource)
   readonly rolesResource = this.appRolesService.rolesResource;

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -71,6 +71,7 @@
           (messageSubmitted)="onMessageSubmitted($event)"
           (messageCancelled)="onMessageCancelled()"
           (fileAttached)="onFileAttached($event)"
+
           (settingsToggled)="onSettingsToggled()">
         </app-chat-input>
       </div>
@@ -126,6 +127,7 @@
             (messageSubmitted)="onMessageSubmitted($event)"
             (messageCancelled)="onMessageCancelled()"
             (fileAttached)="onFileAttached($event)"
+  
             (settingsToggled)="onSettingsToggled()">
           </app-chat-input>
         </div>
@@ -178,6 +180,7 @@
             (messageSubmitted)="onMessageSubmitted($event)"
             (messageCancelled)="onMessageCancelled()"
             (fileAttached)="onFileAttached($event)"
+  
             (settingsToggled)="onSettingsToggled()">
           </app-chat-input>
         </div>
@@ -217,6 +220,7 @@
               (messageSubmitted)="onMessageSubmitted($event)"
               (messageCancelled)="onMessageCancelled()"
               (fileAttached)="onFileAttached($event)"
+    
               (settingsToggled)="onSettingsToggled()">
             </app-chat-input>
           </div>
@@ -279,6 +283,7 @@
           (messageSubmitted)="onMessageSubmitted($event)"
           (messageCancelled)="onMessageCancelled()"
           (fileAttached)="onFileAttached($event)"
+
           (settingsToggled)="onSettingsToggled()">
         </app-chat-input>
       </div>
@@ -346,9 +351,15 @@
           (messageSubmitted)="onMessageSubmitted($event)"
           (messageCancelled)="onMessageCancelled()"
           (fileAttached)="onFileAttached($event)"
+
           (settingsToggled)="onSettingsToggled()">
         </app-chat-input>
       </div>
     </div>
   }
+}
+
+<!-- Voice Conversation Overlay -->
+@if (isVoiceActive()) {
+  <app-voice-overlay (closed)="onVoiceClosed()" />
 }

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -19,6 +19,8 @@ import { SidenavService } from '../../../services/sidenav/sidenav.service';
 import { Assistant } from '../../../assistants/models/assistant.model';
 import { AssistantCardComponent } from '../../../assistants/components/assistant-card.component';
 import { AssistantIndicatorComponent } from '../assistant-indicator/assistant-indicator.component';
+import { VoiceOverlayComponent } from '../voice-overlay';
+import { VoiceChatService } from '../../services/voice';
 
 /**
  * Configuration options for ChatContainerComponent.
@@ -58,6 +60,7 @@ export interface ChatContainerConfig {
     NgIcon,
     AssistantCardComponent,
     AssistantIndicatorComponent,
+    VoiceOverlayComponent,
   ],
   providers: [provideIcons({ heroXMark })],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -67,6 +70,8 @@ export interface ChatContainerConfig {
 export class ChatContainerComponent {
   // Inject sidenav service for full-page mode positioning
   protected sidenavService = inject(SidenavService);
+  private voiceChatService = inject(VoiceChatService);
+  protected readonly isVoiceActive = this.voiceChatService.isVoiceActive;
 
   // Child component reference for scroll functionality
   private messageListComponent = viewChild(MessageListComponent);
@@ -107,6 +112,7 @@ export class ChatContainerComponent {
   assistantNewSession = output<void>();
   assistantEdit = output<void>();
   assistantShare = output<void>();
+  voiceClosed = output<void>();
 
   // Computed signals
   protected readonly hasMessages = computed(() => this.messages().length > 0);
@@ -172,5 +178,9 @@ export class ChatContainerComponent {
 
   onAssistantShare() {
     this.assistantShare.emit();
+  }
+
+  onVoiceClosed() {
+    this.voiceClosed.emit();
   }
 }

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -46,6 +46,18 @@
       </div>
     }
 
+    <!-- Voice Transcript Overlay -->
+    @if (isVoiceActive() && voiceTranscript()) {
+      <div class="border-b border-gray-200 dark:border-gray-700 px-6 py-3">
+        <p class="text-sm text-gray-600 dark:text-gray-300 italic">
+          @if (voiceStatus() === 'speaking') {
+            <span class="font-medium text-green-600 dark:text-green-400">Assistant: </span>
+          }
+          {{ voiceTranscript() }}
+        </p>
+      </div>
+    }
+
     <!-- Main Input Area -->
     <div class="relative">
       <label for="user-message" class="sr-only">How can I help you today?</label>
@@ -100,6 +112,40 @@
               <ng-icon name="heroAdjustmentsHorizontal" class="size-5" aria-hidden="true" />
             </button>
           }
+
+          <!-- Voice Toggle Button -->
+          <button
+            type="button"
+            (click)="toggleVoice()"
+            [class]="voiceButtonClass()"
+            [attr.aria-label]="voiceAriaLabel()"
+            [appTooltip]="voiceTooltip()"
+            appTooltipPosition="top"
+          >
+            @if (voiceStatus() === 'listening') {
+              <!-- Pulsing dot indicator for listening -->
+              <span class="relative flex size-3">
+                <span class="absolute inline-flex size-full animate-ping rounded-full bg-red-400 opacity-75"></span>
+                <span class="relative inline-flex size-3 rounded-full bg-red-500"></span>
+              </span>
+            } @else if (voiceStatus() === 'speaking') {
+              <!-- Wave bars for speaking -->
+              <span class="flex items-center gap-0.5" aria-hidden="true">
+                <span class="h-3 w-0.5 animate-bounce rounded-full bg-green-500" style="animation-delay: 0ms;"></span>
+                <span class="h-4 w-0.5 animate-bounce rounded-full bg-green-500" style="animation-delay: 150ms;"></span>
+                <span class="h-3 w-0.5 animate-bounce rounded-full bg-green-500" style="animation-delay: 300ms;"></span>
+              </span>
+            } @else if (voiceStatus() === 'connecting') {
+              <!-- Spinner for connecting -->
+              <svg class="size-5 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+              </svg>
+            } @else {
+              <!-- Mic icon for idle -->
+              <ng-icon name="heroMicrophone" class="size-5" aria-hidden="true" />
+            }
+          </button>
         </div>
 
         <!-- Right Controls -->

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -46,18 +46,6 @@
       </div>
     }
 
-    <!-- Voice Transcript Overlay -->
-    @if (isVoiceActive() && voiceTranscript()) {
-      <div class="border-b border-gray-200 dark:border-gray-700 px-6 py-3">
-        <p class="text-sm text-gray-600 dark:text-gray-300 italic">
-          @if (voiceStatus() === 'speaking') {
-            <span class="font-medium text-green-600 dark:text-green-400">Assistant: </span>
-          }
-          {{ voiceTranscript() }}
-        </p>
-      </div>
-    }
-
     <!-- Main Input Area -->
     <div class="relative">
       <label for="user-message" class="sr-only">How can I help you today?</label>

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -5,6 +5,7 @@ import {
   heroPlus,
   heroAdjustmentsHorizontal,
   heroClock,
+  heroMicrophone,
 } from '@ng-icons/heroicons/outline';
 import { heroPaperAirplaneSolid, heroStopSolid } from '@ng-icons/heroicons/solid';
 import { ModelDropdownComponent } from '../../../components/model-dropdown/model-dropdown.component';
@@ -21,6 +22,7 @@ import {
   formatBytes
 } from '../../../services/file-upload';
 import { ToastService } from '../../../services/toast/toast.service';
+import { VoiceChatService, type VoiceStatus } from '../../services/voice';
 
 interface Message {
   content: string;
@@ -36,6 +38,7 @@ interface Message {
       heroPlus,
       heroAdjustmentsHorizontal,
       heroClock,
+      heroMicrophone,
       heroStopSolid,
       heroPaperAirplaneSolid
     })
@@ -47,6 +50,7 @@ export class ChatInputComponent {
   // Service injection
   private readonly fileUploadService = inject(FileUploadService);
   private readonly toastService = inject(ToastService);
+  private readonly voiceChatService = inject(VoiceChatService);
 
   // Input: session ID for file uploads
   readonly sessionId = input<string | null>(null);
@@ -94,6 +98,46 @@ export class ChatInputComponent {
   // Allowed file types for input accept attribute
   readonly acceptedFileTypes = ALLOWED_EXTENSIONS.join(',');
 
+  // Voice state (from VoiceChatService)
+  readonly voiceStatus = this.voiceChatService.status;
+  readonly isVoiceActive = this.voiceChatService.isVoiceActive;
+  readonly voiceTranscript = this.voiceChatService.currentTranscript;
+
+  readonly voiceButtonClass = computed(() => {
+    const status = this.voiceStatus();
+    const base = 'flex size-10 items-center justify-center rounded-lg transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]';
+    switch (status) {
+      case 'listening':
+        return `${base} bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 animate-pulse`;
+      case 'speaking':
+        return `${base} bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400`;
+      case 'connecting':
+        return `${base} bg-yellow-100 text-yellow-600 dark:bg-yellow-900/30 dark:text-yellow-400`;
+      default:
+        return `${base} text-gray-500 dark:text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/5 dark:hover:text-gray-300`;
+    }
+  });
+
+  readonly voiceAriaLabel = computed(() => {
+    const status = this.voiceStatus();
+    switch (status) {
+      case 'listening': return 'Listening... Click to stop voice';
+      case 'speaking': return 'Agent is speaking... Click to stop voice';
+      case 'connecting': return 'Connecting voice...';
+      default: return 'Start voice conversation';
+    }
+  });
+
+  readonly voiceTooltip = computed(() => {
+    const status = this.voiceStatus();
+    switch (status) {
+      case 'listening': return 'Listening...';
+      case 'speaking': return 'Speaking...';
+      case 'connecting': return 'Connecting...';
+      default: return 'Voice mode';
+    }
+  });
+
   onSubmit() {
     if (this.isLoading()) {
       this.cancelChatRequest();
@@ -136,6 +180,22 @@ export class ChatInputComponent {
 
   toggleSettings() {
     this.settingsToggled.emit();
+  }
+
+  async toggleVoice() {
+    const sessionId = this.sessionId();
+    if (this.isVoiceActive()) {
+      await this.voiceChatService.disconnect();
+    } else if (sessionId) {
+      try {
+        await this.voiceChatService.connect(sessionId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Failed to start voice';
+        this.toastService.error('Voice Error', msg);
+      }
+    } else {
+      this.toastService.warning('No Session', 'Start a conversation first to use voice mode.');
+    }
   }
 
   async onFileSelect(event: Event) {

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -101,7 +101,7 @@ export class ChatInputComponent {
   // Voice state (from VoiceChatService)
   readonly voiceStatus = this.voiceChatService.status;
   readonly isVoiceActive = this.voiceChatService.isVoiceActive;
-  readonly voiceTranscript = this.voiceChatService.currentTranscript;
+  readonly voiceTranscript = this.voiceChatService.agentTranscript;
 
   readonly voiceButtonClass = computed(() => {
     const status = this.voiceStatus();
@@ -183,18 +183,15 @@ export class ChatInputComponent {
   }
 
   async toggleVoice() {
-    const sessionId = this.sessionId();
     if (this.isVoiceActive()) {
       await this.voiceChatService.disconnect();
-    } else if (sessionId) {
+    } else {
       try {
-        await this.voiceChatService.connect(sessionId);
+        await this.voiceChatService.connect(this.sessionId() || undefined);
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to start voice';
         this.toastService.error('Voice Error', msg);
       }
-    } else {
-      this.toastService.warning('No Session', 'Start a conversation first to use voice mode.');
     }
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
@@ -7,6 +7,14 @@ import {
 } from '@angular/core';
 import { LocalSettingsService } from '../../../../services/local-settings.service';
 
+interface CostBreakdown {
+    total: number;
+    inputCost: number;
+    outputCost: number;
+    cacheReadCost?: number;
+    cacheWriteCost?: number;
+}
+
 interface MessageMetadata {
     latency?: {
         timeToFirstToken?: number;
@@ -24,7 +32,7 @@ interface MessageMetadata {
         sessionId?: string;
         timestamp?: string;
     };
-    cost?: number;
+    cost?: CostBreakdown | number;
 }
 
 @Component({
@@ -104,13 +112,33 @@ interface MessageMetadata {
                     </div>
                 }
 
-                <!-- Cost Badge -->
-                @if (cost() !== null) {
+                <!-- Input Cost Badge -->
+                @if (inputCost() !== null) {
                     <div class="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
                         <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                         </svg>
-                        <span>Cost: {{ formatCost(cost()) }}</span>
+                        <span>In: {{ formatCost(inputCost()) }}</span>
+                    </div>
+                }
+
+                <!-- Output Cost Badge -->
+                @if (outputCost() !== null) {
+                    <div class="inline-flex items-center gap-1.5 rounded-full bg-orange-100 px-3 py-1 text-xs font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-300">
+                        <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        </svg>
+                        <span>Out: {{ formatCost(outputCost()) }}</span>
+                    </div>
+                }
+
+                <!-- Total Cost Badge -->
+                @if (totalCost() !== null) {
+                    <div class="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                        <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        </svg>
+                        <span>Total: {{ formatCost(totalCost()) }}</span>
                     </div>
                 }
         }
@@ -141,7 +169,7 @@ export class MessageMetadataBadgesComponent {
             !!meta.latency?.timeToFirstToken ||
             !!meta.latency?.endToEndLatency ||
             !!meta.tokenUsage ||
-            meta.cost !== undefined
+            meta.cost !== undefined && meta.cost !== null
         );
     });
 
@@ -217,10 +245,32 @@ export class MessageMetadataBadgesComponent {
         return { hitRate, savings: Math.max(0, savings) };
     });
 
-    cost = computed(() => {
+    private costBreakdown = computed<CostBreakdown | null>(() => {
         const meta = this.typedMetadata();
         if (meta?.cost === undefined || meta.cost === null) return null;
+        // Handle backwards compatibility with scalar cost
+        if (typeof meta.cost === 'number') {
+            return { total: meta.cost, inputCost: 0, outputCost: 0 };
+        }
         return meta.cost;
+    });
+
+    inputCost = computed(() => {
+        const breakdown = this.costBreakdown();
+        if (!breakdown || breakdown.inputCost === 0) return null;
+        return breakdown.inputCost;
+    });
+
+    outputCost = computed(() => {
+        const breakdown = this.costBreakdown();
+        if (!breakdown || breakdown.outputCost === 0) return null;
+        return breakdown.outputCost;
+    });
+
+    totalCost = computed(() => {
+        const breakdown = this.costBreakdown();
+        if (!breakdown) return null;
+        return breakdown.total;
     });
 
     /**

--- a/frontend/ai.client/src/app/session/components/voice-overlay/index.ts
+++ b/frontend/ai.client/src/app/session/components/voice-overlay/index.ts
@@ -1,0 +1,1 @@
+export { VoiceOverlayComponent } from './voice-overlay.component';

--- a/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.css
+++ b/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.css
@@ -1,0 +1,202 @@
+@import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* === Overlay entrance === */
+:host {
+  display: block;
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  animation: overlay-enter 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.voice-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(249, 250, 251, 0.97);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  color: var(--color-gray-900);
+}
+
+:host-context(.dark) .voice-overlay-backdrop {
+  background-color: rgba(3, 7, 18, 0.97);
+  color: var(--color-gray-100);
+}
+
+@keyframes overlay-enter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* === Visualizer Orb === */
+.voice-orb {
+  position: relative;
+  width: 10rem;
+  height: 10rem;
+  margin-bottom: 2.5rem;
+}
+
+.voice-orb-core {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  transition: background 600ms ease, box-shadow 600ms ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* -- Connecting state -- */
+.voice-orb-core.connecting {
+  background: radial-gradient(circle at 40% 40%, #fbbf24, #d97706);
+  box-shadow: 0 0 40px rgba(251, 191, 36, 0.3), 0 0 80px rgba(217, 119, 6, 0.15);
+  animation: orb-spin 2s linear infinite;
+}
+
+@keyframes orb-spin {
+  0% { transform: rotate(0deg) scale(0.92); }
+  50% { transform: rotate(180deg) scale(1.04); }
+  100% { transform: rotate(360deg) scale(0.92); }
+}
+
+/* -- Listening state -- */
+.voice-orb-core.listening {
+  background: radial-gradient(circle at 45% 40%, #f87171, #dc2626);
+  box-shadow: 0 0 40px rgba(248, 113, 113, 0.35), 0 0 80px rgba(220, 38, 38, 0.15);
+  animation: orb-breathe 2.5s ease-in-out infinite;
+}
+
+@keyframes orb-breathe {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.06); }
+}
+
+.voice-ripple {
+  position: absolute;
+  inset: -0.5rem;
+  border-radius: 9999px;
+  border: 1.5px solid rgba(248, 113, 113, 0.4);
+  animation: ripple-expand 2.4s ease-out infinite;
+}
+
+.voice-ripple:nth-child(2) {
+  animation-delay: 0.8s;
+}
+
+.voice-ripple:nth-child(3) {
+  animation-delay: 1.6s;
+}
+
+@keyframes ripple-expand {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(2.2);
+    opacity: 0;
+  }
+}
+
+/* -- Speaking state -- */
+.voice-orb-core.speaking {
+  background: radial-gradient(circle at 45% 40%, #4ade80, #16a34a);
+  box-shadow: 0 0 40px rgba(74, 222, 128, 0.35), 0 0 80px rgba(22, 163, 74, 0.15);
+  animation: orb-pulse-speak 2.5s ease-in-out infinite;
+}
+
+@keyframes orb-pulse-speak {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.04); opacity: 0.9; }
+}
+
+/* Wave bars inside orb during speaking */
+.voice-wave-bar {
+  width: 3px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.85);
+  animation: wave-bar 0.8s ease-in-out infinite;
+}
+
+@keyframes wave-bar {
+  0%, 100% { transform: scaleY(0.3); }
+  50% { transform: scaleY(1); }
+}
+
+/*
+ * TODO: Transcript box styles (removed — revisit when transcript display is re-added).
+ *
+ * When re-implementing, the fixed-height box with gradient fade worked well visually:
+ *   .transcript-box        — position:relative; height:7rem; overflow:hidden
+ *   .transcript-box-inner  — overflow-y:auto; scrollbar-width:none
+ *   .transcript-box-gradient — absolute bottom gradient matching backdrop color
+ *
+ * The hard part is pacing text reveal to match audio. See the TODO comment in
+ * voice-overlay.component.html for approaches.
+ */
+
+/* === Status badge === */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.status-badge.connecting {
+  background: rgba(251, 191, 36, 0.15);
+  color: #b45309;
+}
+
+.status-badge.listening {
+  background: rgba(248, 113, 113, 0.15);
+  color: #dc2626;
+}
+
+.status-badge.speaking {
+  background: rgba(74, 222, 128, 0.15);
+  color: #16a34a;
+}
+
+:host-context(.dark) .status-badge.connecting {
+  color: #fbbf24;
+}
+
+:host-context(.dark) .status-badge.listening {
+  color: #f87171;
+}
+
+:host-context(.dark) .status-badge.speaking {
+  color: #4ade80;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: currentColor;
+  animation: dot-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* === Reduced motion === */
+@media (prefers-reduced-motion: reduce) {
+  :host { animation: none; opacity: 1; }
+  .voice-orb-core { animation: none !important; }
+  .voice-ripple { animation: none !important; opacity: 0; }
+  .voice-wave-bar { animation: none !important; transform: scaleY(0.6); }
+  .status-dot { animation: none !important; }
+}

--- a/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.html
+++ b/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.html
@@ -1,0 +1,116 @@
+<!-- Fullscreen voice conversation overlay -->
+<div
+  class="voice-overlay-backdrop"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Voice conversation"
+  cdkTrapFocus
+  [cdkTrapFocusAutoCapture]="true"
+>
+  <!-- Header -->
+  <header class="flex items-center justify-between px-6 py-4 shrink-0">
+    <div class="flex items-center gap-3">
+      <h2 class="text-gray-900 dark:text-white/90 text-base font-semibold tracking-wide">Voice Mode</h2>
+      @if (statusClass()) {
+        <span class="status-badge" [class]="statusClass()">
+          <span class="status-dot" aria-hidden="true"></span>
+          {{ statusLabel() }}
+        </span>
+      }
+    </div>
+    <button
+      type="button"
+      (click)="endSession()"
+      class="flex items-center justify-center size-10 rounded-full text-gray-400 dark:text-white/50 hover:text-gray-700 dark:hover:text-white hover:bg-gray-200 dark:hover:bg-white/10 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:focus-visible:outline-white"
+      aria-label="End voice session"
+    >
+      <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </header>
+
+  <!-- Center: Visualizer + Live Transcript -->
+  <div class="flex-1 flex flex-col items-center justify-center px-6 min-h-0">
+    <!-- Animated Orb -->
+    <div class="voice-orb">
+      <!-- Ripple rings (listening only) -->
+      @if (voiceStatus() === 'listening') {
+        <div class="voice-ripple"></div>
+        <div class="voice-ripple"></div>
+        <div class="voice-ripple"></div>
+      }
+
+      <!-- Core orb -->
+      <div class="voice-orb-core" [class]="statusClass()">
+        <!-- Wave bars inside orb (speaking only) -->
+        @if (voiceStatus() === 'speaking') {
+          <div class="flex items-center justify-center gap-1">
+            <span class="voice-wave-bar h-8" style="animation-delay: 0ms;" aria-hidden="true"></span>
+            <span class="voice-wave-bar h-10" style="animation-delay: 100ms;" aria-hidden="true"></span>
+            <span class="voice-wave-bar h-12" style="animation-delay: 200ms;" aria-hidden="true"></span>
+            <span class="voice-wave-bar h-10" style="animation-delay: 300ms;" aria-hidden="true"></span>
+            <span class="voice-wave-bar h-8" style="animation-delay: 400ms;" aria-hidden="true"></span>
+          </div>
+        }
+
+        <!-- Connecting spinner -->
+        @if (voiceStatus() === 'connecting') {
+          <svg class="size-8 text-gray-600 dark:text-white/80 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+          </svg>
+        }
+
+        <!-- Listening mic icon -->
+        @if (voiceStatus() === 'listening') {
+          <svg class="size-8 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" />
+          </svg>
+        }
+      </div>
+    </div>
+
+    <!-- Status label below the orb -->
+    @if (voiceStatus() === 'connecting') {
+      <p class="text-gray-400 dark:text-white/30 text-sm">Establishing connection...</p>
+    } @else if (voiceStatus() === 'listening') {
+      <p class="text-gray-400 dark:text-white/30 text-sm">Listening...</p>
+    }
+
+    <!--
+      TODO: Revisit live transcript display.
+
+      The service already buffers agent transcript text via a reveal timer
+      (see VoiceChatService._bufferedTranscript / _revealedIndex / agentTranscript).
+      The challenge is syncing revealed text to audio playback — transcript deltas
+      arrive from the WebSocket independently of audio chunks, so a simple timer
+      can't match the cadence of speech.
+
+      Possible approaches to explore:
+      1. Server-side: include a timestamp or word-offset in each bidi_transcript_stream
+         delta so the client can align text reveal to audio position.
+      2. Client-side: track AudioPlayerService queue depth / playback position and
+         use it to pace the reveal timer dynamically instead of a fixed chars/tick.
+      3. Hybrid: reveal text in sentence-level chunks (split on punctuation) timed
+         to audio chunk boundaries rather than character-by-character.
+    -->
+  </div>
+
+  <!-- Bottom: End Button -->
+  <div class="shrink-0 px-6 pb-8 pt-4">
+    <!-- End session button -->
+    <div class="flex justify-center">
+      <button
+        type="button"
+        (click)="endSession()"
+        class="inline-flex items-center gap-2 rounded-full bg-red-600/90 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-red-900/30 transition-all hover:bg-red-500 hover:shadow-red-900/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 active:scale-95"
+      >
+        <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 1 0 12.728 0M12 3v9" />
+        </svg>
+        End Voice Session
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.ts
+++ b/frontend/ai.client/src/app/session/components/voice-overlay/voice-overlay.component.ts
@@ -1,0 +1,48 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  output,
+  computed,
+} from '@angular/core';
+import { A11yModule } from '@angular/cdk/a11y';
+import { VoiceChatService } from '../../services/voice';
+
+@Component({
+  selector: 'app-voice-overlay',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [A11yModule],
+  templateUrl: './voice-overlay.component.html',
+  styleUrl: './voice-overlay.component.css',
+  host: {
+    '(keydown.escape)': 'endSession()',
+  },
+})
+export class VoiceOverlayComponent {
+  private readonly voiceChatService = inject(VoiceChatService);
+
+  /** Emitted when voice session ends (overlay should be removed by parent) */
+  closed = output<void>();
+
+  // Expose service signals to template
+  readonly voiceStatus = this.voiceChatService.status;
+
+  readonly statusLabel = computed(() => {
+    switch (this.voiceStatus()) {
+      case 'connecting': return 'Connecting';
+      case 'listening': return 'Listening';
+      case 'speaking': return 'Speaking';
+      default: return '';
+    }
+  });
+
+  readonly statusClass = computed(() => {
+    const status = this.voiceStatus();
+    return status === 'idle' ? '' : status;
+  });
+
+  endSession(): void {
+    this.voiceChatService.disconnect();
+    this.closed.emit();
+  }
+}

--- a/frontend/ai.client/src/app/session/services/models/content-types.ts
+++ b/frontend/ai.client/src/app/session/services/models/content-types.ts
@@ -236,12 +236,20 @@ export interface Metrics {
   timeToFirstByteMs?: number;
 }
 
+export interface CostBreakdown {
+  total: number;
+  inputCost: number;
+  outputCost: number;
+  cacheReadCost?: number;
+  cacheWriteCost?: number;
+}
+
 export interface MetadataEvent {
   metrics?: Metrics;
   trace?: any;
   usage?: Usage;
-  /** Total cost in USD for this message (calculated from token usage and model pricing) */
-  cost?: number;
+  /** Cost for this message — either a total number (legacy) or a breakdown object */
+  cost?: number | CostBreakdown;
 }
 
 export interface ExceptionEvent {

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -169,8 +169,13 @@ export class MessageMapService {
   /**
    * Add a voice transcript message (from VoiceChatService) to the session.
    * Used when the voice agent completes a response and the transcript is finalized.
+   *
+   * @param sessionId - The session ID to add the message to
+   * @param role - Message role (user or assistant)
+   * @param text - Message text content
+   * @param metadata - Optional metadata (token usage, cost) for badge display
    */
-  addVoiceMessage(sessionId: string, role: 'user' | 'assistant', text: string): Message {
+  addVoiceMessage(sessionId: string, role: 'user' | 'assistant', text: string, metadata?: Record<string, unknown>): Message {
     const currentMessages = this.messageMap()[sessionId]?.() ?? [];
     const messageIndex = currentMessages.length;
     const messageId = `msg-${sessionId}-${messageIndex}`;
@@ -179,6 +184,7 @@ export class MessageMapService {
       id: messageId,
       role,
       content: [{ type: 'text', text }],
+      ...(metadata ? { metadata } : {}),
     };
 
     this.messageMap.update(map => {

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -167,6 +167,34 @@ export class MessageMapService {
   }
 
   /**
+   * Add a voice transcript message (from VoiceChatService) to the session.
+   * Used when the voice agent completes a response and the transcript is finalized.
+   */
+  addVoiceMessage(sessionId: string, role: 'user' | 'assistant', text: string): Message {
+    const currentMessages = this.messageMap()[sessionId]?.() ?? [];
+    const messageIndex = currentMessages.length;
+    const messageId = `msg-${sessionId}-${messageIndex}`;
+
+    const message: Message = {
+      id: messageId,
+      role,
+      content: [{ type: 'text', text }],
+    };
+
+    this.messageMap.update(map => {
+      const updated = { ...map };
+      if (!updated[sessionId]) {
+        updated[sessionId] = signal([message]);
+      } else {
+        updated[sessionId].update(msgs => [...msgs, message]);
+      }
+      return updated;
+    });
+
+    return message;
+  }
+
+  /**
    * Sync streaming messages to the message map.
    * Handles the case where we're appending to existing messages.
    * Preserves all previous complete messages and only replaces the currently streaming assistant response.

--- a/frontend/ai.client/src/app/session/services/voice/audio-player.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/audio-player.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, signal } from '@angular/core';
+import { base64ToSamples } from './pcm-utils';
+
+/**
+ * Audio playback service for Nova Sonic voice responses.
+ *
+ * Plays base64-encoded PCM audio chunks in sequence with gapless
+ * scheduling. Supports interruption (clear all scheduled audio)
+ * and volume control.
+ */
+@Injectable({ providedIn: 'root' })
+export class AudioPlayerService {
+  private readonly _isPlaying = signal(false);
+  readonly isPlaying = this._isPlaying.asReadonly();
+
+  private audioContext: AudioContext | null = null;
+  private gainNode: GainNode | null = null;
+  private scheduledTime = 0;
+  private activeSources: AudioBufferSourceNode[] = [];
+
+  /**
+   * Play a base64-encoded PCM audio chunk.
+   * Chunks are scheduled sequentially for gapless playback.
+   */
+  play(base64Pcm: string, sampleRate: number = 16000): void {
+    if (!base64Pcm) return;
+
+    this.ensureContext(sampleRate);
+    if (!this.audioContext || !this.gainNode) return;
+
+    const samples = base64ToSamples(base64Pcm);
+    const buffer = this.audioContext.createBuffer(1, samples.length, sampleRate);
+    buffer.getChannelData(0).set(samples);
+
+    const source = this.audioContext.createBufferSource();
+    source.buffer = buffer;
+    source.connect(this.gainNode);
+
+    // Schedule at the end of the current queue (gapless)
+    const now = this.audioContext.currentTime;
+    const startTime = Math.max(now, this.scheduledTime);
+    source.start(startTime);
+    this.scheduledTime = startTime + buffer.duration;
+
+    // Track for interruption
+    this.activeSources.push(source);
+    source.onended = () => {
+      const idx = this.activeSources.indexOf(source);
+      if (idx >= 0) this.activeSources.splice(idx, 1);
+      this._isPlaying.set(this.activeSources.length > 0);
+    };
+
+    this._isPlaying.set(true);
+  }
+
+  /**
+   * Stop all scheduled and playing audio immediately.
+   * Used when the user interrupts the agent.
+   */
+  clear(): void {
+    for (const source of this.activeSources) {
+      try {
+        source.stop();
+      } catch {
+        // Already stopped
+      }
+    }
+    this.activeSources = [];
+    this.scheduledTime = 0;
+    this._isPlaying.set(false);
+  }
+
+  /** Set playback volume (0.0 to 1.0). */
+  setVolume(volume: number): void {
+    if (this.gainNode) {
+      this.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+    }
+  }
+
+  /** Release audio resources. */
+  dispose(): void {
+    this.clear();
+    if (this.audioContext?.state !== 'closed') {
+      this.audioContext?.close().catch(() => {});
+    }
+    this.audioContext = null;
+    this.gainNode = null;
+  }
+
+  private ensureContext(sampleRate: number): void {
+    if (this.audioContext) return;
+
+    const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+    this.audioContext = new AudioContextClass({ sampleRate });
+    this.gainNode = this.audioContext.createGain();
+    this.gainNode.connect(this.audioContext.destination);
+    this.scheduledTime = 0;
+  }
+}

--- a/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
@@ -36,10 +36,9 @@ export class AudioRecorderService {
 
   private checkSupport(): boolean {
     if (typeof window === 'undefined') return false;
-    return !!(
-      navigator.mediaDevices?.getUserMedia &&
-      (window.AudioContext || (window as any).webkitAudioContext)
-    );
+    const hasGetUserMedia = typeof navigator.mediaDevices?.getUserMedia === 'function';
+    const hasAudioContext = !!(window.AudioContext || (window as any).webkitAudioContext);
+    return hasGetUserMedia && hasAudioContext;
   }
 
   /**

--- a/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
@@ -1,7 +1,6 @@
-import { Injectable, signal, computed } from '@angular/core';
-import { float32ToPcm16, pcm16ToBase64, resampleLinear, SAMPLES_PER_CHUNK } from './pcm-utils';
-
-const TARGET_SAMPLE_RATE = 16000;
+import { Injectable, signal } from '@angular/core';
+import { float32ToPcm16, pcm16ToBase64, resampleLinear } from './pcm-utils';
+import { VOICE_SAMPLE_RATE, SAMPLES_PER_CHUNK } from './voice.config';
 
 /**
  * Audio capture service using Web Audio API.
@@ -9,9 +8,8 @@ const TARGET_SAMPLE_RATE = 16000;
  * Captures microphone input, resamples to 16kHz mono PCM, and emits
  * base64-encoded chunks at ~100ms intervals for Nova Sonic streaming.
  *
- * Uses ScriptProcessorNode (widely supported) with a buffer of 4096 samples.
- * AudioWorklet would be preferred for production but requires serving a
- * separate JS file — ScriptProcessorNode works without extra build config.
+ * Uses AudioWorkletNode for off-main-thread audio processing.
+ * The worklet processor is served from /audio/pcm-capture.worklet.js.
  */
 @Injectable({ providedIn: 'root' })
 export class AudioRecorderService {
@@ -24,7 +22,7 @@ export class AudioRecorderService {
   private audioContext: AudioContext | null = null;
   private mediaStream: MediaStream | null = null;
   private sourceNode: MediaStreamAudioSourceNode | null = null;
-  private processorNode: ScriptProcessorNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
   private sampleBuffer: Float32Array = new Float32Array(0);
 
   /** Callback invoked with each base64 PCM chunk */
@@ -54,7 +52,7 @@ export class AudioRecorderService {
     try {
       this.mediaStream = await navigator.mediaDevices.getUserMedia({
         audio: {
-          sampleRate: { ideal: TARGET_SAMPLE_RATE },
+          sampleRate: { ideal: VOICE_SAMPLE_RATE },
           channelCount: { exact: 1 },
           echoCancellation: true,
           noiseSuppression: true,
@@ -63,21 +61,21 @@ export class AudioRecorderService {
       });
 
       const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
-      this.audioContext = new AudioContextClass({ sampleRate: TARGET_SAMPLE_RATE });
+      this.audioContext = new AudioContextClass({ sampleRate: VOICE_SAMPLE_RATE });
+
+      await this.audioContext.audioWorklet.addModule('/audio/pcm-capture.worklet.js');
 
       this.sourceNode = this.audioContext.createMediaStreamSource(this.mediaStream);
 
-      // ScriptProcessorNode: 4096 buffer, 1 input channel, 1 output channel
-      this.processorNode = this.audioContext.createScriptProcessor(4096, 1, 1);
+      this.workletNode = new AudioWorkletNode(this.audioContext, 'pcm-capture');
       this.sampleBuffer = new Float32Array(0);
 
-      this.processorNode.onaudioprocess = (event: AudioProcessingEvent) => {
-        const inputData = event.inputBuffer.getChannelData(0);
-        this.processAudioChunk(inputData);
+      this.workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
+        this.processAudioChunk(event.data);
       };
 
-      this.sourceNode.connect(this.processorNode);
-      this.processorNode.connect(this.audioContext.destination);
+      this.sourceNode.connect(this.workletNode);
+      this.workletNode.connect(this.audioContext.destination);
 
       this._isRecording.set(true);
     } catch (err) {
@@ -97,8 +95,8 @@ export class AudioRecorderService {
   private processAudioChunk(inputSamples: Float32Array): void {
     // Resample if browser's actual rate differs from target
     let samples = inputSamples;
-    if (this.audioContext && this.audioContext.sampleRate !== TARGET_SAMPLE_RATE) {
-      samples = resampleLinear(inputSamples, this.audioContext.sampleRate, TARGET_SAMPLE_RATE);
+    if (this.audioContext && this.audioContext.sampleRate !== VOICE_SAMPLE_RATE) {
+      samples = resampleLinear(inputSamples, this.audioContext.sampleRate, VOICE_SAMPLE_RATE);
     }
 
     // Append to buffer
@@ -114,7 +112,7 @@ export class AudioRecorderService {
 
       const pcm = float32ToPcm16(chunk);
       const base64 = pcm16ToBase64(pcm);
-      this.onAudioChunk?.(base64, TARGET_SAMPLE_RATE);
+      this.onAudioChunk?.(base64, VOICE_SAMPLE_RATE);
     }
   }
 
@@ -123,19 +121,19 @@ export class AudioRecorderService {
     if (this.sampleBuffer.length > 0) {
       const pcm = float32ToPcm16(this.sampleBuffer);
       const base64 = pcm16ToBase64(pcm);
-      this.onAudioChunk?.(base64, TARGET_SAMPLE_RATE);
+      this.onAudioChunk?.(base64, VOICE_SAMPLE_RATE);
       this.sampleBuffer = new Float32Array(0);
     }
   }
 
   private cleanup(): void {
-    this.processorNode?.disconnect();
+    this.workletNode?.disconnect();
     this.sourceNode?.disconnect();
     this.mediaStream?.getTracks().forEach(t => t.stop());
     if (this.audioContext?.state !== 'closed') {
       this.audioContext?.close().catch(() => {});
     }
-    this.processorNode = null;
+    this.workletNode = null;
     this.sourceNode = null;
     this.mediaStream = null;
     this.audioContext = null;

--- a/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/audio-recorder.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, signal, computed } from '@angular/core';
+import { float32ToPcm16, pcm16ToBase64, resampleLinear, SAMPLES_PER_CHUNK } from './pcm-utils';
+
+const TARGET_SAMPLE_RATE = 16000;
+
+/**
+ * Audio capture service using Web Audio API.
+ *
+ * Captures microphone input, resamples to 16kHz mono PCM, and emits
+ * base64-encoded chunks at ~100ms intervals for Nova Sonic streaming.
+ *
+ * Uses ScriptProcessorNode (widely supported) with a buffer of 4096 samples.
+ * AudioWorklet would be preferred for production but requires serving a
+ * separate JS file — ScriptProcessorNode works without extra build config.
+ */
+@Injectable({ providedIn: 'root' })
+export class AudioRecorderService {
+  private readonly _isRecording = signal(false);
+  private readonly _isSupported = signal(false);
+
+  readonly isRecording = this._isRecording.asReadonly();
+  readonly isSupported = this._isSupported.asReadonly();
+
+  private audioContext: AudioContext | null = null;
+  private mediaStream: MediaStream | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private processorNode: ScriptProcessorNode | null = null;
+  private sampleBuffer: Float32Array = new Float32Array(0);
+
+  /** Callback invoked with each base64 PCM chunk */
+  onAudioChunk: ((base64Pcm: string, sampleRate: number) => void) | null = null;
+
+  constructor() {
+    this._isSupported.set(this.checkSupport());
+  }
+
+  private checkSupport(): boolean {
+    if (typeof window === 'undefined') return false;
+    return !!(
+      navigator.mediaDevices?.getUserMedia &&
+      (window.AudioContext || (window as any).webkitAudioContext)
+    );
+  }
+
+  /**
+   * Start capturing audio from the microphone.
+   * Requests microphone permission if not already granted.
+   */
+  async start(): Promise<void> {
+    if (this._isRecording()) return;
+    if (!this._isSupported()) {
+      throw new Error('Audio recording not supported in this browser');
+    }
+
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          sampleRate: { ideal: TARGET_SAMPLE_RATE },
+          channelCount: { exact: 1 },
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+
+      const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+      this.audioContext = new AudioContextClass({ sampleRate: TARGET_SAMPLE_RATE });
+
+      this.sourceNode = this.audioContext.createMediaStreamSource(this.mediaStream);
+
+      // ScriptProcessorNode: 4096 buffer, 1 input channel, 1 output channel
+      this.processorNode = this.audioContext.createScriptProcessor(4096, 1, 1);
+      this.sampleBuffer = new Float32Array(0);
+
+      this.processorNode.onaudioprocess = (event: AudioProcessingEvent) => {
+        const inputData = event.inputBuffer.getChannelData(0);
+        this.processAudioChunk(inputData);
+      };
+
+      this.sourceNode.connect(this.processorNode);
+      this.processorNode.connect(this.audioContext.destination);
+
+      this._isRecording.set(true);
+    } catch (err) {
+      this.cleanup();
+      throw err;
+    }
+  }
+
+  /** Stop capturing and release resources. */
+  async stop(): Promise<void> {
+    if (!this._isRecording()) return;
+    this.flushBuffer();
+    this.cleanup();
+    this._isRecording.set(false);
+  }
+
+  private processAudioChunk(inputSamples: Float32Array): void {
+    // Resample if browser's actual rate differs from target
+    let samples = inputSamples;
+    if (this.audioContext && this.audioContext.sampleRate !== TARGET_SAMPLE_RATE) {
+      samples = resampleLinear(inputSamples, this.audioContext.sampleRate, TARGET_SAMPLE_RATE);
+    }
+
+    // Append to buffer
+    const newBuffer = new Float32Array(this.sampleBuffer.length + samples.length);
+    newBuffer.set(this.sampleBuffer);
+    newBuffer.set(samples, this.sampleBuffer.length);
+    this.sampleBuffer = newBuffer;
+
+    // Emit complete chunks
+    while (this.sampleBuffer.length >= SAMPLES_PER_CHUNK) {
+      const chunk = this.sampleBuffer.slice(0, SAMPLES_PER_CHUNK);
+      this.sampleBuffer = this.sampleBuffer.slice(SAMPLES_PER_CHUNK);
+
+      const pcm = float32ToPcm16(chunk);
+      const base64 = pcm16ToBase64(pcm);
+      this.onAudioChunk?.(base64, TARGET_SAMPLE_RATE);
+    }
+  }
+
+  /** Flush any remaining samples in the buffer as a final chunk. */
+  private flushBuffer(): void {
+    if (this.sampleBuffer.length > 0) {
+      const pcm = float32ToPcm16(this.sampleBuffer);
+      const base64 = pcm16ToBase64(pcm);
+      this.onAudioChunk?.(base64, TARGET_SAMPLE_RATE);
+      this.sampleBuffer = new Float32Array(0);
+    }
+  }
+
+  private cleanup(): void {
+    this.processorNode?.disconnect();
+    this.sourceNode?.disconnect();
+    this.mediaStream?.getTracks().forEach(t => t.stop());
+    if (this.audioContext?.state !== 'closed') {
+      this.audioContext?.close().catch(() => {});
+    }
+    this.processorNode = null;
+    this.sourceNode = null;
+    this.mediaStream = null;
+    this.audioContext = null;
+    this.sampleBuffer = new Float32Array(0);
+  }
+}

--- a/frontend/ai.client/src/app/session/services/voice/index.ts
+++ b/frontend/ai.client/src/app/session/services/voice/index.ts
@@ -1,4 +1,5 @@
 export { AudioRecorderService } from './audio-recorder.service';
 export { AudioPlayerService } from './audio-player.service';
-export { VoiceChatService, type VoiceStatus } from './voice-chat.service';
+export { VoiceChatService, type VoiceStatus, type VoiceTranscriptEntry } from './voice-chat.service';
 export * from './pcm-utils';
+export * from './voice.config';

--- a/frontend/ai.client/src/app/session/services/voice/index.ts
+++ b/frontend/ai.client/src/app/session/services/voice/index.ts
@@ -1,0 +1,4 @@
+export { AudioRecorderService } from './audio-recorder.service';
+export { AudioPlayerService } from './audio-player.service';
+export { VoiceChatService, type VoiceStatus } from './voice-chat.service';
+export * from './pcm-utils';

--- a/frontend/ai.client/src/app/session/services/voice/index.ts
+++ b/frontend/ai.client/src/app/session/services/voice/index.ts
@@ -1,5 +1,5 @@
 export { AudioRecorderService } from './audio-recorder.service';
 export { AudioPlayerService } from './audio-player.service';
-export { VoiceChatService, type VoiceStatus, type VoiceTranscriptEntry } from './voice-chat.service';
+export { VoiceChatService, type VoiceStatus, type VoiceTranscriptEntry, type VoiceTokenUsage } from './voice-chat.service';
 export * from './pcm-utils';
 export * from './voice.config';

--- a/frontend/ai.client/src/app/session/services/voice/pcm-utils.ts
+++ b/frontend/ai.client/src/app/session/services/voice/pcm-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * PCM audio encoding/decoding utilities for Nova Sonic voice streaming.
+ *
+ * All functions are pure — no state, no services, no side effects.
+ * Transport format: 16-bit PCM encoded as base64 over JSON WebSocket.
+ */
+
+const TARGET_SAMPLE_RATE = 16000;
+const CHUNK_DURATION_MS = 100;
+/** Number of samples per chunk at 16kHz * 100ms */
+export const SAMPLES_PER_CHUNK = (TARGET_SAMPLE_RATE * CHUNK_DURATION_MS) / 1000; // 1600
+
+/**
+ * Convert Float32 audio samples (-1.0 to 1.0) to 16-bit PCM Int16Array.
+ * Clamps values to prevent distortion.
+ */
+export function float32ToPcm16(samples: Float32Array): Int16Array {
+  const pcm = new Int16Array(samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, samples[i]));
+    pcm[i] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7FFF;
+  }
+  return pcm;
+}
+
+/**
+ * Convert 16-bit PCM Int16Array to Float32 audio samples (-1.0 to 1.0).
+ */
+export function pcm16ToFloat32(pcm: Int16Array): Float32Array {
+  const float = new Float32Array(pcm.length);
+  for (let i = 0; i < pcm.length; i++) {
+    float[i] = pcm[i] / (pcm[i] < 0 ? 0x8000 : 0x7FFF);
+  }
+  return float;
+}
+
+/**
+ * Encode 16-bit PCM as base64 string for WebSocket transmission.
+ */
+export function pcm16ToBase64(pcm: Int16Array): string {
+  const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode base64 string to 16-bit PCM Int16Array.
+ */
+export function base64ToPcm16(b64: string): Int16Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Int16Array(bytes.buffer);
+}
+
+/**
+ * Linear interpolation resampling.
+ * Used when browser's native sample rate differs from target (16kHz).
+ */
+export function resampleLinear(
+  samples: Float32Array,
+  fromRate: number,
+  toRate: number
+): Float32Array {
+  if (fromRate === toRate) return samples;
+
+  const ratio = fromRate / toRate;
+  const outputLength = Math.round(samples.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const srcFloor = Math.floor(srcIndex);
+    const srcCeil = Math.min(srcFloor + 1, samples.length - 1);
+    const frac = srcIndex - srcFloor;
+    output[i] = samples[srcFloor] * (1 - frac) + samples[srcCeil] * frac;
+  }
+
+  return output;
+}
+
+/**
+ * Convenience: Float32 samples → base64 PCM string (for sending to server).
+ */
+export function samplesToBase64(samples: Float32Array): string {
+  return pcm16ToBase64(float32ToPcm16(samples));
+}
+
+/**
+ * Convenience: base64 PCM string → Float32 samples (for playback).
+ */
+export function base64ToSamples(b64: string): Float32Array {
+  return pcm16ToFloat32(base64ToPcm16(b64));
+}

--- a/frontend/ai.client/src/app/session/services/voice/pcm-utils.ts
+++ b/frontend/ai.client/src/app/session/services/voice/pcm-utils.ts
@@ -5,10 +5,7 @@
  * Transport format: 16-bit PCM encoded as base64 over JSON WebSocket.
  */
 
-const TARGET_SAMPLE_RATE = 16000;
-const CHUNK_DURATION_MS = 100;
-/** Number of samples per chunk at 16kHz * 100ms */
-export const SAMPLES_PER_CHUNK = (TARGET_SAMPLE_RATE * CHUNK_DURATION_MS) / 1000; // 1600
+export { SAMPLES_PER_CHUNK, VOICE_SAMPLE_RATE } from './voice.config';
 
 /**
  * Convert Float32 audio samples (-1.0 to 1.0) to 16-bit PCM Int16Array.

--- a/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
@@ -1,0 +1,279 @@
+import { Injectable, signal, computed, inject, OnDestroy } from '@angular/core';
+import { AuthService } from '../../../auth/auth.service';
+import { ConfigService } from '../../../services/config.service';
+import { AudioRecorderService } from './audio-recorder.service';
+import { AudioPlayerService } from './audio-player.service';
+
+export type VoiceStatus = 'idle' | 'connecting' | 'listening' | 'speaking';
+
+/** Idle timeout — auto-disconnect after 60s of silence */
+const IDLE_TIMEOUT_MS = 60_000;
+
+/**
+ * Voice chat orchestration service.
+ *
+ * Coordinates WebSocket connection to /voice/stream, audio recording,
+ * audio playback, and state management for the voice UI.
+ *
+ * Lifecycle:
+ *   1. connect(sessionId) → opens WebSocket, sends config, starts mic
+ *   2. Audio chunks sent as bidi_audio_input
+ *   3. Server events received: bidi_audio_stream → playback,
+ *      bidi_transcript_stream → transcript signal
+ *   4. disconnect() → stops mic, closes WebSocket, clears audio
+ */
+@Injectable({ providedIn: 'root' })
+export class VoiceChatService implements OnDestroy {
+  private readonly authService = inject(AuthService);
+  private readonly configService = inject(ConfigService);
+  private readonly recorder = inject(AudioRecorderService);
+  private readonly player = inject(AudioPlayerService);
+
+  // --- State signals ---
+  private readonly _status = signal<VoiceStatus>('idle');
+  private readonly _currentTranscript = signal('');
+  private readonly _isConnected = signal(false);
+  private readonly _lastTranscriptRole = signal<'user' | 'assistant'>('assistant');
+
+  readonly status = this._status.asReadonly();
+  readonly currentTranscript = this._currentTranscript.asReadonly();
+  readonly lastTranscriptRole = this._lastTranscriptRole.asReadonly();
+  readonly isConnected = this._isConnected.asReadonly();
+  readonly isVoiceActive = computed(() => this._status() !== 'idle');
+
+  /** Emitted when a complete assistant response is finalized */
+  onResponseComplete: ((transcript: string) => void) | null = null;
+
+  // --- Internals ---
+  private ws: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Connect to the voice endpoint and start recording.
+   */
+  async connect(sessionId: string): Promise<void> {
+    if (this._isConnected()) return;
+
+    this.sessionId = sessionId;
+    this._status.set('connecting');
+    this._currentTranscript.set('');
+
+    try {
+      const token = this.authService.getAccessToken();
+      if (!token) {
+        throw new Error('No authentication token available');
+      }
+
+      // Build WebSocket URL from inference API URL
+      const httpUrl = this.configService.inferenceApiUrl();
+      const wsUrl = httpUrl.replace(/^http/, 'ws');
+      const url = `${wsUrl}/voice/stream?session_id=${encodeURIComponent(sessionId)}&token=${encodeURIComponent(token)}`;
+
+      await this.openWebSocket(url, token);
+      await this.recorder.start();
+
+      // Wire audio chunks to WebSocket
+      this.recorder.onAudioChunk = (base64, sampleRate) => {
+        this.sendMessage({
+          type: 'bidi_audio_input',
+          audio: base64,
+          sample_rate: sampleRate,
+        });
+      };
+
+      this._status.set('listening');
+      this._isConnected.set(true);
+      this.resetIdleTimer();
+    } catch (err) {
+      this.cleanupAll();
+      this._status.set('idle');
+      throw err;
+    }
+  }
+
+  /** Disconnect from voice session and release all resources. */
+  async disconnect(): Promise<void> {
+    if (!this._isConnected()) return;
+    this.sendMessage({ type: 'stop' });
+    this.cleanupAll();
+    this._status.set('idle');
+    this._isConnected.set(false);
+  }
+
+  /** Send a text message (fallback when mic not available). */
+  sendText(text: string): void {
+    if (!this._isConnected()) return;
+    this.sendMessage({ type: 'bidi_text_input', text });
+    this.resetIdleTimer();
+  }
+
+  ngOnDestroy(): void {
+    this.cleanupAll();
+  }
+
+  // --- WebSocket ---
+
+  private openWebSocket(url: string, token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(url);
+
+      const timeout = setTimeout(() => {
+        reject(new Error('WebSocket connection timeout'));
+        this.ws?.close();
+      }, 10_000);
+
+      this.ws.onopen = () => {
+        clearTimeout(timeout);
+        // Send config message as first frame
+        this.sendMessage({
+          type: 'config',
+          session_id: this.sessionId,
+          auth_token: token,
+        });
+        resolve();
+      };
+
+      this.ws.onmessage = (event: MessageEvent) => {
+        this.handleServerMessage(event);
+      };
+
+      this.ws.onerror = () => {
+        clearTimeout(timeout);
+        reject(new Error('WebSocket connection failed'));
+      };
+
+      this.ws.onclose = () => {
+        if (this._isConnected()) {
+          // Unexpected close — clean up
+          this.cleanupAll();
+          this._status.set('idle');
+          this._isConnected.set(false);
+        }
+      };
+    });
+  }
+
+  private sendMessage(msg: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  private handleServerMessage(event: MessageEvent): void {
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(event.data as string);
+    } catch {
+      return;
+    }
+
+    const type = data['type'] as string;
+
+    switch (type) {
+      case 'bidi_connection_start':
+        // Connection confirmed
+        break;
+
+      case 'bidi_audio_stream':
+        // Play audio from agent
+        this._status.set('speaking');
+        if (data['audio']) {
+          this.player.play(
+            data['audio'] as string,
+            (data['sample_rate'] as number) || 16000
+          );
+        }
+        this.resetIdleTimer();
+        break;
+
+      case 'bidi_transcript_stream':
+        // Accumulate transcript text
+        if (data['role']) {
+          this._lastTranscriptRole.set(data['role'] as 'user' | 'assistant');
+        }
+        if (data['delta']) {
+          this._currentTranscript.update(t => t + (data['delta'] as string));
+        } else if (data['current_transcript']) {
+          this._currentTranscript.set(data['current_transcript'] as string);
+        }
+        this.resetIdleTimer();
+        break;
+
+      case 'bidi_response_start':
+        this._status.set('speaking');
+        this._currentTranscript.set('');
+        break;
+
+      case 'bidi_response_complete':
+        // Agent finished speaking
+        this._status.set('listening');
+        const transcript = this._currentTranscript();
+        if (transcript) {
+          this.onResponseComplete?.(transcript);
+        }
+        this._currentTranscript.set('');
+        break;
+
+      case 'bidi_interruption':
+        // User interrupted — stop playback
+        this.player.clear();
+        this._status.set('listening');
+        break;
+
+      case 'bidi_usage':
+        // Token usage stats — could emit for metadata display
+        break;
+
+      case 'bidi_error':
+        console.error('Voice error:', data['message']);
+        break;
+
+      case 'bidi_connection_close':
+        this.cleanupAll();
+        this._status.set('idle');
+        this._isConnected.set(false);
+        break;
+
+      case 'pong':
+        // Keepalive response
+        break;
+    }
+  }
+
+  // --- Idle timeout ---
+
+  private resetIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+    }
+    this.idleTimer = setTimeout(() => {
+      if (this._isConnected()) {
+        console.info('Voice idle timeout — disconnecting');
+        this.disconnect();
+      }
+    }, IDLE_TIMEOUT_MS);
+  }
+
+  // --- Cleanup ---
+
+  private cleanupAll(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+
+    this.recorder.onAudioChunk = null;
+    this.recorder.stop().catch(() => {});
+    this.player.clear();
+
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        // Already closed
+      }
+      this.ws = null;
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
@@ -1,13 +1,26 @@
 import { Injectable, signal, computed, inject, OnDestroy } from '@angular/core';
+import { v4 as uuidv4 } from 'uuid';
 import { AuthService } from '../../../auth/auth.service';
 import { ConfigService } from '../../../services/config.service';
 import { AudioRecorderService } from './audio-recorder.service';
 import { AudioPlayerService } from './audio-player.service';
+import {
+  IDLE_TIMEOUT_MS,
+  WS_CONNECT_TIMEOUT_MS,
+  MAX_TRANSCRIPT_ENTRIES,
+  WS_CLOSE_REASONS,
+  REVEAL_CHARS_PER_TICK,
+  REVEAL_TICK_MS,
+  REVEAL_FLUSH_CHARS_PER_TICK,
+} from './voice.config';
 
 export type VoiceStatus = 'idle' | 'connecting' | 'listening' | 'speaking';
 
-/** Idle timeout — auto-disconnect after 60s of silence */
-const IDLE_TIMEOUT_MS = 60_000;
+export interface VoiceTranscriptEntry {
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp: number;
+}
 
 /**
  * Voice chat orchestration service.
@@ -31,18 +44,42 @@ export class VoiceChatService implements OnDestroy {
 
   // --- State signals ---
   private readonly _status = signal<VoiceStatus>('idle');
-  private readonly _currentTranscript = signal('');
   private readonly _isConnected = signal(false);
-  private readonly _lastTranscriptRole = signal<'user' | 'assistant'>('assistant');
+  private readonly _transcriptEntries = signal<VoiceTranscriptEntry[]>([]);
+
+  /**
+   * Buffered reveal transcript system.
+   *
+   * _bufferedTranscript: raw text from WebSocket — grows instantly as deltas arrive.
+   * _revealedIndex: how many characters the UI is allowed to see.
+   * agentTranscript: computed slice — what the template actually renders.
+   *
+   * A reveal timer advances _revealedIndex at speaking pace, creating a
+   * typewriter effect that stays roughly in sync with the audio.
+   */
+  private readonly _bufferedTranscript = signal('');
+  private readonly _revealedIndex = signal(0);
+  private _revealCharsPerTick = REVEAL_CHARS_PER_TICK;
+  private _revealTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Per-turn tracking for transcript entries.
+   *
+   * _currentTurnStart: index into _bufferedTranscript where the current
+   *   assistant turn began, so we can extract just this turn's text.
+   * _userTranscript: accumulates user speech text between assistant turns,
+   *   saved to transcriptEntries when the assistant starts responding.
+   */
+  private _currentTurnStart = 0;
+  private _userTranscript = '';
 
   readonly status = this._status.asReadonly();
-  readonly currentTranscript = this._currentTranscript.asReadonly();
-  readonly lastTranscriptRole = this._lastTranscriptRole.asReadonly();
+  readonly agentTranscript = computed(() =>
+    this._bufferedTranscript().slice(0, this._revealedIndex())
+  );
   readonly isConnected = this._isConnected.asReadonly();
   readonly isVoiceActive = computed(() => this._status() !== 'idle');
-
-  /** Emitted when a complete assistant response is finalized */
-  onResponseComplete: ((transcript: string) => void) | null = null;
+  readonly transcriptEntries = this._transcriptEntries.asReadonly();
 
   // --- Internals ---
   private ws: WebSocket | null = null;
@@ -51,13 +88,19 @@ export class VoiceChatService implements OnDestroy {
 
   /**
    * Connect to the voice endpoint and start recording.
+   * If no sessionId is provided, one is auto-generated.
    */
-  async connect(sessionId: string): Promise<void> {
+  async connect(sessionId?: string): Promise<void> {
     if (this._isConnected()) return;
 
-    this.sessionId = sessionId;
+    this.sessionId = sessionId || uuidv4();
     this._status.set('connecting');
-    this._currentTranscript.set('');
+    this._bufferedTranscript.set('');
+    this._revealedIndex.set(0);
+    this._currentTurnStart = 0;
+    this._userTranscript = '';
+    this.stopRevealTimer();
+    this._transcriptEntries.set([]);
 
     try {
       const token = this.authService.getAccessToken();
@@ -68,7 +111,7 @@ export class VoiceChatService implements OnDestroy {
       // Build WebSocket URL from inference API URL
       const httpUrl = this.configService.inferenceApiUrl();
       const wsUrl = httpUrl.replace(/^http/, 'ws');
-      const url = `${wsUrl}/voice/stream?session_id=${encodeURIComponent(sessionId)}&token=${encodeURIComponent(token)}`;
+      const url = `${wsUrl}/voice/stream?session_id=${encodeURIComponent(this.sessionId!)}&token=${encodeURIComponent(token)}`;
 
       await this.openWebSocket(url, token);
       await this.recorder.start();
@@ -101,6 +144,11 @@ export class VoiceChatService implements OnDestroy {
     this._isConnected.set(false);
   }
 
+  /** Get the current voice session ID (auto-generated or passed to connect). */
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
   /** Send a text message (fallback when mic not available). */
   sendText(text: string): void {
     if (!this._isConnected()) return;
@@ -121,7 +169,7 @@ export class VoiceChatService implements OnDestroy {
       const timeout = setTimeout(() => {
         reject(new Error('WebSocket connection timeout'));
         this.ws?.close();
-      }, 10_000);
+      }, WS_CONNECT_TIMEOUT_MS);
 
       this.ws.onopen = () => {
         clearTimeout(timeout);
@@ -143,9 +191,11 @@ export class VoiceChatService implements OnDestroy {
         reject(new Error('WebSocket connection failed'));
       };
 
-      this.ws.onclose = () => {
+      this.ws.onclose = (event: CloseEvent) => {
         if (this._isConnected()) {
-          // Unexpected close — clean up
+          // Unexpected close — log reason and clean up
+          const reason = WS_CLOSE_REASONS[event.code] || `Disconnected (code ${event.code})`;
+          console.warn(`Voice WebSocket closed: ${reason}`);
           this.cleanupAll();
           this._status.set('idle');
           this._isConnected.set(false);
@@ -187,33 +237,71 @@ export class VoiceChatService implements OnDestroy {
         this.resetIdleTimer();
         break;
 
-      case 'bidi_transcript_stream':
-        // Accumulate transcript text
-        if (data['role']) {
-          this._lastTranscriptRole.set(data['role'] as 'user' | 'assistant');
-        }
+      case 'bidi_transcript_stream': {
+        const role = data['role'] as string | undefined;
+
+        let deltaText = '';
         if (data['delta']) {
-          this._currentTranscript.update(t => t + (data['delta'] as string));
+          const delta = data['delta'];
+          deltaText = typeof delta === 'object' && delta !== null
+            ? (delta as Record<string, unknown>)['text'] as string
+            : delta as string;
         } else if (data['current_transcript']) {
-          this._currentTranscript.set(data['current_transcript'] as string);
+          deltaText = data['current_transcript'] as string;
         }
+
+        if (deltaText) {
+          if (role === 'assistant') {
+            // Buffer for reveal-based display
+            this._bufferedTranscript.update(t => t + deltaText);
+          } else {
+            // Accumulate user speech for transcript entries
+            this._userTranscript += deltaText;
+          }
+        }
+
         this.resetIdleTimer();
         break;
+      }
 
       case 'bidi_response_start':
+        // Save accumulated user speech as a transcript entry
+        if (this._userTranscript.trim()) {
+          this.appendTranscriptEntry({
+            role: 'user',
+            text: this._userTranscript.trim(),
+            timestamp: Date.now(),
+          });
+          this._userTranscript = '';
+        }
+
+        // New assistant turn — add separator if there's prior text, start reveal
+        if (this._bufferedTranscript()) {
+          this._bufferedTranscript.update(t => t + '\n\n');
+          this._revealedIndex.set(this._bufferedTranscript().length);
+        }
+        this._currentTurnStart = this._bufferedTranscript().length;
+        this._revealCharsPerTick = REVEAL_CHARS_PER_TICK;
+        this.startRevealTimer();
         this._status.set('speaking');
-        this._currentTranscript.set('');
         break;
 
-      case 'bidi_response_complete':
-        // Agent finished speaking
-        this._status.set('listening');
-        const transcript = this._currentTranscript();
-        if (transcript) {
-          this.onResponseComplete?.(transcript);
+      case 'bidi_response_complete': {
+        // Extract only this turn's assistant text for the transcript entry
+        const turnText = this._bufferedTranscript().slice(this._currentTurnStart).trim();
+        if (turnText) {
+          this.appendTranscriptEntry({
+            role: 'assistant',
+            text: turnText,
+            timestamp: Date.now(),
+          });
         }
-        this._currentTranscript.set('');
+
+        // Speed up reveal to flush remaining buffered text
+        this._revealCharsPerTick = REVEAL_FLUSH_CHARS_PER_TICK;
+        this._status.set('listening');
         break;
+      }
 
       case 'bidi_interruption':
         // User interrupted — stop playback
@@ -241,6 +329,56 @@ export class VoiceChatService implements OnDestroy {
     }
   }
 
+  // --- Transcript reveal ---
+
+  private startRevealTimer(): void {
+    if (this._revealTimer) return; // already running
+    this._revealTimer = setInterval(() => {
+      const bufferedLen = this._bufferedTranscript().length;
+      const current = this._revealedIndex();
+      if (current >= bufferedLen) {
+        // Caught up — if not speaking anymore, stop the timer
+        if (this._status() !== 'speaking') {
+          this.stopRevealTimer();
+        }
+        return;
+      }
+      // Advance by configured chars per tick, snapping to word boundaries
+      const target = Math.min(current + this._revealCharsPerTick, bufferedLen);
+      // Find the next space or end-of-buffer to avoid splitting mid-word
+      const buf = this._bufferedTranscript();
+      let end = target;
+      if (end < bufferedLen && buf[end] !== ' ' && buf[end] !== '\n') {
+        const nextSpace = buf.indexOf(' ', end);
+        const nextNewline = buf.indexOf('\n', end);
+        const nearest = nextSpace === -1 ? nextNewline
+          : nextNewline === -1 ? nextSpace
+          : Math.min(nextSpace, nextNewline);
+        end = nearest === -1 ? bufferedLen : nearest + 1;
+      }
+      this._revealedIndex.set(end);
+    }, REVEAL_TICK_MS);
+  }
+
+  private stopRevealTimer(): void {
+    if (this._revealTimer) {
+      clearInterval(this._revealTimer);
+      this._revealTimer = null;
+    }
+  }
+
+  // --- Transcript management ---
+
+  /** Append an entry, evicting the oldest if at capacity. */
+  private appendTranscriptEntry(entry: VoiceTranscriptEntry): void {
+    this._transcriptEntries.update(entries => {
+      const updated = [...entries, entry];
+      return updated.length > MAX_TRANSCRIPT_ENTRIES
+        ? updated.slice(updated.length - MAX_TRANSCRIPT_ENTRIES)
+        : updated;
+    });
+  }
+
   // --- Idle timeout ---
 
   private resetIdleTimer(): void {
@@ -258,6 +396,8 @@ export class VoiceChatService implements OnDestroy {
   // --- Cleanup ---
 
   private cleanupAll(): void {
+    this.stopRevealTimer();
+
     if (this.idleTimer) {
       clearTimeout(this.idleTimer);
       this.idleTimer = null;

--- a/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
@@ -4,6 +4,7 @@ import { AuthService } from '../../../auth/auth.service';
 import { ConfigService } from '../../../services/config.service';
 import { AudioRecorderService } from './audio-recorder.service';
 import { AudioPlayerService } from './audio-player.service';
+import { Message } from '../models/message.model';
 import {
   IDLE_TIMEOUT_MS,
   WS_CONNECT_TIMEOUT_MS,
@@ -16,10 +17,20 @@ import {
 
 export type VoiceStatus = 'idle' | 'connecting' | 'listening' | 'speaking';
 
+export interface VoiceTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
 export interface VoiceTranscriptEntry {
   role: 'user' | 'assistant';
   text: string;
   timestamp: number;
+  /** Per-turn token usage (assistant messages only, computed from cumulative bidi_usage deltas) */
+  metadata?: {
+    tokenUsage?: VoiceTokenUsage;
+  };
 }
 
 /**
@@ -72,6 +83,8 @@ export class VoiceChatService implements OnDestroy {
    */
   private _currentTurnStart = 0;
   private _userTranscript = '';
+  /** Whether the current turn's final assistant Message has been created in voiceMessages. */
+  private _assistantFinalStarted = false;
 
   readonly status = this._status.asReadonly();
   readonly agentTranscript = computed(() =>
@@ -80,6 +93,36 @@ export class VoiceChatService implements OnDestroy {
   readonly isConnected = this._isConnected.asReadonly();
   readonly isVoiceActive = computed(() => this._status() !== 'idle');
   readonly transcriptEntries = this._transcriptEntries.asReadonly();
+
+  /**
+   * Real-time voice conversation messages.
+   *
+   * Maintained as Message[] objects that the session page can read directly.
+   * Updated as WebSocket events stream in:
+   *   - bidi_response_start → user Message pushed
+   *   - bidi_transcript_stream (assistant) → last Message text updated
+   *   - bidi_response_complete → metadata attached to last Message
+   */
+  private readonly _voiceMessages = signal<Message[]>([]);
+  readonly voiceMessages = this._voiceMessages.asReadonly();
+  private _voiceMessageIndex = 0;
+
+  /** Clear voice messages after they've been persisted to the message map. */
+  clearVoiceMessages(): void {
+    this._voiceMessages.set([]);
+  }
+
+  // --- Token usage & cost tracking ---
+  /**
+   * Nova Sonic reports CUMULATIVE token counts in bidi_usage events.
+   * To compute per-turn deltas, we snapshot the cumulative total at each
+   * turn boundary and subtract the previous snapshot.
+   */
+  private _cumulativeUsage: VoiceTokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  private _prevTurnCumulativeUsage: VoiceTokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  /** Latest cumulative cost breakdown from the backend (sent with bidi_usage events). */
+  private _cumulativeCost: Record<string, number> | null = null;
+  private _prevTurnCumulativeCost: Record<string, number> | null = null;
 
   // --- Internals ---
   private ws: WebSocket | null = null;
@@ -101,6 +144,13 @@ export class VoiceChatService implements OnDestroy {
     this._userTranscript = '';
     this.stopRevealTimer();
     this._transcriptEntries.set([]);
+    this._voiceMessages.set([]);
+    this._voiceMessageIndex = 0;
+    this._assistantFinalStarted = false;
+    this._cumulativeUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    this._prevTurnCumulativeUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    this._cumulativeCost = null;
+    this._prevTurnCumulativeCost = null;
 
     try {
       const token = this.authService.getAccessToken();
@@ -138,10 +188,79 @@ export class VoiceChatService implements OnDestroy {
   /** Disconnect from voice session and release all resources. */
   async disconnect(): Promise<void> {
     if (!this._isConnected()) return;
+
+    // Flush any assistant text that hasn't been committed to voiceMessages
+    // yet (bidi_response_complete may not arrive before WebSocket closes).
+    this.flushPendingAssistantMessage();
+
+    // Attach token usage to any assistant messages missing metadata
+    // (bidi_response_complete / bidi_usage may not arrive before close).
+    this.attachPendingUsage();
+
     this.sendMessage({ type: 'stop' });
     this.cleanupAll();
     this._status.set('idle');
     this._isConnected.set(false);
+  }
+
+  /**
+   * Attach cumulative token usage to the LAST assistant message if it
+   * doesn't already have metadata. Called on disconnect since
+   * bidi_response_complete (which normally attaches per-turn metadata)
+   * may not arrive before close.
+   *
+   * Only the last assistant message gets the badge — matches the backend
+   * pattern in _finalize_voice_session() which stores cumulative usage
+   * on the last assistant message only.
+   *
+   * Note: cost data requires server-side pricing config and will appear
+   * after page refresh once _finalize_voice_session() has run.
+   */
+  private attachPendingUsage(): void {
+    const total = this._cumulativeUsage;
+    if (total.totalTokens === 0 && !this._cumulativeCost) return;
+
+    this._voiceMessages.update(msgs => {
+      // Find the last assistant message without metadata
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].role === 'assistant' && !msgs[i].metadata) {
+          const metadata: Record<string, unknown> = {};
+          if (total.totalTokens > 0) {
+            metadata['tokenUsage'] = { ...total };
+          }
+          if (this._cumulativeCost) {
+            metadata['cost'] = { ...this._cumulativeCost };
+          }
+          const updated = [...msgs];
+          updated[i] = { ...msgs[i], metadata };
+          return updated;
+        }
+      }
+      return msgs;
+    });
+  }
+
+  /**
+   * If there's buffered assistant text that hasn't been committed to
+   * voiceMessages (no is_final events arrived), flush it from the buffer
+   * so it isn't lost when the WebSocket closes.
+   */
+  private flushPendingAssistantMessage(): void {
+    // If is_final events already created an assistant message, nothing to flush.
+    const msgs = this._voiceMessages();
+    const last = msgs[msgs.length - 1];
+    if (last?.role === 'assistant') return;
+
+    // Fall back to the buffered transcript (may be speculative text, but
+    // better than losing the response entirely).
+    const turnText = this._bufferedTranscript().slice(this._currentTurnStart).trim();
+    if (!turnText) return;
+
+    this._voiceMessages.update(m => [...m, {
+      id: `msg-${this.sessionId}-${this._voiceMessageIndex++}`,
+      role: 'assistant' as const,
+      content: [{ type: 'text', text: turnText }],
+    }]);
   }
 
   /** Get the current voice session ID (auto-generated or passed to connect). */
@@ -239,6 +358,7 @@ export class VoiceChatService implements OnDestroy {
 
       case 'bidi_transcript_stream': {
         const role = data['role'] as string | undefined;
+        const isFinal = !!(data['is_final']);
 
         let deltaText = '';
         if (data['delta']) {
@@ -252,8 +372,32 @@ export class VoiceChatService implements OnDestroy {
 
         if (deltaText) {
           if (role === 'assistant') {
-            // Buffer for reveal-based display
+            // Buffer for reveal-based display (voice overlay)
             this._bufferedTranscript.update(t => t + deltaText);
+
+            // Only commit to voiceMessages from FINAL pass (is_final=true),
+            // skipping speculative text to avoid duplication.
+            if (isFinal) {
+              if (!this._assistantFinalStarted) {
+                this._assistantFinalStarted = true;
+                this._voiceMessages.update(msgs => [...msgs, {
+                  id: `msg-${this.sessionId}-${this._voiceMessageIndex++}`,
+                  role: 'assistant' as const,
+                  content: [{ type: 'text', text: deltaText }],
+                }]);
+              } else {
+                this._voiceMessages.update(msgs => {
+                  const last = msgs[msgs.length - 1];
+                  if (!last || last.role !== 'assistant') return msgs;
+                  const updated = [...msgs];
+                  updated[updated.length - 1] = {
+                    ...last,
+                    content: [{ type: 'text', text: (last.content[0]?.text || '') + deltaText }],
+                  };
+                  return updated;
+                });
+              }
+            }
           } else {
             // Accumulate user speech for transcript entries
             this._userTranscript += deltaText;
@@ -265,15 +409,26 @@ export class VoiceChatService implements OnDestroy {
       }
 
       case 'bidi_response_start':
-        // Save accumulated user speech as a transcript entry
+        // Flush accumulated user speech as a user Message.
+        // _userTranscript is cleared after push, so the second
+        // bidi_response_start (FINAL pass) is a no-op here.
         if (this._userTranscript.trim()) {
+          const userText = this._userTranscript.trim();
           this.appendTranscriptEntry({
             role: 'user',
-            text: this._userTranscript.trim(),
+            text: userText,
             timestamp: Date.now(),
           });
+          this._voiceMessages.update(msgs => [...msgs, {
+            id: `msg-${this.sessionId}-${this._voiceMessageIndex++}`,
+            role: 'user' as const,
+            content: [{ type: 'text', text: userText }],
+          }]);
           this._userTranscript = '';
         }
+
+        // Reset for this turn's final assistant text
+        this._assistantFinalStarted = false;
 
         // New assistant turn — add separator if there's prior text, start reveal
         if (this._bufferedTranscript()) {
@@ -287,13 +442,59 @@ export class VoiceChatService implements OnDestroy {
         break;
 
       case 'bidi_response_complete': {
-        // Extract only this turn's assistant text for the transcript entry
+        // Extract only this turn's assistant text for the transcript entry (overlay)
         const turnText = this._bufferedTranscript().slice(this._currentTurnStart).trim();
+
+        // Compute per-turn token delta from cumulative snapshots
+        const turnUsage: VoiceTokenUsage = {
+          inputTokens: this._cumulativeUsage.inputTokens - this._prevTurnCumulativeUsage.inputTokens,
+          outputTokens: this._cumulativeUsage.outputTokens - this._prevTurnCumulativeUsage.outputTokens,
+          totalTokens: this._cumulativeUsage.totalTokens - this._prevTurnCumulativeUsage.totalTokens,
+        };
+        this._prevTurnCumulativeUsage = { ...this._cumulativeUsage };
+
         if (turnText) {
-          this.appendTranscriptEntry({
+          const entry: VoiceTranscriptEntry = {
             role: 'assistant',
             text: turnText,
             timestamp: Date.now(),
+          };
+          if (turnUsage.totalTokens > 0) {
+            entry.metadata = { tokenUsage: turnUsage };
+          }
+          this.appendTranscriptEntry(entry);
+        }
+
+        // Compute per-turn cost delta from cumulative cost snapshots
+        let turnCost: Record<string, number> | undefined;
+        if (this._cumulativeCost) {
+          if (this._prevTurnCumulativeCost) {
+            turnCost = {};
+            for (const key of Object.keys(this._cumulativeCost)) {
+              turnCost[key] = (this._cumulativeCost[key] || 0) - (this._prevTurnCumulativeCost[key] || 0);
+            }
+          } else {
+            turnCost = { ...this._cumulativeCost };
+          }
+          this._prevTurnCumulativeCost = { ...this._cumulativeCost };
+        }
+
+        // Attach per-turn metadata (usage + cost) to the last assistant Message
+        // (already created by is_final transcript events in bidi_transcript_stream).
+        if (turnUsage.totalTokens > 0 || turnCost) {
+          const metadata: Record<string, unknown> = {};
+          if (turnUsage.totalTokens > 0) {
+            metadata['tokenUsage'] = turnUsage;
+          }
+          if (turnCost) {
+            metadata['cost'] = turnCost;
+          }
+          this._voiceMessages.update(msgs => {
+            const last = msgs[msgs.length - 1];
+            if (!last || last.role !== 'assistant') return msgs;
+            const updated = [...msgs];
+            updated[updated.length - 1] = { ...last, metadata };
+            return updated;
           });
         }
 
@@ -309,9 +510,20 @@ export class VoiceChatService implements OnDestroy {
         this._status.set('listening');
         break;
 
-      case 'bidi_usage':
-        // Token usage stats — could emit for metadata display
+      case 'bidi_usage': {
+        // Nova Sonic reports CUMULATIVE token counts — replace, don't sum
+        const usage = (data['usage'] as Record<string, number>) ?? data;
+        this._cumulativeUsage = {
+          inputTokens: (usage['inputTokens'] as number) ?? this._cumulativeUsage.inputTokens,
+          outputTokens: (usage['outputTokens'] as number) ?? this._cumulativeUsage.outputTokens,
+          totalTokens: (usage['totalTokens'] as number) ?? this._cumulativeUsage.totalTokens,
+        };
+        // Capture cumulative cost breakdown (calculated server-side, sent with bidi_usage)
+        if (data['cost']) {
+          this._cumulativeCost = data['cost'] as Record<string, number>;
+        }
         break;
+      }
 
       case 'bidi_error':
         console.error('Voice error:', data['message']);

--- a/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
@@ -491,7 +491,8 @@ export class VoiceChatService implements OnDestroy {
           }
           this._voiceMessages.update(msgs => {
             const last = msgs[msgs.length - 1];
-            if (!last || last.role !== 'assistant') return msgs;
+            // Skip if not assistant or already has metadata (e.g. set by attachPendingUsage on disconnect)
+            if (!last || last.role !== 'assistant' || last.metadata) return msgs;
             const updated = [...msgs];
             updated[updated.length - 1] = { ...last, metadata };
             return updated;

--- a/frontend/ai.client/src/app/session/services/voice/voice.config.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice.config.ts
@@ -1,0 +1,49 @@
+/**
+ * Voice mode configuration constants.
+ *
+ * Centralizes all tunable values for the voice pipeline so they
+ * can be found and adjusted in one place.
+ */
+
+/** Audio sample rate in Hz. Nova Sonic expects 16kHz mono PCM. */
+export const VOICE_SAMPLE_RATE = 16000;
+
+/** Duration of each audio chunk in milliseconds. */
+export const CHUNK_DURATION_MS = 100;
+
+/** Number of samples per chunk (sampleRate * chunkDuration / 1000). */
+export const SAMPLES_PER_CHUNK = (VOICE_SAMPLE_RATE * CHUNK_DURATION_MS) / 1000; // 1600
+
+/** Auto-disconnect after this many milliseconds of silence. */
+export const IDLE_TIMEOUT_MS = 60_000;
+
+/** WebSocket connection timeout in milliseconds. */
+export const WS_CONNECT_TIMEOUT_MS = 10_000;
+
+/** Maximum transcript entries kept in memory per session. */
+export const MAX_TRANSCRIPT_ENTRIES = 200;
+
+/**
+ * Transcript reveal speed — characters per tick while the agent is speaking.
+ * ~20 chars/sec at 50ms ticks ≈ natural speaking pace.
+ */
+export const REVEAL_CHARS_PER_TICK = 2;
+
+/** Interval in ms between reveal ticks. */
+export const REVEAL_TICK_MS = 50;
+
+/** Characters per tick when flushing remaining text after response completes. */
+export const REVEAL_FLUSH_CHARS_PER_TICK = 5;
+
+/** WebSocket close codes and their user-facing meanings. */
+export const WS_CLOSE_REASONS: Record<number, string> = {
+  1000: 'Session ended normally',
+  1001: 'Server shutting down',
+  1006: 'Connection lost — check your network',
+  1008: 'Policy violation',
+  1011: 'Server error',
+  4001: 'Authentication failed',
+  4003: 'Forbidden',
+  4008: 'Session timeout',
+  4029: 'Rate limited — try again shortly',
+};

--- a/frontend/ai.client/src/app/session/session.page.html
+++ b/frontend/ai.client/src/app/session/session.page.html
@@ -17,6 +17,7 @@
   (assistantNewSession)="newAssistantSession()"
   (assistantEdit)="editAssistant()"
   (assistantShare)="shareAssistant()"
+  (voiceClosed)="onVoiceClosed()"
 />
 
 <!-- Model Settings Panel -->

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -316,7 +316,8 @@ export class ConversationPage implements OnDestroy {
     // Filter out any messages with no text (e.g. interrupted before first delta).
     this.messagesSignal.set(this.messageMapService.getMessagesForSession(sessionId));
     for (const msg of voiceMsgs) {
-      const text = msg.content[0]?.text || '';
+      const textBlock = msg.content.find(b => b.type === 'text');
+      const text = textBlock?.text || '';
       if (!text) continue;
       this.messageMapService.addVoiceMessage(
         sessionId,

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -49,6 +49,7 @@ export class ConversationPage implements OnDestroy {
 
   sessionId = signal<string | null>(null);
   assistantIdFromQuery = signal<string | null>(null);
+
   assistant = signal<Assistant | null>(null);
   assistantError = signal<string | null>(null);
   isLoadingAssistant = signal(false);
@@ -74,8 +75,14 @@ export class ConversationPage implements OnDestroy {
   // Writable signal that holds the current messages signal reference
   private messagesSignal = signal<Signal<Message[]>>(signal([]));
 
-  // Computed that unwraps the current messages signal
-  readonly messages = computed(() => this.messagesSignal()());
+  // Computed that unwraps the current messages signal, merging in
+  // real-time voice messages. Voice messages are cleared on voice close
+  // after being persisted to the map, so there's no double-counting.
+  readonly messages = computed(() => {
+    const base = this.messagesSignal()();
+    const voice = this.voiceChatService.voiceMessages();
+    return voice.length > 0 ? [...base, ...voice] : base;
+  });
 
   // Get user's first name from the user service
   private firstName = computed(() => {
@@ -290,33 +297,55 @@ export class ConversationPage implements OnDestroy {
   }
 
   /**
-   * Called when the voice overlay closes. Persists transcript entries
-   * as chat messages. Creates a new session if one doesn't exist yet.
+   * Called when the voice overlay closes.
    *
-   * For new sessions, we await navigation so the route subscription
-   * settles before we add messages — otherwise the route change can
-   * trigger a loading state that hides the messages we just added.
+   * By this point, disconnect() has already set isVoiceActive = false,
+   * so the messages computed stops merging voiceMessages. We persist
+   * those messages into the message map (so they survive navigation)
+   * and update the URL.
    */
-  async onVoiceClosed() {
-    const entries = this.voiceChatService.transcriptEntries();
-    if (entries.length === 0) return;
+  onVoiceClosed() {
+    const voiceMsgs = this.voiceChatService.voiceMessages();
+    if (voiceMsgs.length === 0) return;
 
-    const sessionId = await this.ensureSessionExists(
-      this.voiceChatService.getSessionId() || undefined
-    );
+    const sessionId = this.voiceChatService.getSessionId();
+    if (!sessionId) return;
 
-    // Wire up the messages signal for this session
+    // Persist voice messages into the message map so they survive
+    // page navigation and show up when the overlay is gone.
+    // Filter out any messages with no text (e.g. interrupted before first delta).
     this.messagesSignal.set(this.messageMapService.getMessagesForSession(sessionId));
+    for (const msg of voiceMsgs) {
+      const text = msg.content[0]?.text || '';
+      if (!text) continue;
+      this.messageMapService.addVoiceMessage(
+        sessionId,
+        msg.role as 'user' | 'assistant',
+        text,
+        msg.metadata ?? undefined,
+      );
+    }
 
-    // Add each transcript entry as a message
-    for (const entry of entries) {
-      this.messageMapService.addVoiceMessage(sessionId, entry.role, entry.text);
+    // Clear voice messages now that they're in the map — prevents any
+    // change detection cycle from seeing both sources simultaneously.
+    this.voiceChatService.clearVoiceMessages();
+
+    // If there's no route session yet, navigate (fire-and-forget).
+    // addSessionToCache MUST happen before navigation so the route
+    // subscription recognises this as new and skips the API fetch
+    // (same sequencing as ChatRequestService.navigateToSession).
+    if (!this.effectiveSessionId()) {
+      const user = this.userService.currentUser();
+      const userId = user?.user_id || 'anonymous';
+      this.sessionService.addSessionToCache(sessionId, userId);
+      this.router.navigate(['s', sessionId], { replaceUrl: true });
     }
 
     // Generate title for new voice sessions (fire and forget)
-    const firstUserEntry = entries.find(e => e.role === 'user');
-    if (firstUserEntry && this.sessionService.isNewSession(sessionId)) {
-      this.chatHttpService.generateTitle(sessionId, firstUserEntry.text)
+    const firstUserMsg = voiceMsgs.find(m => m.role === 'user');
+    const firstUserText = firstUserMsg?.content[0]?.text;
+    if (firstUserText && this.sessionService.isNewSession(sessionId)) {
+      this.chatHttpService.generateTitle(sessionId, firstUserText)
         .then((response) => {
           this.sessionService.updateSessionTitleInCache(sessionId, response.title);
         })
@@ -324,23 +353,6 @@ export class ConversationPage implements OnDestroy {
           console.warn('Failed to generate voice session title:', err);
         });
     }
-  }
-
-  /**
-   * Ensure a session exists — returns the current session ID or creates one.
-   * Awaits navigation for new sessions so the route is settled before the
-   * caller adds messages.
-   */
-  private async ensureSessionExists(preferredId?: string): Promise<string> {
-    const existing = this.effectiveSessionId();
-    if (existing) return existing;
-
-    const sessionId = preferredId || uuidv4();
-    const user = this.userService.currentUser();
-    const userId = user?.user_id || 'anonymous';
-    this.sessionService.addSessionToCache(sessionId, userId);
-    await this.router.navigate(['s', sessionId], { replaceUrl: true });
-    return sessionId;
   }
 
   toggleSettings() {

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -201,14 +201,6 @@ export class ConversationPage implements OnDestroy {
       this.assistantError.set(null);
     });
 
-    // Wire voice transcript completions to message list
-    this.voiceChatService.onResponseComplete = (transcript: string) => {
-      const sid = this.effectiveSessionId();
-      if (sid && transcript.trim()) {
-        this.messageMapService.addVoiceMessage(sid, 'assistant', transcript);
-      }
-    };
-
     // Subscribe to route parameter changes
     this.routeSubscription = this.route.paramMap.subscribe(async params => {
       const id = params.get('sessionId');
@@ -295,6 +287,60 @@ export class ConversationPage implements OnDestroy {
 
   onMessageCancelled() {
     this.chatHttpService.cancelChatRequest();
+  }
+
+  /**
+   * Called when the voice overlay closes. Persists transcript entries
+   * as chat messages. Creates a new session if one doesn't exist yet.
+   *
+   * For new sessions, we await navigation so the route subscription
+   * settles before we add messages — otherwise the route change can
+   * trigger a loading state that hides the messages we just added.
+   */
+  async onVoiceClosed() {
+    const entries = this.voiceChatService.transcriptEntries();
+    if (entries.length === 0) return;
+
+    const sessionId = await this.ensureSessionExists(
+      this.voiceChatService.getSessionId() || undefined
+    );
+
+    // Wire up the messages signal for this session
+    this.messagesSignal.set(this.messageMapService.getMessagesForSession(sessionId));
+
+    // Add each transcript entry as a message
+    for (const entry of entries) {
+      this.messageMapService.addVoiceMessage(sessionId, entry.role, entry.text);
+    }
+
+    // Generate title for new voice sessions (fire and forget)
+    const firstUserEntry = entries.find(e => e.role === 'user');
+    if (firstUserEntry && this.sessionService.isNewSession(sessionId)) {
+      this.chatHttpService.generateTitle(sessionId, firstUserEntry.text)
+        .then((response) => {
+          this.sessionService.updateSessionTitleInCache(sessionId, response.title);
+        })
+        .catch((err) => {
+          console.warn('Failed to generate voice session title:', err);
+        });
+    }
+  }
+
+  /**
+   * Ensure a session exists — returns the current session ID or creates one.
+   * Awaits navigation for new sessions so the route is settled before the
+   * caller adds messages.
+   */
+  private async ensureSessionExists(preferredId?: string): Promise<string> {
+    const existing = this.effectiveSessionId();
+    if (existing) return existing;
+
+    const sessionId = preferredId || uuidv4();
+    const user = this.userService.currentUser();
+    const userId = user?.user_id || 'anonymous';
+    this.sessionService.addSessionToCache(sessionId, userId);
+    await this.router.navigate(['s', sessionId], { replaceUrl: true });
+    return sessionId;
   }
 
   toggleSettings() {

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -22,6 +22,7 @@ import {
   ShareAssistantDialogComponent,
   ShareAssistantDialogData,
 } from '../assistants/components/share-assistant-dialog.component';
+import { VoiceChatService } from './services/voice';
 
 @Component({
   selector: 'app-session-page',
@@ -44,6 +45,7 @@ export class ConversationPage implements OnDestroy {
   private assistantService = inject(AssistantService);
   private router = inject(Router);
   private dialog = inject(Dialog);
+  private voiceChatService = inject(VoiceChatService);
 
   sessionId = signal<string | null>(null);
   assistantIdFromQuery = signal<string | null>(null);
@@ -198,6 +200,14 @@ export class ConversationPage implements OnDestroy {
       this.assistant.set(null);
       this.assistantError.set(null);
     });
+
+    // Wire voice transcript completions to message list
+    this.voiceChatService.onResponseComplete = (transcript: string) => {
+      const sid = this.effectiveSessionId();
+      if (sid && transcript.trim()) {
+        this.messageMapService.addVoiceMessage(sid, 'assistant', transcript);
+      }
+    };
 
     // Subscribe to route parameter changes
     this.routeSubscription = this.route.paramMap.subscribe(async params => {


### PR DESCRIPTION
## Summary
- Add `strands-agents[bidi]` optional dependency group for Nova Sonic speech-to-speech
- Fix BidiAgent import paths (`strands.experimental.bidi`)
- Create WebSocket endpoint at `/voice/stream` with bidirectional audio/text protocol
- Add debug endpoints for session management (`GET /voice/sessions`, `DELETE /voice/sessions/{id}`)
- Include `scripts/test_voice_client.py` for manual end-to-end testing

## Testing the voice endpoint

```bash
# Install bidi deps
cd backend && uv sync --extra agentcore --extra bidi

# Start the server
cd src/apis/inference_api && uv run python main.py

# In another terminal — test with a text message
python scripts/test_voice_client.py --fake-token --text "Hello"
```

## Test plan
- [x] 632/632 tests pass (14 new voice route tests)
- [ ] Manual WebSocket test with test_voice_client.py
- [ ] Verify BidiAgent imports work with bidi extra installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)