### PR TITLE
fix: source ToolAccessService catalog from DynamoDB

### DIFF
--- a/backend/src/apis/app_api/admin/services/tool_access.py
+++ b/backend/src/apis/app_api/admin/services/tool_access.py
@@ -7,9 +7,10 @@ Similar to ModelAccessService but for tools.
 import logging
 from typing import List, Optional, Set
 
+from agents.main_agent.config.constants import Prefixes
+from apis.app_api.tools.freshness import get_all_tool_ids
 from apis.shared.auth.models import User
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
-from agents.main_agent.tools import get_tool_catalog_service
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,6 @@ class ToolAccessService:
     def __init__(self, app_role_service: Optional[AppRoleService] = None):
         """Initialize with optional AppRoleService."""
         self._app_role_service = app_role_service
-        self._tool_catalog = get_tool_catalog_service()
 
     @property
     def app_role_service(self) -> AppRoleService:
@@ -69,6 +69,13 @@ class ToolAccessService:
 
         If no tools are requested, returns all tools the user can access.
 
+        The "universe of known tools" is sourced from the DynamoDB-backed
+        tool catalog (TTL-cached via `freshness.get_all_tool_ids`) so
+        admin-managed MCP-external and A2A tools are recognized. Gateway
+        tools (`gateway_*` prefix) are also accepted: they're loaded
+        dynamically from the AgentCore Gateway at runtime and don't need
+        a catalog entry.
+
         Args:
             user: The user to check
             requested_tools: Optional list of tool IDs the user wants to use.
@@ -80,8 +87,8 @@ class ToolAccessService:
         allowed_tools = await self.get_user_allowed_tools(user)
         has_wildcard = "*" in allowed_tools
 
-        # Get all available tool IDs from catalog
-        all_tool_ids = set(self._tool_catalog.get_tool_ids())
+        # Get all available tool IDs from the DynamoDB catalog
+        all_tool_ids = await get_all_tool_ids()
 
         if requested_tools is None:
             # No specific tools requested - return all allowed
@@ -93,11 +100,11 @@ class ToolAccessService:
 
         # Filter requested tools to only allowed ones
         if has_wildcard:
