### PR TITLE
fix(ci): pass CDK_CERTIFICATE_ARN to frontend synth/deploy jobs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -236,13 +236,14 @@ jobs:
       CDK_FRONTEND_CLOUDFRONT_PRICE_CLASS: ${{ vars.CDK_FRONTEND_CLOUDFRONT_PRICE_CLASS }}
       CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
       CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_CERTIFICATE_ARN: ${{ vars.CDK_CERTIFICATE_ARN }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
       CDK_FRONTEND_BUCKET_NAME: ${{ vars.CDK_FRONTEND_BUCKET_NAME }}
       CDK_APP_VERSION: ${{ needs.build-cdk.outputs.app-version }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -365,13 +366,14 @@ jobs:
       CDK_FRONTEND_CLOUDFRONT_PRICE_CLASS: ${{ vars.CDK_FRONTEND_CLOUDFRONT_PRICE_CLASS }}
       CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
       CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_CERTIFICATE_ARN: ${{ vars.CDK_CERTIFICATE_ARN }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
       CDK_FRONTEND_BUCKET_NAME: ${{ vars.CDK_FRONTEND_BUCKET_NAME }}
       CDK_APP_VERSION: ${{ needs.build-cdk.outputs.app-version }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Frontend workflow's synth and deploy jobs were missing `CDK_CERTIFICATE_ARN`, so `FrontendStack` synthesized with `config.certificateArn` undefined and the `/api/*` CloudFront origin policy fell back to `HTTP_ONLY`.
- The ALB's HTTP listener (`permanent: true` → 301) then redirected every `/api/*` request to its public HTTPS hostname (`api.alpha.boisestate.ai`), breaking same-origin BFF cookie assumptions and downgrading the `/chat/stream` POST to GET on redirect follow → 405 at app-api.
- Adding `CDK_CERTIFICATE_ARN` to both env blocks lets the frontend stack pick `HTTPS_ONLY` and reach the ALB on its HTTPS listener directly.

## Repro before fix
```
$ curl -sI https://alpha.boisestate.ai/api/auth/session
HTTP/2 301
location: https://api.alpha.boisestate.ai:443/auth/session
server: awselb/2.0
```

## Test plan
- [ ] Confirm GitHub Actions `development` environment has `CDK_CERTIFICATE_ARN` set (already used by `infrastructure.yml`)
- [ ] Re-run Frontend workflow against `development`
- [ ] `curl -sI https://alpha.boisestate.ai/api/auth/session` returns 401/200 from `server: uvicorn`, not 301 from `awselb/2.0`
- [ ] SPA chat works end-to-end on alpha (POST `/api/chat/stream` stays POST, SSE streams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)