### PR TITLE
feat(voice): BFF WebSocket-ticket proxy for voice mode (#211)

### DIFF
--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -558,6 +558,35 @@ BFF_SESSION_TTL_SECONDS=28800
 BFF_SESSION_REFRESH_LEEWAY_SECONDS=60
 
 # =============================================================================
+# VOICE WEBSOCKET-TICKET (issue #211)
+# =============================================================================
+# App-api proxies the voice WebSocket so the SPA never holds a Cognito access
+# token. The SPA mints a single-use HMAC ticket via POST /voice/ticket
+# (cookie + CSRF) and presents it on the WS upgrade; app-api validates it,
+# then opens the upstream WS to AgentCore using the BFF-stored Cognito token.
+#
+# Both vars are produced by the InfrastructureStack. When they're unset
+# (no Phase 1 deploy), the replay store falls back to in-memory single-process
+# mode and the ticket service raises 503 — fine for local read-only work but
+# voice mode itself is unavailable.
+
+# DynamoDB table for single-use jti tracking (REQUIRED for voice mode)
+# Purpose: Conditional-put records every consumed ticket jti so a replayed
+# ticket on a second WS upgrade is rejected. TTL on `ttl` reaps consumed
+# rows ~1 minute past ticket expiry.
+# CDK Deployment: Created by InfrastructureStack as VoiceTicketReplayTable
+# Example: <projectPrefix>-voice-ticket-replay
+VOICE_TICKET_REPLAY_TABLE_NAME=
+
+# Secrets Manager ARN holding the HMAC signing key (REQUIRED for voice mode)
+# Purpose: 64-char random string used to HMAC-SHA256-sign each ticket payload.
+# App-api fetches once at startup and caches the bytes for the lifetime of
+# the process. Rotated by replacing the secret value (forces a task restart).
+# Where to find: SSM /<projectPrefix>/voice/ticket-signing-secret-arn
+# Example: arn:aws:secretsmanager:us-west-2:123456789012:secret:<projectPrefix>-voice-ticket-signing-key-XXXXXX
+VOICE_TICKET_SIGNING_SECRET_ARN=
+
+# =============================================================================
 # OIDC AUTHENTICATION PROVIDER CONFIGURATION
 # =============================================================================
 # Authentication providers are managed via the admin OIDC provider setup.

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -131,6 +131,7 @@ from apis.app_api.user_settings.routes import router as user_settings_router
 from apis.app_api.connectors.routes import router as connectors_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
+from apis.app_api.voice import router as voice_router
 
 # Include routers
 app.include_router(health_router)
@@ -156,6 +157,7 @@ app.include_router(system_router)  # System status and first-boot endpoints
 app.include_router(conversations_share_router)  # Share conversations endpoints
 app.include_router(shares_router)  # Share management (update, revoke, export)
 app.include_router(shared_view_router)  # Shared conversation read-only view
+app.include_router(voice_router)  # Cookie-authenticated WS proxy for Nova Sonic voice mode (#211)
 
 # Conditionally register fine-tuning routes
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":

--- a/backend/src/apis/app_api/voice/__init__.py
+++ b/backend/src/apis/app_api/voice/__init__.py
@@ -1,0 +1,21 @@
+"""Voice mode — ticket issuance + WebSocket proxy.
+
+The SPA cannot ride the BFF cookie all the way to inference-api: AgentCore
+Runtime's WebSocket gate validates only Cognito-issued JWTs, and the BFF
+keeps those server-side. So app-api owns both halves of the voice transport:
+
+  1. ``POST /voice/ticket``  — CSRF-protected, issues a single-use ticket
+                              bound to ``{user_sub, session_id, jti, exp}``.
+  2. ``WebSocket /voice/stream`` — verifies the ticket, opens an upstream
+                                  WebSocket to the AgentCore Runtime using
+                                  the Cognito access token from the BFF
+                                  session, and bidirectionally relays JSON
+                                  frames. The browser never sees a Cognito
+                                  token.
+
+See issue #211 for the migration context.
+"""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -162,8 +162,8 @@ async def relay_voice_stream(
                 logger.debug("Ignoring error while closing upstream voice WS: %s", exc, exc_info=True)
         try:
             await session.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to close upstream aiohttp session cleanly: %s", exc, exc_info=True)
 
 
 async def _pump_client_to_upstream(

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -145,8 +145,11 @@ async def relay_voice_stream(
             task.cancel()
             try:
                 await task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
+                # Expected after explicit cancellation.
                 pass
+            except Exception as exc:
+                logger.debug("Ignored exception while cancelling relay task: %s", exc, exc_info=True)
         for task in done:
             exc = task.exception()
             if exc and not isinstance(exc, (asyncio.CancelledError, WebSocketDisconnect)):

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -158,8 +158,8 @@ async def relay_voice_stream(
         if upstream_ws is not None and not upstream_ws.closed:
             try:
                 await upstream_ws.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Ignoring error while closing upstream voice WS: %s", exc, exc_info=True)
         try:
             await session.close()
         except Exception:

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -175,13 +175,14 @@ async def _pump_client_to_upstream(
 ) -> None:
     """Forward every frame from the SPA to the AgentCore upstream.
 
-    The first text frame is treated as the config handshake. Inference-api
-    reads ``auth_token`` from that frame to identify the user — the SPA can't
-    populate it (the BFF holds the token), so we inject it here. We also
-    inject ``user_id`` defensively in case the SPA didn't send one. After
-    that first frame, the relay is verbatim.
+    Every text frame is screened for a JSON config payload and, if matched,
+    has its ``auth_token`` and ``user_id`` overwritten with the BFF-pinned
+    values before being forwarded. The SPA must not be able to influence
+    either field — both pin the identity inference-api attributes the
+    session to. Non-config frames (audio chunks, control messages, anything
+    that isn't a JSON object with ``type == "config"``) pass through
+    unchanged.
     """
-    config_injected = False
     try:
         while True:
             message = await client_ws.receive()
@@ -193,13 +194,11 @@ async def _pump_client_to_upstream(
             byte_frame = message.get("bytes")
 
             if text_frame is not None:
-                if not config_injected:
-                    text_frame = _inject_config_auth(
-                        text_frame,
-                        access_token=cognito_access_token,
-                        user_id=user_id,
-                    )
-                    config_injected = True
+                text_frame = _inject_config_auth(
+                    text_frame,
+                    access_token=cognito_access_token,
+                    user_id=user_id,
+                )
                 await upstream_ws.send_str(text_frame)
             elif byte_frame is not None:
                 # Voice payloads are JSON-with-base64, not binary frames, but
@@ -214,13 +213,13 @@ async def _pump_client_to_upstream(
 
 
 def _inject_config_auth(text_frame: str, *, access_token: str, user_id: str) -> str:
-    """Add ``auth_token`` and ``user_id`` to a JSON config frame.
+    """Overwrite ``auth_token`` and ``user_id`` on a JSON config frame.
 
-    Returns the frame unchanged if it isn't a JSON object — better to forward
-    something the SPA chose than to drop it. Inference-api will reject the
-    upgrade if its config never arrives or carries no auth_token, so a
-    malformed first frame surfaces as an upstream error rather than a silent
-    auth bypass.
+    The SPA must not be able to influence either field — they pin the user
+    identity that inference-api attributes the session to, so any client-
+    supplied value is replaced with the BFF-authenticated one. Anything
+    other than a JSON object with ``type == "config"`` is forwarded
+    untouched (binary audio frames, control messages, malformed payloads).
     """
     try:
         parsed = json.loads(text_frame)
@@ -231,7 +230,7 @@ def _inject_config_auth(text_frame: str, *, access_token: str, user_id: str) -> 
     if parsed.get("type") != "config":
         return text_frame
     parsed["auth_token"] = access_token
-    parsed.setdefault("user_id", user_id)
+    parsed["user_id"] = user_id
     return json.dumps(parsed, separators=(",", ":"))
 
 

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -263,5 +263,5 @@ async def _safe_send_error(client_ws: WebSocket, message: str) -> None:
         return
     try:
         await client_ws.send_json({"type": "bidi_error", "message": message})
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Failed to send bidi_error frame to client: %s", exc)

--- a/backend/src/apis/app_api/voice/proxy.py
+++ b/backend/src/apis/app_api/voice/proxy.py
@@ -1,0 +1,264 @@
+"""WebSocket relay between the SPA and the upstream AgentCore Runtime.
+
+The browser's WebSocket sees only ``wss://<frontend>/api/voice/stream`` (the
+BFF endpoint). The upstream WebSocket talks to either:
+
+* **Cloud:** ``wss://bedrock-agentcore.<region>.amazonaws.com/runtimes/<arn>/ws``
+  with the Cognito access token in ``Sec-WebSocket-Protocol`` so the
+  AgentCore Runtime's JWT Authorizer accepts the upgrade.
+* **Local dev:** ``ws://localhost:8001/voice/stream`` — a plain FastAPI
+  WebSocket on inference-api with no upstream auth gate.
+
+The relay is symmetric and fully duplex: client→upstream and upstream→client
+run as concurrent tasks; the first to complete cancels the other so the
+proxy doesn't leak half-open sockets. Frames are forwarded as text (JSON)
+or binary unchanged. The ticket auth is enforced once, on upgrade — past
+that, the BFF is just a pipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Optional
+from urllib.parse import quote, urlsplit
+
+import aiohttp
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+logger = logging.getLogger(__name__)
+
+# Connect timeout for the upstream upgrade. Generous because the AgentCore
+# proxy can take a few seconds to validate the JWT and route to the runtime.
+_UPSTREAM_CONNECT_TIMEOUT = 15.0
+# Receive/heartbeat. The voice stream is chatty (audio chunks every ~100ms);
+# anything past 60s of silence is a stalled upstream and worth surfacing.
+_UPSTREAM_HEARTBEAT = 30.0
+
+
+def _inference_api_url() -> str:
+    return os.environ.get("INFERENCE_API_URL", "http://localhost:8001")
+
+
+def build_upstream_ws_url(base_url: str) -> str:
+    """Resolve the upstream WS URL from ``INFERENCE_API_URL``.
+
+    Mirrors ``proxy_routes._build_invocations_url`` for the WebSocket path:
+    cloud routes go to ``/runtimes/<encoded-arn>/ws``, local dev routes to
+    ``/voice/stream`` directly. The ARN must be percent-encoded as a single
+    path segment per AgentCore's data-plane contract.
+    """
+    parts = urlsplit(base_url)
+    scheme = "wss" if parts.scheme == "https" else "ws"
+    prefix = "/runtimes/"
+    if parts.netloc.startswith("bedrock-agentcore.") and parts.path.startswith(prefix):
+        arn = parts.path[len(prefix):]
+        encoded_arn = quote(arn, safe="")
+        # AgentCore Runtime serves WebSocket at /ws on the encoded-ARN path.
+        # No `qualifier` query param is documented for WS, but the runtime
+        # rejects extras, so leave it off.
+        return f"{scheme}://{parts.netloc}/runtimes/{encoded_arn}/ws"
+    return f"{scheme}://{parts.netloc}/voice/stream"
+
+
+def _bearer_subprotocol(access_token: str) -> str:
+    """Pack a Cognito access token into AgentCore's accepted subprotocol form.
+
+    The runtime's JWT Authorizer reads ``base64UrlBearerAuthorization.<b64url>``
+    from ``Sec-WebSocket-Protocol`` on the upgrade. Standard base64url with
+    padding stripped — same shape the legacy SPA used pre-BFF cutover.
+    """
+    import base64
+
+    b64 = base64.urlsafe_b64encode(access_token.encode("utf-8")).decode("ascii")
+    return f"base64UrlBearerAuthorization.{b64.rstrip('=')}"
+
+
+async def relay_voice_stream(
+    *,
+    client_ws: WebSocket,
+    cognito_access_token: str,
+    user_id: str,
+) -> None:
+    """Open the upstream WS and relay frames in both directions.
+
+    Caller must have already accepted ``client_ws``. Returns once either
+    side closes; the caller is responsible for closing ``client_ws`` in its
+    finally block. Failures connecting upstream are reported back to the
+    client as a ``bidi_error`` JSON frame before this function returns.
+    """
+    upstream_url = build_upstream_ws_url(_inference_api_url())
+
+    parts = urlsplit(upstream_url)
+    use_subprotocol = parts.netloc.startswith("bedrock-agentcore.")
+    protocols: list[str] = []
+    headers: dict[str, str] = {}
+
+    if use_subprotocol:
+        # Cloud: AgentCore proxy auths via Sec-WebSocket-Protocol.
+        protocols = [_bearer_subprotocol(cognito_access_token), "base64UrlBearerAuthorization"]
+    else:
+        # Local dev: inference-api accepts a plain Authorization header on
+        # the upgrade, and reads the auth_token from the first config
+        # message. We forward the bearer header here so dev parity holds.
+        headers["Authorization"] = f"Bearer {cognito_access_token}"
+
+    timeout = aiohttp.ClientTimeout(total=None, connect=_UPSTREAM_CONNECT_TIMEOUT)
+    session = aiohttp.ClientSession(timeout=timeout)
+    upstream_ws: Optional[aiohttp.ClientWebSocketResponse] = None
+    try:
+        try:
+            upstream_ws = await session.ws_connect(
+                upstream_url,
+                protocols=protocols or (),
+                headers=headers,
+                heartbeat=_UPSTREAM_HEARTBEAT,
+                max_msg_size=0,  # unbounded — voice frames can be large
+            )
+        except aiohttp.WSServerHandshakeError as exc:
+            logger.error("Upstream voice WS handshake failed: %s", exc)
+            await _safe_send_error(client_ws, f"upstream rejected ({exc.status})")
+            return
+        except Exception as exc:
+            logger.error("Upstream voice WS connect failed: %s", exc, exc_info=True)
+            await _safe_send_error(client_ws, "upstream unreachable")
+            return
+
+        forward_to_upstream = asyncio.create_task(
+            _pump_client_to_upstream(
+                client_ws,
+                upstream_ws,
+                cognito_access_token=cognito_access_token,
+                user_id=user_id,
+            )
+        )
+        forward_to_client = asyncio.create_task(_pump_upstream_to_client(upstream_ws, client_ws))
+
+        done, pending = await asyncio.wait(
+            [forward_to_upstream, forward_to_client],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        for task in done:
+            exc = task.exception()
+            if exc and not isinstance(exc, (asyncio.CancelledError, WebSocketDisconnect)):
+                logger.warning("Voice relay task error: %s", exc)
+    finally:
+        if upstream_ws is not None and not upstream_ws.closed:
+            try:
+                await upstream_ws.close()
+            except Exception:
+                pass
+        try:
+            await session.close()
+        except Exception:
+            pass
+
+
+async def _pump_client_to_upstream(
+    client_ws: WebSocket,
+    upstream_ws: aiohttp.ClientWebSocketResponse,
+    *,
+    cognito_access_token: str,
+    user_id: str,
+) -> None:
+    """Forward every frame from the SPA to the AgentCore upstream.
+
+    The first text frame is treated as the config handshake. Inference-api
+    reads ``auth_token`` from that frame to identify the user — the SPA can't
+    populate it (the BFF holds the token), so we inject it here. We also
+    inject ``user_id`` defensively in case the SPA didn't send one. After
+    that first frame, the relay is verbatim.
+    """
+    config_injected = False
+    try:
+        while True:
+            message = await client_ws.receive()
+            msg_type = message.get("type")
+            if msg_type == "websocket.disconnect":
+                return
+
+            text_frame = message.get("text")
+            byte_frame = message.get("bytes")
+
+            if text_frame is not None:
+                if not config_injected:
+                    text_frame = _inject_config_auth(
+                        text_frame,
+                        access_token=cognito_access_token,
+                        user_id=user_id,
+                    )
+                    config_injected = True
+                await upstream_ws.send_str(text_frame)
+            elif byte_frame is not None:
+                # Voice payloads are JSON-with-base64, not binary frames, but
+                # forward bytes too for protocol forward-compat.
+                await upstream_ws.send_bytes(byte_frame)
+    except WebSocketDisconnect:
+        return
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.debug("client→upstream pump exited: %s", exc)
+
+
+def _inject_config_auth(text_frame: str, *, access_token: str, user_id: str) -> str:
+    """Add ``auth_token`` and ``user_id`` to a JSON config frame.
+
+    Returns the frame unchanged if it isn't a JSON object — better to forward
+    something the SPA chose than to drop it. Inference-api will reject the
+    upgrade if its config never arrives or carries no auth_token, so a
+    malformed first frame surfaces as an upstream error rather than a silent
+    auth bypass.
+    """
+    try:
+        parsed = json.loads(text_frame)
+    except (json.JSONDecodeError, TypeError):
+        return text_frame
+    if not isinstance(parsed, dict):
+        return text_frame
+    if parsed.get("type") != "config":
+        return text_frame
+    parsed["auth_token"] = access_token
+    parsed.setdefault("user_id", user_id)
+    return json.dumps(parsed, separators=(",", ":"))
+
+
+async def _pump_upstream_to_client(
+    upstream_ws: aiohttp.ClientWebSocketResponse,
+    client_ws: WebSocket,
+) -> None:
+    """Forward every frame from the AgentCore upstream to the SPA."""
+    try:
+        async for msg in upstream_ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                await client_ws.send_text(msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                await client_ws.send_bytes(msg.data)
+            elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+                return
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                logger.warning("Upstream voice WS error frame: %s", upstream_ws.exception())
+                return
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.debug("upstream→client pump exited: %s", exc)
+
+
+async def _safe_send_error(client_ws: WebSocket, message: str) -> None:
+    """Best-effort error frame to the SPA — swallow failures from a half-closed socket."""
+    if client_ws.application_state != WebSocketState.CONNECTED:
+        return
+    try:
+        await client_ws.send_json({"type": "bidi_error", "message": message})
+    except Exception:
+        pass

--- a/backend/src/apis/app_api/voice/routes.py
+++ b/backend/src/apis/app_api/voice/routes.py
@@ -225,8 +225,8 @@ async def voice_stream(websocket: WebSocket, ticket: Optional[str] = None) -> No
     finally:
         try:
             await websocket.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Voice WS close failed during cleanup: %s", exc, exc_info=True)
 
 
 def _reset_for_tests() -> None:

--- a/backend/src/apis/app_api/voice/routes.py
+++ b/backend/src/apis/app_api/voice/routes.py
@@ -102,6 +102,12 @@ def _allowed_origins() -> set[str]:
     return {o.strip() for o in raw.split(",") if o.strip()}
 
 
+def _sanitize_for_log(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.replace("\r", "").replace("\n", "")
+
+
 def _is_origin_allowed(origin: Optional[str]) -> bool:
     """Browser-WS CSRF defense: the Origin header is set by the browser and
     cannot be forged by JS. Allowlist must be non-empty in production — an
@@ -134,7 +140,7 @@ async def voice_stream(websocket: WebSocket, ticket: Optional[str] = None) -> No
     # Browser-WS CSRF defense — Origin is set by the browser, not JS.
     origin = websocket.headers.get("origin")
     if not _is_origin_allowed(origin):
-        logger.warning("Voice WS rejected: origin %r not in CORS_ORIGINS", origin)
+        logger.warning("Voice WS rejected: origin %r not in CORS_ORIGINS", _sanitize_for_log(origin))
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="origin not allowed")
         return
 

--- a/backend/src/apis/app_api/voice/routes.py
+++ b/backend/src/apis/app_api/voice/routes.py
@@ -26,7 +26,7 @@ import logging
 import os
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, status
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, status
 from pydantic import BaseModel, Field
 
 from apis.shared.auth.dependencies import get_current_user_from_session

--- a/backend/src/apis/app_api/voice/routes.py
+++ b/backend/src/apis/app_api/voice/routes.py
@@ -1,0 +1,228 @@
+"""Voice ticket + WebSocket-proxy routes.
+
+The two endpoints work as a pair:
+
+* ``POST /voice/ticket`` runs through the standard BFF middleware stack
+  (``SessionRefreshMiddleware`` → ``CSRFMiddleware``) so the call is
+  cookie-authenticated and CSRF-checked. It mints a ticket bound to the
+  caller's user_id and chosen ``session_id`` and returns it to the SPA.
+
+* ``WebSocket /voice/stream`` does *not* benefit from the HTTP-only middleware
+  stack — Starlette's ``BaseHTTPMiddleware`` and the CSRF middleware skip
+  WebSocket scope. So the WS route re-implements the auth checks inline:
+  read + unseal the session cookie, look up the session row, verify the
+  ticket signature/expiry, mark the ticket consumed, confirm the ticket's
+  bound session matches the cookie's session, and confirm the request's
+  Origin is allowlisted (the browser-WS CSRF defense).
+
+Past those checks, the route hands off to ``proxy.relay_voice_stream``, which
+opens the upstream WS to the AgentCore Runtime using the BFF-stored Cognito
+access token and pumps frames in both directions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, status
+from pydantic import BaseModel, Field
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.sessions_bff.config import SESSION_COOKIE_NAME
+from apis.shared.sessions_bff.cookie import CookieDecodeError, get_default_codec
+from apis.shared.sessions_bff.repository import SessionRepository
+from apis.shared.voice_ticket import VoiceTicketError, get_default_service
+
+from .proxy import relay_voice_stream
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/voice", tags=["voice"])
+
+
+# ─── POST /voice/ticket ────────────────────────────────────────────────
+
+
+class VoiceTicketRequest(BaseModel):
+    session_id: str = Field(..., min_length=1, max_length=128)
+
+
+class VoiceTicketResponse(BaseModel):
+    ticket: str
+    expires_in: int
+
+
+@router.post(
+    "/ticket",
+    response_model=VoiceTicketResponse,
+    summary="Mint a single-use ticket for the voice WebSocket upgrade",
+    responses={
+        401: {"description": "No active BFF session"},
+        403: {"description": "CSRF token missing or invalid"},
+        503: {"description": "Voice ticket service is not configured"},
+    },
+)
+async def issue_voice_ticket(
+    body: VoiceTicketRequest,
+    user: User = Depends(get_current_user_from_session),
+) -> VoiceTicketResponse:
+    """Issue an HMAC-signed ticket bound to ``{user_id, session_id}``.
+
+    Caller has already passed cookie auth (``get_current_user_from_session``)
+    and CSRF (``CSRFMiddleware``). The ticket TTL is deliberately short — 60
+    seconds is enough to hand off to the WebSocket upgrade and not much more.
+    The SPA fetches a fresh ticket per voice connection; reusing a ticket is
+    rejected as replay by the WS endpoint.
+    """
+    try:
+        service = get_default_service()
+    except RuntimeError as exc:
+        logger.error("Voice ticket service not configured: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Voice service is not configured.",
+        )
+
+    ticket, claims = service.issue(
+        user_id=user.user_id,
+        session_id=body.session_id,
+    )
+    return VoiceTicketResponse(ticket=ticket, expires_in=claims.exp - claims.iat)
+
+
+# ─── WebSocket /voice/stream ───────────────────────────────────────────
+
+
+def _allowed_origins() -> set[str]:
+    raw = os.environ.get("CORS_ORIGINS", "")
+    return {o.strip() for o in raw.split(",") if o.strip()}
+
+
+def _is_origin_allowed(origin: Optional[str]) -> bool:
+    """Browser-WS CSRF defense: the Origin header is set by the browser and
+    cannot be forged by JS. Allowlist must be non-empty in production — an
+    empty allowlist returns False so a misconfigured deploy fails closed.
+    """
+    allowed = _allowed_origins()
+    if not allowed:
+        return False
+    return origin is not None and origin in allowed
+
+
+_session_repository: Optional[SessionRepository] = None
+
+
+def _get_session_repository() -> SessionRepository:
+    global _session_repository
+    if _session_repository is None:
+        _session_repository = SessionRepository()
+    return _session_repository
+
+
+@router.websocket("/stream")
+async def voice_stream(websocket: WebSocket, ticket: Optional[str] = None) -> None:
+    """Cookie + ticket gated WebSocket; relays to the AgentCore Runtime.
+
+    Auth flow runs *before* the ``accept`` so a rejected connection closes
+    cleanly without the SPA seeing a half-open socket. After acceptance,
+    everything is plumbing — the relay handles its own teardown.
+    """
+    # Browser-WS CSRF defense — Origin is set by the browser, not JS.
+    origin = websocket.headers.get("origin")
+    if not _is_origin_allowed(origin):
+        logger.warning("Voice WS rejected: origin %r not in CORS_ORIGINS", origin)
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="origin not allowed")
+        return
+
+    if not ticket:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="ticket required")
+        return
+
+    # Resolve the BFF session from the cookie. WebSockets don't run
+    # SessionRefreshMiddleware, so we replicate the cookie unseal + DDB
+    # lookup here. Refresh-on-near-expiry is intentionally skipped: the
+    # ticket is short-lived and the WS connection is bounded by the access
+    # token's remaining lifetime — let the next REST hit refresh.
+    sealed_cookie = websocket.cookies.get(SESSION_COOKIE_NAME)
+    if not sealed_cookie:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="no session")
+        return
+
+    try:
+        codec = get_default_codec()
+        cookie_payload = codec.unseal(sealed_cookie)
+    except CookieDecodeError:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="bad session")
+        return
+    except Exception as exc:
+        logger.error("Voice WS cookie unseal error: %s", exc, exc_info=True)
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason="server error")
+        return
+
+    repository = _get_session_repository()
+    if not repository.enabled:
+        logger.error("Voice WS rejected: BFF session repository not configured")
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason="server error")
+        return
+    try:
+        session_record = await repository.get(cookie_payload.session_id)
+    except Exception as exc:
+        logger.error("Voice WS session lookup error: %s", exc, exc_info=True)
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason="server error")
+        return
+    if session_record is None:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="session expired")
+        return
+
+    # Verify + consume the ticket. Replay attempts surface as VoiceTicketError.
+    try:
+        service = get_default_service()
+    except RuntimeError as exc:
+        logger.error("Voice WS rejected: ticket service not configured: %s", exc)
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason="server error")
+        return
+
+    try:
+        claims = await service.verify_and_consume(ticket)
+    except VoiceTicketError as exc:
+        logger.info("Voice WS ticket rejected: %s", exc)
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="invalid ticket")
+        return
+    except Exception as exc:
+        logger.error("Voice WS ticket verify error: %s", exc, exc_info=True)
+        await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason="server error")
+        return
+
+    if claims.user_id != session_record.user_id:
+        # Defense in depth: a leaked ticket from a different user can't be
+        # used even if presented with this user's cookie. The cookie's
+        # session_id is the authoritative identity for the WS connection.
+        logger.warning(
+            "Voice WS rejected: ticket user_id %s does not match session user_id",
+            claims.user_id,
+        )
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="ticket mismatch")
+        return
+
+    await websocket.accept()
+
+    try:
+        await relay_voice_stream(
+            client_ws=websocket,
+            cognito_access_token=session_record.cognito_access_token,
+            user_id=session_record.user_id,
+        )
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+
+def _reset_for_tests() -> None:
+    global _session_repository
+    _session_repository = None

