### PR TITLE
feat(auth): add dormant BFF token-handler backend infra (Phase 2)

### DIFF
--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -60,6 +60,10 @@ app = FastAPI(
 )
 
 # Add CORS middleware - origins from CDK-provided CORS_ORIGINS env var
+# NOTE: `allow_credentials=False` is correct for the Bearer flow. Phase 6 BFF
+# cutover serves the SPA same-origin via CloudFront `/api/*` so cookies don't
+# need CORS — but if any cross-origin cookie path is added, this must flip to
+# `True` (and `allow_origins` must list explicit origins, not "*").
 _cors_origins = os.environ.get("CORS_ORIGINS", "").split(",")
 app.add_middleware(
     CORSMiddleware,
@@ -86,8 +90,13 @@ logger.info("Added AgentCore context middleware")
 # AWS calls; `CSRFMiddleware` only acts when a session has been resolved
 # upstream, so it's effectively a no-op in the dormant state too.
 #
-# Starlette executes outer-added-last, so on the request side the order is:
-#   CORS → AgentCoreContext → SessionRefresh → CSRF → router
+# Starlette `add_middleware` prepends, so the LAST-added middleware is
+# outermost. Request-side order is therefore the reverse of the call order
+# below:
+#   request:  SessionRefresh → CSRF → AgentCoreContext → CORS → router
+#   response: router → CORS → AgentCoreContext → CSRF → SessionRefresh
+# This is the order we need: SessionRefresh has to populate
+# `state.bff_session` before CSRF reads it.
 from apis.shared.middleware.csrf import CSRFMiddleware
 from apis.shared.middleware.session_refresh import SessionRefreshMiddleware
 

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -77,6 +77,24 @@ from apis.shared.middleware.agentcore_context import AgentCoreContextMiddleware
 app.add_middleware(AgentCoreContextMiddleware)
 logger.info("Added AgentCore context middleware")
 
+# BFF Token Handler middlewares (Phase 2 — dormant).
+#
+# These two are added unconditionally so a deploy of the Phase 1 CDK env vars
+# can flip the system on without a code redeploy. When the env vars are
+# absent (local dev, environments before Phase 1 lands), `BFFConfig.is_enabled()`
+# returns False and `SessionRefreshMiddleware` short-circuits before doing any
+# AWS calls; `CSRFMiddleware` only acts when a session has been resolved
+# upstream, so it's effectively a no-op in the dormant state too.
+#
+# Starlette executes outer-added-last, so on the request side the order is:
+#   CORS → AgentCoreContext → SessionRefresh → CSRF → router
+from apis.shared.middleware.csrf import CSRFMiddleware
+from apis.shared.middleware.session_refresh import SessionRefreshMiddleware
+
+app.add_middleware(CSRFMiddleware)
+app.add_middleware(SessionRefreshMiddleware)
+logger.info("Added BFF session-refresh + CSRF middlewares (dormant until cookie present)")
+
 
 # Import routers
 from apis.app_api.health import router as health_router

--- a/backend/src/apis/shared/auth/dependencies.py
+++ b/backend/src/apis/shared/auth/dependencies.py
@@ -5,7 +5,7 @@ import jwt
 import logging
 import os
 from typing import Optional
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from .models import User
@@ -240,6 +240,70 @@ async def get_current_user(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail="Authentication service not configured. Cognito environment variables are missing."
     )
+
+
+async def get_current_user_from_session(request: Request) -> User:
+    """FastAPI dependency to authenticate via the BFF session cookie.
+
+    `SessionRefreshMiddleware` is responsible for unsealing the cookie,
+    looking up the session row, refreshing the access token if needed, and
+    attaching the resulting `SessionRecord` to `request.state.bff_session`.
+    This dependency just consumes that and reuses the existing Cognito JWT
+    validator + profile-enrichment pipeline so RBAC, user-profile cache,
+    and the fire-and-forget user-sync background task all behave identically
+    to the Bearer path.
+
+    Phase 2 ships this dependency dormant — no router consumes it yet. Phase
+    6 cuts each router over from `get_current_user` to this one as part of
+    the per-environment cutover.
+
+    Raises:
+        HTTPException 401 if no session was resolved by the upstream
+        middleware (cookie missing, malformed, or session record gone).
+    """
+    record = getattr(request.state, "bff_session", None)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No active session.",
+        )
+
+    validator = _get_cognito_validator()
+    if validator is None:
+        # Same failure mode as the Bearer path: a misconfigured environment
+        # is a 500, not a 401, so it's noisy enough to surface.
+        logger.error("No JWT validator available for session-cookie auth.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication service not configured.",
+        )
+
+    try:
+        # Re-validate signature on every request rather than trusting the
+        # cached row — defense in depth against a compromised DDB row.
+        user = validator.validate_token(record.cognito_access_token)
+    except HTTPException:
+        # An expired/invalid token at this point means the refresh middleware
+        # could not heal the session — treat as no active session.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session token rejected.",
+        )
+    except Exception as exc:
+        logger.error("Session-cookie token validation failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication failed.",
+        )
+
+    user.raw_token = record.cognito_access_token
+    await _enrich_user_from_store(user)
+
+    sync_service = _get_user_sync_service()
+    if sync_service and sync_service.enabled:
+        asyncio.create_task(_sync_user_background(sync_service, user))
+
+    return user
 
 
 async def get_current_user_id(

--- a/backend/src/apis/shared/auth/dependencies.py
+++ b/backend/src/apis/shared/auth/dependencies.py
@@ -180,6 +180,53 @@ def _get_cognito_validator():
     return _cognito_validator
 
 
+# Separate validator for the BFF confidential client. Phase 1 CDK provisions
+# COGNITO_BFF_APP_CLIENT_ID alongside the SPA's COGNITO_APP_CLIENT_ID, and the
+# refresh exchange in `sessions_bff.refresh` issues against the BFF client —
+# so tokens carry `client_id = COGNITO_BFF_APP_CLIENT_ID` and would be rejected
+# by the SPA validator's client_id check.
+_bff_cognito_validator = None
+
+
+def _get_bff_cognito_validator():
+    """Return the validator instance for tokens minted by the BFF flow.
+
+    Reads `COGNITO_USER_POOL_ID`, `COGNITO_BFF_APP_CLIENT_ID`, and
+    `COGNITO_REGION`/`AWS_REGION`. Returns None if any are unset, which
+    matches the dormant-by-default contract: until Phase 1 env vars are
+    deployed there's nothing for this validator to do.
+    """
+    global _bff_cognito_validator
+    if _bff_cognito_validator is not None:
+        return _bff_cognito_validator
+
+    try:
+        from .cognito_jwt_validator import CognitoJWTValidator
+
+        user_pool_id = os.environ.get("COGNITO_USER_POOL_ID")
+        bff_app_client_id = os.environ.get("COGNITO_BFF_APP_CLIENT_ID")
+        region = os.environ.get("COGNITO_REGION") or os.environ.get("AWS_REGION")
+
+        if not user_pool_id or not bff_app_client_id or not region:
+            logger.warning(
+                "BFF Cognito validator not configured. "
+                "Required: COGNITO_USER_POOL_ID, COGNITO_BFF_APP_CLIENT_ID, "
+                "COGNITO_REGION (or AWS_REGION)"
+            )
+            return None
+
+        _bff_cognito_validator = CognitoJWTValidator(
+            user_pool_id=user_pool_id,
+            app_client_id=bff_app_client_id,
+            region=region,
+        )
+        logger.info("BFF CognitoJWTValidator initialized")
+    except Exception as e:
+        logger.error(f"Failed to initialize BFF CognitoJWTValidator: {e}", exc_info=True)
+
+    return _bff_cognito_validator
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)
 ) -> User:
@@ -268,7 +315,10 @@ async def get_current_user_from_session(request: Request) -> User:
             detail="No active session.",
         )
 
-    validator = _get_cognito_validator()
+    # BFF tokens are issued by the confidential BFF app client, not the SPA's
+    # public client — they carry `client_id = COGNITO_BFF_APP_CLIENT_ID` and
+    # would fail the SPA validator's client_id check.
+    validator = _get_bff_cognito_validator()
     if validator is None:
         # Same failure mode as the Bearer path: a misconfigured environment
         # is a 500, not a 401, so it's noisy enough to surface.

