### PR TITLE
fix(chat): align resume cache key with original turn so paused agent isn't orphaned

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -112,9 +112,15 @@ class BaseAgent(ABC):
             self.prompt_builder = SystemPromptBuilder()
             self.system_prompt = self.prompt_builder.build(include_date=True)
 
-        # Capture the resolved system prompt — what we'd need to pass back to
-        # ``get_agent`` to land on the same cache key on resume.
-        self._construction_snapshot["system_prompt"] = self.system_prompt
+        # Snapshot the *unbuilt* system_prompt — i.e. the same string the
+        # caller passed to ``get_agent`` originally. The cache key hashes
+        # this raw value (see ``_create_cache_key``), so storing the built
+        # prompt here causes resume to land on a different cache slot than
+        # the original turn. That leaves the original (paused) agent stuck
+        # in the cache; a later non-resume turn cache-hits to it and
+        # Strands raises "must resume from interrupt with list of
+        # interruptResponse's" because _interrupt_state is still activated.
+        self._construction_snapshot["system_prompt"] = system_prompt
 
         # Initialize tool registry and filter
         self.tool_registry = create_default_registry()

--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -112,7 +112,7 @@ class BaseAgent(ABC):
             self.prompt_builder = SystemPromptBuilder()
             self.system_prompt = self.prompt_builder.build(include_date=True)
 
-        # Snapshot the *unbuilt* system_prompt — i.e. the same string the
+        # Snapshot the *unbuilt* system_prompt — i.e. the same value the
         # caller passed to ``get_agent`` originally. The cache key hashes
         # this raw value (see ``_create_cache_key``), so storing the built
         # prompt here causes resume to land on a different cache slot than
@@ -120,6 +120,14 @@ class BaseAgent(ABC):
         # in the cache; a later non-resume turn cache-hits to it and
         # Strands raises "must resume from interrupt with list of
         # interruptResponse's" because _interrupt_state is still activated.
+        #
+        # Trade-off: if the cache evicts between pause and resume AND the
+        # original ``system_prompt`` was None, the rebuilt agent re-renders
+        # the date via ``include_date=True`` and may pick up *today's* date
+        # rather than the original turn's. Snapshot TTL is 1h, so this only
+        # matters across a midnight crossing. Resume conversation context is
+        # restored from AgentCore Memory regardless, so the model still sees
+        # prior turns; only the system-prompt date line shifts.
         self._construction_snapshot["system_prompt"] = system_prompt
 
         # Initialize tool registry and filter

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -597,6 +597,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 provider=snapshot.provider,
                 max_tokens=snapshot.max_tokens,
                 agent_type=snapshot.agent_type,
+                is_resume=True,
             )
         else:
             # Resolve caching_enabled based on managed model configuration
@@ -622,6 +623,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 provider=input_data.provider,
                 max_tokens=input_data.max_tokens,
                 agent_type=input_data.agent_type,
+                is_resume=False,
             )
 
         # Resume requests must target interrupts that the cached agent

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -88,6 +88,18 @@ _agent_cache: dict = {}
 _CACHE_MAX_SIZE = 100
 
 
