### PR TITLE
fix: allow app-api to delete AgentCore OAuth secrets on connector delete

### DIFF
--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -929,6 +929,20 @@ export class AppApiStack extends cdk.Stack {
       })
     );
 
+    // DeleteOauth2CredentialProvider synchronously deletes the underlying
+    // Secrets Manager secret AgentCore created to hold the OAuth client secret,
+    // and authorizes that DeleteSecret call against the caller's identity.
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'AgentCoreOAuthSecretDelete',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:DeleteSecret'],
+        resources: [
+          `arn:aws:secretsmanager:${config.awsRegion}:${config.awsAccount}:secret:bedrock-agentcore-identity!default/oauth2/*`,
+        ],
+      })
+    );
+
     // Admin CRUD for OAuth2 credential providers stored in AgentCore Identity.
     // Provider-scoped actions are scoped to the default token vault; List
     // requires a broader resource since it enumerates the vault itself.


### PR DESCRIPTION
## Summary
- Admin **DELETE /admin/oauth-providers/{id}** was failing with `AccessDeniedException`. AgentCore's `DeleteOauth2CredentialProvider` synchronously deletes the Secrets Manager secret holding the OAuth client secret, and authorizes that `DeleteSecret` against the caller's identity (the app-api ECS task role) — which lacked the permission.
- Adds a scoped `secretsmanager:DeleteSecret` policy statement to the app-api task role, limited to AgentCore Identity-owned OAuth secrets (`bedrock-agentcore-identity!default/oauth2/*`).

## Repro (from dev-ai logs)
```
DELETE /admin/oauth-providers/gmail-employee → 500
botocore.errorfactory.AccessDeniedException: ... DeleteOauth2CredentialProvider ...
You are not authorized to perform: secretsmanager:DeleteSecret
```

## Test plan
- [ ] `cdk diff` on app-api stack shows only the new `AgentCoreOAuthSecretDelete` policy statement on the task role
- [ ] After deploy, admin DELETE on a connector returns 204 and removes both the AgentCore credential provider and its Secrets Manager secret
- [ ] Confirm the deleted provider no longer appears in `aws secretsmanager list-secrets --filters Key=name,Values=bedrock-agentcore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)