--- a/backend/src/apis/shared/middleware/csrf.py
+++ b/backend/src/apis/shared/middleware/csrf.py
@@ -1,0 +1,89 @@
+"""CSRFMiddleware — guards unsafe-method requests bound to a BFF session.
+
+This middleware only enforces when `request.state.bff_session` is set —
+i.e. when `SessionRefreshMiddleware` upstream has already resolved a valid
+session cookie. Bearer-token requests (the entire pre-cutover SPA, plus
+any direct API consumers like the API key flow) bypass this check entirely.
+
+Pattern: double-submit cookie. The browser stores the CSRF token in
+`__Host-bff_csrf` (readable by JS) and echoes it back in `X-CSRF-Token`
+on each unsafe request. The middleware confirms both copies match each
+other AND match the value derived from the session's secret. This rejects
+classic cross-site form posts that ride the session cookie (the attacker
+can't read the CSRF cookie value to put into the header) without breaking
+same-origin XHR.
+
+Phase 2 is dormant — no router yet sets the session cookie, so this is
+effectively code waiting to be exercised by Phases 3 and 6.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from apis.shared.sessions_bff.config import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
+from apis.shared.sessions_bff.csrf import CSRFHelper
+
+logger = logging.getLogger(__name__)
+
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+# Endpoints that the BFF itself owns and which (a) initiate the session
+# (login/callback), or (b) are explicitly designed to be hit cross-origin
+# pre-session. Listed by exact path to avoid a permissive prefix match.
+_EXEMPT_PATHS = frozenset(
+    {
+        "/auth/login",
+        "/auth/callback",
+        "/auth/logout",  # logout will rotate cookies even on stale CSRF
+    }
+)
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Reject unsafe-method requests that ride the session cookie without
+    a matching CSRF token.
+
+    Returns 403 instead of 401 — semantics: the user *is* authenticated,
+    but the request is not authorized as user-initiated.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.method in _SAFE_METHODS:
+            return await call_next(request)
+
+        if request.url.path in _EXEMPT_PATHS:
+            return await call_next(request)
+
+        # `state.bff_session` is only set by SessionRefreshMiddleware when a
+        # valid cookie was presented. Anything else — Bearer-token requests,
+        # anonymous public endpoints — bypasses CSRF entirely.
+        session = getattr(request.state, "bff_session", None)
+        if session is None:
+            return await call_next(request)
+
+        header_token = request.headers.get(CSRF_HEADER_NAME, "")
+        cookie_token = request.cookies.get(CSRF_COOKIE_NAME, "")
+
+        if not CSRFHelper.validate(
+            session.csrf_secret,
+            session.session_id,
+            header_token,
+            cookie_token,
+        ):
+            logger.warning(
+                "CSRF validation failed for %s %s",
+                request.method,
+                request.url.path,
+            )
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={"detail": "CSRF token missing or invalid."},
+            )
+
+        return await call_next(request)

--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -172,6 +172,10 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 return None, True
 
             now = int(time.time())
+            # TODO(phase-7): if this write fails, Cognito has rotated the
+            # refresh token but DDB still holds the old one — the session is
+            # silently broken on the next refresh attempt. Add a short retry
+            # loop or a conditional update with a version attribute.
             await self._repository.update_tokens(
                 session_id=session_id,
                 access_token=refreshed.access_token,

--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -1,0 +1,209 @@
+"""SessionRefreshMiddleware — unseals the BFF session cookie, optionally
+refreshes the underlying Cognito access token, and stashes the resulting
+`SessionRecord` on `request.state.bff_session` for downstream dependencies.
+
+Dormant by default: when the request has no `__Host-bff_session` cookie (the
+state during Phases 2–5), this is a fast pass-through. When `BFFConfig` is
+not enabled (env vars unset, e.g. local dev or pre-Phase-1 environments),
+the middleware short-circuits before doing any work.
+
+Refresh-storm coalescing: the per-session `asyncio.Lock` from
+`sessions_bff.lock` ensures multiple concurrent requests for the same
+session id only trigger one Cognito refresh exchange — without this, N
+parallel tab refreshes can tumble each other's refresh tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from apis.shared.sessions_bff.cache import SessionCache
+from apis.shared.sessions_bff.config import (
+    BFFConfig,
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+)
+from apis.shared.sessions_bff.cookie import CookieCodec, CookieDecodeError
+from apis.shared.sessions_bff.csrf import CSRFHelper
+from apis.shared.sessions_bff.lock import get_session_lock
+from apis.shared.sessions_bff.models import SessionRecord
+from apis.shared.sessions_bff.refresh import (
+    CognitoRefreshClient,
+    CognitoRefreshError,
+)
+from apis.shared.sessions_bff.repository import SessionRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SessionRefreshMiddleware(BaseHTTPMiddleware):
+    """Populates `request.state.bff_session` from the session cookie.
+
+    Construct lazily — collaborators (repo, codec, refresh client, cache)
+    are created on first request so importing this module has no AWS side
+    effects (matters for tests).
+    """
+
+    def __init__(
+        self,
+        app,
+        *,
+        config: Optional[BFFConfig] = None,
+        repository: Optional[SessionRepository] = None,
+        cookie_codec: Optional[CookieCodec] = None,
+        refresh_client: Optional[CognitoRefreshClient] = None,
+        cache: Optional[SessionCache] = None,
+    ) -> None:
+        super().__init__(app)
+        self._config = config
+        self._repository = repository
+        self._cookie_codec = cookie_codec
+        self._refresh_client = refresh_client
+        self._cache = cache
+
+    def _ensure_collaborators(self) -> None:
+        if self._config is None:
+            self._config = BFFConfig.from_env()
+        if self._repository is None:
+            self._repository = SessionRepository(
+                table_name=self._config.sessions_table_name
+            )
+        if self._cookie_codec is None:
+            self._cookie_codec = CookieCodec(
+                kms_key_arn=self._config.cookie_signing_key_arn
+            )
+        if self._refresh_client is None:
+            self._refresh_client = CognitoRefreshClient(
+                app_client_id=self._config.cognito_bff_app_client_id,
+                app_client_secret_arn=self._config.cognito_bff_app_client_secret_arn,
+            )
+        if self._cache is None:
+            self._cache = SessionCache(
+                ttl_seconds=self._config.refresh_leeway_seconds
+            )
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        self._ensure_collaborators()
+        assert self._config is not None  # for type-checker; set by ensure
+
+        if not self._config.is_enabled():
+            return await call_next(request)
+
+        cookie_value = request.cookies.get(SESSION_COOKIE_NAME)
+        if not cookie_value:
+            # No BFF cookie — Bearer-token requests, anonymous health checks,
+            # static assets. Pass through untouched.
+            return await call_next(request)
+
+        record, clear_cookie = await self._resolve_session(cookie_value)
+        if record is not None:
+            request.state.bff_session = record
+            request.state.bff_csrf_token = CSRFHelper.derive_token(
+                record.csrf_secret, record.session_id
+            )
+
+        response = await call_next(request)
+
+        if clear_cookie:
+            self._clear_cookies(response)
+
+        return response
+
+    async def _resolve_session(
+        self, cookie_value: str
+    ) -> tuple[Optional[SessionRecord], bool]:
+        """Return (record, should_clear_cookie).
+
+        `should_clear_cookie` is True when the cookie is present but
+        unrecoverable — bad seal, missing row, expired TTL, or refresh failure.
+        """
+        try:
+            payload = self._cookie_codec.unseal(cookie_value)
+        except CookieDecodeError:
+            logger.info("Discarding unrecoverable BFF cookie (bad seal)")
+            return None, True
+
+        session_id = payload.session_id
+
+        cached = self._cache.get(session_id) if self._cache else None
+        if cached is not None and not cached.needs_refresh(
+            int(time.time()), self._config.refresh_leeway_seconds
+        ):
+            return cached, False
+
+        record = await self._repository.get(session_id)
+        if record is None:
+            logger.info("Discarding BFF cookie — no matching session row")
+            return None, True
+
+        if not record.needs_refresh(
+            int(time.time()), self._config.refresh_leeway_seconds
+        ):
+            self._cache.set(record)
+            return record, False
+
+        # Coalesce concurrent refreshes for the same session id.
+        async with get_session_lock(session_id):
+            # Re-check after acquiring the lock — another waiter may have
+            # already refreshed, in which case we serve the fresh row.
+            current = await self._repository.get(session_id)
+            if current is None:
+                return None, True
+            if not current.needs_refresh(
+                int(time.time()), self._config.refresh_leeway_seconds
+            ):
+                self._cache.set(current)
+                return current, False
+
+            try:
+                refreshed = self._refresh_client.refresh(
+                    username=current.username,
+                    refresh_token=current.cognito_refresh_token,
+                )
+            except CognitoRefreshError:
+                # Refresh refused — treat as terminal, force re-login.
+                self._cache.invalidate(session_id)
+                return None, True
+
+            now = int(time.time())
+            await self._repository.update_tokens(
+                session_id=session_id,
+                access_token=refreshed.access_token,
+                refresh_token=refreshed.refresh_token,
+                id_token=refreshed.id_token,
+                access_token_exp=refreshed.access_token_exp,
+                last_seen_at=now,
+            )
+            updated = SessionRecord(
+                session_id=current.session_id,
+                user_id=current.user_id,
+                username=current.username,
+                cognito_access_token=refreshed.access_token,
+                cognito_refresh_token=refreshed.refresh_token,
+                id_token=refreshed.id_token,
+                access_token_exp=refreshed.access_token_exp,
+                csrf_secret=current.csrf_secret,
+                created_at=current.created_at,
+                last_seen_at=now,
+                ttl=current.ttl,
+            )
+            self._cache.set(updated)
+            return updated, False
+
+    @staticmethod
+    def _clear_cookies(response: Response) -> None:
+        """Clear both BFF cookies on a response. Used after an unrecoverable
+        cookie is detected so the browser stops sending it."""
+        # `__Host-` prefix requires `Secure`, `Path=/`, and no `Domain`.
+        response.delete_cookie(
+            SESSION_COOKIE_NAME, path="/", secure=True, httponly=True, samesite="lax"
+        )
+        response.delete_cookie(
+            CSRF_COOKIE_NAME, path="/", secure=True, httponly=False, samesite="lax"
+        )

--- a/backend/src/apis/shared/sessions_bff/__init__.py
+++ b/backend/src/apis/shared/sessions_bff/__init__.py
@@ -1,0 +1,31 @@
+"""BFF Token Handler — server-side session storage backing httpOnly cookies.
+
+This package implements the dormant infrastructure for the Bearer→cookie
+migration (Phase 2). Browsers receive an opaque, AES-GCM-sealed session id in
+a `__Host-bff_session` cookie; tokens stay in DynamoDB and never reach the
+client. The cookie value is unsealed by `CookieCodec`, the row is fetched by
+`SessionRepository`, and the resulting `SessionRecord` is attached to
+`request.state.bff_session` by `SessionRefreshMiddleware`.
+
+The package is no-op-by-default: `BFFConfig.is_enabled()` returns False unless
+the Phase 1 CDK env vars are present, which keeps local dev and the existing
+Bearer-token path untouched until Phase 6 cutover.
+"""
+
+from .config import BFFConfig
+from .cookie import CookieCodec, CookieDecodeError
+from .csrf import CSRFHelper
+from .lock import get_session_lock
+from .models import CookiePayload, SessionRecord
+from .repository import SessionRepository
+
+__all__ = [
+    "BFFConfig",
+    "CookieCodec",
+    "CookieDecodeError",
+    "CookiePayload",
+    "CSRFHelper",
+    "SessionRecord",
+    "SessionRepository",
+    "get_session_lock",
+]

--- a/backend/src/apis/shared/sessions_bff/cache.py
+++ b/backend/src/apis/shared/sessions_bff/cache.py
@@ -8,6 +8,13 @@ the refresh middleware would *not* refresh anyway.
 This is not a security boundary — it's a hot-path optimization for
 many-tabs-on-one-page bursts where the same session id hits the BFF dozens
 of times per second. The repository remains the source of truth.
