### PR TITLE
fix: voice WebSocket AgentCore auth and bidi dependency

### DIFF
--- a/backend/Dockerfile.inference-api
+++ b/backend/Dockerfile.inference-api
@@ -25,12 +25,12 @@ COPY backend/uv.lock ./
 # --no-dev: exclude development dependencies
 # --no-editable: non-editable install for production
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --extra agentcore --no-install-project --no-dev --no-editable
+    uv sync --frozen --extra agentcore --extra bidi --no-install-project --no-dev --no-editable
 
 # Copy source code and install the project itself
 COPY backend/src ./src
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --extra agentcore --no-dev --no-editable
+    uv sync --frozen --extra agentcore --extra bidi --no-dev --no-editable
 
 # Production stage
 FROM --platform=linux/arm64 python:3.13-slim@sha256:739e7213785e88c0f702dcdc12c0973afcbd606dbf021a589cab77d6b00b579d


### PR DESCRIPTION
## Summary
- Adds `--extra bidi` to both `uv sync` commands in `Dockerfile.inference-api` so `strands-agents[bidi]` is installed in the container (was causing `BidiAgent` import failure and 403 on voice WebSocket)
- Fixes AgentCore connection detection in `voice_routes.py` — detects AgentCore path via `X-Amzn-Bedrock-AgentCore-Runtime-Custom-*` headers instead of `Sec-WebSocket-Protocol` (which AgentCore strips before forwarding to the container)

## Test plan
- [ ] Rebuild and deploy the inference API container image
- [ ] Verify `BidiAgent not available` log message no longer appears at startup
- [ ] Verify voice WebSocket connection succeeds through AgentCore proxy
- [ ] Verify local dev voice WebSocket still works with query-param token auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)