### PR TITLE
feat: per-tool MCP approval gate driven by tool catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ tmp/
 # Claude - exclude personal settings
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # OS generated files
 ehthumbs.db

--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -15,9 +15,7 @@ from agents.main_agent.session import SessionFactory
 from agents.main_agent.session.hooks import (
     StopHook,
     OAuthConsentHook,
-    EmailApprovalHook,
-    ExternalWriteApprovalHook,
-    DangerousToolApprovalHook,
+    MCPExternalApprovalHook,
 )
 from agents.main_agent.tools import (
     create_default_registry,
@@ -233,12 +231,30 @@ class BaseAgent(ABC):
         # the hook is a no-op for tools that don't have a registered provider.
         hooks.append(self._build_oauth_consent_hook())
 
-        # Approval gates for dangerous operations
-        hooks.append(EmailApprovalHook())
-        hooks.append(ExternalWriteApprovalHook())
-        hooks.append(DangerousToolApprovalHook())
+        # Per-tool approval gate. Sources its gating set from the catalog
+        # (`MCPServerConfig.tools[*].needs_approval`); a no-op for any tool
+        # without a flag.
+        hooks.append(self._build_mcp_external_approval_hook())
 
         return hooks
+
+    def _build_mcp_external_approval_hook(self) -> MCPExternalApprovalHook:
+        """Resolve a Strands `selected_tool` to the per-tool approval set
+        cached by the external MCP integration. Mirrors the provider lookup
+        used by the OAuth consent hook."""
+        from agents.main_agent.integrations.external_mcp_client import (
+            get_external_mcp_integration,
+        )
+        from strands.tools.mcp import MCPAgentTool
+
+        integration = get_external_mcp_integration()
+
+        def approval_names_lookup(selected_tool: object) -> set[str]:
+            if not isinstance(selected_tool, MCPAgentTool):
+                return set()
+            return integration.approval_names_for_client(selected_tool.mcp_client)
+
+        return MCPExternalApprovalHook(approval_names_lookup=approval_names_lookup)
 
     def _build_oauth_consent_hook(self) -> OAuthConsentHook:
         """Construct the OAuth consent hook with closures over the MCP

--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -226,6 +226,13 @@ class ExternalMCPIntegration:
         # MCPClient object identity -> provider_id, populated alongside `clients`.
         # Consumed by OAuthConsentHook via `provider_for_client`.
         self._provider_for_client_id: dict[int, str] = {}
+        # MCPClient identity -> set of MCP-server-exposed tool names that the
+        # admin has flagged needs_approval=True. Snapshotted at client-build
+        # time from the tool's MCPServerConfig. Consumed by the per-tool
+        # approval hook, which keys off the parent ToolDefinition rather
+        # than a global tool-name list (so two MCP servers can share a tool
+        # name and only one is gated).
+        self._approval_names_for_client_id: dict[int, set[str]] = {}
 
     def _get_cache_key(self, tool_id: str, user_id: Optional[str], requires_oauth: bool) -> str:
         if requires_oauth and user_id:
@@ -235,6 +242,10 @@ class ExternalMCPIntegration:
     def provider_for_client(self, client: Any) -> Optional[str]:
         """Return the OAuth provider_id backing `client`, or None."""
         return self._provider_for_client_id.get(id(client))
+
+    def approval_names_for_client(self, client: Any) -> set[str]:
+        """Return the set of tool names on `client` flagged needs_approval."""
+        return self._approval_names_for_client_id.get(id(client), set())
 
     async def load_external_tools(
         self,
@@ -300,6 +311,7 @@ class ExternalMCPIntegration:
                     stale = self.clients.pop(cache_key)
                     self._client_versions.pop(cache_key, None)
                     self._provider_for_client_id.pop(id(stale), None)
+                    self._approval_names_for_client_id.pop(id(stale), None)
 
                 static_token: Optional[str] = None
                 token_provider: Optional[Callable[[], Optional[str]]] = None
@@ -356,6 +368,9 @@ class ExternalMCPIntegration:
                     self._client_versions[cache_key] = tool_version
                     if provider_id:
                         self._provider_for_client_id[id(client)] = provider_id
+                    approval_names = tool.mcp_config.approval_required_names()
+                    if approval_names:
+                        self._approval_names_for_client_id[id(client)] = approval_names
                     clients.append(client)
                     auth_label = (
                         " (with OIDC forwarding)" if forward_auth and static_token
@@ -399,6 +414,7 @@ class ExternalMCPIntegration:
             client = self.clients.pop(key)
             self._client_versions.pop(key, None)
             self._provider_for_client_id.pop(id(client), None)
+            self._approval_names_for_client_id.pop(id(client), None)
 
         if keys_to_remove:
             logger.info(f"Cleared {len(keys_to_remove)} cached MCP clients for user {user_id}")
@@ -420,6 +436,7 @@ class ExternalMCPIntegration:
             client = self.clients.pop(key)
             self._client_versions.pop(key, None)
             self._provider_for_client_id.pop(id(client), None)
+            self._approval_names_for_client_id.pop(id(client), None)
 
         if keys_to_remove:
             logger.info(f"Cleared {len(keys_to_remove)} cached MCP clients for tool {tool_id}")

--- a/backend/src/agents/main_agent/session/hooks/__init__.py
+++ b/backend/src/agents/main_agent/session/hooks/__init__.py
@@ -2,23 +2,10 @@
 
 from agents.main_agent.session.hooks.oauth_consent import OAuthConsentHook
 from agents.main_agent.session.hooks.stop import StopHook
-from agents.main_agent.session.hooks.tool_approval import (
-    ToolApprovalHook,
-    EmailApprovalHook,
-    ExternalWriteApprovalHook,
-    DangerousToolApprovalHook,
-)
+from agents.main_agent.session.hooks.tool_approval import MCPExternalApprovalHook
 
 __all__ = [
     "OAuthConsentHook",
     "StopHook",
-    "ToolApprovalHook",
-    "EmailApprovalHook",
-    "ExternalWriteApprovalHook",
-    "DangerousToolApprovalHook",
+    "MCPExternalApprovalHook",
 ]
-
-
-
-
-

--- a/backend/src/agents/main_agent/session/hooks/tool_approval.py
+++ b/backend/src/agents/main_agent/session/hooks/tool_approval.py
@@ -1,90 +1,117 @@
+"""Per-tool approval gate for external MCP tools.
+
+Pauses the agent before invoking any MCP tool that the admin flagged with
+`needs_approval=True` in the tool catalog. The pause uses Strands' interrupt
+protocol: the streaming layer surfaces a `tool_approval_required` SSE event
+to the frontend, the user clicks Approve/Deny, and the resume request feeds
+the decision back here via `event.interrupt(...)`'s return value.
+
+Design notes:
+- Approval is scoped to the parent MCP server (the same tool name on a
+  different server can be unflagged); the gating set comes from
+  `ExternalMCPIntegration.approval_names_for_client`.
+- A declined approval becomes a `cancel_tool` so the agent sees a tool error
+  it can apologize/replan against, rather than a silent no-op.
+- The interrupt name is scoped by `toolUseId` so two parallel calls of the
+  same tool in one turn produce distinct interrupts (and distinct SSE events
+  the frontend can correlate per-prompt).
 """
-Tool approval hooks for gating dangerous operations.
 
-These hooks intercept tool calls before execution and can request
-user confirmation for operations that modify external systems.
+from __future__ import annotations
 
-Based on the approval hook pattern from:
-https://github.com/aws-samples/sample-strands-agent-with-agentcore
-"""
-
+import json
 import logging
-from typing import Any, Set
+from typing import Any, Callable, Optional, Set
 
-from strands.hooks import HookProvider, HookRegistry, BeforeToolCallEvent
+from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
 
 logger = logging.getLogger(__name__)
 
 
-class ToolApprovalHook(HookProvider):
-    """
-    Base approval hook that gates specified tool names.
+def _encode_tool_input(value: Any) -> Optional[str]:
+    """JSON-encode tool input for transport + persistence.
 
-    Subclasses define which tool names require approval and what
-    message to show the user. The hook sets the approval_required
-    flag on the event, which the streaming layer can surface to
-    the client for user confirmation.
+    Returns None for empty / missing input so the frontend can skip the
+    "Inspect arguments" affordance. `default=str` keeps the call total —
+    a tool that snuck a non-JSON-serializable value into its args still
+    produces *some* readable string instead of crashing the hook.
     """
+    if value is None:
+        return None
+    if isinstance(value, dict) and not value:
+        return None
+    try:
+        return json.dumps(value, indent=2, default=str)
+    except (TypeError, ValueError):
+        return str(value)
 
-    # Subclasses override these
-    tool_names: Set[str] = set()
-    approval_message: str = "This operation requires approval."
+
+# Resolves a Strands `selected_tool` to the set of MCP-server-exposed tool
+# names that the admin flagged needs_approval, scoped to the parent MCP
+# server. Returns an empty set when the tool isn't an external MCP tool, or
+# when no per-tool flags apply. Indirected so the hook stays decoupled from
+# the integration module.
+ApprovalNamesLookup = Callable[[Any], Set[str]]
+
+
+# Default user-facing message; admins can extend this later by wiring a
+# per-tool message field through the catalog if needed.
+_DEFAULT_APPROVAL_MESSAGE = (
+    "This tool is configured to require user approval before it runs. "
+    "Approve to proceed, or decline to cancel the call."
+)
+
+
+class MCPExternalApprovalHook(HookProvider):
+    """Pause the agent for user approval before a flagged MCP tool runs."""
+
+    def __init__(self, approval_names_lookup: ApprovalNamesLookup):
+        self._approval_names_lookup = approval_names_lookup
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
-        registry.add_callback(BeforeToolCallEvent, self.check_approval)
+        registry.add_callback(BeforeToolCallEvent, self._gate)
 
-    def check_approval(self, event: BeforeToolCallEvent) -> None:
-        """Check if the tool call requires user approval."""
+    def _gate(self, event: BeforeToolCallEvent) -> None:
+        approval_names = self._approval_names_lookup(event.selected_tool)
+        if not approval_names:
+            return
+
         tool_name = event.tool_use.get("name", "")
-        if tool_name in self.tool_names:
-            logger.info(f"Tool approval required: {tool_name}")
-            # The approval_required attribute signals the streaming layer
-            # to elicit user confirmation before proceeding
-            event.tool_use["_approval_required"] = True
-            event.tool_use["_approval_message"] = self.approval_message
+        if tool_name not in approval_names:
+            return
 
+        tool_use_id = event.tool_use.get("toolUseId", "")
+        tool_input = _encode_tool_input(event.tool_use.get("input"))
 
-class EmailApprovalHook(ToolApprovalHook):
-    """Gate bulk email operations (send, delete, forward)."""
+        logger.info(
+            "Pausing for user approval: tool=%s tool_use_id=%s",
+            tool_name,
+            tool_use_id,
+        )
 
-    tool_names = {
-        "send_email",
-        "send_bulk_email",
-        "delete_emails",
-        "forward_email",
-    }
-    approval_message = (
-        "This tool will perform an email operation. "
-        "Please confirm you want to proceed."
-    )
+        # Strands' BeforeToolCallEvent already folds toolUseId into the
+        # interrupt id; we add it to the name too so logs and metadata
+        # entries are unambiguous when multiple parallel calls are paused.
+        response = event.interrupt(
+            name=f"tool_approval:{tool_use_id or tool_name}",
+            reason={
+                "type": "tool_approval_required",
+                "toolUseId": tool_use_id,
+                "toolName": tool_name,
+                "toolInput": tool_input,
+                "message": _DEFAULT_APPROVAL_MESSAGE,
+            },
+        )
 
+        # The frontend POSTs `{"response": "approved"}` or
+        # `{"response": "declined"}`; the routes layer wraps it in
+        # `{"interruptResponse": ...}` so by the time the response lands
+        # here it's the inner string. Anything other than "approved" is
+        # treated as a decline — fail closed.
+        if response == "approved":
+            return
 
-class ExternalWriteApprovalHook(ToolApprovalHook):
-    """Gate operations that write to external systems (GitHub, APIs, etc.)."""
-
-    tool_names = {
-        "create_pull_request",
-        "merge_pull_request",
-        "create_issue",
-        "push_code",
-        "deploy",
-        "delete_repository",
-    }
-    approval_message = (
-        "This tool will modify an external system. "
-        "Please confirm you want to proceed."
-    )
-
-
-class DangerousToolApprovalHook(ToolApprovalHook):
-    """Gate tools with irreversible side effects."""
-
-    tool_names = {
-        "delete_file",
-        "drop_table",
-        "execute_sql",
-    }
-    approval_message = (
-        "This tool performs an irreversible operation. "
-        "Please confirm you want to proceed."
-    )
+        event.cancel_tool = (
+            f"User declined to approve the {tool_name!r} tool call; "
+            "the agent should not invoke it."
+        )

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -195,20 +195,27 @@ class StreamCoordinator:
                     # Don't yield this event to the client (will send final metadata before done)
                     continue
 
-                # If the agent paused on an OAuth interrupt, surface one
-                # `oauth_required` SSE event per pending interrupt before the
-                # stream closes. The frontend uses these to drive the consent
-                # popup and then POSTs interrupt responses to resume the turn.
+                # If the agent paused on an interrupt, surface one SSE event
+                # per pending interrupt before the stream closes. The frontend
+                # uses these to drive its prompts (OAuth popup, tool-approval
+                # modal) and POSTs the user's response back to resume the turn.
                 # Done before the metadata branch so the events land between
-                # message_stop and the final metadata/done block. Persistence
-                # to session metadata happens inside the extractor so a refresh
-                # rediscovers the consent prompt.
+                # message_stop and the final metadata/done block. The OAuth
+                # extractor also writes the PausedTurnSnapshot — running first
+                # means the tool-approval extractor doesn't need to duplicate
+                # that work for tool-approval-only pauses.
                 if event.get("type") == "done":
                     for sse in await self._extract_oauth_required_events(
                         agent,
                         session_id=session_id,
                         user_id=user_id,
                         main_agent_wrapper=main_agent_wrapper,
+                    ):
+                        yield sse
+                    for sse in await self._extract_tool_approval_required_events(
+                        agent,
+                        session_id=session_id,
+                        user_id=user_id,
                     ):
                         yield sse
 
@@ -654,6 +661,83 @@ class StreamCoordinator:
                     provider_id=provider_id,
                     authorization_url=authorization_url,
                     interrupt_id=interrupt.id,
+                ).to_sse_format()
+            )
+        return events
+
+    async def _extract_tool_approval_required_events(
+        self,
+        agent: Any,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> List[str]:
+        """Yield one SSE-formatted `tool_approval_required` event per pending
+        per-tool approval interrupt on the agent, persisting each one to
+        session metadata so the frontend can rediscover them after a refresh.
+
+        The PausedTurnSnapshot is written by the OAuth extractor on the same
+        ``done`` event, so a tool-approval-only pause still has the
+        construction context needed to rebuild the agent on resume.
+
+        Persistence is best-effort: a DynamoDB write failure logs but does
+        not break the live SSE flow.
+        """
+        from apis.shared.sessions.metadata import add_pending_interrupt
+        from apis.shared.sessions.models import PendingInterrupt
+        from apis.shared.tool_approval.models import ToolApprovalRequiredEvent
+
+        interrupt_state = getattr(agent, "_interrupt_state", None)
+        if not interrupt_state or not getattr(interrupt_state, "activated", False):
+            return []
+
+        events: List[str] = []
+        for interrupt in interrupt_state.interrupts.values():
+            reason = interrupt.reason or {}
+            if not isinstance(reason, dict) or reason.get("type") != "tool_approval_required":
+                continue
+            tool_name = reason.get("toolName")
+            if not tool_name:
+                logger.warning(
+                    "Tool approval interrupt missing toolName: id=%s", interrupt.id
+                )
+                continue
+
+            tool_use_id = reason.get("toolUseId", "")
+            tool_input = reason.get("toolInput")
+            message = reason.get("message", "")
+
+            # Persist the breadcrumb before yielding so a client that
+            # refreshes mid-prompt can rehydrate the approve/decline UI.
+            # Only attempt when we have session/user context — preview /
+            # anonymous flows have no metadata record to write to.
+            if session_id and user_id:
+                try:
+                    await add_pending_interrupt(
+                        session_id=session_id,
+                        user_id=user_id,
+                        interrupt=PendingInterrupt(
+                            interrupt_id=interrupt.id,
+                            kind="tool_approval",
+                            tool_use_id=tool_use_id,
+                            tool_name=tool_name,
+                            tool_input=tool_input,
+                            message=message,
+                            created_at=datetime.now(timezone.utc).isoformat(),
+                        ),
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to persist tool_approval pending_interrupt %s: %s",
+                        interrupt.id, e, exc_info=True,
+                    )
+
+            events.append(
+                ToolApprovalRequiredEvent(
+                    interrupt_id=interrupt.id,
+                    tool_use_id=tool_use_id,
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    message=message,
                 ).to_sse_format()
             )
         return events

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -200,16 +200,21 @@ class StreamCoordinator:
                 # uses these to drive its prompts (OAuth popup, tool-approval
                 # modal) and POSTs the user's response back to resume the turn.
                 # Done before the metadata branch so the events land between
-                # message_stop and the final metadata/done block. The OAuth
-                # extractor also writes the PausedTurnSnapshot — running first
-                # means the tool-approval extractor doesn't need to duplicate
-                # that work for tool-approval-only pauses.
+                # message_stop and the final metadata/done block. The
+                # PausedTurnSnapshot is persisted once per pause regardless of
+                # interrupt flavor, so any extractor's resume path can rebuild
+                # the agent shape after a refresh / cache eviction.
                 if event.get("type") == "done":
-                    for sse in await self._extract_oauth_required_events(
+                    await self._persist_paused_turn_snapshot(
                         agent,
                         session_id=session_id,
                         user_id=user_id,
                         main_agent_wrapper=main_agent_wrapper,
+                    )
+                    for sse in await self._extract_oauth_required_events(
+                        agent,
+                        session_id=session_id,
+                        user_id=user_id,
                     ):
                         yield sse
                     for sse in await self._extract_tool_approval_required_events(
@@ -554,13 +559,73 @@ class StreamCoordinator:
             except Exception as persist_error:
                 logger.error(f"Failed to persist stream error to session: {persist_error}")
 
+    async def _persist_paused_turn_snapshot(
+        self,
+        agent: Any,
+        session_id: Optional[str],
+        user_id: Optional[str],
+        main_agent_wrapper: Any,
+    ) -> None:
+        """Persist a ``PausedTurnSnapshot`` capturing the agent's construction
+        params so a resume after refresh / cache eviction rebuilds the same
+        agent shape (matching tool registry) and lets Strands restore
+        ``_interrupt_state`` from AgentCore Memory.
+
+        Called once per pause from the ``done`` branch — shared across
+        interrupt extractors so any flavor of pause (OAuth consent, tool
+        approval, future variants) gets a snapshot. Multiple interrupts in
+        the same turn share one snapshot; they were all built against the
+        same agent. TTL matches AgentCore Identity's consent window so stale
+        snapshots don't pin storage and a too-late resume returns a clean
+        400.
+
+        Persistence is best-effort: a DynamoDB write failure logs but does
+        not break the live SSE flow.
+        """
+        from datetime import timedelta
+        from apis.shared.sessions.metadata import set_paused_turn
+        from apis.shared.sessions.models import PausedTurnSnapshot
+
+        interrupt_state = getattr(agent, "_interrupt_state", None)
+        if not interrupt_state or not getattr(interrupt_state, "activated", False):
+            return
+        if not (session_id and user_id):
+            return
+        snapshot_source = (
+            getattr(main_agent_wrapper, "_construction_snapshot", None)
+            if main_agent_wrapper
+            else None
+        )
+        if not snapshot_source:
+            return
+
+        try:
+            now = datetime.now(timezone.utc)
+            snapshot = PausedTurnSnapshot(
+                enabled_tools=snapshot_source.get("enabled_tools"),
+                model_id=snapshot_source.get("model_id"),
+                provider=snapshot_source.get("provider"),
+                temperature=snapshot_source.get("temperature"),
+                system_prompt=snapshot_source.get("system_prompt"),
+                caching_enabled=snapshot_source.get("caching_enabled"),
+                max_tokens=snapshot_source.get("max_tokens"),
+                agent_type=snapshot_source.get("agent_type"),
+                captured_at=now.isoformat(),
+                expires_at=(now + timedelta(hours=1)).isoformat(),
+            )
+            await set_paused_turn(session_id, user_id, snapshot)
+        except Exception as e:
+            logger.error(
+                "Failed to persist paused_turn snapshot for session %s: %s",
+                session_id, e, exc_info=True,
+            )
+
     async def _extract_oauth_required_events(
         self,
         agent: Any,
         session_id: Optional[str] = None,
         user_id: Optional[str] = None,
         triggering_message_id: Optional[str] = None,
-        main_agent_wrapper: Any = None,
     ) -> List[str]:
         """Yield one SSE-formatted `oauth_required` event per pending OAuth
         interrupt on the agent, persisting each one to session metadata so
@@ -573,52 +638,20 @@ class StreamCoordinator:
         approval gates added later) are ignored here so they can be handled
         by their own SSE event types.
 
