### PR TITLE
fix: look up runtime workload identity via SDK custom resource

### DIFF
--- a/infrastructure/lib/inference-api-stack.ts
+++ b/infrastructure/lib/inference-api-stack.ts
@@ -6,6 +6,7 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as xray from 'aws-cdk-lib/aws-xray';
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { AppConfig, getResourceName, getTruncatedResourceName, applyStandardTags, buildCorsOrigins } from './config';
 
@@ -1239,16 +1240,36 @@ export class InferenceApiStack extends cdk.Stack {
     });
 
     // AgentCore Identity auto-creates a workload identity when the runtime is
-    // created and exposes the ARN as a CFN attribute. App-api (which lives
-    // outside the runtime gateway) needs the name segment to mint workload
-    // tokens via GetWorkloadAccessTokenForUserId — i.e. to act as this same
-    // workload so its OAuth vault is shared with the runtime.
+    // created. App-api (which lives outside the runtime gateway) needs the
+    // name segment to mint workload tokens via GetWorkloadAccessTokenForUserId
+    // — i.e. to act as this same workload so its OAuth vault is shared with
+    // the runtime.
+    //
+    // The runtime resource exposes WorkloadIdentityDetails as a top-level CFN
+    // attribute, but Fn::GetAtt rejects the nested `.WorkloadIdentityArn` path
+    // because the resource provider schema doesn't declare it as readable.
+    // Look it up via the control plane SDK instead.
     //
     // ARN format:
     //   arn:aws:bedrock-agentcore:<region>:<account>:workload-identity-directory/default/workload-identity/<name>
-    const workloadIdentityArn = cdk.Token.asString(
-      cdk.Fn.getAtt(this.runtime.logicalId, 'WorkloadIdentityDetails.WorkloadIdentityArn')
-    );
+    const runtimeLookup = new cr.AwsCustomResource(this, 'RuntimeWorkloadIdentityLookup', {
+      onUpdate: {
+        service: '@aws-sdk/client-bedrock-agentcore-control',
+        action: 'GetAgentRuntime',
+        parameters: { agentRuntimeId: this.runtime.attrAgentRuntimeId },
+        physicalResourceId: cr.PhysicalResourceId.fromResponse('agentRuntimeId'),
+        outputPaths: ['workloadIdentityDetails.workloadIdentityArn'],
+      },
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ['bedrock-agentcore:GetAgentRuntime'],
+          resources: [this.runtime.attrAgentRuntimeArn],
+        }),
+      ]),
+      installLatestAwsSdk: true,
+    });
+    runtimeLookup.node.addDependency(this.runtime);
+    const workloadIdentityArn = runtimeLookup.getResponseField('workloadIdentityDetails.workloadIdentityArn');
     const workloadIdentityName = cdk.Fn.select(
       1,
       cdk.Fn.split('workload-identity/', workloadIdentityArn)


### PR DESCRIPTION
## Summary

- PR #180 added two SSM parameters sourced from `Fn::GetAtt(AgentCoreRuntime, 'WorkloadIdentityDetails.WorkloadIdentityArn')`. CloudFormation rejects that nested attribute path — the `AWS::BedrockAgentCore::Runtime` resource provider schema only exposes `WorkloadIdentityDetails` as a top-level readonly attribute, not the nested ARN field. Every InferenceApiStack deploy since #180 has failed with `Requested attribute WorkloadIdentityDetails.WorkloadIdentityArn must be a readonly property in schema...`, which in turn blocked AppApiStack from deploying because it reads the missing `runtime-workload-identity-name` parameter.
- Replace the broken `getAtt` with an `AwsCustomResource` that calls `bedrock-agentcore-control:GetAgentRuntime` and pulls the ARN out of the SDK response (the SDK *does* expose `workloadIdentityDetails.workloadIdentityArn`, even though CFN's GetAtt schema doesn't). The two SSM parameters now read from the custom resource's response field; their parameter names and consumers (app-api's `AGENTCORE_RUNTIME_WORKLOAD_NAME` env var) are unchanged.

## Test plan

- [ ] `cdk synth InferenceApiStack` succeeds and generates `RuntimeWorkloadIdentityLookup` (AwsCustomResource), an IAM policy granting `bedrock-agentcore:GetAgentRuntime` on the runtime ARN, and the two SSM parameters wired to the custom resource's `workloadIdentityDetails.workloadIdentityArn` response field.
- [ ] Deploy `InferenceApiStack` to `dev-boisestateai-v2` — the stack reaches `UPDATE_COMPLETE` and the two SSM parameters are populated with non-empty values.
- [ ] Verify `aws ssm get-parameter --name /dev-boisestateai-v2/inference-api/runtime-workload-identity-name` returns a value matching the `hosted_agent_*` pattern.
- [ ] Deploy `AppApiStack` and confirm it no longer fails on the missing parameter, and the running container has `AGENTCORE_RUNTIME_WORKLOAD_NAME` set.
- [ ] Smoke-test a connector consent flow on app-api end-to-end (since that flow is the consumer of this env var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)