+
+Logout caveat (Phase 3): when `/auth/logout` deletes the DDB row, in-process
+caches on other tasks (and on the same task, until the TTL ticks past) will
+keep serving the old record for up to `refresh_leeway_seconds`. Phase 3's
+logout handler must call `cache.invalidate(session_id)` locally and accept
+that other tasks lag by at most one TTL window — full coherence requires the
+Phase 7 multi-task coordination work.
 """
 
 from __future__ import annotations

--- a/backend/src/apis/shared/sessions_bff/cache.py
+++ b/backend/src/apis/shared/sessions_bff/cache.py
@@ -1,0 +1,39 @@
+"""In-process LRU cache for `SessionRecord` lookups.
+
+The cache window is bounded by the refresh leeway: a record is only safe to
+serve from cache as long as its access token still has more than the leeway
+window left. We size the TTL to match so a cache hit is always a record that
+the refresh middleware would *not* refresh anyway.
+
+This is not a security boundary — it's a hot-path optimization for
+many-tabs-on-one-page bursts where the same session id hits the BFF dozens
+of times per second. The repository remains the source of truth.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cachetools import TTLCache
+
+from .models import SessionRecord
+
+
+class SessionCache:
+    """Bounded TTL cache keyed by session id."""
+
+    def __init__(self, *, max_size: int = 1024, ttl_seconds: int = 60) -> None:
+        # Floor TTL at 1s; cachetools rejects 0/negative.
+        self._cache: TTLCache = TTLCache(maxsize=max_size, ttl=max(1, ttl_seconds))
+
+    def get(self, session_id: str) -> Optional[SessionRecord]:
+        return self._cache.get(session_id)
+
+    def set(self, record: SessionRecord) -> None:
+        self._cache[record.session_id] = record
+
+    def invalidate(self, session_id: str) -> None:
+        self._cache.pop(session_id, None)
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/backend/src/apis/shared/sessions_bff/config.py
+++ b/backend/src/apis/shared/sessions_bff/config.py
@@ -1,0 +1,70 @@
+"""Configuration for the BFF Token Handler.
+
+Reads the seven env vars wired by Phase 1 CDK on the app-api task. The whole
+package is gated by `is_enabled()` — when `BFF_SESSIONS_TABLE_NAME` is unset
+(local dev, environments before Phase 1 deploys), every BFF code path becomes
+a no-op so the existing Bearer flow keeps working.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Cookie name. The `__Host-` prefix forbids `Domain` and requires `Secure` +
+# `Path=/`, which gives us same-origin-only delivery for free.
+SESSION_COOKIE_NAME = "__Host-bff_session"
+CSRF_COOKIE_NAME = "__Host-bff_csrf"
+CSRF_HEADER_NAME = "X-CSRF-Token"
+
+# Defaults for the optional env vars. Match the Phase 1 CDK defaults.
+_DEFAULT_TTL_SECONDS = 28800  # 8 hours
+_DEFAULT_REFRESH_LEEWAY_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class BFFConfig:
+    """Resolved BFF configuration from env vars.
+
+    Construct with `BFFConfig.from_env()`. The dataclass is frozen so callers
+    can cache it without worrying about mutation.
+    """
+
+    sessions_table_name: Optional[str]
+    cookie_signing_key_arn: Optional[str]
+    session_ttl_seconds: int
+    refresh_leeway_seconds: int
+    cognito_bff_app_client_id: Optional[str]
+    cognito_bff_app_client_secret_arn: Optional[str]
+    inference_api_url: Optional[str]
+
+    @classmethod
+    def from_env(cls) -> "BFFConfig":
+        return cls(
+            sessions_table_name=os.environ.get("BFF_SESSIONS_TABLE_NAME") or None,
+            cookie_signing_key_arn=os.environ.get("BFF_COOKIE_SIGNING_KEY_ARN") or None,
+            session_ttl_seconds=int(
+                os.environ.get("BFF_SESSION_TTL_SECONDS") or _DEFAULT_TTL_SECONDS
+            ),
+            refresh_leeway_seconds=int(
+                os.environ.get("BFF_SESSION_REFRESH_LEEWAY_SECONDS")
+                or _DEFAULT_REFRESH_LEEWAY_SECONDS
+            ),
+            cognito_bff_app_client_id=os.environ.get("COGNITO_BFF_APP_CLIENT_ID") or None,
+            cognito_bff_app_client_secret_arn=os.environ.get(
+                "COGNITO_BFF_APP_CLIENT_SECRET_ARN"
+            )
+            or None,
+            inference_api_url=os.environ.get("INFERENCE_API_URL") or None,
+        )
+
+    def is_enabled(self) -> bool:
+        """True when the BFF backplane is provisioned and the package should
+        activate. Until Phase 1 CDK is deployed (or in local dev without the
+        env vars set), this is False and middleware/dependencies short-circuit
+        as pass-throughs."""
+        return bool(self.sessions_table_name and self.cookie_signing_key_arn)

--- a/backend/src/apis/shared/sessions_bff/cookie.py
+++ b/backend/src/apis/shared/sessions_bff/cookie.py
@@ -1,0 +1,142 @@
+"""Cookie codec — AES-GCM-sealed session id with a KMS-wrapped data key.
+
+Phase 1 CDK provisioned `BFFCookieSigningKey` as a symmetric KMS key. We
+follow the envelope-encryption pattern from the CDK comment:
+
+    1. At first use, call `kms:GenerateDataKey(KeyId=...)` to get a 256-bit
+       AES key. The plaintext key is held in process memory; the wrapped
+       blob is discarded.
+    2. Cookie value = base64url( version || nonce || AES-GCM(payload) ).
+       The KMS key is *not* embedded — rotation requires a task restart,
+       which is fine for Phase 2 (rotation is on the Phase 7 hardening list).
+    3. `unseal` is constant-time on failure: any decode/auth-tag error maps
+       to `CookieDecodeError` so callers can't time-distinguish failure modes.
+
+Payload is JSON-encoded so we can extend `CookiePayload` later without
+breaking format compatibility (the version byte gates that). The whole
+sealed cookie fits comfortably under 256 bytes for a 36-char session id.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import secrets
+import struct
+from threading import Lock
+from typing import Optional
+
+import boto3
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from .models import CookiePayload
+
+logger = logging.getLogger(__name__)
+
+_COOKIE_VERSION = 1
+_NONCE_BYTES = 12  # AES-GCM standard
+_VERSION_BYTES = 1
+
+
+class CookieDecodeError(Exception):
+    """Raised when a cookie value can't be unsealed.
+
+    Carries no detail — the caller treats every failure identically (clear
+    the cookie, force re-login). Distinguishing causes leaks oracle bits.
+    """
+
+
+class CookieCodec:
+    """Stateful seal/unseal pair backed by a process-cached KMS data key.
+
+    Construct one per process. The first `seal()` or `unseal()` call lazily
+    fetches the data key via `kms:GenerateDataKey`; subsequent calls reuse
+    the cached cipher. Thread-safe on the lazy-init path.
+    """
+
+    def __init__(
+        self,
+        kms_key_arn: Optional[str] = None,
+        *,
+        kms_client: Optional[object] = None,
+    ) -> None:
+        if kms_key_arn is None:
+            kms_key_arn = os.environ.get("BFF_COOKIE_SIGNING_KEY_ARN") or ""
+        self._kms_key_arn = kms_key_arn
+        self._kms_client = kms_client
+        self._cipher: Optional[AESGCM] = None
+        self._init_lock = Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._kms_key_arn)
+
+    def _ensure_cipher(self) -> AESGCM:
+        if self._cipher is not None:
+            return self._cipher
+        with self._init_lock:
+            if self._cipher is not None:
+                return self._cipher
+            if not self._kms_key_arn:
+                raise CookieDecodeError()
+            kms = self._kms_client or boto3.client("kms")
+            response = kms.generate_data_key(
+                KeyId=self._kms_key_arn,
+                KeySpec="AES_256",
+            )
+            plaintext_key = response["Plaintext"]
+            self._cipher = AESGCM(plaintext_key)
+            logger.info("BFF cookie codec initialized (KMS data key fetched)")
+            return self._cipher
+
+    def seal(self, payload: CookiePayload) -> str:
+        """Encode and seal a payload into a cookie value string."""
+        cipher = self._ensure_cipher()
+        body = json.dumps(
+            {
+                "sid": payload.session_id,
+                "v": payload.version,
+                **({"x": payload.extras} if payload.extras else {}),
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        nonce = secrets.token_bytes(_NONCE_BYTES)
+        ciphertext = cipher.encrypt(nonce, body, associated_data=None)
+        blob = struct.pack("!B", _COOKIE_VERSION) + nonce + ciphertext
+        return base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii")
+
+    def unseal(self, value: str) -> CookiePayload:
+        """Reverse `seal`. Any failure raises `CookieDecodeError` with no
+        information about the cause."""
+        try:
+            cipher = self._ensure_cipher()
+            padded = value + "=" * (-len(value) % 4)
+            blob = base64.urlsafe_b64decode(padded.encode("ascii"))
+            if len(blob) < _VERSION_BYTES + _NONCE_BYTES + 16:
+                raise CookieDecodeError()
+            (version,) = struct.unpack("!B", blob[:_VERSION_BYTES])
+            if version != _COOKIE_VERSION:
+                raise CookieDecodeError()
+            nonce = blob[_VERSION_BYTES : _VERSION_BYTES + _NONCE_BYTES]
+            ciphertext = blob[_VERSION_BYTES + _NONCE_BYTES :]
+            body = cipher.decrypt(nonce, ciphertext, associated_data=None)
+            data = json.loads(body.decode("utf-8"))
+            sid = data.get("sid")
+            if not isinstance(sid, str) or not sid:
+                raise CookieDecodeError()
+            return CookiePayload(
+                session_id=sid,
+                version=int(data.get("v", _COOKIE_VERSION)),
+                extras=data.get("x") or {},
+            )
+        except CookieDecodeError:
+            raise
+        except (InvalidTag, ValueError, KeyError, json.JSONDecodeError):
+            raise CookieDecodeError()
+        except Exception:
+            # Belt-and-suspenders: any unexpected error becomes the same
+            # opaque failure to preserve constant-time behavior.
+            raise CookieDecodeError()

--- a/backend/src/apis/shared/sessions_bff/cookie.py
+++ b/backend/src/apis/shared/sessions_bff/cookie.py
@@ -104,25 +104,41 @@ class CookieCodec:
             separators=(",", ":"),
         ).encode("utf-8")
         nonce = secrets.token_bytes(_NONCE_BYTES)
-        ciphertext = cipher.encrypt(nonce, body, associated_data=None)
-        blob = struct.pack("!B", _COOKIE_VERSION) + nonce + ciphertext
+        # Bind the version byte into the GCM authentication tag — flipping
+        # the leading version on the wire then invalidates the tag rather
+        # than just tripping the version check downstream.
+        version_aad = struct.pack("!B", _COOKIE_VERSION)
+        ciphertext = cipher.encrypt(nonce, body, associated_data=version_aad)
+        blob = version_aad + nonce + ciphertext
         return base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii")
 
     def unseal(self, value: str) -> CookiePayload:
-        """Reverse `seal`. Any failure raises `CookieDecodeError` with no
-        information about the cause."""
+        """Reverse `seal`.
+
+        Decode-style failures (bad ciphertext, tampered tag, garbage input,
+        unknown version) raise `CookieDecodeError` with no information about
+        the cause — callers treat every decode failure identically.
+
+        Infrastructure failures from `_ensure_cipher` (KMS unavailable, etc.)
+        propagate up so the middleware can return 5xx instead of silently
+        clearing the session cookie and forcing every active user to re-login
+        on a transient KMS hiccup.
+        """
+        # Cipher acquisition is intentionally outside the try/except below —
+        # a botocore error here must not be coerced into CookieDecodeError.
+        cipher = self._ensure_cipher()
         try:
-            cipher = self._ensure_cipher()
             padded = value + "=" * (-len(value) % 4)
             blob = base64.urlsafe_b64decode(padded.encode("ascii"))
             if len(blob) < _VERSION_BYTES + _NONCE_BYTES + 16:
                 raise CookieDecodeError()
-            (version,) = struct.unpack("!B", blob[:_VERSION_BYTES])
+            version_bytes = blob[:_VERSION_BYTES]
+            (version,) = struct.unpack("!B", version_bytes)
             if version != _COOKIE_VERSION:
                 raise CookieDecodeError()
             nonce = blob[_VERSION_BYTES : _VERSION_BYTES + _NONCE_BYTES]
             ciphertext = blob[_VERSION_BYTES + _NONCE_BYTES :]
-            body = cipher.decrypt(nonce, ciphertext, associated_data=None)
+            body = cipher.decrypt(nonce, ciphertext, associated_data=version_bytes)
             data = json.loads(body.decode("utf-8"))
             sid = data.get("sid")
             if not isinstance(sid, str) or not sid:
@@ -134,9 +150,13 @@ class CookieCodec:
             )
         except CookieDecodeError:
             raise