--- a/backend/src/apis/shared/voice_ticket/__init__.py
+++ b/backend/src/apis/shared/voice_ticket/__init__.py
@@ -1,0 +1,21 @@
+"""Voice WebSocket-upgrade ticket — single-use, HMAC-signed, short-lived.
+
+Issued by app-api on a CSRF-protected POST and consumed by app-api on the
+WebSocket upgrade before it relays to the AgentCore Runtime upstream. App-api
+is both issuer and verifier; inference-api never sees the ticket. The Cognito
+JWT that authenticates the upstream hop is held server-side in the BFF
+session and forwarded by app-api — see ``app_api/voice/proxy.py``.
+"""
+
+from .codec import VoiceTicketClaims, VoiceTicketCodec, VoiceTicketError
+from .replay import VoiceTicketReplayStore
+from .service import VoiceTicketService, get_default_service
+
+__all__ = [
+    "VoiceTicketClaims",
+    "VoiceTicketCodec",
+    "VoiceTicketError",
+    "VoiceTicketReplayStore",
+    "VoiceTicketService",
+    "get_default_service",
+]

--- a/backend/src/apis/shared/voice_ticket/codec.py
+++ b/backend/src/apis/shared/voice_ticket/codec.py
@@ -1,0 +1,144 @@
+"""Ticket codec — base64url(payload) "." base64url(HMAC-SHA256(payload, key)).
+
+Payload is a compact JSON object: ``{"v":1,"sub":...,"sid":...,"jti":...,"iat":...,"exp":...}``.
+Both halves are base64url without padding so the ticket survives a query
+string or ``Sec-WebSocket-Protocol`` value without escaping.
+
+The codec is stateless aside from holding the signing key. A caching wrapper
+in ``service.py`` lazy-fetches the key from Secrets Manager once per process.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+
+_TICKET_VERSION = 1
+
+
+class VoiceTicketError(Exception):
+    """Raised when a ticket fails to decode, verify, or has expired.
+
+    The message is intentionally generic — verifiers should not echo it back
+    to clients, and callers should not branch on the message text. Distinguish
+    only by exception type.
+    """
+
+
+@dataclass(frozen=True)
+class VoiceTicketClaims:
+    """Verified ticket payload.
+
+    ``jti`` is the random per-ticket id used by the replay store to enforce
+    single-use. ``exp`` is epoch seconds.
+    """
+
+    user_id: str
+    session_id: str
+    jti: str
+    iat: int
+    exp: int
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode(value + padding)
+    except (ValueError, TypeError) as exc:
+        raise VoiceTicketError("invalid base64url") from exc
+
+
+class VoiceTicketCodec:
+    """Issue and verify HMAC-signed voice tickets.
+
+    Construct one per process with the shared signing key. ``issue`` mints a
+    fresh ticket, ``verify`` validates signature, expiry, and ``v`` version.
+    Replay protection is the caller's responsibility — pass the returned
+    ``jti`` to ``VoiceTicketReplayStore.consume``.
+    """
+
+    def __init__(self, signing_key: bytes) -> None:
+        if not signing_key:
+            raise ValueError("signing_key must be non-empty")
+        self._key = signing_key
+
+    def issue(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        ttl_seconds: int = 60,
+        now: Optional[int] = None,
+    ) -> tuple[str, VoiceTicketClaims]:
+        if not user_id or not session_id:
+            raise ValueError("user_id and session_id are required")
+        issued_at = int(now if now is not None else time.time())
+        claims = VoiceTicketClaims(
+            user_id=user_id,
+            session_id=session_id,
+            jti=secrets.token_urlsafe(16),
+            iat=issued_at,
+            exp=issued_at + ttl_seconds,
+        )
+        payload = {
+            "v": _TICKET_VERSION,
+            "sub": claims.user_id,
+            "sid": claims.session_id,
+            "jti": claims.jti,
+            "iat": claims.iat,
+            "exp": claims.exp,
+        }
+        body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        sig = _b64url_encode(self._sign(body.encode("ascii")))
+        return f"{body}.{sig}", claims
+
+    def verify(self, ticket: str, *, now: Optional[int] = None) -> VoiceTicketClaims:
+        if not isinstance(ticket, str) or "." not in ticket:
+            raise VoiceTicketError("malformed ticket")
+        body, _, sig = ticket.partition(".")
+        if not body or not sig:
+            raise VoiceTicketError("malformed ticket")
+        expected_sig = _b64url_encode(self._sign(body.encode("ascii")))
+        if not hmac.compare_digest(sig, expected_sig):
+            raise VoiceTicketError("signature mismatch")
+        try:
+            payload = json.loads(_b64url_decode(body))
+        except json.JSONDecodeError as exc:
+            raise VoiceTicketError("invalid payload") from exc
+        if not isinstance(payload, dict) or payload.get("v") != _TICKET_VERSION:
+            raise VoiceTicketError("unsupported ticket version")
+
+        try:
+            user_id = str(payload["sub"])
+            session_id = str(payload["sid"])
+            jti = str(payload["jti"])
+            iat = int(payload["iat"])
+            exp = int(payload["exp"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise VoiceTicketError("invalid payload") from exc
+
+        clock = int(now if now is not None else time.time())
+        if exp <= clock:
+            raise VoiceTicketError("ticket expired")
+
+        return VoiceTicketClaims(
+            user_id=user_id,
+            session_id=session_id,
+            jti=jti,
+            iat=iat,
+            exp=exp,
+        )
+
+    def _sign(self, body: bytes) -> bytes:
+        return hmac.new(self._key, body, hashlib.sha256).digest()

--- a/backend/src/apis/shared/voice_ticket/replay.py
+++ b/backend/src/apis/shared/voice_ticket/replay.py
@@ -1,0 +1,105 @@
+"""DynamoDB-backed replay store — single-use ``jti`` enforcement.
+
+Conditional ``PutItem`` with ``attribute_not_exists(jti)`` so the first
+attempt wins atomically and any subsequent ``consume`` for the same
+``jti`` returns False. The row carries a ``ttl`` attribute matched by the
+table's TTL config, so consumed rows are reaped automatically a short
+period after the ticket would have expired anyway.
+
+In-memory fallback: when the table name is unset (local dev), the store
+keeps a process-local set of consumed jti's. Single-process only — fine
+for `uv run python -m main` workflows, not safe for multi-worker dev.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceTicketReplayStore:
+    """Records consumed ``jti`` values with TTL.
+
+    ``consume`` returns True on first use, False if the jti has already
+    been recorded. Other failures (connection error, unexpected ClientError)
+    propagate so callers fail closed rather than silently letting a ticket
+    through.
+    """
+
+    def __init__(self, table_name: Optional[str] = None) -> None:
+        if table_name is None:
+            table_name = os.environ.get("VOICE_TICKET_REPLAY_TABLE_NAME", "")
+        self._table_name = table_name
+        self._enabled = bool(table_name)
+
+        if self._enabled:
+            self._dynamodb = boto3.resource("dynamodb")
+            self._table = self._dynamodb.Table(table_name)
+            self._fallback_seen: Optional[set[str]] = None
+            self._fallback_lock = None
+            logger.info("VoiceTicketReplayStore initialized with table: %s", table_name)
+        else:
+            self._dynamodb = None
+            self._table = None
+            self._fallback_seen = set()
+            self._fallback_lock = threading.Lock()
+            logger.debug("VoiceTicketReplayStore in-memory mode (table name unset)")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def consume(self, jti: str, *, exp: int) -> bool:
+        """Record ``jti`` as consumed; return True on first use, False on replay.
+
+        ``exp`` is the ticket's epoch-second expiry; the row's TTL is set a
+        short window past it so a replay attempt that races the TTL reaper
+        still finds the row.
+        """
+        if not jti:
+            raise ValueError("jti must be non-empty")
+
+        ttl = max(int(exp) + 30, int(time.time()) + 60)
+
+        if not self._enabled:
+            assert self._fallback_seen is not None and self._fallback_lock is not None
+            with self._fallback_lock:
+                if jti in self._fallback_seen:
+                    return False
+                self._fallback_seen.add(jti)
+            return True
+
+        try:
+            self._table.put_item(
+                Item={"jti": jti, "ttl": ttl},
+                ConditionExpression="attribute_not_exists(jti)",
+            )
+            return True
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return False
+            raise
+
+
+_default_store: Optional[VoiceTicketReplayStore] = None
+
+
+def get_default_store() -> VoiceTicketReplayStore:
+    """Process-wide singleton. First call constructs the boto3 client lazily."""
+    global _default_store
+    if _default_store is None:
+        _default_store = VoiceTicketReplayStore()
+    return _default_store
+
+
+def _reset_default_store_for_tests() -> None:
+    global _default_store
+    _default_store = None

