### PR TITLE
fix(chat): URL-encode runtime ARN + add qualifier on BFF proxy

### DIFF
--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -26,6 +26,7 @@ import os
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from urllib.parse import quote, urlsplit
 
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
@@ -34,11 +35,36 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/chat", tags=["bff-chat-proxy"])
 
-_INFERENCE_API_URL = os.environ.get("INFERENCE_API_URL", "http://localhost:8001")
+def _inference_api_url() -> str:
+    return os.environ.get("INFERENCE_API_URL", "http://localhost:8001")
 
 # Long enough to cover a full agent turn (model + tool calls), bounded so a
 # wedged upstream eventually surfaces.
 _PROXY_TIMEOUT_SECONDS = 300.0
+
+
+def _build_invocations_url(base_url: str) -> str:
+    """Resolve the upstream `/invocations` URL from `INFERENCE_API_URL`.
+
+    Cloud: `INFERENCE_API_URL` is the AgentCore Runtime data-plane base
+    (`https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<ARN>`),
+    where `<ARN>` is unencoded in SSM. The data-plane route is
+    `POST /runtimes/{agentRuntimeArn}/invocations?qualifier={qualifier}`
+    with `{agentRuntimeArn}` as a single URL-encoded path segment — so the
+    ARN's literal `/` and `:` must be percent-encoded or AWS returns 404.
+    A `qualifier` is also required; we use `DEFAULT`.
+
+    Local dev: `INFERENCE_API_URL` is `http://localhost:8001`, where
+    `/invocations` is a real FastAPI route on inference-api directly. No
+    encoding or qualifier needed.
+    """
+    parts = urlsplit(base_url)
+    prefix = "/runtimes/"
+    if parts.netloc.startswith("bedrock-agentcore.") and parts.path.startswith(prefix):
+        arn = parts.path[len(prefix):]
+        encoded_arn = quote(arn, safe="")
+        return f"{parts.scheme}://{parts.netloc}/runtimes/{encoded_arn}/invocations?qualifier=DEFAULT"
+    return f"{base_url}/invocations"
 
 
 def _build_upstream_client() -> httpx.AsyncClient:
@@ -63,7 +89,7 @@ async def chat_stream(
     so streaming events (notably `oauth_required` after `message_stop`)
     reach the browser without being held back by an intermediary.
     """
-    target_url = f"{_INFERENCE_API_URL}/invocations"
+    target_url = _build_invocations_url(_inference_api_url())
     body = await request.body()
 
     headers = {

--- a/backend/tests/apis/app_api/chat/test_proxy_routes.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes.py
@@ -235,7 +235,7 @@ def test_omits_oauth2_callback_url_header_when_caller_did_not_send_one(
 def test_targets_invocations_path_on_inference_api(
     monkeypatch: pytest.MonkeyPatch, chat_path: str,
 ) -> None:
-    monkeypatch.setattr(proxy_routes, "_INFERENCE_API_URL", "http://upstream:9999")
+    monkeypatch.setenv("INFERENCE_API_URL", "http://upstream:9999")
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -250,6 +250,40 @@ def test_targets_invocations_path_on_inference_api(
 
     TestClient(app).post(chat_path, json={"message": "hi"})
     assert captured["url"] == "http://upstream:9999/invocations"
+
+
+def test_agentcore_runtime_url_encodes_arn_and_appends_qualifier(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str,
+) -> None:
+    """AgentCore Runtime data plane requires a URL-encoded ARN segment and
+    a `qualifier` query string. SSM stores the ARN unencoded, so the proxy
+    has to re-encode the path and append `qualifier=DEFAULT`. Without this,
+    AWS returns 404 because the unencoded `/` in the ARN splits the path
+    into too many segments.
+    """
+    monkeypatch.setenv(
+        "INFERENCE_API_URL",
+        "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/"
+        "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/foo-AbCdEf",
+    )
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200, content=b"event: done\ndata: {}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(record=_record(), user_override=_user())
+
+    TestClient(app).post(chat_path, json={"message": "hi"})
+    assert captured["url"] == (
+        "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/"
+        "arn%3Aaws%3Abedrock-agentcore%3Aus-west-2%3A123456789012%3Aruntime"
+        "%2Ffoo-AbCdEf/invocations?qualifier=DEFAULT"
+    )
 
 
 # ── Non-SSE relay (e.g. inference-api returns JSON validation error pre-stream) ──


### PR DESCRIPTION
## Summary
- Percent-encode the AgentCore Runtime ARN as a single path segment and append `?qualifier=DEFAULT` when the BFF chat proxy calls the AgentCore Runtime data plane. Localhost dev unchanged.
- Adds a regression test pinning the cloud URL shape; reworks the existing target-URL test to drive via the `INFERENCE_API_URL` env var (the public seam).

## Why
`POST /api/chat/stream` was returning 404 in the dev cloud env. The proxy was hitting

```
https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/arn:aws:bedrock-agentcore:us-west-2:.../runtime/dev_..._agentcore_runtime-XXXX/invocations
```

The data-plane route is `POST /runtimes/{agentRuntimeArn}/invocations?qualifier={qualifier}` where `{agentRuntimeArn}` must be a single URL-encoded segment. The unencoded `/` inside the ARN split the path into too many segments → AWS 404 → app-api dutifully forwarded it back as `POST /chat/stream → 404`.

Pre-[#230](https://github.com/Boise-State-Development/agentcore-public-stack/pull/230) the distribution-wide `errorResponses` block was rewriting that 404 to `200 + index.html`, which is exactly the JSON-parse symptom #230 set out to fix. Post-#230 the underlying 404 is now visible — that's how this bug surfaced.

The fix lives in the proxy (not CDK) because the ARN is a CFN token at synth time and CloudFormation has no URL-encode intrinsic; encoding has to happen in code, and the only consumer is this single call site.

## Test plan
- [x] `uv run python -m pytest tests/apis/app_api/chat/ -q` — 19 passed locally
- [ ] Deploy to dev cloud and verify `POST /api/chat/stream` returns the SSE stream instead of 404
- [ ] Smoke-test a chat turn end-to-end in the SPA on alpha

🤖 Generated with [Claude Code](https://claude.com/claude-code)