-        except (InvalidTag, ValueError, KeyError, json.JSONDecodeError):
-            raise CookieDecodeError()
-        except Exception:
-            # Belt-and-suspenders: any unexpected error becomes the same
-            # opaque failure to preserve constant-time behavior.
+        except (
+            InvalidTag,
+            ValueError,
+            KeyError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            UnicodeEncodeError,
+            struct.error,
+        ):
             raise CookieDecodeError()

--- a/backend/src/apis/shared/sessions_bff/csrf.py
+++ b/backend/src/apis/shared/sessions_bff/csrf.py
@@ -1,0 +1,69 @@
+"""CSRF helpers (double-submit cookie pattern).
+
+Each session row carries a per-session `csrf_secret`. The current CSRF token
+is `HMAC_SHA256(csrf_secret, session_id)` truncated to 32 hex chars and is
+mirrored in two places:
+
+    1. The `__Host-bff_csrf` cookie (readable by JS — that's the point)
+    2. The `X-CSRF-Token` request header on every unsafe-method request
+
+The middleware compares the two with `hmac.compare_digest`. A cross-origin
+attacker can ride the `__Host-bff_session` cookie (browsers send it) but
+cannot read the `__Host-bff_csrf` cookie value to mirror it into the header,
+because same-origin policy blocks reads of other-origin script responses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+
+
+def generate_secret() -> str:
+    """A fresh per-session CSRF secret. Stored on the session record."""
+    return secrets.token_urlsafe(32)
+
+
+def derive_token(secret: str, session_id: str) -> str:
+    """Stable token a client mirrors between cookie and header.
+
+    Re-derived on every request from the session's secret, so rotation is
+    free: rotating the secret invalidates outstanding tokens immediately.
+    """
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        session_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return digest[:32]
+
+
+def tokens_match(a: str, b: str) -> bool:
+    """Constant-time equality. Handles None/empty without timing leakage."""
+    if not a or not b:
+        return False
+    return hmac.compare_digest(a, b)
+
+
+class CSRFHelper:
+    """Thin OO wrapper used by the middleware.
+
+    Kept as a class so the middleware is easy to inject in tests, but the
+    stateless functions above are the actual primitives.
+    """
+
+    @staticmethod
+    def generate_secret() -> str:
+        return generate_secret()
+
+    @staticmethod
+    def derive_token(secret: str, session_id: str) -> str:
+        return derive_token(secret, session_id)
+
+    @staticmethod
+    def validate(secret: str, session_id: str, header_token: str, cookie_token: str) -> bool:
+        if not tokens_match(header_token, cookie_token):
+            return False
+        expected = derive_token(secret, session_id)
+        return tokens_match(header_token, expected)

--- a/backend/src/apis/shared/sessions_bff/csrf.py
+++ b/backend/src/apis/shared/sessions_bff/csrf.py
@@ -40,7 +40,14 @@ def derive_token(secret: str, session_id: str) -> str:
 
 
 def tokens_match(a: str, b: str) -> bool:
-    """Constant-time equality. Handles None/empty without timing leakage."""
+    """Constant-time equality once both sides are non-empty.
+
+    The empty/None short-circuit is *not* constant-time — it leaks "one
+    input was empty" via timing. That's fine here: an attacker who omits
+    the header or cookie already knows they did, so there's nothing to
+    learn. Once both inputs have content, `hmac.compare_digest` covers
+    the cryptographically meaningful comparison.
+    """
     if not a or not b:
         return False
     return hmac.compare_digest(a, b)

--- a/backend/src/apis/shared/sessions_bff/lock.py
+++ b/backend/src/apis/shared/sessions_bff/lock.py
@@ -1,0 +1,53 @@
+"""Per-session asyncio lock registry — refresh-token storm coalescing.
+
+Without this, N tabs that boot up at the same moment trigger N parallel
+refresh-token exchanges with Cognito. Cognito rotation invalidates the
+previous refresh token on each exchange, so N-1 of those tabs lose their
+session.
+
+Holding a per-session lock around the refresh path serializes the exchanges
+within a single app-api task. Across tasks (multi-replica deployments) the
+storm is still possible — full mitigation moves to Phase 7 (a DDB conditional
+write or a short-lived "refresh in flight" marker). For Phase 2 the in-process
+lock matches the storm shape we've actually seen during dev (multi-tab on one
+laptop hitting one task) and is the lightweight solution called out in the
+project memory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from threading import Lock as _ThreadLock
+from typing import Dict
+from weakref import WeakValueDictionary
+
+# We use a WeakValueDictionary so locks don't leak indefinitely as session
+# ids churn. A lock is collected once nothing holds a reference, which is
+# correct because a held lock keeps itself alive via the awaiter's frame.
+_locks: "WeakValueDictionary[str, asyncio.Lock]" = WeakValueDictionary()
+_registry_guard = _ThreadLock()
+
+
+def get_session_lock(session_id: str) -> asyncio.Lock:
+    """Return the per-session lock, creating it on first request.
+
+    Safe to call concurrently — the registry insert is guarded by a thread
+    lock so two coroutines on different threads can't race-create different
+    `asyncio.Lock` objects for the same session id.
+    """
+    existing = _locks.get(session_id)
+    if existing is not None:
+        return existing
+    with _registry_guard:
+        existing = _locks.get(session_id)
+        if existing is not None:
+            return existing
+        new_lock = asyncio.Lock()
+        _locks[session_id] = new_lock
+        return new_lock
+
+
+def _reset_for_tests() -> None:
+    """Test-only escape hatch — drop all tracked locks."""
+    with _registry_guard:
+        _locks.clear()

--- a/backend/src/apis/shared/sessions_bff/models.py
+++ b/backend/src/apis/shared/sessions_bff/models.py
@@ -1,0 +1,54 @@
+"""Data models for BFF session storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SessionRecord:
+    """Server-side session row stored in the BFF sessions table.
+
+    The Cognito tokens never leave the server: the browser only ever sees the
+    sealed `session_id` carried in the `__Host-bff_session` cookie.
+    """
+
+    session_id: str
+    user_id: str  # Cognito `sub` claim
+    username: str  # Cognito `cognito:username`; required to compute SECRET_HASH on refresh
+    cognito_access_token: str
+    cognito_refresh_token: str
+    id_token: Optional[str]
+    access_token_exp: int  # epoch seconds, for refresh leeway comparison
+    csrf_secret: str  # bound to this session; double-submit token derives from it
+    created_at: int  # epoch seconds
+    last_seen_at: int  # epoch seconds
+    ttl: int  # epoch seconds; DynamoDB `ttl` attribute drives row expiry
+
+    def needs_refresh(self, now_epoch: int, leeway_seconds: int) -> bool:
+        """True iff the access token will expire within `leeway_seconds`.
+
+        The refresh middleware uses this to decide whether to take the
+        per-session lock and call Cognito.
+        """
+        return self.access_token_exp - now_epoch <= leeway_seconds
+
+
+@dataclass
+class CookiePayload:
+    """Decoded shape of a sealed cookie value.
+
+    The cookie carries a tiny versioned record so we can rotate the codec
+    later without invalidating the world. Only `session_id` is functionally
+    required today; `version` lets us route to a future codec if we change
+    the seal format.
+    """
+
+    session_id: str
+    version: int = 1
+
+    # Reserved for future use (e.g. cookie-side expiry hint to skip a DDB
+    # lookup on obviously-stale cookies). Keep field present so the encoded
+    # shape doesn't change when we add it.
+    extras: dict = field(default_factory=dict)

--- a/backend/src/apis/shared/sessions_bff/refresh.py
+++ b/backend/src/apis/shared/sessions_bff/refresh.py
@@ -1,0 +1,150 @@
+"""Cognito refresh-token exchange for the BFF Token Handler.
+
+The middleware delegates here when a session record's access token is within
+the refresh leeway window. We use `cognito-idp:InitiateAuth` with
+`AuthFlow=REFRESH_TOKEN_AUTH`. Since the BFF app client is *confidential*
+(provisioned with `generateSecret: true` in Phase 1 CDK), every InitiateAuth
+call must include `SECRET_HASH = Base64( HMAC-SHA256( client_secret,
+username + client_id ) )`.
+
+The client secret is fetched from Secrets Manager once per process and
+cached. If Cognito returns an error, callers should treat the session as
+revoked and clear the cookie — the most common cause is rotation killing
+the previous refresh token.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RefreshResult:
+    access_token: str
+    # Cognito does not always rotate refresh tokens — fall back to the prior
+    # one when the response omits it.
+    refresh_token: str
+    id_token: Optional[str]
+    access_token_exp: int  # epoch seconds
+
+
+class CognitoRefreshError(Exception):
+    """Raised when Cognito refuses to refresh the session.
+
+    Always treat as terminal: the cookie should be cleared and the user
+    re-authenticated.
+    """
+
+
+class CognitoRefreshClient:
+    """Holds cached SDK + secret references for the refresh path."""
+
+    def __init__(
+        self,
+        *,
+        app_client_id: Optional[str] = None,
+        app_client_secret_arn: Optional[str] = None,
+        region: Optional[str] = None,
+        cognito_idp_client: Optional[object] = None,
+        secrets_manager_client: Optional[object] = None,
+    ) -> None:
+        self._app_client_id = app_client_id or os.environ.get("COGNITO_BFF_APP_CLIENT_ID") or ""
+        self._secret_arn = (
+            app_client_secret_arn
+            or os.environ.get("COGNITO_BFF_APP_CLIENT_SECRET_ARN")
+            or ""
+        )
+        self._region = (
+            region
+            or os.environ.get("COGNITO_REGION")
+            or os.environ.get("AWS_REGION")
+            or "us-west-2"
+        )
+        self._cognito_idp = cognito_idp_client
+        self._secrets_manager = secrets_manager_client
+        self._client_secret: Optional[str] = None
+        self._secret_lock = Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._app_client_id and self._secret_arn)
+
+    def _resolve_client_secret(self) -> str:
+        if self._client_secret is not None:
+            return self._client_secret
+        with self._secret_lock:
+            if self._client_secret is not None:
+                return self._client_secret
+            sm = self._secrets_manager or boto3.client(
+                "secretsmanager", region_name=self._region
+            )
+            response = sm.get_secret_value(SecretId=self._secret_arn)
+            value = response.get("SecretString") or ""
+            # Phase 1 stores the secret as a plain string; tolerate a JSON
+            # `{"clientSecret": "..."}` wrapper too in case CDK changes.
+            if value.startswith("{"):
+                try:
+                    parsed = json.loads(value)
+                    value = parsed.get("clientSecret") or parsed.get("client_secret") or value
+                except json.JSONDecodeError:
+                    pass
+            if not value:
+                raise CognitoRefreshError("BFF client secret resolved to empty string")
+            self._client_secret = value
+            return value
+
+    def _secret_hash(self, username: str) -> str:
+        secret = self._resolve_client_secret()
+        msg = (username + self._app_client_id).encode("utf-8")
+        digest = hmac.new(secret.encode("utf-8"), msg, hashlib.sha256).digest()
+        return base64.b64encode(digest).decode("ascii")
+
+    def _idp(self):
+        if self._cognito_idp is not None:
+            return self._cognito_idp
+        return boto3.client("cognito-idp", region_name=self._region)
+
+    def refresh(self, *, username: str, refresh_token: str) -> RefreshResult:
+        """Call Cognito to exchange the refresh token for a fresh access
+        token. Raises `CognitoRefreshError` on any failure."""
+        if not self.enabled:
+            raise CognitoRefreshError("BFF refresh client is not configured")
+
+        try:
+            response = self._idp().initiate_auth(
+                AuthFlow="REFRESH_TOKEN_AUTH",
+                ClientId=self._app_client_id,
+                AuthParameters={
+                    "REFRESH_TOKEN": refresh_token,
+                    "SECRET_HASH": self._secret_hash(username),
+                },
+            )
+        except Exception as exc:
+            logger.warning("BFF Cognito refresh failed for %s: %s", username, exc)
+            raise CognitoRefreshError(str(exc)) from exc
+
+        result = response.get("AuthenticationResult") or {}
+        access_token = result.get("AccessToken")
+        if not access_token:
+            raise CognitoRefreshError("Cognito refresh returned no access token")
+        expires_in = int(result.get("ExpiresIn", 3600))
+        return RefreshResult(
+            access_token=access_token,
+            # Cognito only returns RefreshToken when rotation kicks in.
+            refresh_token=result.get("RefreshToken") or refresh_token,
+            id_token=result.get("IdToken"),
+            access_token_exp=int(time.time()) + expires_in,
+        )

