### PR TITLE
fix: align voice WebSocket with reference architecture accept-first pattern

### DIFF
--- a/backend/src/apis/inference_api/chat/voice_routes.py
+++ b/backend/src/apis/inference_api/chat/voice_routes.py
@@ -312,8 +312,13 @@ async def voice_stream(websocket: WebSocket):
             except json.JSONDecodeError:
                 logger.warning(f"Invalid enabled_tools JSON: {_sanitize_log(enabled_tools_raw)}")
 
-        # Determine subprotocol for accept — AgentCore sends the bearer token
-        # via Sec-WebSocket-Protocol as "base64UrlBearerAuthorization.<b64>"
+        # Detect AgentCore path via custom headers (AgentCore strips
+        # Sec-WebSocket-Protocol, so we can't rely on subprotocol detection)
+        is_agentcore = bool(
+            websocket.headers.get("x-amzn-bedrock-agentcore-runtime-custom-sessionid")
+        )
+
+        # Check if browser sent subprotocol (may reach container in local-proxy setups)
         requested_protocols = websocket.headers.get("sec-websocket-protocol", "")
         accept_subprotocol = None
         if "base64UrlBearerAuthorization" in requested_protocols:
@@ -321,7 +326,7 @@ async def voice_stream(websocket: WebSocket):
 
         # Local dev: authenticate before accepting using query-param token
         user_info = _extract_user_from_token(token) if token else None
-        if not accept_subprotocol and not user_info:
+        if not is_agentcore and not accept_subprotocol and not user_info:
             # Not an AgentCore connection AND no valid local token → reject
             await websocket.close(code=4001, reason="Authentication required")
             return
@@ -333,7 +338,7 @@ async def voice_stream(websocket: WebSocket):
             # AgentCore path: auth_token will come from config message
             auth_token = ""
 
-        # Accept the WebSocket connection (with subprotocol if AgentCore)
+        # Accept the WebSocket connection (with subprotocol if applicable)
         await websocket.accept(subprotocol=accept_subprotocol)
         logger.info(f"Voice WebSocket connected: session={_sanitize_log(session_id)}, user={_sanitize_log(user_id or 'pending')}")
 


### PR DESCRIPTION
## Summary
- Rewrites voice WebSocket handler to match the [sample-strands-agent-with-agentcore](https://github.com/aws-samples/sample-strands-agent-with-agentcore) reference architecture
- **Accept immediately** — no pre-accept auth; AgentCore validates JWT at the proxy layer
- **Config message always read** — `auth_token`, `session_id`, `user_id`, and `enabled_tools` arrive via the first client message, supplementing any headers or query params
- **Helper functions** `_get_param_from_request` / `_get_enabled_tools_from_request` for clean AgentCore custom header → query param fallback
- **`/voice/stream`** as main route, **`/ws`** as alias for AgentCore Runtime compatibility
- Frontend uses `/voice/stream` for local dev, `/ws` for AgentCore

## Test plan
- [ ] Rebuild and deploy inference API container
- [ ] Verify voice WebSocket connects successfully through AgentCore proxy (`/ws`)
- [ ] Verify local dev voice WebSocket works via `/voice/stream` with query-param token
- [ ] Verify unauthenticated connections (no token in query param or config message) are rejected with 4001 after config message timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)