### PR TITLE
fix(auth): slide BFF session lifetime + harden refresh-token rotation

### DIFF
--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -15,6 +15,7 @@ parallel tab refreshes can tumble each other's refresh tokens.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Optional
@@ -184,6 +185,61 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
             self._cache.set(record)
         return new_max_age
 
+    async def _persist_refresh(
+        self,
+        *,
+        session_id: str,
+        refreshed,
+        last_seen_at: int,
+        ttl: int,
+        rotated: bool,
+    ) -> bool:
+        """Write refreshed tokens to DDB. Retry when rotation makes it critical.
+
+        Returns True on success or on a benign (non-rotation) failure. Returns
+        False only when rotation happened *and* every retry failed — caller
+        should treat that as session-unrecoverable.
+        """
+        # Three attempts on rotation (≈350ms total worst-case), single shot
+        # otherwise. boto3 already retries below us for transient API errors;
+        # this layer handles longer blips and validation/throttling errors
+        # that boto3 lets through.
+        attempts = 3 if rotated else 1
+        for attempt in range(attempts):
+            try:
+                await self._repository.update_tokens(
+                    session_id=session_id,
+                    access_token=refreshed.access_token,
+                    refresh_token=refreshed.refresh_token,
+                    id_token=refreshed.id_token,
+                    access_token_exp=refreshed.access_token_exp,
+                    last_seen_at=last_seen_at,
+                    ttl=ttl,
+                )
+                return True
+            except Exception as exc:
+                last_exc = exc
+                if attempt + 1 < attempts:
+                    await asyncio.sleep(0.05 * (2**attempt))  # 50ms, 100ms
+
+        if rotated:
+            logger.error(
+                "BFF refresh-token rotation persist failed for %s after %d attempts: %s — "
+                "invalidating session to force re-auth.",
+                session_id,
+                attempts,
+                last_exc,
+            )
+            return False
+
+        # No rotation — old refresh token still works, next request will retry.
+        logger.warning(
+            "BFF token persist failed for %s (no rotation, session still serviceable): %s",
+            session_id,
+            last_exc,
+        )
+        return True
+
     async def _resolve_session(
         self, cookie_value: str
     ) -> tuple[Optional[SessionRecord], bool]:
@@ -251,18 +307,26 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 now + self._config.session_ttl_seconds,
                 absolute_cap,
             )
