### PR TITLE
fix: share workload identity between inference-api and app-api

### DIFF
--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -10,13 +10,13 @@ fronts the inference API only proxies `/invocations` and `/ping`, so custom
 paths like `/connectors/{id}/status` get a 404 from AWS before reaching the
 container.
 
-The IdentityClient still needs a workload access token to talk to AgentCore
-Identity. App-api isn't behind the runtime gateway, so the
-WorkloadAccessToken header isn't injected — the client falls back to
-minting one via `bedrock-agentcore:GetWorkloadAccessTokenForUserId` against
-the runtime workload identified by `AGENTCORE_RUNTIME_WORKLOAD_NAME`. This
-keeps both APIs operating against a single shared OAuth vault so the agent
-loop on inference-api sees tokens vaulted from the settings page here.
+The IdentityClient mints workload access tokens against the shared
+platform workload identity (configured via `AGENTCORE_RUNTIME_WORKLOAD_NAME`,
+populated from `/<projectPrefix>/oauth/platform-workload-identity-name`).
+The runtime's auto-created workload identity is service-linked and only
+mintable from inside the runtime container, so we own a separate identity
+that both APIs share. That keeps the OAuth vault unified — tokens vaulted
+from the settings page here are visible to the agent loop on inference-api.
 
 The frontend supplies `OAuth2CallbackUrl` as an explicit header on these
 calls; `AgentCoreContextMiddleware` (installed on app-api in `main.py`)
@@ -245,8 +245,8 @@ async def initiate_consent(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=(
                 "AgentCore workload context unavailable. Set "
-                "AGENTCORE_RUNTIME_WORKLOAD_NAME to the runtime workload "
-                "identity and grant the task role "
+                "AGENTCORE_RUNTIME_WORKLOAD_NAME to the shared platform "
+                "workload identity and grant the task role "
                 "bedrock-agentcore:GetWorkloadAccessTokenForUserId."
             ),
         )

--- a/backend/src/apis/shared/oauth/agentcore_identity.py
+++ b/backend/src/apis/shared/oauth/agentcore_identity.py
@@ -9,12 +9,17 @@ calls) and the app API (settings-page connector status / consent flows).
 Lives in `apis/shared/oauth/` so neither API has to reach into the other's
 package.
 
-The client pulls the per-invocation workload identity token from
-`BedrockAgentCoreContext`, which is populated by `AgentCoreContextMiddleware`
-when the request comes through the AgentCore Runtime gateway. Outside the
-runtime (app-api, local dev), the mint fallback at `_resolve_workload_token`
-takes over — set `AGENTCORE_RUNTIME_WORKLOAD_NAME` to the runtime workload
-identity to act as that workload.
+Both APIs mint user-scoped workload access tokens against a shared platform
+workload identity (defined in InfrastructureStack, exported as
+`/<projectPrefix>/oauth/platform-workload-identity-name`). They cannot
+share the runtime's auto-created identity — that one is service-linked and
+only mintable from inside the runtime container — so we own a separate
+identity that both APIs act as via `GetWorkloadAccessTokenForUserId`.
+
+`AGENTCORE_RUNTIME_WORKLOAD_NAME` (env var, name kept for diff hygiene)
+points at this shared identity. When unset, `_resolve_workload_token`
+falls back to the runtime-injected `BedrockAgentCoreContext` token — used
+by tests and legacy code paths.
 
 Two results are possible when fetching a token:
 
@@ -63,17 +68,12 @@ class _ShortCircuitPoller(TokenPoller):
     async def poll_for_token(self) -> str:
         raise _ConsentRequired()
 
