### PR TITLE
fix: grant GetSecretValue on AgentCore OAuth provider secrets

### DIFF
--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -940,6 +940,9 @@ export class AppApiStack extends cdk.Stack {
     //   - PutSecretValue + UpdateSecret: UpdateOauth2CredentialProvider
     //     (re-submits the full config including a new clientSecret)
     //   - DeleteSecret: DeleteOauth2CredentialProvider
+    //   - GetSecretValue: GetResourceOauth2Token (AgentCore reads the
+    //     client secret on every consent / token-refresh call, using the
+    //     caller's IAM identity)
     taskDefinition.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         sid: 'AgentCoreOAuthSecretLifecycle',
@@ -947,6 +950,7 @@ export class AppApiStack extends cdk.Stack {
         actions: [
           'secretsmanager:CreateSecret',
           'secretsmanager:DeleteSecret',
+          'secretsmanager:GetSecretValue',
           'secretsmanager:PutSecretValue',
           'secretsmanager:UpdateSecret',
           'secretsmanager:TagResource',

--- a/infrastructure/lib/inference-api-stack.ts
+++ b/infrastructure/lib/inference-api-stack.ts
@@ -218,6 +218,25 @@ export class InferenceApiStack extends cdk.Stack {
       ],
     }));
 
+    // AgentCore Identity stores each provider's OAuth client secret in a
+    // Secrets Manager secret under `bedrock-agentcore-identity!default/oauth2/*`.
+    // GetResourceOauth2Token (called by the agent loop's tool gating
+    // hooks) reads that secret using the caller's IAM identity. Since the
+    // shared platform workload design (#187) routes inference-api through
+    // the same explicit-mint path as app-api, the runtime now needs the
+    // same permission.
+    runtimeExecutionRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AgentCoreOAuthSecretRead',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'secretsmanager:GetSecretValue',
+        'secretsmanager:DescribeSecret',
+      ],
+      resources: [
+        `arn:aws:secretsmanager:${config.awsRegion}:${config.awsAccount}:secret:bedrock-agentcore-identity!default/oauth2/*`,
+      ],
+    }));
+
     // DynamoDB Users Table permissions (imported from Infrastructure Stack)
     const usersTableArn = ssm.StringParameter.valueForStringParameter(
       this,


### PR DESCRIPTION
## Summary
- After [#187](https://github.com/Boise-State-Development/agentcore-public-stack/pull/187) routed both APIs through the explicit-mint workload-token path, app-api's `/connectors/{id}/initiate-consent` returns `500 AccessDeniedException: ... not authorized to perform: secretsmanager:GetSecretValue` from `GetResourceOauth2Token`.
- AgentCore Identity stores each OAuth provider's client secret in a Secrets Manager entry under `bedrock-agentcore-identity!default/oauth2/*`. `GetResourceOauth2Token` reads it server-side using the caller's IAM identity. The existing `AgentCoreOAuthSecretLifecycle` policy on app-api covered Create/Update/Delete/Describe (admin CRUD on providers) but missed Get.
- Add `secretsmanager:GetSecretValue` on this prefix to both API task roles.

## Why both stacks
Pre-#187, inference-api's runtime-injected workload token took a privileged path that didn't require the caller's IAM perm on these secrets. Post-#187 inference-api uses the same explicit mint path as app-api, so it now needs the same permission — without it the agent loop's OAuth-gated tool flows (Google Calendar, etc.) would hit the same 500 the next time they're invoked. App-api is the immediate breakage; inference-api is the latent one.

## Files
- `infrastructure/lib/app-api-stack.ts` — append `secretsmanager:GetSecretValue` to the existing `AgentCoreOAuthSecretLifecycle` policy.
- `infrastructure/lib/inference-api-stack.ts` — new `AgentCoreOAuthSecretRead` policy on the runtime execution role with `GetSecretValue` + `DescribeSecret` scoped to the same prefix.

## Order
- **#187 must be deployed first.** Without it, the upstream workload-identity 500 still masks this issue.
- **This PR must merge before testing the consent flow end-to-end** — without it `/initiate-consent` 500s after #187 deploys.
- **#188** (frontend callback URL fix) can land in any order vs this PR; both are required for the settings-page consent flow to fully succeed.

## Test plan
- [ ] After deploy of #187 + this PR + #188, settings page → connect `google-calendar-employee` → expect 200, OAuth popup, callback, "Connected" badge.
- [ ] App-api logs show no `AccessDeniedException` from `GetResourceOauth2Token`.
- [ ] Agent chat using a Google Calendar tool — expect token reuse, no re-consent prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)