### PR TITLE
feat(infra): BFF token-handler resources (Phase 1)

### DIFF
--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -348,6 +348,40 @@ export class AppApiStack extends cdk.Stack {
     );
 
     // ============================================================
+    // BFF Resources (imported from Infrastructure Stack)
+    // ============================================================
+    // Token Handler BFF: sessions table, cookie signing key, confidential
+    // Cognito client. See project_bff_migration memory for the rollout plan.
+    const bffSessionsTableName = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/bff-sessions-table-name`
+    );
+    const bffSessionsTableArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/bff-sessions-table-arn`
+    );
+    const bffCookieSigningKeyArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/bff-cookie-signing-key-arn`
+    );
+    const cognitoBFFAppClientId = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/cognito/bff-app-client-id`
+    );
+    const cognitoBFFAppClientSecretArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/cognito/bff-app-client-secret-arn`
+    );
+
+    // Inference API runtime endpoint URL — needed by both the existing
+    // converse proxy (currently broken in cloud due to a missing env var)
+    // and the upcoming chat SSE proxy in Phase 4 of the BFF migration.
+    const inferenceApiRuntimeEndpointUrl = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/inference-api/runtime-endpoint-url`
+    );
+
+    // ============================================================
     // File Upload Storage (imported from Infrastructure Stack)
     // ============================================================
     // These resources were moved to InfrastructureStack to avoid a circular
@@ -476,6 +510,16 @@ export class AppApiStack extends cdk.Stack {
           this,
           `/${config.projectPrefix}/shares/shared-conversations-table-name`
         ),
+        // BFF Token Handler — wired in Phase 1, used starting Phase 2.
+        BFF_SESSIONS_TABLE_NAME: bffSessionsTableName,
+        BFF_COOKIE_SIGNING_KEY_ARN: bffCookieSigningKeyArn,
+        BFF_SESSION_TTL_SECONDS: '28800',
+        BFF_SESSION_REFRESH_LEEWAY_SECONDS: '60',
+        COGNITO_BFF_APP_CLIENT_ID: cognitoBFFAppClientId,
+        COGNITO_BFF_APP_CLIENT_SECRET_ARN: cognitoBFFAppClientSecretArn,
+        // Inference API runtime endpoint — used by the converse proxy today
+        // and the chat SSE proxy added in Phase 4.
+        INFERENCE_API_URL: inferenceApiRuntimeEndpointUrl,
       },
       portMappings: [
         {
@@ -933,6 +977,40 @@ export class AppApiStack extends cdk.Stack {
         effect: iam.Effect.ALLOW,
         actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
         resources: [`${oauthClientSecretsArn}*`], // Wildcard for random suffix
+      })
+    );
+
+    // BFF Token Handler — sessions table, cookie signing key, BFF client secret.
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'BFFSessionsTableAccess',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:UpdateItem',
+          'dynamodb:DeleteItem',
+        ],
+        resources: [bffSessionsTableArn],
+      })
+    );
+
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'BFFCookieSigningKeyAccess',
+        effect: iam.Effect.ALLOW,
+        // GenerateDataKey at startup; Decrypt is reserved for future key rotation.
+        actions: ['kms:GenerateDataKey', 'kms:Decrypt', 'kms:DescribeKey'],
+        resources: [bffCookieSigningKeyArn],
+      })
+    );
+
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'CognitoBFFAppClientSecretAccess',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: [`${cognitoBFFAppClientSecretArn}*`], // Wildcard for random suffix
       })
     );
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -372,6 +372,41 @@ export class InfrastructureStack extends cdk.Stack {
       tier: ssm.ParameterTier.STANDARD,
     });
 
