### PR TITLE
feat(auth): BFF Token Handler cutover (Phase 6 a/b/c)

### DIFF
--- a/backend/src/agents/main_agent/USAGE_EXAMPLES.md
+++ b/backend/src/agents/main_agent/USAGE_EXAMPLES.md
@@ -347,8 +347,8 @@ from agents.main_agent import MainAgent
 
 app = FastAPI()
 
-@app.post("/chat/stream")
-async def chat_stream(session_id: str, message: str, enabled_tools: list[str]):
+@app.post("/chat/agent-stream")
+async def chat_agent_stream(session_id: str, message: str, enabled_tools: list[str]):
     agent = MainAgent(
         session_id=session_id,
         enabled_tools=enabled_tools

--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -15,7 +15,7 @@ from fastapi.responses import StreamingResponse
 from apis.app_api.documents.services.document_service import list_assistant_documents
 from apis.inference_api.chat.routes import stream_conversational_message
 from apis.inference_api.chat.service import get_agent
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.errors import ErrorCode, build_conversational_error_event
 from apis.shared.assistants.models import (
@@ -51,7 +51,7 @@ router = APIRouter(prefix="/assistants", tags=["assistants"])
 
 
 @router.post("/draft", response_model=AssistantResponse, response_model_exclude_none=True)
-async def create_assistant_draft_endpoint(request: CreateAssistantDraftRequest, current_user: User = Depends(get_current_user)):
+async def create_assistant_draft_endpoint(request: CreateAssistantDraftRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Create a draft assistant with auto-generated ID.
 
@@ -92,7 +92,7 @@ async def create_assistant_draft_endpoint(request: CreateAssistantDraftRequest, 
 
 
 @router.post("", response_model=AssistantResponse, response_model_exclude_none=True)
-async def create_assistant_endpoint(request: CreateAssistantRequest, current_user: User = Depends(get_current_user)):
+async def create_assistant_endpoint(request: CreateAssistantRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Create a complete assistant with all required fields.
 
@@ -148,7 +148,7 @@ async def list_assistants_endpoint(
     next_token: Optional[str] = Query(None, description="Pagination token for retrieving the next page"),
     include_drafts: bool = Query(False, description="Include draft assistants"),
     include_public: bool = Query(False, description="Include public assistants (in addition to user's own)"),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """
     List assistants for the authenticated user with pagination support.
@@ -233,7 +233,7 @@ async def list_assistants_endpoint(
 
 
 @router.get("/{assistant_id}", response_model=AssistantResponse, response_model_exclude_none=True)
-async def get_assistant_endpoint(assistant_id: str, current_user: User = Depends(get_current_user)):
+async def get_assistant_endpoint(assistant_id: str, current_user: User = Depends(get_current_user_or_session)):
     """
     Retrieve a specific assistant by ID with visibility-based access control.
 
@@ -285,7 +285,7 @@ async def get_assistant_endpoint(assistant_id: str, current_user: User = Depends
 
 
 @router.put("/{assistant_id}", response_model=AssistantResponse, response_model_exclude_none=True)
-async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantRequest, current_user: User = Depends(get_current_user)):
+async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Update an assistant (deep merge).
 
@@ -346,7 +346,7 @@ async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantR
 
 
 @router.delete("/{assistant_id}", status_code=204)
-async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depends(get_current_user)):
+async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depends(get_current_user_or_session)):
     """Delete an assistant and all associated documents using soft-delete + background cleanup."""
     user_id = current_user.user_id
     logger.info("DELETE /assistants/{assistant_id}")
@@ -387,7 +387,7 @@ async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depe
 
 
 @router.post("/{assistant_id}/test-chat")
-async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatRequest, current_user: User = Depends(get_current_user)):
+async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Test chat endpoint for assistants with RAG functionality.
 
@@ -523,7 +523,7 @@ async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatReques
 
 
 @router.post("/{assistant_id}/shares", response_model=AssistantSharesResponse)
-async def share_assistant_endpoint(assistant_id: str, request: ShareAssistantRequest, current_user: User = Depends(get_current_user)):
+async def share_assistant_endpoint(assistant_id: str, request: ShareAssistantRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Share an assistant with specified email addresses.
 
@@ -568,7 +568,7 @@ async def share_assistant_endpoint(assistant_id: str, request: ShareAssistantReq
 
 
 @router.delete("/{assistant_id}/shares", response_model=AssistantSharesResponse)
-async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistantRequest, current_user: User = Depends(get_current_user)):
+async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistantRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Remove shares from an assistant for specified email addresses.
 
@@ -612,7 +612,7 @@ async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistan
 
 
 @router.get("/{assistant_id}/shares", response_model=AssistantSharesResponse)
-async def get_assistant_shares_endpoint(assistant_id: str, current_user: User = Depends(get_current_user)):
+async def get_assistant_shares_endpoint(assistant_id: str, current_user: User = Depends(get_current_user_or_session)):
     """
     Get list of email addresses an assistant is shared with.
 

--- a/backend/src/apis/app_api/auth/api_keys/routes.py
+++ b/backend/src/apis/app_api/auth/api_keys/routes.py
@@ -10,7 +10,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 
 from apis.shared.auth.api_keys.models import (
@@ -34,7 +34,7 @@ router = APIRouter(prefix="/auth/api-keys", tags=["api-keys"])
 )
 async def create_api_key(
     request: CreateApiKeyRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ) -> CreateApiKeyResponse:
     """Generate a new API key for the authenticated user.
 
@@ -58,7 +58,7 @@ async def create_api_key(
     summary="Get your API key",
 )
 async def get_api_key(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ) -> GetApiKeyResponse:
     """Return metadata for the authenticated user's API key, if one exists."""
     service = get_api_key_service()
@@ -80,7 +80,7 @@ async def get_api_key(
 )
 async def delete_api_key(
     key_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ) -> DeleteApiKeyResponse:
     """Revoke an API key. Only the key owner can delete it."""
     service = get_api_key_service()

--- a/backend/src/apis/app_api/auth/bff/routes.py
+++ b/backend/src/apis/app_api/auth/bff/routes.py
@@ -16,6 +16,7 @@ production code path consumes the cookies yet.
 from __future__ import annotations
 
 import logging
+import re
 import secrets
 import time
 import urllib.parse
@@ -119,13 +120,40 @@ def _require_ready(config: BFFAuthConfig) -> None:
 # ─── /auth/login ───────────────────────────────────────────────────────
 
 
+# Cognito's `identity_provider` query parameter accepts the IdP name and
+# tells Cognito to skip the Hosted UI provider chooser and forward the
+# user straight to that IdP. The SPA's federated-login buttons rely on
+# this for one-click SSO; we forward an allowlisted set of characters
+# only so a malicious referrer can't smuggle CRLF or other authorize-URL
+# tampering payloads through the BFF.
+_PROVIDER_ID_ALLOWED = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+
+
+def _sanitized_provider_id(raw: Optional[str]) -> Optional[str]:
+    """Return `raw` if it matches the IdP-name allowlist, else None.
+
+    Reject silently rather than 4xx so an old SPA bundle that sends a
+    legacy provider ID doesn't break the login flow — Cognito will just
+    show its provider chooser instead.
+    """
+    if raw is None:
+        return None
+    return raw if _PROVIDER_ID_ALLOWED.match(raw) else None
+
+
 @router.get("/login", summary="Begin the BFF OAuth code flow")
-async def bff_login() -> RedirectResponse:
+async def bff_login(provider: Optional[str] = None) -> RedirectResponse:
     """302 to the Cognito Hosted UI authorize endpoint with a fresh state.
 
     Uses the existing `state_store` (in-memory locally, DynamoDB in cloud)
     to bind one-time-use state tokens to a TTL — the callback validates and
     deletes the state in one atomic step.
+
+    When `provider` is supplied (e.g. by the SPA's federated-IdP button),
+    it's forwarded to Cognito as `identity_provider` so the user skips
+    the Hosted UI chooser and lands on the right IdP directly. Values
+    are filtered through `_PROVIDER_ID_ALLOWED` to defeat header/URL
+    injection via the query string.
     """
     config = BFFAuthConfig.from_env()
     _require_ready(config)
@@ -140,15 +168,18 @@ async def bff_login() -> RedirectResponse:
         ttl_seconds=_STATE_TTL_SECONDS,
     )
 
-    params = urllib.parse.urlencode(
-        {
-            "response_type": "code",
-            "client_id": config.bff_config.cognito_bff_app_client_id,
-            "scope": _AUTHORIZE_SCOPES,
-            "redirect_uri": config.callback_url,
-            "state": state,
-        }
-    )
+    authorize_params = {
+        "response_type": "code",
+        "client_id": config.bff_config.cognito_bff_app_client_id,
+        "scope": _AUTHORIZE_SCOPES,
+        "redirect_uri": config.callback_url,
+        "state": state,
+    }
+    sanitized_provider = _sanitized_provider_id(provider)
+    if sanitized_provider:
+        authorize_params["identity_provider"] = sanitized_provider
+
+    params = urllib.parse.urlencode(authorize_params)
     authorize_url = f"{config.cognito_domain_url}/oauth2/authorize?{params}"
     return RedirectResponse(url=authorize_url, status_code=status.HTTP_302_FOUND)
 

--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -75,6 +75,17 @@ async def chat_stream(
         "Authorization": f"Bearer {current_user.raw_token}",
     }
 
+    # Forward OAuth2CallbackUrl when the SPA supplies it. Inference-api's
+    # AgentCoreContextMiddleware reads this header to scope the on-tool
+    # OAuth consent landing URL to the SPA's origin (allowlisted via
+    # CORS_ORIGINS). Without it, MCP-tool consent flows can't redirect
+    # back to the SPA's `/oauth-complete` page and `oauth_required` SSE
+    # events are unusable. Forwarded as-is — the inference-api side
+    # re-validates against its own CORS_ORIGINS allowlist.
+    forwarded_callback = request.headers.get("OAuth2CallbackUrl")
+    if forwarded_callback:
+        headers["OAuth2CallbackUrl"] = forwarded_callback
+
     # The client lifecycle must outlive this handler — closing it via
     # `async with` while a stream is in flight makes httpx drain the upstream
     # response during `__aexit__`, buffering the entire SSE stream before

--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -1,7 +1,7 @@
 """BFF chat proxy — forwards browser SSE chat requests to inference-api.
 
-`POST /chat/proxy-stream` is the cookie-authenticated counterpart to the
-SPA's current direct-to-inference-api chat call. The flow:
+`POST /chat/stream` is the cookie-authenticated counterpart to the SPA's
+current direct-to-inference-api chat call. The flow:
 
   Browser  → CloudFront `/api/*`  → app-api  → inference-api `/invocations`
            (httpOnly session cookie)         (Authorization: Bearer <token>)
@@ -13,8 +13,13 @@ access token — to inference-api, which already accepts Cognito Bearer
 tokens via `get_current_user_trusted` on `/invocations`. No inference-api
 changes needed (architecture decision #4 in the BFF migration plan).
 
-Phase 4 ships this dormant — no SPA caller exists yet. Phase 6b will
-rename this to `/chat/stream` once the SPA cuts over to cookie auth.
+Two paths are registered against the same handler:
+  - `/chat/stream` is the canonical Phase 6 name. The legacy in-process
+    Bearer agent route that previously owned this path was renamed to
+    `/chat/agent-stream` in the same PR.
+  - `/chat/proxy-stream` is the Phase 4 original. Kept live so a rolling
+    deploy of app-api ECS tasks during the cutover doesn't 404 the SPA
+    when it lands on a not-yet-rotated task. Removed in Phase 7.
 """
 
 from __future__ import annotations
@@ -50,17 +55,7 @@ def _build_upstream_client() -> httpx.AsyncClient:
     return httpx.AsyncClient(timeout=httpx.Timeout(_PROXY_TIMEOUT_SECONDS))
 
 
-@router.post(
-    "/proxy-stream",
-    summary="Cookie-authenticated SSE proxy to inference-api /invocations",
-    responses={
-        401: {"description": "No active BFF session"},
-        403: {"description": "CSRF token missing or invalid"},
-        502: {"description": "Inference API unreachable"},
-        504: {"description": "Inference API request timed out"},
-    },
-)
-async def chat_proxy_stream(
+async def chat_stream(
     request: Request,
     current_user: User = Depends(get_current_user_from_session),
 ):
@@ -149,3 +144,33 @@ async def chat_proxy_stream(
         media_type=content_type or "application/json",
         status_code=response.status_code,
     )
+
+
+# Register the same handler under both paths. `/chat/stream` is the
+# canonical Phase 6 name; `/chat/proxy-stream` stays live for the
+# rolling-deploy + soak window and is removed in Phase 7. Distinct
+# operation_ids keep the OpenAPI doc unambiguous when both routes exist.
+_route_responses = {
+    401: {"description": "No active BFF session"},
+    403: {"description": "CSRF token missing or invalid"},
+    502: {"description": "Inference API unreachable"},
+    504: {"description": "Inference API request timed out"},
+}
+
+router.add_api_route(
+    "/stream",
+    chat_stream,
+    methods=["POST"],
+    summary="Cookie-authenticated SSE proxy to inference-api /invocations",
+    operation_id="chat_stream",
+    responses=_route_responses,
+)
+
+router.add_api_route(
+    "/proxy-stream",
+    chat_stream,
+    methods=["POST"],
+    summary="Phase 4 alias of /chat/stream — removed in Phase 7",
+    operation_id="chat_proxy_stream",
+    responses=_route_responses,
+)

--- a/backend/src/apis/app_api/chat/routes.py
+++ b/backend/src/apis/app_api/chat/routes.py
@@ -3,8 +3,13 @@
 Application-specific chat endpoints moved from inference_api to keep
 AgentCore Runtime API clean. These endpoints handle:
 - Conversation title generation
-- Legacy chat streaming
+- In-process agent streaming (`POST /chat/agent-stream`, Bearer auth)
 - Multimodal chat input
+
+`/chat/agent-stream` was named `/chat/stream` until the Phase 6 BFF
+cutover, which reclaimed that path for the cookie-authenticated proxy
+to inference-api. Bearer-authenticated callers (API-key tooling, scripts)
+must update to the new path.
 """
 
 import asyncio
@@ -28,7 +33,7 @@ from apis.shared.sessions.metadata import get_session_metadata, store_session_me
 from apis.inference_api.chat.models import ChatEvent, ChatRequest, FileContent, GenerateTitleRequest, GenerateTitleResponse
 from apis.inference_api.chat.routes import stream_conversational_message
 from apis.inference_api.chat.service import generate_conversation_title, get_agent
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user, get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.errors import (
     ErrorCode,
@@ -52,7 +57,7 @@ STREAM_TIMEOUT_SECONDS = 600  # 10 minutes
 
 
 @router.post("/generate-title")
-async def generate_title(request: GenerateTitleRequest, current_user: User = Depends(get_current_user)):
+async def generate_title(request: GenerateTitleRequest, current_user: User = Depends(get_current_user_or_session)):
     """
     Generate a conversation title for a new session.
 
@@ -90,11 +95,19 @@ async def generate_title(request: GenerateTitleRequest, current_user: User = Dep
         return GenerateTitleResponse(title="New Conversation", session_id=request.session_id)
 
 
-@router.post("/stream")
-async def chat_stream(request: ChatRequest, current_user: User = Depends(get_current_user)):
+@router.post("/agent-stream")
+async def chat_agent_stream(request: ChatRequest, current_user: User = Depends(get_current_user)):
     """
-    Legacy chat stream endpoint (for backward compatibility)
-    Uses default tools (all available) if enabled_tools not specified
+    Bearer-authenticated in-process agent stream.
+
+    Runs the agent loop inside this app-api process and streams the SSE
+    response back. Distinct from `/chat/stream` (Phase 6 BFF cookie proxy
+    to inference-api) and `/chat/api-converse` (X-API-Key proxy). This
+    endpoint was previously registered at `/chat/stream`; it was moved to
+    `/chat/agent-stream` in the Phase 6 BFF cutover so the shorter path
+    could be reclaimed for the browser-facing cookie route.
+
+    Uses default tools (all available) if enabled_tools not specified.
     Uses the authenticated user's ID from the JWT token.
 
     Tool authorization:

--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -32,7 +32,7 @@ import boto3
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from apis.shared.auth import User, get_current_user
+from apis.shared.auth import User, get_current_user_or_session
 from apis.shared.oauth.agentcore_identity import (
     CallbackUrlUnavailableError,
     WorkloadTokenUnavailableError,
@@ -106,7 +106,7 @@ def _visible_to_user(provider: OAuthProvider, user_role_ids: List[str]) -> bool:
 
 @router.get("/", response_model=UserConnectorListResponse)
 async def list_connectors(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     role_service: AppRoleService = Depends(get_app_role_service),
 ) -> UserConnectorListResponse:
@@ -203,7 +203,7 @@ async def _resolve_visible_provider(
 )
 async def initiate_consent(
     provider_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     role_service: AppRoleService = Depends(get_app_role_service),
     disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),
@@ -273,7 +273,7 @@ async def initiate_consent(
 )
 async def connector_status(
     provider_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     role_service: AppRoleService = Depends(get_app_role_service),
     disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),
@@ -333,7 +333,7 @@ async def connector_status(
 )
 async def complete_consent(
     body: CompleteConsentRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),
 ) -> CompleteConsentResponse:
     """Finalize an OAuth consent flow after the popup redirects home.
@@ -394,7 +394,7 @@ async def complete_consent(
 )
 async def disconnect_connector(
     provider_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     role_service: AppRoleService = Depends(get_app_role_service),
     disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),

--- a/backend/src/apis/app_api/costs/routes.py
+++ b/backend/src/apis/app_api/costs/routes.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Optional
 import logging
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.costs.models import UserCostSummary
 from apis.shared.costs.aggregator import CostAggregator
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/costs", tags=["costs"])
 @router.get("/summary", response_model=UserCostSummary)
 async def get_cost_summary(
     period: Optional[str] = Query(None, description="Period (YYYY-MM), defaults to current month"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Get cost summary for the authenticated user (fast path)
@@ -75,7 +75,7 @@ async def get_cost_summary(
 async def get_detailed_report(
     start_date: str = Query(..., description="ISO 8601 start date (YYYY-MM-DD)"),
     end_date: str = Query(..., description="ISO 8601 end date (YYYY-MM-DD)"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Get detailed cost report for custom date range

--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -11,7 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 
-from apis.shared.auth import User, get_current_user
+from apis.shared.auth import User, get_current_user_or_session
 from apis.shared.files.models import (
     PresignRequest,
     PresignResponse,
@@ -44,7 +44,7 @@ router = APIRouter(prefix="/files", tags=["files"])
 @router.post("/presign", response_model=PresignResponse)
 async def request_presigned_url(
     request: PresignRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     service: FileUploadService = Depends(get_file_upload_service),
 ):
     """
@@ -107,7 +107,7 @@ async def request_presigned_url(
 @router.post("/{upload_id}/complete", response_model=CompleteUploadResponse)
 async def complete_upload(
     upload_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     service: FileUploadService = Depends(get_file_upload_service),
 ):
     """
@@ -167,7 +167,7 @@ async def list_files(
     sort_order: SortOrder = Query(
         SortOrder.DESC, alias="sortOrder", description="Sort order: asc or desc"
     ),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     service: FileUploadService = Depends(get_file_upload_service),
 ):
     """
@@ -192,7 +192,7 @@ async def list_files(
 @router.delete("/{upload_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_file(
     upload_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     service: FileUploadService = Depends(get_file_upload_service),
 ):
     """
@@ -222,7 +222,7 @@ async def delete_file(
 
 @router.get("/quota", response_model=QuotaResponse)
 async def get_quota(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     service: FileUploadService = Depends(get_file_upload_service),
 ):
     """

--- a/backend/src/apis/app_api/fine_tuning/dependencies.py
+++ b/backend/src/apis/app_api/fine_tuning/dependencies.py
@@ -4,7 +4,7 @@ import os
 import logging
 from fastapi import Depends, HTTPException, status
 from apis.shared.auth import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from .repository import FineTuningAccessRepository, get_fine_tuning_access_repository
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ DEFAULT_MONTHLY_QUOTA_HOURS = float(
 
 
 async def require_fine_tuning_access(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     repo: FineTuningAccessRepository = Depends(get_fine_tuning_access_repository),
 ) -> dict:
     """FastAPI dependency that enforces fine-tuning access.

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -11,7 +11,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from apis.shared.auth import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from .models import FineTuningAccessResponse
 from .repository import (
     FineTuningAccessRepository,
@@ -50,7 +50,7 @@ router = APIRouter(prefix="/fine-tuning", tags=["fine-tuning"])
 
 @router.get("/access", response_model=FineTuningAccessResponse)
 async def check_access(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     repo: FineTuningAccessRepository = Depends(get_fine_tuning_access_repository),
 ):
     """Check if the current user has fine-tuning access and return quota info.
@@ -196,7 +196,7 @@ async def search_huggingface_models(
 @router.post("/presign", response_model=PresignResponse)
 async def presign_upload(
     request: PresignRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
 ):
@@ -228,7 +228,7 @@ async def presign_upload(
 @router.post("/jobs", response_model=JobResponse, status_code=status.HTTP_201_CREATED)
 async def create_job(
     request: CreateJobRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
@@ -346,7 +346,7 @@ async def create_job(
 
 @router.get("/jobs", response_model=JobListResponse)
 async def list_jobs(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
 ):
@@ -361,7 +361,7 @@ async def list_jobs(
 @router.get("/jobs/{job_id}", response_model=JobResponse)
 async def get_job(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),
@@ -384,7 +384,7 @@ async def get_job(
 @router.get("/jobs/{job_id}/logs")
 async def get_job_logs(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),
@@ -404,7 +404,7 @@ async def get_job_logs(
 @router.get("/jobs/{job_id}/download")
 async def download_artifact(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
@@ -433,7 +433,7 @@ async def download_artifact(
 @router.delete("/jobs/{job_id}")
 async def stop_job(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),
@@ -621,7 +621,7 @@ def _sync_inference_status(
 
 @router.get("/trained-models")
 async def list_trained_models(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
@@ -656,7 +656,7 @@ async def list_trained_models(
 @router.post("/inference/presign", response_model=PresignResponse)
 async def inference_presign_upload(
     request: PresignRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
 ):
@@ -684,7 +684,7 @@ async def inference_presign_upload(
 @router.post("/inference", response_model=InferenceJobResponse, status_code=status.HTTP_201_CREATED)
 async def create_inference_job(
     request: CreateInferenceJobRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     jobs_repo: FineTuningJobsRepository = Depends(get_fine_tuning_jobs_repository),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
@@ -768,7 +768,7 @@ async def create_inference_job(
 
 @router.get("/inference", response_model=InferenceJobListResponse)
 async def list_inference_jobs(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
 ):
@@ -783,7 +783,7 @@ async def list_inference_jobs(
 @router.get("/inference/{job_id}", response_model=InferenceJobResponse)
 async def get_inference_job(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),
@@ -804,7 +804,7 @@ async def get_inference_job(
 @router.get("/inference/{job_id}/logs")
 async def get_inference_logs(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),
@@ -824,7 +824,7 @@ async def get_inference_logs(
 @router.get("/inference/{job_id}/download")
 async def download_inference_result(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
@@ -859,7 +859,7 @@ async def download_inference_result(
 @router.delete("/inference/{job_id}")
 async def stop_inference_job(
     job_id: str,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
     grant: dict = Depends(require_fine_tuning_access),
     inf_repo: InferenceRepository = Depends(get_inference_repository),
     sagemaker: SageMakerService = Depends(get_sagemaker_service),

--- a/backend/src/apis/app_api/memory/routes.py
+++ b/backend/src/apis/app_api/memory/routes.py
@@ -26,7 +26,7 @@ from .services.memory_service import (
     get_memory_config_info,
     delete_memory,
 )
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ router = APIRouter(prefix="/memory", tags=["memory"])
 
 @router.get("/status")
 async def get_memory_status(
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Get the current status and configuration of AgentCore Memory.
@@ -60,7 +60,7 @@ async def get_memory_status(
 async def get_preferences_endpoint(
     query: Optional[str] = Query(None, description="Optional search query for semantic matching"),
     top_k: int = Query(10, ge=1, le=50, alias="topK", description="Number of results to return"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve learned user preferences from AgentCore Memory.
@@ -125,7 +125,7 @@ async def get_preferences_endpoint(
 async def get_facts_endpoint(
     query: Optional[str] = Query(None, description="Optional search query for semantic matching"),
     top_k: int = Query(10, ge=1, le=50, alias="topK", description="Number of results to return"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve learned facts about the user from AgentCore Memory.
@@ -191,7 +191,7 @@ async def get_summaries_endpoint(
     session_id: str,
     query: Optional[str] = Query(None, description="Optional search query for semantic matching"),
     top_k: int = Query(10, ge=1, le=50, alias="topK", description="Number of results to return"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve session summaries from AgentCore Memory.
@@ -260,7 +260,7 @@ async def get_summaries_endpoint(
 @router.get("", response_model_exclude_none=True)
 async def get_all_memories_endpoint(
     top_k: int = Query(20, ge=1, le=50, alias="topK", description="Number of results per category"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve all memories for the authenticated user.
@@ -337,7 +337,7 @@ async def get_all_memories_endpoint(
 @router.post("/search", response_model=MemoriesResponse, response_model_exclude_none=True)
 async def search_memories_endpoint(
     request: MemorySearchRequest,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Semantic search across user memories.
@@ -407,7 +407,7 @@ async def search_memories_endpoint(
 
 @router.get("/strategies", response_model=StrategiesResponse, response_model_exclude_none=True)
 async def get_strategies_endpoint(
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Get configured memory strategies.
@@ -460,7 +460,7 @@ async def get_strategies_endpoint(
 @router.delete("/{record_id}", response_model=DeleteMemoryResponse)
 async def delete_memory_endpoint(
     record_id: str,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Delete a specific memory record.

--- a/backend/src/apis/app_api/models/routes.py
+++ b/backend/src/apis/app_api/models/routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Depends, status
 import logging
 
 from apis.app_api.admin.models import ManagedModelsListResponse
-from apis.shared.auth import User, get_current_user
+from apis.shared.auth import User, get_current_user_or_session
 from apis.shared.models.managed_models import list_all_managed_models
 from apis.app_api.admin.services.model_access import (
     ModelAccessService,
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/models", tags=["models"])
 
 @router.get("", response_model=ManagedModelsListResponse)
 async def list_models_for_user(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     model_access_service: ModelAccessService = Depends(get_model_access_service),
 ):
     """

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -27,7 +27,7 @@ from apis.shared.sessions.metadata import (
 )
 from .services.session_service import SessionService
 from apis.app_api.shares.service import get_share_service
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ router = APIRouter(prefix="/sessions", tags=["sessions"])
 async def list_user_sessions_endpoint(
     limit: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of sessions to return"),
     next_token: Optional[str] = Query(None, description="Pagination token for retrieving the next page of results"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     List sessions for the authenticated user with pagination support.
@@ -96,7 +96,7 @@ async def list_user_sessions_endpoint(
 @router.get("/{session_id}/metadata", response_model=SessionMetadataResponse, response_model_exclude_none=True)
 async def get_session_metadata_endpoint(
     session_id: str,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve session metadata for a specific session.
@@ -152,7 +152,7 @@ async def get_session_metadata_endpoint(
 async def update_session_metadata_endpoint(
     session_id: str,
     request: UpdateSessionMetadataRequest,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Update session metadata for a specific session.
@@ -292,7 +292,7 @@ async def update_session_metadata_endpoint(
 async def delete_session_endpoint(
     session_id: str,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Delete a conversation.
@@ -378,7 +378,7 @@ async def delete_session_endpoint(
 async def bulk_delete_sessions_endpoint(
     request: BulkDeleteSessionsRequest,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Bulk delete multiple conversations.
@@ -487,7 +487,7 @@ async def get_session_messages_endpoint(
     session_id: str,
     limit: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of messages to return"),
     next_token: Optional[str] = Query(None, description="Pagination token for retrieving the next page of results"),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user_or_session)
 ):
     """
     Retrieve messages for a specific session with pagination support.
@@ -552,7 +552,7 @@ async def get_session_messages_endpoint(
 async def dismiss_pending_interrupt_endpoint(
     session_id: str,
     interrupt_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Dismiss a pending OAuth consent interrupt for the caller's session.
 

--- a/backend/src/apis/app_api/shares/routes.py
+++ b/backend/src/apis/app_api/shares/routes.py
@@ -11,7 +11,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 
 from .models import (
@@ -56,7 +56,7 @@ shared_view_router = APIRouter(prefix="/shared", tags=["shares"])
 async def create_share(
     session_id: str,
     request: CreateShareRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Create a point-in-time share snapshot for a conversation."""
     try:
@@ -84,7 +84,7 @@ async def create_share(
 )
 async def list_shares_for_session(
     session_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """List all shares for a session (owner only)."""
     try:
@@ -110,7 +110,7 @@ async def list_shares_for_session(
 async def update_share(
     share_id: str,
     request: UpdateShareRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Update access level or allowed emails on an existing share."""
     try:
@@ -134,7 +134,7 @@ async def update_share(
 @shares_router.delete("/{share_id}", status_code=204)
 async def revoke_share(
     share_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Revoke (delete) a specific share."""
     try:
@@ -155,7 +155,7 @@ async def revoke_share(
 @shares_router.post("/{share_id}/export", status_code=201)
 async def export_shared_conversation(
     share_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Export a shared conversation into a new session for the current user."""
     try:
@@ -187,7 +187,7 @@ async def export_shared_conversation(
 )
 async def get_shared_conversation(
     share_id: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """Retrieve a shared conversation snapshot (access-controlled)."""
     try:

--- a/backend/src/apis/app_api/tools/routes.py
+++ b/backend/src/apis/app_api/tools/routes.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from apis.shared.auth import User, get_current_user
+from apis.shared.auth import User, get_current_user_or_session
 from apis.shared.rbac.service import get_app_role_service
 
 # Import legacy service for backward compatibility
@@ -73,7 +73,7 @@ class UserToolPermissionsResponse(BaseModel):
 
 @router.get("/", response_model=UserToolsResponse)
 async def get_user_tools(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
 ):
     """
     Get tools available to the current user with preferences merged.
@@ -107,7 +107,7 @@ async def get_user_tools(
 @router.put("/preferences")
 async def update_tool_preferences(
     request: ToolPreferencesRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
 ):
     """
     Save user's tool enabled/disabled preferences.
@@ -142,7 +142,7 @@ async def list_all_tools(
     category: Optional[str] = Query(
         None, description="Filter by category (search, data, utilities, code, gateway)"
     ),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
 ):
     """
     List all tools available in the system (legacy endpoint).
@@ -188,7 +188,7 @@ async def list_all_tools(
 
 @router.get("/my-permissions", response_model=UserToolPermissionsResponse)
 async def get_my_tool_permissions(
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
 ):
     """
     Get the current user's tool permissions.
@@ -220,7 +220,7 @@ async def list_available_tools(
     category: Optional[str] = Query(
         None, description="Filter by category (search, data, utilities, code, gateway)"
     ),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_session),
 ):
     """
     List tools available to the current user (legacy endpoint).

--- a/backend/src/apis/app_api/user_settings/routes.py
+++ b/backend/src/apis/app_api/user_settings/routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 import logging
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.user_settings.models import UserSettings, UserSettingsUpdate
 from apis.shared.user_settings.repository import UserSettingsRepository
@@ -20,7 +20,7 @@ def get_user_settings_repository() -> UserSettingsRepository:
 
 @router.get("", response_model=UserSettings)
 async def get_settings(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     repo: UserSettingsRepository = Depends(get_user_settings_repository),
 ):
     """Get the current user's settings."""
@@ -32,7 +32,7 @@ async def get_settings(
 @router.put("", response_model=UserSettings)
 async def update_settings(
     body: UserSettingsUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     repo: UserSettingsRepository = Depends(get_user_settings_repository),
 ):
     """Update the current user's settings (partial merge)."""

--- a/backend/src/apis/app_api/users/routes.py
+++ b/backend/src/apis/app_api/users/routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 import logging
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.users.repository import UserRepository
@@ -22,7 +22,7 @@ def get_user_repository() -> UserRepository:
 
 @router.get("/me/permissions", response_model=UserPermissionsResponse)
 async def get_my_permissions(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
 ):
     """
     Get the current user's effective permissions resolved from AppRoles.
@@ -52,7 +52,7 @@ async def get_my_permissions(
 @router.post("/me/sync", status_code=204)
 async def sync_my_profile(
     body: UserProfileSyncRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     user_repo: UserRepository = Depends(get_user_repository),
 ):
     """
@@ -102,7 +102,7 @@ async def sync_my_profile(
 async def search_users(
     q: str = Query(..., description="Search query (email or name, partial match)"),
     limit: int = Query(20, ge=1, le=50, description="Maximum number of results"),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_or_session),
     user_repo: UserRepository = Depends(get_user_repository)
 ):
     """

--- a/backend/src/apis/shared/auth/__init__.py
+++ b/backend/src/apis/shared/auth/__init__.py
@@ -1,12 +1,13 @@
 """Shared authentication utilities for API projects."""
 
-from .dependencies import get_current_user, security
+from .dependencies import get_current_user, get_current_user_or_session, security
 from .models import User
 from .state_store import StateStore, InMemoryStateStore, DynamoDBStateStore, create_state_store
 from .rbac import require_app_roles, require_admin
 
 __all__ = [
     "get_current_user",
+    "get_current_user_or_session",
     "security",
     "User",
     "StateStore",

--- a/backend/src/apis/shared/auth/dependencies.py
+++ b/backend/src/apis/shared/auth/dependencies.py
@@ -356,21 +356,63 @@ async def get_current_user_from_session(request: Request) -> User:
     return user
 
 
+async def get_current_user_or_session(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> User:
+    """Resolve the current user from either a BFF session cookie OR a Bearer token.
+
+    Phase 6 transition dependency. Routes that the SPA hits during normal
+    use are migrated from `Depends(get_current_user)` (Bearer-only) to this
+    so that:
+
+      - A SPA that has cut over to cookie auth (Phase 6c) authenticates
+        via the BFF session resolved by `SessionRefreshMiddleware`.
+      - Any caller still presenting a valid Bearer token (the SPA's
+        rollback bundle, scripted clients, third-party API consumers)
+        keeps working without code changes.
+
+    Resolution order: cookie first, Bearer second. If neither is present
+    or both fail, raises 401. The cookie path uses the BFF Cognito client
+    validator; the Bearer path uses the SPA Cognito client validator —
+    same as the standalone `get_current_user_from_session` and
+    `get_current_user` dependencies, just composed.
+
+    Phase 7 deletes this and the per-route swaps land back on the
+    cookie-only `get_current_user_from_session` once the Bearer code
+    path is removed from the SPA.
+    """
+    record = getattr(request.state, "bff_session", None)
+    if record is not None:
+        # Cookie-bearing request — defer to the cookie validator. Mirrors
+        # `get_current_user_from_session` so behaviour matches the
+        # cookie-only routes byte-for-byte.
+        return await get_current_user_from_session(request)
+
+    if credentials is not None:
+        # Bearer fallback — defer to the Bearer validator with the same
+        # enrichment / sync side-effects as the standalone dependency.
+        return await get_current_user(credentials)
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required. Provide a BFF session cookie or a Bearer token.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
 async def get_current_user_id(
-    user: User = Depends(get_current_user)
+    user: User = Depends(get_current_user_or_session)
 ) -> str:
     """
     FastAPI dependency to get the current user's ID as a string.
 
-    This is a convenience wrapper around get_current_user that extracts
-    just the user_id field. Useful when you only need the user ID and not
-    the full User object.
-
-    Args:
-        user: User object from get_current_user dependency
-
-    Returns:
-        User ID string
+    Convenience wrapper around `get_current_user_or_session` that returns
+    just the user_id field. Phase 6 changed the underlying dep from
+    Bearer-only `get_current_user` to the dual-auth
+    `get_current_user_or_session` so routes that only need the user ID
+    accept the same auth shapes (cookie OR Bearer) as the rest of the
+    SPA-facing surface.
     """
     return user.user_id
 

--- a/backend/src/apis/shared/auth/rbac.py
+++ b/backend/src/apis/shared/auth/rbac.py
@@ -9,7 +9,7 @@ from typing import Callable
 from fastapi import Depends, HTTPException, status
 import logging
 
-from .dependencies import get_current_user
+from .dependencies import get_current_user_or_session
 from .models import User
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def require_app_roles(*required_app_roles: str) -> Callable:
     Raises:
         HTTPException: 403 if user lacks all required AppRoles
     """
-    async def checker(user: User = Depends(get_current_user)) -> User:
+    async def checker(user: User = Depends(get_current_user_or_session)) -> User:
         from apis.shared.rbac.service import get_app_role_service
 
         try:

--- a/backend/tests/apis/app_api/auth/bff/test_login.py
+++ b/backend/tests/apis/app_api/auth/bff/test_login.py
@@ -89,3 +89,61 @@ def test_login_states_are_unique_per_request(app_for_login):
         )
     )["state"]
     assert s1 != s2
+
+
+# ─── identity_provider passthrough (Phase 6c) ──────────────────────────
+
+
+def _authorize_params(response) -> dict[str, str]:
+    return dict(
+        urllib.parse.parse_qsl(
+            urllib.parse.urlparse(response.headers["location"]).query
+        )
+    )
+
+
+def test_login_forwards_provider_to_cognito_as_identity_provider(app_for_login):
+    """Phase 6c: SPA's federated-login buttons pass `?provider=<idp>` so
+    Cognito skips the Hosted UI chooser and lands on the right IdP."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login?provider=GoogleSSO")
+
+    assert response.status_code == 302
+    params = _authorize_params(response)
+    assert params["identity_provider"] == "GoogleSSO"
+    # Other authorize params still present.
+    assert params["response_type"] == "code"
+    assert params["state"]
+
+
+def test_login_omits_identity_provider_when_provider_param_absent(app_for_login):
+    """No `?provider=` → Cognito Hosted UI shows its provider chooser."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+
+    params = _authorize_params(response)
+    assert "identity_provider" not in params
+
+
+@pytest.mark.parametrize(
+    "bad_provider",
+    [
+        "Google\r\nSet-Cookie: x=y",  # CRLF injection — would split the URL
+        "evil%20<script>",            # angle brackets / spaces
+        "google&extra=injected",      # `&` would split out a forged param
+        "x" * 200,                    # over the length cap
+        "",                           # empty — distinct from "absent"
+    ],
+)
+def test_login_silently_drops_malformed_provider(app_for_login, bad_provider):
+    """Reject silently rather than 4xx — an old SPA bundle that sends an
+    invalid provider should still complete login through the chooser
+    instead of dead-ending on a 400."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get(
+        "/auth/login", params={"provider": bad_provider}
+    )
+
+    assert response.status_code == 302
+    params = _authorize_params(response)
+    assert "identity_provider" not in params

--- a/backend/tests/apis/app_api/chat/test_proxy_routes.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes.py
@@ -190,6 +190,54 @@ def test_forwards_request_body_verbatim(
     assert captured["content_type"] == "application/json"
 
 
+def test_forwards_oauth2_callback_url_header(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
+) -> None:
+    """The SPA sets OAuth2CallbackUrl on /chat/stream so inference-api's
+    AgentCoreContextMiddleware can scope on-tool OAuth consent redirects
+    back to the SPA's origin. The proxy must forward it verbatim — without
+    it, `oauth_required` SSE events can't complete a consent flow."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["oauth_callback"] = request.headers.get("oauth2callbackurl")
+        return httpx.Response(
+            200, content=b"event: done\ndata: {}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(record=_record(), user_override=_user())
+
+    TestClient(app).post(
+        chat_path,
+        json={"message": "hi"},
+        headers={"OAuth2CallbackUrl": "https://app.example.com/oauth-complete"},
+    )
+    assert captured["oauth_callback"] == "https://app.example.com/oauth-complete"
+
+
+def test_omits_oauth2_callback_url_header_when_caller_did_not_send_one(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
+) -> None:
+    """No SPA-supplied header → don't synthesize one. Inference-api falls
+    back to its env-var default (set by CDK) when missing."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["oauth_callback"] = request.headers.get("oauth2callbackurl")
+        return httpx.Response(
+            200, content=b"event: done\ndata: {}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(record=_record(), user_override=_user())
+
+    TestClient(app).post(chat_path, json={"message": "hi"})
+    assert captured["oauth_callback"] is None
+
+
 def test_targets_invocations_path_on_inference_api(
     monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:

--- a/backend/tests/apis/app_api/chat/test_proxy_routes.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes.py
@@ -1,9 +1,12 @@
-"""Tests for `POST /chat/proxy-stream` (Phase 4 BFF chat proxy).
+"""Tests for the BFF chat proxy (Phase 4 + Phase 6).
 
 Covers the proxy mechanics in isolation — auth gate, body/header relay,
-SSE streaming, and error mapping. The full SessionRefreshMiddleware ↔
-CSRFMiddleware stack is exercised separately in
-`test_proxy_routes_csrf.py`.
+SSE streaming, and error mapping. Every test is parametrized over both
+registered paths (`/chat/stream` and `/chat/proxy-stream`) so the
+duplicate route registration in proxy_routes.py stays a true alias and
+can't drift into two divergent handlers. The full
+SessionRefreshMiddleware ↔ CSRFMiddleware stack is exercised separately
+in `test_proxy_routes_csrf.py`.
 """
 
 from __future__ import annotations
@@ -93,19 +96,28 @@ def _patch_upstream(
     )
 
 
+# Both registered paths must behave identically. Phase 6 ships /chat/stream
+# alongside the original /chat/proxy-stream; Phase 7 deletes the latter.
+@pytest.fixture(params=["/chat/stream", "/chat/proxy-stream"])
+def chat_path(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
 # ── Auth gate ─────────────────────────────────────────────────────────────
 
 
-def test_returns_401_when_no_session_attached() -> None:
+def test_returns_401_when_no_session_attached(chat_path: str) -> None:
     app = _build_app(record=None)
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 401
 
 
 # ── Happy path: SSE relay ─────────────────────────────────────────────────
 
 
-def test_relays_sse_response_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_relays_sse_response_verbatim(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     sse_body = (
         b'event: message_start\ndata: {"role": "assistant"}\n\n'
         b'event: content_block_delta\ndata: {"text": "hello"}\n\n'
@@ -124,7 +136,7 @@ def test_relays_sse_response_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/event-stream")
@@ -133,7 +145,9 @@ def test_relays_sse_response_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.content == sse_body
 
 
-def test_forwards_authorization_bearer_from_session(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_forwards_authorization_bearer_from_session(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -146,11 +160,13 @@ def test_forwards_authorization_bearer_from_session(monkeypatch: pytest.MonkeyPa
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user(raw_token="the-stored-token"))
 
-    TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    TestClient(app).post(chat_path, json={"message": "hi"})
     assert captured["authorization"] == "Bearer the-stored-token"
 
 
-def test_forwards_request_body_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_forwards_request_body_verbatim(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -166,7 +182,7 @@ def test_forwards_request_body_verbatim(monkeypatch: pytest.MonkeyPatch) -> None
 
     payload = b'{"session_id":"s1","message":"hello there","enabled_tools":["foo"]}'
     TestClient(app).post(
-        "/chat/proxy-stream",
+        chat_path,
         content=payload,
         headers={"Content-Type": "application/json"},
     )
@@ -175,7 +191,7 @@ def test_forwards_request_body_verbatim(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_targets_invocations_path_on_inference_api(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:
     monkeypatch.setattr(proxy_routes, "_INFERENCE_API_URL", "http://upstream:9999")
     captured: dict = {}
@@ -190,7 +206,7 @@ def test_targets_invocations_path_on_inference_api(
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    TestClient(app).post(chat_path, json={"message": "hi"})
     assert captured["url"] == "http://upstream:9999/invocations"
 
 
@@ -198,7 +214,7 @@ def test_targets_invocations_path_on_inference_api(
 
 
 def test_relays_non_sse_response_with_status_and_content_type(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         # Simulate inference-api returning a non-streaming success — a small
@@ -212,7 +228,7 @@ def test_relays_non_sse_response_with_status_and_content_type(
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
     assert response.content == b'{"ok": true}'
@@ -221,54 +237,58 @@ def test_relays_non_sse_response_with_status_and_content_type(
 # ── Upstream error propagation ────────────────────────────────────────────
 
 
-def test_propagates_upstream_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_propagates_upstream_4xx(monkeypatch: pytest.MonkeyPatch, chat_path: str) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, content=b"token rejected by inference-api")
 
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 401
     assert "token rejected" in response.text
 
 
-def test_propagates_upstream_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_propagates_upstream_5xx(monkeypatch: pytest.MonkeyPatch, chat_path: str) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, content=b"upstream overloaded")
 
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 503
 
 
-def test_returns_502_when_upstream_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_returns_502_when_upstream_unreachable(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("Connection refused")
 
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 502
     assert response.json()["detail"] == "Inference API is unreachable"
 
 
-def test_returns_504_on_upstream_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_returns_504_on_upstream_timeout(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ReadTimeout("Read timed out")
 
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 504
 
 
 def test_returns_502_on_unexpected_upstream_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise RuntimeError("something is on fire")
@@ -276,5 +296,5 @@ def test_returns_502_on_unexpected_upstream_error(
     _patch_upstream(monkeypatch, handler)
     app = _build_app(record=_record(), user_override=_user())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 502

--- a/backend/tests/apis/app_api/chat/test_proxy_routes_csrf.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes_csrf.py
@@ -1,9 +1,11 @@
-"""CSRF integration tests for `POST /chat/proxy-stream`.
+"""CSRF integration tests for the BFF chat proxy.
 
-`/chat/proxy-stream` is a POST that rides the BFF session cookie, so it
-MUST be guarded by CSRFMiddleware. This file confirms (a) the route is
-not accidentally listed in the middleware's exempt set, and (b) a valid
-double-submit token allows the request through.
+Both `/chat/stream` (Phase 6) and `/chat/proxy-stream` (Phase 4) are
+POSTs that ride the BFF session cookie, so both MUST be guarded by
+CSRFMiddleware. This file confirms (a) neither route is accidentally
+listed in the middleware's exempt set, and (b) a valid double-submit
+token allows the request through. Tests are parametrized over both
+paths so the alias guarantee can't drift.
 """
 
 from __future__ import annotations
@@ -98,17 +100,26 @@ def _patch_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_proxy_stream_without_csrf_returns_403(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(params=["/chat/stream", "/chat/proxy-stream"])
+def chat_path(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+def test_proxy_stream_without_csrf_returns_403(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     """Session attached but no CSRF cookie/header → CSRF middleware rejects."""
     _patch_upstream(monkeypatch)
     app = _build_app(record=_record())
 
-    response = TestClient(app).post("/chat/proxy-stream", json={"message": "hi"})
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 403
     assert "CSRF" in response.json()["detail"]
 
 
-def test_proxy_stream_with_valid_csrf_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_proxy_stream_with_valid_csrf_passes(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
     record = _record()
     csrf_token = CSRFHelper.derive_token(record.csrf_secret, record.session_id)
 
@@ -116,7 +127,7 @@ def test_proxy_stream_with_valid_csrf_passes(monkeypatch: pytest.MonkeyPatch) ->
     app = _build_app(record=record)
 
     response = TestClient(app).post(
-        "/chat/proxy-stream",
+        chat_path,
         json={"message": "hi"},
         cookies={CSRF_COOKIE_NAME: csrf_token},
         headers={CSRF_HEADER_NAME: csrf_token},
@@ -126,7 +137,7 @@ def test_proxy_stream_with_valid_csrf_passes(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_proxy_stream_csrf_header_mismatch_returns_403(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:
     """Cookie present but header value differs — classic forged-form scenario."""
     record = _record()
@@ -136,7 +147,7 @@ def test_proxy_stream_csrf_header_mismatch_returns_403(
     app = _build_app(record=record)
 
     response = TestClient(app).post(
-        "/chat/proxy-stream",
+        chat_path,
         json={"message": "hi"},
         cookies={CSRF_COOKIE_NAME: csrf_token},
         headers={CSRF_HEADER_NAME: "different-token"},
@@ -144,10 +155,13 @@ def test_proxy_stream_csrf_header_mismatch_returns_403(
     assert response.status_code == 403
 
 
-def test_proxy_stream_path_not_in_csrf_exempt_set() -> None:
-    """Future-proofing: surface a regression if someone adds /chat/proxy-stream
-    to the CSRF exempt list. The point of this proxy is to be guarded —
-    exempting it would defeat the whole BFF-cookie security model."""
+def test_chat_proxy_paths_not_in_csrf_exempt_set() -> None:
+    """Future-proofing: surface a regression if someone adds either chat
+    proxy path to the CSRF exempt list. The point of this proxy is to be
+    guarded — exempting it would defeat the whole BFF-cookie security
+    model. Both paths must be checked because Phase 6 introduces
+    /chat/stream alongside the original /chat/proxy-stream."""
     from apis.shared.middleware.csrf import _EXEMPT_PATHS
 
+    assert "/chat/stream" not in _EXEMPT_PATHS
     assert "/chat/proxy-stream" not in _EXEMPT_PATHS

--- a/backend/tests/apis/app_api/test_connectors_routes.py
+++ b/backend/tests/apis/app_api/test_connectors_routes.py
@@ -52,14 +52,16 @@ def _make_user(user_id: str) -> User:
 @pytest.fixture
 def app_for_user():
     """Build a minimal FastAPI app with the connectors router mounted and
-    the `get_current_user` dependency stubbed to a specific user.
+    the dual-auth `get_current_user_or_session` dependency stubbed to a
+    specific user. Phase 6 swapped these routes from Bearer-only auth to
+    cookie-or-Bearer; the override key has to track that.
     Returns a factory so each test picks the caller's identity.
     """
 
     def _build(user_id: str) -> FastAPI:
         app = FastAPI()
         app.include_router(routes.router)
-        app.dependency_overrides[routes.get_current_user] = lambda: _make_user(user_id)
+        app.dependency_overrides[routes.get_current_user_or_session] = lambda: _make_user(user_id)
         return app
 
     return _build

--- a/backend/tests/apis/shared/sessions_bff/test_dependency_user_or_session.py
+++ b/backend/tests/apis/shared/sessions_bff/test_dependency_user_or_session.py
@@ -1,0 +1,173 @@
+"""Tests for `get_current_user_or_session` (Phase 6 dual-auth dep).
+
+The dependency resolves the current user from either a BFF session
+cookie OR a Bearer token. It exists only for the Phase 6 → 7 transition
+window: routes the SPA hits during normal use are migrated to this dep
+so that a SPA still on the Bearer rollback bundle and a SPA on the new
+cookie bundle both work against the same backend.
+
+Resolution order: cookie first, Bearer second. The two underlying paths
+delegate to `get_current_user_from_session` and `get_current_user`
+respectively, both of which have their own coverage — these tests pin
+down only the COMPOSITION (which path gets picked, what 401 looks like
+when neither is available, that the cookie path wins when both are
+present).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from apis.shared.auth.dependencies import get_current_user_or_session
+from apis.shared.auth.models import User
+from apis.shared.sessions_bff.models import SessionRecord
+
+
+def _record() -> SessionRecord:
+    now = int(time.time())
+    return SessionRecord(
+        session_id="sess-001",
+        user_id="cookie-user",
+        username="alice",
+        cognito_access_token="cookie.access.token",
+        cognito_refresh_token="cookie.refresh.token",
+        id_token="cookie.id.token",
+        access_token_exp=now + 3600,
+        csrf_secret="csrf-secret",
+        created_at=now,
+        last_seen_at=now,
+        ttl=now + 28800,
+    )
+
+
+class _AttachSession(BaseHTTPMiddleware):
+    def __init__(self, app, record: SessionRecord | None) -> None:
+        super().__init__(app)
+        self._record = record
+
+    async def dispatch(self, request, call_next):
+        if self._record is not None:
+            request.state.bff_session = self._record
+        return await call_next(request)
+
+
+def _build_app(*, record: SessionRecord | None) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(_AttachSession, record=record)
+
+    @app.get("/me")
+    async def me(user: User = Depends(get_current_user_or_session)):
+        return {"user_id": user.user_id, "via": "cookie" if user.user_id == "cookie-user" else "bearer"}
+
+    return app
+
+
+def _noop_enrich(_user):
+    return None
+
+
+def test_uses_cookie_when_session_attached() -> None:
+    """Cookie path: bff_session is on request.state, no Bearer needed."""
+    fake_validator = MagicMock()
+    fake_validator.validate_token.return_value = User(
+        email="alice@example.com",
+        user_id="cookie-user",
+        name="Alice",
+        roles=["user"],
+    )
+    with patch(
+        "apis.shared.auth.dependencies._get_bff_cognito_validator",
+        return_value=fake_validator,
+    ), patch(
+        "apis.shared.auth.dependencies._enrich_user_from_store",
+        side_effect=_noop_enrich,
+    ), patch(
+        "apis.shared.auth.dependencies._get_user_sync_service",
+        return_value=None,
+    ):
+        app = _build_app(record=_record())
+        response = TestClient(app).get("/me")
+        assert response.status_code == 200
+        assert response.json() == {"user_id": "cookie-user", "via": "cookie"}
+        fake_validator.validate_token.assert_called_once_with("cookie.access.token")
+
+
+def test_falls_back_to_bearer_when_no_session() -> None:
+    """No session attached → Bearer path runs against the SPA validator."""
+    fake_validator = MagicMock()
+    fake_validator.validate_token.return_value = User(
+        email="bob@example.com",
+        user_id="bearer-user",
+        name="Bob",
+        roles=["user"],
+    )
+    with patch(
+        "apis.shared.auth.dependencies._get_cognito_validator",
+        return_value=fake_validator,
+    ), patch(
+        "apis.shared.auth.dependencies._enrich_user_from_store",
+        side_effect=_noop_enrich,
+    ), patch(
+        "apis.shared.auth.dependencies._get_user_sync_service",
+        return_value=None,
+    ):
+        app = _build_app(record=None)
+        response = TestClient(app).get(
+            "/me", headers={"Authorization": "Bearer the-bearer-token"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"user_id": "bearer-user", "via": "bearer"}
+        fake_validator.validate_token.assert_called_once_with("the-bearer-token")
+
+
+def test_cookie_takes_precedence_when_both_present() -> None:
+    """Both Bearer and cookie present → cookie wins. This is the SPA's
+    rollback bundle scenario: the user has a stale localStorage Bearer
+    token AND a fresh BFF session cookie. The cookie is the post-cutover
+    truth source, so it should authoritatively decide."""
+    cookie_validator = MagicMock()
+    cookie_validator.validate_token.return_value = User(
+        email="alice@example.com",
+        user_id="cookie-user",
+        name="Alice",
+        roles=["user"],
+    )
+    bearer_validator = MagicMock()  # Should never be called
+
+    with patch(
+        "apis.shared.auth.dependencies._get_bff_cognito_validator",
+        return_value=cookie_validator,
+    ), patch(
+        "apis.shared.auth.dependencies._get_cognito_validator",
+        return_value=bearer_validator,
+    ), patch(
+        "apis.shared.auth.dependencies._enrich_user_from_store",
+        side_effect=_noop_enrich,
+    ), patch(
+        "apis.shared.auth.dependencies._get_user_sync_service",
+        return_value=None,
+    ):
+        app = _build_app(record=_record())
+        response = TestClient(app).get(
+            "/me", headers={"Authorization": "Bearer stale-bearer-token"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"user_id": "cookie-user", "via": "cookie"}
+        cookie_validator.validate_token.assert_called_once_with("cookie.access.token")
+        bearer_validator.validate_token.assert_not_called()
+
+
+def test_returns_401_when_neither_cookie_nor_bearer_present() -> None:
+    """Anonymous request: no session on state, no Authorization header."""
+    app = _build_app(record=None)
+    response = TestClient(app).get("/me")
+    assert response.status_code == 401
+    assert response.json()["detail"].startswith("Authentication required")
+    # Carries the WWW-Authenticate header so the SPA bootstrap path can
+    # distinguish "session expired" from "service down".
+    assert response.headers.get("www-authenticate") == "Bearer"

--- a/backend/tests/fine_tuning/test_admin_routes.py
+++ b/backend/tests/fine_tuning/test_admin_routes.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 from apis.shared.auth.models import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.shared.auth.rbac import require_admin
 from apis.app_api.fine_tuning.repository import FineTuningAccessRepository
 
@@ -27,7 +27,7 @@ def _create_app():
 
 
 def _override_auth(app: FastAPI, user: User):
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_current_user_or_session] = lambda: user
     app.dependency_overrides[require_admin] = lambda: user
 
 

--- a/backend/tests/fine_tuning/test_inference_routes.py
+++ b/backend/tests/fine_tuning/test_inference_routes.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth.models import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.app_api.fine_tuning.routes import router
 from apis.app_api.fine_tuning.dependencies import require_fine_tuning_access
 from apis.app_api.fine_tuning.job_repository import get_fine_tuning_jobs_repository
@@ -27,7 +27,7 @@ def _setup_deps(
     jobs_repo=None, inf_repo=None, s3_service=None,
     sagemaker=None, access_repo=None,
 ):
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_current_user_or_session] = lambda: user
     app.dependency_overrides[require_fine_tuning_access] = lambda: grant
     if jobs_repo:
         app.dependency_overrides[get_fine_tuning_jobs_repository] = lambda: jobs_repo
@@ -559,7 +559,7 @@ class TestRequiresAccess:
         app.dependency_overrides[require_fine_tuning_access] = _raise_403
 
         user = make_user(email="denied@example.com")
-        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_user_or_session] = lambda: user
 
         client = TestClient(app)
 

--- a/backend/tests/fine_tuning/test_job_routes.py
+++ b/backend/tests/fine_tuning/test_job_routes.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth.models import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.app_api.fine_tuning.routes import router, _estimate_training_progress
 from apis.app_api.fine_tuning.dependencies import require_fine_tuning_access
 from apis.app_api.fine_tuning.job_repository import get_fine_tuning_jobs_repository
@@ -25,7 +25,7 @@ def _create_app():
 
 
 def _setup_deps(app, user, grant, jobs_repo=None, s3_service=None, sagemaker=None, access_repo=None, script_service=None):
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_current_user_or_session] = lambda: user
     app.dependency_overrides[require_fine_tuning_access] = lambda: grant
     if jobs_repo:
         app.dependency_overrides[get_fine_tuning_jobs_repository] = lambda: jobs_repo
@@ -471,7 +471,7 @@ class TestRequiresAccess:
         app.dependency_overrides[require_fine_tuning_access] = _raise_403
 
         user = make_user(email="denied@example.com")
-        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_user_or_session] = lambda: user
 
         client = TestClient(app)
 

--- a/backend/tests/fine_tuning/test_user_routes.py
+++ b/backend/tests/fine_tuning/test_user_routes.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth.models import User
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user_or_session
 from apis.app_api.fine_tuning.routes import router
 from apis.app_api.fine_tuning.repository import get_fine_tuning_access_repository
 
@@ -18,7 +18,7 @@ def _create_app():
 
 
 def _override_auth(app: FastAPI, user: User):
-    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_current_user_or_session] = lambda: user
 
 
 def _override_repo(app: FastAPI, repo: MagicMock):
@@ -75,7 +75,7 @@ class TestCheckAccess:
 
         def _raise_401():
             raise HTTPException(status_code=401, detail="Not authenticated")
-        app.dependency_overrides[get_current_user] = _raise_401
+        app.dependency_overrides[get_current_user_or_session] = _raise_401
 
         client = TestClient(app)
         resp = client.get("/fine-tuning/access")

--- a/backend/tests/routes/conftest.py
+++ b/backend/tests/routes/conftest.py
@@ -25,7 +25,7 @@ import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user, get_current_user_or_session
 from apis.shared.auth.models import User
 
 
@@ -92,17 +92,29 @@ def make_user():
 
 
 def mock_auth_user(app: FastAPI, user: User) -> None:
-    """Override get_current_user to return the given User.
+    """Override the auth dependency to return the given User.
 
     Requirement 1.1: authenticated TestClient with Auth_Dependency overridden.
+
+    Overrides BOTH `get_current_user` (Bearer-only) and
+    `get_current_user_or_session` (cookie-or-Bearer, Phase 6 dep) so
+    routes that have migrated to the dual-auth dep also see the mocked
+    user. Without the second override they'd hit the real cookie/Bearer
+    resolution path and 401.
     """
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_current_user_or_session] = lambda: user
 
 
 def mock_no_auth(app: FastAPI) -> None:
-    """Override get_current_user to raise HTTP 401.
+    """Override the auth dependencies to raise HTTP 401.
 
     Requirement 1.2: unauthenticated TestClient behaviour.
+
+    Both Bearer (`get_current_user`) and dual-auth
+    (`get_current_user_or_session`) dependencies are overridden so the
+    "no auth provided" assertion holds regardless of which dep the route
+    uses.
     """
 
     def _raise_401():
@@ -112,6 +124,7 @@ def mock_no_auth(app: FastAPI) -> None:
         )
 
     app.dependency_overrides[get_current_user] = _raise_401
+    app.dependency_overrides[get_current_user_or_session] = _raise_401
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routes/test_chat.py
+++ b/backend/tests/routes/test_chat.py
@@ -3,7 +3,7 @@
 Endpoints under test:
 - POST /chat/generate-title  → 200 with generated title
 - POST /chat/generate-title  → 401 for unauthenticated request
-- POST /chat/stream           → streaming response with text/event-stream
+- POST /chat/agent-stream           → streaming response with text/event-stream
 - POST /chat/multimodal       → streaming response
 
 Requirements: 5.1, 5.2, 5.3, 5.4
@@ -95,12 +95,12 @@ class TestGenerateTitle:
 
 
 # ---------------------------------------------------------------------------
-# Requirement 5.3: POST /chat/stream returns streaming response
+# Requirement 5.3: POST /chat/agent-stream returns streaming response
 # ---------------------------------------------------------------------------
 
 
 class TestChatStream:
-    """POST /chat/stream returns a streaming response."""
+    """POST /chat/agent-stream returns a streaming response."""
 
     def test_returns_streaming_response(self, app, make_user, authenticated_client):
         """Req 5.3: Should return streaming response with text/event-stream."""
@@ -138,7 +138,7 @@ class TestChatStream:
             mock_tool_svc.return_value = mock_tool_access
 
             resp = client.post(
-                "/chat/stream",
+                "/chat/agent-stream",
                 json={
                     "session_id": "sess-001",
                     "message": "Hello, how are you?",
@@ -152,7 +152,7 @@ class TestChatStream:
         """Req 5.3: Should return 401 when no auth is provided."""
         client = unauthenticated_client(app)
         resp = client.post(
-            "/chat/stream",
+            "/chat/agent-stream",
             json={"session_id": "sess-001", "message": "Hello"},
         )
         assert resp.status_code == 401

--- a/backend/tests/routes/test_delete_endpoints.py
+++ b/backend/tests/routes/test_delete_endpoints.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from apis.app_api.documents.routes import router as documents_router
 from apis.app_api.assistants.routes import router as assistants_router
 from apis.app_api.documents.models import Document
-from apis.shared.auth.dependencies import get_current_user_id, get_current_user
+from apis.shared.auth.dependencies import get_current_user_id, get_current_user_or_session
 from apis.shared.auth.models import User
 
 
@@ -144,7 +144,7 @@ class TestAssistantDeleteEndpoint:
     def app(self):
         _app = FastAPI()
         _app.include_router(assistants_router)
-        _app.dependency_overrides[get_current_user] = _make_user
+        _app.dependency_overrides[get_current_user_or_session] = _make_user
         return _app
 
     def test_delete_soft_deletes_all_docs(self, app):

--- a/backend/tests/routes/test_pbt_auth_sweep.py
+++ b/backend/tests/routes/test_pbt_auth_sweep.py
@@ -18,7 +18,7 @@ from fastapi.testclient import TestClient
 from hypothesis import given, settings, HealthCheck
 from hypothesis import strategies as st
 
-from apis.shared.auth.dependencies import get_current_user
+from apis.shared.auth.dependencies import get_current_user, get_current_user_or_session
 from apis.shared.auth.models import User
 from apis.shared.auth.rbac import require_admin
 
@@ -164,7 +164,11 @@ class TestNonAdminRoleRejection:
             name="Property 4 User",
             roles=roles,
         )
+        # `require_admin` was migrated to `get_current_user_or_session` in
+        # Phase 6, so the override has to track the new dep — the legacy
+        # Bearer key is kept too for any test that still relies on it.
         app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_current_user_or_session] = lambda: user
 
         # Mock AppRoleService to return no admin AppRoles (simulates
         # JWT roles that don't map to system_admin in DynamoDB)

--- a/docs/feature-summaries/MULTIMODAL_FILE_ATTACHMENTS.md
+++ b/docs/feature-summaries/MULTIMODAL_FILE_ATTACHMENTS.md
@@ -42,7 +42,7 @@ Users can attach files to chat messages. Files are uploaded to S3 via pre-signed
 │  Frontend                      Backend                         AWS          │
 │  ────────                      ───────                         ───          │
 │                                                                             │
-│  1. POST /chat/stream          2. FileResolver.resolve_files()              │
+│  1. POST /chat/agent-stream    2. FileResolver.resolve_files()              │
 │     {message, file_upload_ids}    ─────────────────────────────► S3        │
 │     ─────────────────────────►    - Fetch each file from S3                │
 │                                   - Base64 encode content                   │

--- a/frontend/ai.client/src/app/app.config.spec.ts
+++ b/frontend/ai.client/src/app/app.config.spec.ts
@@ -1,6 +1,16 @@
 import { APP_INITIALIZER } from '@angular/core';
 import { ConfigService } from './services/config.service';
+import { SessionService } from './auth/session.service';
 import { appConfig } from './app.config';
+
+/**
+ * Phase 6c chained two services into APP_INITIALIZER: ConfigService loads
+ * runtime config first, then SessionService bootstraps the BFF cookie
+ * session. Tests below exercise both paths.
+ */
+function makeMockSessionService() {
+  return { bootstrap: vi.fn().mockResolvedValue(undefined) } as any;
+}
 
 describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => {
   describe('APP_INITIALIZER Configuration', () => {
@@ -19,13 +29,15 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
       );
     });
 
-    it('should have ConfigService as dependency for APP_INITIALIZER', () => {
+    it('should have ConfigService and SessionService as dependencies for APP_INITIALIZER', () => {
       const providers = appConfig.providers || [];
       const initializerProvider = providers.find(
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      expect(initializerProvider?.deps).toEqual([ConfigService]);
+      // Order matters — `initializeApp(configService, sessionService)`
+      // awaits config before bootstrap reads `appApiUrl`.
+      expect(initializerProvider?.deps).toEqual([ConfigService, SessionService]);
     });
 
     it('should configure APP_INITIALIZER as multi-provider', () => {
@@ -63,7 +75,7 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
       ) as any;
 
       // Execute the factory with the mock service
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
 
       // Verify it returns a function
       expect(typeof initializerFn).toBe('function');
@@ -93,7 +105,7 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
       ) as any;
 
       // Create and execute the initializer
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       const result = initializerFn();
 
       // Should be a Promise
@@ -130,12 +142,12 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      // Verify ConfigService is injected into the factory
-      expect(initializerProvider?.deps).toEqual([ConfigService]);
-      
+      // Verify both services are injected into the factory
+      expect(initializerProvider?.deps).toEqual([ConfigService, SessionService]);
+
       // Verify the factory function signature
       expect(initializerProvider?.useFactory).toBeDefined();
-      expect(initializerProvider?.useFactory.length).toBe(1); // Takes 1 argument (ConfigService)
+      expect(initializerProvider?.useFactory.length).toBe(2);
     });
   });
 
@@ -151,7 +163,7 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       initializerFn();
 
       // Should call loadConfig, not any other method
@@ -170,7 +182,7 @@ describe('APP_INITIALIZER Integration - App Bootstrap with Valid Config', () => 
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       const result = initializerFn();
 
       // The promise should reject (Angular will handle this)
@@ -196,7 +208,7 @@ describe('APP_INITIALIZER Integration - Fallback Scenarios', () => {
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       const result = initializerFn();
 
       // Should resolve successfully (fallback handled internally)
@@ -215,7 +227,7 @@ describe('APP_INITIALIZER Integration - Fallback Scenarios', () => {
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       
       // The initializer will reject, but Angular's error handling
       // should allow the app to continue (with fallback config)
@@ -243,7 +255,7 @@ describe('APP_INITIALIZER Integration - Fallback Scenarios', () => {
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       const result = initializerFn();
 
       await expect(result).resolves.toBeUndefined();
@@ -263,7 +275,7 @@ describe('APP_INITIALIZER Integration - Fallback Scenarios', () => {
         (p: any) => p.provide === APP_INITIALIZER
       ) as any;
 
-      const initializerFn = initializerProvider.useFactory(mockConfigService);
+      const initializerFn = initializerProvider.useFactory(mockConfigService, makeMockSessionService());
       const result = initializerFn();
 
       await expect(result).resolves.toBeUndefined();

--- a/frontend/ai.client/src/app/app.config.ts
+++ b/frontend/ai.client/src/app/app.config.ts
@@ -4,9 +4,11 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authInterceptor } from './auth/auth.interceptor';
+import { csrfInterceptor } from './auth/csrf.interceptor';
 import { errorInterceptor } from './auth/error.interceptor';
 import { MARKED_OPTIONS, MarkedOptions, MarkedRenderer, provideMarkdown } from 'ngx-markdown';
 import { ConfigService } from './services/config.service';
+import { SessionService } from './auth/session.service';
 
 function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -21,29 +23,45 @@ function markedOptionsFactory(): MarkedOptions {
 }
 
 /**
- * Application initialization factory
- * 
- * Loads runtime configuration from /config.json before the app starts.
- * This ensures all services have access to configuration values when they initialize.
- * 
- * The initialization:
- * - Fetches config.json from the server
- * - Validates the configuration structure
- * - Falls back to environment.ts if fetch fails
- * - Allows the app to continue even if config loading fails
- * 
- * @param configService - The ConfigService instance
- * @returns Factory function that returns a Promise
+ * Application initialization factory.
+ *
+ * Two things must happen before the SPA is allowed to start rendering:
+ *
+ *   1. `ConfigService.loadConfig()` fetches `/config.json` so every
+ *      service can read `appApiUrl`, `cognitoDomainUrl`, etc. without
+ *      racing the bootstrap.
+ *   2. `SessionService.bootstrap()` calls `GET ${appApiUrl}/auth/session`
+ *      to establish the BFF cookie session. On 401 it redirects to the
+ *      BFF's `/auth/login`, which routes to Cognito Hosted UI — this is
+ *      the new Phase 6c login entry point.
+ *
+ * They MUST run sequentially: `bootstrap()` reads `appApiUrl` out of
+ * `ConfigService` to compose the session URL. Multiple `APP_INITIALIZER`
+ * providers run in parallel via `Promise.all`, so we collapse both
+ * steps into a single factory that awaits them in order.
+ *
+ * Failure handling matches the dormant-Phase-5 contract on
+ * `SessionService.bootstrap()`: HTTP errors leave the SPA in a clean
+ * unauthenticated state without redirecting (so a transient outage
+ * doesn't kick everyone out); 401 specifically does redirect to the
+ * BFF login.
  */
-function initializeApp(configService: ConfigService) {
-  return () => configService.loadConfig();
+function initializeApp(configService: ConfigService, sessionService: SessionService) {
+  return async () => {
+    await configService.loadConfig();
+    await sessionService.bootstrap();
+  };
 }
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideHttpClient(
-      withInterceptors([authInterceptor, errorInterceptor]),
+      // Order matters: csrfInterceptor runs after authInterceptor so the
+      // Bearer fallback (still present for the rollback bundle) is
+      // attached first; CSRF then layers on top for the cookie path.
+      // errorInterceptor stays last so it sees the final response.
+      withInterceptors([authInterceptor, csrfInterceptor, errorInterceptor]),
     ),
     provideMarkdown({
       markedOptions: {
@@ -52,12 +70,13 @@ export const appConfig: ApplicationConfig = {
       },
     }),
     provideRouter(routes, withComponentInputBinding()),
-    
-    // Load runtime configuration before app starts
+
+    // Load runtime configuration AND bootstrap the BFF session before the
+    // first component renders. See `initializeApp` for the chaining rationale.
     {
       provide: APP_INITIALIZER,
       useFactory: initializeApp,
-      deps: [ConfigService],
+      deps: [ConfigService, SessionService],
       multi: true
     }
   ]

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { signal } from '@angular/core';
 import { PreviewChatService } from './preview-chat.service';
-import { AuthService } from '../../../auth/auth.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { ConfigService } from '../../../services/config.service';
 
 // Mock fetchEventSource
@@ -12,31 +12,32 @@ vi.mock('@microsoft/fetch-event-source', () => ({
 
 describe('PreviewChatService', () => {
   let service: PreviewChatService;
-  let authService: any;
+  let bffSession: any;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
-    
-    const authServiceMock = {
-      isTokenExpired: vi.fn().mockReturnValue(false),
-      getAccessToken: vi.fn().mockReturnValue('mock-token'),
-      refreshAccessToken: vi.fn(),
+
+    // Phase 6c: preview chat now goes through the BFF chat proxy with
+    // cookie auth, so the only auth surface the service touches is the
+    // CSRF helper on the BFF SessionService.
+    const bffSessionMock = {
+      csrfHeaders: vi.fn().mockReturnValue({}),
     };
 
     const configServiceMock = {
-      inferenceApiUrl: signal('http://localhost:8001'),
+      appApiUrl: signal('http://localhost:8000'),
     };
 
     TestBed.configureTestingModule({
       providers: [
         PreviewChatService,
-        { provide: AuthService, useValue: authServiceMock },
+        { provide: BffSessionService, useValue: bffSessionMock },
         { provide: ConfigService, useValue: configServiceMock },
       ],
     });
 
     service = TestBed.inject(PreviewChatService);
-    authService = TestBed.inject(AuthService);
+    bffSession = TestBed.inject(BffSessionService);
   });
 
   afterEach(() => {
@@ -104,15 +105,16 @@ describe('PreviewChatService', () => {
     expect(service.sessionId()).toMatch(/^preview-/);
   });
 
-  it('should handle auth token refresh', async () => {
-    authService.isTokenExpired.mockReturnValue(true);
-    authService.refreshAccessToken.mockResolvedValue(undefined);
+  it('attaches the CSRF header from the BFF SessionService when present', async () => {
+    bffSession.csrfHeaders.mockReturnValue({ 'X-CSRF-Token': 'tok-xyz' });
 
     const { fetchEventSource } = await import('@microsoft/fetch-event-source');
     (fetchEventSource as any).mockResolvedValue(undefined);
 
     await service.sendMessage('Hello', 'assistant-1');
 
-    expect(authService.refreshAccessToken).toHaveBeenCalled();
+    const init = (fetchEventSource as any).mock.calls.at(-1)[1];
+    expect(init.headers['X-CSRF-Token']).toBe('tok-xyz');
+    expect(init.credentials).toBe('include');
   });
 });

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal, computed } from '@angular/core';
 import { v4 as uuidv4 } from 'uuid';
 import { fetchEventSource, EventSourceMessage } from '@microsoft/fetch-event-source';
-import { AuthService } from '../../../auth/auth.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { ConfigService } from '../../../services/config.service';
 import { Message } from '../../../session/services/models/message.model';
 import { PREVIEW_SESSION_PREFIX } from '../../../shared/constants/session.constants';
@@ -26,7 +26,7 @@ import {
  */
 @Injectable()
 export class PreviewChatService {
-  private authService = inject(AuthService);
+  private bffSession = inject(BffSessionService);
   private config = inject(ConfigService);
 
   // Local state signals (isolated from global ChatStateService)
@@ -49,26 +49,6 @@ export class PreviewChatService {
 
   // Computed
   readonly hasMessages = computed(() => this.messagesSignal().length > 0);
-
-  /**
-   * Get bearer token for streaming responses (with refresh if needed)
-   */
-  private async getBearerTokenForStreamingResponse(): Promise<string> {
-    if (this.authService.isTokenExpired()) {
-      try {
-        await this.authService.refreshAccessToken();
-      } catch (error) {
-        console.error('Failed to refresh token:', error);
-      }
-    }
-
-    const token = this.authService.getAccessToken();
-    if (!token) {
-      throw new Error('No access token available');
-    }
-
-    return token;
-  }
 
   /**
    * Create callbacks for the stream parser.
@@ -188,14 +168,15 @@ export class PreviewChatService {
     const callbacks = this.createCallbacks();
 
     try {
-      const token = await this.getBearerTokenForStreamingResponse();
-
-      // Single runtime endpoint from configuration
-      const runtimeEndpointUrl = this.config.inferenceApiUrl();
-      if (!runtimeEndpointUrl) {
-        throw new Error('Inference API URL not configured. Please check your configuration.');
+      // Phase 6c: route the preview stream through the BFF chat proxy
+      // (cookie auth) instead of inference-api directly. Same SSE
+      // protocol; the proxy is transparent.
+      const appApiUrl = this.config.appApiUrl();
+      if (!appApiUrl) {
+        throw new Error('App API URL not configured. Please check your configuration.');
       }
-      const url = `${runtimeEndpointUrl}/invocations?qualifier=DEFAULT`;
+      const baseUrl = appApiUrl.endsWith('/') ? appApiUrl.slice(0, -1) : appApiUrl;
+      const url = `${baseUrl}/chat/stream`;
 
       // NOTE: Field name is 'rag_assistant_id' to avoid collision with AWS Bedrock
       // AgentCore Runtime's internal 'assistant_id' field handling (causes 424 error)
@@ -208,13 +189,18 @@ export class PreviewChatService {
         enabled_tools: [], // No tools in preview
       };
 
+      // `fetchEventSource` bypasses the HttpClient pipeline, so the
+      // csrfInterceptor doesn't run here. Attach X-CSRF-Token by hand.
+      const csrfHeaders = this.bffSession.csrfHeaders();
+
       await fetchEventSource(url, {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
           Accept: 'text/event-stream',
           OAuth2CallbackUrl: `${window.location.origin}/oauth-complete`,
+          ...csrfHeaders,
         },
         body: JSON.stringify(requestBody),
         signal: this.abortController.signal,

--- a/frontend/ai.client/src/app/auth/csrf.interceptor.spec.ts
+++ b/frontend/ai.client/src/app/auth/csrf.interceptor.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpRequest, HttpHandlerFn, HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { csrfInterceptor } from './csrf.interceptor';
+import { SessionService } from './session.service';
+
+describe('csrfInterceptor', () => {
+  let session: { csrfHeaders: ReturnType<typeof vi.fn> };
+
+  function runInterceptor(req: HttpRequest<unknown>): HttpRequest<unknown> {
+    let captured!: HttpRequest<unknown>;
+    const next: HttpHandlerFn = (forwarded) => {
+      captured = forwarded;
+      return of(new HttpResponse({ status: 200 }));
+    };
+    TestBed.runInInjectionContext(() => {
+      csrfInterceptor(req, next).subscribe();
+    });
+    return captured;
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    session = { csrfHeaders: vi.fn().mockReturnValue({}) };
+    TestBed.configureTestingModule({
+      providers: [{ provide: SessionService, useValue: session }],
+    });
+  });
+
+  it('skips GET, HEAD, and OPTIONS without consulting SessionService', () => {
+    // HttpRequest overloads accept GET/HEAD or OPTIONS/DELETE separately,
+    // so build each safe-method request through its specific overload.
+    const safeRequests: HttpRequest<unknown>[] = [
+      new HttpRequest('GET', '/api/auth/session'),
+      new HttpRequest('HEAD', '/api/auth/session'),
+      new HttpRequest('OPTIONS', '/api/auth/session'),
+    ];
+    for (const req of safeRequests) {
+      const forwarded = runInterceptor(req);
+      expect(forwarded).toBe(req);
+    }
+    // Skipping safe methods is the perf-sensitive happy path — no signal reads.
+    expect(session.csrfHeaders).not.toHaveBeenCalled();
+  });
+
+  it('passes the request through unchanged when SessionService has no token', () => {
+    session.csrfHeaders.mockReturnValue({});
+    const req = new HttpRequest('POST', '/api/sessions', {});
+    const forwarded = runInterceptor(req);
+    expect(forwarded).toBe(req);
+    expect(forwarded.headers.has('X-CSRF-Token')).toBe(false);
+  });
+
+  it('attaches X-CSRF-Token from SessionService on POST', () => {
+    session.csrfHeaders.mockReturnValue({ 'X-CSRF-Token': 'csrf-secret-abc' });
+    const req = new HttpRequest('POST', '/api/sessions/bulk-delete', { ids: [] });
+    const forwarded = runInterceptor(req);
+    expect(forwarded.headers.get('X-CSRF-Token')).toBe('csrf-secret-abc');
+    expect(forwarded.url).toBe('/api/sessions/bulk-delete');
+    expect(forwarded.body).toEqual({ ids: [] });
+  });
+
+  it('attaches the header on PUT, PATCH, and DELETE', () => {
+    session.csrfHeaders.mockReturnValue({ 'X-CSRF-Token': 'tok' });
+    const requests: HttpRequest<unknown>[] = [
+      new HttpRequest('PUT', '/api/x', {}),
+      new HttpRequest('PATCH', '/api/x', {}),
+      new HttpRequest('DELETE', '/api/x'),
+    ];
+    for (const req of requests) {
+      const forwarded = runInterceptor(req);
+      expect(forwarded.headers.get('X-CSRF-Token')).toBe('tok');
+    }
+  });
+});

--- a/frontend/ai.client/src/app/auth/csrf.interceptor.ts
+++ b/frontend/ai.client/src/app/auth/csrf.interceptor.ts
@@ -1,0 +1,44 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { SessionService } from './session.service';
+
+/**
+ * CSRF interceptor — mirrors the BFF session's CSRF token onto unsafe-method
+ * requests so app-api's `CSRFMiddleware` lets them through.
+ *
+ * Phase 6c wires this in alongside the existing `authInterceptor` (Bearer
+ * fallback) and `errorInterceptor`. The two auth paths coexist during the
+ * cutover and rollback window:
+ *
+ *   - Cookie path (post-cutover): browser auto-attaches `__Host-bff_session`
+ *     and `__Host-bff_csrf` (same-origin via CloudFront `/api/*`). This
+ *     interceptor reads the CSRF value out of `SessionService` (mirrored
+ *     into a JS-readable signal during `bootstrap()`) and sets it as the
+ *     `X-CSRF-Token` header so server-side double-submit succeeds.
+ *
+ *   - Bearer fallback (pre-cutover bundle, scripted callers): SessionService
+ *     never bootstrapped, `csrfHeaders()` returns `{}`, this interceptor is
+ *     a no-op and the request proceeds with whatever auth the caller set.
+ *
+ * Safe methods (GET/HEAD/OPTIONS) are skipped — `CSRFMiddleware` doesn't
+ * enforce on them anyway. `fetchEventSource` lives outside the HttpClient
+ * pipeline (chat SSE path), so chat-http.service.ts attaches the header
+ * manually using the same `csrfHeaders()` helper.
+ */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export const csrfInterceptor: HttpInterceptorFn = (req, next) => {
+  if (SAFE_METHODS.has(req.method)) {
+    return next(req);
+  }
+
+  const session = inject(SessionService);
+  const headers = session.csrfHeaders();
+
+  if (Object.keys(headers).length === 0) {
+    return next(req);
+  }
+
+  return next(req.clone({ setHeaders: headers }));
+};

--- a/frontend/ai.client/src/app/auth/login/login.page.ts
+++ b/frontend/ai.client/src/app/auth/login/login.page.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
-import { AuthService } from '../auth.service';
+import { SessionService } from '../session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { ConfigService } from '../../services/config.service';
 import { SystemService } from '../../services/system.service';
@@ -141,7 +141,7 @@ interface AuthProviderPublicListResponse {
   `
 })
 export class LoginPage implements OnInit, OnDestroy {
-  private authService = inject(AuthService);
+  private sessionService = inject(SessionService);
   private sidenavService = inject(SidenavService);
   private config = inject(ConfigService);
   private http = inject(HttpClient);
@@ -192,35 +192,25 @@ export class LoginPage implements OnInit, OnDestroy {
     }
   }
 
-  async handleCognitoLogin(): Promise<void> {
+  handleCognitoLogin(): void {
     this.isLoading.set(true);
     this.activeProviderId.set(null);
     this.errorMessage.set(null);
 
-    try {
-      this.storeReturnUrl();
-      await this.authService.login();
-    } catch (error) {
-      this.isLoading.set(false);
-      const errorMsg = error instanceof Error ? error.message : 'An error occurred during login';
-      this.errorMessage.set(errorMsg);
-    }
+    // Persist the return URL for the rollback bundle (legacy AuthService
+    // reads it post-callback). Harmless under the BFF flow — the BFF
+    // server-side redirect goes to BFF_POST_LOGIN_REDIRECT_URL today.
+    this.storeReturnUrl();
+    this.sessionService.redirectToLogin();
   }
 
-  async handleProviderLogin(provider: AuthProviderPublicInfo): Promise<void> {
+  handleProviderLogin(provider: AuthProviderPublicInfo): void {
     this.isLoading.set(true);
     this.activeProviderId.set(provider.provider_id);
     this.errorMessage.set(null);
 
-    try {
-      this.storeReturnUrl();
-      await this.authService.login(provider.provider_id);
-    } catch (error) {
-      this.isLoading.set(false);
-      this.activeProviderId.set(null);
-      const errorMsg = error instanceof Error ? error.message : 'An error occurred during login';
-      this.errorMessage.set(errorMsg);
-    }
+    this.storeReturnUrl();
+    this.sessionService.redirectToLogin({ providerId: provider.provider_id });
   }
 
   /**

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -184,10 +184,34 @@ describe('SessionService', () => {
     });
 
     it('respects an explicit returnUrl', () => {
-      service.redirectToLogin('/somewhere/else');
+      service.redirectToLogin({ returnUrl: '/somewhere/else' });
 
       expect(window.location.href).toBe(
         'http://localhost:8000/auth/login?return_to=%2Fsomewhere%2Felse',
+      );
+    });
+
+    it('forwards providerId as the `provider` query param', () => {
+      window.location.pathname = '/';
+      window.location.search = '';
+
+      service.redirectToLogin({ providerId: 'GoogleSSO' });
+
+      // The BFF reads `provider` and forwards to Cognito as
+      // `identity_provider`, which short-circuits the Hosted UI chooser.
+      expect(window.location.href).toBe(
+        'http://localhost:8000/auth/login?return_to=%2F&provider=GoogleSSO',
+      );
+    });
+
+    it('skips the provider param when providerId is empty', () => {
+      window.location.pathname = '/';
+      window.location.search = '';
+
+      service.redirectToLogin({ providerId: '' });
+
+      expect(window.location.href).toBe(
+        'http://localhost:8000/auth/login?return_to=%2F',
       );
     });
   });

--- a/frontend/ai.client/src/app/auth/session.service.ts
+++ b/frontend/ai.client/src/app/auth/session.service.ts
@@ -87,14 +87,24 @@ export class SessionService {
    * Navigate the browser to `{appApiUrl}/auth/login`. The BFF stashes
    * a state cookie and 302s on to Cognito Hosted UI.
    *
-   * @param returnUrl Optional path to land on after the round-trip. The
-   *   BFF's `/auth/callback` honours its own `BFF_POST_LOGIN_REDIRECT_URL`
-   *   today; the `returnUrl` query is plumbed for a future enhancement
-   *   and is harmless if the BFF ignores it.
+   * @param options.returnUrl Optional path to land on after the round-trip.
+   *   The BFF's `/auth/callback` honours its own
+   *   `BFF_POST_LOGIN_REDIRECT_URL` today; the `return_to` query is plumbed
+   *   for a future enhancement and is harmless if the BFF ignores it.
+   * @param options.providerId Optional federated IdP name (e.g. the
+   *   value the SPA's federated-login button knows about). The BFF
+   *   forwards it to Cognito as `identity_provider` so the user skips
+   *   the Hosted UI chooser and lands on that IdP directly. The BFF
+   *   sanitises the value server-side; an unknown provider falls back
+   *   to the chooser rather than failing.
    */
-  redirectToLogin(returnUrl?: string): void {
-    const target = returnUrl ?? `${window.location.pathname}${window.location.search}`;
-    const params = new URLSearchParams({ return_to: target });
+  redirectToLogin(options?: { returnUrl?: string; providerId?: string }): void {
+    const returnUrl = options?.returnUrl
+      ?? `${window.location.pathname}${window.location.search}`;
+    const params = new URLSearchParams({ return_to: returnUrl });
+    if (options?.providerId) {
+      params.set('provider', options.providerId);
+    }
     window.location.href = `${this.baseUrl()}/auth/login?${params.toString()}`;
   }
 

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -4,13 +4,13 @@ import { Router } from '@angular/router';
 import { signal } from '@angular/core';
 import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
-import { AuthService } from '../../auth/auth.service';
+import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 
 describe('Sidenav', () => {
   let mockRouter: any;
   let mockSessionService: any;
-  let mockAuthService: any;
+  let mockBffSession: any;
   let mockSidenavService: any;
   let mockUserService: any;
 
@@ -21,7 +21,8 @@ describe('Sidenav', () => {
       currentSession: signal({ sessionId: 'test-session', userId: 'u1', title: 'Test Session', status: 'active' as const, createdAt: '', lastMessageAt: '', messageCount: 0 }),
       hasCurrentSession: signal(true),
     };
-    mockAuthService = { logout: vi.fn() };
+    // Phase 6c: logout is owned by the BFF SessionService now.
+    mockBffSession = { logout: vi.fn().mockResolvedValue(undefined) };
     mockSidenavService = {
       isCollapsed: signal(false),
       close: vi.fn(),
@@ -33,7 +34,7 @@ describe('Sidenav', () => {
       providers: [
         { provide: Router, useValue: mockRouter },
         { provide: SessionService, useValue: mockSessionService },
-        { provide: AuthService, useValue: mockAuthService },
+        { provide: BffSessionService, useValue: mockBffSession },
         { provide: SidenavService, useValue: mockSidenavService },
         { provide: UserService, useValue: mockUserService },
       ],
@@ -70,9 +71,10 @@ describe('Sidenav', () => {
     expect(mockSidenavService.toggleCollapsed).toHaveBeenCalled();
   });
 
-  it('should handle logout', async () => {
+  it('should handle logout via the BFF and route the user to /auth/login', async () => {
     const component = await createComponent();
-    component.handleLogout();
-    expect(mockAuthService.logout).toHaveBeenCalled();
+    await component.handleLogout();
+    expect(mockBffSession.logout).toHaveBeenCalledTimes(1);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/auth/login']);
   });
 });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -3,7 +3,7 @@ import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SessionList } from './components/session-list/session-list';
 import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
-import { AuthService } from '../../auth/auth.service';
+import { SessionService as BffSessionService } from '../../auth/session.service';
 import { UserDropdownComponent } from '../topnav/components/user-dropdown.component';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
@@ -17,7 +17,7 @@ import { TooltipDirective } from '../tooltip/tooltip.directive';
 export class Sidenav {
   private router = inject(Router);
   private sessionService = inject(SessionService);
-  private authService = inject(AuthService);
+  private bffSession = inject(BffSessionService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -51,7 +51,13 @@ export class Sidenav {
     this.sidenavService.toggleCollapsed();
   }
 
-  handleLogout() {
-    this.authService.logout();
+  async handleLogout(): Promise<void> {
+    // BFF logout: 204 + cleared cookies. The user is then anonymous;
+    // the next page navigation triggers SessionService.bootstrap() in
+    // APP_INITIALIZER, which 401s and redirects to BFF /auth/login.
+    // We push the user to /login explicitly here so the redirect-to-OAuth
+    // happens from a known route rather than wherever the sidenav lived.
+    await this.bffSession.logout();
+    this.router.navigate(['/auth/login']);
   }
 }

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
@@ -5,7 +5,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { signal } from '@angular/core';
 import { ChatHttpService } from './chat-http.service';
 import { ConfigService } from '../../../services/config.service';
-import { AuthService } from '../../../auth/auth.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { SessionService } from '../session/session.service';
 import { StreamParserService } from './stream-parser.service';
 import { ChatStateService } from './chat-state.service';
@@ -15,7 +15,6 @@ import { ErrorService } from '../../../services/error/error.service';
 describe('ChatHttpService', () => {
   let service: ChatHttpService;
   let httpMock: HttpTestingController;
-  let authService: any;
   let chatStateService: any;
 
   beforeEach(() => {
@@ -26,7 +25,10 @@ describe('ChatHttpService', () => {
         provideHttpClientTesting(),
         ChatHttpService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000'), inferenceApiUrl: signal('http://localhost:8001') } },
-        { provide: AuthService, useValue: { getAccessToken: vi.fn().mockReturnValue('tok'), isTokenExpired: vi.fn().mockReturnValue(false), refreshAccessToken: vi.fn(), ensureAuthenticated: vi.fn().mockResolvedValue(undefined), isAuthenticated: vi.fn().mockReturnValue(true), getProviderId: vi.fn().mockReturnValue('p1') } },
+        // Phase 6c: chat-http now reads CSRF from the BFF SessionService
+        // and lets cookie auth ride along with the request rather than
+        // attaching a Bearer manually.
+        { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}) } },
         { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn() } },
         { provide: StreamParserService, useValue: {} },
         { provide: ChatStateService, useValue: { isStreaming: signal(false), streamingSessionId: signal(null), abortCurrentRequest: vi.fn(), setChatLoading: vi.fn(), resetState: vi.fn(), getAbortController: vi.fn().mockReturnValue(new AbortController()) } },
@@ -36,7 +38,6 @@ describe('ChatHttpService', () => {
     });
     service = TestBed.inject(ChatHttpService);
     httpMock = TestBed.inject(HttpTestingController);
-    authService = TestBed.inject(AuthService);
     chatStateService = TestBed.inject(ChatStateService);
   });
 
@@ -63,32 +64,5 @@ describe('ChatHttpService', () => {
     expect(chatStateService.abortCurrentRequest).toHaveBeenCalled();
     expect(chatStateService.setChatLoading).toHaveBeenCalledWith(false);
     expect(chatStateService.resetState).toHaveBeenCalled();
-  });
-
-  it('should get bearer token for streaming response with valid token', async () => {
-    authService.isTokenExpired.mockReturnValue(false);
-    const token = await service.getBearerTokenForStreamingResponse();
-    expect(token).toBe('tok');
-    expect(authService.refreshAccessToken).not.toHaveBeenCalled();
-  });
-
-  it('should get bearer token for streaming response with expired token', async () => {
-    authService.isTokenExpired.mockReturnValue(true);
-    authService.refreshAccessToken.mockResolvedValue(undefined);
-    authService.getAccessToken.mockReturnValueOnce('tok').mockReturnValueOnce('new-tok');
-    const token = await service.getBearerTokenForStreamingResponse();
-    expect(token).toBe('new-tok');
-    expect(authService.refreshAccessToken).toHaveBeenCalled();
-  });
-
-  it('should throw error when no token available', async () => {
-    authService.getAccessToken.mockReturnValue(null);
-    await expect(service.getBearerTokenForStreamingResponse()).rejects.toThrow();
-  });
-
-  it('should throw error when token refresh fails', async () => {
-    authService.isTokenExpired.mockReturnValue(true);
-    authService.refreshAccessToken.mockRejectedValue(new Error('Refresh failed'));
-    await expect(service.getBearerTokenForStreamingResponse()).rejects.toThrow();
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -3,8 +3,8 @@ import { EventSourceMessage, fetchEventSource } from '@microsoft/fetch-event-sou
 import { StreamParserService } from './stream-parser.service';
 import { ChatStateService } from './chat-state.service';
 import { MessageMapService } from '../session/message-map.service';
-import { AuthService } from '../../../auth/auth.service';
 import { ConfigService } from '../../../services/config.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { firstValueFrom } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { SessionService } from '../session/session.service';
@@ -40,33 +40,48 @@ export class ChatHttpService {
   private streamParserService = inject(StreamParserService);
   private chatStateService = inject(ChatStateService);
   private messageMapService = inject(MessageMapService);
-  private authService = inject(AuthService);
   private config = inject(ConfigService);
   private http = inject(HttpClient);
   private sessionService = inject(SessionService);
+  private bffSession = inject(BffSessionService);
   private errorService = inject(ErrorService);
 
   async sendChatRequest(requestObject: any): Promise<void> {
     const abortController = this.chatStateService.getAbortController();
 
-    const token = await this.getBearerTokenForStreamingResponse();
+    // Phase 6c: stream goes through the app-api BFF proxy at
+    // `${appApiUrl}/chat/stream` (cookie auth) instead of hitting
+    // inference-api `/invocations` directly with a Bearer token. Same
+    // SSE protocol on the wire — the proxy is transparent. Cookies
+    // travel because the SPA and `/api/*` are same-origin via
+    // CloudFront; for local dev the same origin still works because
+    // the SPA is configured to point at `http://localhost:8000` (the
+    // app-api directly) and the BFF dual-auth dep accepts Bearer too.
+    const appApiUrl = this.config.appApiUrl();
+    if (!appApiUrl) {
+      throw new FatalError('App API URL not configured. Please check your configuration.');
+    }
+    const baseUrl = appApiUrl.endsWith('/') ? appApiUrl.slice(0, -1) : appApiUrl;
 
-        // Single runtime endpoint from configuration
-        const runtimeEndpointUrl = this.config.inferenceApiUrl();
-        if (!runtimeEndpointUrl) {
-          throw new FatalError('Inference API URL not configured. Please check your configuration.');
-        }
+    // `fetchEventSource` is outside the HttpClient pipeline, so the
+    // csrfInterceptor never runs against it — attach the X-CSRF-Token
+    // header manually using the same SessionService helper. Returns
+    // an empty object before bootstrap or in the Bearer rollback path.
+    const csrfHeaders = this.bffSession.csrfHeaders();
 
-    // Normalize: strip trailing /invocations if already present to avoid doubling
-    const baseUrl = runtimeEndpointUrl.replace(/\/invocations\/?$/, '');
-
-    return fetchEventSource(`${baseUrl}/invocations?qualifier=DEFAULT`, {
+    return fetchEventSource(`${baseUrl}/chat/stream`, {
       method: 'POST',
+      // Send the BFF session cookie (`__Host-bff_session`) on cross-origin
+      // dev (localhost:4200 → localhost:8000) and on same-origin prod
+      // (CloudFront). Browsers attach same-origin cookies regardless;
+      // `include` is the explicit form that also works cross-origin
+      // when the backend's CORS allows credentials.
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         Accept: 'text/event-stream',
         OAuth2CallbackUrl: `${window.location.origin}/oauth-complete`,
+        ...csrfHeaders,
       },
       body: JSON.stringify(requestObject),
       signal: abortController.signal,
@@ -228,29 +243,6 @@ export class ChatHttpService {
       // Don't show to user as it's a background operation
       throw error;
     }
-  }
-
-  async getBearerTokenForStreamingResponse(): Promise<string> {
-    // Get token from AuthService, refresh if expired
-    let token = this.authService.getAccessToken();
-    if (!token) {
-      throw new FatalError('No authentication token available. Please login again.');
-    }
-
-    // Check if token needs refresh
-    if (this.authService.isTokenExpired()) {
-      try {
-        await this.authService.refreshAccessToken();
-        token = this.authService.getAccessToken();
-        if (!token) {
-          throw new FatalError('Failed to refresh authentication token. Please login again.');
-        }
-      } catch (error) {
-        throw new FatalError('Failed to refresh authentication token. Please login again.');
-      }
-    }
-
-    return token;
   }
 
 }

--- a/infrastructure/lib/frontend-stack.ts
+++ b/infrastructure/lib/frontend-stack.ts
@@ -111,8 +111,14 @@ export class FrontendStack extends cdk.Stack {
     // accessed through the App API backend, not directly from the frontend.
     // ============================================================================
 
+    // Phase 6a (BFF cutover): SPA always talks to app-api via the same-origin
+    // CloudFront `/api/*` behavior added below. Keeping `appApiUrl` relative
+    // (a) eliminates CORS preflights on every request and (b) lets the SPA
+    // attach `__Host-` cookies without crossing origins. The absolute ALB URL
+    // imported from SSM still feeds the new HttpOrigin — it just isn't
+    // exposed to the browser anymore.
     const runtimeConfig = {
-      appApiUrl: appApiUrl,
+      appApiUrl: '/api',
       environment: config.production ? 'production' : 'development',
       version: config.appVersion,
       cognitoDomainUrl: cognitoDomainUrl,
@@ -123,6 +129,7 @@ export class FrontendStack extends cdk.Stack {
 
     console.log('🔧 Generated runtime configuration:');
     console.log(`   Environment: ${runtimeConfig.environment}`);
+    console.log(`   App API URL (browser): ${runtimeConfig.appApiUrl} (CloudFront /api/* → ALB ${appApiUrl})`);
 
     // Generate bucket name with account ID to ensure global uniqueness
     const bucketName = config.frontend.bucketName || 
@@ -205,6 +212,82 @@ export class FrontendStack extends cdk.Stack {
       }
     );
 
+    // ============================================================================
+    // BFF /api/* behavior — same-origin proxy to the app-api ALB
+    // ============================================================================
+    // Phase 6a of the BFF Token Handler migration. The SPA hits `/api/*` on the
+    // CloudFront origin; CloudFront forwards to the app-api ALB. This makes
+    // app-api same-origin with the SPA so `__Host-` session cookies work and
+    // there is no CORS preflight on the chat hot path.
+    //
+    // - HttpOrigin hostname is parsed out of the absolute SSM ALB URL using
+    //   Fn.split/Fn.select because the value is a CDK token at synth time.
+    // - Path-strip CloudFront Function removes `/api` so app-api stays
+    //   prefix-unaware (local dev still hits `localhost:8000` directly).
+    // - CACHING_DISABLED + ALL_VIEWER_EXCEPT_HOST_HEADER: every /api/* response
+    //   is dynamic and must forward cookies + CSRF + auth headers untouched.
+    // - No response-headers-policy: SSE responses must keep the origin's
+    //   Content-Type/Cache-Control/X-Accel-Buffering headers verbatim.
+    // - compress: false because gzip on text/event-stream re-introduces the
+    //   buffering bug we fixed in Phase 4.
+    // ============================================================================
+
+    // Strip leading "/api" from the request URI before forwarding to the ALB.
+    // CloudFront Functions run at viewer-request, ~1ms, no Lambda cold start.
+    const apiPathStripFunction = new cloudfront.Function(this, 'ApiPathStripFunction', {
+      functionName: getResourceName(config, 'api-path-strip'),
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      comment: 'Strip /api prefix before forwarding requests to the app-api ALB origin',
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var req = event.request;
+  if (req.uri === '/api') {
+    req.uri = '/';
+  } else if (req.uri.indexOf('/api/') === 0) {
+    req.uri = req.uri.substring(4);
+  }
+  return req;
+}
+`),
+    });
+
+    // Extract the bare hostname from the absolute ALB URL (e.g.
+    // "https://api.example.com" -> "api.example.com"). The value is a CDK
+    // token resolved at deploy time, so use Fn.split/Fn.select rather than
+    // JS string ops.
+    const appApiOriginHostname = cdk.Fn.select(2, cdk.Fn.split('/', appApiUrl));
+
+    // HTTPS to the origin when an ALB cert is configured; HTTP fallback for
+    // dev environments without `certificateArn`. CloudFront → ALB always
+    // crosses public internet, so HTTPS is preferred whenever possible.
+    const appApiOrigin = new origins.HttpOrigin(appApiOriginHostname, {
+      protocolPolicy: config.certificateArn
+        ? cloudfront.OriginProtocolPolicy.HTTPS_ONLY
+        : cloudfront.OriginProtocolPolicy.HTTP_ONLY,
+      // Long-running SSE streams need a generous read timeout. 180s is the
+      // CloudFront default max without a service-quota increase; if any SSE
+      // stream goes >180s without sending data, the proxy needs to emit a
+      // heartbeat (verified during the Phase 6 soak window).
+      readTimeout: cdk.Duration.seconds(180),
+      keepaliveTimeout: cdk.Duration.seconds(60),
+    });
+
+    const apiBehavior: cloudfront.BehaviorOptions = {
+      origin: appApiOrigin,
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+      cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD,
+      cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+      originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+      compress: false,
+      functionAssociations: [
+        {
+          function: apiPathStripFunction,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        },
+      ],
+    };
+
     // CloudFront distribution configuration
     let distributionProps: cloudfront.DistributionProps = {
       comment: `${config.projectPrefix} Frontend Distribution`,
@@ -215,6 +298,9 @@ export class FrontendStack extends cdk.Stack {
         responseHeadersPolicy,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+      },
+      additionalBehaviors: {
+        '/api/*': apiBehavior,
       },
       defaultRootObject: 'index.html',
       // Custom error responses for SPA routing
@@ -309,6 +395,11 @@ export class FrontendStack extends cdk.Stack {
         s3deploy.CacheControl.mustRevalidate(), // Force revalidation after TTL
       ],
       prune: false, // Don't delete other files (static assets deployed separately)
+      // Invalidate the cached config.json on every deploy so a Phase 6
+      // cutover (appApiUrl flip) takes effect immediately at the edge
+      // instead of waiting out the 5-minute TTL.
+      distribution: this.distribution,
+      distributionPaths: ['/config.json'],
     });
 
     console.log('📦 Runtime config deployment configured:');


### PR DESCRIPTION
## Summary

Final per-environment cutover for the BFF Token Handler migration started in Phase 1. Three commits land sequentially in this PR; each is independently sensible to review.

- **6a [`3dafc1c4`](../commit/3dafc1c4)** — CloudFront `/api/*` behavior on the frontend distribution forwards to the app-api ALB. SPA's `appApiUrl` flips to `/api` so the BFF is same-origin (`__Host-` cookies, no CORS preflight). CloudFront Function strips `/api` so backend stays prefix-unaware. `BucketDeployment` invalidates `config.json`. `originReadTimeout: 180s` (a quota bump request before prod soak would let us go higher for long SSE streams).
- **6b [`0b9fa7e2`](../commit/0b9fa7e2)** — **BREAKING:** legacy in-process Bearer agent route renamed `POST /chat/stream` → `POST /chat/agent-stream` (docs + tests + the [USAGE_EXAMPLES.md](../blob/feature/bff-phase-6-cutover/backend/src/agents/main_agent/USAGE_EXAMPLES.md) and [MULTIMODAL_FILE_ATTACHMENTS.md](../blob/feature/bff-phase-6-cutover/docs/feature-summaries/MULTIMODAL_FILE_ATTACHMENTS.md) updated). New `POST /chat/stream` is the BFF cookie-auth proxy, registered against the same handler as `/chat/proxy-stream` for rolling-deploy safety. New `get_current_user_or_session` dual-auth dep accepts cookie OR Bearer; swapped in across 14 SPA-facing route files plus `require_app_roles` so admin pages also accept cookies. `get_current_user_id` rewrapped on top of the dual-auth dep so documents inherits it for free.
- **6c [`e84874dc`](../commit/e84874dc)** — `APP_INITIALIZER` now chains `ConfigService.loadConfig()` → `SessionService.bootstrap()`. New CSRF interceptor mirrors `SessionService.csrfHeaders()` onto unsafe-method requests. ChatHttpService + PreviewChatService stream from `${appApiUrl}/chat/stream` with `credentials: 'include'`. LoginPage + Sidenav swap their callsites to SessionService. Backend follow-ons in this commit: `/auth/login` accepts a sanitised `provider` query param so federated SSO buttons keep one-click semantics; `/chat/stream` proxy forwards `OAuth2CallbackUrl` so on-tool `oauth_required` consent flows still work. AuthService Bearer code stays but is no longer first-party-called — `git revert e84874dc` is the rollback.

## Why now

Closes the XSS-in-localStorage attack surface the migration was opened against. Same-origin via CloudFront also kills the per-chat CORS preflight. Beta users have been notified that aggressive cutover is the plan; rollback paths are layered (config flip → bundle revert → commit revert → Phase-1-through-5 backstop).

## Test plan

- [x] Backend `pytest tests/`: 2,294 passing. The 76 failures are pre-existing order-dependent flakiness in `tests/shared/test_cognito_idp_service.py`, `test_oauth_repositories.py`, `test_auth_providers*.py` (all pass standalone, identical set on develop). +11 net-new passing tests vs develop.
- [x] Frontend `npm test`: 1005/1005 vitest passing.
- [x] Frontend `npm run build`: clean.
- [x] CDK `npm run build` + `cdk synth FrontendStack`: clean (verified for both no-cert HTTP-origin and cert HTTPS-origin paths).
- [ ] **Deploy/soak (operators):** dev → soak ≥1 hr → staging → soak ≥1 hr → prod, all in one day. Watch for: `__Host-` cookie attachment, `oauth_required` SSE flowing end-to-end, federated-SSO one-click still works, no Bearer 401 storms in app-api logs.
- [ ] **Pre-prod:** file a CloudFront service-quota bump request to raise origin response timeout above 180s (long-quiet SSE streams).

## Breaking changes (call out in release notes at next cut)

`POST /chat/stream` is now the BFF cookie-auth proxy. Bearer-authenticated external callers (API-key tooling, scripts) must update to `POST /chat/agent-stream`. The SPA itself does not call `/chat/agent-stream`.

## Phase 7 follow-ups (separate PR)

Delete `/chat/proxy-stream` alias, delete AuthService Bearer code, decommission the public PKCE Cognito client, delete unused `inferenceApiUrl` from config, fix BFF `/auth/callback` to honour `return_to` for deep-link login, and file the pre-existing test pollution in `tests/shared/test_cognito_idp_service.py` etc. as its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)