### PR TITLE
fix(auth): bounce logout through Cognito Hosted UI

### DIFF
--- a/backend/src/apis/app_api/auth/bff/routes.py
+++ b/backend/src/apis/app_api/auth/bff/routes.py
@@ -6,7 +6,9 @@
                          writes sealed cookies, redirects to the SPA.
 `GET  /auth/session`   — returns the current user + CSRF token. Read by
                          the SPA on bootstrap to confirm "am I logged in?"
-`POST /auth/logout`    — drops the session row, clears both cookies.
+`POST /auth/logout`    — drops the session row, clears both cookies, and
+                         returns the Cognito Hosted UI logout URL so the
+                         SPA can finish the round-trip.
 
 These routes are dormant until Phase 5 wires the SPA — a /auth/login hit
 today will work end-to-end as long as Phase 1 env vars are set, but no
@@ -23,6 +25,7 @@ import urllib.parse
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
 from starlette.responses import RedirectResponse
 
 from apis.shared.auth.dependencies import get_current_user_from_session
@@ -495,17 +498,49 @@ async def bff_session(
 # ─── /auth/logout ──────────────────────────────────────────────────────
 
 
+def _cognito_logout_url(config: BFFAuthConfig) -> Optional[str]:
+    """Build the Cognito Hosted UI logout URL, or None if not configured.
+
+    Cognito's `/logout` endpoint clears the Hosted UI session cookie that
+    sits independent of our BFF cookies; without this hop the user "logs
+    out" of our session but Cognito silently re-issues a code on the next
+    /authorize, so they're back in without a credential prompt.
+
+    The `logout_uri` must exactly match a value registered on the BFF app
+    client's `logoutUrls` (CDK strips the trailing slash there, so we
+    strip it here too).
+    """
+    if not (
+        config.cognito_domain_url
+        and config.bff_config.cognito_bff_app_client_id
+        and config.post_login_redirect_url
+    ):
+        return None
+    params = urllib.parse.urlencode(
+        {
+            "client_id": config.bff_config.cognito_bff_app_client_id,
+            "logout_uri": config.post_login_redirect_url.rstrip("/"),
+        }
+    )
+    return f"{config.cognito_domain_url}/logout?{params}"
+
+
 @router.post("/logout", summary="Drop the BFF session and clear cookies")
 async def bff_logout(request: Request) -> Response:
     """Best-effort logout.
 
     Reads the session cookie directly rather than going through the dep so
     we can clear cookies for already-stale sessions too — the user clicked
-    "log out", they get logged out, full stop. Returns 204 plus cleared
-    cookies; the SPA owns the post-logout UX.
+    "log out", they get logged out, full stop. Returns the Cognito Hosted
+    UI logout URL so the SPA can finish the round-trip and clear the
+    upstream session cookie too; otherwise Cognito's own session keeps
+    silently re-authenticating the user on the next /authorize.
     """
     config = BFFAuthConfig.from_env()
-    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    response = JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"post_logout_url": _cognito_logout_url(config)},
+    )
     clear_session_cookies(response)
 
     cookie_value = request.cookies.get(SESSION_COOKIE_NAME)

--- a/backend/tests/apis/app_api/auth/bff/test_logout.py
+++ b/backend/tests/apis/app_api/auth/bff/test_logout.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,6 +14,23 @@ from apis.shared.sessions_bff.config import (
     SESSION_COOKIE_NAME,
 )
 from apis.shared.sessions_bff.models import CookiePayload, SessionRecord
+
+from .conftest import BFF_CLIENT_ID, COGNITO_DOMAIN_URL, POST_LOGIN_URL
+
+
+def _assert_post_logout_url(response_body: dict) -> None:
+    """The Cognito Hosted UI logout URL must point at our domain with the
+    BFF client_id and a logout_uri matching what CDK registers (no trailing
+    slash). Cognito rejects mismatched URIs at runtime, so we pin it here."""
+    url = response_body.get("post_logout_url")
+    assert url, f"expected post_logout_url, got {response_body!r}"
+    parsed = urlparse(url)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == (
+        f"{COGNITO_DOMAIN_URL}/logout"
+    )
+    qs = parse_qs(parsed.query)
+    assert qs["client_id"] == [BFF_CLIENT_ID]
+    assert qs["logout_uri"] == [POST_LOGIN_URL.rstrip("/")]
 
 
 def _seed_record(repository, session_id: str = "sess-x") -> SessionRecord:
@@ -47,7 +65,8 @@ def test_logout_with_valid_cookie_deletes_row_and_clears_cookies(
         "/auth/logout", cookies={SESSION_COOKIE_NAME: sealed}
     )
 
-    assert response.status_code == 204
+    assert response.status_code == 200
+    _assert_post_logout_url(response.json())
     set_cookie_blob = " ".join(response.headers.get_list("set-cookie"))
     assert SESSION_COOKIE_NAME in set_cookie_blob
     assert CSRF_COOKIE_NAME in set_cookie_blob
