### PR TITLE
fix: send bare /oauth-complete callback in connector OAuth2 header

### DIFF
--- a/frontend/ai.client/src/app/settings/connectors/services/user-connectors.service.ts
+++ b/frontend/ai.client/src/app/settings/connectors/services/user-connectors.service.ts
@@ -59,7 +59,6 @@ export class UserConnectorsService {
   async getStatus(providerId: string): Promise<ConnectorStatusResponse> {
     await this.auth.ensureAuthenticated();
     const callback = new URL('/oauth-complete', window.location.origin);
-    callback.searchParams.set('provider_id', providerId);
     return await firstValueFrom(
       this.http.get<ConnectorStatusResponse>(
         `${this.appApiUrl()}/${providerId}/status`,
@@ -75,11 +74,11 @@ export class UserConnectorsService {
   async initiateConsent(providerId: string): Promise<InitiateConsentResponse> {
     await this.auth.ensureAuthenticated();
     // AgentCore's GetResourceOauth2Token requires a callback URL. App-api
-    // reads this header via the shared AgentCoreContextMiddleware. We tack
-    // the provider_id onto the callback URL as a query param so
-    // /oauth-complete can surface the right providerId in its postMessage.
+    // reads this header via the shared AgentCoreContextMiddleware. The
+    // backend's `_resolve_callback_url` re-appends `provider_id` itself,
+    // and AgentCoreContextMiddleware rejects any URL with a query string
+    // as a redirect-pivot guard — so we send a bare `/oauth-complete`.
     const callback = new URL('/oauth-complete', window.location.origin);
-    callback.searchParams.set('provider_id', providerId);
     const raw = await firstValueFrom(
       this.http.post<Record<string, unknown>>(
         `${this.appApiUrl()}/${providerId}/initiate-consent`,


### PR DESCRIPTION
## Summary
- After [#187](https://github.com/Boise-State-Development/agentcore-public-stack/pull/187) cleared the workload-identity 500, the settings page now returns `503 Service Unavailable — No OAuth2 callback URL available` when clicking a connector. Surfaced because the next layer (callback URL handling) was previously masked by the upstream failure.
- The frontend was appending `?provider_id=<name>` to the callback URL it sends in the `OAuth2CallbackUrl` header. `AgentCoreContextMiddleware._is_safe_callback_url` rejects any URL with a query string or fragment as a redirect-pivot guard (the header is client-supplied; an attacker could otherwise pivot the OAuth redirect to capture the auth code on consent). With the header rejected, `_resolve_callback_url` falls through to its env-var fallback (unset on app-api), which raises and surfaces as the 503.
- Drop the `searchParams.set('provider_id', ...)` calls in `getStatus` and `initiateConsent`. The append was redundant anyway — the backend's `_resolve_callback_url` re-tags `provider_id` itself ([agentcore_identity.py:306](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/backend/src/apis/shared/oauth/agentcore_identity.py#L306)) before handing the URL to the AgentCore SDK, so `/oauth-complete` still receives the param it needs to dismiss the right pending consent.

## Why a separate PR
This is a frontend-only change orthogonal to #187's backend/CDK work. Keeping them separate so each can be reviewed and reverted independently.

## Files
- `frontend/ai.client/src/app/settings/connectors/services/user-connectors.service.ts` — drop two `callback.searchParams.set('provider_id', providerId)` lines and refresh the comment to record the redirect-pivot rationale.

## Test plan
- [ ] After deploy, settings page → connect `google-calendar-employee` → expect 200 from `/connectors/{id}/initiate-consent`, OAuth popup opens, user consents, `/oauth-complete` page receives `provider_id` query param (server-appended), connection finalizes, "Connected" badge renders.
- [ ] App-api logs show no `Rejected OAuth2CallbackUrl header` warning for these requests.
- [ ] App-api logs show no `WARNING ... missing callback URL` from `connectors.routes`.
- [ ] Subsequent agent chat using a Google Calendar tool finds the vaulted token without re-prompting (validates the shared-vault assertion from #187).

## Note
`#187` should be merged + deployed before this PR's effect can be observed in the cloud — without #187 the workload-identity 500 still masks this 503. Order: #187 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)