### PR TITLE
fix(costs): coerce cost_delta to a finite Decimal in summary writers

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -9,6 +9,7 @@ Architecture:
 
 import logging
 import json
+import math
 import os
 import base64
 from typing import Iterable, List, Optional, Tuple, Any, Dict
@@ -53,6 +54,29 @@ def _convert_decimal_to_float(obj: Any) -> Any:
         return [_convert_decimal_to_float(item) for item in obj]
     else:
         return obj
+
+
+def _coerce_cost_total(raw: Any) -> float:
+    """Normalize a ``MessageMetadata.cost`` value to a finite float total.
+
+    ``MessageMetadata.cost`` is ``Optional[Union[float, Dict[str, float]]]`` —
+    the streaming path stores a breakdown dict (``{"total": ..., "inputCost": ...}``)
+    while the legacy path stores a bare float. Downstream summary writers
+    only want the scalar total; passing the dict through caused
+    ``Decimal(str(...))`` to throw ``ConversionSyntax`` at the DynamoDB
+    boundary. NaN/inf and non-numeric values collapse to 0.0.
+    """
+    if isinstance(raw, dict):
+        raw = raw.get("total")
+    if raw is None:
+        return 0.0
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(value):
+        return 0.0
+    return value
 
 
 
@@ -301,8 +325,10 @@ async def _update_cost_summary_async(
         import asyncio
         from datetime import datetime
 
-        # Extract cost and usage from metadata
-        cost = message_metadata.cost or 0.0
+        # Extract cost and usage from metadata. cost may be a breakdown dict
+        # ({"total": ..., "inputCost": ...}) on the streaming path or a bare
+        # float on the legacy path; the summary writer needs the scalar total.
+        cost = _coerce_cost_total(message_metadata.cost)
         token_usage = message_metadata.token_usage
 
         usage_delta = {}
@@ -342,8 +368,11 @@ async def _update_cost_summary_async(
 
                     logger.debug(f"🔍 Pricing dict: {pricing_dict}")
 
-                    input_price = pricing_dict.get("inputPricePerMtok", 0)
-                    cache_read_price = pricing_dict.get("cacheReadPricePerMtok", 0)
+                    # `or 0` (not `.get(..., 0)`) — managed-model rows can
+                    # store an explicit None for cache_read pricing, which
+                    # would otherwise propagate into arithmetic below.
+                    input_price = pricing_dict.get("inputPricePerMtok") or 0
+                    cache_read_price = pricing_dict.get("cacheReadPricePerMtok") or 0
 
                     # Calculate savings: what we would have paid vs what we actually paid
                     standard_cost = (cache_read_tokens / 1_000_000) * input_price

--- a/backend/src/apis/shared/storage/dynamodb_storage.py
+++ b/backend/src/apis/shared/storage/dynamodb_storage.py
@@ -29,7 +29,31 @@ Schema:
 import os
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
+
+
+def _safe_decimal(value: Any) -> Decimal:
+    """Coerce ``value`` to a finite ``Decimal``, falling back to ``Decimal("0")``.
+
+    The cost-summary writers receive ``cost_delta`` / ``cache_savings_delta``
+    from upstream call sites that occasionally hand over a dict, ``None``,
+    or a non-finite float (NaN / inf). ``Decimal(str(...))`` raises
+    ``decimal.InvalidOperation`` for those inputs, and DynamoDB rejects
+    NaN / inf even when conversion succeeds. Treating bad input as zero
+    keeps the rollup write atomic and idempotent rather than crashing the
+    whole non-critical summary update.
+    """
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value if value.is_finite() else Decimal("0")
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal("0")
+    if not result.is_finite():
+        return Decimal("0")
+    return result
 
 try:
     import boto3
@@ -332,13 +356,13 @@ class DynamoDBStorage(MetadataStorage):
             """
 
             expression_values = {
-                ":cost": Decimal(str(cost_delta)),
+                ":cost": _safe_decimal(cost_delta),
                 ":one": 1,
                 ":input": usage_delta.get("inputTokens", 0),
                 ":output": usage_delta.get("outputTokens", 0),
                 ":cacheRead": usage_delta.get("cacheReadInputTokens", 0),
                 ":cacheWrite": usage_delta.get("cacheWriteInputTokens", 0),
-                ":savings": Decimal(str(cache_savings_delta)),
+                ":savings": _safe_decimal(cache_savings_delta),
                 ":now": timestamp,
                 ":periodStart": f"{period}-01T00:00:00Z",
                 ":periodEnd": f"{period}-31T23:59:59Z",
@@ -467,7 +491,7 @@ class DynamoDBStorage(MetadataStorage):
                     "#cacheWriteTokens": "cacheWriteTokens"
                 },
                 ExpressionAttributeValues={
-                    ":cost": Decimal(str(cost_delta)),
+                    ":cost": _safe_decimal(cost_delta),
                     ":one": 1,
                     ":input": usage_delta.get("inputTokens", 0),
                     ":output": usage_delta.get("outputTokens", 0),
@@ -842,7 +866,7 @@ class DynamoDBStorage(MetadataStorage):
             """
 
             expression_values = {
-                ":cost": Decimal(str(cost_delta)),
+                ":cost": _safe_decimal(cost_delta),
                 ":one": 1,
                 ":input": usage_delta.get("inputTokens", 0),
                 ":output": usage_delta.get("outputTokens", 0),
@@ -916,13 +940,13 @@ class DynamoDBStorage(MetadataStorage):
             """
 
             expression_values = {
-                ":cost": Decimal(str(cost_delta)),
+                ":cost": _safe_decimal(cost_delta),
                 ":one": 1,
                 ":input": usage_delta.get("inputTokens", 0),
                 ":output": usage_delta.get("outputTokens", 0),
                 ":cacheRead": usage_delta.get("cacheReadInputTokens", 0),
                 ":cacheWrite": usage_delta.get("cacheWriteInputTokens", 0),
-                ":savings": Decimal(str(cache_savings_delta)),
+                ":savings": _safe_decimal(cache_savings_delta),
                 ":now": datetime.now(timezone.utc).isoformat(),
                 ":type": "monthly"
             }
@@ -995,7 +1019,7 @@ class DynamoDBStorage(MetadataStorage):
             """
 
             expression_values = {
-                ":cost": Decimal(str(cost_delta)),
+                ":cost": _safe_decimal(cost_delta),
                 ":one": 1,
                 ":input": usage_delta.get("inputTokens", 0),
                 ":output": usage_delta.get("outputTokens", 0),

--- a/backend/tests/costs/test_dynamodb_storage_costs.py
+++ b/backend/tests/costs/test_dynamodb_storage_costs.py
@@ -207,6 +207,86 @@ class TestUpdateUserCostSummary:
         assert bd["claude_sonnet"]["requests"] == 1
 
 
+# ── defensive cost_delta coercion ────────────────────────────────────────────
+
+
+class TestUpdateUserCostSummaryDefensiveCoercion:
+    """Regression tests for the Decimal(str(cost_delta)) ConversionSyntax crash.
+
+    Upstream callers occasionally hand the summary writer a dict (the new
+    streaming-cost breakdown), None (uncomputed cost), or a non-finite float
+    (from None pricing fields). All of these used to raise InvalidOperation
+    and abort the rollup write. They must now degrade to a 0 contribution.
+    """
+
+    @pytest.mark.asyncio
+    async def test_none_cost_delta_does_not_raise(self, storage, sample_usage_delta):
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta=None, usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP,
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert result["totalCost"] == pytest.approx(0.0)
+        assert result["totalRequests"] == 1
+
+    @pytest.mark.asyncio
+    async def test_dict_cost_delta_does_not_raise(self, storage, sample_usage_delta):
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta={"total": 0.0, "inputCost": 0.0, "outputCost": 0.0},
+            usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP,
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert result["totalCost"] == pytest.approx(0.0)
+        assert result["totalRequests"] == 1
+
+    @pytest.mark.asyncio
+    async def test_nan_cost_delta_does_not_raise(self, storage, sample_usage_delta):
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta=float("nan"), usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP,
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert result["totalCost"] == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_inf_cost_delta_does_not_raise(self, storage, sample_usage_delta):
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta=float("inf"), usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP,
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert result["totalCost"] == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_none_cache_savings_does_not_raise(self, storage, sample_usage_delta):
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta=1.0, usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP, cache_savings_delta=None,
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert result["totalCost"] == pytest.approx(1.0)
+        assert result["cacheSavings"] == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_dict_cost_delta_with_model_id_does_not_raise(self, storage, sample_usage_delta):
+        """The model-breakdown sub-write also coerces cost_delta safely."""
+        await storage.update_user_cost_summary(
+            user_id="u1", period=PERIOD,
+            cost_delta={"total": 0.0}, usage_delta=sample_usage_delta,
+            timestamp=TIMESTAMP,
+            model_id="gpt-4o", model_name="GPT-4o", provider="openai",
+        )
+        result = await storage.get_user_cost_summary("u1", PERIOD)
+        assert "gpt_4o" in result["modelBreakdown"]
+        assert result["modelBreakdown"]["gpt_4o"]["cost"] == pytest.approx(0.0)
+
+
 # ── _update_model_breakdown ──────────────────────────────────────────────────
 
 class TestUpdateModelBreakdown:

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -1,5 +1,7 @@
 """Task 10: Sessions metadata tests (moto DynamoDB)."""
 
+import math
+
 import pytest
 from apis.shared.sessions.models import SessionMetadata, MessageMetadata, TokenUsage, ModelInfo
 
@@ -672,3 +674,65 @@ class TestPausedTurnSnapshot:
         interrupts = await get_pending_interrupts("s1", "u1")
         assert len(interrupts) == 1
         assert interrupts[0].interrupt_id == "i1"
+
+
+class TestCoerceCostTotal:
+    """Normalize ``MessageMetadata.cost`` (float | dict | None) to a finite float total.
+
+    Regression tests for the cost-summary writer crash: the streaming path
+    builds a breakdown dict (``{"total": ..., "inputCost": ...}``), which
+    used to flow through ``Decimal(str(...))`` and raise
+    ``decimal.InvalidOperation``.
+    """
+
+    def test_dict_with_total_returns_total(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total({"total": 0.0105, "inputCost": 0.003}) == pytest.approx(0.0105)
+
+    def test_dict_without_total_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total({"inputCost": 0.003, "outputCost": 0.0075}) == 0.0
+
+    def test_dict_with_none_total_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total({"total": None}) == 0.0
+
+    def test_float_passthrough(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(0.42) == pytest.approx(0.42)
+
+    def test_int_passthrough(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(7) == 7.0
+
+    def test_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(0.0) == 0.0
+
+    def test_none_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(None) == 0.0
+
+    def test_nan_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(float("nan")) == 0.0
+
+    def test_inf_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total(float("inf")) == 0.0
+        assert _coerce_cost_total(float("-inf")) == 0.0
+
+    def test_non_numeric_returns_zero(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total("not-a-number") == 0.0
+        assert _coerce_cost_total(["list"]) == 0.0
+
+    def test_string_numeric_coerces(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        assert _coerce_cost_total("0.5") == pytest.approx(0.5)
+
+    def test_returns_finite_float(self):
+        from apis.shared.sessions.metadata import _coerce_cost_total
+        result = _coerce_cost_total({"total": 1.5})
+        assert isinstance(result, float)
+        assert math.isfinite(result)


### PR DESCRIPTION
## Summary

Fixes a `decimal.InvalidOperation` (`ConversionSyntax`) raised by the cost-summary writer in `_update_cost_summary_async` whenever the streaming pipeline produced a breakdown-dict cost. The per-message cost record write succeeded (its dict is recursively float→Decimal converted), but the summary update crashed and was caught by the "non-critical" handler — so user-facing chat was fine, but the rollup table was silently stale.

Trace from a real session:

```
Failed to update cost summary (non-critical): [<class 'decimal.ConversionSyntax'>]
  File "backend/src/apis/shared/storage/dynamodb_storage.py", line 335, in update_user_cost_summary
    ":cost": Decimal(str(cost_delta)),
```

Root cause: `MessageMetadata.cost` is `Optional[Union[float, Dict[str, float]]]`. `_calculate_message_cost` returns the dict form (`{"total": ..., "inputCost": ...}`), and `metadata.py` did `cost = message_metadata.cost or 0.0`, passing the dict straight into `Decimal(str(...))`. The bug was triggered (but not caused) by `us.anthropic.claude-sonnet-4-6` having `cache_read_price=None` in managed-models; that just made everything roll up to a `$0.0`-valued breakdown dict that exposed the latent bug.

## Fix

Two layers of defense:

- **Upstream** (`backend/src/apis/shared/sessions/metadata.py`): new `_coerce_cost_total` helper extracts a finite float total from a dict / float / None / NaN / inf. Also tightened the cache-savings calculation to use `or 0` (not `.get(..., 0)`) on pricing reads so a stored `None` doesn't propagate into arithmetic.
- **Boundary** (`backend/src/apis/shared/storage/dynamodb_storage.py`): new `_safe_decimal` helper replaces every `Decimal(str(cost_delta | cache_savings_delta))` site (5 total: `update_user_cost_summary`, `_update_model_breakdown`, `update_daily_rollup`, `update_monthly_rollup`, `update_model_rollup`). Bad input collapses to `Decimal("0")` rather than aborting the rollup.

## Out of scope (follow-up)

- The `us.anthropic.claude-sonnet-4-6` row in the managed-models table is missing real pricing (cache_read shows up as `None`). Whoever owns that data should backfill it; the crash fix doesn't depend on it.
- The interrupt/OAuth flow is intentionally untouched — separate live debugging is in progress there.

## Test plan

- [x] `uv run python -m pytest tests/ -v` from `backend/` — **2220 passed, 3 skipped**
- [x] New focused unit tests:
  - `TestCoerceCostTotal` (12 cases) covers dict/float/int/None/NaN/inf/non-numeric inputs to the upstream helper
  - `TestUpdateUserCostSummaryDefensiveCoercion` (6 cases) confirms the DDB writer no longer raises for `None` / dict / NaN / inf `cost_delta`, with and without `model_id`
- [ ] Smoke-check in dev once deployed: chat with a model whose pricing has missing cache_read, confirm rollup `totalCost` increments without "Failed to update cost summary (non-critical)" log noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)