### PR TITLE
fix: grant app-api task role full AgentCore OAuth secret lifecycle perms

### DIFF
--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -929,14 +929,27 @@ export class AppApiStack extends cdk.Stack {
       })
     );
 
-    // DeleteOauth2CredentialProvider synchronously deletes the underlying
-    // Secrets Manager secret AgentCore created to hold the OAuth client secret,
-    // and authorizes that DeleteSecret call against the caller's identity.
+    // AgentCore Identity stores each provider's OAuth client secret in a
+    // Secrets Manager secret it provisions under `bedrock-agentcore-identity!
+    // default/oauth2/*`. Create/Update/Delete on the provider authorize the
+    // corresponding Secrets Manager call against the caller's identity (the
+    // app-api ECS task role), so the full lifecycle of admin CRUD needs:
+    //   - CreateSecret + TagResource: CreateOauth2CredentialProvider
+    //   - PutSecretValue + UpdateSecret: UpdateOauth2CredentialProvider
+    //     (re-submits the full config including a new clientSecret)
+    //   - DeleteSecret: DeleteOauth2CredentialProvider
     taskDefinition.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
-        sid: 'AgentCoreOAuthSecretDelete',
+        sid: 'AgentCoreOAuthSecretLifecycle',
         effect: iam.Effect.ALLOW,
-        actions: ['secretsmanager:DeleteSecret'],
+        actions: [
+          'secretsmanager:CreateSecret',
+          'secretsmanager:DeleteSecret',
+          'secretsmanager:PutSecretValue',
+          'secretsmanager:UpdateSecret',
+          'secretsmanager:TagResource',
+          'secretsmanager:DescribeSecret',
+        ],
         resources: [
           `arn:aws:secretsmanager:${config.awsRegion}:${config.awsAccount}:secret:bedrock-agentcore-identity!default/oauth2/*`,
         ],


### PR DESCRIPTION
## Summary
- Admin **create** and **update** of OAuth credential providers were failing with `AccessDeniedException` on `secretsmanager:CreateSecret` / `PutSecretValue` — the same shape as the delete-flow bug fixed in #182.
- AgentCore Identity provisions the underlying `bedrock-agentcore-identity!default/oauth2/*` secret under the caller's identity (the app-api ECS task role), so the full provider CRUD lifecycle needs the matching Secrets Manager permissions, not just `DeleteSecret`.
- Consolidates the previous `AgentCoreOAuthSecretDelete` statement into a single `AgentCoreOAuthSecretLifecycle` statement covering `CreateSecret`, `DeleteSecret`, `PutSecretValue`, `UpdateSecret`, `TagResource`, and `DescribeSecret`. Resource scope is unchanged.

Repro from `dev-ai`:
```
botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException)
when calling the CreateOauth2CredentialProvider operation: ... not authorized to
perform: secretsmanager:CreateSecret
```

## Test plan
- [ ] `npx cdk diff AppApiStack` shows only the IAM policy update on the app-api task role
- [ ] Deploy `AppApiStack` to dev-ai
- [ ] Admin → create OAuth provider (e.g. `google-calendar-employee`) succeeds with HTTP 201
- [ ] Admin → update that provider with a new client secret succeeds
- [ ] Admin → delete that provider succeeds (regression check on the prior fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)