-        Also persists a ``PausedTurnSnapshot`` capturing the agent's
-        construction params, so a resume after refresh / cache eviction
-        rebuilds the same agent shape (matching tool registry) and lets
-        Strands restore ``_interrupt_state`` from AgentCore Memory.
+        The ``PausedTurnSnapshot`` is written separately by
+        :meth:`_persist_paused_turn_snapshot` on the same ``done`` event —
+        any pause flavor needs the snapshot, so it's hoisted out of here.
 
         Persistence is best-effort: a DynamoDB write failure logs but does
         not break the live SSE flow.
         """
-        from datetime import timedelta
         from apis.shared.oauth.models import OAuthRequiredEvent
-        from apis.shared.sessions.metadata import add_pending_interrupt, set_paused_turn
-        from apis.shared.sessions.models import PausedTurnSnapshot, PendingInterrupt
+        from apis.shared.sessions.metadata import add_pending_interrupt
+        from apis.shared.sessions.models import PendingInterrupt
 
         interrupt_state = getattr(agent, "_interrupt_state", None)
         if not interrupt_state or not getattr(interrupt_state, "activated", False):
             return []
-
-        # Snapshot the turn-construction context once per pause, before the
-        # per-interrupt loop. Multiple OAuth interrupts in the same turn
-        # share one snapshot — they were all built against the same agent.
-        # TTL matches AgentCore Identity's consent window so stale snapshots
-        # don't pin storage and a too-late resume returns a clean 400.
-        snapshot_source = (
-            getattr(main_agent_wrapper, "_construction_snapshot", None) if main_agent_wrapper else None
-        )
-        if session_id and user_id and snapshot_source:
-            try:
-                now = datetime.now(timezone.utc)
-                snapshot = PausedTurnSnapshot(
-                    enabled_tools=snapshot_source.get("enabled_tools"),
-                    model_id=snapshot_source.get("model_id"),
-                    provider=snapshot_source.get("provider"),
-                    temperature=snapshot_source.get("temperature"),
-                    system_prompt=snapshot_source.get("system_prompt"),
-                    caching_enabled=snapshot_source.get("caching_enabled"),
-                    max_tokens=snapshot_source.get("max_tokens"),
-                    agent_type=snapshot_source.get("agent_type"),
-                    captured_at=now.isoformat(),
-                    expires_at=(now + timedelta(hours=1)).isoformat(),
-                )
-                await set_paused_turn(session_id, user_id, snapshot)
-            except Exception as e:
-                logger.error(
-                    "Failed to persist paused_turn snapshot for session %s: %s",
-                    session_id, e, exc_info=True,
-                )
 
         events: List[str] = []
         for interrupt in interrupt_state.interrupts.values():
@@ -675,9 +708,10 @@ class StreamCoordinator:
         per-tool approval interrupt on the agent, persisting each one to
         session metadata so the frontend can rediscover them after a refresh.
 
-        The PausedTurnSnapshot is written by the OAuth extractor on the same
-        ``done`` event, so a tool-approval-only pause still has the
-        construction context needed to rebuild the agent on resume.
+        The ``PausedTurnSnapshot`` needed to rebuild the agent on resume is
+        written by :meth:`_persist_paused_turn_snapshot` on the same
+        ``done`` event — independent of which interrupt flavor caused the
+        pause.
 
         Persistence is best-effort: a DynamoDB write failure logs but does
         not break the live SSE flow.

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -1,5 +1,6 @@
 """Admin API routes for tool catalog management."""
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -16,6 +17,10 @@ from apis.app_api.tools.models import (
     AdminToolResponse,
     AdminToolListResponse,
     ToolDefinition,
+    MCPDiscoverRequest,
+    MCPDiscoverResponse,
+    DiscoveredMCPTool,
+    MCPAuthType,
 )
 
 logger = logging.getLogger(__name__)
@@ -227,6 +232,78 @@ async def admin_delete_tool(
 
     action = "deleted" if hard else "disabled"
     return {"message": f"Tool '{tool_id}' {action} successfully"}
+
+
+# =============================================================================
+# MCP Server Discovery
+# =============================================================================
+
+
+@router.post("/discover", response_model=MCPDiscoverResponse)
+async def admin_discover_mcp_tools(
+    request: MCPDiscoverRequest,
+    admin: User = Depends(require_admin),
+):
+    """Connect to an MCP server with the given config and return its tool list.
+
+    Used by the admin tool form to populate the per-tool entries instead of
+    asking admins to type each name. OAuth-gated servers are not supported —
+    the admin's session can't supply an end-user token.
+
+    Args:
+        request: MCP server connection details (URL, transport, auth)
+        admin: Authenticated admin user (injected)
+
+    Returns:
+        MCPDiscoverResponse with the discovered tools and their descriptions
+    """
+    from agents.main_agent.integrations.external_mcp_client import (
+        create_external_mcp_client,
+    )
+
+    if request.auth_type in (MCPAuthType.OAUTH2.value, MCPAuthType.OAUTH2):
+        raise HTTPException(
+            status_code=400,
+            detail="OAuth-gated MCP servers can't be discovered server-side; "
+            "list the tool names manually.",
+        )
+
+    client = create_external_mcp_client(config=request.to_config())
+    if client is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Could not build an MCP client for the supplied config — "
+            "check the server URL and transport.",
+        )
+
+    def _list_tools():
+        # MCPClient is a sync context manager that opens a session on enter;
+        # `list_tools_sync` performs the MCP `tools/list` call. We push it to
+        # a thread so the async event loop stays responsive during connect.
+        with client:
+            return list(client.list_tools_sync())
+
+    try:
+        tools = await asyncio.to_thread(_list_tools)
+    except Exception as exc:
+        logger.exception("MCP discovery failed for %s", request.server_url)
+        raise HTTPException(
+            status_code=502,
+            detail=f"MCP server did not respond to tools/list: {exc}",
+        )
+
+    discovered: list[DiscoveredMCPTool] = []
+    for tool in tools:
+        # Strands wraps each MCP tool as an MCPAgentTool; spec details live on
+        # `mcp_tool` (mirrors the wire-format `Tool` from the MCP SDK).
+        spec = getattr(tool, "mcp_tool", None)
+        name = getattr(spec, "name", None) or getattr(tool, "tool_name", None)
+        description = getattr(spec, "description", None)
+        if not name:
+            continue
+        discovered.append(DiscoveredMCPTool(name=name, description=description))
+
+    return MCPDiscoverResponse(tools=discovered)
 
 
 # =============================================================================

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -250,6 +250,15 @@ async def admin_discover_mcp_tools(
     asking admins to type each name. OAuth-gated servers are not supported —
     the admin's session can't supply an end-user token.
 
+    Trust boundary: this endpoint deliberately accepts an arbitrary
+    ``server_url`` from an authenticated admin and connects to it from the
+    backend's network position. That's the same trust we already extend
+    when the admin saves an MCP tool configuration (the agent loop will
+    connect to whatever URL is in the catalog), so we don't add an
+    SSRF allowlist here. Admins are expected to be able to reach internal
+    MCP servers — that's the deployment shape. If a future change exposes
+    this beyond admins, add an allowlist (scheme + host) before shipping.
+
     Args:
         request: MCP server connection details (URL, transport, auth)
         admin: Authenticated admin user (injected)

--- a/backend/src/apis/app_api/tools/models.py
+++ b/backend/src/apis/app_api/tools/models.py
@@ -79,6 +79,51 @@ class ToolStatus(str, Enum):
 # =============================================================================
 
 
+class MCPToolEntry(BaseModel):
+    """A single tool exposed by an MCP server, with per-tool flags."""
+
+    name: str = Field(..., description="Tool name as exposed by the MCP server")
+    needs_approval: bool = Field(
+        default=False,
+        description="If true, the agent must request user confirmation before invoking this tool.",
+    )
+    description: Optional[str] = Field(
+        None, description="Optional admin-supplied description for this tool"
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "needsApproval": self.needs_approval,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MCPToolEntry":
+        return cls(
+            name=data.get("name", ""),
+            needs_approval=bool(data.get("needsApproval", False)),
+            description=data.get("description"),
+        )
+
+
+def _parse_mcp_tools(raw: object) -> List[MCPToolEntry]:
+    """Parse the mcp_config.tools field, accepting either the new entry-dict
+    format or the legacy `List[str]` format written by older catalog rows.
+    """
+    if not isinstance(raw, list):
+        return []
+    entries: List[MCPToolEntry] = []
+    for item in raw:
+        if isinstance(item, MCPToolEntry):
+            entries.append(item)
+        elif isinstance(item, dict):
+            entries.append(MCPToolEntry.from_dict(item))
+        elif isinstance(item, str):
+            entries.append(MCPToolEntry(name=item))
+    return entries
+
+
 class MCPServerConfig(BaseModel):
     """
     Configuration for external MCP server connections.
