### PR TITLE
fix(chat): own httpx client lifecycle in api-converse proxy so SSE streams flush headers immediately

### DIFF
--- a/backend/src/apis/app_api/chat/converse_routes.py
+++ b/backend/src/apis/app_api/chat/converse_routes.py
@@ -23,6 +23,18 @@ router = APIRouter(prefix="/chat", tags=["api-converse"])
 
 _INFERENCE_API_URL = os.environ.get("INFERENCE_API_URL", "http://localhost:8001")
 
+_PROXY_TIMEOUT_SECONDS = 300.0
+
+
+def _build_upstream_client() -> httpx.AsyncClient:
+    """Single seam where the proxy's upstream client is constructed.
+
+    Tests substitute a MockTransport-backed client here without having to
+    monkey-patch the global `httpx.AsyncClient` symbol — which would also
+    intercept any test-side httpx clients running in the same process.
+    """
+    return httpx.AsyncClient(timeout=httpx.Timeout(_PROXY_TIMEOUT_SECONDS))
+
 
 @router.post(
     "/api-converse",
@@ -53,69 +65,72 @@ async def api_converse_proxy(
 
     logger.info(f"Proxying api-converse to {target_url}")
 
+    # The client lifecycle must outlive this handler — closing it via
+    # `async with` while a stream is in flight makes httpx drain the upstream
+    # response during `__aexit__`, buffering the entire SSE stream before
+    # headers reach the browser. Open the client manually and tie its
+    # cleanup to the streaming generator's `finally` (or to the early-exit
+    # paths below) so headers can flush as soon as the upstream's first
+    # response message arrives.
+    client = _build_upstream_client()
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(300.0)) as client:
-            response = await client.send(
-                client.build_request(
-                    "POST",
-                    target_url,
-                    headers=headers,
-                    content=body,
-                ),
-                stream=True,
-            )
-
-            # Non-2xx from inference API — relay the error
-            if response.status_code >= 400:
-                error_body = await response.aread()
-                await response.aclose()
-                raise HTTPException(
-                    status_code=response.status_code,
-                    detail=error_body.decode("utf-8", errors="replace"),
-                )
-
-            # Check if the response is SSE (streaming)
-            content_type = response.headers.get("content-type", "")
-            if "text/event-stream" in content_type:
-                async def stream_relay():
-                    try:
-                        async for chunk in response.aiter_bytes():
-                            yield chunk
-                    finally:
-                        await response.aclose()
-
-                return StreamingResponse(
-                    stream_relay(),
-                    media_type="text/event-stream",
-                    headers={
-                        "Cache-Control": "no-cache",
-                        "X-Accel-Buffering": "no",
-                    },
-                )
-
-            # Non-streaming: read full response and return
-            response_body = await response.aread()
-            await response.aclose()
-            return StreamingResponse(
-                iter([response_body]),
-                media_type=content_type or "application/json",
-                status_code=response.status_code,
-            )
-
-    except HTTPException:
-        raise
+        response = await client.send(
+            client.build_request("POST", target_url, headers=headers, content=body),
+            stream=True,
+        )
     except httpx.ConnectError:
+        await client.aclose()
         logger.error(f"Cannot reach Inference API at {target_url}")
         raise HTTPException(status_code=502, detail="Inference API is unreachable")
     except httpx.TimeoutException:
+        await client.aclose()
         logger.error(f"Inference API request timed out: {target_url}")
-        raise HTTPException(
-            status_code=504,
-            detail="Inference API request timed out",
-        )
+        raise HTTPException(status_code=504, detail="Inference API request timed out")
     except Exception as exc:
+        await client.aclose()
         logger.error(f"Proxy error: {exc}", exc_info=True)
         raise HTTPException(
             status_code=502,
             detail="An unexpected error occurred while proxying to the Inference API",
         )
+
+    if response.status_code >= 400:
+        try:
+            error_body = await response.aread()
+        finally:
+            await response.aclose()
+            await client.aclose()
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=error_body.decode("utf-8", errors="replace"),
+        )
+
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        async def stream_relay():
+            try:
+                async for chunk in response.aiter_bytes():
+                    yield chunk
+            finally:
+                await response.aclose()
+                await client.aclose()
+
+        return StreamingResponse(
+            stream_relay(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    try:
+        response_body = await response.aread()
+    finally:
+        await response.aclose()
+        await client.aclose()
+    return StreamingResponse(
+        iter([response_body]),
+        media_type=content_type or "application/json",
+        status_code=response.status_code,
+    )


### PR DESCRIPTION
## Summary

- Mirror the Phase 4 BFF-chat-proxy lifecycle fix into the API-key `/chat/api-converse` proxy.
- Replace `async with httpx.AsyncClient(...)` with manual lifecycle management so `__aexit__` doesn't drain the upstream SSE response (which buffers the entire stream before headers can flush downstream).
- Add a `_build_upstream_client()` seam that mirrors `proxy_routes.py`, useful for future tests.

## Why

`async with httpx.AsyncClient(...) as client:` wrapping a `StreamingResponse` return is a known footgun: when the handler returns, `__aexit__` closes the client, and httpx drains the upstream's full response before letting the close complete. That buffers the whole SSE stream, defeating the point of `text/event-stream` + `X-Accel-Buffering: no`. Phase 4 of the BFF migration hit this exact bug on `proxy_routes.py` and resolved it the same way.

The api-converse proxy used the same `async with` pattern. This change brings it into line:

- Build the client manually via the new `_build_upstream_client()` seam.
- Close the client in the streaming generator's `finally` (SSE branch), in `try/finally` blocks after `aread()` (non-SSE and 4xx/5xx branches), and on every early-exit exception path before raising.
- The bug rationale is preserved as an inline comment so the next reader doesn't reintroduce the `async with` pattern.

## Independent of BFF migration

`/chat/api-converse` is API-key authenticated (X-API-Key header), not cookie-authenticated. The lifecycle fix is a standalone bugfix and is safe to ship on `develop` without coupling to the BFF migration phases. (Phase 4 ships separately on its own PR.)

## Why no TTFB test added

The api-converse flow is internal/external-API-consumer-facing, not browser-driven, and the `tests/apis/app_api/chat/` directory currently only has tests for the BFF proxy. The TTFB test pattern in `test_proxy_routes_streaming.py` (uvicorn-in-a-thread + slow MockTransport upstream) would apply here, but the user-facing buffering risk is much lower for an API-key client than for the SPA. Skipped per scope.

## Test plan

- [ ] `cd backend && uv run python -m pytest tests/routes/test_converse_cost_accounting.py -v` (these tests target `inference_api.chat.converse_routes`, not the app-api proxy modified here, so they should be unaffected — confirms no accidental coupling)
- [ ] Manual: `curl -N -H 'X-API-Key: …' -H 'Content-Type: application/json' -d '{...}' http://localhost:8000/chat/api-converse` and confirm the first SSE event arrives before the upstream finishes producing all events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)