--- a/backend/src/apis/shared/voice_ticket/service.py
+++ b/backend/src/apis/shared/voice_ticket/service.py
@@ -1,0 +1,132 @@
+"""High-level facade — issue + verify + replay enforcement in one call.
+
+The codec and replay store are useful in isolation for tests, but production
+code paths want a single ``service.issue()`` / ``service.verify_and_consume()``
+call against a process-wide singleton. Resolving the signing key and the
+replay table is lazy: the first call fetches the secret from Secrets Manager
+and caches the bytes for the lifetime of the process.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from threading import Lock
+from typing import Optional
+
+import boto3
+
+from .codec import VoiceTicketClaims, VoiceTicketCodec, VoiceTicketError
+from .replay import VoiceTicketReplayStore, get_default_store
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceTicketService:
+    """Bundles a codec with a replay store.
+
+    ``verify_and_consume`` is the only call that touches both — keeping the
+    "verify then mark consumed" sequence atomic to one call site means a
+    future caller can't accidentally verify without enforcing single-use.
+    """
+
+    def __init__(
+        self,
+        *,
+        codec: VoiceTicketCodec,
+        replay_store: VoiceTicketReplayStore,
+        ttl_seconds: int = 60,
+    ) -> None:
+        self._codec = codec
+        self._replay_store = replay_store
+        self._ttl_seconds = ttl_seconds
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl_seconds
+
+    def issue(self, *, user_id: str, session_id: str) -> tuple[str, VoiceTicketClaims]:
+        return self._codec.issue(
+            user_id=user_id,
+            session_id=session_id,
+            ttl_seconds=self._ttl_seconds,
+        )
+
+    async def verify_and_consume(self, ticket: str) -> VoiceTicketClaims:
+        """Verify the ticket and mark its jti consumed.
+
+        Raises ``VoiceTicketError`` on signature/expiry/format failure or on
+        replay (jti already recorded). Replays are reported as a generic
+        ``VoiceTicketError`` so callers don't branch on the cause — the user
+        flow is identical: reject the WS upgrade, ask the SPA to re-fetch.
+        """
+        claims = self._codec.verify(ticket)
+        accepted = await self._replay_store.consume(claims.jti, exp=claims.exp)
+        if not accepted:
+            raise VoiceTicketError("ticket already consumed")
+        return claims
+
+
+# ─── Lazy process-wide singleton ────────────────────────────────────────
+
+_default_service: Optional[VoiceTicketService] = None
+_init_lock = Lock()
+
+
+def _resolve_signing_key(
+    *,
+    secret_arn: Optional[str] = None,
+    region: Optional[str] = None,
+    secrets_manager_client: Optional[object] = None,
+) -> bytes:
+    """Fetch the HMAC signing key from Secrets Manager.
+
+    Tolerates both the plain-string SecretString format and a
+    ``{"secret": "..."}`` JSON wrapper (which is the shape CDK writes via
+    ``generateSecretString`` with a ``generateStringKey``).
+    """
+    arn = secret_arn or os.environ.get("VOICE_TICKET_SIGNING_SECRET_ARN") or ""
+    if not arn:
+        raise RuntimeError("VOICE_TICKET_SIGNING_SECRET_ARN is not configured")
+    sm_region = (
+        region
+        or os.environ.get("AWS_REGION")
+        or "us-west-2"
+    )
+    sm = secrets_manager_client or boto3.client("secretsmanager", region_name=sm_region)
+    response = sm.get_secret_value(SecretId=arn)
+    value = response.get("SecretString") or ""
+    if value.startswith("{"):
+        try:
+            parsed = json.loads(value)
+            value = parsed.get("secret") or parsed.get("clientSecret") or value
+        except json.JSONDecodeError:
+            logger.debug(
+                "voice ticket signing secret looked like JSON but failed to decode; using raw value"
+            )
+    if not value:
+        raise RuntimeError("voice ticket signing secret resolved to empty string")
+    return value.encode("utf-8")
+
+
+def get_default_service() -> VoiceTicketService:
+    """Process-wide singleton. First call fetches the signing secret."""
+    global _default_service
+    if _default_service is not None:
+        return _default_service
+    with _init_lock:
+        if _default_service is not None:
+            return _default_service
+        key = _resolve_signing_key()
+        codec = VoiceTicketCodec(key)
+        _default_service = VoiceTicketService(
+            codec=codec,
+            replay_store=get_default_store(),
+        )
+        return _default_service
+
+
+def _reset_default_service_for_tests() -> None:
+    global _default_service
+    _default_service = None

--- a/backend/tests/apis/app_api/voice/test_inject_config.py
+++ b/backend/tests/apis/app_api/voice/test_inject_config.py
@@ -1,0 +1,44 @@
+"""Tests for the config-message injection.
+
+The SPA can no longer hold a Cognito access token (BFF cutover), so the
+voice WS proxy injects ``auth_token`` and ``user_id`` into the SPA's first
+config frame before forwarding upstream. Inference-api reads those fields
+from that frame to identify the user.
+"""
+
+from __future__ import annotations
+
+import json
+
+from apis.app_api.voice.proxy import _inject_config_auth
+
+
+def test_injects_auth_token_and_user_id() -> None:
+    raw = json.dumps({"type": "config", "session_id": "sess-A"})
+    out = _inject_config_auth(raw, access_token="cognito-token", user_id="user-1")
+    parsed = json.loads(out)
+    assert parsed["auth_token"] == "cognito-token"
+    assert parsed["user_id"] == "user-1"
+    assert parsed["session_id"] == "sess-A"
+
+
+def test_preserves_existing_user_id_from_spa() -> None:
+    raw = json.dumps({"type": "config", "session_id": "sess-A", "user_id": "spa-set"})
+    parsed = json.loads(_inject_config_auth(raw, access_token="t", user_id="proxy-set"))
+    # Don't clobber a value the SPA explicitly set.
+    assert parsed["user_id"] == "spa-set"
+    # auth_token always comes from the proxy.
+    assert parsed["auth_token"] == "t"
+
+
+def test_non_config_frame_is_passthrough() -> None:
+    raw = json.dumps({"type": "bidi_audio_input", "audio": "base64..."})
+    assert _inject_config_auth(raw, access_token="t", user_id="u") == raw
+
+
+def test_non_json_frame_is_passthrough() -> None:
+    assert _inject_config_auth("not-json", access_token="t", user_id="u") == "not-json"
+
+
+def test_non_object_json_is_passthrough() -> None:
+    assert _inject_config_auth("[1,2,3]", access_token="t", user_id="u") == "[1,2,3]"

--- a/backend/tests/apis/app_api/voice/test_inject_config.py
+++ b/backend/tests/apis/app_api/voice/test_inject_config.py
@@ -1,9 +1,10 @@
 """Tests for the config-message injection.
 
 The SPA can no longer hold a Cognito access token (BFF cutover), so the