@@ -112,9 +157,10 @@ class MCPServerConfig(BaseModel):
     )
 
     # MCP tool discovery
-    tools: List[str] = Field(
+    tools: List[MCPToolEntry] = Field(
         default_factory=list,
-        description="List of tool names available on this MCP server. Empty means discover at runtime.",
+        description="Tools available on this MCP server, with per-tool flags. "
+        "Empty means discover at runtime (no per-tool flags applied).",
     )
 
     # Health check
@@ -140,14 +186,16 @@ class MCPServerConfig(BaseModel):
             "awsRegion": self.aws_region,
             "apiKeyHeader": self.api_key_header,
             "secretArn": self.secret_arn,
-            "tools": self.tools,
+            "tools": [entry.to_dict() for entry in self.tools],
             "healthCheckEnabled": self.health_check_enabled,
             "healthCheckIntervalSeconds": self.health_check_interval_seconds,
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "MCPServerConfig":
-        """Create from dictionary."""
+        """Create from dictionary. Accepts the legacy `List[str]` tools format
+        for rows written before per-tool flags shipped — same precedent as the
+        legacy-protocol mapping in ToolDefinition.from_dynamo_item."""
         return cls(
             server_url=data.get("serverUrl", ""),
             transport=data.get("transport", MCPTransport.STREAMABLE_HTTP),
@@ -155,10 +203,14 @@ class MCPServerConfig(BaseModel):
             aws_region=data.get("awsRegion"),
             api_key_header=data.get("apiKeyHeader"),
             secret_arn=data.get("secretArn"),
-            tools=data.get("tools", []),
+            tools=_parse_mcp_tools(data.get("tools", [])),
             health_check_enabled=data.get("healthCheckEnabled", False),
             health_check_interval_seconds=data.get("healthCheckIntervalSeconds", 300),
         )
+
+    def approval_required_names(self) -> set[str]:
+        """Return the names of tools flagged as requiring user approval."""
+        return {entry.name for entry in self.tools if entry.needs_approval}
 
 
 class A2AAgentConfig(BaseModel):
@@ -488,6 +540,31 @@ class ToolPreferencesRequest(BaseModel):
     )
 
 
+class MCPToolEntryPayload(BaseModel):
+    """Wire-format for an MCPToolEntry on the admin API."""
+
+    name: str
+    needs_approval: bool = Field(default=False, alias="needsApproval")
+    description: Optional[str] = None
+
+    model_config = {"populate_by_name": True}
+
+    def to_model(self) -> MCPToolEntry:
+        return MCPToolEntry(
+            name=self.name,
+            needs_approval=self.needs_approval,
+            description=self.description,
+        )
+
+    @classmethod
+    def from_model(cls, entry: MCPToolEntry) -> "MCPToolEntryPayload":
+        return cls(
+            name=entry.name,
+            needs_approval=entry.needs_approval,
+            description=entry.description,
+        )
+
+
 class MCPServerConfigRequest(BaseModel):
     """Request body for MCP server configuration."""
 
@@ -499,7 +576,7 @@ class MCPServerConfigRequest(BaseModel):
     aws_region: Optional[str] = Field(None, alias="awsRegion")
     api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
     secret_arn: Optional[str] = Field(None, alias="secretArn")
-    tools: List[str] = Field(default_factory=list)
+    tools: List[MCPToolEntryPayload] = Field(default_factory=list)
     health_check_enabled: bool = Field(default=False, alias="healthCheckEnabled")
     health_check_interval_seconds: int = Field(
         default=300, alias="healthCheckIntervalSeconds"
@@ -516,7 +593,7 @@ class MCPServerConfigRequest(BaseModel):
             aws_region=self.aws_region,
             api_key_header=self.api_key_header,
             secret_arn=self.secret_arn,
-            tools=self.tools,
+            tools=[entry.to_model() for entry in self.tools],
             health_check_enabled=self.health_check_enabled,
             health_check_interval_seconds=self.health_check_interval_seconds,
         )
@@ -645,7 +722,7 @@ class MCPServerConfigResponse(BaseModel):
     aws_region: Optional[str] = Field(None, alias="awsRegion")
     api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
     secret_arn: Optional[str] = Field(None, alias="secretArn")
-    tools: List[str] = Field(default_factory=list)
+    tools: List[MCPToolEntryPayload] = Field(default_factory=list)
     health_check_enabled: bool = Field(default=False, alias="healthCheckEnabled")
     health_check_interval_seconds: int = Field(
         default=300, alias="healthCheckIntervalSeconds"
@@ -667,7 +744,7 @@ class MCPServerConfigResponse(BaseModel):
             aws_region=config.aws_region,
             api_key_header=config.api_key_header,
             secret_arn=config.secret_arn,
-            tools=config.tools,
+            tools=[MCPToolEntryPayload.from_model(entry) for entry in config.tools],
             health_check_enabled=config.health_check_enabled,
             health_check_interval_seconds=config.health_check_interval_seconds,
         )
@@ -769,5 +846,47 @@ class AdminToolListResponse(BaseModel):
 
     tools: List[AdminToolResponse]
     total: int
+
+
+class MCPDiscoverRequest(BaseModel):
+    """Request body for POST /api/admin/tools/discover.
+
+    Same fields as MCPServerConfigRequest minus the `tools` list — the
+    point of discovery is to populate that list. OAuth-gated and OIDC-
+    forwarded servers can't be discovered admin-side (no end-user token
+    available); the route returns a 400 in those cases."""
+
+    server_url: str = Field(..., alias="serverUrl")
+    transport: MCPTransport = Field(default=MCPTransport.STREAMABLE_HTTP)
+    auth_type: MCPAuthType = Field(default=MCPAuthType.AWS_IAM, alias="authType")
+    aws_region: Optional[str] = Field(None, alias="awsRegion")
+    api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
+    secret_arn: Optional[str] = Field(None, alias="secretArn")
+
+    model_config = {"populate_by_name": True, "use_enum_values": True}
+
+    def to_config(self) -> MCPServerConfig:
+        return MCPServerConfig(
+            server_url=self.server_url,
+            transport=self.transport,
+            auth_type=self.auth_type,
+            aws_region=self.aws_region,
+            api_key_header=self.api_key_header,
+            secret_arn=self.secret_arn,
+            tools=[],
+        )
+
+
+class DiscoveredMCPTool(BaseModel):
+    """A tool discovered from a live MCP server's list_tools call."""
+
+    name: str
+    description: Optional[str] = None
+
+
+class MCPDiscoverResponse(BaseModel):
+    """Response body for POST /api/admin/tools/discover."""
+
+    tools: List[DiscoveredMCPTool]
 
 

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -21,28 +21,66 @@ class VisualDisplayState(BaseModel):
 
 
 class PendingInterrupt(BaseModel):
-    """An OAuth consent request that paused an agent turn and is awaiting user action.
+    """A paused-turn breadcrumb the frontend uses to rediscover prompts on
+    reload — without it, a browser refresh leaves the prompt stuck and the
+    tool call orphaned in ``pending`` forever.
 
-    Persisted to session metadata when ``OAuthConsentHook`` fires the interrupt
-    so the frontend can rediscover pending consents on reload — without it, a
-    browser refresh leaves the consent prompt stuck and the tool call orphaned
-    in ``pending`` forever.
+    Two variants share this shape (discriminated by ``kind``):
 
-    Note: ``authorization_url`` is intentionally omitted. AgentCore Identity's
-    consent URLs are short-lived; storing them invites stale-URL bugs on
-    refresh-after-an-hour. Frontend re-fetches via ``initiate-consent`` on
-    Connect.
+    - ``oauth`` — written by ``OAuthConsentHook``. Carries ``provider_id``;
+      the frontend re-fetches a fresh consent URL via ``initiate-consent``
+      on Connect (URLs are short-lived; storing them invites stale-URL bugs).
+    - ``tool_approval`` — written by ``MCPExternalApprovalHook``. Carries
+      ``tool_name`` + ``tool_input`` + ``message`` so the inline approve/decline
+      prompt rehydrates with the same context the user saw before refresh.
+      ``tool_input`` is stored as a JSON-encoded string to avoid DynamoDB's
+      Decimal/float coercion when the agent's tool input contains nested
+      objects with floats.
+
+    Default ``kind`` is ``oauth`` for backward compatibility with rows
+    written before per-tool approval shipped.
     """
 
     model_config = ConfigDict(populate_by_name=True)
     interrupt_id: str = Field(..., alias="interruptId", description="Strands interrupt id used to resume the paused turn")
-    provider_id: str = Field(..., alias="providerId", description="Connector providerId needing consent")
+    kind: Literal["oauth", "tool_approval"] = Field(
+        default="oauth",
+        description="Discriminator: which variant this interrupt represents",
+    )
     triggering_message_id: Optional[str] = Field(
         None,
         alias="triggeringMessageId",
         description="Id of the assistant message whose tool call triggered this interrupt, when known",
     )
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp when the interrupt was recorded")
+
+    # OAuth-only fields
+    provider_id: Optional[str] = Field(
+        default=None,
+        alias="providerId",
+        description="(oauth) Connector providerId needing consent",
+    )
+
+    # tool_approval-only fields
+    tool_use_id: Optional[str] = Field(
+        default=None,
+        alias="toolUseId",
+        description="(tool_approval) Strands tool-use id of the paused call",
+    )
+    tool_name: Optional[str] = Field(
+        default=None,
+        alias="toolName",
+        description="(tool_approval) MCP-server-exposed name of the tool",
+    )
+    tool_input: Optional[str] = Field(
+        default=None,
+        alias="toolInput",
+        description="(tool_approval) JSON-encoded tool input arguments",
+    )
+    message: Optional[str] = Field(
+        default=None,
+        description="(tool_approval) Admin-supplied or default approval message",
+    )
 
 
 class PausedTurnSnapshot(BaseModel):

--- a/backend/src/apis/shared/tool_approval/models.py
+++ b/backend/src/apis/shared/tool_approval/models.py
@@ -1,0 +1,45 @@
+"""Models for the per-tool approval interrupt flow.
+
+Mirrors `apis.shared.oauth.models.OAuthRequiredEvent`: a Strands hook raises
+an interrupt before invoking a flagged tool, the streaming layer surfaces
+the SSE event to the frontend, the user clicks Approve/Deny, and the
+resume request feeds the decision back via `interrupt_responses`.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolApprovalRequiredEvent(BaseModel):
+    """SSE event signalling that an MCP tool needs user approval before it runs.
+
+    Emitted mid-turn when `MCPExternalApprovalHook` raises a Strands interrupt:
+    the in-flight tool call is held in `_interrupt_state`, the frontend
+    receives this event and renders an inline approve/deny prompt, and the
+    user's decision POSTs back to `/invocations` with an
+    `interrupt_responses` entry whose `response` is `"approved"` or
+    `"declined"`.
+
+    `tool_input` is a JSON-encoded string rather than a structured object —
+    the same shape is persisted as a `PendingInterrupt` breadcrumb (where
+    DynamoDB would otherwise coerce floats to Decimal), so we use one shape
+    end-to-end and let the frontend render the string verbatim.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = "tool_approval_required"
+    interrupt_id: str = Field(..., alias="interruptId")
+    tool_use_id: str = Field(..., alias="toolUseId")
+    tool_name: str = Field(..., alias="toolName")
+    tool_input: Optional[str] = Field(default=None, alias="toolInput")
+    message: str
+
+    def to_sse_format(self) -> str:
+        import json
+
+        return (
+            f"event: tool_approval_required\n"
+            f"data: {json.dumps(self.model_dump(by_alias=True, exclude_none=True))}\n\n"
+        )

--- a/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
+++ b/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
@@ -184,7 +184,10 @@ def _fake_tool(updated_at, tool_id="gmail"):
     return SimpleNamespace(
         tool_id=tool_id,
         protocol="mcp_external",
-        mcp_config=SimpleNamespace(server_url="https://example.com/mcp"),
+        mcp_config=SimpleNamespace(
+            server_url="https://example.com/mcp",
+            approval_required_names=lambda: set(),
+        ),
         forward_auth_token=False,
         requires_oauth_provider=None,
         updated_at=updated_at,

--- a/backend/tests/agents/main_agent/session/test_tool_approval.py
+++ b/backend/tests/agents/main_agent/session/test_tool_approval.py
@@ -1,106 +1,147 @@
-"""Tests for tool approval hooks."""
+"""Tests for the per-tool approval hook.
 
-import pytest
+The hook reads a per-MCP-server approval set from the integration cache and
+pauses the agent (Strands interrupt) when a flagged tool is about to run.
+The user's resume response either lets the call proceed ("approved") or
+cancels it ("declined" — anything not "approved" fails closed).
+"""
+
+from typing import Any
 from unittest.mock import MagicMock
 
-from agents.main_agent.session.hooks.tool_approval import (
-    ToolApprovalHook,
-    EmailApprovalHook,
-    ExternalWriteApprovalHook,
-    DangerousToolApprovalHook,
-)
+from agents.main_agent.session.hooks.tool_approval import MCPExternalApprovalHook
 
 
-def _make_event(tool_name: str):
-    """Create a mock BeforeToolCallEvent."""
+def _make_event(tool_name: str, tool_use_id: str = "tu-1", interrupt_response: Any = None):
+    """Mock BeforeToolCallEvent with a configurable interrupt() return value."""
     event = MagicMock()
-    event.tool_use = {"name": tool_name}
+    event.tool_use = {
+        "name": tool_name,
+        "toolUseId": tool_use_id,
+        "input": {"foo": "bar"},
+    }
+    event.cancel_tool = None
+    event.interrupt = MagicMock(return_value=interrupt_response)
+    event.selected_tool = MagicMock()
     return event
 
 
-class TestEmailApprovalHook:
-    """Req AH-1: Email operations require approval."""
+class TestMCPExternalApprovalHook:
+    """Req: per-tool approval gate uses real Strands interrupts and acts on
+    the user's response, not a flag-and-continue pattern."""
 