--- a/backend/src/apis/shared/sessions_bff/repository.py
+++ b/backend/src/apis/shared/sessions_bff/repository.py
@@ -1,0 +1,178 @@
+"""DynamoDB repository for BFF session records.
+
+Schema (single-table, fits the `BFFSessionsTable` provisioned in Phase 1):
+
+    PK = SESSION#<session_id>
+    SK = META
+
+    Attrs: user_id, cognito_access_token, cognito_refresh_token, id_token,
+           access_token_exp, csrf_secret, created_at, last_seen_at, ttl
+
+The `ttl` attribute is wired to DynamoDB TTL so absolute session lifetime is
+enforced by the table itself — even if a session row is somehow leaked from
+the cleanup paths, DynamoDB will eventually evict it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import SessionRecord
+
+logger = logging.getLogger(__name__)
+
+
+class SessionRepository:
+    """Async-shaped wrapper over the BFF sessions DynamoDB table.
+
+    The methods are declared `async` to match the rest of `apis.shared`,
+    but boto3 is sync — calls run on the event loop thread. That mirrors
+    `UserRepository` and is intentional: refresh-storm coalescing happens
+    one layer up via `get_session_lock()`, so the lookup itself never
+    fans out enough to need a thread pool.
+    """
+
+    def __init__(self, table_name: Optional[str] = None) -> None:
+        if table_name is None:
+            table_name = os.environ.get("BFF_SESSIONS_TABLE_NAME", "")
+
+        self._table_name = table_name
+        self._enabled = bool(table_name)
+
+        if self._enabled:
+            self._dynamodb = boto3.resource("dynamodb")
+            self._table = self._dynamodb.Table(table_name)
+            logger.info("SessionRepository initialized with table: %s", table_name)
+        else:
+            self._dynamodb = None
+            self._table = None
+            logger.debug("SessionRepository disabled — BFF_SESSIONS_TABLE_NAME unset")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def _key(session_id: str) -> dict:
+        return {"PK": f"SESSION#{session_id}", "SK": "META"}
+
+    @staticmethod
+    def _item_to_record(item: dict) -> SessionRecord:
+        return SessionRecord(
+            session_id=item["session_id"],
+            user_id=item["user_id"],
+            username=item["username"],
+            cognito_access_token=item["cognito_access_token"],
+            cognito_refresh_token=item["cognito_refresh_token"],
+            id_token=item.get("id_token"),
+            access_token_exp=int(item["access_token_exp"]),
+            csrf_secret=item["csrf_secret"],
+            created_at=int(item["created_at"]),
+            last_seen_at=int(item["last_seen_at"]),
+            ttl=int(item["ttl"]),
+        )
+
+    @staticmethod
+    def _record_to_item(record: SessionRecord) -> dict:
+        item = {
+            **SessionRepository._key(record.session_id),
+            "session_id": record.session_id,
+            "user_id": record.user_id,
+            "username": record.username,
+            "cognito_access_token": record.cognito_access_token,
+            "cognito_refresh_token": record.cognito_refresh_token,
+            "access_token_exp": record.access_token_exp,
+            "csrf_secret": record.csrf_secret,
+            "created_at": record.created_at,
+            "last_seen_at": record.last_seen_at,
+            "ttl": record.ttl,
+        }
+        if record.id_token is not None:
+            item["id_token"] = record.id_token
+        return item
+
+    async def get(self, session_id: str) -> Optional[SessionRecord]:
+        if not self._enabled:
+            return None
+        try:
+            response = self._table.get_item(Key=self._key(session_id))
+        except ClientError as exc:
+            logger.error("BFF session get_item failed for %s: %s", session_id, exc)
+            return None
+        item = response.get("Item")
+        if not item:
+            return None
+        # Defense in depth: if the row's TTL has passed but DDB hasn't swept
+        # it yet (eventual TTL eviction is best-effort, not real-time),
+        # treat it as missing.
+        if int(item.get("ttl", 0)) <= int(time.time()):
+            return None
+        return self._item_to_record(item)
+
+    async def put(self, record: SessionRecord) -> None:
+        if not self._enabled:
+            return
+        self._table.put_item(Item=self._record_to_item(record))
+
+    async def update_tokens(
+        self,
+        session_id: str,
+        access_token: str,
+        refresh_token: str,
+        id_token: Optional[str],
+        access_token_exp: int,
+        last_seen_at: int,
+    ) -> None:
+        """Atomically replace the Cognito tokens after a refresh.
+
+        The refresh middleware calls this once it has a fresh access token.
+        Note that Cognito's refresh-token rotation may issue a new refresh
+        token too, hence the explicit `refresh_token` parameter.
+        """
+        if not self._enabled:
+            return
+        update_expr = (
+            "SET cognito_access_token = :at, "
+            "cognito_refresh_token = :rt, "
+            "access_token_exp = :exp, "
+            "last_seen_at = :seen"
+        )
+        expr_values = {
+            ":at": access_token,
+            ":rt": refresh_token,
+            ":exp": access_token_exp,
+            ":seen": last_seen_at,
+        }
+        if id_token is not None:
+            update_expr += ", id_token = :id"
+            expr_values[":id"] = id_token
+        self._table.update_item(
+            Key=self._key(session_id),
+            UpdateExpression=update_expr,
+            ExpressionAttributeValues=expr_values,
+        )
+
+    async def touch_last_seen(self, session_id: str, last_seen_at: int) -> None:
+        if not self._enabled:
+            return
+        try:
+            self._table.update_item(
+                Key=self._key(session_id),
+                UpdateExpression="SET last_seen_at = :seen",
+                ExpressionAttributeValues={":seen": last_seen_at},
+            )
+        except ClientError as exc:
+            # Touch failures are non-critical — log and move on rather than
+            # surfacing as a request error.
+            logger.warning("BFF session touch failed for %s: %s", session_id, exc)
+
+    async def delete(self, session_id: str) -> None:
+        if not self._enabled:
+            return
+        self._table.delete_item(Key=self._key(session_id))

--- a/backend/tests/apis/shared/sessions_bff/conftest.py
+++ b/backend/tests/apis/shared/sessions_bff/conftest.py
@@ -1,0 +1,88 @@
+"""Shared fixtures for sessions_bff tests.
+
+Provides a moto-backed BFF sessions table that matches the schema provisioned
+by Phase 1 CDK (`PK`, `SK`, `ttl` enabled), plus a ready-to-use repository
+and a sample SessionRecord factory.
+"""
+
+from __future__ import annotations
+
+import time
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.sessions_bff.models import SessionRecord
+from apis.shared.sessions_bff.repository import SessionRepository
+
+BFF_SESSIONS_TABLE = "test-bff-sessions"
+
+
+def _create_bff_sessions_table(dynamodb) -> None:
+    dynamodb.create_table(
+        TableName=BFF_SESSIONS_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture
+def bff_aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("BFF_SESSIONS_TABLE_NAME", BFF_SESSIONS_TABLE)
+
+
+@pytest.fixture
+def moto_bff_dynamodb(bff_aws_env):
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        _create_bff_sessions_table(dynamodb)
+        yield dynamodb
+
+
+@pytest.fixture
+def repository(moto_bff_dynamodb) -> SessionRepository:
+    return SessionRepository(table_name=BFF_SESSIONS_TABLE)
+
+
+@pytest.fixture
+def sample_record():
+    """Factory for building SessionRecord instances with sensible defaults."""
+
+    def _make(
+        *,
+        session_id: str = "sess-001",
+        user_id: str = "user-sub-001",
+        username: str = "alice",
+        access_token: str = "access.token.value",
+        refresh_token: str = "refresh.token.value",
+        id_token: str = "id.token.value",
+        access_token_exp: int | None = None,
+        ttl: int | None = None,
+    ) -> SessionRecord:
+        now = int(time.time())
+        return SessionRecord(
+            session_id=session_id,
+            user_id=user_id,
+            username=username,
+            cognito_access_token=access_token,
+            cognito_refresh_token=refresh_token,
+            id_token=id_token,
+            access_token_exp=access_token_exp if access_token_exp is not None else now + 3600,
+            csrf_secret="csrf-secret-deadbeef",
+            created_at=now,
+            last_seen_at=now,
+            ttl=ttl if ttl is not None else now + 28800,
+        )
+
+    return _make

--- a/backend/tests/apis/shared/sessions_bff/test_config.py
+++ b/backend/tests/apis/shared/sessions_bff/test_config.py
@@ -1,0 +1,46 @@
+"""Tests for BFFConfig env-driven loader and is_enabled gating."""
+
+from __future__ import annotations
+
+import pytest
+
+from apis.shared.sessions_bff.config import BFFConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_bff_env(monkeypatch):
+    for key in (
+        "BFF_SESSIONS_TABLE_NAME",
+        "BFF_COOKIE_SIGNING_KEY_ARN",
+        "BFF_SESSION_TTL_SECONDS",
+        "BFF_SESSION_REFRESH_LEEWAY_SECONDS",
+        "COGNITO_BFF_APP_CLIENT_ID",
+        "COGNITO_BFF_APP_CLIENT_SECRET_ARN",
+        "INFERENCE_API_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_disabled_when_env_unset() -> None:
+    cfg = BFFConfig.from_env()
+    assert cfg.is_enabled() is False
+    assert cfg.session_ttl_seconds == 28800
+    assert cfg.refresh_leeway_seconds == 60
+
+
+def test_enabled_requires_table_and_kms(monkeypatch) -> None:
+    monkeypatch.setenv("BFF_SESSIONS_TABLE_NAME", "tbl")
+    cfg_no_kms = BFFConfig.from_env()
+    assert cfg_no_kms.is_enabled() is False
+
+    monkeypatch.setenv("BFF_COOKIE_SIGNING_KEY_ARN", "arn:aws:kms:...")
+    cfg_both = BFFConfig.from_env()
+    assert cfg_both.is_enabled() is True
+
+
+def test_overrides_ttl_and_leeway(monkeypatch) -> None:
+    monkeypatch.setenv("BFF_SESSION_TTL_SECONDS", "1234")
+    monkeypatch.setenv("BFF_SESSION_REFRESH_LEEWAY_SECONDS", "7")
+    cfg = BFFConfig.from_env()
+    assert cfg.session_ttl_seconds == 1234
+    assert cfg.refresh_leeway_seconds == 7

--- a/backend/tests/apis/shared/sessions_bff/test_cookie.py
+++ b/backend/tests/apis/shared/sessions_bff/test_cookie.py
@@ -1,0 +1,101 @@
+"""Tests for the AES-GCM cookie codec.
+
+Uses an injected `AESGCM` cipher to avoid mocking KMS — `CookieCodec` exposes
+the `_cipher` attribute which we set directly. (Production callers always go
+through `_ensure_cipher`, which is what the KMS-integration test exercises.)
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import secrets
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from apis.shared.sessions_bff.cookie import CookieCodec, CookieDecodeError
+from apis.shared.sessions_bff.models import CookiePayload
+
+
+def _codec_with_cipher() -> CookieCodec:
+    codec = CookieCodec(kms_key_arn="arn:aws:kms:fake")
+    codec._cipher = AESGCM(secrets.token_bytes(32))
+    return codec
+
+
+def test_seal_and_unseal_round_trip() -> None:
+    codec = _codec_with_cipher()
+    payload = CookiePayload(session_id="sess-abc-123", version=1)
+
+    sealed = codec.seal(payload)
+    decoded = codec.unseal(sealed)
+
+    assert decoded.session_id == payload.session_id
+    assert decoded.version == 1
+
+
+def test_seal_produces_distinct_ciphertexts_each_call() -> None:
+    """Nonce is random — two seals of the same payload must differ."""
+    codec = _codec_with_cipher()
+    payload = CookiePayload(session_id="sess-abc-123")
+    assert codec.seal(payload) != codec.seal(payload)
+
+
+def test_unseal_rejects_tampered_ciphertext() -> None:
+    codec = _codec_with_cipher()
+    sealed = codec.seal(CookiePayload(session_id="sess-x"))
+
+    # Flip a byte deep in the ciphertext.
+    raw = bytearray(base64.urlsafe_b64decode(sealed + "=" * (-len(sealed) % 4)))
+    raw[-1] ^= 0x01
+    tampered = base64.urlsafe_b64encode(bytes(raw)).rstrip(b"=").decode("ascii")
+
+    with pytest.raises(CookieDecodeError):
+        codec.unseal(tampered)
+
+
+def test_unseal_rejects_garbage() -> None:
+    codec = _codec_with_cipher()
+    with pytest.raises(CookieDecodeError):
+        codec.unseal("not-a-real-cookie-value")
+
+
+def test_unseal_rejects_unknown_version() -> None:
+    codec = _codec_with_cipher()
+    cipher = codec._cipher
+    nonce = secrets.token_bytes(12)
+    ciphertext = cipher.encrypt(nonce, b'{"sid":"x"}', None)
+    # Version byte = 99 (unknown).
+    blob = bytes([99]) + nonce + ciphertext
+    sealed = base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii")
+    with pytest.raises(CookieDecodeError):
+        codec.unseal(sealed)
+
+
+def test_unseal_rejects_missing_session_id() -> None:
+    codec = _codec_with_cipher()
+    cipher = codec._cipher
+    nonce = secrets.token_bytes(12)
+    # Valid version, but JSON has no `sid` key.
+    ciphertext = cipher.encrypt(nonce, b'{"v":1}', None)
+    blob = bytes([1]) + nonce + ciphertext
+    sealed = base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii")
+    with pytest.raises(CookieDecodeError):
+        codec.unseal(sealed)
+
+
+def test_unseal_with_wrong_key_fails() -> None:
+    codec_a = _codec_with_cipher()
+    codec_b = _codec_with_cipher()  # different random key
+
+    sealed = codec_a.seal(CookiePayload(session_id="sess-x"))
+    with pytest.raises(CookieDecodeError):
+        codec_b.unseal(sealed)
+
+
+def test_seal_preserves_extras() -> None:
+    codec = _codec_with_cipher()
+    payload = CookiePayload(session_id="s", extras={"hint": "abc"})
+    decoded = codec.unseal(codec.seal(payload))
+    assert decoded.extras == {"hint": "abc"}