-voice WS proxy injects ``auth_token`` and ``user_id`` into the SPA's first
+voice WS proxy overwrites ``auth_token`` and ``user_id`` on every JSON
 config frame before forwarding upstream. Inference-api reads those fields
-from that frame to identify the user.
+from the config frame to identify the user, so the SPA must not be able
+to set them.
 """
 
 from __future__ import annotations
@@ -22,12 +23,18 @@ def test_injects_auth_token_and_user_id() -> None:
     assert parsed["session_id"] == "sess-A"
 
 
-def test_preserves_existing_user_id_from_spa() -> None:
-    raw = json.dumps({"type": "config", "session_id": "sess-A", "user_id": "spa-set"})
+def test_overrides_spa_supplied_user_id_and_auth_token() -> None:
+    # The SPA must not be able to influence either field — both pin the
+    # identity inference-api attributes the session to, so a client-supplied
+    # value would be an impersonation vector. The proxy always wins.
+    raw = json.dumps({
+        "type": "config",
+        "session_id": "sess-A",
+        "user_id": "spa-set",
+        "auth_token": "spa-set-token",
+    })
     parsed = json.loads(_inject_config_auth(raw, access_token="t", user_id="proxy-set"))
-    # Don't clobber a value the SPA explicitly set.
-    assert parsed["user_id"] == "spa-set"
-    # auth_token always comes from the proxy.
+    assert parsed["user_id"] == "proxy-set"
     assert parsed["auth_token"] == "t"
 
 

--- a/backend/tests/apis/app_api/voice/test_proxy_url.py
+++ b/backend/tests/apis/app_api/voice/test_proxy_url.py
@@ -1,0 +1,39 @@
+"""Tests for the voice WS upstream-URL builder.
+
+Mirrors the contract enforced by ``proxy_routes._build_invocations_url``
+for the WebSocket path: cloud routes encode the runtime ARN, local-dev
+routes hit ``/voice/stream`` directly.
+"""
+
+from __future__ import annotations
+
+from apis.app_api.voice.proxy import build_upstream_ws_url
+
+
+CLOUD_BASE = (
+    "https://bedrock-agentcore.us-east-1.amazonaws.com"
+    "/runtimes/arn:aws:bedrock-agentcore:us-east-1:123:runtime/abc"
+)
+
+
+def test_cloud_url_encodes_arn_segment() -> None:
+    url = build_upstream_ws_url(CLOUD_BASE)
+    # Colons and slashes inside the ARN must be percent-encoded.
+    assert "arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123%3Aruntime%2Fabc" in url
+    assert url.startswith("wss://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/")
+    assert url.endswith("/ws")
+
+
+def test_cloud_url_uses_wss_scheme() -> None:
+    url = build_upstream_ws_url(CLOUD_BASE)
+    assert url.startswith("wss://")
+
+
+def test_local_dev_url_skips_runtime_path() -> None:
+    url = build_upstream_ws_url("http://localhost:8001")
+    assert url == "ws://localhost:8001/voice/stream"
+
+
+def test_local_dev_url_with_https_uses_wss() -> None:
+    url = build_upstream_ws_url("https://localhost:8001")
+    assert url == "wss://localhost:8001/voice/stream"

--- a/backend/tests/apis/app_api/voice/test_routes.py
+++ b/backend/tests/apis/app_api/voice/test_routes.py
@@ -1,0 +1,195 @@
+"""Tests for the app-api voice routes — ticket POST and WS auth gating.
+
+Full end-to-end WebSocket relay tests would need an upstream WS mock and
+are out of scope here; the unit-level codec/replay/service tests cover the
+ticket primitive separately. These tests focus on the route's auth gates:
+origin allowlist, missing/invalid ticket, replay rejection, and ticket↔
+session user-id binding.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import apis.app_api.voice.routes as voice_routes
+from apis.app_api.voice.routes import router as voice_router
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.sessions_bff.models import CookiePayload, SessionRecord
+from apis.shared.voice_ticket.codec import VoiceTicketCodec
+from apis.shared.voice_ticket.replay import VoiceTicketReplayStore
+from apis.shared.voice_ticket.service import VoiceTicketService
+
+
+SIGNING_KEY = b"k" * 64
+USER_ID = "user-001"
+SESSION_ID = "sess-AAA"
+COGNITO_TOKEN = "cognito-access-token"
+ORIGIN = "http://localhost:4200"
+
+
+@pytest.fixture(autouse=True)
+def cors_origins(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", ORIGIN)
+
+
+@pytest.fixture
+def voice_service() -> VoiceTicketService:
+    return VoiceTicketService(
+        codec=VoiceTicketCodec(SIGNING_KEY),
+        replay_store=VoiceTicketReplayStore(table_name=""),
+        ttl_seconds=60,
+    )
+
+
+@pytest.fixture
+def session_record() -> SessionRecord:
+    return SessionRecord(
+        session_id="bff-sess-1",
+        user_id=USER_ID,
+        username="alice",
+        cognito_access_token=COGNITO_TOKEN,
+        cognito_refresh_token="r",
+        id_token=None,
+        access_token_exp=2_000_000_000,
+        csrf_secret="csrf-secret",
+        created_at=0,
+        last_seen_at=0,
+        ttl=2_000_000_000,
+    )
+
+
+class _FakeRepository:
+    def __init__(self, record: Optional[SessionRecord]) -> None:
+        self._record = record
+        self.enabled = True
+
+    async def get(self, session_id: str) -> Optional[SessionRecord]:
+        if self._record and self._record.session_id == session_id:
+            return self._record
+        return None
+
+
+class _FakeCodec:
+    """Stand-in for CookieCodec — unseal returns a fixed session_id without KMS."""
+
+    def __init__(self, session_id: str) -> None:
+        self._session_id = session_id
+
+    def unseal(self, _value: str) -> CookiePayload:
+        return CookiePayload(session_id=self._session_id)
+
+
+@pytest.fixture
+def app(voice_service, session_record, monkeypatch) -> FastAPI:
+    voice_routes._reset_for_tests()
+    monkeypatch.setattr(voice_routes, "get_default_service", lambda: voice_service)
+    monkeypatch.setattr(
+        voice_routes, "get_default_codec", lambda: _FakeCodec(session_record.session_id)
+    )
+    monkeypatch.setattr(
+        voice_routes, "_get_session_repository", lambda: _FakeRepository(session_record)
+    )
+
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(voice_router)
+
+    async def _stub_user() -> User:
+        return User(
+            user_id=USER_ID,
+            email="alice@example.com",
+            name="Alice",
+            roles=[],
+            raw_token="t",
+        )
+
+    fastapi_app.dependency_overrides[get_current_user_from_session] = _stub_user
+
+    # Stub out the upstream relay so the WS handler returns immediately
+    # after the auth checks pass — we're verifying gates, not the proxy.
+    async def _noop_relay(*, client_ws, cognito_access_token, user_id):
+        await client_ws.send_json({"type": "noop"})
+
+    monkeypatch.setattr(voice_routes, "relay_voice_stream", _noop_relay)
+    return fastapi_app
+
+
+# --- POST /voice/ticket -----------------------------------------------
+
+
+def test_post_ticket_returns_signed_ticket(app: FastAPI, voice_service) -> None:
+    client = TestClient(app)
+    res = client.post("/voice/ticket", json={"session_id": "sess-A"})
+    assert res.status_code == 200
+    body = res.json()
+    assert "ticket" in body and body["ticket"]
+    assert body["expires_in"] == 60
+
+    # Round-trip: the ticket must verify against the same signing key.
+    claims = voice_service._codec.verify(body["ticket"])
+    assert claims.user_id == USER_ID
+    assert claims.session_id == "sess-A"
+
+
+def test_post_ticket_validates_session_id_present(app: FastAPI) -> None:
+    client = TestClient(app)
+    res = client.post("/voice/ticket", json={})
+    assert res.status_code == 422
+
+
+# --- WebSocket /voice/stream ------------------------------------------
+
+
+def test_ws_rejects_missing_ticket(app: FastAPI) -> None:
+    client = TestClient(app)
+    with pytest.raises(Exception):
+        with client.websocket_connect("/voice/stream", headers={"origin": ORIGIN}):
+            pass
+
+
+def test_ws_rejects_disallowed_origin(app: FastAPI, voice_service) -> None:
+    ticket, _ = voice_service.issue(user_id=USER_ID, session_id="sess-A")
+    client = TestClient(app)
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            f"/voice/stream?ticket={ticket}", headers={"origin": "https://evil.com"}
+        ):
+            pass
+
+
+def test_ws_rejects_replayed_ticket(app: FastAPI, voice_service, session_record) -> None:
+    ticket, _ = voice_service.issue(user_id=USER_ID, session_id="sess-A")
+    cookie = {"__Host-bff_session": "sealed"}
+    client = TestClient(app, cookies=cookie)
+
+    # First use should pass the gates and reach the noop relay.
+    with client.websocket_connect(
+        f"/voice/stream?ticket={ticket}", headers={"origin": ORIGIN}
+    ) as ws:
+        msg = ws.receive_json()
+        assert msg["type"] == "noop"
+
+    # Second use of the same ticket must be rejected before accept.
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            f"/voice/stream?ticket={ticket}", headers={"origin": ORIGIN}
+        ):
+            pass
+
+
+def test_ws_rejects_ticket_for_different_user(
+    app: FastAPI, voice_service, session_record
+) -> None:
+    # Ticket bound to a user_id that doesn't match the BFF session row.
+    ticket, _ = voice_service.issue(user_id="other-user", session_id="sess-A")
+    cookie = {"__Host-bff_session": "sealed"}
+    client = TestClient(app, cookies=cookie)
+    with pytest.raises(Exception):
+        with client.websocket_connect(
+            f"/voice/stream?ticket={ticket}", headers={"origin": ORIGIN}
+        ):
+            pass