-    def test_send_email_flagged(self):
-        hook = EmailApprovalHook()
-        event = _make_event("send_email")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
-
-    def test_delete_emails_flagged(self):
-        hook = EmailApprovalHook()
-        event = _make_event("delete_emails")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
-
-    def test_read_email_not_flagged(self):
-        hook = EmailApprovalHook()
+    def test_unflagged_tool_runs_without_pause(self):
+        hook = MCPExternalApprovalHook(approval_names_lookup=lambda _: set())
         event = _make_event("read_email")
-        hook.check_approval(event)
-        assert "_approval_required" not in event.tool_use
+        hook._gate(event)
+        event.interrupt.assert_not_called()
+        assert event.cancel_tool is None
 
-    def test_approval_message_set(self):
-        hook = EmailApprovalHook()
-        event = _make_event("send_email")
-        hook.check_approval(event)
-        assert "email operation" in event.tool_use["_approval_message"]
+    def test_tool_not_in_approval_set_runs_without_pause(self):
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"send_email"}
+        )
+        event = _make_event("read_email")
+        hook._gate(event)
+        event.interrupt.assert_not_called()
+        assert event.cancel_tool is None
 
+    def test_flagged_tool_with_approved_response_proceeds(self):
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"send_email"}
+        )
+        event = _make_event("send_email", interrupt_response="approved")
+        hook._gate(event)
 
-class TestExternalWriteApprovalHook:
-    """Req AH-2: External system writes require approval."""
+        event.interrupt.assert_called_once()
+        # Approved → no cancel
+        assert event.cancel_tool is None
 
-    def test_create_pr_flagged(self):
-        hook = ExternalWriteApprovalHook()
-        event = _make_event("create_pull_request")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
+    def test_flagged_tool_with_declined_response_cancels(self):
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"send_email"}
+        )
+        event = _make_event("send_email", interrupt_response="declined")
+        hook._gate(event)
 
-    def test_deploy_flagged(self):
-        hook = ExternalWriteApprovalHook()
-        event = _make_event("deploy")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
+        event.interrupt.assert_called_once()
+        assert event.cancel_tool is not None
+        assert "send_email" in event.cancel_tool
 
-    def test_list_repos_not_flagged(self):
-        hook = ExternalWriteApprovalHook()
-        event = _make_event("list_repositories")
-        hook.check_approval(event)
-        assert "_approval_required" not in event.tool_use
+    def test_unknown_response_treated_as_decline(self):
+        """Fail closed: anything other than the literal "approved" string
+        cancels. Guards against bug-introduced typos or partial responses."""
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"send_email"}
+        )
+        event = _make_event("send_email", interrupt_response={"unexpected": "shape"})
+        hook._gate(event)
 
+        assert event.cancel_tool is not None
 
-class TestDangerousToolApprovalHook:
-    """Req AH-3: Irreversible operations require approval."""
+    def test_interrupt_payload_carries_tool_name_and_input(self):
+        """The frontend modal needs tool name and the args to render a
+        meaningful prompt. The reason payload is the contract — assert it.
+        ``toolInput`` ships as a JSON-encoded string so DynamoDB persistence
+        doesn't coerce floats and the frontend can render it verbatim."""
+        import json
 
-    def test_delete_file_flagged(self):
-        hook = DangerousToolApprovalHook()
-        event = _make_event("delete_file")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"create_event"}
+        )
+        event = _make_event(
+            "create_event", tool_use_id="tu-99", interrupt_response="approved"
+        )
+        hook._gate(event)
 
-    def test_execute_sql_flagged(self):
-        hook = DangerousToolApprovalHook()
-        event = _make_event("execute_sql")
-        hook.check_approval(event)
-        assert event.tool_use.get("_approval_required") is True
+        call_kwargs = event.interrupt.call_args.kwargs
+        reason = call_kwargs["reason"]
+        assert reason["type"] == "tool_approval_required"
+        assert reason["toolName"] == "create_event"
+        assert reason["toolUseId"] == "tu-99"
+        assert json.loads(reason["toolInput"]) == {"foo": "bar"}
+        assert "message" in reason
 
-    def test_calculator_not_flagged(self):
-        hook = DangerousToolApprovalHook()
-        event = _make_event("calculator")
-        hook.check_approval(event)
-        assert "_approval_required" not in event.tool_use
+    def test_empty_tool_input_serializes_as_none(self):
+        """Empty input → None so the frontend skips the args affordance."""
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"create_event"}
+        )
+        event = _make_event("create_event", interrupt_response="approved")
+        event.tool_use["input"] = {}
+        hook._gate(event)
 
+        reason = event.interrupt.call_args.kwargs["reason"]
+        assert reason["toolInput"] is None
 
-class TestToolApprovalHookBase:
-    """Req AH-4: Base hook class behavior."""
+    def test_interrupt_name_disambiguates_parallel_calls(self):
+        """Two parallel calls of the same tool must produce distinct
+        interrupt names so the frontend can correlate per-prompt."""
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"create_event"}
+        )
+        event_a = _make_event(
+            "create_event", tool_use_id="tu-A", interrupt_response="approved"
+        )
+        event_b = _make_event(
+            "create_event", tool_use_id="tu-B", interrupt_response="approved"
+        )
 
-    def test_empty_tool_names_flags_nothing(self):
-        hook = ToolApprovalHook()
-        event = _make_event("anything")
-        hook.check_approval(event)
-        assert "_approval_required" not in event.tool_use
+        hook._gate(event_a)
+        hook._gate(event_b)
 
-    def test_register_hooks_adds_callback(self):
-        hook = EmailApprovalHook()
+        name_a = event_a.interrupt.call_args.kwargs["name"]
+        name_b = event_b.interrupt.call_args.kwargs["name"]
+        assert name_a != name_b
+        assert "tu-A" in name_a
+        assert "tu-B" in name_b
+
+    def test_register_hooks_subscribes_to_before_tool_call(self):
+        from strands.hooks import BeforeToolCallEvent
+
+        hook = MCPExternalApprovalHook(approval_names_lookup=lambda _: set())
         registry = MagicMock()
         hook.register_hooks(registry)
         registry.add_callback.assert_called_once()
+        args = registry.add_callback.call_args.args
+        assert args[0] is BeforeToolCallEvent

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14'",
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
@@ -75,33 +76,33 @@ dev = [
 requires-dist = [
     { name = "agentcore-stack", extras = ["agentcore", "bidi", "dev"], marker = "extra == 'all'" },
     { name = "aiofiles", specifier = "==25.1.0" },
-    { name = "authlib", specifier = "==1.6.9" },
-    { name = "aws-opentelemetry-distro", marker = "extra == 'agentcore'", specifier = "==0.16.0" },
-    { name = "bedrock-agentcore", marker = "extra == 'agentcore'", specifier = "==1.6.0" },
+    { name = "authlib", specifier = "==1.7.0" },
+    { name = "aws-opentelemetry-distro", marker = "extra == 'agentcore'", specifier = "==0.17.0" },
+    { name = "bedrock-agentcore", marker = "extra == 'agentcore'", specifier = "==1.6.4" },
     { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
-    { name = "boto3", specifier = "==1.42.83" },
+    { name = "boto3", specifier = "==1.42.96" },
     { name = "cachetools", specifier = "==6.2.4" },
-    { name = "fastapi", specifier = "==0.135.3" },
-    { name = "google-genai", marker = "extra == 'agentcore'", specifier = "==1.70.0" },
+    { name = "fastapi", specifier = "==0.136.1" },
+    { name = "google-genai", marker = "extra == 'agentcore'", specifier = "==1.73.1" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.151.11" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.152.3" },
     { name = "moto", extras = ["dynamodb", "cognitoidp"], marker = "extra == 'dev'", specifier = "==5.1.22" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "numpy", marker = "extra == 'dev'", specifier = "==2.2.6" },
-    { name = "openai", marker = "extra == 'agentcore'", specifier = "==2.30.0" },
+    { name = "openai", marker = "extra == 'agentcore'", specifier = "==2.32.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.9" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "starlette", specifier = "==1.0.0" },
-    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.34.1" },
-    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.34.1" },
-    { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.3.0" },
+    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.37.0" },
+    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.37.0" },
+    { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.5.1" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20251011" },
-    { name = "uvicorn", extras = ["standard"], specifier = "==0.44.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
 ]
 provides-extras = ["agentcore", "bidi", "dev", "all"]
 
@@ -320,19 +321,20 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
 name = "aws-opentelemetry-distro"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -368,6 +370,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-mysql" },
     { name = "opentelemetry-instrumentation-mysqlclient" },
+    { name = "opentelemetry-instrumentation-openai-agents-v2" },
     { name = "opentelemetry-instrumentation-pika" },
     { name = "opentelemetry-instrumentation-psycopg2" },
     { name = "opentelemetry-instrumentation-pymemcache" },
@@ -381,6 +384,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-sqlite3" },
     { name = "opentelemetry-instrumentation-starlette" },
     { name = "opentelemetry-instrumentation-system-metrics" },
+    { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-instrumentation-tornado" },
     { name = "opentelemetry-instrumentation-tortoiseorm" },
     { name = "opentelemetry-instrumentation-urllib" },
@@ -396,9 +400,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/e4/4bce0ddae504b8054f16796d1387038875af44aea69edfd5f32afe52e2ab/aws_opentelemetry_distro-0.16.0.tar.gz", hash = "sha256:7fa0eaac7f8303ac0506bf68931b2de4f6173b41a28b837216e4949afafe2d8d", size = 281980, upload-time = "2026-03-13T20:29:29.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/3c/66a219362127d5edb83c9e230b92a25272ac9cc65a5e937211dea2226892/aws_opentelemetry_distro-0.17.0.tar.gz", hash = "sha256:c7e71b78573bca94437937608383332d911124b12a1f0de2134617759bc6f624", size = 323843, upload-time = "2026-04-09T22:22:41.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/9c/736768e8ca5236accda9fd5ede42862a4a4278a7e7aba8c957de983890e5/aws_opentelemetry_distro-0.16.0-py3-none-any.whl", hash = "sha256:a5a651e312ec845bbe185de42cb6cd8ff283060766a6b5eaf2b7426dd43abab1", size = 188918, upload-time = "2026-03-13T20:29:27.988Z" },
+    { url = "https://files.pythonhosted.org/packages/86/dc/8d8637d447883da357a603236c066da58f5793f0ad6313c579aaac361820/aws_opentelemetry_distro-0.17.0-py3-none-any.whl", hash = "sha256:6abc38c8923192b609f4233050472e6dc7841a763640e50cf048c545ac1dcdae", size = 211721, upload-time = "2026-04-09T22:22:40.033Z" },
 ]
 
 [[package]]
@@ -501,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.0"
+version = "1.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -513,9 +517,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/f6/2884c954343e794e3419348f5ffb0276a26f57b30af11f9fe63c4ca535c0/bedrock_agentcore-1.6.0.tar.gz", hash = "sha256:7ea176c3226dc6af8c399a8f9abb58629948cd8ed8675ece9f2f32b94e861b92", size = 512010, upload-time = "2026-03-31T23:10:06.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/f8/bcf158979324f4f4d171588afffadb2154fa8499701290bfc7bdaf82bd3a/bedrock_agentcore-1.6.0-py3-none-any.whl", hash = "sha256:a4cd02f2bfb80fcc7a8c8835be8d55c778339f8286b071ac3aae579460dd2eb2", size = 164034, upload-time = "2026-03-31T23:10:04.902Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
 ]
 
 [[package]]
@@ -564,30 +568,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.83"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/87/1ed88eaa1e814841a37e71fee74c2b74341d14b791c0c6038b7ba914bea1/boto3-1.42.83.tar.gz", hash = "sha256:cc5621e603982cb3145b7f6c9970e02e297a1a0eb94637cc7f7b69d3017640ee", size = 112719, upload-time = "2026-04-03T19:34:21.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/b1/8a066bc8f02937d49783c0b3948ab951d8284e6fde436cab9f359dbd4d93/boto3-1.42.83-py3-none-any.whl", hash = "sha256:544846fdb10585bb7837e409868e8e04c6b372fa04479ba1597ce82cf1242076", size = 140555, upload-time = "2026-04-03T19:34:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.85"
+version = "1.42.97"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/ac/7f14b05cf43e4baae99f4570b02e10b2aebf242dfd86245523340390c834/botocore-1.42.85.tar.gz", hash = "sha256:2ee61f80b7724a143e16d0a85408ef5fa20b99dce7a3c8ec5d25cc8dced164c1", size = 15159562, upload-time = "2026-04-07T19:40:43.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/95/c37edb602948fad2253ffd1bb3dba5b938645bd1845ee4160350136a0f41/botocore-1.42.97.tar.gz", hash = "sha256:5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310", size = 15269348, upload-time = "2026-04-27T20:39:05.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/f3/c1fbaff4c509c616fd01f44357283a8992f10b3a05d932b22e602aa3a221/botocore-1.42.85-py3-none-any.whl", hash = "sha256:828b67722caeb7e240eefedee74050e803d1fa102958ead9c4009101eefd5381", size = 14839741, upload-time = "2026-04-07T19:40:40.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d2/8e025ba1a4e257879af72d06913272311af79673d82fa2581a351b924317/botocore-1.42.97-py3-none-any.whl", hash = "sha256:77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc", size = 14950367, upload-time = "2026-04-27T20:39:01.261Z" },
 ]
 
 [[package]]
@@ -1049,7 +1053,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.3"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1058,9 +1062,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1204,7 +1208,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.70.0"
+version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1218,9 +1222,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/dd/28e4682904b183acbfad3fe6409f13a42f69bb8eab6e882d3bcbea1dde01/google_genai-1.70.0.tar.gz", hash = "sha256:36b67b0fc6f319e08d1f1efd808b790107b1809c8743a05d55dfcf9d9fad7719", size = 519550, upload-time = "2026-04-01T10:52:46.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/a3/d4564c8a9beaf6a3cef8d70fa6354318572cebfee65db4f01af0d41f45ba/google_genai-1.70.0-py3-none-any.whl", hash = "sha256:b74c24549d8b4208f4c736fd11857374788e1ffffc725de45d706e35c97fceee", size = 760584, upload-time = "2026-04-01T10:52:44.349Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -1387,15 +1391,15 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.151.11"
+version = "6.152.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/58/41af0d539b3c95644d1e4e353cbd6ac9473e892ea21802546a8886b79078/hypothesis-6.151.11.tar.gz", hash = "sha256:f33dcb68b62c7b07c9ac49664989be898fa8ce57583f0dc080259a197c6c7ff1", size = 463779, upload-time = "2026-04-05T17:35:55.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/90/fc0b263b6f2622e5f8d2aa93f2e95ba79718a5faa7d2a74bfab10d6b0905/hypothesis-6.152.3.tar.gz", hash = "sha256:c4e5300d3755b6c8a270a28fe5abff40153e927328e89d2bb0229c1384618998", size = 466478, upload-time = "2026-04-26T17:31:07.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/06/f49393eca84b87b17a67aaebf9f6251190ba1e9fe9f2236504049fc43fee/hypothesis-6.151.11-py3-none-any.whl", hash = "sha256:7ac05173206746cec8312f95164a30a4eb4916815413a278922e63ff1e404648", size = 529572, upload-time = "2026-04-05T17:35:53.438Z" },
+    { url = "https://files.pythonhosted.org/packages/90/38/15475b91a4c12721d2be3349e9d6cf8649c76ed9bc1287e2de7c8d06c261/hypothesis-6.152.3-py3-none-any.whl", hash = "sha256:4b47f00916c858ed49cf870a2f08b04e5fff5afae0bb78f3b4a6d9c74fd6c7bc", size = 532154, upload-time = "2026-04-26T17:31:04.42Z" },
 ]
 
 [[package]]
