### PR TITLE
feat: open ngx-markdown links in new tab

### DIFF
--- a/frontend/ai.client/src/app/app.config.ts
+++ b/frontend/ai.client/src/app/app.config.ts
@@ -5,8 +5,20 @@ import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth/auth.interceptor';
 import { errorInterceptor } from './auth/error.interceptor';
-import { provideMarkdown } from 'ngx-markdown';
+import { MARKED_OPTIONS, MarkedOptions, MarkedRenderer, provideMarkdown } from 'ngx-markdown';
 import { ConfigService } from './services/config.service';
+
+function markedOptionsFactory(): MarkedOptions {
+  const renderer = new MarkedRenderer();
+  const renderLink = renderer.link;
+
+  renderer.link = function (link) {
+    const html = renderLink.call(this, link);
+    return html.replace(/^<a /, '<a target="_blank" rel="noopener noreferrer" ');
+  };
+
+  return { renderer };
+}
 
 /**
  * Application initialization factory
@@ -33,7 +45,12 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(
       withInterceptors([authInterceptor, errorInterceptor]),
     ),
-    provideMarkdown(),
+    provideMarkdown({
+      markedOptions: {
+        provide: MARKED_OPTIONS,
+        useFactory: markedOptionsFactory,
+      },
+    }),
     provideRouter(routes, withComponentInputBinding()),
     
     // Load runtime configuration before app starts


### PR DESCRIPTION
## Summary
- Configure ngx-markdown's marked renderer to emit `target="_blank" rel="noopener noreferrer"` on all rendered links so they open in a new tab
- `rel="noopener noreferrer"` prevents reverse-tabnabbing via `window.opener` and avoids leaking the referring URL
- Wraps the default `link` renderer rather than reimplementing it, so href/title escaping and inline-token parsing for link text continue to come from marked

## Test plan
- [ ] Hard-refresh the app (bootstrap config requires a full reload, not just HMR)
- [ ] Render an assistant message containing a markdown link (e.g. `[example](https://example.com)`) and confirm the anchor opens in a new tab
- [ ] Inspect the rendered DOM and confirm `<a href="..." target="_blank" rel="noopener noreferrer">` is present
- [ ] Verify other markdown features (headings, code blocks, tables, lists, mermaid, katex) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)