--- a/backend/tests/apis/shared/voice_ticket/test_codec.py
+++ b/backend/tests/apis/shared/voice_ticket/test_codec.py
@@ -1,0 +1,111 @@
+"""Tests for the voice-ticket HMAC codec."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+
+from apis.shared.voice_ticket.codec import VoiceTicketCodec, VoiceTicketError
+
+
+SIGNING_KEY = b"k" * 64
+
+
+def _make_codec() -> VoiceTicketCodec:
+    return VoiceTicketCodec(SIGNING_KEY)
+
+
+def test_issue_then_verify_roundtrip() -> None:
+    codec = _make_codec()
+    ticket, claims = codec.issue(user_id="user-1", session_id="sess-A", ttl_seconds=60)
+    verified = codec.verify(ticket)
+    assert verified.user_id == "user-1"
+    assert verified.session_id == "sess-A"
+    assert verified.jti == claims.jti
+    assert verified.exp - verified.iat == 60
+
+
+def test_issue_rejects_empty_inputs() -> None:
+    codec = _make_codec()
+    with pytest.raises(ValueError):
+        codec.issue(user_id="", session_id="sess")
+    with pytest.raises(ValueError):
+        codec.issue(user_id="user", session_id="")
+
+
+def test_construct_rejects_empty_key() -> None:
+    with pytest.raises(ValueError):
+        VoiceTicketCodec(b"")
+
+
+def test_verify_rejects_tampered_payload() -> None:
+    codec = _make_codec()
+    ticket, _ = codec.issue(user_id="user-1", session_id="sess-A")
+    body, sig = ticket.split(".", 1)
+
+    # Re-encode the payload with a different sub but keep the original sig.
+    decoded = json.loads(_b64url_decode_to_bytes(body))
+    decoded["sub"] = "attacker"
+    tampered_body = _b64url_encode(json.dumps(decoded, separators=(",", ":")).encode("utf-8"))
+    tampered_ticket = f"{tampered_body}.{sig}"
+
+    with pytest.raises(VoiceTicketError):
+        codec.verify(tampered_ticket)
+
+
+def test_verify_rejects_signature_signed_with_other_key() -> None:
+    codec = _make_codec()
+    other = VoiceTicketCodec(b"x" * 64)
+    ticket, _ = other.issue(user_id="user-1", session_id="sess-A")
+    with pytest.raises(VoiceTicketError):
+        codec.verify(ticket)
+
+
+def test_verify_rejects_expired_ticket() -> None:
+    codec = _make_codec()
+    issued_at = int(time.time()) - 120
+    ticket, _ = codec.issue(user_id="user-1", session_id="sess-A", ttl_seconds=60, now=issued_at)
+    with pytest.raises(VoiceTicketError):
+        codec.verify(ticket)
+
+
+def test_verify_rejects_malformed_ticket() -> None:
+    codec = _make_codec()
+    for bad in ["", ".", "abc", "abc.", ".abc", "no-dot-here"]:
+        with pytest.raises(VoiceTicketError):
+            codec.verify(bad)
+
+
+def test_verify_rejects_unsupported_version() -> None:
+    codec = _make_codec()
+    ticket, _ = codec.issue(user_id="user-1", session_id="sess-A")
+    body, _, _ = ticket.partition(".")
+    decoded = json.loads(_b64url_decode_to_bytes(body))
+    decoded["v"] = 99
+    bad_body = _b64url_encode(json.dumps(decoded, separators=(",", ":")).encode("utf-8"))
+    # Re-sign with our key so signature passes; the version check should still fail.
+    sig = _b64url_encode(_hmac(SIGNING_KEY, bad_body.encode("ascii")))
+    with pytest.raises(VoiceTicketError):
+        codec.verify(f"{bad_body}.{sig}")
+
+
+# --- helpers ----------------------------------------------------------
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode_to_bytes(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _hmac(key: bytes, body: bytes) -> bytes:
+    import hashlib
+    import hmac
+
+    return hmac.new(key, body, hashlib.sha256).digest()

--- a/backend/tests/apis/shared/voice_ticket/test_replay.py
+++ b/backend/tests/apis/shared/voice_ticket/test_replay.py
@@ -1,0 +1,37 @@
+"""Tests for the voice-ticket replay store (in-memory fallback path)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from apis.shared.voice_ticket.replay import VoiceTicketReplayStore
+
+
+@pytest.mark.asyncio
+async def test_first_consume_succeeds_second_fails() -> None:
+    store = VoiceTicketReplayStore(table_name="")
+    exp = int(time.time()) + 60
+    assert await store.consume("jti-1", exp=exp) is True
+    assert await store.consume("jti-1", exp=exp) is False
+
+
+@pytest.mark.asyncio
+async def test_distinct_jtis_independent() -> None:
+    store = VoiceTicketReplayStore(table_name="")
+    exp = int(time.time()) + 60
+    assert await store.consume("jti-A", exp=exp) is True
+    assert await store.consume("jti-B", exp=exp) is True
+
+
+@pytest.mark.asyncio
+async def test_consume_rejects_empty_jti() -> None:
+    store = VoiceTicketReplayStore(table_name="")
+    with pytest.raises(ValueError):
+        await store.consume("", exp=int(time.time()) + 60)
+
+
+def test_in_memory_mode_when_table_unset() -> None:
+    store = VoiceTicketReplayStore(table_name="")
+    assert store.enabled is False

