### PR TITLE
fix(infra): scope SPA fallback so /api/* 4xx responses pass through

### DIFF
--- a/infrastructure/lib/frontend-stack.ts
+++ b/infrastructure/lib/frontend-stack.ts
@@ -245,6 +245,40 @@ function handler(event) {
       ],
     };
 
+    // ============================================================================
+    // SPA routing — rewrite non-asset paths to /index.html at viewer-request
+    // ============================================================================
+    // Distribution-wide `errorResponses` (the previous approach) caught 403/404
+    // from EVERY behavior, including `/api/*`, which silently rewrote real API
+    // errors into `200 + index.html` and broke JSON parsing on the SPA. Doing
+    // the rewrite at viewer-request on the default behavior keeps SPA fallback
+    // scoped to S3-bound traffic and lets API 4xx responses pass through with
+    // their original status and JSON body.
+    //
+    // Anything with a file extension (`.js`, `.css`, `.png`, etc.) is treated
+    // as a static asset and forwarded to S3 unchanged. Everything else (SPA
+    // routes like `/auth/login`, `/chat/123`) is rewritten to `/index.html`
+    // so Angular's router can take over.
+    const spaRoutingFunction = new cloudfront.Function(this, 'SpaRoutingFunction', {
+      functionName: getResourceName(config, 'spa-routing'),
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      comment: 'Rewrite SPA routes to /index.html so Angular can handle client-side routing',
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var req = event.request;
+  var uri = req.uri;
+  // Static asset (has a file extension in the last path segment) → leave as-is.
+  var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+  if (lastSegment.indexOf('.') !== -1) {
+    return req;
+  }
+  // SPA route → serve index.html so the Angular router can resolve it.
+  req.uri = '/index.html';
+  return req;
+}
+`),
+    });
+
     // CloudFront distribution configuration
     let distributionProps: cloudfront.DistributionProps = {
       comment: `${config.projectPrefix} Frontend Distribution`,
@@ -255,26 +289,17 @@ function handler(event) {
         responseHeadersPolicy,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+        functionAssociations: [
+          {
+            function: spaRoutingFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
       },
       additionalBehaviors: {
         '/api/*': apiBehavior,
       },
       defaultRootObject: 'index.html',
-      // Custom error responses for SPA routing
-      errorResponses: [
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: '/index.html',
-          ttl: cdk.Duration.minutes(5),
-        },
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: '/index.html',
-          ttl: cdk.Duration.minutes(5),
-        },
-      ],
       priceClass: cloudfront.PriceClass[config.frontend.cloudFrontPriceClass as keyof typeof cloudfront.PriceClass],
       enabled: true,
       httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,


### PR DESCRIPTION
## Summary
- Distribution-wide `errorResponses` rewrote 403/404 from every CloudFront behavior — including the same-origin `/api/*` proxy added in Phase 6 — into `200 + index.html`. The SPA then choked parsing HTML as JSON (e.g. a real `Session not found` 404 from `GET /api/sessions/{id}/metadata` surfaced as an Angular HttpClient parse error).
- Replace the `errorResponses` block with a viewer-request CloudFront Function on the default S3 behavior that rewrites non-asset paths (anything without a file extension) to `/index.html`. SPA deep-linking keeps working; API errors keep their original status and JSON body.
- `/api/*` behavior is unchanged.

## Test plan
- [ ] `cd infrastructure && npx cdk diff` — expect a new `SpaRoutingFunction` and the distribution updated to drop `errorResponses` and add a `FunctionAssociations` on the default behavior.
- [ ] Deploy to dev/alpha.
- [ ] SPA deep links still work: `/auth/login`, `/chat/<id>` served directly return the SPA.
- [ ] Static assets still load (no 404s in network tab on the home page).
- [ ] Repro the original bug: `GET /api/sessions/<bogus-id>/metadata` returns JSON 404, not HTML 200. Angular `HttpClient` parse error is gone.
- [ ] Smoke-test `/api/*` happy paths (auth, sessions list, chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)