+    // Sessions Table - BFF token-handler sessions (httpOnly cookie -> Cognito tokens)
+    // Stores per-session Cognito access/refresh/id tokens server-side so the
+    // browser only sees an opaque session id in an httpOnly cookie. TTL on the
+    // table enforces absolute session lifetime (default 8h, configurable on app-api).
+    const bffSessionsTable = new dynamodb.Table(this, "BFFSessionsTable", {
+      tableName: getResourceName(config, "bff-sessions"),
+      partitionKey: {
+        name: "PK",
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "SK",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: "ttl",
+      pointInTimeRecovery: true,
+      removalPolicy: getRemovalPolicy(config),
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    new ssm.StringParameter(this, "BFFSessionsTableNameParameter", {
+      parameterName: `/${config.projectPrefix}/auth/bff-sessions-table-name`,
+      stringValue: bffSessionsTable.tableName,
+      description: "BFF sessions table name",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, "BFFSessionsTableArnParameter", {
+      parameterName: `/${config.projectPrefix}/auth/bff-sessions-table-arn`,
+      stringValue: bffSessionsTable.tableArn,
+      description: "BFF sessions table ARN",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
     // Users Table - User profiles synced from JWT for admin lookup
     const usersTable = new dynamodb.Table(this, "UsersTable", {
       tableName: getResourceName(config, "users"),
@@ -582,6 +617,23 @@ export class InfrastructureStack extends cdk.Stack {
       description: "KMS key for encrypting OAuth user tokens at rest",
       enableKeyRotation: true,
       removalPolicy: getRemovalPolicy(config),
+    });
+
+    // KMS Key for sealing BFF session cookies (AES-GCM via GenerateDataKey).
+    // App-api fetches a data key once at startup and caches the plaintext
+    // in process memory; the cookie value is the AES-GCM-sealed session id.
+    const bffCookieSigningKey = new kms.Key(this, "BFFCookieSigningKey", {
+      alias: getResourceName(config, "bff-cookie-signing-key"),
+      description: "KMS key for sealing BFF session cookies (data-key wrapping)",
+      enableKeyRotation: true,
+      removalPolicy: getRemovalPolicy(config),
+    });
+
+    new ssm.StringParameter(this, "BFFCookieSigningKeyArnParameter", {
+      parameterName: `/${config.projectPrefix}/auth/bff-cookie-signing-key-arn`,
+      stringValue: bffCookieSigningKey.keyArn,
+      description: "KMS key ARN for BFF session cookie sealing",
+      tier: ssm.ParameterTier.STANDARD,
     });
 
     // OAuth Providers Table - Admin-configured OAuth provider settings
@@ -1179,6 +1231,48 @@ export class InfrastructureStack extends cdk.Stack {
       ],
     });
 
+    // BFF App Client — confidential client used by app-api for the
+    // server-side OAuth token exchange in the Token Handler BFF flow.
+    // The client secret authenticates the /oauth2/token call from app-api,
+    // adding a layer of defense beyond PKCE since the secret never leaves
+    // the server. Existing public PKCE client (above) stays in place
+    // through the migration cutover as a safety net.
+    const bffCallbackUrls = config.domainName
+      ? [`https://${config.domainName}/api/auth/callback`]
+      : ['http://localhost:8000/auth/callback'];
+    const bffLogoutUrls = config.domainName
+      ? [`https://${config.domainName}`]
+      : ['http://localhost:4200'];
+
+    const bffAppClient = userPool.addClient('CognitoBFFAppClient', {
+      userPoolClientName: getResourceName(config, 'bff-app-client'),
+      generateSecret: true,
+      authFlows: { userSrp: false, custom: false },
+      oAuth: {
+        flows: { authorizationCodeGrant: true },
+        scopes: [
+          cognito.OAuthScope.OPENID,
+          cognito.OAuthScope.PROFILE,
+          cognito.OAuthScope.EMAIL,
+        ],
+        callbackUrls: bffCallbackUrls,
+        logoutUrls: bffLogoutUrls,
+      },
+      preventUserExistenceErrors: true,
+      supportedIdentityProviders: [
+        cognito.UserPoolClientIdentityProvider.COGNITO,
+      ],
+    });
+
+    // Persist the generated client secret in Secrets Manager so app-api can
+    // read it via secretsmanager:GetSecretValue (auditable, rotatable).
+    const bffAppClientSecret = new secretsmanager.Secret(this, 'CognitoBFFAppClientSecret', {
+      secretName: getResourceName(config, 'cognito-bff-app-client-secret'),
+      description: 'Client secret for the Cognito BFF app client (Token Handler flow)',
+      secretStringValue: bffAppClient.userPoolClientSecret,
+      removalPolicy: getRemovalPolicy(config),
+    });
+
     // Cognito Domain — prefix-based using project prefix or override
     const cognitoDomain = userPool.addDomain('CognitoDomain', {
       cognitoDomain: {
@@ -1219,6 +1313,20 @@ export class InfrastructureStack extends cdk.Stack {
       parameterName: `/${config.projectPrefix}/auth/cognito/issuer-url`,
       stringValue: `https://cognito-idp.${config.awsRegion}.amazonaws.com/${userPool.userPoolId}`,
       description: 'Cognito OIDC issuer URL',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'CognitoBFFAppClientIdParameter', {
+      parameterName: `/${config.projectPrefix}/auth/cognito/bff-app-client-id`,
+      stringValue: bffAppClient.userPoolClientId,
+      description: 'Cognito BFF (confidential) app client ID',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'CognitoBFFAppClientSecretArnParameter', {
+      parameterName: `/${config.projectPrefix}/auth/cognito/bff-app-client-secret-arn`,
+      stringValue: bffAppClientSecret.secretArn,
+      description: 'Secrets Manager ARN for the Cognito BFF app client secret',
       tier: ssm.ParameterTier.STANDARD,
     });
 


### PR DESCRIPTION
## Summary

Phase 1 of the [Token Handler BFF migration](https://github.com/Boise-State-Development/agentcore-public-stack/issues/211) — provisions the AWS resources the BFF needs without changing any application behavior. Subsequent phases (backend code, frontend cutover) consume what this PR sets up.

- **`BFFSessionsTable`** (DynamoDB, `ttl` attribute, PITR) — server-side store for Cognito access/refresh/id tokens keyed by an opaque session id from an httpOnly cookie. 8h default lifetime.
- **`BFFCookieSigningKey`** (KMS, rotation enabled) — used at app-api startup via `GenerateDataKey`; the cached plaintext data key seals session cookies with AES-GCM.
- **`CognitoBFFAppClient`** (confidential, `generateSecret: true`) — server-side OAuth code exchange with client secret authentication, additional defense beyond PKCE. Existing public PKCE client (`CognitoAppClient`) stays in place through the migration cutover. Secret persisted in Secrets Manager via the standard CDK `userPoolClientSecret` custom-resource pattern.
- **App-api task wired** with new env vars (`BFF_*`, `COGNITO_BFF_*`, `INFERENCE_API_URL`) and IAM grants (`BFFSessionsTableAccess`, `BFFCookieSigningKeyAccess`, `CognitoBFFAppClientSecretAccess`).

### Side-fix worth flagging

`INFERENCE_API_URL` was never wired onto the app-api task before this PR. The existing `api_converse_proxy` in [`apps/app_api/chat/converse_routes.py`](backend/src/apis/app_api/chat/converse_routes.py) was silently falling back to `http://localhost:8001` in cloud — broken. This PR fixes that as a side effect; Phase 4's chat SSE proxy reuses the same env var.

## Test plan

- [x] `npm run build` — clean
- [x] `npx cdk synth` — clean (only pre-existing deprecation/import warnings)
- [x] All 9 new resources verified in synth output (`BFFSessionsTable*`, `BFFCookieSigningKey*`, `CognitoBFFAppClient*`, `CognitoBFFAppClientSecret*`)
- [x] All 3 new IAM SIDs verified on app-api task role
- [x] `userPoolClientSecret` resolves via `Fn::GetAtt` against `Custom::DescribeCognitoUserPoolClient` (CDK's standard pattern)
- [ ] Deploy to a non-prod environment to validate the `Custom::DescribeCognitoUserPoolClient` resource provisions and the BFF client secret reaches Secrets Manager
- [ ] After deploy, confirm the new SSM parameters are populated:
  - `/<projectPrefix>/auth/bff-sessions-table-name`
  - `/<projectPrefix>/auth/bff-sessions-table-arn`
  - `/<projectPrefix>/auth/bff-cookie-signing-key-arn`
  - `/<projectPrefix>/auth/cognito/bff-app-client-id`
  - `/<projectPrefix>/auth/cognito/bff-app-client-secret-arn`

## Notes

- No backend or frontend changes — purely additive infra. Safe to deploy on its own; reverting is a clean rollback.
- The new BFF Cognito client's callback URL is set to `https://<domainName>/api/auth/callback`, anticipating the CloudFront `/api/*` → ALB behavior added in Phase 6 (cutover). The URL is harmless until that behavior exists.
- Phase 2 (backend dormant infra) will be opened on a fresh branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)