--- a/backend/tests/apis/shared/voice_ticket/test_service.py
+++ b/backend/tests/apis/shared/voice_ticket/test_service.py
@@ -1,0 +1,58 @@
+"""Tests for the high-level VoiceTicketService facade.
+
+These cover the end-to-end "verify then mark consumed" sequence that the
+WebSocket route depends on. Replay must be rejected even if the signature
+and expiry are valid.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apis.shared.voice_ticket.codec import VoiceTicketCodec, VoiceTicketError
+from apis.shared.voice_ticket.replay import VoiceTicketReplayStore
+from apis.shared.voice_ticket.service import VoiceTicketService
+
+
+def _make_service() -> VoiceTicketService:
+    return VoiceTicketService(
+        codec=VoiceTicketCodec(b"k" * 64),
+        replay_store=VoiceTicketReplayStore(table_name=""),
+        ttl_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_then_verify_consumes_jti() -> None:
+    service = _make_service()
+    ticket, claims = service.issue(user_id="user-1", session_id="sess-A")
+    verified = await service.verify_and_consume(ticket)
+    assert verified.user_id == "user-1"
+    assert verified.session_id == "sess-A"
+    assert verified.jti == claims.jti
+
+
+@pytest.mark.asyncio
+async def test_replay_is_rejected() -> None:
+    service = _make_service()
+    ticket, _ = service.issue(user_id="user-1", session_id="sess-A")
+    await service.verify_and_consume(ticket)
+    with pytest.raises(VoiceTicketError):
+        await service.verify_and_consume(ticket)
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_does_not_consume_jti() -> None:
+    """A failed signature check must short-circuit before the replay store
+    sees the jti, otherwise an attacker could lock out a real user by
+    pre-consuming jti's they observe.
+    """
+    service = _make_service()
+    ticket, claims = service.issue(user_id="user-1", session_id="sess-A")
+    body, _, sig = ticket.partition(".")
+    forged = f"{body}.{sig[:-2]}AA"  # tamper sig
+    with pytest.raises(VoiceTicketError):
+        await service.verify_and_consume(forged)
+    # The legitimate ticket must still be redeemable.
+    verified = await service.verify_and_consume(ticket)
+    assert verified.jti == claims.jti

--- a/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-chat.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, signal, computed, inject, OnDestroy } from '@angular/core';
 import { v4 as uuidv4 } from 'uuid';
+import { ConfigService } from '../../../services/config.service';
 import { AudioRecorderService } from './audio-recorder.service';
 import { AudioPlayerService } from './audio-player.service';
+import { VoiceTicketService } from './voice-ticket.service';
 import { Message } from '../models/message.model';
 import {
   IDLE_TIMEOUT_MS,
@@ -48,6 +50,8 @@ export interface VoiceTranscriptEntry {
 export class VoiceChatService implements OnDestroy {
   private readonly recorder = inject(AudioRecorderService);
   private readonly player = inject(AudioPlayerService);
+  private readonly ticketService = inject(VoiceTicketService);
+  private readonly config = inject(ConfigService);
 
   // --- State signals ---
   private readonly _status = signal<VoiceStatus>('idle');
@@ -149,16 +153,22 @@ export class VoiceChatService implements OnDestroy {
     this._prevTurnCumulativeCost = null;
 
     try {
-      // Voice used a direct browser → inference-api WebSocket flow that
-      // depended on a Cognito Bearer token in localStorage and the public
-      // PKCE Cognito client. Phase 7 retired both as part of the BFF
-      // cutover, so the existing transport can no longer authenticate.
-      // A short-lived WebSocket-ticket pattern lands in issue #211 — until
-      // then, voice mode is unavailable.
-      throw new Error(
-        'Voice mode is temporarily unavailable while the BFF migration ' +
-        'completes (tracking issue #211).',
-      );
+      // Issue #211: voice now flows through a BFF WebSocket proxy.
+      // 1. Mint a short-lived ticket via the cookie-authenticated REST endpoint.
+      //    The CSRF interceptor attaches X-CSRF-Token automatically.
+      // 2. Open WS to /api/voice/stream?ticket=... — same-origin via CloudFront,
+      //    cookie auto-sent. App-api validates the ticket on upgrade and
+      //    opens the upstream WS to AgentCore using the BFF-stored Cognito token.
+      const { ticket } = await this.ticketService.issue(this.sessionId!);
+
+      const httpUrl = this.config.appApiUrl();
+      const wsBase = httpUrl.startsWith('http')
+        ? httpUrl.replace(/^http/, 'ws')
+        : `${window.location.origin.replace(/^http/, 'ws')}${httpUrl}`;
+      const url = `${wsBase}/voice/stream?ticket=${encodeURIComponent(ticket)}`;
+
+      await this.openWebSocket(url, this.sessionId!);
+      await this.recorder.start();
 
       // Wire audio chunks to WebSocket
       this.recorder.onAudioChunk = (base64, sampleRate) => {
@@ -275,9 +285,9 @@ export class VoiceChatService implements OnDestroy {
 
   // --- WebSocket ---
 
-  private openWebSocket(url: string, token: string, protocols?: string[]): Promise<void> {
+  private openWebSocket(url: string, sessionId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.ws = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
+      this.ws = new WebSocket(url);
 
       const timeout = setTimeout(() => {
         reject(new Error('WebSocket connection timeout'));
@@ -286,11 +296,12 @@ export class VoiceChatService implements OnDestroy {
 
       this.ws.onopen = () => {
         clearTimeout(timeout);
-        // Send config message as first frame
+        // Send config message as first frame. The BFF voice proxy injects
+        // the auth_token + user_id into this frame before forwarding upstream
+        // to inference-api — the SPA no longer holds a Cognito token.
         this.sendMessage({
           type: 'config',
-          session_id: this.sessionId,
-          auth_token: token,
+          session_id: sessionId,
         });
         resolve();
       };

--- a/frontend/ai.client/src/app/session/services/voice/voice-ticket.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-ticket.service.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+
+import { VoiceTicketService } from './voice-ticket.service';
+import { ConfigService } from '../../../services/config.service';
+
+describe('VoiceTicketService', () => {
+  let service: VoiceTicketService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(VoiceTicketService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    TestBed.resetTestingModule();
+  });
+
+  it('POSTs the session_id to /voice/ticket and returns the response', async () => {
+    const promise = service.issue('sess-A');
+    const req = httpMock.expectOne('http://localhost:8000/voice/ticket');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ session_id: 'sess-A' });
+    req.flush({ ticket: 't.k', expires_in: 60 });
+    await expect(promise).resolves.toEqual({ ticket: 't.k', expires_in: 60 });
+  });
+
+  it('propagates HTTP errors', async () => {
+    const promise = service.issue('sess-B');
+    const req = httpMock.expectOne('http://localhost:8000/voice/ticket');
+    req.flush(
+      { detail: 'CSRF token missing or invalid.' },
+      { status: 403, statusText: 'Forbidden' },
+    );
+    await expect(promise).rejects.toBeDefined();
+  });
+});

--- a/frontend/ai.client/src/app/session/services/voice/voice-ticket.service.ts
+++ b/frontend/ai.client/src/app/session/services/voice/voice-ticket.service.ts
@@ -1,0 +1,37 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import { ConfigService } from '../../../services/config.service';
+
+export interface VoiceTicketResponse {
+  ticket: string;
+  expires_in: number;
+}
+
+/**
+ * Mints a single-use ticket for the voice WebSocket upgrade.
+ *
+ * The voice transport is BFF-proxied (issue #211): the SPA never holds a
+ * Cognito access token, so it can't authenticate the WS upgrade directly
+ * against the AgentCore Runtime. Instead, the SPA POSTs to the BFF
+ * (`/api/voice/ticket`) — that call rides the session cookie and CSRF
+ * header automatically via the existing interceptor — and gets back a
+ * short-lived HMAC-signed ticket. The ticket is then passed as a query
+ * param on `wss://.../api/voice/stream`; app-api validates it on upgrade
+ * and opens the upstream WS itself using the BFF-stored token.
+ */
+@Injectable({ providedIn: 'root' })
+export class VoiceTicketService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  async issue(sessionId: string): Promise<VoiceTicketResponse> {
+    return firstValueFrom(
+      this.http.post<VoiceTicketResponse>(
+        `${this.config.appApiUrl()}/voice/ticket`,
+        { session_id: sessionId },
+      ),
+    );
+  }
+}

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -380,6 +380,23 @@ export class AppApiStack extends cdk.Stack {
       `/${config.projectPrefix}/auth/cognito/bff-app-client-secret-arn`
     );
 
+    // Voice WebSocket-ticket replay table + signing secret. Used by app-api
+    // to issue/verify single-use tickets on the SPA→app-api WS upgrade
+    // before relaying to the AgentCore Runtime upstream. App-api is the
+    // sole consumer of both resources.
+    const voiceTicketReplayTableName = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/voice/ticket-replay-table-name`
+    );
+    const voiceTicketReplayTableArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/voice/ticket-replay-table-arn`
+    );
+    const voiceTicketSigningSecretArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/voice/ticket-signing-secret-arn`
+    );
+
     // Inference API runtime endpoint URL — needed by both the existing
     // converse proxy (currently broken in cloud due to a missing env var)
     // and the upcoming chat SSE proxy in Phase 4 of the BFF migration.
@@ -538,6 +555,11 @@ export class AppApiStack extends cdk.Stack {
         // Inference API runtime endpoint — used by the converse proxy today
         // and the chat SSE proxy added in Phase 4.
         INFERENCE_API_URL: inferenceApiRuntimeEndpointUrl,
+        // Voice WS-upgrade ticket — see apis/shared/voice_ticket. Replay
+        // table is single-use jti tracking; signing secret is the HMAC key
+        // app-api fetches once at startup.
+        VOICE_TICKET_REPLAY_TABLE_NAME: voiceTicketReplayTableName,
+        VOICE_TICKET_SIGNING_SECRET_ARN: voiceTicketSigningSecretArn,
       },
       portMappings: [
         {
@@ -1029,6 +1051,26 @@ export class AppApiStack extends cdk.Stack {
         effect: iam.Effect.ALLOW,
         actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
         resources: [`${cognitoBFFAppClientSecretArn}*`], // Wildcard for random suffix
+      })
+    );
+
+    // Voice WebSocket-ticket — replay table (conditional puts for single-use
+    // jti) and signing secret (HMAC key fetched once at startup).
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'VoiceTicketReplayTableAccess',
+        effect: iam.Effect.ALLOW,
+        actions: ['dynamodb:PutItem', 'dynamodb:GetItem'],
+        resources: [voiceTicketReplayTableArn],
+      })
+    );
+
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'VoiceTicketSigningSecretAccess',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: [`${voiceTicketSigningSecretArn}*`], // Wildcard for random suffix
       })
     );
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -407,6 +407,62 @@ export class InfrastructureStack extends cdk.Stack {
       tier: ssm.ParameterTier.STANDARD,
     });
 
+    // Voice Ticket Replay Table - single-use jti tracking for the WS-upgrade
+    // ticket exchanged between SPA and app-api before proxying voice traffic
+    // upstream to the AgentCore Runtime. The ticket lives entirely within
+    // app-api (issuer == verifier), so this table is owned by app-api alone.
+    // jti is the partition key; TTL on `ttl` reaps consumed rows ~1 minute
+    // after expiry. Conditional puts on the jti enforce single-use.
+    const voiceTicketReplayTable = new dynamodb.Table(this, "VoiceTicketReplayTable", {
+      tableName: getResourceName(config, "voice-ticket-replay"),
+      partitionKey: {
+        name: "jti",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: "ttl",
+      removalPolicy: getRemovalPolicy(config),
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    new ssm.StringParameter(this, "VoiceTicketReplayTableNameParameter", {
+      parameterName: `/${config.projectPrefix}/voice/ticket-replay-table-name`,
+      stringValue: voiceTicketReplayTable.tableName,
+      description: "Voice ticket replay table name",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, "VoiceTicketReplayTableArnParameter", {
+      parameterName: `/${config.projectPrefix}/voice/ticket-replay-table-arn`,
+      stringValue: voiceTicketReplayTable.tableArn,
+      description: "Voice ticket replay table ARN",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    // Voice Ticket Signing Secret - HMAC-SHA256 key used by app-api to sign
+    // and verify short-lived (~60s) WebSocket-upgrade tickets. Sourced once
+    // at startup and cached in process memory. Mirrors the AuthenticationSecret
+    // pattern; rotated by replacing the secret value.
+    const voiceTicketSigningSecret = new secretsmanager.Secret(this, "VoiceTicketSigningSecret", {
+      secretName: getResourceName(config, "voice-ticket-signing-key"),
+      description: "HMAC signing key for voice WebSocket-upgrade tickets",
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ description: "Voice ticket signing key" }),
+        generateStringKey: "secret",
+        excludePunctuation: true,
+        includeSpace: false,
+        passwordLength: 64,
+      },
+      removalPolicy: getRemovalPolicy(config),
+    });
+
+    new ssm.StringParameter(this, "VoiceTicketSigningSecretArnParameter", {
+      parameterName: `/${config.projectPrefix}/voice/ticket-signing-secret-arn`,
+      stringValue: voiceTicketSigningSecret.secretArn,
+      description: "Voice ticket signing secret ARN",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
     // Users Table - User profiles synced from JWT for admin lookup
     const usersTable = new dynamodb.Table(this, "UsersTable", {
       tableName: getResourceName(config, "users"),


### PR DESCRIPTION
## Summary

Re-enables voice mode (disabled by the Phase 7 BFF cutover) via a server-side WebSocket proxy on app-api. The SPA never holds a Cognito access token; app-api is the sole verifier of a single-use HMAC ticket and the sole holder of the upstream credential.

**Architecture:**
```
SPA --(cookie + ticket)--> app-api WS --(Cognito token from BFF session)--> AgentCore Runtime --> inference-api
```

The original issue's "ticket directly to inference-api" approach couldn't work: AgentCore Runtime's `customJwtAuthorizer` only accepts Cognito-issued JWTs at the proxy layer. The "out-of-scope" WS-proxy alternative turned out to be the right answer once we noticed that — the JSON-with-base64 voice protocol relays cleanly through aiohttp, no binary-frame complexity.

## Changes

- **CDK:** new `VoiceTicketReplayTable` (DDB, jti partition key, TTL attribute) and `VoiceTicketSigningSecret` (Secrets Manager, 64-char auto-generated). IAM grants + env vars wired on app-api. Inference-api stack unchanged.
- **Shared primitive** at `apis/shared/voice_ticket/`: HMAC-SHA256 codec, DDB conditional-put replay store with in-memory fallback for local dev, service facade enforcing verify-then-consume atomically.
- **app-api routes** at `apis/app_api/voice/`:
  - `POST /voice/ticket` — cookie + CSRF authenticated; issues 60s tickets bound to `{user_sub, session_id, jti, exp}`.
  - `WebSocket /voice/stream` — gates on Origin allowlist, cookie unseal, ticket verify + replay, and ticket↔session `user_id` binding before relaying. WS upgrade auth re-implemented inline since `BaseHTTPMiddleware`/`CSRFMiddleware` don't run on WS scope.
  - **aiohttp relay** intercepts the SPA's first config frame to inject `auth_token` + `user_id` (the SPA can no longer set these), then pumps frames in both directions until either side closes. Cloud uses `Sec-WebSocket-Protocol` for AgentCore proxy auth; local dev uses `Authorization` header.
- **SPA:** `VoiceTicketService` for the REST hop (CSRF interceptor auto-attaches `X-CSRF-Token`); `VoiceChatService.connect()` reactivated — fetches ticket, opens WS at `${appApiUrl}/voice/stream?ticket=…`, sends a config frame without `auth_token`.
- **CloudFront:** existing `/api/*` behavior already supports WS upgrade (`ALLOW_ALL` + `CACHING_DISABLED` + `ALL_VIEWER_EXCEPT_HOST_HEADER`); no change needed.

## Tests

- 30 new backend tests (codec / replay / service / URL builder / config injection / route auth gates). All 92 related tests pass.
- 2 new frontend tests for `VoiceTicketService`.
- Architecture-boundary tests still pass.

## Test plan

- [ ] Deploy to a non-prod environment and confirm voice mode connects end-to-end (mic → Nova Sonic → playback).
- [ ] Verify a replayed ticket is rejected at the WS upgrade.
- [ ] Verify a ticket from user A can't be used with user B's cookie.
- [ ] Soak test for >60s of quiet voice traffic to confirm CloudFront's WS idle behavior.
- [ ] Confirm the CDK signing-secret + replay-table provision cleanly on a fresh deploy.

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)