@@ -2083,7 +2087,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.0"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -2092,51 +2096,51 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/a2/a965c8c3fcd4fa8b84ba0d46606181b0d0a1d50f274c67877f3e9ed4882c/mypy-1.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d99f515f95fd03a90875fdb2cca12ff074aa04490db4d190905851bdf8a549a8", size = 14430138, upload-time = "2026-03-31T16:52:37.843Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6e/043477501deeb8eabbab7f1a2f6cac62cfb631806dc1d6862a04a7f5011b/mypy-1.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bd0212976dc57a5bfeede7c219e7cd66568a32c05c9129686dd487c059c1b88a", size = 13311282, upload-time = "2026-03-31T16:55:11.021Z" },
-    { url = "https://files.pythonhosted.org/packages/65/aa/bd89b247b83128197a214f29f0632ff3c14f54d4cd70d144d157bd7d7d6e/mypy-1.20.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f8426d4d75d68714abc17a4292d922f6ba2cfb984b72c2278c437f6dae797865", size = 13750889, upload-time = "2026-03-31T16:52:02.909Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/9d/2860be7355c45247ccc0be1501c91176318964c2a137bd4743f58ce6200e/mypy-1.20.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02cca0761c75b42a20a2757ae58713276605eb29a08dd8a6e092aa347c4115ca", size = 14619788, upload-time = "2026-03-31T16:50:48.928Z" },
-    { url = "https://files.pythonhosted.org/packages/75/7f/3ef3e360c91f3de120f205c8ce405e9caf9fc52ef14b65d37073e322c114/mypy-1.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3a49064504be59e59da664c5e149edc1f26c67c4f8e8456f6ba6aba55033018", size = 14918849, upload-time = "2026-03-31T16:51:10.478Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/72/af970dfe167ef788df7c5e6109d2ed0229f164432ce828bc9741a4250e64/mypy-1.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:ebea00201737ad4391142808ed16e875add5c17f676e0912b387739f84991e13", size = 10822007, upload-time = "2026-03-31T16:50:25.268Z" },
-    { url = "https://files.pythonhosted.org/packages/93/94/ba9065c2ebe5421619aff684b793d953e438a8bfe31a320dd6d1e0706e81/mypy-1.20.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80cf77847d0d3e6e3111b7b25db32a7f8762fd4b9a3a72ce53fe16a2863b281", size = 9756158, upload-time = "2026-03-31T16:48:36.213Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1c/74cb1d9993236910286865679d1c616b136b2eae468493aa939431eda410/mypy-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4525e7010b1b38334516181c5b81e16180b8e149e6684cee5a727c78186b4e3b", size = 14343972, upload-time = "2026-03-31T16:49:04.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/01399515eca280386e308cf57901e68d3a52af18691941b773b3380c1df8/mypy-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a17c5d0bdcca61ce24a35beb828a2d0d323d3fcf387d7512206888c900193367", size = 13225007, upload-time = "2026-03-31T16:50:08.151Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ac/b4ba5094fb2d7fe9d2037cd8d18bbe02bcf68fd22ab9ff013f55e57ba095/mypy-1.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f75ff57defcd0f1d6e006d721ccdec6c88d4f6a7816eb92f1c4890d979d9ee62", size = 13663752, upload-time = "2026-03-31T16:49:26.064Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a7/460678d3cf7da252d2288dad0c602294b6ec22a91932ec368cc11e44bb6e/mypy-1.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b503ab55a836136b619b5fc21c8803d810c5b87551af8600b72eecafb0059cb0", size = 14532265, upload-time = "2026-03-31T16:53:55.077Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3e/051cca8166cf0438ae3ea80e0e7c030d7a8ab98dffc93f80a1aa3f23c1a2/mypy-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1973868d2adbb4584a3835780b27436f06d1dc606af5be09f187aaa25be1070f", size = 14768476, upload-time = "2026-03-31T16:50:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/be/66/8e02ec184f852ed5c4abb805583305db475930854e09964b55e107cdcbc4/mypy-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:2fcedb16d456106e545b2bfd7ef9d24e70b38ec252d2a629823a4d07ebcdb69e", size = 10818226, upload-time = "2026-03-31T16:53:15.624Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4b/383ad1924b28f41e4879a74151e7a5451123330d45652da359f9183bcd45/mypy-1.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:379edf079ce44ac8d2805bcf9b3dd7340d4f97aad3a5e0ebabbf9d125b84b442", size = 9750091, upload-time = "2026-03-31T16:54:12.162Z" },
-    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
-    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
-    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
-    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
-    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
-    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
-    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
-    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
-    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ce2502df2cecf2ef997b6c6527c4a223b92feb9e7b790cdc8dcd683f3a8a/mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4", size = 14457059, upload-time = "2026-04-21T17:06:14.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/34/417ee60b822cc80c0f3dc9f495ad7fd8dbb8d8b2cf4baf22d4046d25d01d/mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997", size = 13346816, upload-time = "2026-04-21T17:10:41.433Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/85/e20951978702df58379d0bcc2e8f7ccdca4e78cd7dc66dd3ddbf9b29d517/mypy-1.20.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97d7b9a485b40f8ca425460e89bf1da2814625b2da627c0dcc6aa46c92631d14", size = 13772593, upload-time = "2026-04-21T17:08:11.24Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a5/5441a13259ec516c56fd5de0fd96a69a9590ae6c5e5d3e5174aa84b97973/mypy-1.20.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e1c12f6d2db3d78b909b5f77513c11eb7f2dd2782b96a3ab6dffc7d44575c99", size = 14656635, upload-time = "2026-04-21T17:09:54.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/51/b89c69157c5e1f19fd125a65d991166a26906e7902f026f00feebbcfa2b9/mypy-1.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:89dce27e142d25ffbc154c1819383b69f2e9234dc4ed4766f42e0e8cb264ab5c", size = 14943278, upload-time = "2026-04-21T17:09:15.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/6b0eeecfe96d7cce1d71c66b8e03cb304aa70ec11f1955dc1d6b46aca3c3/mypy-1.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:f376e37f9bf2a946872fc5fd1199c99310748e3c26c7a26683f13f8bdb756cbd", size = 10851915, upload-time = "2026-04-21T17:06:03.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/6593dc88545d75fb96416184be5392da5e2a8e8c2802a8597913e16ae25c/mypy-1.20.2-cp310-cp310-win_arm64.whl", hash = "sha256:6e2b469efd811707bc530fd1effef0f5d6eebcb7fe376affae69025da4b979a2", size = 9786676, upload-time = "2026-04-21T17:07:02.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4d/9ebeae211caccbdaddde7ed5e31dfcf57faac66be9b11deb1dc6526c8078/mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c", size = 14371307, upload-time = "2026-04-21T17:08:56.442Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d7/93473d34b61f04fac1aecc01368485c89c5c4af7a4b9a0cab5d77d04b63f/mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3", size = 13258917, upload-time = "2026-04-21T17:05:50.978Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/30/3dd903e8bafb7b5f7bf87fcd58f8382086dea2aa19f0a7b357f21f63071b/mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254", size = 13700516, upload-time = "2026-04-21T17:11:33.161Z" },
+    { url = "https://files.pythonhosted.org/packages/07/05/c61a140aba4c729ac7bc99ae26fc627c78a6e08f5b9dd319244ea71a3d7e/mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98", size = 14562889, upload-time = "2026-04-21T17:05:27.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/87/da78243742ffa8a36d98c3010f0d829f93d5da4e6786f1a1a6f2ad616502/mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac", size = 14803844, upload-time = "2026-04-21T17:10:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/37/52/10a1ddf91b40f843943a3c6db51e2df59c9e237f29d355e95eaab427461f/mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67", size = 10846300, upload-time = "2026-04-21T17:12:23.886Z" },
+    { url = "https://files.pythonhosted.org/packages/20/02/f9a4415b664c53bd34d6709be59da303abcae986dc4ac847b402edb6fa1e/mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100", size = 9779498, upload-time = "2026-04-21T17:09:23.695Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -2212,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2224,9 +2228,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]
@@ -2707,6 +2711,21 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-openai-agents-v2"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/15/b6a303454d2800d772cdebc490c1d598d06d0e541619db80195eb9ea85c6/opentelemetry_instrumentation_openai_agents_v2-0.1.0.tar.gz", hash = "sha256:1033f4b261ce07f65d197ac0e9c499302c805eae987a6cc4e7f99bb279363477", size = 22423, upload-time = "2025-10-15T19:04:59.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/0a/b6f47734e1d7f936cbc52ef8e673d3e08d9c3c8a13d9549c03f978758076/opentelemetry_instrumentation_openai_agents_v2-0.1.0-py3-none-any.whl", hash = "sha256:e4e3dfba32bd6eeee0624eca9be54341ab7cc4f7a3bb895354f2f9d6f7afe2f3", size = 25002, upload-time = "2025-10-15T19:04:58.562Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-pika"
 version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
@@ -3101,6 +3120,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-genai"
+version = "0.3b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/d8/4dd2fb622d26ec45b10ef63eb87fd512f5d7467c7bd35ce390629bd6dff8/opentelemetry_util_genai-0.3b0.tar.gz", hash = "sha256:83e127789a9ad615b8ca65f05fc36955a67ce257b06142bfd46159a3b7ed73d3", size = 31800, upload-time = "2026-02-20T16:16:14.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/e5/fada54909e445d7b4007f8b96221d571999efeab9446f3127cc1cebe5e07/opentelemetry_util_genai-0.3b0-py3-none-any.whl", hash = "sha256:ebc2b01bcb891ddc7218452470d189d3321cd742653299ff8e7de45debcfb986", size = 28426, upload-time = "2026-02-20T16:16:12.027Z" },
 ]
 
 [[package]]
@@ -3629,7 +3662,7 @@ crypto = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -3640,9 +3673,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -4129,27 +4162,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.9"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
-    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -4321,7 +4354,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.34.1"
+version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -4337,9 +4370,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/22/f958d52a794e508a31ace8b8cbba0379226a98fac9826f3b757f95912b70/strands_agents-1.34.1.tar.gz", hash = "sha256:d1ff614dc364ce54348c24b011bbef6c466a0dd33e19996bd1a4ec4aab846cb1", size = 796829, upload-time = "2026-04-01T20:37:29.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/88/cf23aa713ea68c8a0ad5144341da7ee022e88ce6206512aeafddba257b75/strands_agents-1.37.0.tar.gz", hash = "sha256:3fe6821f730f0468eee91e1ff38eb27a5244046893ffba63e8f5345288096509", size = 824168, upload-time = "2026-04-22T19:18:01.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/eb/b0db0fb9ae691d3ed0ac9f9604b60f9154671baf4c61853c0b6607e2a91e/strands_agents-1.34.1-py3-none-any.whl", hash = "sha256:edc5ccd4fbc64bf203ced282083ed011953f628cf8f060e1c88e6a2fd8429f3a", size = 393990, upload-time = "2026-04-01T20:37:27.906Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ff/bede1b8d5fe1c776bd5ed33575505681b3b65ab20889fe6b8344b92fc82d/strands_agents-1.37.0-py3-none-any.whl", hash = "sha256:2fa12e22ed1dac228aa93e91c2ea5381d9b3f08416ed8162222b61b255fee0b1", size = 404526, upload-time = "2026-04-22T19:17:59.634Z" },
 ]
 
 [package.optional-dependencies]
@@ -4350,7 +4383,7 @@ bidi = [
 
 [[package]]
 name = "strands-agents-tools"
-version = "0.3.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4371,9 +4404,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/ab/078ea5ccab4f97aaa80500de844e1c744e4e77e6f2a4c67f62f10040c6a3/strands_agents_tools-0.3.0.tar.gz", hash = "sha256:10913ca85acb6da36ae05f2507e4f0c88d6b8b8034d1b4db6e93f3f6b7264fd0", size = 476838, upload-time = "2026-03-26T19:25:45.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/fc/8a9da78b5c4a8802367a8eeec046f98eda742b1ee1b2fff568c81c1b3479/strands_agents_tools-0.5.1.tar.gz", hash = "sha256:616ba88b5849d9fd495da057ccb670108580320b8cb0fc4faac5fc327f2622aa", size = 483123, upload-time = "2026-04-22T20:01:13.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/42/61dd37e0ad3c8b22cce83ef4c7ee21e8f6f3fc071f5096106090cb8ded60/strands_agents_tools-0.3.0-py3-none-any.whl", hash = "sha256:0d55aae56abfe1e336cdb718027d8780938881135b61b15f1dfbb1fa6e2d7cba", size = 313555, upload-time = "2026-03-26T19:25:44.147Z" },
+    { url = "https://files.pythonhosted.org/packages/64/59/79360f718683ae15cefeb8b0ca1e6d96608c4581280fb12b0f502375a705/strands_agents_tools-0.5.1-py3-none-any.whl", hash = "sha256:790865d073410e9a16ac44ce3a46c169b98e1f89844ce8670472b869257b7686", size = 316122, upload-time = "2026-04-22T20:01:11.599Z" },
 ]
 
 [[package]]
