### PR TITLE
feat: route chat turns through agent_type factory

### DIFF
--- a/backend/src/agents/main_agent/skills/definitions/canvas-morning-check/SKILL.md
+++ b/backend/src/agents/main_agent/skills/definitions/canvas-morning-check/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: canvas-morning-check
+description: Educator morning course health check for Canvas LMS. Shows submission rates, struggling students, grade distribution, and upcoming deadlines. Trigger phrases include "morning check", "course status", "how are my students", or any start-of-day teaching review.
+---
+
+# Canvas Morning Check
+
+A comprehensive course health check for educators using Canvas LMS. Run it at the start of a teaching day or week to surface submission gaps, students who need support, and upcoming deadlines -- then take action directly from the results.
+
+## Prerequisites
+
+- **Canvas MCP server** must be running and connected to the agent's MCP client.
+- The authenticated user must have an **educator or instructor role** in the target Canvas course(s).
+- **FERPA compliance**: Set `ENABLE_DATA_ANONYMIZATION=true` in the Canvas MCP server environment to anonymize student names in all output. When enabled, names render as `Student_xxxxxxxx` hashes.
+
+## Steps
+
+### 1. Identify Target Course(s)
+
+Ask the user which course(s) to check. Accept a course code, Canvas ID, or "all" to iterate through every active course.
+
+If the user does not specify, prompt:
+
+> Which course would you like to check? (Or say "all" for all active courses.)
+
+Use the `list_courses` MCP tool if you need to look up available courses.
+
+### 2. Collect Recent Submission Data
+
+For each target course:
+
+1. Call `list_assignments` to find assignments with a due date in the **past 7 days**.
+2. For each recent assignment, call `get_assignment_analytics` to collect:
+   - Submission rate (submitted / enrolled)
+   - Average, high, and low scores
+   - Late submission count
+
+### 3. Identify Struggling Students
+
+Call `list_submissions` to retrieve student submission records, then flag students based on these thresholds:
+
+| Urgency | Criteria |
+|---------|----------|
+| **Critical** | Missing 3+ assignments in the past 2 weeks, or average grade below 60% |
+| **Needs attention** | Missing 2 assignments, or average grade 60--70%, or 3+ late submissions |
+| **On track** | All submissions current, grade above 70% |
+
+Use `get_student_analytics` for deeper per-student analysis when the user requests it.
+
+### 4. Check Upcoming Deadlines
+
+Call `list_assignments` filtered to the **next 7 days**. For each upcoming assignment, surface:
+
+- Assignment name
+- Due date and time
+- Point value
+- Current submission count (if submissions have started)
+
+### 5. Generate the Status Report
+
+Present results in a structured format:
+
+```
+## Course Status: [Course Name]
+
+### Submission Overview
+| Assignment | Due Date | Submitted | Rate | Avg Score |
+|------------|----------|-----------|------|-----------|
+| Quiz 3     | Feb 24   | 28/32     | 88%  | 85.2      |
+| Essay 2    | Feb 26   | 25/32     | 78%  | --        |
+
+### Students Needing Support
+**Critical (3+ missing):**
+- Student_a8f7e23 (missing: Quiz 3, Essay 2, HW 5)
+
+**Needs Attention (2 missing):**
+- Student_c9b21f8 (missing: Essay 2, HW 5)
+- Student_d3e45f1 (missing: Quiz 3, Essay 2)
+
+### Upcoming This Week
+- **Mar 3:** Final Project (100 pts) - 5 submitted so far
+- **Mar 5:** Discussion 8 (20 pts)
+
+### Suggested Actions
+1. Send reminder to 3 students with critical status
+2. Review Essay 2 submissions (78% rate, below average)
+3. Post announcement about Final Project deadline
+```
+
+### 6. Offer Follow-up Actions
+
+After presenting the report, offer actionable next steps:
+
+> Would you like me to:
+> 1. Draft and send a message to struggling students (uses `send_conversation`)
+> 2. Send reminders about upcoming deadlines (uses `send_peer_review_reminders` or `send_conversation`)
+> 3. Get detailed analytics for a specific assignment (uses `get_assignment_analytics`)
+> 4. Check another course
+
+If the user selects option 1, use the `send_conversation` MCP tool to message the identified students directly through Canvas.
+
+## MCP Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `list_courses` | Discover active courses |
+| `list_assignments` | Find recent and upcoming assignments |
+| `get_assignment_analytics` | Submission rates and score statistics |
+| `list_submissions` | Per-student submission records |
+| `get_student_analytics` | Detailed per-student performance data |
+| `send_conversation` | Message students through Canvas inbox |
+
+## Example
+
+**User:** "Morning check for CS 101"
+
+**Agent:** Runs the workflow above, outputs the status report.
+
+**User:** "Send a reminder to students missing Quiz 3"
+
+**Agent:** Calls `send_conversation` to message the identified students with a reminder.
+
+## Notes
+
+- When anonymization is enabled, maintain a local mapping of anonymous IDs so follow-up actions (messaging, grading) still target the correct students.
+- This skill works best as a weekly routine -- Monday mornings are ideal.
+- Pairs well with the `canvas-week-plan` skill for student-facing planning.

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -602,6 +602,7 @@ class StreamCoordinator:
                     system_prompt=snapshot_source.get("system_prompt"),
                     caching_enabled=snapshot_source.get("caching_enabled"),
                     max_tokens=snapshot_source.get("max_tokens"),