-# In production, the AgentCore Runtime proxies every request to the inference
-# API with a `WorkloadAccessToken` header bound to (runtime workload, user).
-# `AgentCoreContextMiddleware` copies that header onto `BedrockAgentCoreContext`
-# so downstream code can fetch user-federated OAuth tokens without threading
-# it through function args.
-#
-# Local dev doesn't go through the runtime, so the header is absent. When
-# `AGENTCORE_RUNTIME_WORKLOAD_NAME` is set, we fall back to minting a workload
-# token against that runtime ourselves via
-# `bedrock-agentcore:GetWorkloadAccessTokenForUserId`. The caller's AWS
-# principal must be authorised for that action on the target workload.
+# Name of the shared platform workload identity. Both inference-api and
+# app-api mint user-scoped workload tokens against this identity via
+# `bedrock-agentcore:GetWorkloadAccessTokenForUserId`, so they share a
+# single OAuth token vault. The env var name is historical (it pre-dates
+# the shared-identity design when it pointed at the runtime's own
+# workload) — kept to avoid churning every deployment workflow at once.
 _RUNTIME_WORKLOAD_ENV = "AGENTCORE_RUNTIME_WORKLOAD_NAME"
 
 # Same shape as above for the OAuth2 callback URL. The runtime injects an
@@ -190,12 +190,11 @@ class AgentCoreIdentityClient:
     ) -> TokenResult:
         """Fetch a user-federated OAuth2 access token for `provider_name`.
 
-        In production the workload identity token comes from
-        `BedrockAgentCoreContext` (populated by `AgentCoreContextMiddleware`
-        from the AgentCore Runtime's request header). For local dev the
-        header is absent — when `AGENTCORE_RUNTIME_WORKLOAD_NAME` is set
-        and `user_id` is provided, we mint a workload token ourselves
-        against that runtime.
+        In production both APIs mint a fresh workload token against the
+        shared platform workload identity (configured via
+        `AGENTCORE_RUNTIME_WORKLOAD_NAME`), bound to `user_id`. When the
+        env var is unset, falls back to the runtime-injected
+        `BedrockAgentCoreContext` token — used by tests.
 
         If the user has not consented (or re-consent is required), returns a
         `TokenResult` with `authorization_url` populated instead of raising.
@@ -210,9 +209,9 @@ class AgentCoreIdentityClient:
             force_authentication: If True, bypasses the token vault cache and
                 forces the user through the consent flow again. Used for
                 scope upgrades.
-            user_id: User identifier for the local-dev workload-token
-                fallback. Ignored in production where the context already
-                has a token.
+            user_id: User identifier for workload-token minting. Required
+                when `AGENTCORE_RUNTIME_WORKLOAD_NAME` is set (the
+                production path).
 
         Returns:
             `TokenResult` with either `access_token` or `authorization_url`.
@@ -307,45 +306,54 @@ class AgentCoreIdentityClient:
         return urlunparse(parsed._replace(query=urlencode(existing)))
 
     def _resolve_workload_token(self, user_id: Optional[str]) -> str:
-        """Return a workload access token, preferring the runtime-supplied one.
+        """Return a workload access token bound to the configured workload.
 
-        Falls back to minting via `GetWorkloadAccessTokenForUserId` when the
-        context has no token, the `AGENTCORE_RUNTIME_WORKLOAD_NAME` env var
-        is set, and the caller passed `user_id`. Any other combination
-        raises `WorkloadTokenUnavailableError`.
+        When `AGENTCORE_RUNTIME_WORKLOAD_NAME` is set we always mint a fresh
+        token against that workload via `GetWorkloadAccessTokenForUserId`,
+        regardless of whether a context token is present. The runtime
+        injects its own workload token (bound to its auto-created
+        service-linked identity), but vault entries are keyed by workload
+        — so using the runtime-injected token here would fragment the vault
+        across services. Both APIs mint against the same shared platform
+        workload identity instead, so app-api's settings-page consent flow
+        and the runtime's agent loop see the same vaulted tokens.
+
+        When the env var is not set (tests, legacy code paths), fall back
+        to the runtime-injected context token if present, otherwise raise.
         """
