### PR TITLE
fix(auth): land anonymous users on SPA /auth/login instead of Cognito

### DIFF
--- a/frontend/ai.client/src/app/app.config.ts
+++ b/frontend/ai.client/src/app/app.config.ts
@@ -40,10 +40,12 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withComponentInputBinding()),
 
     // Bootstrap the BFF cookie session before the first component renders.
-    // GET ${appApiUrl}/auth/session — on 401, SessionService redirects to the
-    // BFF's /auth/login (Cognito Hosted UI) and hangs the promise so no SPA
-    // route renders before the page tears down. Transport errors leave the
-    // SPA in a clean unauthenticated state without redirecting.
+    // GET ${appApiUrl}/auth/session — on 401, SessionService sends the browser
+    // to the SPA's /auth/login page (with a returnUrl) and hangs the promise
+    // so no protected route renders before the page tears down. If we're
+    // already on /auth/login the bootstrap resolves and the page renders so
+    // the user can pick a provider. Transport errors leave the SPA in a clean
+    // unauthenticated state without redirecting.
     provideAppInitializer(() => inject(SessionService).bootstrap()),
   ]
 };

--- a/frontend/ai.client/src/app/auth/error.interceptor.ts
+++ b/frontend/ai.client/src/app/auth/error.interceptor.ts
@@ -43,7 +43,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
           req.url.includes(endpoint)
         );
 
