### PR TITLE
chore: update seed bootstrap data and main_agent docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -420,9 +420,9 @@ All modules are properly packaged and can be imported directly:
 # Import shared auth utilities
 from apis.shared.auth import get_current_user, User, StateStore
 
-# Import agentcore modules
-from agentcore.agent.agent import ChatbotAgent
-from agentcore.local_tools.weather import get_weather
+# Import agent modules
+from agents.main_agent import MainAgent
+from agents.local_tools.url_fetcher import fetch_url_content
 ```
 
 ## Dependencies Overview

--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -338,7 +338,7 @@ DEFAULT_TOOLS: list[dict[str, Any]] = [
         "description": "Perform mathematical calculations and evaluations.",
         "category": "utility",
         "protocol": "local",
-        "enabledByDefault": False,
+        "enabledByDefault": True,
         "isPublic": False,
         "forwardAuthToken": False,
     },

--- a/backend/src/agents/main_agent/README.md
+++ b/backend/src/agents/main_agent/README.md
@@ -67,7 +67,7 @@ from agents.main_agent import MainAgent
 agent = MainAgent(
     session_id="session-123",
     user_id="user-456",
-    enabled_tools=["calculator", "weather", "gateway_wikipedia"],
+    enabled_tools=["calculator", "fetch_url_content", "gateway_wikipedia"],
     model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
     temperature=0.7,
     caching_enabled=True
@@ -75,7 +75,7 @@ agent = MainAgent(
 
 # Stream responses
 async for event in agent.stream_async(
-    message="What's the weather in Seattle?",
+    message="Summarize this page: https://example.com",
     files=None
 ):
     print(event)
@@ -128,7 +128,7 @@ prompt = builder.build(include_date=True)
 # Filter tools
 registry = create_default_registry()
 filter = ToolFilter(registry)
-tools, gateway_ids = filter.filter_tools(["calculator", "weather"])
+tools, gateway_ids = filter.filter_tools(["calculator", "fetch_url_content"])
 ```
 
 ## Module Details

--- a/backend/src/agents/main_agent/USAGE_EXAMPLES.md
+++ b/backend/src/agents/main_agent/USAGE_EXAMPLES.md
@@ -14,7 +14,7 @@ async def simple_chat():
     # Create agent with default settings
     agent = MainAgent(
         session_id="demo-session-001",
-        enabled_tools=["calculator", "weather"]
+        enabled_tools=["calculator", "fetch_url_content"]
     )
 
     # Stream a simple message
@@ -33,7 +33,7 @@ from agents.main_agent import MainAgent
 agent = MainAgent(
     session_id="session-001",
     user_id="user-123",
-    enabled_tools=["calculator", "weather", "visualization"],
+    enabled_tools=["calculator", "fetch_url_content", "create_visualization"],
     model_id="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
     temperature=0.3,
     caching_enabled=True
@@ -268,7 +268,7 @@ os.environ['AWS_REGION'] = 'us-west-2'
 agent = MainAgent(
     session_id="cloud-session",
     user_id="user-123",  # For cross-session preferences
-    enabled_tools=["calculator", "weather"]
+    enabled_tools=["calculator", "fetch_url_content"]
 )
 
 # User preferences and facts are automatically retrieved
@@ -299,7 +299,7 @@ from agents.main_agent import MainAgent
 
 agent = MainAgent(
     session_id="stats-session",
-    enabled_tools=["calculator", "weather", "gateway_wikipedia", "unknown_tool"]
+    enabled_tools=["calculator", "fetch_url_content", "gateway_wikipedia", "unknown_tool"]
 )
 
 # Get tool statistics
@@ -370,7 +370,7 @@ async def safe_stream():
     agent = MainAgent(session_id="safe-session")
 
     try:
-        async for event in agent.stream_async("What's the weather?"):
+        async for event in agent.stream_async("Summarize https://example.com"):
             print(event)
     except Exception as e:
         print(f"Error: {e}")
@@ -393,7 +393,7 @@ logging.basicConfig(
 
 agent = MainAgent(
     session_id="monitored-session",
-    enabled_tools=["calculator", "weather"]
+    enabled_tools=["calculator", "fetch_url_content"]
 )
 
 # All agent operations are logged
@@ -462,7 +462,7 @@ from agentcore.agent.agent import ChatbotAgent
 agent = ChatbotAgent(
     session_id="session-123",
     user_id="user-456",
-    enabled_tools=["calculator", "weather"],
+    enabled_tools=["calculator", "fetch_url_content"],
     model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
     temperature=0.7,
     system_prompt=None,
@@ -480,7 +480,7 @@ from agents.main_agent import MainAgent
 agent = MainAgent(
     session_id="session-123",
     user_id="user-456",
-    enabled_tools=["calculator", "weather"],
+    enabled_tools=["calculator", "fetch_url_content"],
     model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
     temperature=0.7,
     system_prompt=None,


### PR DESCRIPTION
## Summary
- Follow-up to #176 — these changes were committed locally on `feature/refactor-tool-catalog` after the PR was merged, so they didn't make it in.
- Flips `calculator` to `enabledByDefault: True` in seed bootstrap data.
- Updates stale doc examples in `backend/README.md`, `main_agent/README.md`, and `USAGE_EXAMPLES.md` to reference the current modules (`agents.main_agent`, `fetch_url_content`) instead of the old `agentcore`/`weather` names.

## Test plan
- [ ] Re-run `seed_bootstrap_data.py` against a dev environment and confirm calculator is enabled by default for new tenants.
- [ ] Spot-check the README/USAGE_EXAMPLES code snippets against current imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)