### PR TITLE
fix: grant CreateTokenVault and wire OAuth providers table to app-api

### DIFF
--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -445,6 +445,7 @@ export class AppApiStack extends cdk.Stack {
         DYNAMODB_API_KEYS_TABLE_NAME: apiKeysTableName,
         OAUTH_TOKEN_ENCRYPTION_KEY_ARN: oauthTokenEncryptionKeyArn,
         OAUTH_CLIENT_SECRETS_ARN: oauthClientSecretsArn,
+        DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME: oauthProvidersTableName,
         DYNAMODB_AUTH_PROVIDERS_TABLE_NAME: authProvidersTableName,
         AUTH_PROVIDER_SECRETS_ARN: authProviderSecretsArn,
         DYNAMODB_USER_SETTINGS_TABLE_NAME: userSettingsTableName,
@@ -921,11 +922,14 @@ export class AppApiStack extends cdk.Stack {
     // Admin CRUD for OAuth2 credential providers stored in AgentCore Identity.
     // Provider-scoped actions are scoped to the default token vault; List
     // requires a broader resource since it enumerates the vault itself.
+    // CreateTokenVault is required because the first CreateOauth2CredentialProvider
+    // call in a region implicitly provisions the `default` token vault.
     taskDefinition.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         sid: 'AgentCoreCredentialProviderAdmin',
         effect: iam.Effect.ALLOW,
         actions: [
+          'bedrock-agentcore:CreateTokenVault',
           'bedrock-agentcore:CreateOauth2CredentialProvider',
           'bedrock-agentcore:UpdateOauth2CredentialProvider',
           'bedrock-agentcore:DeleteOauth2CredentialProvider',


### PR DESCRIPTION
## Summary

- Add `bedrock-agentcore:CreateTokenVault` to the AppApi task role. The first `CreateOauth2CredentialProvider` call in a region implicitly provisions the `default` token vault, so without this action the very first connector creation returns 500 with `AccessDeniedException`. Once the vault exists, subsequent calls would have succeeded — but the dev environment hit this on the first attempt.
- Wire `DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME` into the AppApi container env. The IAM grant (line 883) and SSM lookup (line 220) were already there from #174; only the env passthrough was missing. Without it, `OAuthProviderRepository` logs `WARNING: ... repository is disabled` at startup and the post-AgentCore DB write in `create_provider()` would fail, triggering the orphan-rollback path.

## Context

Found while debugging a 500 on `POST /admin/oauth-providers/` in the dev-ai account. CloudWatch (`/ecs/dev-boisestateai-v2/app-api`) showed:

```
botocore.errorfactory.AccessDeniedException: ... is not authorized to perform:
bedrock-agentcore:CreateTokenVault on resource:
arn:aws:bedrock-agentcore:us-west-2:490617140655:token-vault/default
```

## Test plan

- [ ] `cd infrastructure && npm install` (local `node_modules` is on `aws-cdk-lib@2.220.0` but pinned to `2.248.0`; pre-existing, blocks `cdk synth` until synced)
- [ ] `npx cdk diff dev-boisestateai-v2-AppApiStack --profile dev-ai` — confirm only the IAM policy and env var change
- [ ] `npx cdk deploy dev-boisestateai-v2-AppApiStack --profile dev-ai`
- [ ] Retry `POST /admin/oauth-providers/` from the admin UI — expect 201 and a row in the OAuth providers DynamoDB table
- [ ] Verify in CloudWatch that the `DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME not set` warning is gone on next task start

🤖 Generated with [Claude Code](https://claude.com/claude-code)