-        if (!isSilentEndpoint) {
+        // 401s mean the BFF session is missing or expired. SessionService
+        // handles that by routing the user to /auth/login — a toast on top
+        // is just noise and tends to flash before the redirect lands.
+        const isUnauthorized = error.status === 401;
+
+        if (!isSilentEndpoint && !isUnauthorized) {
           // Use ErrorService to display the error
           errorService.handleHttpError(error);
         }

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -93,13 +93,14 @@ describe('SessionService', () => {
       expect(user as any).not.toHaveProperty('csrf_token');
     });
 
-    it('redirects to /auth/login on 401 and clears state', async () => {
+    it('redirects to the SPA /auth/login page on 401 and clears state', async () => {
       window.location.pathname = '/admin/users';
       window.location.search = '?tab=roles';
 
-      // bootstrap() intentionally never resolves on 401 — it hangs to keep
-      // APP_INITIALIZER blocking until the queued window.location.href fires.
-      // We don't await the promise; we flush microtasks and inspect state.
+      // bootstrap() intentionally never resolves on 401 (when navigation is
+      // queued) — it hangs to keep APP_INITIALIZER blocking until the queued
+      // window.location.href fires. We don't await the promise; we flush
+      // microtasks and inspect state.
       void service.bootstrap();
 
       const req = httpMock.expectOne('http://localhost:8000/auth/session');
@@ -114,8 +115,25 @@ describe('SessionService', () => {
 
       const expectedReturn = encodeURIComponent('/admin/users?tab=roles');
       expect(window.location.href).toBe(
-        `http://localhost:8000/auth/login?return_to=${expectedReturn}`,
+        `/auth/login?returnUrl=${expectedReturn}`,
       );
+    });
+
+    it('does not redirect when the 401 lands on /auth/login itself', async () => {
+      window.location.pathname = '/auth/login';
+      window.location.search = '';
+
+      const promise = service.bootstrap();
+
+      const req = httpMock.expectOne('http://localhost:8000/auth/session');
+      req.flush('unauthorized', { status: 401, statusText: 'Unauthorized' });
+
+      await promise;
+
+      expect(service.bootstrapped()).toBe(true);
+      expect(service.user()).toBeNull();
+      expect(service.csrfToken()).toBeNull();
+      expect(window.location.href).toBe('');
     });
 
     it('does not redirect on a non-401 transport error', async () => {

--- a/frontend/ai.client/src/app/auth/session.service.ts
+++ b/frontend/ai.client/src/app/auth/session.service.ts
@@ -13,8 +13,8 @@ import { BffLogoutResponse, BffSessionResponse, BffSessionUser } from './bff-ses
  *     `__Host-bff_session` cookie travels automatically because the BFF
  *     is same-origin via CloudFront `/api/*`.
  *   - Expose signals for the current user and the CSRF token.
- *   - On 401, redirect the browser to `{appApiUrl}/auth/login` (the BFF
- *     redirects on to Cognito Hosted UI).
+ *   - On 401, redirect the browser to the SPA's `/auth/login` page so the
+ *     user picks a provider before we hand off to Cognito Hosted UI.
  *   - Provide the `X-CSRF-Token` header value for non-GET requests; the
  *     `csrfInterceptor` reads it here and attaches it to outgoing requests.
  *
@@ -51,10 +51,9 @@ export class SessionService {
   readonly isAuthenticated = computed(() => this._user() !== null);
 
   /**
-   * Fetch the current session from the BFF. On 401 the browser is
-   * redirected to `/auth/login`; the returned promise still resolves
-   * (the navigation will tear the page down anyway, but resolving
-   * keeps the contract predictable for callers in tests).
+   * Fetch the current session from the BFF. On 401 the browser is sent
+   * to the SPA's `/auth/login` page (unless we're already there) so the
+   * user can pick a provider before we hand off to Cognito Hosted UI.
    *
    * Network errors leave the service in a clean unauthenticated state
    * without redirecting — a transient failure shouldn't kick the user
@@ -73,7 +72,14 @@ export class SessionService {
       this._user.set(null);
       this._csrfToken.set(null);
       if (error instanceof HttpErrorResponse && error.status === 401) {
-        this.redirectToLogin();
+        if (window.location.pathname === '/auth/login') {
+          // Already on the SPA login page — let it render so the user
+          // can pick a provider.
+          return;
+        }
+        const returnUrl = `${window.location.pathname}${window.location.search}`;
+        const params = new URLSearchParams({ returnUrl });
+        window.location.href = `/auth/login?${params.toString()}`;
         // window.location.href only queues the navigation. Hang the promise
         // so APP_INITIALIZER blocks the SPA from rendering a route before
         // the browser tears the page down.

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -52,11 +52,9 @@ export class Sidenav {
   }
 
   async handleLogout(): Promise<void> {
-    // BFF logout: 204 + cleared cookies. The user is then anonymous;
-    // the next page navigation triggers SessionService.bootstrap() in
-    // APP_INITIALIZER, which 401s and redirects to BFF /auth/login.
-    // We push the user to /login explicitly here so the redirect-to-OAuth
-    // happens from a known route rather than wherever the sidenav lived.
+    // BFF logout clears cookies and bounces through the Cognito Hosted UI
+    // logout URL (handled inside bffSession.logout). We also push the user
+    // to /auth/login defensively in case the navigation is short-circuited.
     await this.bffSession.logout();
     this.router.navigate(['/auth/login']);
   }


### PR DESCRIPTION
## Summary
- On a 401 from `/auth/session`, `SessionService.bootstrap()` now navigates to the SPA's `/auth/login` page (with `?returnUrl=`) instead of bouncing through the BFF straight to Cognito Hosted UI. Users land on the Sign In screen with provider buttons and choose how to authenticate.
- If the 401 lands on `/auth/login` itself, bootstrap resolves and the page renders — no redirect loop.
- `errorInterceptor` now suppresses 401 toasts. `SessionService` already handles 401 by redirecting; the "Authentication Required / No active session" toast was just flashing before the navigation tore the page down.
- `SessionService.redirectToLogin()` is unchanged — the SPA login page still uses it (with an explicit provider) to start the OAuth flow when the user clicks a Sign In button.

## Test plan
- [ ] Clear `__Host-bff_session` and `__Host-bff_csrf` cookies, hard-reload `/` → land on `/auth/login?returnUrl=%2F` with no toast flash, see the SPA's Sign In screen (not Cognito)
- [ ] Visit `/admin/users?tab=roles` while signed out → land on `/auth/login?returnUrl=%2Fadmin%2Fusers%3Ftab%3Droles`
- [ ] Click **Sign in with Cognito** → goes to Cognito Hosted UI (unchanged path)
- [ ] After auth, returned to the original deep link, not just `/`
- [ ] Hard-reload `/auth/login` while signed out → page renders, no redirect loop
- [ ] Other 4xx/5xx errors (e.g. forbidden admin endpoint as non-admin) still produce a toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)