### PR TITLE
fix(infra): unblock dev deploy (cognito URL parsing + CloudFront readTimeout)

### DIFF
--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -188,8 +188,10 @@ export function loadConfig(scope: cdk.App): AppConfig {
         || scope.node.tryGetContext('cognito')?.domainPrefix
         || projectPrefix,
       callbackUrls: process.env.CDK_COGNITO_CALLBACK_URLS?.split(',')
+        .map((s) => s.trim()).filter(Boolean)
         || scope.node.tryGetContext('cognito')?.callbackUrls,
       logoutUrls: process.env.CDK_COGNITO_LOGOUT_URLS?.split(',')
+        .map((s) => s.trim()).filter(Boolean)
         || scope.node.tryGetContext('cognito')?.logoutUrls,
       supportedIdentityProviders: process.env.CDK_COGNITO_SUPPORTED_IDPS?.split(',')
         .map((s) => s.trim()).filter(Boolean)

--- a/infrastructure/lib/frontend-stack.ts
+++ b/infrastructure/lib/frontend-stack.ts
@@ -221,11 +221,11 @@ function handler(event) {
       protocolPolicy: config.certificateArn
         ? cloudfront.OriginProtocolPolicy.HTTPS_ONLY
         : cloudfront.OriginProtocolPolicy.HTTP_ONLY,
-      // Long-running SSE streams need a generous read timeout. 180s is the
+      // Long-running SSE streams need a generous read timeout. 60s is the
       // CloudFront default max without a service-quota increase; if any SSE
-      // stream goes >180s without sending data, the proxy needs to emit a
+      // stream goes >60s without sending data, the proxy needs to emit a
       // heartbeat (verified during the Phase 6 soak window).
-      readTimeout: cdk.Duration.seconds(180),
+      readTimeout: cdk.Duration.seconds(60),
       keepaliveTimeout: cdk.Duration.seconds(60),
     });
 


### PR DESCRIPTION
## Summary
Two independent fixes for the failing `dev-boisestateai-v2` deploy:

- **InfrastructureStack** — `CDK_COGNITO_CALLBACK_URLS` / `CDK_COGNITO_LOGOUT_URLS` env vars contained a trailing comma, so `.split(',')` produced an empty string that failed Cognito's UserPoolClient regex validation. Apply the same `trim().filter(Boolean)` pattern already used by `supportedIdentityProviders` just below.
- **FrontendStack** — CloudFront's per-origin `readTimeout` caps at 60s without a service-quota increase, so the `180s` value triggered `InvalidRequest`. Lowered to 60s and corrected the now-misleading comment. SSE streams over 60s already rely on the proxy heartbeat verified during the Phase 6 soak.

## Test plan
- [ ] Re-run the `Deploy Infrastructure` workflow against `dev-boisestateai-v2` and confirm both stacks reach `UPDATE_COMPLETE`.
- [ ] (Optional belt-and-suspenders) Strip the trailing comma from the `CDK_COGNITO_CALLBACK_URLS` and `CDK_COGNITO_LOGOUT_URLS` GitHub repo variables.
- [ ] Smoke test SSE chat after deploy to confirm CloudFront does not cut streams (heartbeat keeps connection under 60s gaps).

If we want to keep a longer origin read timeout, the path forward is an AWS Support quota increase for "CloudFront Origin Response Timeout"; this PR keeps us inside the default ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)