### PR TITLE
fix: gate session metadata creation on GSI lookup

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -700,10 +700,23 @@ async def _store_session_metadata_cloud(
 async def ensure_session_metadata_exists(session_id: str, user_id: str) -> bool:
     """Idempotently create a session metadata row if it doesn't exist yet.
 
-    Uses a conditional ``put_item`` keyed on ``attribute_not_exists(PK)`` so
-    concurrent first-turn requests for the same session can't clobber each
-    other. Returns ``True`` when a new row was created (caller can use this
-    as the "first turn" signal, e.g. to fire title generation).
+    Returns ``True`` when a new row was created (caller can use this as the
+    "first turn" signal, e.g. to fire title generation).
+
+    Existence is gated on a ``SessionLookupIndex`` GSI lookup rather than a
+    conditional ``put_item``: the main-table SK encodes ``lastMessageAt``
+    (rotated each turn by ``update_session_activity`` to keep recency
+    listing correct), so each call generates a different SK and an
+    ``attribute_not_exists(PK)`` ConditionExpression would be evaluated
+    against an item that never existed at that exact key — the put would
+    always succeed and the same session would gain a new duplicate row
+    every turn.
+
+    The GSI is eventually consistent, so a residual race remains for
+    genuinely concurrent first-turn requests for the same brand-new
+    session_id. That window is bounded to the GSI replication lag (sub-
+    100ms typical) and is the same one tracked alongside the schema
+    change in issue #175.
 
     No-op for preview sessions, which intentionally skip persistence.
     """
@@ -716,11 +729,14 @@ async def ensure_session_metadata_exists(session_id: str, user_id: str) -> bool:
 
     try:
         import boto3
-        from botocore.exceptions import ClientError
         from datetime import datetime, timezone
 
         dynamodb = boto3.resource("dynamodb")
         table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if existing is not None:
+            return False
 
         now = datetime.now(timezone.utc).isoformat()
         item = {
@@ -739,15 +755,9 @@ async def ensure_session_metadata_exists(session_id: str, user_id: str) -> bool:
             "tags": [],
         }
 
-        try:
-            table.put_item(Item=item, ConditionExpression="attribute_not_exists(PK)")
-            logger.info(f"💾 Pre-created session metadata for {session_id}")
-            return True
-        except ClientError as e:
-            if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
-                # Session already exists — expected for continuing conversations.
-                return False
-            raise
+        table.put_item(Item=item)
+        logger.info(f"💾 Pre-created session metadata for {session_id}")
+        return True
     except Exception as e:
         # Best-effort: failures must not block the stream. update_session_activity
         # self-heals by retrying this call once if the row is missing post-stream.

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -370,6 +370,48 @@ class TestUpdateSessionActivity:
         assert items == []
 
 
+class TestEnsureSessionMetadataExists:
+    @pytest.mark.asyncio
+    async def test_repeated_calls_do_not_create_duplicates(self, sessions_metadata_table):
+        """Regression: each turn calls ensure_session_metadata_exists; the SK
+        encodes a timestamp, so a put-with-conditional cannot gate creation
+        and would produce one duplicate row per turn (sidebar duplication bug).
+        """
+        from apis.shared.sessions.metadata import ensure_session_metadata_exists
+
+        first = await ensure_session_metadata_exists("s1", "u1")
+        second = await ensure_session_metadata_exists("s1", "u1")
+        third = await ensure_session_metadata_exists("s1", "u1")
+
+        assert first is True
+        assert second is False
+        assert third is False
+
+        items = sessions_metadata_table.scan()["Items"]
+        s_items = [i for i in items if i["SK"].startswith("S#ACTIVE#") and i.get("sessionId") == "s1"]
+        assert len(s_items) == 1
+
+    @pytest.mark.asyncio
+    async def test_survives_sk_rotation(self, sessions_metadata_table):
+        """After update_session_activity rotates the SK, a subsequent ensure
+        call must still recognize the session via the GSI and skip the put.
+        """
+        from apis.shared.sessions.metadata import (
+            ensure_session_metadata_exists,
+            update_session_activity,
+        )
+
+        await ensure_session_metadata_exists("s1", "u1")
+        await update_session_activity(session_id="s1", user_id="u1", last_model="claude-3")
+
+        again = await ensure_session_metadata_exists("s1", "u1")
+        assert again is False
+
+        items = sessions_metadata_table.scan()["Items"]
+        s_items = [i for i in items if i["SK"].startswith("S#ACTIVE#") and i.get("sessionId") == "s1"]
+        assert len(s_items) == 1
+
+
 class TestAddPendingInterruptListAppend:
     """list_append-based persistence — race-free with no read-modify-write."""
 


### PR DESCRIPTION
## Summary

- `ensure_session_metadata_exists` was creating a duplicate row on every turn — the SK encodes `lastMessageAt` (rotated each turn by `update_session_activity` for recency listing), so its `attribute_not_exists(PK)` ConditionExpression was evaluated against an item that never existed at that exact key. The conditional always passed, and the sidebar accumulated one duplicate entry per user message, all linking to the same `session_id`.
- Gate creation on a `SessionLookupIndex` GSI lookup instead, which is the existing index used elsewhere for sessionId → row resolution.
- The GSI is eventually consistent, so a residual race remains for genuinely concurrent first-turn requests for the same brand-new session_id (bounded to GSI replication lag, ~sub-100ms). This is the same window already tracked alongside the schema change in #175.

Regression introduced in #180 / `18b96c9` (this week, hasn't reached production).

## Test plan

- [x] `tests/shared/test_sessions_metadata.py` — all 40 tests pass, including two new ones:
  - `test_repeated_calls_do_not_create_duplicates` — three sequential calls produce one row, returns `(True, False, False)`.
  - `test_survives_sk_rotation` — after `update_session_activity` rotates the SK, a subsequent `ensure` call still recognizes the session via the GSI and skips the put.
- [x] `tests/routes/test_inference.py`, `tests/routes/test_chat.py`, `tests/apis/test_citation_events.py` — all pass.
- [ ] Manual: in dev, send several messages to a new chat and confirm the sidebar shows exactly one entry.
- [ ] Heads-up: dev/staging may have leftover duplicate rows from before this fix; those will need a one-shot cleanup (not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)