+def _is_paused_on_interrupt(agent: BaseAgent) -> bool:
+    """Return True if the wrapped Strands agent is mid-interrupt.
+
+    Used by ``get_agent`` to decide whether to evict a stale paused agent
+    from the cache. ``getattr`` chains with defaults can never raise, so
+    no try/except is needed.
+    """
+    inner = getattr(agent, "agent", None)
+    state = getattr(inner, "_interrupt_state", None)
+    return bool(state is not None and getattr(state, "activated", False))
+
+
 async def get_agent(
     session_id: str,
     user_id: Optional[str] = None,
@@ -152,21 +164,14 @@ async def get_agent(
         # paused agent stays in the original slot — and a later non-resume
         # turn cache-hits to it. Strands then raises "must resume from
         # interrupt with list of interruptResponse's". Discard and rebuild.
-        if not is_resume:
-            try:
-                inner = getattr(cached, "agent", None)
-                state = getattr(inner, "_interrupt_state", None)
-                if state is not None and getattr(state, "activated", False):
-                    logger.warning(
-                        "Cached agent is paused on an interrupt but request is not a resume; "
-                        "evicting and rebuilding (session=%s user=%s)",
-                        session_id, user_id,
-                    )
-                    del _agent_cache[cache_key]
-                    cached = None
-            except Exception:
-                logger.exception("Failed to inspect cached agent interrupt state")
-        if cached is not None:
+        if not is_resume and _is_paused_on_interrupt(cached):
+            logger.warning(
+                "Cached agent is paused on an interrupt but request is not a resume; "
+                "evicting and rebuilding (session=%s user=%s)",
+                session_id, user_id,
+            )
+            del _agent_cache[cache_key]
+        else:
             logger.debug("✅ Agent cache hit")
             return cached
 

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -100,6 +100,7 @@ async def get_agent(
     provider: Optional[str] = None,
     max_tokens: Optional[int] = None,
     agent_type: Optional[str] = None,
+    is_resume: bool = False,
 ) -> BaseAgent:
     """
     Get or create agent instance with current configuration for session
@@ -143,8 +144,31 @@ async def get_agent(
 
     # Check cache
     if cache_key in _agent_cache:
-        logger.debug("✅ Agent cache hit")
-        return _agent_cache[cache_key]
+        cached = _agent_cache[cache_key]
+        # Defense in depth: a non-resume request should never be served a
+        # paused agent. If we ever desync the cache key between the original
+        # turn and a resume (e.g. snapshot stores a normalized form of one
+        # of the params), the resume rebuilds under a new key while the
+        # paused agent stays in the original slot — and a later non-resume
+        # turn cache-hits to it. Strands then raises "must resume from
+        # interrupt with list of interruptResponse's". Discard and rebuild.
+        if not is_resume:
+            try:
+                inner = getattr(cached, "agent", None)
+                state = getattr(inner, "_interrupt_state", None)
+                if state is not None and getattr(state, "activated", False):
+                    logger.warning(
+                        "Cached agent is paused on an interrupt but request is not a resume; "
+                        "evicting and rebuilding (session=%s user=%s)",
+                        session_id, user_id,
+                    )
+                    del _agent_cache[cache_key]
+                    cached = None
+            except Exception:
+                logger.exception("Failed to inspect cached agent interrupt state")
+        if cached is not None:
+            logger.debug("✅ Agent cache hit")
+            return cached
 
     # Cache miss - create new agent
     logger.debug("⚠️ Agent cache miss - creating new instance")

--- a/backend/tests/apis/inference_api/test_chat_service.py
+++ b/backend/tests/apis/inference_api/test_chat_service.py
@@ -1,0 +1,185 @@
+"""Tests for ``apis.inference_api.chat.service.get_agent`` cache behavior.
+
+Covers the OAuth-resume cache fix (#207):
+
+1. Cache key alignment — when ``system_prompt`` is ``None`` on the original
+   turn and the persisted snapshot also stores ``None``, the resume call
+   hashes to the same cache slot and reuses the paused agent.
+2. Defense-in-depth eviction — a non-resume request that lands on a cached
+   agent whose ``_interrupt_state.activated`` is True must drop the cached
+   instance and build a fresh one.
+3. Resume requests must NOT trigger the eviction path; the whole point of
+   resuming is to reuse the paused agent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from apis.inference_api.chat import service
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Each test starts with an empty agent cache."""
+    service.clear_agent_cache()
+    yield
+    service.clear_agent_cache()
+
+
+def _fake_agent(*, system_prompt=None, activated: bool = False) -> MagicMock:
+    """Build a stand-in for BaseAgent that exposes the attrs ``get_agent`` reads.
+
+    Mirrors the real shape: ``BaseAgent.agent`` is the wrapped Strands agent
+    and Strands stores interrupt state on ``agent._interrupt_state``. The
+    construction snapshot mirrors ``BaseAgent.__init__`` post-fix — it stores
+    the *unbuilt* ``system_prompt`` so resume hashes back to the same cache
+    slot.
+    """
+    inner = SimpleNamespace(_interrupt_state=SimpleNamespace(activated=activated))
+    wrapper = MagicMock(spec=["agent", "_construction_snapshot"])
+    wrapper.agent = inner
+    wrapper._construction_snapshot = {"system_prompt": system_prompt}
+    return wrapper
+
+
+@pytest.fixture
+def mock_create_agent():
+    """Patch out the agent factory so ``get_agent`` returns a fresh fake each call.
+
+    The fake's snapshot mirrors the real ``BaseAgent`` post-fix: it stores
+    the unbuilt ``system_prompt`` parameter (not a rendered output).
+    """
+    with patch.object(service, "create_agent") as mock:
+        mock.side_effect = lambda **kwargs: _fake_agent(
+            system_prompt=kwargs.get("system_prompt")
+        )
+        yield mock
+
+
+@pytest.fixture
+def mock_freshness_hash():
+    """Stable freshness hash so cache keys depend only on the inputs we care about."""
+    with patch(
+        "apis.shared.tools.freshness.get_freshness_hash",
+        new=AsyncMock(return_value="fresh"),
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_resume_replay_from_snapshot_hits_same_cache_slot(
+    mock_create_agent, mock_freshness_hash
+):
+    """The regression fixed in #207. Original turn with ``system_prompt=None``
+    pauses on OAuth consent; ``stream_coordinator`` writes the construction
+    snapshot to DynamoDB; the resume request reads ``snapshot.system_prompt``
+    and feeds it back into ``get_agent``. With the fix, the snapshot stores
+    the unbuilt prompt (``None``), which hashes to the same cache key as the
+    original turn — so resume reuses the paused agent. With the bug
+    (snapshot stored the rendered base+date string), the cache key would
+    diverge and resume would rebuild, orphaning the paused agent.
+    """
+    # Original turn: system_prompt=None
+    first = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        system_prompt=None,
+        is_resume=False,
+    )
+    first.agent._interrupt_state.activated = True
+
+    # Production replay: stream_coordinator persists _construction_snapshot
+    # and the resume request feeds snapshot.system_prompt back into get_agent.
+    snapshot_system_prompt = first._construction_snapshot["system_prompt"]
+    assert snapshot_system_prompt is None, (
+        "post-fix snapshot must store the unbuilt prompt (None), not a "
+        "rendered string — otherwise resume hashes to a different cache slot"
+    )
+
+    second = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        system_prompt=snapshot_system_prompt,
+        is_resume=True,
+    )
+
+    assert second is first, "resume should return the same cached (paused) agent"
+    assert mock_create_agent.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_resume_evicts_paused_cached_agent(
+    mock_create_agent, mock_freshness_hash
+):
+    """If a paused agent ever ends up cached on a non-resume cache lookup
+    (the bug we're hardening against), evict it and build fresh. Strands would
+    otherwise reject the next plain user message with ``must resume from
+    interrupt with list of interruptResponse's``.
+    """
+    paused = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=False,
+    )
+    paused.agent._interrupt_state.activated = True
+
+    rebuilt = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=False,
+    )
+
+    assert rebuilt is not paused, "non-resume must not be served the paused agent"
+    assert mock_create_agent.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_evict_paused_cached_agent(
+    mock_create_agent, mock_freshness_hash
+):
+    """The eviction path is gated on ``is_resume=False``. A genuine resume
+    request must reuse the paused agent so Strands' ``_interrupt_state.resume``
+    receives the original interrupt entry list — otherwise we'd rebuild the
+    agent and the resume would have nothing to resume against.
+    """
+    paused = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=False,
+    )
+    paused.agent._interrupt_state.activated = True
+
+    resumed = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=True,
+    )
+
+    assert resumed is paused
+    assert mock_create_agent.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_resume_keeps_non_paused_cached_agent(
+    mock_create_agent, mock_freshness_hash
+):
+    """Sanity check: the eviction path only fires when ``activated`` is True.
+    A normal cache hit on a healthy agent stays a cache hit.
+    """
+    first = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=False,
+    )
+    second = await service.get_agent(
+        session_id="s1",
+        user_id="u1",
+        is_resume=False,
+    )
+
+    assert second is first
+    assert mock_create_agent.call_count == 1


### PR DESCRIPTION
## Summary

Follow-up turns after a successful OAuth-consent resume were failing with:

```
TypeError: prompt_type=<class 'str'> | must resume from interrupt with list of interruptResponse's
```

**Root cause:** the agent cache keyed on the unbuilt `system_prompt` parameter, but `BaseAgent` snapshotted the *built* prompt (`SystemPromptBuilder(...).build(...)`). Resume passed the built form back into `get_agent`, hashing to a different cache slot. The resume cache-MISSED, built a fresh agent, and left the original (paused, `_interrupt_state.activated=True`) agent stranded under the original key. The next plain user message cache-HIT the stranded agent, and Strands' `_interrupt_state.resume(prompt)` rejected the string prompt.

**Fix:** snapshot the *unbuilt* `system_prompt` so resume hashes to the same cache slot as the original turn. Plus a defense-in-depth eviction path: if `get_agent` cache-hits a paused agent on a non-resume request, drop it and rebuild.

## Diagnosis trace

Reproduced locally with debug logging tracking `id(agent)`:

| Turn | Cache | id_main | activated |
|------|-------|---------|-----------|
| 1 (initial pause) | first build | `4544057072` | True |
| 2 (resume) | **MISS — built fresh** | `4633915904` | False at end |
| 3 (follow-up) | **HIT — Turn 1's stranded agent** | `4544057072` | True → TypeError |

After fix:

| Turn | Cache | id_main | activated |
|------|-------|---------|-----------|
| 2 (resume) | (built once) | `4639291344` | False at end |
| 3 (follow-up) | **HIT same instance** | `4639291344` | False → 200 OK |

## Test plan

- [x] Manual repro: ask agent to use Gmail → consent → tool result → send follow-up. Verify 200 OK and no `TypeError` in inference-api logs.
- [x] Verify Turn 2 (resume) and Turn 3 (follow-up) hit the same `id(agent)` (one cached instance per config, not two).
- [x] Verify defense-in-depth fires if a paused agent ever ends up cached on a non-resume request — log line `Cached agent is paused on an interrupt but request is not a resume; evicting and rebuilding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)