### PR TITLE
fix(test): absorb stray resource() loader request in cost.service.spec

### DIFF
--- a/frontend/ai.client/src/app/settings/pages/usage/services/cost.service.spec.ts
+++ b/frontend/ai.client/src/app/settings/pages/usage/services/cost.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestRequest } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { CostService } from './cost.service';
 import { ConfigService } from '../../../../services/config.service';
@@ -26,63 +27,78 @@ describe('CostService', () => {
     TestBed.resetTestingModule();
   });
 
+  // The CostService exposes a `resource()` field that auto-fires its loader on a
+  // microtask. Under the vitest worker pool, a sibling spec can provoke the resource
+  // graph to tick, producing an extra GET /costs/summary that lands in this spec's
+  // HttpTestingController. `expectOne` then sees 2 requests and the assertion flakes.
+  // Match by URL predicate and flush every match so the field-initializer request
+  // is absorbed alongside the one our `it` actually triggered.
+  const flushAll = <T extends object>(predicate: (url: string) => boolean, body: T): TestRequest[] => {
+    const reqs = httpMock.match(r => predicate(r.url));
+    expect(reqs.length).toBeGreaterThan(0);
+    reqs.forEach(r => r.flush(body));
+    return reqs;
+  };
+
   it('should fetch cost summary', async () => {
     const mockResponse = { totalCost: 10.50, totalRequests: 100 };
-    
+
     const promise = service.fetchCostSummary();
     await vi.waitFor(() => {
-      httpMock.expectOne('http://localhost:8000/costs/summary').flush(mockResponse);
+      flushAll(url => url === 'http://localhost:8000/costs/summary', mockResponse);
     });
-    
+
     const result = await promise;
     expect(result).toEqual(mockResponse);
   });
 
   it('should fetch cost summary with period', async () => {
     const mockResponse = { totalCost: 5.25, totalRequests: 50 };
-    
+
     const promise = service.fetchCostSummary('2025-01');
     await vi.waitFor(() => {
-      httpMock.expectOne('http://localhost:8000/costs/summary?period=2025-01').flush(mockResponse);
+      flushAll(url => url.endsWith('/costs/summary?period=2025-01'), mockResponse);
     });
-    
+
     const result = await promise;
     expect(result).toEqual(mockResponse);
   });
 
   it('should fetch detailed report', async () => {
     const mockResponse = { totalCost: 15.75, totalRequests: 150 };
-    
+
     const promise = service.fetchDetailedReport('2025-01-01', '2025-01-31');
     await vi.waitFor(() => {
-      httpMock.expectOne('http://localhost:8000/costs/detailed-report?start_date=2025-01-01&end_date=2025-01-31').flush(mockResponse);
+      flushAll(
+        url => url.endsWith('/costs/detailed-report?start_date=2025-01-01&end_date=2025-01-31'),
+        mockResponse,
+      );
     });
-    
+
     const result = await promise;
     expect(result).toEqual(mockResponse);
   });
 
   it('should get cost summary for month', async () => {
     const mockResponse = { totalCost: 8.00, totalRequests: 80 };
-    
+
     const promise = service.getCostSummaryForMonth(2025, 1);
     await vi.waitFor(() => {
-      httpMock.expectOne('http://localhost:8000/costs/summary?period=2025-01').flush(mockResponse);
+      flushAll(url => url.endsWith('/costs/summary?period=2025-01'), mockResponse);
     });
-    
+
     const result = await promise;
     expect(result).toEqual(mockResponse);
   });
 
   it('should get cost summary for last N days', async () => {
     const mockResponse = { totalCost: 3.25, totalRequests: 30 };
-    
+
     const promise = service.getCostSummaryForLastNDays(7);
     await vi.waitFor(() => {
-      const req = httpMock.expectOne(r => r.url.includes('/costs/detailed-report'));
-      req.flush(mockResponse);
+      flushAll(url => url.includes('/costs/detailed-report'), mockResponse);
     });
-    
+
     const result = await promise;
     expect(result).toEqual(mockResponse);
   });


### PR DESCRIPTION
## Summary
- `CostService.currentMonthSummary` is a `resource()` field whose loader auto-fires on a microtask. Under the vitest worker pool, a sibling spec can provoke the resource graph to tick — sending an extra `GET /costs/summary` into this spec's `HttpTestingController`. `expectOne` then sees two requests and the assertion flakes (eventually surfacing as `found none` after `vi.waitFor` retries time out).
- Switch each `httpMock.expectOne(...)` to `httpMock.match(<url predicate>)` and flush every match. The field-initializer request is absorbed alongside the one each `it` actually triggered.
- Spec-only change. No production code touched (option 1 from the bug report). `currentMonthSummary` is consumed by `usage-settings.page.ts` so the lazy/delete refactor would be a separate change.

## Test plan
- [x] `cd frontend/ai.client && ./node_modules/.bin/ng test --include='src/app/settings/pages/usage/services/cost.service.spec.ts'` — 5/5 passing, ran 3× consecutively to confirm.
- [x] `./node_modules/.bin/ng test` — cost.service.spec passes in the full-suite run. Remaining timeouts in `app.spec.ts`, `shared-view.page.spec.ts`, and `model-settings.spec.ts` are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)