@@ -4574,16 +4607,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [package.optional-dependencies]

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -40,6 +40,15 @@ export type A2AAuthType = 'none' | 'aws-iam' | 'agentcore' | 'api-key';
 export type ToolStatus = 'active' | 'deprecated' | 'disabled' | 'coming_soon';
 
 /**
+ * A single tool exposed by an MCP server, with per-tool flags.
+ */
+export interface MCPToolEntry {
+  name: string;
+  needsApproval: boolean;
+  description?: string | null;
+}
+
+/**
  * MCP server configuration for external MCP tools.
  */
 export interface MCPServerConfig {
@@ -49,7 +58,7 @@ export interface MCPServerConfig {
   awsRegion?: string | null;
   apiKeyHeader?: string | null;
   secretArn?: string | null;
-  tools: string[];
+  tools: MCPToolEntry[];
   healthCheckEnabled: boolean;
   healthCheckIntervalSeconds: number;
 }
@@ -159,6 +168,33 @@ export interface ToolUpdateRequest {
  */
 export interface SetToolRolesRequest {
   appRoleIds: string[];
+}
+
+/**
+ * Request body for POST /api/admin/tools/discover.
+ */
+export interface MCPDiscoverRequest {
+  serverUrl: string;
+  transport: MCPTransport;
+  authType: MCPAuthType;
+  awsRegion?: string | null;
+  apiKeyHeader?: string | null;
+  secretArn?: string | null;
+}
+
+/**
+ * A tool returned by MCP server discovery.
+ */
+export interface DiscoveredMCPTool {
+  name: string;
+  description?: string | null;
+}
+
+/**
+ * Response from POST /api/admin/tools/discover.
+ */
+export interface MCPDiscoverResponse {
+  tools: DiscoveredMCPTool[];
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -8,7 +8,7 @@ import {
   effect,
 } from '@angular/core';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormArray, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -17,6 +17,8 @@ import {
   heroUserGroup,
   heroLink,
   heroShieldCheck,
+  heroPlus,
+  heroTrash,
 } from '@ng-icons/heroicons/outline';
 import { AdminToolService } from '../services/admin-tool.service';
 import { ConnectorsService } from '../../connectors/services/connectors.service';
@@ -28,6 +30,7 @@ import {
   MCP_AUTH_TYPES,
   A2A_AUTH_TYPES,
   MCPServerConfig,
+  MCPToolEntry,
   A2AAgentConfig,
   ToolProtocol,
 } from '../models/admin-tool.model';
@@ -36,7 +39,7 @@ import {
   selector: 'app-tool-form',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterLink, ReactiveFormsModule, NgIcon],
-  providers: [provideIcons({ heroArrowLeft, heroCheck, heroServer, heroUserGroup, heroLink, heroShieldCheck })],
+  providers: [provideIcons({ heroArrowLeft, heroCheck, heroServer, heroUserGroup, heroLink, heroShieldCheck, heroPlus, heroTrash })],
   host: {
     class: 'block p-6',
   },
@@ -269,19 +272,75 @@ import {
               }
 
               <!-- MCP Tools -->
-              <div class="mb-4">
-                <label for="mcpTools" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Available Tools
-                </label>
-                <textarea
-                  id="mcpTools"
-                  formControlName="mcpTools"
-                  rows="3"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 font-mono text-sm"
-                  placeholder="search_policies&#10;get_policy_by_number&#10;list_policy_categories"
-                ></textarea>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  One tool name per line. Leave empty to discover tools at runtime.
+              <div class="mb-4" formArrayName="mcpTools">
+                <div class="flex items-center justify-between mb-2">
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Available Tools
+                  </label>
+                  <div class="flex items-center gap-2">
+                    <button
+                      type="button"
+                      (click)="discoverMcpTools()"
+                      [disabled]="discovering() || !form.get('mcpServerUrl')?.value"
+                      class="inline-flex items-center gap-1 px-2 py-1 text-sm text-blue-700 hover:text-blue-900 dark:text-blue-300 dark:hover:text-blue-100 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {{ discovering() ? 'Discovering…' : 'Discover from server' }}
+                    </button>
+                    <button
+                      type="button"
+                      (click)="addMcpTool()"
+                      class="inline-flex items-center gap-1 px-2 py-1 text-sm text-blue-700 hover:text-blue-900 dark:text-blue-300 dark:hover:text-blue-100"
+                    >
+                      <ng-icon name="heroPlus" class="size-4" />
+                      Add Tool
+                    </button>
+                  </div>
+                </div>
+                @if (discoverError()) {
+                  <p class="mb-2 text-sm text-red-600 dark:text-red-400">
+                    {{ discoverError() }}
+                  </p>
+                }
+
+                @if (mcpToolsArray.length === 0) {
+                  <p class="text-xs text-gray-500 dark:text-gray-400 italic">
+                    No tools listed. Leave empty to discover tools at runtime — per-tool approval flags will not apply.
+                  </p>
+                } @else {
+                  <div class="space-y-2">
+                    @for (row of mcpToolsArray.controls; track $index) {
+                      <div [formGroupName]="$index" class="flex items-start gap-2 p-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-sm">
+                        <div class="flex-1">
+                          <input
+                            type="text"
+                            formControlName="name"
+                            class="w-full px-2 py-1 text-sm font-mono border border-gray-300 rounded-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600"
+                            placeholder="tool_name"
+                            [attr.aria-label]="'Tool name ' + ($index + 1)"
+                          />
+                        </div>
+                        <label class="flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 whitespace-nowrap pt-1.5">
+                          <input
+                            type="checkbox"
+                            formControlName="needsApproval"
+                            class="size-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+                          />
+                          <span>Needs approval</span>
+                        </label>
+                        <button
+                          type="button"
+                          (click)="removeMcpTool($index)"
+                          class="p-1 text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
+                          [attr.aria-label]="'Remove tool ' + ($index + 1)"
+                        >
+                          <ng-icon name="heroTrash" class="size-4" />
+                        </button>
+                      </div>
+                    }
+                  </div>
+                }
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  Tools flagged "Needs approval" will pause the agent for user confirmation before invocation.
                 </p>
               </div>
 
@@ -581,6 +640,8 @@ export class ToolFormPage implements OnInit {
   saving = signal(false);
   error = signal<string | null>(null);
   toolId = signal<string | null>(null);
+  discovering = signal(false);
+  discoverError = signal<string | null>(null);
 
   readonly isEditMode = computed(() => !!this.toolId());
   readonly selectedProtocol = signal<ToolProtocol>('local');
@@ -606,7 +667,7 @@ export class ToolFormPage implements OnInit {
     mcpAwsRegion: [''],
     mcpApiKeyHeader: [''],
     mcpSecretArn: [''],
-    mcpTools: [''],
+    mcpTools: this.fb.array([] as FormGroup[]),
     mcpHealthCheckEnabled: [false],
     // A2A Agent configuration
     a2aAgentUrl: [''],
@@ -633,6 +694,77 @@ export class ToolFormPage implements OnInit {
     if (!protocol) return '';
     const found = this.protocols.find(p => p.value === protocol);
     return found?.description || '';
+  }
+
+  get mcpToolsArray(): FormArray<FormGroup> {
+    return this.form.get('mcpTools') as FormArray<FormGroup>;
+  }
+
+  private buildMcpToolRow(entry?: MCPToolEntry): FormGroup {
+    return this.fb.group({
+      name: [entry?.name ?? '', [Validators.required]],
+      needsApproval: [entry?.needsApproval ?? false],
+      description: [entry?.description ?? ''],
+    });
+  }
+
+  addMcpTool(): void {
+    this.mcpToolsArray.push(this.buildMcpToolRow());
+  }
+
+  removeMcpTool(index: number): void {
+    this.mcpToolsArray.removeAt(index);
+  }
+
+  async discoverMcpTools(): Promise<void> {
+    const formValue = this.form.getRawValue();
+    if (!formValue.mcpServerUrl) {
+      return;
+    }
+
+    this.discovering.set(true);
+    this.discoverError.set(null);
+    try {
+      const response = await this.adminToolService.discoverMCPTools({
+        serverUrl: formValue.mcpServerUrl,
+        transport: formValue.mcpTransport,
+        authType: formValue.mcpAuthType,
+        awsRegion: formValue.mcpAwsRegion || null,
+        apiKeyHeader: formValue.mcpApiKeyHeader || null,
+        secretArn: formValue.mcpSecretArn || null,
+      });
+
+      // Merge: keep existing rows (and their needsApproval flag), append any
+      // newly-discovered names. Update descriptions on existing rows when the
+      // server returned one and the row is empty.
+      const existingByName = new Map<string, FormGroup>();
+      for (const ctrl of this.mcpToolsArray.controls) {
+        const name = (ctrl.get('name')?.value ?? '').trim();
+        if (name) {
+          existingByName.set(name, ctrl);
+        }
+      }
+
+      for (const tool of response.tools) {
+        const existing = existingByName.get(tool.name);
+        if (existing) {
+          if (tool.description && !existing.get('description')?.value) {
+            existing.get('description')?.setValue(tool.description);
+          }
+        } else {
+          this.mcpToolsArray.push(this.buildMcpToolRow({
+            name: tool.name,
+            needsApproval: false,
+            description: tool.description ?? null,
+          }));
+        }
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Discovery failed.';
+      this.discoverError.set(message);
+    } finally {
+      this.discovering.set(false);
+    }
   }
 
   async ngOnInit(): Promise<void> {
@@ -691,9 +823,12 @@ export class ToolFormPage implements OnInit {
           mcpAwsRegion: tool.mcpConfig.awsRegion || '',
           mcpApiKeyHeader: tool.mcpConfig.apiKeyHeader || '',
           mcpSecretArn: tool.mcpConfig.secretArn || '',
-          mcpTools: tool.mcpConfig.tools.join('\n'),
           mcpHealthCheckEnabled: tool.mcpConfig.healthCheckEnabled,
         });
+        this.mcpToolsArray.clear();
+        for (const entry of tool.mcpConfig.tools) {
+          this.mcpToolsArray.push(this.buildMcpToolRow(entry));
+        }
       }
 
       // A2A configuration
@@ -732,6 +867,14 @@ export class ToolFormPage implements OnInit {
       // Build MCP config if protocol is mcp_external
       let mcpConfig: MCPServerConfig | undefined;
       if (formValue.protocol === 'mcp_external' && formValue.mcpServerUrl) {
+        const mcpTools: MCPToolEntry[] = (formValue.mcpTools ?? [])
+          .map((row: { name?: string; needsApproval?: boolean; description?: string | null }) => ({
+            name: (row.name ?? '').trim(),
+            needsApproval: !!row.needsApproval,
+            description: row.description?.trim() || null,
+          }))
+          .filter((row: MCPToolEntry) => row.name.length > 0);
+
         mcpConfig = {
           serverUrl: formValue.mcpServerUrl,
           transport: formValue.mcpTransport,
@@ -739,7 +882,7 @@ export class ToolFormPage implements OnInit {
           awsRegion: formValue.mcpAwsRegion || null,
           apiKeyHeader: formValue.mcpApiKeyHeader || null,
           secretArn: formValue.mcpSecretArn || null,
-          tools: formValue.mcpTools ? formValue.mcpTools.split('\n').map((t: string) => t.trim()).filter((t: string) => t) : [],
+          tools: mcpTools,
           healthCheckEnabled: formValue.mcpHealthCheckEnabled,
           healthCheckIntervalSeconds: 300,
         };

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
@@ -10,6 +10,8 @@ import {
   ToolUpdateRequest,
   ToolRolesResponse,
   ToolRoleAssignment,
+  MCPDiscoverRequest,
+  MCPDiscoverResponse,
 } from '../models/admin-tool.model';
 
 /**
@@ -203,5 +205,14 @@ export class AdminToolService {
    */
   reload(): void {
     this.toolsResource.reload();
+  }
+
+  /**
+   * Connect to an MCP server with the given config and return its tool list.
+   */
+  async discoverMCPTools(request: MCPDiscoverRequest): Promise<MCPDiscoverResponse> {
+    return firstValueFrom(
+      this.http.post<MCPDiscoverResponse>(`${this.baseUrl()}/discover`, request)
+    );
   }
 }

--- a/frontend/ai.client/src/app/services/tool-approval/tool-approval.service.ts
+++ b/frontend/ai.client/src/app/services/tool-approval/tool-approval.service.ts
@@ -7,10 +7,10 @@ import { Injectable, computed, signal } from '@angular/core';
  * approve/decline prompt and resumes the same turn with the user's
  * decision via {@link ToolApprovalResumeHandler}.
  *
- * Unlike OAuth, these prompts are inline in the chat stream and tied to
- * the live SSE turn — a refresh during the prompt orphans it. That's
- * acceptable for v1; if persistent recovery is needed later, mirror
- * the `PendingInterrupt` breadcrumb the OAuth flow uses.
+ * Refresh recovery: the backend persists a `PendingInterrupt` breadcrumb
+ * (`kind: "tool_approval"`) on the same `done` event, so reloading the
+ * page mid-prompt rehydrates it via `MessageMapService.hydratePendingInterrupts`
+ * — same flow as OAuth consent.
  */
 export interface ToolApprovalRequest {
   interruptId: string;

--- a/frontend/ai.client/src/app/services/tool-approval/tool-approval.service.ts
+++ b/frontend/ai.client/src/app/services/tool-approval/tool-approval.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+/**
+ * Pending tool-approval prompt surfaced by the backend when an MCP tool
+ * flagged `needs_approval` in the catalog is about to run. The agent's
+ * tool call is paused (Strands interrupt); the chat UI renders an inline
+ * approve/decline prompt and resumes the same turn with the user's
+ * decision via {@link ToolApprovalResumeHandler}.
+ *
+ * Unlike OAuth, these prompts are inline in the chat stream and tied to
+ * the live SSE turn — a refresh during the prompt orphans it. That's
+ * acceptable for v1; if persistent recovery is needed later, mirror
+ * the `PendingInterrupt` breadcrumb the OAuth flow uses.
+ */
+export interface ToolApprovalRequest {
+  interruptId: string;
+  toolUseId: string;
+  toolName: string;
+  /** JSON-encoded tool input arguments. Pre-stringified by the backend. */
+  toolInput?: string;
+  message: string;
+  receivedAt: number;
+  /** Id of the assistant message whose tool call triggered this prompt;
+   *  used by the inline message renderer to anchor the prompt. */
+  messageId?: string;
+  sessionId?: string;
+}
+
+export type ToolApprovalDecision = 'approved' | 'declined';
+
+/**
+ * Handler the chat layer registers to resume a paused agent turn after
+ * the user makes an approval decision. Receives the interrupt id whose
+ * tool call should now proceed (or be cancelled) plus the decision; the
+ * handler is expected to POST to `/invocations` with the matching
+ * `interrupt_responses` entry.
+ */
+export type ToolApprovalResumeHandler = (
+  interruptId: string,
+  decision: ToolApprovalDecision,
+  context?: { sessionId?: string },
+) => void | Promise<void>;
+
+/**
+ * Tracks per-tool approval prompts surfaced by the SSE stream and
+ * coordinates their resolution. The stream parser calls
+ * {@link requestApproval} when a `tool_approval_required` event arrives;
+ * components render an approve/decline UI bound to {@link pending}.
+ * When the user clicks Approve or Decline, {@link resolve} drops the
+ * request locally and asks the registered {@link ToolApprovalResumeHandler}
+ * to fire the resume request.
+ */
+@Injectable({ providedIn: 'root' })
+export class ToolApprovalService {
+  private readonly requests = signal<Map<string, ToolApprovalRequest>>(new Map());
+
+  // Interrupt ids we've already surfaced this session, so a re-emission
+  // (stream replay, network retry) doesn't resurrect a resolved prompt.
+  // A new tool call always carries a fresh interrupt id, so legitimate
+  // prompts aren't suppressed.
+  private readonly seenInterruptIds = new Set<string>();
+
+  private resumeHandler: ToolApprovalResumeHandler | null = null;
+
+  readonly pending = computed<ToolApprovalRequest[]>(() =>
+    Array.from(this.requests().values()).sort(
+      (a, b) => a.receivedAt - b.receivedAt,
+    ),
+  );
+
+  readonly hasPending = computed<boolean>(() => this.requests().size > 0);
+
+  /**
+   * Register an approval request coming off the SSE stream. Idempotent
+   * for the same interruptId — re-emission during a stream replay won't
+   * resurrect a resolved prompt.
+   */
+  requestApproval(input: {
+    interruptId: string;
+    toolUseId: string;
+    toolName: string;
+    toolInput?: string;
+    message: string;
+    messageId?: string;
+    sessionId?: string;
+  }): void {
+    if (this.seenInterruptIds.has(input.interruptId)) {
+      return;
+    }
+    this.seenInterruptIds.add(input.interruptId);
+    this.requests.update((map) => {
+      const next = new Map(map);
+      next.set(input.interruptId, {
+        ...input,
+        receivedAt: Date.now(),
+      });
+      return next;
+    });
+  }
+
+  /**
+   * Resolve a pending approval. Drops the request locally and forwards
+   * the decision to the registered resume handler so the chat layer can
+   * POST a resume request. No-op if the request is unknown (already
+   * resolved).
+   */
+  async resolve(interruptId: string, decision: ToolApprovalDecision): Promise<void> {
+    const request = this.requests().get(interruptId);
+    if (!request) {
+      return;
+    }
+
+    this.requests.update((map) => {
+      const next = new Map(map);
+      next.delete(interruptId);
+      return next;
+    });
+
+    if (!this.resumeHandler) {
+      console.warn(
+        'ToolApprovalService: no resume handler registered; decision dropped',
+        { interruptId, decision },
+      );
+      return;
+    }
+
+    try {
+      await this.resumeHandler(interruptId, decision, {
+        sessionId: request.sessionId,
+      });
+    } catch (err) {
+      console.error('ToolApprovalService: resume handler failed', err);
+    }
+  }
+
+  /**
+   * Register the chat layer's resume callback. Replaces any existing
+   * handler; the chat layer is the single owner.
+   */
+  setResumeHandler(handler: ToolApprovalResumeHandler | null): void {
+    this.resumeHandler = handler;
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-approval-prompt/tool-approval-prompt.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-approval-prompt/tool-approval-prompt.component.ts
@@ -1,0 +1,320 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroChevronRight,
+  heroCheck,
+  heroCommandLine,
+  heroShieldCheck,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import {
+  ToolApprovalDecision,
+  ToolApprovalRequest,
+  ToolApprovalService,
+} from '../../../../../services/tool-approval/tool-approval.service';
+
+/**
+ * Inline tool-approval prompt rendered alongside the assistant message
+ * whose tool call needs user approval. Visual language mirrors
+ * `OAuthConsentPromptComponent`: a compact horizontal pill with a 2px
+ * primary-500 left accent, the shared `.action-btn` for the affirmative
+ * action, and the same lift-on-mount animation. Adds an optional
+ * args-inspection footer when the tool was invoked with arguments.
+ */
+@Component({
+  selector: 'app-tool-approval-prompt',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({
+      heroChevronRight,
+      heroCheck,
+      heroCommandLine,
+      heroShieldCheck,
+      heroXMark,
+    }),
+  ],
+  host: { class: 'block' },
+  template: `
+    <div
+      class="approval-prompt group relative max-w-xl overflow-hidden rounded-lg border border-gray-200/80 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)] dark:border-white/10 dark:bg-slate-800/70"
+      role="region"
+      aria-live="polite"
+      [attr.aria-label]="'Approval required for tool ' + request().toolName"
+    >
+      <span
+        class="absolute inset-y-0 left-0 w-[2px] bg-primary-500 dark:bg-primary-400"
+        aria-hidden="true"
+      ></span>
+
+      <!-- Main row: matches the OAuth pill layout. -->
+      <div class="flex items-center gap-2.5 py-1.5 pr-1.5 pl-3">
+        <div
+          class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-50 ring-1 ring-gray-200/70 dark:bg-slate-900 dark:ring-white/10"
+        >
+          <ng-icon
+            name="heroCommandLine"
+            class="size-5 text-gray-700 dark:text-gray-300"
+            aria-hidden="true"
+          />
+        </div>
+
+        <div class="min-w-0 flex-1">
+          <p
+            class="inline-flex items-center gap-1 text-[10px] leading-none font-semibold uppercase tracking-[0.08em] text-primary-600 dark:text-primary-300"
+          >
+            <ng-icon name="heroShieldCheck" class="size-3" aria-hidden="true" />
+            Approval needed
+          </p>
+          <p class="text-xs/5 text-gray-900 dark:text-gray-100">
+            Approve
+            <code
+              class="rounded bg-gray-100 px-1 py-0.5 font-mono text-[11px] font-semibold text-gray-900 dark:bg-white/10 dark:text-gray-100"
+              >{{ request().toolName }}</code
+            >
+            to let the assistant continue.
+          </p>
+        </div>
+
+        <div class="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            (click)="resolve('declined')"
+            class="decline-btn"
+            [disabled]="resolving()"
+            aria-label="Decline tool call"
+          >
+            <ng-icon name="heroXMark" class="size-3" aria-hidden="true" />
+            <span>Decline</span>
+          </button>
+          <button
+            type="button"
+            (click)="resolve('approved')"
+            class="action-btn"
+            [disabled]="resolving()"
+            aria-label="Approve tool call"
+          >
+            @if (resolving()) {
+              <svg
+                class="size-3 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                ></circle>
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                ></path>
+              </svg>
+              <span>Working…</span>
+            } @else {
+              <ng-icon name="heroCheck" class="size-3" aria-hidden="true" />
+              <span>Approve</span>
+            }
+          </button>
+        </div>
+      </div>
+
+      <!-- Args inspector: shown only when the tool was called with input. -->
+      @if (hasInput()) {
+        <div
+          class="border-t border-gray-200/80 px-3 py-1.5 dark:border-white/10"
+        >
+          <button
+            type="button"
+            (click)="toggleArgs()"
+            [attr.aria-expanded]="argsExpanded()"
+            class="inline-flex items-center gap-1 rounded text-[11px] font-medium text-gray-500 transition-colors hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            <ng-icon
+              name="heroChevronRight"
+              class="size-3 transition-transform duration-150"
+              [class.rotate-90]="argsExpanded()"
+              aria-hidden="true"
+            />
+            <span>{{ argsExpanded() ? 'Hide arguments' : 'View arguments' }}</span>
+          </button>
+          @if (argsExpanded()) {
+            <pre
+              class="args-fold mt-1.5 max-h-72 overflow-auto rounded-md border border-gray-200/80 bg-gray-50 px-2.5 py-2 font-mono text-[11px] leading-relaxed text-gray-800 dark:border-white/10 dark:bg-slate-900/60 dark:text-gray-200"
+            >{{ formattedInput() }}</pre>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    @import 'tailwindcss';
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    :host {
+      display: block;
+    }
+
+    .approval-prompt {
+      animation: approval-rise 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    /* Override the global \`.message-block p\` rule (styles.css) which adds
+       a 16px margin-bottom for prose paragraphs. Inside the prompt the two
+       <p>s are a tight label + description pair. */
+    .approval-prompt p {
+      margin-bottom: 0;
+    }
+
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.625rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: white;
+      background: var(--color-secondary-500);
+      transition:
+        background-color 120ms ease,
+        transform 120ms ease;
+    }
+
+    .action-btn:hover:not(:disabled) {
+      background: var(--color-secondary-600);
+    }
+
+    .action-btn:active:not(:disabled) {
+      transform: translateY(1px);
+    }
+
+    .action-btn:focus-visible {
+      outline: 2px solid var(--color-secondary-500);
+      outline-offset: 2px;
+    }
+
+    .action-btn:disabled {
+      opacity: 0.85;
+      cursor: default;
+    }
+
+    .decline-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--color-gray-600);
+      background: transparent;
+      transition:
+        background-color 120ms ease,
+        color 120ms ease;
+    }
+
+    .decline-btn:hover:not(:disabled) {
+      background: var(--color-gray-100);
+      color: var(--color-gray-900);
+    }
+
+    .decline-btn:focus-visible {
+      outline: 2px solid var(--color-gray-400);
+      outline-offset: 2px;
+    }
+
+    .decline-btn:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+
+    :where(.dark, .dark *) .decline-btn {
+      color: var(--color-gray-300);
+    }
+
+    :where(.dark, .dark *) .decline-btn:hover:not(:disabled) {
+      background: rgb(255 255 255 / 0.08);
+      color: white;
+    }
+
+    .args-fold {
+      animation: args-fold 0.2s ease-out;
+    }
+
+    @keyframes approval-rise {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes args-fold {
+      from {
+        opacity: 0;
+        transform: translateY(-2px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .approval-prompt,
+      .args-fold {
+        animation: none;
+      }
+      .action-btn,
+      .decline-btn {
+        transition: none;
+      }
+    }
+  `,
+})
+export class ToolApprovalPromptComponent {
+  request = input.required<ToolApprovalRequest>();
+
+  private approvalService = inject(ToolApprovalService);
+
+  protected argsExpanded = signal(false);
+  protected resolving = signal(false);
+
+  protected hasInput = computed<boolean>(() => {
+    const value = this.request().toolInput;
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+
+  protected formattedInput = computed<string>(() => this.request().toolInput ?? '');
+
+  toggleArgs(): void {
+    this.argsExpanded.update((v) => !v);
+  }
+
+  async resolve(decision: ToolApprovalDecision): Promise<void> {
+    if (this.resolving()) return;
+    this.resolving.set(true);
+    try {
+      await this.approvalService.resolve(this.request().interruptId, decision);
+    } finally {
+      this.resolving.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -39,6 +39,14 @@
     </div>
   }
 
+  <!-- Per-tool approval prompts (catalog-flagged needs_approval). Tied to
+       the live SSE turn; refresh during the prompt orphans it. -->
+  @for (request of pendingToolApprovals(); track request.interruptId) {
+    <div class="flex justify-start">
+      <app-tool-approval-prompt [request]="request" />
+    </div>
+  }
+
   <!-- Loading indicator -->
   @if (isChatLoading()) {
     <div class="py-4">

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -7,10 +7,15 @@ import { MessageMetadataBadgesComponent } from './components/message-metadata-ba
 import { CitationDisplayComponent } from '../citation-display/citation-display.component';
 import { PulsatingLoaderComponent } from '../../../components/pulsating-loader.component';
 import { OAuthConsentPromptComponent } from './components/oauth-consent-prompt/oauth-consent-prompt.component';
+import { ToolApprovalPromptComponent } from './components/tool-approval-prompt/tool-approval-prompt.component';
 import {
   OAuthConsentRequest,
   OAuthConsentService,
 } from '../../../services/oauth-consent/oauth-consent.service';
+import {
+  ToolApprovalRequest,
+  ToolApprovalService,
+} from '../../../services/tool-approval/tool-approval.service';
 
 @Component({
   selector: 'app-message-list',
@@ -21,6 +26,7 @@ import {
     CitationDisplayComponent,
     PulsatingLoaderComponent,
     OAuthConsentPromptComponent,
+    ToolApprovalPromptComponent,
   ],
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
@@ -40,6 +46,7 @@ export class MessageListComponent implements OnDestroy {
   embeddedMode = input<boolean>(false);
 
   private consentService = inject(OAuthConsentService);
+  private toolApprovalService = inject(ToolApprovalService);
 
   /** Pending consent prompts whose anchor message id isn't in the loaded
    *  message list — typically the case when an interrupt fires on a turn
@@ -50,6 +57,13 @@ export class MessageListComponent implements OnDestroy {
     const ids = new Set(this.messages().map((m) => m.id));
     return this.consentService.pending().filter((req) => !req.messageId || !ids.has(req.messageId));
   });
+
+  /** Pending tool-approval prompts. Always rendered at the end of the
+   *  conversation since these are tied to the live SSE turn (no refresh
+   *  hydration in v1). */
+  protected pendingToolApprovals = computed<ToolApprovalRequest[]>(() =>
+    this.toolApprovalService.pending(),
+  );
 
   // Calculate the spacer height dynamically
   // This creates space at the bottom so user messages can scroll to the top

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -58,9 +58,14 @@ export class MessageListComponent implements OnDestroy {
     return this.consentService.pending().filter((req) => !req.messageId || !ids.has(req.messageId));
   });
 
-  /** Pending tool-approval prompts. Always rendered at the end of the
-   *  conversation since these are tied to the live SSE turn (no refresh
-   *  hydration in v1). */
+  /** Pending tool-approval prompts, rendered at the end of the conversation.
+   *  Sourced from both live `tool_approval_required` SSE events during a
+   *  turn and the `PendingInterrupt(kind="tool_approval")` rows that
+   *  `MessageMapService.hydratePendingInterrupts` replays on session load,
+   *  so a mid-prompt refresh rehydrates the prompt rather than orphaning
+   *  it. We don't anchor next to the triggering assistant message (the way
+   *  OAuth prompts do) because the approval is for the *next* tool call,
+   *  not the assistant text that just streamed. */
   protected pendingToolApprovals = computed<ToolApprovalRequest[]>(() =>
     this.toolApprovalService.pending(),
   );

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -11,6 +11,10 @@ import { ToolService } from '../../../services/tool/tool.service';
 import { FileUploadService } from '../../../services/file-upload';
 import { FileAttachmentData } from '../models/message.model';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+import {
+  ToolApprovalDecision,
+  ToolApprovalService,
+} from '../../../services/tool-approval/tool-approval.service';
 import { ErrorService } from '../../../services/error/error.service';
 import { StreamParserService } from './stream-parser.service';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -36,6 +40,7 @@ export class ChatRequestService implements OnDestroy {
   private toolService = inject(ToolService);
   private fileUploadService = inject(FileUploadService);
   private oauthConsentService = inject(OAuthConsentService);
+  private toolApprovalService = inject(ToolApprovalService);
   private streamParserService = inject(StreamParserService);
   private errorService = inject(ErrorService);
   private router = inject(Router);
@@ -45,10 +50,14 @@ export class ChatRequestService implements OnDestroy {
     this.oauthConsentService.setResumeHandler((interruptIds, context) =>
       this.resumeFromOAuthConsent(interruptIds, context?.sessionId),
     );
+    this.toolApprovalService.setResumeHandler((interruptId, decision, context) =>
+      this.resumeFromToolApproval(interruptId, decision, context?.sessionId),
+    );
   }
 
   ngOnDestroy(): void {
     this.oauthConsentService.setResumeHandler(null);
+    this.toolApprovalService.setResumeHandler(null);
   }
 
   async submitChatRequest(
@@ -216,6 +225,54 @@ export class ChatRequestService implements OnDestroy {
       if (this.isExpiredInterruptError(error)) {
         this.errorService.addError(
           'Authorization expired',
+          'The agent paused too long ago to resume this turn automatically. Please send your message again.',
+        );
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Resume the paused agent turn after the user approves or declines a
+   * flagged MCP tool call. The hook on the backend reads the response
+   * string ("approved" / "declined") and either lets the tool proceed or
+   * cancels it.
+   */
+  private async resumeFromToolApproval(
+    interruptId: string,
+    decision: ToolApprovalDecision,
+    sessionId?: string,
+  ): Promise<void> {
+    if (!sessionId) {
+      return;
+    }
+
+    this.streamParserService.reset(sessionId);
+    this.messageMapService.startStreaming(sessionId);
+    this.chatStateService.createNewAbortController();
+    this.chatStateService.setChatLoading(true);
+
+    const resumeRequest: Record<string, unknown> = {
+      session_id: sessionId,
+      message: '',
+      interrupt_responses: [
+        {
+          interruptId,
+          response: decision,
+        },
+      ],
+    };
+
+    try {
+      await this.chatHttpService.sendChatRequest(resumeRequest);
+    } catch (error) {
+      this.chatStateService.setChatLoading(false);
+      this.messageMapService.endStreaming();
+
+      if (this.isExpiredInterruptError(error)) {
+        this.errorService.addError(
+          'Approval expired',
           'The agent paused too long ago to resume this turn automatically. Please send your message again.',
         );
         return;

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -15,7 +15,11 @@ import {
   QuotaExceeded,
 } from '../../../services/quota/quota-warning.service';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
-import type { OAuthRequiredEvent } from '../../../shared/utils/stream-parser';
+import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
+import type {
+  OAuthRequiredEvent,
+  ToolApprovalRequiredEvent,
+} from '../../../shared/utils/stream-parser';
 import {
   processStreamEvent,
   createStreamLineParser,
@@ -51,6 +55,7 @@ export class StreamParserService {
   private errorService = inject(ErrorService);
   private quotaWarningService = inject(QuotaWarningService);
   private oauthConsentService = inject(OAuthConsentService);
+  private toolApprovalService = inject(ToolApprovalService);
 
   // =========================================================================
   // State Signals
@@ -315,6 +320,26 @@ export class StreamParserService {
           lastAssistantId,
           this.sessionId ?? undefined,
         );
+      },
+
+      onToolApprovalRequired: (data: ToolApprovalRequiredEvent) => {
+        const messages = this.allMessages();
+        let lastAssistantId: string | undefined;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === 'assistant') {
+            lastAssistantId = messages[i].id;
+            break;
+          }
+        }
+        this.toolApprovalService.requestApproval({
+          interruptId: data.interruptId,
+          toolUseId: data.toolUseId,
+          toolName: data.toolName,
+          toolInput: data.toolInput ?? undefined,
+          message: data.message,
+          messageId: lastAssistantId,
+          sessionId: this.sessionId ?? undefined,
+        });
       },
 
       onError: (data) => this.handleError(data),

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -5,6 +5,7 @@ import { StreamParserService } from '../chat/stream-parser.service';
 import { PendingInterrupt, SessionService } from './session.service';
 import { FileUploadService, FileMetadata } from '../../../services/file-upload';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
 
 /** Regex to match file attachment marker in message text: [Attached files: file1.pdf, file2.png] */
 const ATTACHED_FILES_PATTERN = /\n\n\[Attached files: ([^\]]+)\]$/;
@@ -44,6 +45,7 @@ export class MessageMapService {
   private sessionService = inject(SessionService);
   private fileUploadService = inject(FileUploadService);
   private oauthConsentService = inject(OAuthConsentService);
+  private toolApprovalService = inject(ToolApprovalService);
 
   constructor() {
     // Reactive effect: automatically sync streaming messages to the message map
@@ -297,10 +299,12 @@ export class MessageMapService {
   }
 
   /**
-   * Replay persisted pending OAuth interrupts into the consent service so
-   * the inline prompt re-renders. If the backend records a triggering message
-   * id we use it directly; otherwise we anchor to the most recent assistant
-   * message (mirroring the live-stream behavior in stream-parser.service.ts).
+   * Replay persisted pending interrupts into the matching service so the
+   * inline prompt re-renders. Branches on `kind` (defaults to "oauth" for
+   * legacy rows written before per-tool approval shipped). If the backend
+   * recorded a triggering message id we use it directly; otherwise we
+   * anchor to the most recent assistant message, mirroring the live-stream
+   * behavior in stream-parser.service.ts.
    */
   private hydratePendingInterrupts(
     sessionId: string,
@@ -318,11 +322,42 @@ export class MessageMapService {
       }
     }
     for (const interrupt of interrupts) {
+      const messageId = interrupt.triggeringMessageId ?? lastAssistantId;
+      const kind = interrupt.kind ?? 'oauth';
+
+      if (kind === 'tool_approval') {
+        if (!interrupt.toolName) {
+          console.warn(
+            'Skipping tool_approval interrupt with no toolName',
+            interrupt.interruptId,
+          );
+          continue;
+        }
+        this.toolApprovalService.requestApproval({
+          interruptId: interrupt.interruptId,
+          toolUseId: interrupt.toolUseId ?? '',
+          toolName: interrupt.toolName,
+          toolInput: interrupt.toolInput ?? undefined,
+          message: interrupt.message ?? '',
+          messageId,
+          sessionId,
+        });
+        continue;
+      }
+
+      // OAuth (default for legacy rows without `kind`)
+      if (!interrupt.providerId) {
+        console.warn(
+          'Skipping oauth interrupt with no providerId',
+          interrupt.interruptId,
+        );
+        continue;
+      }
       this.oauthConsentService.requestConsent(
         interrupt.providerId,
         undefined, // URL is fetched lazily on Connect — stored URLs go stale
         interrupt.interruptId,
-        interrupt.triggeringMessageId ?? lastAssistantId,
+        messageId,
         sessionId,
       );
     }

--- a/frontend/ai.client/src/app/session/services/session/session.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.ts
@@ -38,12 +38,26 @@ export interface SessionsListResponse {
 export interface PendingInterrupt {
   /** Strands interrupt id used to resume the paused turn */
   interruptId: string;
-  /** Connector providerId needing consent */
-  providerId: string;
+  /**
+   * Discriminator: which variant this interrupt represents. Older rows
+   * written before per-tool approval shipped omit this — backend defaults
+   * to "oauth" on read.
+   */
+  kind?: 'oauth' | 'tool_approval';
   /** Id of the assistant message whose tool call triggered this interrupt, if known */
   triggeringMessageId?: string | null;
   /** ISO 8601 timestamp when the interrupt was recorded */
   createdAt: string;
+  /** (oauth) Connector providerId needing consent */
+  providerId?: string | null;
+  /** (tool_approval) Strands tool-use id of the paused call */
+  toolUseId?: string | null;
+  /** (tool_approval) MCP-server-exposed tool name */
+  toolName?: string | null;
+  /** (tool_approval) JSON-encoded tool input arguments */
+  toolInput?: string | null;
+  /** (tool_approval) Message to display in the approval prompt */
+  message?: string | null;
 }
 
 /**

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -56,6 +56,7 @@ export {
   validateConversationalStreamError,
   validateCitation,
   validateOAuthRequiredEvent,
+  validateToolApprovalRequiredEvent,
 } from './stream-parser-core';
 
 // Types
@@ -76,6 +77,7 @@ export type {
   StreamErrorEvent,
   ConversationalStreamErrorEvent,
   OAuthRequiredEvent,
+  ToolApprovalRequiredEvent,
   StreamEventType,
   StreamEventData,
   ParsedStreamEvent,

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -37,6 +37,7 @@ import type {
   StreamErrorEvent,
   ConversationalStreamErrorEvent,
   OAuthRequiredEvent,
+  ToolApprovalRequiredEvent,
   ToolProgress,
 } from './stream-parser-types';
 import type { MetadataEvent } from '../../../session/services/models/content-types';
@@ -78,6 +79,9 @@ export interface StreamParserCallbacks {
 
   // OAuth consent required (external MCP tool needs user authorization)
   onOAuthRequired?: (data: OAuthRequiredEvent) => void;
+
+  // Tool approval required (catalog flagged this MCP tool needs_approval)
+  onToolApprovalRequired?: (data: ToolApprovalRequiredEvent) => void;
 
   // Error handling
   onError?: (data: StreamErrorEvent | ConversationalStreamErrorEvent | string) => void;
@@ -344,6 +348,27 @@ export function validateOAuthRequiredEvent(data: unknown): data is OAuthRequired
 }
 
 /**
+ * Validate ToolApprovalRequiredEvent structure
+ */
+export function validateToolApprovalRequiredEvent(
+  data: unknown,
+): data is ToolApprovalRequiredEvent {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const event = data as Partial<ToolApprovalRequiredEvent>;
+
+  return (
+    event.type === 'tool_approval_required' &&
+    typeof event.interruptId === 'string' &&
+    event.interruptId.length > 0 &&
+    typeof event.toolName === 'string' &&
+    event.toolName.length > 0
+  );
+}
+
+/**
  * Validate Citation structure
  */
 export function validateCitation(data: unknown): data is Citation {
@@ -513,6 +538,14 @@ export function processStreamEvent(
           callbacks.onOAuthRequired?.(data);
         } else {
           callbacks.onParseError?.('oauth_required: invalid data structure');
+        }
+        break;
+
+      case 'tool_approval_required':
+        if (validateToolApprovalRequiredEvent(data)) {
+          callbacks.onToolApprovalRequired?.(data);
+        } else {
+          callbacks.onParseError?.('tool_approval_required: invalid data structure');
         }
         break;
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -100,6 +100,26 @@ export interface OAuthRequiredEvent {
 }
 
 /**
+ * Tool approval required event — emitted when an MCP tool flagged
+ * `needs_approval` in the catalog is about to run. The agent's tool call
+ * is paused (Strands interrupt); the frontend renders an inline
+ * approve/decline prompt and resumes the same turn by POSTing the carried
+ * `interruptId` with `response: "approved" | "declined"`.
+ */
+export interface ToolApprovalRequiredEvent {
+  type: 'tool_approval_required';
+  interruptId: string;
+  toolUseId: string;
+  toolName: string;
+  /** JSON-encoded tool input arguments. Pre-stringified by the backend so
+   *  one shape works for both the live SSE event and the persisted
+   *  PendingInterrupt breadcrumb (which DynamoDB would otherwise coerce
+   *  floats inside). */
+  toolInput?: string;
+  message: string;
+}
+
+/**
  * Tool result event data structure
  */
 export interface ToolResultEventData {


### PR DESCRIPTION
## Summary
- Replace the three hardcoded approval hooks (Email / ExternalWrite / Dangerous) with a single `MCPExternalApprovalHook` whose gating set comes from per-tool `needs_approval` flags on each `MCPServerConfig`. Admins now control which tools require approval from the catalog.
- Introduce a `tool_approval_required` SSE event + Strands interrupt flow: the agent pauses before invoking a flagged tool, the frontend renders an inline approve/decline prompt next to the assistant message, and the user's decision resumes the turn (decline becomes a `cancel_tool` so the agent can replan).
- Persist a `tool_approval` variant of `PendingInterrupt` (alongside the existing `oauth` variant) so the inline prompt rehydrates with full context after a browser refresh.
- Add an admin `/admin/tools/discover` endpoint and FormArray UI on the tool form so admins can populate tool entries from the live MCP server instead of typing names by hand.

## Test plan
- [ ] Backend: `cd backend && uv run python -m pytest tests/agents/main_agent/session/test_tool_approval.py tests/agents/main_agent/integrations/test_external_mcp_client.py -v`
- [ ] Configure an MCP tool in the admin UI, flag one tool `needs_approval`, confirm the approve/decline prompt appears mid-turn and that approve runs the tool while decline produces a cancel error the agent acknowledges
- [ ] Refresh the page mid-prompt and confirm the approval prompt rehydrates from `PendingInterrupt`
- [ ] Verify legacy `List[str]` rows in the catalog still load (back-compat path in `MCPServerConfig.from_dict`)
- [ ] Test the admin Discover button against a non-OAuth MCP server and confirm OAuth servers are rejected with a 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)