### PR TITLE
test(oauth): scrub AGENTCORE_RUNTIME_WORKLOAD_NAME in agentcore-identity tests

### DIFF
--- a/backend/tests/apis/shared/oauth/conftest.py
+++ b/backend/tests/apis/shared/oauth/conftest.py
@@ -1,0 +1,23 @@
+"""Shared fixtures for agentcore-identity OAuth tests.
+
+These tests exercise `_resolve_workload_token` branches that depend on
+whether `AGENTCORE_RUNTIME_WORKLOAD_NAME` is set. Other tests in the
+broader pytest run can transitively call `load_dotenv(override=True)`
+(e.g. via `apis.app_api.main`), which mutates `os.environ` for the rest
+of the process. If `src/.env` defines that var, these tests then take
+the workload-mint path instead of the cache-hit / consent-required path
+they intend to exercise — failing with `WorkloadTokenUnavailableError`.
+
+The autouse fixture below scrubs the var before every test in this
+package so results are deterministic regardless of suite ordering or
+local `.env` contents.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_workload_env(monkeypatch):
+    monkeypatch.delenv("AGENTCORE_RUNTIME_WORKLOAD_NAME", raising=False)


### PR DESCRIPTION
## Summary
- Fixes a pre-existing pytest pollution bug where 8 tests in `tests/apis/shared/oauth/test_agentcore_identity.py` fail when run as part of the broader `tests/apis/` suite, but pass in isolation.
- Root cause: another test in the broader run transitively calls `load_dotenv(override=True)` (via `apis.app_api.main`'s module-level call), which leaks `AGENTCORE_RUNTIME_WORKLOAD_NAME` from `src/.env` into `os.environ` for the rest of the pytest process. The agentcore-identity tests then take the workload-mint branch in `_resolve_workload_token` instead of the cache-hit / consent-required branch they intend to exercise, failing with `WorkloadTokenUnavailableError`.
- Fix: add an autouse fixture in `backend/tests/apis/shared/oauth/conftest.py` that `monkeypatch.delenv("AGENTCORE_RUNTIME_WORKLOAD_NAME", raising=False)` before every test in the package. Deterministic regardless of suite ordering or local `.env` contents.

## Test plan
- [x] `cd backend && uv run python -m pytest tests/apis/shared/oauth/test_agentcore_identity.py` — 30 passed (regression check)
- [x] `cd backend && uv run python -m pytest tests/apis/` — 143 passed (no leak in this worktree, but no regression either)
- [x] Sanity: with `AGENTCORE_RUNTIME_WORKLOAD_NAME=local_dev_inference` exported in the shell, oauth tests still pass with the conftest in place
- [x] Sanity: removing the conftest reproduces exactly the 8 failures listed in the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)