@@ -59,20 +78,24 @@ def test_logout_with_valid_cookie_deletes_row_and_clears_cookies(
     assert "Item" not in response_item
 
 
-def test_logout_without_cookie_clears_cookies_204(app):
+def test_logout_without_cookie_clears_cookies(app):
     response = TestClient(app).post("/auth/logout")
-    assert response.status_code == 204
+    assert response.status_code == 200
+    _assert_post_logout_url(response.json())
     set_cookie_blob = " ".join(response.headers.get_list("set-cookie"))
     assert SESSION_COOKIE_NAME in set_cookie_blob
     assert CSRF_COOKIE_NAME in set_cookie_blob
 
 
-def test_logout_with_unsealable_cookie_still_clears_and_returns_204(app, repository):
+def test_logout_with_unsealable_cookie_still_clears_and_returns_post_logout_url(
+    app, repository
+):
     """A garbage cookie should not crash logout — clear and exit cleanly."""
     response = TestClient(app).post(
         "/auth/logout", cookies={SESSION_COOKIE_NAME: "this-is-not-a-sealed-cookie"}
     )
-    assert response.status_code == 204
+    assert response.status_code == 200
+    _assert_post_logout_url(response.json())
     set_cookie_blob = " ".join(response.headers.get_list("set-cookie"))
     assert SESSION_COOKIE_NAME in set_cookie_blob
 
@@ -87,7 +110,8 @@ def test_logout_invalidates_local_cache(app, codec, repository):
     response = TestClient(app).post(
         "/auth/logout", cookies={SESSION_COOKIE_NAME: sealed}
     )
-    assert response.status_code == 204
+    assert response.status_code == 200
+    _assert_post_logout_url(response.json())
     assert cache.get(record.session_id) is None
 
 
@@ -100,5 +124,18 @@ def test_logout_is_idempotent(app, codec, repository):
     r1 = client.post("/auth/logout", cookies={SESSION_COOKIE_NAME: sealed})
     r2 = client.post("/auth/logout", cookies={SESSION_COOKIE_NAME: sealed})
 
-    assert r1.status_code == 204
-    assert r2.status_code == 204
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    _assert_post_logout_url(r1.json())
+    _assert_post_logout_url(r2.json())
+
+
+def test_logout_returns_null_post_logout_url_when_cognito_unconfigured(
+    app, monkeypatch
+):
+    """If COGNITO_DOMAIN_URL isn't set, the Cognito hop is impossible —
+    fall back to a null URL and let the SPA navigate locally."""
+    monkeypatch.delenv("COGNITO_DOMAIN_URL", raising=False)
+    response = TestClient(app).post("/auth/logout")
+    assert response.status_code == 200
+    assert response.json() == {"post_logout_url": None}

--- a/frontend/ai.client/src/app/auth/bff-session.model.ts
+++ b/frontend/ai.client/src/app/auth/bff-session.model.ts
@@ -21,3 +21,16 @@ export interface BffSessionUser {
 export interface BffSessionResponse extends BffSessionUser {
   csrf_token: string;
 }
+
+/**
+ * `POST /auth/logout` response. The BFF clears its own cookies inline
+ * but Cognito's Hosted UI session cookie sits on the Cognito domain —
+ * if we don't bounce the browser through `${cognitoDomain}/logout`,
+ * Cognito silently re-issues a code on the next /authorize and the
+ * user is back in without a credential prompt. The SPA navigates to
+ * `post_logout_url` to end that upstream session. Null when Cognito
+ * isn't configured (local dev with the BFF in degraded mode).
+ */
+export interface BffLogoutResponse {
+  post_logout_url: string | null;
+}

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -217,7 +217,7 @@ describe('SessionService', () => {
   });
 
   describe('logout', () => {
-    it('POSTs /auth/logout with the CSRF header and clears local state', async () => {
+    it('POSTs /auth/logout, clears local state, and navigates to the Cognito logout URL', async () => {
       const bootPromise = service.bootstrap();
       httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
       await bootPromise;
@@ -227,13 +227,34 @@ describe('SessionService', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.withCredentials).toBe(true);
       expect(req.request.headers.get('X-CSRF-Token')).toBe('csrf-secret-abc');
-      req.flush(null, { status: 204, statusText: 'No Content' });
+      req.flush({
+        post_logout_url:
+          'https://example.auth.us-east-1.amazoncognito.com/logout?client_id=cid&logout_uri=http%3A%2F%2Flocalhost%3A4200',
+      });
 
       await logoutPromise;
 
       expect(service.user()).toBeNull();
       expect(service.csrfToken()).toBeNull();
       expect(service.isAuthenticated()).toBe(false);
+      expect(window.location.href).toBe(
+        'https://example.auth.us-east-1.amazoncognito.com/logout?client_id=cid&logout_uri=http%3A%2F%2Flocalhost%3A4200',
+      );
+    });
+
+    it('does not navigate when post_logout_url is null', async () => {
+      const bootPromise = service.bootstrap();
+      httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
+      await bootPromise;
+
+      const logoutPromise = service.logout();
+      const req = httpMock.expectOne('http://localhost:8000/auth/logout');
+      req.flush({ post_logout_url: null });
+
+      await logoutPromise;
+
+      expect(service.user()).toBeNull();
+      expect(window.location.href).toBe('');
     });
 
     it('clears local state even when /auth/logout fails', async () => {
@@ -249,6 +270,7 @@ describe('SessionService', () => {
 
       expect(service.user()).toBeNull();
       expect(service.csrfToken()).toBeNull();
+      expect(window.location.href).toBe('');
     });
   });
 });

--- a/frontend/ai.client/src/app/auth/session.service.ts
+++ b/frontend/ai.client/src/app/auth/session.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http
 import { firstValueFrom } from 'rxjs';
 
 import { ConfigService } from '../services/config.service';
-import { BffSessionResponse, BffSessionUser } from './bff-session.model';
+import { BffLogoutResponse, BffSessionResponse, BffSessionUser } from './bff-session.model';
 
 /**
  * SessionService — backs the BFF Token-Handler cookie session.
@@ -122,23 +122,32 @@ export class SessionService {
   }
 
   /**
-   * POST `{appApiUrl}/auth/logout`. The BFF returns 204 plus cleared
-   * cookies; we mirror that by clearing local signals. The endpoint is
+   * POST `{appApiUrl}/auth/logout`. The BFF clears its own cookies and
+   * returns the Cognito Hosted UI logout URL so we can end the upstream
+   * session — without that hop Cognito silently re-issues a code on the
+   * next /authorize and the user lands back in without re-auth. We
+   * mirror the cookie clear locally and navigate the browser to that
+   * URL; the SPA tears down on its own from there. The endpoint is
    * CSRF-exempt server-side, but we send the header anyway so a future
    * tightening doesn't silently break us.
    */
   async logout(): Promise<void> {
     const url = `${this.baseUrl()}/auth/logout`;
+    let postLogoutUrl: string | null = null;
     try {
-      await firstValueFrom(
-        this.http.post(url, null, {
+      const response = await firstValueFrom(
+        this.http.post<BffLogoutResponse>(url, null, {
           withCredentials: true,
           headers: this.csrfHttpHeaders(),
         }),
       );
+      postLogoutUrl = response?.post_logout_url ?? null;
     } finally {
       this._user.set(null);
       this._csrfToken.set(null);
+    }
+    if (postLogoutUrl) {
+      window.location.href = postLogoutUrl;
     }
   }
 


### PR DESCRIPTION
## Summary

- BFF `POST /auth/logout` now returns `{post_logout_url: string | null}` (200) instead of bare 204. The URL points at Cognito's Hosted UI `/logout` endpoint with `client_id` + `logout_uri` matching what CDK registers on the BFF app client.
- `SessionService.logout()` reads that URL and `window.location.href`'s the browser there after clearing local state; Cognito ends its session and 302s back to the registered `logout_uri`. Null result (no Cognito config) → SPA falls back to local navigation only.
- Without this hop, Cognito's session cookie outlives the BFF logout. The next `/oauth2/authorize` silently re-issues a code and the user is logged back in without a credential prompt — a regression introduced by the Phase 7 cutover (the legacy `AuthService.logout()` used to do this redirect).

## Test plan

- [ ] Backend: `cd backend && uv run python -m pytest tests/apis/app_api/auth/bff/test_logout.py -v` — 6 cases including null-URL fallback and idempotency.
- [ ] Local UI happy path:
  - Start backend (`cd backend/src/apis/app_api && uv run python main.py`) and frontend (`cd frontend/ai.client && npm run start`); log in via Cognito.
  - Click user dropdown → Logout. DevTools Network: `POST /auth/logout` returns 200 with `post_logout_url` set.
  - Browser navigates to `${cognito_domain}/logout?client_id=...&logout_uri=http%3A%2F%2Flocalhost%3A4200`, then back to localhost.
  - SPA bootstrap → 401 → BFF `/auth/login` → Cognito Hosted UI **prompts for credentials** (the bug fix).
- [ ] Cookie sanity: `__Host-bff_session` and `__Host-bff_csrf` gone from `localhost:4200` after logout; Cognito session cookie on `dev-boisestateai-v2.auth.us-west-2.amazoncognito.com` cleared after the hop.
- [ ] Edge case: clear cookies manually first, then logout — still 200 + `post_logout_url`, browser still bounces through Cognito.
- [ ] Cloud (alpha after deploy): same flow but `POST /api/auth/logout` (same-origin), `logout_uri=https://alpha.boisestate.ai`.

## Notes

The `logout_uri` is built from `BFF_POST_LOGIN_REDIRECT_URL` with the trailing slash stripped — that matches what `infrastructure-stack.ts` registers in `bffLogoutUrls` (`https://${domainName}` and `http://localhost:4200`, no trailing slash). Cognito rejects mismatched URIs at runtime, so the test pins this exact shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)