--- a/backend/tests/apis/shared/sessions_bff/test_cookie.py
+++ b/backend/tests/apis/shared/sessions_bff/test_cookie.py
@@ -77,8 +77,8 @@ def test_unseal_rejects_missing_session_id() -> None:
     codec = _codec_with_cipher()
     cipher = codec._cipher
     nonce = secrets.token_bytes(12)
-    # Valid version, but JSON has no `sid` key.
-    ciphertext = cipher.encrypt(nonce, b'{"v":1}', None)
+    # Valid version, AAD matches what unseal expects, but JSON has no `sid`.
+    ciphertext = cipher.encrypt(nonce, b'{"v":1}', bytes([1]))
     blob = bytes([1]) + nonce + ciphertext
     sealed = base64.urlsafe_b64encode(blob).rstrip(b"=").decode("ascii")
     with pytest.raises(CookieDecodeError):
@@ -99,3 +99,16 @@ def test_seal_preserves_extras() -> None:
     payload = CookiePayload(session_id="s", extras={"hint": "abc"})
     decoded = codec.unseal(codec.seal(payload))
     assert decoded.extras == {"hint": "abc"}
+
+
+def test_unseal_propagates_kms_infrastructure_errors() -> None:
+    """KMS unavailable is not a decode error — it must surface so the caller
+    can return 5xx instead of clearing the cookie and forcing re-login."""
+    from unittest.mock import MagicMock
+
+    fake_kms = MagicMock()
+    fake_kms.generate_data_key.side_effect = RuntimeError("KMS unreachable")
+
+    codec = CookieCodec(kms_key_arn="arn:aws:kms:fake", kms_client=fake_kms)
+    with pytest.raises(RuntimeError, match="KMS unreachable"):
+        codec.unseal("doesnt-matter")

--- a/backend/tests/apis/shared/sessions_bff/test_csrf.py
+++ b/backend/tests/apis/shared/sessions_bff/test_csrf.py
@@ -1,0 +1,56 @@
+"""Tests for CSRF token derivation and validation."""
+
+from __future__ import annotations
+
+from apis.shared.sessions_bff.csrf import CSRFHelper, derive_token, tokens_match
+
+
+def test_derive_token_is_deterministic() -> None:
+    secret = "csrf-secret"
+    sid = "sess-001"
+    assert derive_token(secret, sid) == derive_token(secret, sid)
+
+
+def test_derive_token_changes_with_session_id() -> None:
+    secret = "csrf-secret"
+    assert derive_token(secret, "sess-A") != derive_token(secret, "sess-B")
+
+
+def test_derive_token_changes_with_secret() -> None:
+    sid = "sess-001"
+    assert derive_token("secret-A", sid) != derive_token("secret-B", sid)
+
+
+def test_derive_token_truncated_to_32_chars() -> None:
+    assert len(derive_token("secret", "sid")) == 32
+
+
+def test_tokens_match_constant_time_safe_paths() -> None:
+    assert tokens_match("abc", "abc") is True
+    assert tokens_match("abc", "abd") is False
+    assert tokens_match("", "abc") is False
+    assert tokens_match("abc", "") is False
+
+
+def test_validate_happy_path() -> None:
+    secret = "csrf-secret"
+    sid = "sess-001"
+    token = CSRFHelper.derive_token(secret, sid)
+    assert CSRFHelper.validate(secret, sid, token, token) is True
+
+
+def test_validate_rejects_header_cookie_mismatch() -> None:
+    secret = "csrf-secret"
+    sid = "sess-001"
+    token = CSRFHelper.derive_token(secret, sid)
+    assert CSRFHelper.validate(secret, sid, token, "different") is False
+
+
+def test_validate_rejects_header_with_wrong_session_secret() -> None:
+    """Even if header == cookie, an attacker-supplied token must not validate."""
+    forged = "0" * 32
+    assert CSRFHelper.validate("real-secret", "sess-001", forged, forged) is False
+
+
+def test_validate_rejects_empty() -> None:
+    assert CSRFHelper.validate("s", "sid", "", "") is False

--- a/backend/tests/apis/shared/sessions_bff/test_csrf_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_csrf_middleware.py
@@ -1,0 +1,152 @@
+"""Tests for CSRFMiddleware.
+
+The middleware only enforces when an upstream layer has already populated
+`request.state.bff_session`. We simulate that with a tiny test middleware
+that injects a known SessionRecord — keeps these tests focused on CSRF
+behavior rather than re-exercising session refresh.
+"""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from apis.shared.middleware.csrf import CSRFMiddleware
+from apis.shared.sessions_bff.config import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+)
+from apis.shared.sessions_bff.csrf import CSRFHelper
+from apis.shared.sessions_bff.models import SessionRecord
+
+
+def _record() -> SessionRecord:
+    now = int(time.time())
+    return SessionRecord(
+        session_id="sess-001",
+        user_id="user-sub",
+        username="alice",
+        cognito_access_token="at",
+        cognito_refresh_token="rt",
+        id_token="id",
+        access_token_exp=now + 3600,
+        csrf_secret="csrf-secret",
+        created_at=now,
+        last_seen_at=now,
+        ttl=now + 28800,
+    )
+
+
+class _AttachSession(BaseHTTPMiddleware):
+    """Test helper — pretends SessionRefreshMiddleware ran successfully."""
+
+    def __init__(self, app, record: SessionRecord | None) -> None:
+        super().__init__(app)
+        self._record = record
+
+    async def dispatch(self, request, call_next):
+        if self._record is not None:
+            request.state.bff_session = self._record
+        return await call_next(request)
+
+
+def _build_app(*, attach_record: SessionRecord | None) -> FastAPI:
+    app = FastAPI()
+    # Outer (added last) wraps inner — request order: AttachSession → CSRF → route.
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(_AttachSession, record=attach_record)
+
+    @app.get("/safe")
+    def safe() -> dict:
+        return {"ok": True}
+
+    @app.post("/submit")
+    def submit() -> dict:
+        return {"ok": True}
+
+    return app
+
+
+def test_safe_method_bypasses_csrf() -> None:
+    record = _record()
+    app = _build_app(attach_record=record)
+    response = TestClient(app).get("/safe")
+    assert response.status_code == 200
+
+
+def test_post_without_session_bypasses_csrf() -> None:
+    """Bearer-token requests have no `bff_session` on state — must pass through."""
+    app = _build_app(attach_record=None)
+    response = TestClient(app).post("/submit")
+    assert response.status_code == 200
+
+
+def test_post_with_matching_token_succeeds() -> None:
+    record = _record()
+    app = _build_app(attach_record=record)
+    token = CSRFHelper.derive_token(record.csrf_secret, record.session_id)
+
+    response = TestClient(app).post(
+        "/submit",
+        headers={CSRF_HEADER_NAME: token},
+        cookies={CSRF_COOKIE_NAME: token},
+    )
+    assert response.status_code == 200
+
+
+def test_post_without_csrf_token_returns_403() -> None:
+    record = _record()
+    app = _build_app(attach_record=record)
+    response = TestClient(app).post("/submit")
+    assert response.status_code == 403
+
+
+def test_post_with_only_header_returns_403() -> None:
+    record = _record()
+    app = _build_app(attach_record=record)
+    token = CSRFHelper.derive_token(record.csrf_secret, record.session_id)
+    response = TestClient(app).post("/submit", headers={CSRF_HEADER_NAME: token})
+    assert response.status_code == 403
+
+
+def test_post_with_mismatched_header_and_cookie_returns_403() -> None:
+    record = _record()
+    app = _build_app(attach_record=record)
+    token = CSRFHelper.derive_token(record.csrf_secret, record.session_id)
+    response = TestClient(app).post(
+        "/submit",
+        headers={CSRF_HEADER_NAME: token},
+        cookies={CSRF_COOKIE_NAME: "different"},
+    )
+    assert response.status_code == 403
+
+
+def test_post_with_forged_token_pair_returns_403() -> None:
+    """Equal but incorrect (attacker-supplied) token pair must not validate."""
+    record = _record()
+    app = _build_app(attach_record=record)
+    forged = "0" * 32
+    response = TestClient(app).post(
+        "/submit",
+        headers={CSRF_HEADER_NAME: forged},
+        cookies={CSRF_COOKIE_NAME: forged},
+    )
+    assert response.status_code == 403
+
+
+def test_login_path_is_exempt() -> None:
+    """Login/callback are exempt because they bootstrap the session."""
+    record = _record()
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(_AttachSession, record=record)
+
+    @app.post("/auth/login")
+    def login() -> dict:
+        return {"ok": True}
+
+    response = TestClient(app).post("/auth/login")
+    assert response.status_code == 200

