### PR TITLE
refactor: flip connector frontend call sites to app-api

### DIFF
--- a/frontend/ai.client/src/app/oauth-complete/oauth-complete.page.ts
+++ b/frontend/ai.client/src/app/oauth-complete/oauth-complete.page.ts
@@ -266,9 +266,9 @@ export class OAuthCompletePage implements OnInit, OnDestroy {
     sessionUri: string,
     providerId: string | null,
   ): Promise<void> {
-    const baseUrl = this.config.inferenceApiUrl().replace(/\/invocations\/?$/, '');
+    const baseUrl = this.config.appApiUrl();
     if (!baseUrl) {
-      throw new Error('inferenceApiUrl not configured');
+      throw new Error('appApiUrl not configured');
     }
     const token = this.authService.getAccessToken();
     if (!token) {

--- a/frontend/ai.client/src/app/settings/connectors/services/user-connectors.service.ts
+++ b/frontend/ai.client/src/app/settings/connectors/services/user-connectors.service.ts
@@ -21,10 +21,10 @@ function toCamelCase<T>(obj: Record<string, unknown>): T {
 /**
  * User-facing connectors service.
  *
- * Catalog lives on app-api (`GET /connectors`). Consent initiation lives
- * on inference-api (`POST /connectors/{id}/initiate-consent`) because
- * AgentCore's IdentityClient needs the workload token that the runtime
- * middleware injects only on the inference path.
+ * All routes live on app-api. The AgentCore runtime data plane only proxies
+ * `/invocations` and `/ping`, so the previous inference-api consent endpoints
+ * were unreachable in cloud — app-api mints workload context via the
+ * `AGENTCORE_RUNTIME_WORKLOAD_NAME` fallback in `agentcore_identity.py`.
  */
 @Injectable({ providedIn: 'root' })
 export class UserConnectorsService {
@@ -33,9 +33,6 @@ export class UserConnectorsService {
   private readonly config = inject(ConfigService);
 
   private readonly appApiUrl = computed(() => `${this.config.appApiUrl()}/connectors`);
-  private readonly inferenceUrl = computed(
-    () => `${this.config.inferenceApiUrl()}/connectors`,
-  );
 
   readonly connectorsResource = resource<UserConnector[], void>({
     loader: async () => {
@@ -65,7 +62,7 @@ export class UserConnectorsService {
     callback.searchParams.set('provider_id', providerId);
     return await firstValueFrom(
       this.http.get<ConnectorStatusResponse>(
-        `${this.inferenceUrl()}/${providerId}/status`,
+        `${this.appApiUrl()}/${providerId}/status`,
         {
           headers: {
             OAuth2CallbackUrl: callback.toString(),
@@ -77,16 +74,15 @@ export class UserConnectorsService {
 
   async initiateConsent(providerId: string): Promise<InitiateConsentResponse> {
     await this.auth.ensureAuthenticated();
-    // AgentCore's GetResourceOauth2Token requires a callback URL. The runtime
-    // reads this header in prod via AgentCoreContextMiddleware; the settings
-    // page bypasses the runtime, so we set it explicitly on the request.
-    // We also tack the provider_id onto the callback URL as a query param so
+    // AgentCore's GetResourceOauth2Token requires a callback URL. App-api
+    // reads this header via the shared AgentCoreContextMiddleware. We tack
+    // the provider_id onto the callback URL as a query param so
     // /oauth-complete can surface the right providerId in its postMessage.
     const callback = new URL('/oauth-complete', window.location.origin);
     callback.searchParams.set('provider_id', providerId);
     const raw = await firstValueFrom(
       this.http.post<Record<string, unknown>>(
-        `${this.inferenceUrl()}/${providerId}/initiate-consent`,
+        `${this.appApiUrl()}/${providerId}/initiate-consent`,
         {},
         {
           headers: {
@@ -99,16 +95,15 @@ export class UserConnectorsService {
   }
 
   /**
-   * Best-effort disconnect: clears the inference-api's local token cache
-   * for this user/provider and flags it for forced re-consent on next
-   * use. AgentCore Identity exposes no per-user vault-delete, so the
-   * upstream token at the provider keeps existing until it expires or
-   * the user revokes our app from their provider account.
+   * Best-effort disconnect: persists the disconnect intent so the next tool
+   * call forces a fresh consent flow. AgentCore Identity exposes no per-user
+   * vault-delete, so the upstream token at the provider keeps existing
+   * until it expires or the user revokes our app from their provider account.
    */
   async disconnect(providerId: string): Promise<void> {
     await this.auth.ensureAuthenticated();
     await firstValueFrom(
-      this.http.delete(`${this.inferenceUrl()}/${providerId}/connection`),
+      this.http.delete(`${this.appApiUrl()}/${providerId}/connection`),
     );
   }
 


### PR DESCRIPTION
## Summary
- PR 2 of 2 — finishes the connector consent move started in [#180](https://github.com/Boise-State-Development/agentcore-public-stack/pull/180). All five user-facing connector requests now hit `appApiUrl()` instead of `inferenceApiUrl()`, fixing the cloud-only 404s caused by the AgentCore runtime data plane only proxying `/invocations` and `/ping`.
- `settings/connectors/services/user-connectors.service.ts`: dropped the `inferenceUrl` computed; routed `status`, `initiate-consent`, and `disconnect` through `appApiUrl`. `OAuth2CallbackUrl` header is unchanged — the shared `AgentCoreContextMiddleware` from #180 reads it on app-api now.
- `oauth-complete/oauth-complete.page.ts`: `complete-consent` POST goes to `appApiUrl()` directly. Dropped the `/invocations` strip since the ALB base URL has no runtime suffix.

## Test plan
- [ ] `grep -r "inferenceApiUrl\|inferenceUrl" frontend/ai.client/src/app/settings/connectors frontend/ai.client/src/app/oauth-complete` returns nothing.
- [ ] Settings → Connectors loads the catalog with `GET /connectors/` → :8000.
- [ ] Per-card status renders `GET /connectors/{id}/status` → :8000 with the `OAuth2CallbackUrl` header.
- [ ] Click Connect on a provider → `POST /connectors/{id}/initiate-consent` → :8000 returns either `authorizationUrl` or `connected: true`.
- [ ] Complete OAuth flow in popup → `POST /connectors/complete-consent` → :8000, no `inferenceApiUrl not configured` console error.
- [ ] Disconnect → `DELETE /connectors/{id}/connection` → :8000 returns 204.
- [ ] No requests to :8001 from those two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)