### PR TITLE
fix: inject OAuth2CallbackUrl env fallback for runtime-stripped header

### DIFF
--- a/backend/src/apis/shared/oauth/agentcore_identity.py
+++ b/backend/src/apis/shared/oauth/agentcore_identity.py
@@ -76,16 +76,16 @@ class _ShortCircuitPoller(TokenPoller):
 # workload) — kept to avoid churning every deployment workflow at once.
 _RUNTIME_WORKLOAD_ENV = "AGENTCORE_RUNTIME_WORKLOAD_NAME"
 
-# Same shape as above for the OAuth2 callback URL. The runtime injects an
-# `OAuth2CallbackUrl` header on every proxied request; in local dev that
-# header is absent and `BedrockAgentCoreContext.get_oauth2_callback_url()`
-# returns None. Without a callback URL the SDK builds an authorize URL whose
-# redirect points to a default that never reaches our `/oauth-complete`
-# page, so consent silently fails to finalize and the user is re-prompted on
-# every request. Set this env var to your frontend's `/oauth-complete` URL
-# (e.g. `http://localhost:4200/oauth-complete`) to make chat-triggered
-# consent work outside the runtime.
-_LOCAL_CALLBACK_URL_ENV = "AGENTCORE_LOCAL_OAUTH_CALLBACK_URL"
+# Same shape as above for the OAuth2 callback URL. App-api receives an
+# `OAuth2CallbackUrl` header from the frontend on settings-page connector
+# calls. Inference-api does not — the AgentCore Runtime gateway strips
+# custom request headers before they reach the container, so the frontend's
+# header on /invocations never arrives and `get_oauth2_callback_url()`
+# returns None. Both APIs therefore set this env var via CDK
+# (`<frontend-url>/oauth-complete`) as the runtime-stripped-header fallback
+# for the agent loop's consent flow. Local dev sets the same var to
+# `http://localhost:4200/oauth-complete`.
+_CALLBACK_URL_ENV = "AGENTCORE_LOCAL_OAUTH_CALLBACK_URL"
 
 
 def _vendor_baseline_params(provider_type: Optional[str]) -> Dict[str, str]:
@@ -274,10 +274,12 @@ class AgentCoreIdentityClient:
     ) -> str:
         """Pick the OAuth2 callback URL and tag it with `provider_id`.
 
-        Resolution order: explicit arg → request-scoped context (Runtime
-        header) → `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL` env var (local-dev
-        escape hatch). Raises `CallbackUrlUnavailableError` when none is
-        available — passing None to the SDK silently breaks consent.
+        Resolution order: explicit arg → request-scoped context (frontend
+        header on app-api; absent on inference-api because the runtime
+        strips custom headers) → `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL` env
+        var (set by CDK on both API tasks; also used in local dev). Raises
+        `CallbackUrlUnavailableError` when none is available — passing None
+        to the SDK silently breaks consent.
 
         AgentCore's redirect doesn't echo any provider hint, so we append
         `provider_id` as a query param so `/oauth-complete` can dismiss the
@@ -288,16 +290,15 @@ class AgentCoreIdentityClient:
         base = (
             explicit
             or BedrockAgentCoreContext.get_oauth2_callback_url()
-            or os.environ.get(_LOCAL_CALLBACK_URL_ENV)
+            or os.environ.get(_CALLBACK_URL_ENV)
         )
         if not base:
             raise CallbackUrlUnavailableError(
-                "No OAuth2 callback URL available. In production the "
-                "AgentCore Runtime injects this via the `OAuth2CallbackUrl` "
-                "header; for local dev set "
-                f"{_LOCAL_CALLBACK_URL_ENV} to your frontend's "
-                "/oauth-complete URL (e.g. "
-                "http://localhost:4200/oauth-complete)."
+                "No OAuth2 callback URL available. App-api expects the "
+                "`OAuth2CallbackUrl` header from the frontend; inference-api "
+                f"reads {_CALLBACK_URL_ENV} (set by CDK) because the runtime "
+                "gateway strips custom headers. For local dev export "
+                f"{_CALLBACK_URL_ENV}=http://localhost:4200/oauth-complete."
             )
 
         parsed = urlparse(base)

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -405,6 +405,11 @@ export class AppApiStack extends cdk.Stack {
         PROJECT_PREFIX: config.projectPrefix,
         FRONTEND_URL: config.domainName ? `https://${config.domainName}` : 'http://localhost:4200',
         CORS_ORIGINS: buildCorsOrigins(config, config.appApi.additionalCorsOrigins).join(','),
+        // OAuth2 callback URL fallback when the frontend's `OAuth2CallbackUrl`
+        // header is absent — see apis/shared/oauth/agentcore_identity.py.
+        AGENTCORE_LOCAL_OAUTH_CALLBACK_URL: config.domainName
+          ? `https://${config.domainName}/oauth-complete`
+          : 'http://localhost:4200/oauth-complete',
         DYNAMODB_QUOTA_TABLE: userQuotasTableName,
         DYNAMODB_EVENTS_TABLE: quotaEventsTableName,
         DYNAMODB_OIDC_STATE_TABLE_NAME: oidcStateTableName,

--- a/infrastructure/lib/inference-api-stack.ts
+++ b/infrastructure/lib/inference-api-stack.ts
@@ -995,6 +995,16 @@ export class InferenceApiStack extends cdk.Stack {
         FRONTEND_URL: config.domainName ? `https://${config.domainName}` : 'http://localhost:4200',
         CORS_ORIGINS: corsOrigins,
 
+        // OAuth2 callback URL fallback for the agent loop's consent flow.
+        // Frontends send `OAuth2CallbackUrl` on /invocations, but the
+        // AgentCore Runtime gateway strips custom headers before they reach
+        // the container, so `BedrockAgentCoreContext.get_oauth2_callback_url()`
+        // is empty here. `_resolve_callback_url` falls back to this env var —
+        // see apis/shared/oauth/agentcore_identity.py.
+        AGENTCORE_LOCAL_OAUTH_CALLBACK_URL: config.domainName
+          ? `https://${config.domainName}/oauth-complete`
+          : 'http://localhost:4200/oauth-complete',
+
         // Shared platform workload identity (created in InfrastructureStack).
         // Both inference-api and app-api mint user-scoped workload tokens
         // against this identity so they share a single OAuth token vault.


### PR DESCRIPTION
## Summary
- After [#187](https://github.com/Boise-State-Development/agentcore-public-stack/pull/187) and [#189](https://github.com/Boise-State-Development/agentcore-public-stack/pull/189) cleared the upstream workload-identity / IAM issues, OAuth-gated MCP tools (Google Calendar, etc.) now fail mid-agent-loop with: `No OAuth token provided. The MCP client must send 'Authorization: Bearer <google_access_token>'`.
- Inference-api logs (CloudWatch `/aws/bedrock-agentcore/runtimes/dev_boisestateai_v2_agentcore_runtime-NbooIbGhsT-DEFAULT`) show the actual cause: `agents.main_agent.session.hooks.oauth_consent - ERROR - No OAuth2 callback URL for provider=google-calendar-employee`. `_resolve_callback_url` ([agentcore_identity.py:286](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/backend/src/apis/shared/oauth/agentcore_identity.py#L286)) raises `CallbackUrlUnavailableError` because none of its three sources have a value.
- The frontend [does send `OAuth2CallbackUrl`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts#L69) on `/invocations`, but **the AgentCore Runtime gateway strips custom request headers before they reach the container**, so the middleware never sees the header (no `Rejected OAuth2CallbackUrl header` warning appears in logs either, ruling out a CORS-allowlist rejection). The middleware's prior comment that the runtime "injects" `OAuth2CallbackUrl` automatically was wrong for `/invocations`.
- Set `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL=<frontend-url>/oauth-complete` on both API tasks via CDK so the existing env-var fallback in `_resolve_callback_url` resolves in cloud.

## Why both stacks
- **inference-api** is the immediate breakage — runtime gateway drops the header.
- **app-api** still receives the header from the frontend on `/connectors/{id}/initiate-consent` (the path #188 fixed), so the env var is symmetric/defensive. If the frontend ever omits the header on a code path we missed, app-api now degrades to the same fallback instead of 503'ing.

## Files
- `infrastructure/lib/inference-api-stack.ts` — add `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL` to runtime container env.
- `infrastructure/lib/app-api-stack.ts` — add the same env var for symmetry.
- `backend/src/apis/shared/oauth/agentcore_identity.py` — update the env-var docstring + `CallbackUrlUnavailableError` message to drop the "local-dev only" framing (rename internal constant `_LOCAL_CALLBACK_URL_ENV` → `_CALLBACK_URL_ENV`; the env var **name** is unchanged for back-compat with existing local `.env` files).

## Test plan
- [ ] After deploy, settings page shows the existing google-calendar-employee connection (no re-consent needed).
- [ ] Agent chat invokes `list_calendars` / `list_events` — succeeds with the vaulted token (no "No OAuth token provided" error).
- [ ] CloudWatch log group `/aws/bedrock-agentcore/runtimes/dev_boisestateai_v2_agentcore_runtime-NbooIbGhsT-DEFAULT` shows no `CallbackUrlUnavailableError` from `oauth_consent`.
- [ ] Local dev still works (existing `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL=http://localhost:4200/oauth-complete` exports continue to satisfy the same env var).

## Order
- Independent of #187 / #188 / #189. Can deploy on top of `develop` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)