--- a/backend/tests/apis/shared/sessions_bff/test_dependency_session_user.py
+++ b/backend/tests/apis/shared/sessions_bff/test_dependency_session_user.py
@@ -69,7 +69,7 @@ def test_returns_user_when_session_attached() -> None:
         roles=["user"],
     )
     with patch(
-        "apis.shared.auth.dependencies._get_cognito_validator",
+        "apis.shared.auth.dependencies._get_bff_cognito_validator",
         return_value=fake_validator,
     ), patch(
         "apis.shared.auth.dependencies._enrich_user_from_store"
@@ -108,7 +108,7 @@ def test_returns_401_when_token_validation_fails() -> None:
         status_code=status.HTTP_401_UNAUTHORIZED, detail="bad sig"
     )
     with patch(
-        "apis.shared.auth.dependencies._get_cognito_validator",
+        "apis.shared.auth.dependencies._get_bff_cognito_validator",
         return_value=fake_validator,
     ):
         app = _build_app(record=_record())
@@ -118,7 +118,7 @@ def test_returns_401_when_token_validation_fails() -> None:
 
 def test_returns_500_when_validator_unconfigured() -> None:
     with patch(
-        "apis.shared.auth.dependencies._get_cognito_validator",
+        "apis.shared.auth.dependencies._get_bff_cognito_validator",
         return_value=None,
     ):
         app = _build_app(record=_record())