+        workload_name = os.environ.get(_RUNTIME_WORKLOAD_ENV)
+        if workload_name:
+            if not user_id:
+                raise WorkloadTokenUnavailableError(
+                    f"{_RUNTIME_WORKLOAD_ENV} is set but no user_id was "
+                    "provided. Workload token minting requires a user_id."
+                )
+            logger.info(
+                "Minting workload access token for user=%s workload=%s",
+                user_id,
+                workload_name,
+            )
+            response = self._control_client.get_workload_access_token_for_user_id(
+                workloadName=workload_name,
+                userId=user_id,
+            )
+            minted_token = response.get("workloadAccessToken")
+            if not minted_token:
+                raise WorkloadTokenUnavailableError(
+                    "GetWorkloadAccessTokenForUserId returned no token"
+                )
+            return minted_token
+
         context_token = BedrockAgentCoreContext.get_workload_access_token()
         if context_token:
             return context_token
 
-        workload_name = os.environ.get(_RUNTIME_WORKLOAD_ENV)
-        if not workload_name:
-            raise WorkloadTokenUnavailableError(
-                "No WorkloadAccessToken on context. For local dev, set "
-                f"{_RUNTIME_WORKLOAD_ENV} to your deployed runtime's "
-                "workload identity name (e.g. hosted_agent_XXXXX)."
-            )
-        if not user_id:
-            raise WorkloadTokenUnavailableError(
-                "No WorkloadAccessToken on context and no user_id provided "
-                "for the local-dev mint fallback."
-            )
-
-        logger.info(
-            "Minting workload access token for user=%s workload=%s (local dev)",
-            user_id,
-            workload_name,
+        raise WorkloadTokenUnavailableError(
+            f"No WorkloadAccessToken on context and {_RUNTIME_WORKLOAD_ENV} "
+            "is unset. Set the env var to the shared platform workload "
+            "identity name (exported as "
+            "/<projectPrefix>/oauth/platform-workload-identity-name)."
         )
-        response = self._control_client.get_workload_access_token_for_user_id(
-            workloadName=workload_name,
-            userId=user_id,
-        )
-        minted_token = response.get("workloadAccessToken")
-        if not minted_token:
-            raise WorkloadTokenUnavailableError(
-                "GetWorkloadAccessTokenForUserId returned no token"
-            )
-        return minted_token
 
 
 _default_client: Optional[AgentCoreIdentityClient] = None

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -447,14 +447,16 @@ export class AppApiStack extends cdk.Stack {
         OAUTH_CLIENT_SECRETS_ARN: oauthClientSecretsArn,
         DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME: oauthProvidersTableName,
         DYNAMODB_OAUTH_USER_TOKENS_TABLE_NAME: oauthUserTokensTableName,
-        // Lets the connector consent flow mint workload tokens against the
-        // runtime's workload identity so its OAuth vault is shared with the
-        // agent loop on inference-api. Required by IdentityClient when the
-        // request isn't proxied through the AgentCore Runtime gateway (i.e.
-        // every app-api request).
+        // Shared platform workload identity (created in InfrastructureStack).
+        // Both app-api and inference-api mint against this same identity so
+        // the OAuth token vault is shared: a user consents once via the
+        // settings page and the runtime agent loop sees the same vaulted
+        // token. The runtime's own auto-created identity is service-linked
+        // and only mintable from inside the runtime container, so we cannot
+        // share that one across services.
         AGENTCORE_RUNTIME_WORKLOAD_NAME: ssm.StringParameter.valueForStringParameter(
           this,
-          `/${config.projectPrefix}/inference-api/runtime-workload-identity-name`
+          `/${config.projectPrefix}/oauth/platform-workload-identity-name`
         ),
         DYNAMODB_AUTH_PROVIDERS_TABLE_NAME: authProvidersTableName,
         AUTH_PROVIDER_SECRETS_ARN: authProviderSecretsArn,
@@ -980,11 +982,11 @@ export class AppApiStack extends cdk.Stack {
       })
     );
 