-            # Wildcard: allow all requested tools that exist
-            # (allow gateway tools even if not in catalog)
+            # Wildcard: allow all requested tools that exist in the catalog,
+            # plus any gateway-prefixed tools (loaded dynamically at runtime)
             return [
                 t for t in requested_tools
-                if t in all_tool_ids or t.startswith("gateway_")
+                if t in all_tool_ids or t.startswith(Prefixes.GATEWAY_TOOL)
             ]
         else:
             # Only return intersection of requested and allowed

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -130,9 +130,15 @@ async def admin_create_tool(
 
     try:
         created = await service.create_tool(tool, admin)
-        return AdminToolResponse.from_tool_definition(created)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    # Drop the all-tool-ids snapshot so the new tool is recognized by
+    # ToolAccessService on the very next chat turn in this process.
+    from apis.app_api.tools.freshness import invalidate as invalidate_freshness
+    invalidate_freshness(created.tool_id)
+
+    return AdminToolResponse.from_tool_definition(created)
 
 
 @router.put("/{tool_id}", response_model=AdminToolResponse)

--- a/backend/src/apis/app_api/tools/freshness.py
+++ b/backend/src/apis/app_api/tools/freshness.py
@@ -1,21 +1,34 @@
-"""Per-process TTL cache of tool-config freshness tokens.
+"""Per-process TTL caches over the tool catalog.
 
-Cheap change-detection signal for the agent and MCP-client caches: any
-admin edit to a tool bumps its `updated_at`, so including the freshness
-hash in a cache key causes the next build to miss and rebuild with the
-fresh config.
+Two caches live here, both backed by DynamoDB reads of the tool
+catalog:
 
-Reads are TTL-cached so the per-turn overhead is bounded to at most one
-DynamoDB GetItem per tool per TTL window, per process. Admin routes
-call `invalidate(tool_id)` after a write so same-process visibility is
-immediate; other processes see the change within one TTL window.
+1. **Per-tool freshness tokens** (`get_tool_updated_at`,
+   `get_freshness_hash`). Cheap change-detection signal for the agent
+   and MCP-client caches: any admin edit to a tool bumps its
+   `updated_at`, so including the freshness hash in a cache key causes
+   the next build to miss and rebuild with the fresh config.
+
+2. **All-known-tool-ids snapshot** (`get_all_tool_ids`). The set of
+   tool IDs known to the catalog — the source of truth for the
+   "universe of tools" that authorization (`ToolAccessService`) needs
+   to enumerate. Wildcard-access users in particular need this to know
+   which tools to expand `*` into, and to validate requested tools
+   against.
+
+Reads are TTL-cached so the per-turn overhead is bounded to at most
+one DynamoDB read per cache key per TTL window, per process. Admin
+routes call `invalidate(tool_id)` after a write so same-process
+visibility is immediate; other processes see the change within one
+TTL window. `invalidate` clears the all-tool-ids snapshot too, since
+any create/delete shifts that set.
 """
 
 import asyncio
 import hashlib
 import logging
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +36,17 @@ logger = logging.getLogger(__name__)
 # None is stored when the tool is missing, so negative lookups are also
 # TTL-cached — a deleted tool doesn't trigger a DynamoDB read every turn.
 _cache: Dict[str, Tuple[Optional[str], float]] = {}
+
+# (frozen_set_of_tool_ids, monotonic_fetched_at) — None means uncached.
+_all_tool_ids_cache: Optional[Tuple[FrozenSet[str], float]] = None
+
 _TTL_SECONDS = 10.0
 
 
 def _reset_for_tests() -> None:
+    global _all_tool_ids_cache
     _cache.clear()
+    _all_tool_ids_cache = None
 
 
 async def _fetch_updated_at(tool_id: str) -> Optional[str]:
@@ -80,13 +99,51 @@ async def get_freshness_hash(tool_ids: List[str]) -> str:
     return hashlib.md5(payload.encode()).hexdigest()[:16]
 
 
+async def get_all_tool_ids() -> FrozenSet[str]:
+    """Return the set of all known tool IDs, TTL-cached per process.
+
+    Listed once per TTL window via `repository.list_tools()` and reused
+    across that window. Used by `ToolAccessService` to enumerate "every
+    tool the system knows about" without scanning DynamoDB on every
+    chat turn.
+
+    On a repository error, returns the last-known set if available, else
+    an empty frozenset — never raises (auth must not break on a transient
+    DB blip).
+    """
+    global _all_tool_ids_cache
+    now = time.monotonic()
+    cached = _all_tool_ids_cache
+    if cached is not None and now - cached[1] < _TTL_SECONDS:
+        return cached[0]
+
+    from apis.app_api.tools.repository import get_tool_catalog_repository
+
+    try:
+        repo = get_tool_catalog_repository()
+        tools = await repo.list_tools()
+        ids = frozenset(t.tool_id for t in tools)
+    except Exception:
+        logger.exception("Failed to list tool IDs for catalog snapshot")
+        return cached[0] if cached is not None else frozenset()
+
+    _all_tool_ids_cache = (ids, now)
+    return ids
+
+
 def invalidate(tool_id: Optional[str] = None) -> None:
     """Drop an entry (or the whole cache) from the TTL store.
+
+    Always clears the all-tool-ids snapshot too, since any create/delete
+    shifts that set (and an admin write is the only reason to invalidate
+    anyway).
 
     Call this from admin write paths so changes are visible in the same
     process on the very next turn, without waiting for the TTL to lapse.
     """
+    global _all_tool_ids_cache
     if tool_id is None:
         _cache.clear()
     else:
         _cache.pop(tool_id, None)
+    _all_tool_ids_cache = None

--- a/backend/src/apis/app_api/tools/freshness.py
+++ b/backend/src/apis/app_api/tools/freshness.py
@@ -37,16 +37,18 @@ logger = logging.getLogger(__name__)
 # TTL-cached — a deleted tool doesn't trigger a DynamoDB read every turn.
 _cache: Dict[str, Tuple[Optional[str], float]] = {}
 
-# (frozen_set_of_tool_ids, monotonic_fetched_at) — None means uncached.
-_all_tool_ids_cache: Optional[Tuple[FrozenSet[str], float]] = None
+# Single-slot snapshot of (frozen_set_of_tool_ids, monotonic_fetched_at).
+# Held in a list so we mutate index 0 in place rather than rebinding the
+# module-level name — same pattern as `_cache` above (mutated, never
+# reassigned), which keeps the module state easy to reason about.
+_all_tool_ids_cache: List[Optional[Tuple[FrozenSet[str], float]]] = [None]
 
 _TTL_SECONDS = 10.0
 
 
 def _reset_for_tests() -> None:
-    global _all_tool_ids_cache
     _cache.clear()
-    _all_tool_ids_cache = None
+    _all_tool_ids_cache[0] = None
 
 
 async def _fetch_updated_at(tool_id: str) -> Optional[str]:
@@ -111,9 +113,8 @@ async def get_all_tool_ids() -> FrozenSet[str]:
     an empty frozenset — never raises (auth must not break on a transient
     DB blip).
     """
-    global _all_tool_ids_cache
     now = time.monotonic()
-    cached = _all_tool_ids_cache
+    cached = _all_tool_ids_cache[0]
     if cached is not None and now - cached[1] < _TTL_SECONDS:
         return cached[0]
 
@@ -127,7 +128,7 @@ async def get_all_tool_ids() -> FrozenSet[str]:
         logger.exception("Failed to list tool IDs for catalog snapshot")
         return cached[0] if cached is not None else frozenset()
 
-    _all_tool_ids_cache = (ids, now)
+    _all_tool_ids_cache[0] = (ids, now)
     return ids
 
 
@@ -141,9 +142,8 @@ def invalidate(tool_id: Optional[str] = None) -> None:
     Call this from admin write paths so changes are visible in the same
     process on the very next turn, without waiting for the TTL to lapse.
     """
-    global _all_tool_ids_cache
     if tool_id is None:
         _cache.clear()
     else:
         _cache.pop(tool_id, None)
-    _all_tool_ids_cache = None
+    _all_tool_ids_cache[0] = None

--- a/backend/tests/apis/app_api/admin/services/test_tool_access.py
+++ b/backend/tests/apis/app_api/admin/services/test_tool_access.py
@@ -1,0 +1,174 @@
+"""Tests for ToolAccessService.
+
+Verifies that filter_allowed_tools sources its "universe of known
+tools" from the DynamoDB-backed catalog (via the freshness snapshot)
+rather than the legacy in-memory catalog. This is critical for
+admin-managed MCP-external and A2A tools, which only exist in
+DynamoDB.
+"""
+
+from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+
+import pytest
+
+from apis.app_api.tools import freshness
+from apis.app_api.admin.services.tool_access import ToolAccessService
+from apis.shared.auth.models import User
+from apis.shared.rbac.models import UserEffectivePermissions
+
+
+@pytest.fixture(autouse=True)
+def _reset_freshness():
+    freshness._reset_for_tests()
+    yield
+    freshness._reset_for_tests()
+
+
+def _user(roles=None) -> User:
+    return User(
+        email="admin@example.com",
+        user_id="admin-1",
+        name="Admin",
+        roles=roles or [],
+    )
+
+
+def _permissions(tools, app_roles=("admin",)) -> UserEffectivePermissions:
+    return UserEffectivePermissions(
+        user_id="admin-1",
+        app_roles=list(app_roles),
+        tools=list(tools),
+        models=[],
+        quota_tier=None,
+        resolved_at="2026-04-26T00:00:00Z",
+    )
+
+
+def _service(permissions: UserEffectivePermissions) -> ToolAccessService:
+    role_service = AsyncMock()
+    role_service.resolve_user_permissions = AsyncMock(return_value=permissions)
+    return ToolAccessService(app_role_service=role_service)
+
+
+def _patch_catalog(tool_ids):
+    """Patch the repository.list_tools call that backs freshness snapshot."""
+    repo = SimpleNamespace(
+        list_tools=AsyncMock(
+            return_value=[SimpleNamespace(tool_id=tid) for tid in tool_ids]
+        )
+    )
+    return patch(
+        "apis.app_api.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wildcard_user_sees_mcp_external_tool_added_via_admin_form():
+    """An MCP-external tool added via the admin form (DynamoDB only,
+    not in the legacy in-memory catalog) must be returned by
+    filter_allowed_tools for a wildcard-access admin.
+
+    This is the core regression: before this fix, the wildcard branch
+    only enumerated tools from the legacy catalog and the new tool
+    silently disappeared.
+    """
+    service = _service(_permissions(["*"]))
+
+    with _patch_catalog(
+        ["calculator", "fetch_url_content", "linear_create_issue"]
+    ):
+        # No requested_tools — wildcard should expand to ALL known tools
+        result = await service.filter_allowed_tools(_user(), None)
+
+    assert "linear_create_issue" in result, (
+        "MCP-external tool added via admin form must be visible to "
+        "wildcard users"
+    )
+    assert set(result) == {
+        "calculator",
+        "fetch_url_content",
+        "linear_create_issue",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wildcard_user_filters_out_unknown_tool():
+    """A tool that is not in the catalog must be filtered out, even
+    for wildcard users — wildcard means 'every known tool', not
+    'every tool ID a client claims to want'."""
+    service = _service(_permissions(["*"]))
+
+    with _patch_catalog(["calculator", "fetch_url_content"]):
+        result = await service.filter_allowed_tools(
+            _user(),
+            requested_tools=[
+                "calculator",
+                "made_up_tool",  # not in catalog
+                "fetch_url_content",
+            ],
+        )
+
+    assert "made_up_tool" not in result
+    assert set(result) == {"calculator", "fetch_url_content"}
+
+
+@pytest.mark.asyncio
+async def test_wildcard_user_keeps_gateway_tools_even_when_not_in_catalog():
+    """Gateway tools (gateway_* prefix) are loaded dynamically from the
+    AgentCore Gateway and aren't persisted to the DynamoDB catalog.
+    The prefix-based bypass must keep them allowed for wildcard users.
+    """
+    service = _service(_permissions(["*"]))
+
+    with _patch_catalog(["calculator"]):
+        result = await service.filter_allowed_tools(
+            _user(),
+            requested_tools=["calculator", "gateway_wikipedia"],
+        )
+
+    assert set(result) == {"calculator", "gateway_wikipedia"}
+
+
+@pytest.mark.asyncio
+async def test_non_wildcard_user_sees_intersection_of_granted_and_catalog():
+    """Non-wildcard users get the intersection of their granted tools
+    and the catalog when no specific tools are requested."""
+    service = _service(_permissions(["calculator", "linear_create_issue"]))
+
+    with _patch_catalog(["calculator", "linear_create_issue", "weather"]):
+        result = await service.filter_allowed_tools(_user(), None)
+
+    assert set(result) == {"calculator", "linear_create_issue"}
+
+
+@pytest.mark.asyncio
+async def test_non_wildcard_user_denies_unauthorized_request():
+    """Non-wildcard users must not get tools they aren't granted, even
+    if those tools exist in the catalog."""
+    service = _service(_permissions(["calculator"]))
+
+    with _patch_catalog(["calculator", "linear_create_issue"]):
+        result = await service.filter_allowed_tools(
+            _user(),
+            requested_tools=["calculator", "linear_create_issue"],
+        )
+
+    assert result == ["calculator"]
+
+
+@pytest.mark.asyncio
+async def test_check_access_and_filter_reports_denied():
+    """check_access_and_filter must split allowed and denied lists and
+    surface the denied set to the caller (so chat routes can log)."""
+    service = _service(_permissions(["calculator"]))
+
+    with _patch_catalog(["calculator", "linear_create_issue"]):
+        allowed, denied = await service.check_access_and_filter(
+            _user(),
+            requested_tools=["calculator", "linear_create_issue"],
+        )
+
+    assert allowed == ["calculator"]
+    assert denied == ["linear_create_issue"]


### PR DESCRIPTION
## Summary
- `ToolAccessService.filter_allowed_tools` enumerated tools from the legacy in-memory catalog (`agents.main_agent.tools.get_tool_catalog_service().get_tool_ids()`), so MCP-external and A2A tools added via the admin form (which only persist to DynamoDB) were silently filtered out for wildcard-access users.
- Wire the service to a new TTL-cached `freshness.get_all_tool_ids()` snapshot backed by the DynamoDB tool catalog. Bounded to ≤1 `list_tools` per 10-second window per process.
- Gateway tools keep their `gateway_*` prefix-based bypass (loaded dynamically from the AgentCore Gateway at runtime — no catalog entry needed).
- Admin create/update/delete now invalidate the snapshot so changes are visible on the next chat turn in-process. Other processes pick up changes within one TTL window.
- Legacy `agents/main_agent/tools/tool_catalog.py` is kept — still used for metadata in `apis/app_api/tools/service.py` (DDB-empty fallback) and the legacy `/tools/catalog` and `/tools/available` endpoints. Not orphaned.

## Test plan
- [x] New tests in `backend/tests/apis/app_api/admin/services/test_tool_access.py` covering:
  - MCP-external tool added via admin form is returned by `filter_allowed_tools` for a wildcard user (the core regression)
  - Tools not in the catalog are filtered out for wildcard users
  - Gateway-prefixed tools pass through even when not in the catalog
  - Non-wildcard users see the intersection of `granted_tools` and the catalog
  - `check_access_and_filter` correctly reports denied tools
- [x] `cd backend && uv run python -m pytest tests/ -v` — 2187 passed, 3 skipped, 1 unrelated Hypothesis timing flake (`test_non_admin_roles_get_403` exceeded 200ms deadline once; passes in isolation)
- [ ] Manually verify in deployed env: create an MCP-external tool via the admin form, confirm a system_admin user can invoke it in chat (was previously dropped on the wildcard branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)