--- a/backend/tests/apis/shared/sessions_bff/test_dependency_session_user.py
+++ b/backend/tests/apis/shared/sessions_bff/test_dependency_session_user.py
@@ -1,0 +1,126 @@
+"""Tests for `get_current_user_from_session`.
+
+The dependency reads `request.state.bff_session` (populated by
+SessionRefreshMiddleware), revalidates the stored Cognito access token via
+the existing CognitoJWTValidator, and returns a `User`. We mock the
+validator so we don't need real JWKS — that's covered by existing
+CognitoJWTValidator tests.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.sessions_bff.models import SessionRecord
+
+
+def _record() -> SessionRecord:
+    now = int(time.time())
+    return SessionRecord(
+        session_id="sess-001",
+        user_id="user-sub",
+        username="alice",
+        cognito_access_token="access.token",
+        cognito_refresh_token="refresh.token",
+        id_token="id.token",
+        access_token_exp=now + 3600,
+        csrf_secret="csrf-secret",
+        created_at=now,
+        last_seen_at=now,
+        ttl=now + 28800,
+    )
+
+
+class _AttachSession(BaseHTTPMiddleware):
+    def __init__(self, app, record: SessionRecord | None) -> None:
+        super().__init__(app)
+        self._record = record
+
+    async def dispatch(self, request, call_next):
+        if self._record is not None:
+            request.state.bff_session = self._record
+        return await call_next(request)
+
+
+def _build_app(*, record: SessionRecord | None) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(_AttachSession, record=record)
+
+    @app.get("/me")
+    async def me(user: User = Depends(get_current_user_from_session)):
+        return {"user_id": user.user_id, "email": user.email}
+
+    return app
+
+
+def test_returns_user_when_session_attached() -> None:
+    fake_validator = MagicMock()
+    fake_validator.validate_token.return_value = User(
+        email="alice@example.com",
+        user_id="user-sub",
+        name="Alice",
+        roles=["user"],
+    )
+    with patch(
+        "apis.shared.auth.dependencies._get_cognito_validator",
+        return_value=fake_validator,
+    ), patch(
+        "apis.shared.auth.dependencies._enrich_user_from_store"
+    ) as enrich, patch(
+        "apis.shared.auth.dependencies._get_user_sync_service",
+        return_value=None,
+    ):
+        # Make _enrich_user_from_store an awaitable no-op
+        async def _noop(_user):
+            return None
+
+        enrich.side_effect = _noop
+
+        app = _build_app(record=_record())
+        response = TestClient(app).get("/me")
+        assert response.status_code == 200
+        assert response.json() == {
+            "user_id": "user-sub",
+            "email": "alice@example.com",
+        }
+        fake_validator.validate_token.assert_called_once_with("access.token")
+
+
+def test_returns_401_when_no_session_on_state() -> None:
+    """No upstream middleware ran (or the cookie was missing) → 401."""
+    app = _build_app(record=None)
+    response = TestClient(app).get("/me")
+    assert response.status_code == 401
+
+
+def test_returns_401_when_token_validation_fails() -> None:
+    from fastapi import HTTPException, status
+
+    fake_validator = MagicMock()
+    fake_validator.validate_token.side_effect = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="bad sig"
+    )
+    with patch(
+        "apis.shared.auth.dependencies._get_cognito_validator",
+        return_value=fake_validator,
+    ):
+        app = _build_app(record=_record())
+        response = TestClient(app).get("/me")
+        assert response.status_code == 401
+
+
+def test_returns_500_when_validator_unconfigured() -> None:
+    with patch(
+        "apis.shared.auth.dependencies._get_cognito_validator",
+        return_value=None,
+    ):
+        app = _build_app(record=_record())
+        response = TestClient(app).get("/me")
+        assert response.status_code == 500

--- a/backend/tests/apis/shared/sessions_bff/test_repository.py
+++ b/backend/tests/apis/shared/sessions_bff/test_repository.py
@@ -1,0 +1,79 @@
+"""Tests for SessionRepository against moto-backed DynamoDB."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_for_missing_session(repository) -> None:
+    assert await repository.get("does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trip(repository, sample_record) -> None:
+    record = sample_record()
+    await repository.put(record)
+    fetched = await repository.get(record.session_id)
+    assert fetched is not None
+    assert fetched.session_id == record.session_id
+    assert fetched.user_id == record.user_id
+    assert fetched.username == record.username
+    assert fetched.cognito_access_token == record.cognito_access_token
+    assert fetched.cognito_refresh_token == record.cognito_refresh_token
+    assert fetched.id_token == record.id_token
+    assert fetched.csrf_secret == record.csrf_secret
+
+
+@pytest.mark.asyncio
+async def test_update_tokens_replaces_token_attrs(repository, sample_record) -> None:
+    record = sample_record()
+    await repository.put(record)
+
+    new_exp = int(time.time()) + 7200
+    await repository.update_tokens(
+        session_id=record.session_id,
+        access_token="new.access",
+        refresh_token="new.refresh",
+        id_token="new.id",
+        access_token_exp=new_exp,
+        last_seen_at=int(time.time()),
+    )
+
+    fetched = await repository.get(record.session_id)
+    assert fetched is not None
+    assert fetched.cognito_access_token == "new.access"
+    assert fetched.cognito_refresh_token == "new.refresh"
+    assert fetched.id_token == "new.id"
+    assert fetched.access_token_exp == new_exp
+
+
+@pytest.mark.asyncio
+async def test_get_treats_ttl_expired_row_as_missing(
+    repository, sample_record
+) -> None:
+    """DDB TTL eviction is best-effort; the repo enforces it on read."""
+    record = sample_record(ttl=int(time.time()) - 1)
+    await repository.put(record)
+    assert await repository.get(record.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_row(repository, sample_record) -> None:
+    record = sample_record()
+    await repository.put(record)
+    await repository.delete(record.session_id)
+    assert await repository.get(record.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_repository_is_inert() -> None:
+    from apis.shared.sessions_bff.repository import SessionRepository
+
+    repo = SessionRepository(table_name="")
+    assert repo.enabled is False
+    # All ops succeed silently — no exceptions, no AWS calls.
+    assert await repo.get("any") is None
+    await repo.delete("any")

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
@@ -1,0 +1,322 @@
+"""Tests for SessionRefreshMiddleware.
+
+Covered:
+    - Pass-through when BFF is not enabled (env vars unset).
+    - Pass-through when no session cookie is present (Bearer-token requests).
+    - Cookie present + session valid → record attached to `request.state`.
+    - Cookie present + bad seal → cookie cleared on response.
+    - Cookie present + session row missing → cookie cleared.
+    - Cookie present + access token within leeway → refresh path called once.
+    - Storm coalescing: N concurrent requests for the same session trigger
+      exactly one Cognito refresh exchange.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from apis.shared.middleware.session_refresh import SessionRefreshMiddleware
+from apis.shared.sessions_bff import lock as lock_module
+from apis.shared.sessions_bff.cache import SessionCache
+from apis.shared.sessions_bff.config import (
+    BFFConfig,
+    SESSION_COOKIE_NAME,
+)
+from apis.shared.sessions_bff.cookie import CookieCodec
+from apis.shared.sessions_bff.models import CookiePayload, SessionRecord
+from apis.shared.sessions_bff.refresh import RefreshResult
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_locks() -> None:
+    """Clear the process-wide lock registry between tests so storm-coalescing
+    behavior is independent across cases."""
+    lock_module._reset_for_tests()
+
+
+def _make_codec() -> CookieCodec:
+    codec = CookieCodec(kms_key_arn="arn:aws:kms:fake")
+    codec._cipher = AESGCM(secrets.token_bytes(32))
+    return codec
+
+
+def _make_record(
+    *,
+    session_id: str = "sess-001",
+    access_token_exp: Optional[int] = None,
+) -> SessionRecord:
+    now = int(time.time())
+    return SessionRecord(
+        session_id=session_id,
+        user_id="user-sub-001",
+        username="alice",
+        cognito_access_token="access.original",
+        cognito_refresh_token="refresh.original",
+        id_token="id.original",
+        access_token_exp=access_token_exp if access_token_exp is not None else now + 3600,
+        csrf_secret="csrf-secret",
+        created_at=now,
+        last_seen_at=now,
+        ttl=now + 28800,
+    )
+
+
+def _enabled_config() -> BFFConfig:
+    return BFFConfig(
+        sessions_table_name="tbl",
+        cookie_signing_key_arn="arn:aws:kms:fake",
+        session_ttl_seconds=28800,
+        refresh_leeway_seconds=60,
+        cognito_bff_app_client_id="client-id",
+        cognito_bff_app_client_secret_arn="arn:secret",
+        inference_api_url=None,
+    )
+
+
+def _build_app(
+    *,
+    config: BFFConfig,
+    repository,
+    codec: CookieCodec,
+    refresh_client,
+    cache: Optional[SessionCache] = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        SessionRefreshMiddleware,
+        config=config,
+        repository=repository,
+        cookie_codec=codec,
+        refresh_client=refresh_client,
+        cache=cache or SessionCache(ttl_seconds=60),
+    )
+
+    @app.get("/echo")
+    async def echo(request: Request):
+        record = getattr(request.state, "bff_session", None)
+        return {
+            "has_session": record is not None,
+            "session_id": record.session_id if record else None,
+            "access_token": record.cognito_access_token if record else None,
+        }
+
+    return app
+
+
+def test_passthrough_when_bff_disabled() -> None:
+    config = BFFConfig(
+        sessions_table_name=None,
+        cookie_signing_key_arn=None,
+        session_ttl_seconds=28800,
+        refresh_leeway_seconds=60,
+        cognito_bff_app_client_id=None,
+        cognito_bff_app_client_secret_arn=None,
+        inference_api_url=None,
+    )
+    repo = AsyncMock()
+    refresh = MagicMock()
+    app = _build_app(
+        config=config, repository=repo, codec=_make_codec(), refresh_client=refresh
+    )
+    response = TestClient(app).get("/echo")
+    assert response.status_code == 200
+    assert response.json() == {
+        "has_session": False,
+        "session_id": None,
+        "access_token": None,
+    }
+    repo.get.assert_not_called()
+
+
+def test_passthrough_when_no_cookie_present() -> None:
+    repo = AsyncMock()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(),
+        repository=repo,
+        codec=_make_codec(),
+        refresh_client=refresh,
+    )
+    response = TestClient(app).get("/echo")
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    repo.get.assert_not_called()
+
+
+def test_valid_cookie_attaches_session_to_request_state() -> None:
+    record = _make_record()
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_session"] is True
+    assert body["session_id"] == record.session_id
+    assert body["access_token"] == "access.original"
+    refresh.refresh.assert_not_called()
+
+
+def test_unrecoverable_cookie_is_cleared() -> None:
+    repo = AsyncMock()
+    repo.get.return_value = None
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    response = TestClient(app).get(
+        "/echo", cookies={SESSION_COOKIE_NAME: "garbage-value"}
+    )
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    # Set-Cookie header on the response with Max-Age=0 (delete_cookie semantics)
+    set_cookie = response.headers.get("set-cookie", "")
+    assert SESSION_COOKIE_NAME in set_cookie
+
+
+def test_missing_session_row_clears_cookie() -> None:
+    """Cookie unseals fine but the DDB row is gone — clear the cookie."""
+    repo = AsyncMock()
+    repo.get.return_value = None
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id="sess-gone"))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    assert SESSION_COOKIE_NAME in response.headers.get("set-cookie", "")
+
+
+def test_near_expiry_session_triggers_refresh_once() -> None:
+    record = _make_record(access_token_exp=int(time.time()) + 5)  # within 60s leeway
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh.return_value = RefreshResult(
+        access_token="access.fresh",
+        refresh_token="refresh.fresh",
+        id_token="id.fresh",
+        access_token_exp=int(time.time()) + 3600,
+    )
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_session"] is True
+    # The refreshed token should be exposed downstream.
+    assert body["access_token"] == "access.fresh"
+    refresh.refresh.assert_called_once_with(
+        username="alice", refresh_token="refresh.original"
+    )
+    repo.update_tokens.assert_awaited_once()
+
+
+def test_refresh_failure_clears_cookie() -> None:
+    from apis.shared.sessions_bff.refresh import CognitoRefreshError
+
+    record = _make_record(access_token_exp=int(time.time()) + 5)
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh.side_effect = CognitoRefreshError("rotated")
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    assert SESSION_COOKIE_NAME in response.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_storm_coalesces_to_single_refresh() -> None:
+    """N concurrent in-flight requests for the same session id must only
+    drive one Cognito refresh exchange, even if the refresh itself is slow.
+
+    This guards against the multi-tab refresh-token-rotation storm called
+    out in the project memory."""
+    record = _make_record(access_token_exp=int(time.time()) + 5)
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+
+    call_count = {"n": 0}
+
+    def slow_refresh(*, username: str, refresh_token: str) -> RefreshResult:
+        # Tight, synchronous bump — the lock guards entry, so this only
+        # needs to be called sequentially to make the test meaningful.
+        call_count["n"] += 1
+        return RefreshResult(
+            access_token=f"access.fresh.{call_count['n']}",
+            refresh_token="refresh.fresh",
+            id_token="id.fresh",
+            access_token_exp=int(time.time()) + 3600,
+        )
+
+    refresh = MagicMock()
+    refresh.refresh.side_effect = slow_refresh
+
+    # After the first refresh, repo.get returns the *fresh* record so other
+    # waiters short-circuit out of the refresh branch.
+    fresh_record = _make_record(
+        access_token_exp=int(time.time()) + 3600
+    )
+    fresh_record.cognito_access_token = "access.fresh.1"
+    fresh_record.cognito_refresh_token = "refresh.fresh"
+    repo.get.side_effect = [record, record, fresh_record, fresh_record, fresh_record]
+    repo.update_tokens = AsyncMock()
+
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+
+    # Use httpx AsyncClient driven against the ASGI app for true concurrency.
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, sealed)
+        responses = await asyncio.gather(
+            *(client.get("/echo") for _ in range(5))
+        )
+
+    for r in responses:
+        assert r.status_code == 200
+    # Critical assertion: only one refresh call across all 5 concurrent reqs.
+    assert call_count["n"] == 1

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
@@ -29,6 +29,7 @@ from apis.shared.sessions_bff import lock as lock_module
 from apis.shared.sessions_bff.cache import SessionCache
 from apis.shared.sessions_bff.config import (
     BFFConfig,
+    CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
 )
 from apis.shared.sessions_bff.cookie import CookieCodec
@@ -187,9 +188,13 @@ def test_unrecoverable_cookie_is_cleared() -> None:
     )
     assert response.status_code == 200
     assert response.json()["has_session"] is False
-    # Set-Cookie header on the response with Max-Age=0 (delete_cookie semantics)
-    set_cookie = response.headers.get("set-cookie", "")
-    assert SESSION_COOKIE_NAME in set_cookie
+    # Both BFF cookies must be cleared so the browser stops echoing the
+    # bad pair on every subsequent request. `getlist` because Set-Cookie
+    # appears once per cookie cleared.
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    cleared = " ".join(set_cookie_headers)
+    assert SESSION_COOKIE_NAME in cleared
+    assert CSRF_COOKIE_NAME in cleared
 
 
 def test_missing_session_row_clears_cookie() -> None:


### PR DESCRIPTION
## Summary

- Phase 2 of the [Bearer→cookie BFF migration](https://github.com/Boise-State-Development/agentcore-public-stack/pull/212). Lands the **server-side plumbing dormant** — no behavior change until a session cookie exists, which won't happen until Phase 3 ships the `/auth/*` routes.
- Adds `apis/shared/sessions_bff/` package: `BFFConfig` (env-driven, gated by `is_enabled()`), `SessionRepository` (DDB CRUD with TTL semantics), `CookieCodec` (KMS `GenerateDataKey` → AES-GCM seal of session id), CSRF double-submit helpers, TTL cache, per-session `asyncio.Lock` registry for refresh-storm coalescing, and `CognitoRefreshClient` (`InitiateAuth` REFRESH_TOKEN_AUTH with cached SECRET_HASH).
- Adds `SessionRefreshMiddleware` and `CSRFMiddleware` registered on app-api in [main.py](backend/src/apis/app_api/main.py). Both are registered unconditionally so a Phase 1 env-var deploy can flip them on without a code redeploy. They short-circuit when `BFFConfig.is_enabled()` is False (local dev, environments before Phase 1 deployed) and when no `__Host-bff_session` cookie is present (Bearer-token requests).
- Adds `get_current_user_from_session` dependency in [apis/shared/auth/dependencies.py](backend/src/apis/shared/auth/dependencies.py) for Phase 6 router cutover. **No router consumes it yet** — intentional per the Phase 2 scope.

## Design choices worth flagging

- **Cookie name** `__Host-bff_session` — the prefix forbids `Domain=` and requires `Secure` + `Path=/`, giving same-origin-only delivery for free once CloudFront `/api/*` lands in Phase 6.
- **Envelope encryption, cached DEK** — at first use, `kms:GenerateDataKey` returns a 256-bit AES key; plaintext is cached in process memory, wrapped blob discarded. Matches the Phase 1 CDK comment. Key rotation requires a task restart, which is on the Phase 7 hardening list.
- **Refresh storm coalescing** — per-session `asyncio.Lock` prevents N parallel tab refreshes from tumbling each other's refresh tokens via Cognito rotation. In-process only (Phase 7 will extend to multi-task with a DDB conditional write).
- **CSRF only enforced when a session is bound** — Bearer-token requests bypass entirely, so this PR doesn't break the existing SPA.

## Test plan

- [x] `pytest tests/apis/shared/sessions_bff/ -v` — 46 new tests all pass
  - Cookie codec: round-trip, tampered ciphertext rejected, garbage rejected, unknown-version rejected, wrong-key rejected
  - Repository: CRUD round-trip via moto, TTL-expired row treated as missing, disabled repo is inert
  - CSRF: helper validation, middleware exempts safe methods + Bearer requests, rejects mismatched/missing/forged tokens, exempts `/auth/login|callback|logout`
  - SessionRefreshMiddleware: pass-through when disabled, pass-through when no cookie, valid cookie attaches state, unrecoverable cookie cleared, refresh-failure cookie cleared
  - **Storm coalescing test** (the one called out in the migration plan): 5 concurrent requests against an `httpx.AsyncClient(ASGITransport)` for the same near-expiry session → exactly one Cognito refresh exchange
- [x] `pytest tests/apis/shared/ tests/architecture/` — 92/92 pass, no import-boundary violations
- [x] `pytest tests/apis/app_api/ tests/auth/` — 102/102 pass, no regressions from `dependencies.py` changes
- [x] `python -c "from apis.app_api import main"` — app-api imports cleanly with 4 middlewares registered (CORS → AgentCoreContext → SessionRefresh → CSRF)
- [ ] No infrastructure or runtime change to verify in cloud — this PR is dormant code

🤖 Generated with [Claude Code](https://claude.com/claude-code)