### PR TITLE
fix(ci): always build frontend with Angular production config

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -49,7 +49,11 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Build and Deploy Configuration (non-sensitive, repository-level)
-  BUILD_CONFIG: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production') || 'development' }}
+  # All cloud builds use the Angular `production` configuration so fileReplacements
+  # swaps `environment.ts` → `environment.production.ts` (appApiUrl `/api`). The
+  # `environment` input below still selects which AWS env we deploy *to*; it does
+  # not need to map to an Angular build configuration.
+  BUILD_CONFIG: production
   CDK_REQUIRE_APPROVAL: never
   WAIT_FOR_INVALIDATION: false
   # Suppress repeated config dumps from load-env.sh in CI logs


### PR DESCRIPTION
## Summary
- Pin `BUILD_CONFIG=production` in `.github/workflows/frontend.yml` so every cloud build runs `ng build --configuration production` and applies the `environment.ts` → `environment.production.ts` `fileReplacements` (swapping `appApiUrl: 'http://localhost:8000'` for `'/api'`).
- The previous expression set `BUILD_CONFIG=development` on pushes to `develop`, which has no `fileReplacements` and shipped a bundle that called `localhost:8000` from the deployed origin.

## Why
After the BFF cutover, the dev deploy at `alpha.boisestate.ai` started throwing:

```
Access to XMLHttpRequest at 'http://localhost:8000/auth/session' from origin
'https://alpha.boisestate.ai' has been blocked by CORS policy: Permission was
denied for this request to access the `loopback` address space.
```

That's Chrome's Private Network Access guard kicking in once the bundled URL pointed at `localhost`. Forcing the production Angular configuration restores `/api` (same-origin via CloudFront → app-api ALB).

The Angular `production` configuration here only differs from `development` in `optimization`, `sourceMap`, `outputHashing`, and `fileReplacements` — none of which need to vary between dev and prod cloud envs. The workflow's `environment` input still controls which AWS env we deploy *to*.

## Test plan
- [ ] CI green on this PR
- [ ] After merge to `develop`, frontend workflow runs and CloudFront serves a bundle whose `main-*.js` no longer contains `http://localhost:8000`
- [ ] Hard-reload `https://alpha.boisestate.ai`; `/auth/session` and `/system/status` resolve against `/api/...` and the loopback PNA error is gone
- [ ] `npm start` locally still hits `http://localhost:8000` (uses `development` config, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)