-    // User-facing consent flows: app-api impersonates the runtime's workload
-    // identity to look up vaulted tokens and finalize OAuth2 sessions on
-    // behalf of users. Mirrors the inference-api task role's permissions —
-    // both APIs need to act as the same workload so they read/write a single
-    // shared token vault. Without these, /connectors/{id}/{status,initiate,
+    // User-facing consent flows: app-api mints user-scoped workload tokens
+    // against the shared platform workload identity (defined in
+    // InfrastructureStack) so it shares the OAuth vault with the
+    // inference-api agent loop. Mirrors the runtime task role's
+    // permissions. Without these, /connectors/{id}/{status,initiate,
     // disconnect,complete} return 503 from the app-api routes.
     taskDefinition.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({

--- a/infrastructure/lib/inference-api-stack.ts
+++ b/infrastructure/lib/inference-api-stack.ts
@@ -6,7 +6,6 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as xray from 'aws-cdk-lib/aws-xray';
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
-import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { AppConfig, getResourceName, getTruncatedResourceName, applyStandardTags, buildCorsOrigins } from './config';
 
@@ -479,7 +478,7 @@ export class InferenceApiStack extends cdk.Stack {
       ],
       resources: [
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default`,
-        `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default/workload-identity/hosted_agent_*`,
+        `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default/workload-identity/*`,
       ],
     }));
 
@@ -498,7 +497,7 @@ export class InferenceApiStack extends cdk.Stack {
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/default`,
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/default/*`,
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default`,
-        `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default/workload-identity/hosted_agent_*`,
+        `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/default/workload-identity/*`,
       ],
     }));
 
@@ -976,6 +975,17 @@ export class InferenceApiStack extends cdk.Stack {
         // URLs
         FRONTEND_URL: config.domainName ? `https://${config.domainName}` : 'http://localhost:4200',
         CORS_ORIGINS: corsOrigins,
+
+        // Shared platform workload identity (created in InfrastructureStack).
+        // Both inference-api and app-api mint user-scoped workload tokens
+        // against this identity so they share a single OAuth token vault.
+        // The runtime auto-creates its own service-linked identity, but it
+        // cannot be shared cross-service — see InfrastructureStack and
+        // `_resolve_workload_token` in apis/shared/oauth/agentcore_identity.py.
+        AGENTCORE_RUNTIME_WORKLOAD_NAME: ssm.StringParameter.valueForStringParameter(
+          this,
+          `/${config.projectPrefix}/oauth/platform-workload-identity-name`
+        ),
       },
     });
     this.runtime.node.addDependency(runtimeExecutionRole);
@@ -1239,55 +1249,10 @@ export class InferenceApiStack extends cdk.Stack {
       tier: ssm.ParameterTier.STANDARD,
     });
 
-    // AgentCore Identity auto-creates a workload identity when the runtime is
-    // created. App-api (which lives outside the runtime gateway) needs the
-    // name segment to mint workload tokens via GetWorkloadAccessTokenForUserId
-    // — i.e. to act as this same workload so its OAuth vault is shared with
-    // the runtime.
-    //
-    // The runtime resource exposes WorkloadIdentityDetails as a top-level CFN
-    // attribute, but Fn::GetAtt rejects the nested `.WorkloadIdentityArn` path
-    // because the resource provider schema doesn't declare it as readable.
-    // Look it up via the control plane SDK instead.
-    //
-    // ARN format:
-    //   arn:aws:bedrock-agentcore:<region>:<account>:workload-identity-directory/default/workload-identity/<name>
-    const runtimeLookup = new cr.AwsCustomResource(this, 'RuntimeWorkloadIdentityLookup', {
-      onUpdate: {
-        service: '@aws-sdk/client-bedrock-agentcore-control',
-        action: 'GetAgentRuntime',
-        parameters: { agentRuntimeId: this.runtime.attrAgentRuntimeId },
-        physicalResourceId: cr.PhysicalResourceId.fromResponse('agentRuntimeId'),
-        outputPaths: ['workloadIdentityDetails.workloadIdentityArn'],
-      },
-      policy: cr.AwsCustomResourcePolicy.fromStatements([
-        new iam.PolicyStatement({
-          actions: ['bedrock-agentcore:GetAgentRuntime'],
-          resources: [this.runtime.attrAgentRuntimeArn],
-        }),
-      ]),
-      installLatestAwsSdk: true,
-    });
-    runtimeLookup.node.addDependency(this.runtime);
-    const workloadIdentityArn = runtimeLookup.getResponseField('workloadIdentityDetails.workloadIdentityArn');
-    const workloadIdentityName = cdk.Fn.select(
-      1,
-      cdk.Fn.split('workload-identity/', workloadIdentityArn)
-    );
-
-    new ssm.StringParameter(this, 'RuntimeWorkloadIdentityArnParameter', {
-      parameterName: `/${config.projectPrefix}/inference-api/runtime-workload-identity-arn`,
-      stringValue: workloadIdentityArn,
-      description: 'AgentCore Runtime workload identity ARN (auto-created by AgentCore Identity)',
-      tier: ssm.ParameterTier.STANDARD,
-    });
-
-    new ssm.StringParameter(this, 'RuntimeWorkloadIdentityNameParameter', {
-      parameterName: `/${config.projectPrefix}/inference-api/runtime-workload-identity-name`,
-      stringValue: workloadIdentityName,
-      description: 'AgentCore Runtime workload identity name (last segment of WorkloadIdentityArn)',
-      tier: ssm.ParameterTier.STANDARD,
-    });
+    // The runtime auto-creates its own service-linked workload identity, but
+    // we don't surface it: it's only mintable from inside the runtime
+    // container, so cross-service callers can't use it. Both APIs share the
+    // platform workload identity defined in InfrastructureStack instead.
 
     // Construct the full runtime endpoint URL for frontend consumption
     const runtimeEndpointUrl = cdk.Fn.sub(

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
@@ -147,6 +148,42 @@ export class InfrastructureStack extends cdk.Stack {
       parameterName: `/${config.projectPrefix}/auth/secret-name`,
       stringValue: this.authSecret.secretName,
       description: 'Authentication Secret Name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    // ============================================================
+    // AgentCore Identity - Shared Platform Workload
+    // ============================================================
+    // AgentCore Runtimes auto-create their own workload identity, but it is
+    // service-linked: only the runtime container itself can mint tokens
+    // against it via GetWorkloadAccessTokenForUserId. App-api lives outside
+    // the runtime gateway and was failing 500 with `WorkloadIdentity is
+    // linked to a service and cannot retrieve an access token by the caller`.
+    //
+    // We create our own workload identity here so both APIs can mint against
+    // it. The OAuth token vault is keyed by (workload identity, user,
+    // provider), so sharing one identity is what lets the settings-page
+    // consent flow and the runtime agent loop see the same vaulted tokens —
+    // a user consents once and both code paths find the token.
+    //
+    // The runtime's auto-created identity is left in place (we can't tell
+    // CreateAgentRuntime to use a pre-existing one) but is no longer used
+    // for vault calls — see `_resolve_workload_token` in the backend.
+    const platformWorkloadIdentity = new bedrock.CfnWorkloadIdentity(this, 'PlatformWorkloadIdentity', {
+      name: getResourceName(config, 'platform-workload'),
+    });
+
+    new ssm.StringParameter(this, 'PlatformWorkloadIdentityNameParameter', {
+      parameterName: `/${config.projectPrefix}/oauth/platform-workload-identity-name`,
+      stringValue: platformWorkloadIdentity.name,
+      description: 'Shared AgentCore workload identity used by both inference-api and app-api for OAuth vault calls',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'PlatformWorkloadIdentityArnParameter', {
+      parameterName: `/${config.projectPrefix}/oauth/platform-workload-identity-arn`,
+      stringValue: platformWorkloadIdentity.attrWorkloadIdentityArn,
+      description: 'Shared AgentCore workload identity ARN',
       tier: ssm.ParameterTier.STANDARD,
     });
 


### PR DESCRIPTION
## Summary
- App-api was returning 500 from `/connectors/{id}/{status,initiate-consent}` with `WorkloadIdentity is linked to a service and cannot retrieve an access token by the caller`. The env var `AGENTCORE_RUNTIME_WORKLOAD_NAME` pointed at the runtime's auto-created workload identity, which AgentCore service-links to the runtime — only the runtime container itself can mint tokens against it.
- Create a dedicated `CfnWorkloadIdentity` in `InfrastructureStack` and have both inference-api and app-api mint user-scoped workload tokens against it. The OAuth vault is keyed by (workload, user, provider), so sharing one identity keeps the settings-page consent flow and the runtime agent loop on a single vault — user consents once, both code paths find the token.
- `_resolve_workload_token` flips precedence: when the env var is set (production), always mint instead of preferring the runtime-injected context token — using that token would key vault calls under the service-linked identity and split the vault. When unset (tests, legacy), the context token is the fallback.

## Why this design
- `CreateAgentRuntime` has no parameter to attach a pre-existing workload identity, so we cannot tell the runtime to use ours. Its auto-created identity stays in place but is no longer consulted for vault calls — the runtime-injected `WorkloadAccessToken` header is now ignored by `IdentityClient` whenever the env var is set.
- Other paths considered: a separate workload per service would split the vault and force users to re-consent in two places; routing all token fetches from runtime → app-api would add latency, a new failure mode, and a circular dependency.

## Files
- `infrastructure/lib/infrastructure-stack.ts` — new `CfnWorkloadIdentity` + SSM exports under `/<projectPrefix>/oauth/platform-workload-identity-{name,arn}`.
- `infrastructure/lib/app-api-stack.ts` — env var now reads the platform SSM param.
- `infrastructure/lib/inference-api-stack.ts` — env var added; broadened IAM resource scopes from `workload-identity/hosted_agent_*` to `workload-identity/*`; removed the dead `RuntimeWorkloadIdentityLookup` custom resource and its SSM exports.
- `backend/src/apis/shared/oauth/agentcore_identity.py` — `_resolve_workload_token` always mints when env var set; module + function docstrings refreshed.
- `backend/src/apis/app_api/connectors/routes.py` — comment refresh.

## Deploy order
**InfrastructureStack → InferenceApiStack → AppApiStack.** Infrastructure must deploy first so the SSM params exist before the API stacks read them.

## Test plan
- [ ] CDK synth passes locally for all stacks.
- [ ] Existing identity unit tests pass (`tests/apis/shared/oauth/test_agentcore_identity.py`, 26 tests).
- [ ] Deploy in dev (alpha.boisestate.ai) in the order above.
- [ ] Settings page → connect `google-calendar-employee` → expect 200 from `/connectors/{id}/initiate-consent`, OAuth popup, callback, "Connected" badge.
- [ ] Chat with a tool that uses Google Calendar → expect the agent to find the same vaulted token (no re-consent prompt). This is the assertion that the shared-workload design actually shares the vault.
- [ ] Inference-api logs show `Minting workload access token for user=... workload=<projectPrefix>-platform-workload` confirming it's using the shared identity, not the runtime's.

## Latent issue surfaced during diagnosis (not fixed here)
While diagnosing the 500 we also saw a `WARNING - Rejected OAuth2CallbackUrl header: not in CORS_ORIGINS allowlist or path != /oauth-complete`. The frontend sends the callback URL with a `?provider_id=...` query string, but `agentcore_context._is_safe_callback_url` rejects any URL with a query string (the server re-tags `provider_id` itself in `_resolve_callback_url`). Once the workload-identity 500 is fixed, this will surface as a 503 from the same endpoints. Tracking separately — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)