+                    agent_type=snapshot_source.get("agent_type"),
                     captured_at=now.isoformat(),
                     expires_at=(now + timedelta(hours=1)).isoformat(),
                 )

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -52,6 +52,10 @@ class InvocationRequest(BaseModel):
     # new one. `message` is ignored in that case — the original prompt is
     # already in the agent's interrupt context.
     interrupt_responses: Optional[List[InterruptResponseEntry]] = None
+    # Selects which agent factory variant builds the turn. Defaults to "chat"
+    # (MainAgent / ChatAgent) when omitted, so existing clients are unaffected.
+    # Pass "skill" to route through SkillAgent's progressive skill disclosure.
+    agent_type: Optional[str] = None
 
 
 class InvocationResponse(BaseModel):

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -596,6 +596,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=snapshot.caching_enabled,
                 provider=snapshot.provider,
                 max_tokens=snapshot.max_tokens,
+                agent_type=snapshot.agent_type,
             )
         else:
             # Resolve caching_enabled based on managed model configuration
@@ -620,6 +621,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=input_data.provider,
                 max_tokens=input_data.max_tokens,
+                agent_type=input_data.agent_type,
             )
 
         # Resume requests must target interrupts that the cached agent

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -11,7 +11,8 @@ from typing import Optional, List, Tuple
 import boto3
 
 # from agentcore.agent.agent import ChatbotAgent
-from agents.main_agent.main_agent import MainAgent
+from agents.main_agent.agent_types import create_agent
+from agents.main_agent.base_agent import BaseAgent
 from apis.shared.sessions.metadata import update_session_title
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ def _create_cache_key(
     provider: Optional[str],
     max_tokens: Optional[int],
     freshness_hash: str,
+    agent_type: Optional[str],
 ) -> Tuple:
     """
     Create a cache key for agent instances.
@@ -75,6 +77,7 @@ def _create_cache_key(
         provider or "bedrock",
         max_tokens or 0,
         freshness_hash,
+        agent_type or "chat",
     )
 
 
@@ -95,8 +98,9 @@ async def get_agent(
     system_prompt: Optional[str] = None,
     caching_enabled: Optional[bool] = None,
     provider: Optional[str] = None,
-    max_tokens: Optional[int] = None
-) -> MainAgent:
+    max_tokens: Optional[int] = None,
+    agent_type: Optional[str] = None,
+) -> BaseAgent:
     """
     Get or create agent instance with current configuration for session
 