-            # TODO: if this write fails after Cognito rotated the refresh
-            # token, DDB still holds the dead one — next request silently
-            # 401s. Hardened in a follow-up commit.
-            await self._repository.update_tokens(
+            # Detect refresh-token rotation. When Cognito rotates, the OLD
+            # refresh token is dead the moment the new one is issued — so a
+            # DDB write failure here means the session is unrecoverable on
+            # the *next* request even though *this* one succeeded. Retry
+            # aggressively, then fail-closed (clear cookie now) so the user
+            # re-auths immediately rather than getting silently 401'd later.
+            # Without rotation, the previous refresh token is still valid,
+            # so a DDB write failure is benign: the next request will just
+            # re-trigger refresh with the same (still good) refresh token.
+            rotated = refreshed.refresh_token != current.cognito_refresh_token
+            persist_ok = await self._persist_refresh(
                 session_id=session_id,
-                access_token=refreshed.access_token,
-                refresh_token=refreshed.refresh_token,
-                id_token=refreshed.id_token,
-                access_token_exp=refreshed.access_token_exp,
+                refreshed=refreshed,
                 last_seen_at=now,
                 ttl=new_ttl,
+                rotated=rotated,
             )
+            if not persist_ok:
+                self._cache.invalidate(session_id)
+                return None, True
             updated = SessionRecord(
                 session_id=current.session_id,
                 user_id=current.user_id,

--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -107,18 +107,82 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         record, clear_cookie = await self._resolve_session(cookie_value)
+        renewal_max_age: Optional[int] = None
         if record is not None:
             request.state.bff_session = record
             request.state.bff_csrf_token = CSRFHelper.derive_token(
                 record.csrf_secret, record.session_id
             )
+            # Decide whether this request should slide the session forward.
+            # `_maybe_slide` writes DDB if past the throttle window and returns
+            # the cookie Max-Age to re-emit (or None to leave the existing
+            # cookie alone).
+            renewal_max_age = await self._maybe_slide(record)
 
         response = await call_next(request)
 
         if clear_cookie:
             self._clear_cookies(response)
+        elif renewal_max_age is not None and record is not None:
+            self._reemit_cookies(
+                response,
+                sealed_session_value=cookie_value,
+                csrf_token=request.state.bff_csrf_token,
+                max_age_seconds=renewal_max_age,
+            )
 
         return response
+
+    async def _maybe_slide(self, record: SessionRecord) -> Optional[int]:
+        """Slide the session's DDB TTL + return a fresh cookie Max-Age.
+
+        Returns None when no slide is warranted (within throttle window, or
+        past the absolute lifetime cap). Otherwise returns the Max-Age the
+        caller should write into the response's Set-Cookie headers.
+
+        The absolute cap is enforced as `created_at + absolute_lifetime`. Once
+        past it, the cookie is allowed to expire on its own original Max-Age
+        — we don't extend, but we also don't proactively clear (the user
+        might still complete the in-flight request).
+        """
+        assert self._config is not None
+        now = int(time.time())
+        absolute_cap = record.created_at + self._config.absolute_lifetime_seconds
+        remaining_to_cap = absolute_cap - now
+        if remaining_to_cap <= 0:
+            return None
+
+        new_max_age = min(self._config.session_ttl_seconds, remaining_to_cap)
+
+        # Throttle: only write to DDB if it's been long enough since the last
+        # touch. The cookie re-emit is coupled to the write so the browser
+        # and DDB stay in sync about when the session should expire.
+        if (
+            now - record.last_seen_at
+            < self._config.sliding_renewal_throttle_seconds
+        ):
+            return None
+
+        new_ttl = now + new_max_age
+        try:
+            await self._repository.touch_last_seen(
+                record.session_id, last_seen_at=now, ttl=new_ttl
+            )
+        except Exception as exc:
+            # Don't fail the request if the slide-write fails — the user
+            # still has a valid session for the rest of its current TTL.
+            logger.warning(
+                "BFF session slide failed for %s: %s", record.session_id, exc
+            )
+            return None
+
+        # Reflect the slide locally so subsequent same-request reads (and the
+        # cache) don't think the row still needs a slide.
+        record.last_seen_at = now
+        record.ttl = new_ttl
+        if self._cache is not None:
+            self._cache.set(record)
+        return new_max_age
 
     async def _resolve_session(
         self, cookie_value: str
@@ -177,10 +241,19 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 return None, True
 
             now = int(time.time())
-            # TODO(phase-7): if this write fails, Cognito has rotated the
-            # refresh token but DDB still holds the old one — the session is
-            # silently broken on the next refresh attempt. Add a short retry
-            # loop or a conditional update with a version attribute.
+            # Slide the row's DDB TTL alongside the token rotation: the user
+            # is provably active. Capped at `created_at + absolute_lifetime`
+            # so a long-lived browser tab can't roll the session forever.
+            absolute_cap = (
+                current.created_at + self._config.absolute_lifetime_seconds
+            )
+            new_ttl = min(
+                now + self._config.session_ttl_seconds,
+                absolute_cap,
+            )
+            # TODO: if this write fails after Cognito rotated the refresh
+            # token, DDB still holds the dead one — next request silently
+            # 401s. Hardened in a follow-up commit.
             await self._repository.update_tokens(
                 session_id=session_id,
                 access_token=refreshed.access_token,
@@ -188,6 +261,7 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 id_token=refreshed.id_token,
                 access_token_exp=refreshed.access_token_exp,
                 last_seen_at=now,
+                ttl=new_ttl,
             )
             updated = SessionRecord(
                 session_id=current.session_id,
@@ -200,10 +274,45 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 csrf_secret=current.csrf_secret,
                 created_at=current.created_at,
                 last_seen_at=now,
-                ttl=current.ttl,
+                ttl=new_ttl,
             )
             self._cache.set(updated)
             return updated, False
+
+    @staticmethod
+    def _reemit_cookies(
+        response: Response,
+        *,
+        sealed_session_value: str,
+        csrf_token: str,
+        max_age_seconds: int,
+    ) -> None:
+        """Re-emit both BFF cookies with a fresh `Max-Age`.
+
+        The sealed value is the *same* one the browser already holds (cookie
+        seals are stable for a given session_id) — only the Max-Age slides
+        forward. Attribute set must mirror `auth/bff/cookies.py:set_session_cookies`
+        exactly so the browser updates the existing cookie rather than
+        creating a phantom twin.
+        """
+        response.set_cookie(
+            key=SESSION_COOKIE_NAME,
+            value=sealed_session_value,
+            max_age=max_age_seconds,
+            path="/",
+            secure=True,
+            httponly=True,
+            samesite="lax",
+        )
+        response.set_cookie(
+            key=CSRF_COOKIE_NAME,
+            value=csrf_token,
+            max_age=max_age_seconds,
+            path="/",
+            secure=True,
+            httponly=False,
+            samesite="lax",
+        )
 
     @staticmethod
     def _clear_cookies(response: Response) -> None:

--- a/backend/src/apis/shared/sessions_bff/config.py
+++ b/backend/src/apis/shared/sessions_bff/config.py
@@ -24,6 +24,14 @@ CSRF_HEADER_NAME = "X-CSRF-Token"
 # Defaults for the optional env vars. Match the Phase 1 CDK defaults.
 _DEFAULT_TTL_SECONDS = 28800  # 8 hours
 _DEFAULT_REFRESH_LEEWAY_SECONDS = 60
+# Hard cap on a single login's lifetime regardless of activity. 30d matches
+# the Cognito refresh-token default — past that, the upstream refresh would
+# fail anyway, so there's no value in carrying the cookie further.
+_DEFAULT_ABSOLUTE_LIFETIME_SECONDS = 30 * 24 * 3600
+# Don't write to DDB / re-emit cookies on every request; coalesce to once per
+# minute. Tabs that hit the BFF more often than this just ride the existing
+# row.
+_DEFAULT_SLIDING_RENEWAL_THROTTLE_SECONDS = 60
 
 
 @dataclass(frozen=True)
@@ -41,6 +49,11 @@ class BFFConfig:
     cognito_bff_app_client_id: Optional[str]
     cognito_bff_app_client_secret_arn: Optional[str]
     inference_api_url: Optional[str]
+    # Defaults provided so test fixtures and any direct constructor call sites
+    # don't have to learn about these fields. `from_env()` is what production
+    # uses and it always supplies values.
+    absolute_lifetime_seconds: int = _DEFAULT_ABSOLUTE_LIFETIME_SECONDS
+    sliding_renewal_throttle_seconds: int = _DEFAULT_SLIDING_RENEWAL_THROTTLE_SECONDS
 
     @classmethod
     def from_env(cls) -> "BFFConfig":
@@ -53,6 +66,14 @@ class BFFConfig:
             refresh_leeway_seconds=int(
                 os.environ.get("BFF_SESSION_REFRESH_LEEWAY_SECONDS")
                 or _DEFAULT_REFRESH_LEEWAY_SECONDS
+            ),
+            absolute_lifetime_seconds=int(
+                os.environ.get("BFF_SESSION_ABSOLUTE_LIFETIME_SECONDS")
+                or _DEFAULT_ABSOLUTE_LIFETIME_SECONDS
+            ),
+            sliding_renewal_throttle_seconds=int(
+                os.environ.get("BFF_SESSION_SLIDING_RENEWAL_THROTTLE_SECONDS")
+                or _DEFAULT_SLIDING_RENEWAL_THROTTLE_SECONDS
             ),
             cognito_bff_app_client_id=os.environ.get("COGNITO_BFF_APP_CLIENT_ID") or None,
             cognito_bff_app_client_secret_arn=os.environ.get(

--- a/backend/src/apis/shared/sessions_bff/repository.py
+++ b/backend/src/apis/shared/sessions_bff/repository.py
@@ -128,12 +128,16 @@ class SessionRepository:
         id_token: Optional[str],
         access_token_exp: int,
         last_seen_at: int,
+        ttl: Optional[int] = None,
     ) -> None:
         """Atomically replace the Cognito tokens after a refresh.
 
         The refresh middleware calls this once it has a fresh access token.
         Note that Cognito's refresh-token rotation may issue a new refresh
-        token too, hence the explicit `refresh_token` parameter.
+        token too, hence the explicit `refresh_token` parameter. When `ttl`
+        is supplied, the row's DynamoDB TTL slides forward in the same write
+        — a refresh proves the user is active, so the session row's expiry
+        should slide alongside it.
         """
         if not self._enabled:
             return
@@ -152,21 +156,47 @@ class SessionRepository:
         if id_token is not None:
             update_expr += ", id_token = :id"
             expr_values[":id"] = id_token
-        self._table.update_item(
-            Key=self._key(session_id),
-            UpdateExpression=update_expr,
-            ExpressionAttributeValues=expr_values,
-        )
+        if ttl is not None:
+            update_expr += ", #ttl = :ttl"
+            expr_values[":ttl"] = ttl
+        kwargs = {
+            "Key": self._key(session_id),
+            "UpdateExpression": update_expr,
+            "ExpressionAttributeValues": expr_values,
+        }
+        if ttl is not None:
+            # `ttl` is a reserved word in DynamoDB expressions.
+            kwargs["ExpressionAttributeNames"] = {"#ttl": "ttl"}
+        self._table.update_item(**kwargs)
 
-    async def touch_last_seen(self, session_id: str, last_seen_at: int) -> None:
+    async def touch_last_seen(
+        self,
+        session_id: str,
+        last_seen_at: int,
+        ttl: Optional[int] = None,
+    ) -> None:
+        """Slide `last_seen_at` (and optionally `ttl`) without touching tokens.
+
+        Used by the sliding-session path in `SessionRefreshMiddleware`: an
+        active user that doesn't yet need a token refresh still needs the
+        DDB TTL pushed forward so the row doesn't reap out from under them.
+        """
         if not self._enabled:
             return
+        update_expr = "SET last_seen_at = :seen"
+        expr_values: dict = {":seen": last_seen_at}
+        kwargs: dict = {
+            "Key": self._key(session_id),
+            "UpdateExpression": update_expr,
+            "ExpressionAttributeValues": expr_values,
+        }
+        if ttl is not None:
+            update_expr += ", #ttl = :ttl"
+            expr_values[":ttl"] = ttl
+            kwargs["UpdateExpression"] = update_expr
+            kwargs["ExpressionAttributeNames"] = {"#ttl": "ttl"}
         try:
-            self._table.update_item(
-                Key=self._key(session_id),
-                UpdateExpression="SET last_seen_at = :seen",
-                ExpressionAttributeValues={":seen": last_seen_at},
-            )
+            self._table.update_item(**kwargs)
         except ClientError as exc:
             # Touch failures are non-critical — log and move on rather than
             # surfacing as a request error.

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
@@ -502,3 +502,75 @@ def test_refresh_path_bumps_ttl_when_persisting_tokens() -> None:
     assert kwargs["ttl"] - now > 28000  # bumped by ~session_ttl_seconds
 
 
+# ─── Refresh-token rotation hardening ───────────────────────────────────
+
+
+def test_rotation_persist_failure_invalidates_session() -> None:
+    """When Cognito rotates the refresh token (returns a new one) AND every
+    DDB write retry fails, the session must be invalidated immediately:
+    the old refresh token is dead at Cognito, so leaving the row stale
+    guarantees a silent 401 on the next request. Better to force re-auth
+    now while the user is in the loop."""
+    record = _make_record(access_token_exp=int(time.time()) + 5)
+    repo = AsyncMock()
+    repo.get.return_value = record
+    repo.update_tokens.side_effect = RuntimeError("DDB throttled")
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh.return_value = RefreshResult(
+        access_token="access.fresh",
+        refresh_token="refresh.ROTATED",  # rotation kicked in
+        id_token="id.fresh",
+        access_token_exp=int(time.time()) + 3600,
+    )
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    # Three retry attempts on rotation.
+    assert repo.update_tokens.await_count == 3
+    # Cookie must be cleared so the browser stops carrying a now-zombie session.
+    cleared = " ".join(response.headers.get_list("set-cookie"))
+    assert SESSION_COOKIE_NAME in cleared
+
+
+def test_non_rotation_persist_failure_does_not_invalidate() -> None:
+    """If Cognito did NOT rotate (returned the same refresh token) and the
+    DDB write fails, the session is still serviceable — the existing
+    refresh token is still valid for the next attempt. Don't punish the
+    user with a re-auth for a transient DDB blip."""
+    record = _make_record(access_token_exp=int(time.time()) + 5)
+    repo = AsyncMock()
+    repo.get.return_value = record
+    repo.update_tokens.side_effect = RuntimeError("DDB throttled")
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh.return_value = RefreshResult(
+        access_token="access.fresh",
+        refresh_token="refresh.original",  # SAME — no rotation
+        id_token="id.fresh",
+        access_token_exp=int(time.time()) + 3600,
+    )
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_session"] is True
+    assert body["access_token"] == "access.fresh"  # in-memory record updated
+    # Single attempt only when no rotation.
+    assert repo.update_tokens.await_count == 1
+    # Cookie must NOT be cleared.
+    cleared = " ".join(response.headers.get_list("set-cookie"))
+    assert "Max-Age=0" not in cleared
+
+

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
@@ -71,15 +71,22 @@ def _make_record(
     )
 
 
-def _enabled_config() -> BFFConfig:
+def _enabled_config(
+    *,
+    sliding_renewal_throttle_seconds: int = 60,
+    absolute_lifetime_seconds: int = 30 * 24 * 3600,
+    session_ttl_seconds: int = 28800,
+) -> BFFConfig:
     return BFFConfig(
         sessions_table_name="tbl",
         cookie_signing_key_arn="arn:aws:kms:fake",
-        session_ttl_seconds=28800,
+        session_ttl_seconds=session_ttl_seconds,
         refresh_leeway_seconds=60,
         cognito_bff_app_client_id="client-id",
         cognito_bff_app_client_secret_arn="arn:secret",
         inference_api_url=None,
+        absolute_lifetime_seconds=absolute_lifetime_seconds,
+        sliding_renewal_throttle_seconds=sliding_renewal_throttle_seconds,
     )
 
 
@@ -325,3 +332,173 @@ async def test_storm_coalesces_to_single_refresh() -> None:
         assert r.status_code == 200
     # Critical assertion: only one refresh call across all 5 concurrent reqs.
     assert call_count["n"] == 1
+
+
+# ─── Sliding-session tests ─────────────────────────────────────────────
+
+
+def _slide_set_cookie_max_age(set_cookie_headers: list[str]) -> Optional[int]:
+    """Pull the session-cookie Max-Age out of the response's Set-Cookie list.
+
+    Returns None when no session cookie was emitted. Used to assert that
+    a slide was reflected to the browser, not just to DDB.
+    """
+    for header in set_cookie_headers:
+        if not header.startswith(f"{SESSION_COOKIE_NAME}="):
+            continue
+        for part in header.split(";"):
+            part = part.strip()
+            if part.lower().startswith("max-age="):
+                return int(part.split("=", 1)[1])
+    return None
+
+
+def test_slide_within_throttle_window_does_not_write_or_reemit() -> None:
+    """A request arriving within `sliding_renewal_throttle_seconds` of the
+    last touch must not generate a DDB write or re-set the cookie. Without
+    the throttle, every request would cost a write."""
+    record = _make_record()
+    # Pretend the row was touched 5s ago — well inside the 60s throttle.
+    record.last_seen_at = int(time.time()) - 5
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    repo.touch_last_seen.assert_not_called()
+    repo.update_tokens.assert_not_called()
+    # No Set-Cookie for the session cookie — we left the existing one alone.
+    assert _slide_set_cookie_max_age(response.headers.get_list("set-cookie")) is None
+
+
+def test_slide_past_throttle_writes_ddb_and_reemits_cookie() -> None:
+    """Once `last_seen_at` is older than the throttle window, the slide
+    fires: one DDB touch with a fresh ttl, plus a Set-Cookie carrying a
+    fresh Max-Age = session_ttl_seconds."""
+    record = _make_record()
+    record.last_seen_at = int(time.time()) - 120  # past the 60s throttle
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    # Exactly one slide-write, and it carries a ttl bumped by ~session_ttl_seconds.
+    repo.touch_last_seen.assert_awaited_once()
+    args, kwargs = repo.touch_last_seen.await_args
+    # session_id passed positionally; last_seen_at/ttl by keyword.
+    assert (args[0] if args else kwargs.get("session_id")) == record.session_id
+    now = int(time.time())
+    assert abs(kwargs["last_seen_at"] - now) < 5
+    # ttl must be roughly now + session_ttl_seconds (28800), not the original
+    # ttl on the record. Wide window because TestClient adds latency.
+    assert kwargs["ttl"] - now > 28000
+    repo.update_tokens.assert_not_called()  # slide path, not refresh path
+
+    max_age = _slide_set_cookie_max_age(response.headers.get_list("set-cookie"))
+    assert max_age is not None
+    assert max_age == 28800
+
+
+def test_slide_past_absolute_cap_does_not_extend() -> None:
+    """When `created_at + absolute_lifetime` has already passed, the slide
+    must be a no-op — we don't roll a session beyond its hard cap. The
+    user keeps the rest of whatever validity their cookie still has."""
+    record = _make_record()
+    # absolute_lifetime = 100s; created 200s ago → past the cap.
+    record.created_at = int(time.time()) - 200
+    record.last_seen_at = int(time.time()) - 120  # past throttle
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(absolute_lifetime_seconds=100),
+        repository=repo,
+        codec=codec,
+        refresh_client=refresh,
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    repo.touch_last_seen.assert_not_called()
+    assert _slide_set_cookie_max_age(response.headers.get_list("set-cookie")) is None
+
+
+def test_slide_max_age_capped_by_remaining_absolute_lifetime() -> None:
+    """When session_ttl_seconds would exceed remaining absolute lifetime,
+    the slide caps Max-Age at the remaining window so the cookie can't
+    outlive the absolute cap."""
+    record = _make_record()
+    # absolute_lifetime = 1000s; created 600s ago → 400s remaining.
+    record.created_at = int(time.time()) - 600
+    record.last_seen_at = int(time.time()) - 120
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    app = _build_app(
+        config=_enabled_config(
+            absolute_lifetime_seconds=1000,
+            session_ttl_seconds=28800,  # would normally be Max-Age
+        ),
+        repository=repo,
+        codec=codec,
+        refresh_client=refresh,
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    max_age = _slide_set_cookie_max_age(response.headers.get_list("set-cookie"))
+    # Capped near 400s, not 28800s. Wide tolerance for TestClient latency.
+    assert max_age is not None
+    assert 350 <= max_age <= 400
+
+
+def test_refresh_path_bumps_ttl_when_persisting_tokens() -> None:
+    """The token-rotation write must also slide the row's ttl forward —
+    otherwise a session that just refreshed could still expire moments
+    later because the original ttl was set at login."""
+    record = _make_record(access_token_exp=int(time.time()) + 5)  # within leeway
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh.return_value = RefreshResult(
+        access_token="access.fresh",
+        refresh_token="refresh.original",  # no rotation
+        id_token="id.fresh",
+        access_token_exp=int(time.time()) + 3600,
+    )
+    app = _build_app(
+        config=_enabled_config(), repository=repo, codec=codec, refresh_client=refresh
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    repo.update_tokens.assert_awaited_once()
+    kwargs = repo.update_tokens.await_args.kwargs
+    assert "ttl" in kwargs
+    now = int(time.time())
+    assert kwargs["ttl"] - now > 28000  # bumped by ~session_ttl_seconds
+
+


### PR DESCRIPTION
## Summary

- **Slide the BFF session forward on activity.** The `__Host-bff_session` cookie's `Max-Age` was pinned at login to `BFF_SESSION_TTL_SECONDS` (default 8h) and never extended, so an active user got logged out at the 8h wall-clock mark even though their Cognito refresh token was still good for ~30 days. The DDB row's `ttl` had the same problem. `SessionRefreshMiddleware` now slides both forward (throttled to one DDB write per minute per session), capped by `BFF_SESSION_ABSOLUTE_LIFETIME_SECONDS` (default 30d).
- **Close the refresh-token rotation cliff.** When Cognito rotated the refresh token but the subsequent DDB write failed, the row silently kept the dead refresh token — the next request then hit `CognitoRefreshError` and the user was logged out with no warning. The new `_persist_refresh()` helper retries on rotation and fails-closed (forces re-auth this request) when retries exhaust; non-rotation persist failures stay benign since the existing refresh token is still valid.

## Why

Phil reported a 401 on `GET /auth/session` after some idle time. The diagnosis: the refresh middleware never got a chance to run because the cookie itself had already expired client-side. Cognito refresh-token validity (~30d) was effectively useless — the BFF capped sessions at 8h hard.

## What changed

| File | Change |
|---|---|
| `apis/shared/sessions_bff/config.py` | New fields `absolute_lifetime_seconds` / `sliding_renewal_throttle_seconds` + their env vars `BFF_SESSION_ABSOLUTE_LIFETIME_SECONDS` / `BFF_SESSION_SLIDING_RENEWAL_THROTTLE_SECONDS`. Defaulted at the dataclass level so existing constructor sites (tests) don't have to learn about them. |
| `apis/shared/sessions_bff/repository.py` | `update_tokens` and `touch_last_seen` grew an optional `ttl` arg. Uses `#ttl` `ExpressionAttributeNames` since `ttl` is reserved in DDB expressions. |
| `apis/shared/middleware/session_refresh.py` | New `_maybe_slide()` runs on every successful resolution (cache hit *and* DDB hit), throttled to one write per minute, capped at `created_at + absolute_lifetime`. New `_persist_refresh()` helper handles the rotation-aware retry/fail-closed write semantics. The refresh path also now bumps `ttl` so a successful refresh slides the row's expiry alongside the tokens. |
| Tests | +7 covering throttle gate, slide write+cookie, absolute cap, max-age cap-by-remaining-lifetime, refresh-path ttl bump, rotation persist failure, non-rotation persist failure. |

Two commits, split for review:
- `e17d6ea1 feat(auth): slide BFF session lifetime on activity`
- `d727c175 fix(auth): close the BFF refresh-token rotation cliff`

## Behavior

| Scenario | Before | After |
|---|---|---|
| Idle 8h, then request | 401 + redirect to login | Cookie + DDB TTL slide; logged in |
| Active continuously past 30d | (n/a — kicked at 8h) | Hard logout at 30d |
| Rotation + DDB write fails | Silent 401 on next request | 3 retries, then forced re-auth this request |
| No rotation + DDB write fails | (same as above — silent break) | Session preserved; existing refresh token still valid |
| 100 req/sec on one session | 100 writes/sec (if it worked) | 1 write/min (throttled) |

## Reviewer notes

- Cookie attribute set in the middleware's `_reemit_cookies` mirrors `auth/bff/cookies.py:set_session_cookies` exactly (`__Host-` prefix → `Path=/`, `Secure`, no `Domain`, `samesite=lax`). Don't drift them.
- The 30d default for `absolute_lifetime_seconds` matches the Cognito refresh-token default — past that the upstream refresh would fail anyway, so there's no point carrying the cookie further.
- The 60s renewal throttle keeps writes cheap on chatty SPA polling. Lower it if/when we add a session-activity audit log that needs finer resolution.
- Skipped a conditional update with a version attribute in `_persist_refresh` — overkill given the per-`session_id` `asyncio.Lock` already coalesces in-process and cross-task races are rare inside the refresh-leeway window. Worth reconsidering if we ever observe a real concurrent-writer issue.

## Test plan

- [x] `tests/apis/shared/sessions_bff` — 56/56 green (49 baseline + 7 new)
- [x] `tests/apis/app_api/auth` + `tests/architecture` — 147/147 green together with shared
- [ ] Manual: log in, leave the SPA idle past 8h, confirm next request stays authenticated and the session cookie's `Max-Age` slid forward
- [ ] Manual: log in, leave for >30d (or temporarily set `BFF_SESSION_ABSOLUTE_LIFETIME_SECONDS=120` and wait), confirm hard logout
- [ ] Smoke check on dev that no fresh 401s appear in app-api logs after a typical workday