@@ -117,7 +121,7 @@ async def get_agent(
         max_tokens: Maximum tokens to generate
 
     Returns:
-        MainAgent instance (cached or newly created)
+        BaseAgent subclass instance (cached or newly created)
     """
     from apis.app_api.tools.freshness import get_freshness_hash
 
@@ -134,6 +138,7 @@ async def get_agent(
         provider=provider,
         max_tokens=max_tokens,
         freshness_hash=freshness_hash,
+        agent_type=agent_type,
     )
 
     # Check cache
@@ -144,8 +149,12 @@ async def get_agent(
     # Cache miss - create new agent
     logger.debug("⚠️ Agent cache miss - creating new instance")
 
-    # Create agent with multi-provider support
-    agent = MainAgent(
+    # Create agent via the type registry. Default "chat" preserves the
+    # existing MainAgent (= ChatAgent) behavior; "skill" routes through
+    # SkillAgent's progressive skill disclosure.
+    resolved_agent_type = agent_type or "chat"
+    agent = create_agent(
+        agent_type=resolved_agent_type,
         session_id=session_id,
         user_id=user_id,
         auth_token=auth_token,
@@ -155,8 +164,13 @@ async def get_agent(
         system_prompt=system_prompt,
         caching_enabled=caching_enabled,
         provider=provider,
-        max_tokens=max_tokens
+        max_tokens=max_tokens,
     )
+
+    # Stamp the type onto the construction snapshot so a paused turn can
+    # resume on the same factory variant after cache eviction.
+    if hasattr(agent, "_construction_snapshot"):
+        agent._construction_snapshot["agent_type"] = resolved_agent_type
 
     # Add to cache with LRU eviction
     if len(_agent_cache) >= _CACHE_MAX_SIZE:

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -68,6 +68,7 @@ class PausedTurnSnapshot(BaseModel):
     system_prompt: Optional[str] = Field(default=None, alias="systemPrompt")
     caching_enabled: Optional[bool] = Field(default=None, alias="cachingEnabled")
     max_tokens: Optional[int] = Field(default=None, alias="maxTokens")
+    agent_type: Optional[str] = Field(default=None, alias="agentType")
     captured_at: str = Field(..., alias="capturedAt", description="ISO 8601 timestamp when the turn paused")
     expires_at: str = Field(..., alias="expiresAt", description="ISO 8601 timestamp after which the snapshot is no longer valid for resume")
 


### PR DESCRIPTION
## Summary

- Replaces hard-coded `MainAgent(...)` in `inference-api/chat/service.py` with `create_agent(agent_type, ...)` so requests can route through `SkillAgent` (progressive skill disclosure) without redeploying
- Default stays `"chat"` (= existing `MainAgent` / `ChatAgent`), so existing clients are unaffected
- `agent_type` is folded into the LRU cache key and persisted on `PausedTurnSnapshot` so OAuth-paused turns resume on the same factory variant

This is the minimal wiring that makes [PR #142's SkillAgent](https://github.com/Boise-State-Development/agentcore-public-stack/pull/142) reachable from a real chat turn — the registry, dispatcher/executor meta-tools, and `web-search` skill all already exist; they just had no path from the request layer.

## How to smoke-test the skill path

1. Local: `cd backend/src/apis/inference_api && uv run python main.py`
2. POST to `/invocations` with `agent_type: "skill"` in the body and `enabled_tools` including `fetch_url_content`
3. Watch logs for `SkillAgent created: 1 skills, ... 2 meta-tools (dispatcher + executor)`
4. Confirm the LLM picks the `web-search` skill via `skill_dispatcher` rather than seeing the raw tool

If `enabled_tools` doesn't include any tool the registry can bind, `SkillAgent` falls back to `ChatAgent` behavior (logged as `No skills discovered — falling back…`). The bind is via `_skill_name` decorator metadata — for the `web-search` skill, that's `fetch_url_content`.

## Test plan

- [x] `tests/routes/test_chat.py` (8) — chat route tests still pass
- [x] `tests/agents/main_agent/skills/` (38) — registry + dispatcher/executor tests
- [x] `tests/agents/main_agent/test_agent_types.py` (9) — factory registry
- [x] `tests/shared/test_sessions_metadata.py` (38) — paused-turn snapshot serialization
- [ ] Deploy to dev and POST `agent_type: "skill"` end-to-end
- [ ] Verify a non-skill turn (`agent_type` omitted) is byte-equivalent to today's behavior
- [ ] Verify OAuth-paused → resume on a `"skill"` turn rebuilds as `SkillAgent`

## Out of scope (follow-ups)

- Frontend wiring to send `agent_type: "skill"` (probably a hidden dev toggle first)
- Move `SKILL.md` definitions out of `backend/src/agents/main_agent/skills/definitions/` to the app root, like the [reference repo](https://github.com/aws-samples/sample-strands-agent-with-agentcore) does
- YAML skill registry as the binding source of truth (today binding is decorator-only, which won't cleanly extend to gateway/MCP tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)