### PR TITLE
feat(compaction): surface compaction events with refresh-survival

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -49,6 +49,7 @@ npx cdk deploy --all
 | `tool_use` / `tool_result` | Tool invocation and result |
 | `stream_error` | Conversational error |
 | `oauth_required` | External MCP tool needs user consent — payload `{providerId, authorizationUrl}`, one event per provider emitted after `message_stop` |
+| `compaction` | Backend rolled older turns into a summary on this turn — payload `{previousCheckpoint, newCheckpoint, summarizedTurns, inputTokens}`, emitted after the final `metadata` event so the badge updates first, before `done` |
 | `done` | Stream complete |
 
 ## Multi-Protocol Tool Architecture

--- a/backend/src/agents/main_agent/session/compaction_models.py
+++ b/backend/src/agents/main_agent/session/compaction_models.py
@@ -25,6 +25,10 @@ class CompactionState:
     summary: Optional[str] = None  # Pre-computed summary for skipped messages
     last_input_tokens: int = 0  # Input tokens from last turn
     updated_at: Optional[str] = None  # ISO timestamp of last update
+    # Cumulative count of turns rolled into a summary across every
+    # compaction event in this session. Surfaced on session-metadata GET so
+    # the frontend's end-of-conversation indicator survives a refresh.
+    total_summarized_turns: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for DynamoDB storage."""
@@ -32,7 +36,8 @@ class CompactionState:
             "checkpoint": self.checkpoint,
             "summary": self.summary,
             "lastInputTokens": self.last_input_tokens,
-            "updatedAt": self.updated_at
+            "updatedAt": self.updated_at,
+            "totalSummarizedTurns": self.total_summarized_turns,
         }
 
     @classmethod
@@ -44,8 +49,27 @@ class CompactionState:
             checkpoint=int(data.get("checkpoint", 0)),
             summary=data.get("summary"),
             last_input_tokens=int(data.get("lastInputTokens", 0)),
-            updated_at=data.get("updatedAt")
+            updated_at=data.get("updatedAt"),
+            total_summarized_turns=int(data.get("totalSummarizedTurns", 0)),
         )
+
+
+@dataclass
+class CompactionResult:
+    """
+    Returned by ``TurnBasedSessionManager.update_after_turn`` when a turn
+    crosses the token threshold and the checkpoint advances. Carries the
+    information the frontend needs to render an inline "earlier messages
+    summarized" divider in the conversation.
+
+    ``summarized_turns`` is the *delta* count of turns rolled into the
+    summary at this compaction event (not the cumulative total across
+    prior compactions), so each divider stands on its own.
+    """
+    previous_checkpoint: int
+    new_checkpoint: int
+    summarized_turns: int
+    input_tokens: int
 
 
 @dataclass

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -25,7 +25,7 @@ from agents.main_agent.config.constants import EnvVars
 from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig
 
-from .compaction_models import CompactionState, CompactionConfig
+from .compaction_models import CompactionState, CompactionConfig, CompactionResult
 
 if TYPE_CHECKING:
     from strands.agent.agent import Agent
@@ -137,8 +137,6 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         2. Let the SDK restore agent state and load messages from AgentCore Memory
         3. Apply compaction (checkpoint + truncation) on the loaded messages
         """
-        is_new_session = self._is_new_session
-
         logger.info(f"TurnBasedSessionManager.initialize() called for agent_id={agent.agent_id}")
 
         # Let the SDK handle all session restore logic:
@@ -156,8 +154,15 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         self._valid_cutoff_indices = []
         self._all_messages_for_summary = []
 
-        # Apply compaction for existing sessions with compaction enabled
-        if is_new_session:
+        # The cutoff cache is also re-derived per turn in `update_after_turn`
+        # so it stays correct even when messages load via hooks after init
+        # (the AgentCoreMemory path leaves `agent.messages` empty here on
+        # subsequent turns of an existing session — `_is_new_session` is True
+        # because `read_session()` doesn't find the SDK's session metadata
+        # event). The init-time pass below is still needed to apply prior
+        # checkpoint state (skip + summary prepend + truncation) to messages
+        # the SDK *did* load.
+        if not agent.messages:
             return
 
         if not self.compaction_config or not self.compaction_config.enabled:
@@ -465,15 +470,28 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
     # Post-Turn Compaction (Stage 2)
     # =========================================================================
 
-    async def update_after_turn(self, input_tokens: int) -> None:
+    async def update_after_turn(
+        self,
+        input_tokens: int,
+        current_messages: Optional[List[Dict]] = None,
+    ) -> Optional[CompactionResult]:
         """
         Update compaction state after a turn completes.
 
         Called by StreamCoordinator with input token count from model response.
         Triggers checkpoint creation when token threshold exceeded.
+
+        Returns a ``CompactionResult`` when the checkpoint advances on this
+        turn so the caller can emit a ``compaction`` SSE event; otherwise
+        returns ``None``.
+
+        ``current_messages`` is the agent's live message list. When provided,
+        the cutoff cache is re-derived from it so compaction works even when
+        AgentCoreMemory loads messages via hooks (skipping the initialize-time
+        prime path).
         """
         if not self.compaction_config or not self.compaction_config.enabled:
-            return
+            return None
 
         if self.compaction_state is None:
             self.compaction_state = CompactionState()
@@ -482,17 +500,30 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
 
         if input_tokens <= self.compaction_config.token_threshold:
             self._save_compaction_state(self.compaction_state)
-            return
+            return None
 
         logger.info(
             f"Threshold exceeded: {input_tokens:,} > "
             f"{self.compaction_config.token_threshold:,}"
         )
 
+        # Refresh cutoff cache from the agent's current messages — at this
+        # point in the turn lifecycle the user message + assistant response
+        # have been added, so this is authoritative even if `initialize()`
+        # ran with an empty list.
+        if current_messages:
+            self._valid_cutoff_indices = self._find_valid_cutoff_indices(current_messages)
+            self._all_messages_for_summary = current_messages[:]
+            logger.info(
+                f"Refreshed cutoff cache from current messages: "
+                f"{len(self._valid_cutoff_indices)} valid cutoffs across "
+                f"{len(current_messages)} messages"
+            )
+
         if not self._valid_cutoff_indices:
             logger.info("No valid cutoff points cached, skipping checkpoint update")
             self._save_compaction_state(self.compaction_state)
-            return
+            return None
 
         total_turns = len(self._valid_cutoff_indices)
         protected_turns = self.compaction_config.protected_turns
@@ -503,16 +534,23 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
                 f"keeping all messages"
             )
             self._save_compaction_state(self.compaction_state)
-            return
+            return None
 
         new_checkpoint = self._valid_cutoff_indices[-protected_turns]
         current_checkpoint = self.compaction_state.checkpoint
 
         if new_checkpoint <= current_checkpoint:
             self._save_compaction_state(self.compaction_state)
-            return
+            return None
 
         logger.info(f"Checkpoint update: {current_checkpoint} -> {new_checkpoint}")
+
+        # Count turns rolled into the summary on THIS event (delta, not
+        # cumulative) — each inline divider stands on its own.
+        summarized_turns = sum(
+            1 for idx in self._valid_cutoff_indices
+            if current_checkpoint < idx <= new_checkpoint
+        )
 
         # Retrieve or generate summary for compacted messages
         summaries = self._retrieve_session_summaries()
@@ -524,11 +562,23 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
 
         self.compaction_state.checkpoint = new_checkpoint
         self.compaction_state.summary = summary
+        # Running total persisted alongside the rest of the compaction state
+        # so a refresh can rehydrate the end-of-conversation summary indicator.
+        self.compaction_state.total_summarized_turns += summarized_turns
         self._save_compaction_state(self.compaction_state)
 
         logger.info(
             f"Compaction checkpoint set: {new_checkpoint}, "
-            f"summary_length={len(summary) if summary else 0}"
+            f"summary_length={len(summary) if summary else 0}, "
+            f"summarized_turns={summarized_turns}, "
+            f"total_summarized_turns={self.compaction_state.total_summarized_turns}"
+        )
+
+        return CompactionResult(
+            previous_checkpoint=current_checkpoint,
+            new_checkpoint=new_checkpoint,
+            summarized_turns=summarized_turns,
+            input_tokens=input_tokens,
         )
 
     # =========================================================================

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -87,6 +87,14 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         # Compaction state (loaded during initialize)
         self.compaction_state: Optional[CompactionState] = None
 
+        # Whether compaction_state was loaded from DynamoDB. The
+        # AgentCoreMemory path leaves `agent.messages` empty during
+        # `initialize()`, so `_apply_compaction()` (and its load) is skipped
+        # for subsequent turns of an existing session. `update_after_turn`
+        # checks this flag and lazy-loads to avoid clobbering the persisted
+        # `checkpoint` / `total_summarized_turns` with default zeros.
+        self._compaction_state_loaded: bool = False
+
         # Cached data for checkpoint calculation
         self._valid_cutoff_indices: List[int] = []
         self._all_messages_for_summary: List[Dict] = []
@@ -199,6 +207,7 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
 
         # Load compaction state from DynamoDB
         self.compaction_state = self._load_compaction_state()
+        self._compaction_state_loaded = True
 
         # Cache valid cutoff indices (user text messages, not tool results)
         self._valid_cutoff_indices = self._find_valid_cutoff_indices(all_messages)
@@ -495,6 +504,16 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
 
         if self.compaction_state is None:
             self.compaction_state = CompactionState()
+
+        # Lazy-load persisted state if `initialize()` skipped the load. This
+        # happens on the AgentCoreMemory path for existing sessions, where
+        # `agent.messages` is empty at init time (messages arrive via hooks
+        # after init). Without this, the first `_save_compaction_state` below
+        # would overwrite the persisted `checkpoint` and
+        # `total_summarized_turns` with default zeros.
+        if not self._compaction_state_loaded:
+            self.compaction_state = self._load_compaction_state()
+            self._compaction_state_loaded = True
 
         self.compaction_state.last_input_tokens = input_tokens
 

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -322,6 +322,38 @@ class StreamCoordinator:
                         final_metadata_event = {"type": "metadata", "data": final_metadata}
                         yield self._format_sse_event(final_metadata_event)
 
+                    # Update compaction state after the final metadata event so
+                    # the badge updates first, then the divider drops in. If the
+                    # checkpoint advanced on this turn, emit a `compaction` SSE
+                    # so the frontend can place an inline "earlier messages
+                    # summarized" divider. Fires after metadata, before done.
+                    if hasattr(session_manager, "update_after_turn"):
+                        usage = accumulated_metadata.get("usage", {})
+                        total_input_tokens = (
+                            usage.get("inputTokens", 0)
+                            + usage.get("cacheReadInputTokens", 0)
+                            + usage.get("cacheWriteInputTokens", 0)
+                        )
+                        if total_input_tokens > 0:
+                            try:
+                                current_messages = getattr(agent, "messages", None)
+                                compaction_result = await session_manager.update_after_turn(
+                                    total_input_tokens,
+                                    current_messages=current_messages,
+                                )
+                                logger.info(f"   Compaction state updated: {total_input_tokens:,} input tokens")
+                                if compaction_result is not None:
+                                    compaction_payload = {
+                                        "type": "compaction",
+                                        "previousCheckpoint": compaction_result.previous_checkpoint,
+                                        "newCheckpoint": compaction_result.new_checkpoint,
+                                        "summarizedTurns": compaction_result.summarized_turns,
+                                        "inputTokens": compaction_result.input_tokens,
+                                    }
+                                    yield f"event: compaction\ndata: {json.dumps(compaction_payload)}\n\n"
+                            except Exception as e:
+                                logger.warning(f"Failed to update compaction state: {e}")
+
                 # Intercept legacy "error" events from stream_processor and convert to conversational format
                 # This ensures errors appear as assistant messages in the chat UI
                 if event.get("type") == "error":
@@ -540,22 +572,6 @@ class StreamCoordinator:
                     logger.info(f"💾 Stored displayText for user message {user_message_index}")
                 except Exception as e:
                     logger.error(f"Failed to store user displayText: {e}", exc_info=True)
-
-            # Update compaction state if session manager supports it
-            # This tracks input token usage and triggers compaction when threshold exceeded
-            if hasattr(session_manager, "update_after_turn"):
-                input_tokens = accumulated_metadata.get("usage", {}).get("inputTokens", 0)
-                # Also include cache tokens for accurate context size tracking
-                cache_read_tokens = accumulated_metadata.get("usage", {}).get("cacheReadInputTokens", 0)
-                cache_write_tokens = accumulated_metadata.get("usage", {}).get("cacheWriteInputTokens", 0)
-                total_input_tokens = input_tokens + cache_read_tokens + cache_write_tokens
-
-                if total_input_tokens > 0:
-                    try:
-                        await session_manager.update_after_turn(total_input_tokens)
-                        logger.info(f"   Compaction state updated: {total_input_tokens:,} input tokens")
-                    except Exception as e:
-                        logger.warning(f"Failed to update compaction state: {e}")
 
         except Exception as e:
             # Handle errors with emergency flush

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -1380,6 +1380,16 @@ async def _get_session_metadata_cloud(
         if "pendingInterrupts" in item:
             item["pendingInterrupts"] = _dedupe_interrupt_dicts(item["pendingInterrupts"])
 
+        # Lift the running compaction-summary turn count out of the nested
+        # `compaction` map so it shows up as a top-level field on the
+        # response model. Older sessions without compaction state simply
+        # leave the field unset.
+        compaction_data = item.get("compaction")
+        if isinstance(compaction_data, dict):
+            total = compaction_data.get("totalSummarizedTurns")
+            if total is not None:
+                item["totalSummarizedTurns"] = int(total)
+
         return SessionMetadata.model_validate(item)
 
     except Exception as e:

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -205,6 +205,16 @@ class SessionMetadata(BaseModel):
         description="Model max input tokens at the time of the most recent turn",
     )
 
+    # Cumulative count of turns rolled into a compaction summary across this
+    # session's lifetime. Lifted out of the nested `compaction` map at GET
+    # time so the frontend can rehydrate the end-of-conversation indicator
+    # without knowing the internal compaction-state shape.
+    total_summarized_turns: Optional[int] = Field(
+        default=None,
+        alias="totalSummarizedTurns",
+        description="Cumulative count of turns rolled into a compaction summary in this session",
+    )
+
 
 class UpdateSessionMetadataRequest(BaseModel):
     """Request body for updating session metadata"""
@@ -251,6 +261,11 @@ class SessionMetadataResponse(BaseModel):
         None,
         alias="contextWindow",
         description="Model max input tokens at the time of the most recent turn",
+    )
+    total_summarized_turns: Optional[int] = Field(
+        default=None,
+        alias="totalSummarizedTurns",
+        description="Cumulative count of turns rolled into a compaction summary in this session",
     )
 
 

--- a/backend/tests/agents/main_agent/session/test_compaction_models.py
+++ b/backend/tests/agents/main_agent/session/test_compaction_models.py
@@ -43,7 +43,13 @@ class TestCompactionStateToDict:
             updated_at="2024-01-01T00:00:00Z",
         )
         d = state.to_dict()
-        assert set(d.keys()) == {"checkpoint", "summary", "lastInputTokens", "updatedAt"}
+        assert set(d.keys()) == {
+            "checkpoint",
+            "summary",
+            "lastInputTokens",
+            "updatedAt",
+            "totalSummarizedTurns",
+        }
 
     def test_to_dict_values_match(self):
         state = CompactionState(

--- a/backend/tests/agents/main_agent/session/test_turn_based_session_manager.py
+++ b/backend/tests/agents/main_agent/session/test_turn_based_session_manager.py
@@ -726,6 +726,7 @@ class TestUpdateAfterTurn:
     async def test_below_threshold_saves_token_count(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True  # opt out of lazy-load
         mgr._save_compaction_state = MagicMock()
         await mgr.update_after_turn(500)  # below 1000 threshold
         assert mgr.compaction_state.last_input_tokens == 500
@@ -735,6 +736,7 @@ class TestUpdateAfterTurn:
     async def test_above_threshold_creates_checkpoint(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
         mgr._retrieve_session_summaries = MagicMock(return_value=[])
 
@@ -753,6 +755,7 @@ class TestUpdateAfterTurn:
     async def test_not_enough_turns_keeps_all(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
 
         # Only 3 turns = protected_turns, so no compaction possible
@@ -765,6 +768,7 @@ class TestUpdateAfterTurn:
     async def test_empty_cutoff_indices_skips_checkpoint(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
 
         mgr._valid_cutoff_indices = []  # no valid cutoffs (e.g., new session)
@@ -777,6 +781,7 @@ class TestUpdateAfterTurn:
     async def test_checkpoint_unchanged_no_update(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState(checkpoint=4)
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
 
         # 5 turns — checkpoint would be at index 4 again, same as current
@@ -791,6 +796,7 @@ class TestUpdateAfterTurn:
         """New turns should advance the checkpoint."""
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState(checkpoint=4)
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
         mgr._retrieve_session_summaries = MagicMock(return_value=["Updated summary"])
 
@@ -805,6 +811,7 @@ class TestUpdateAfterTurn:
     async def test_uses_ltm_summaries_when_available(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
         mgr._retrieve_session_summaries = MagicMock(return_value=["LTM summary 1", "LTM summary 2"])
 
@@ -819,6 +826,7 @@ class TestUpdateAfterTurn:
     async def test_falls_back_to_generated_summary(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
         mgr._retrieve_session_summaries = MagicMock(return_value=[])
 
@@ -833,11 +841,178 @@ class TestUpdateAfterTurn:
     async def test_initializes_compaction_state_if_none(self, make_session_manager, compaction_config):
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr.compaction_state = None
+        mgr._compaction_state_loaded = True
         mgr._save_compaction_state = MagicMock()
 
         await mgr.update_after_turn(500)
         assert mgr.compaction_state is not None
         assert mgr.compaction_state.last_input_tokens == 500
+
+    # -----------------------------------------------------------------------
+    # Cumulative `total_summarized_turns` across multiple compaction events
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_total_summarized_turns_returned_in_result(
+        self, make_session_manager, compaction_config
+    ):
+        """First compaction returns a CompactionResult with the delta count."""
+        mgr = make_session_manager(compaction_config=compaction_config)
+        mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
+        mgr._save_compaction_state = MagicMock()
+        mgr._retrieve_session_summaries = MagicMock(return_value=[])
+
+        mgr._valid_cutoff_indices = [0, 2, 4, 6, 8]  # 5 turns
+        mgr._all_messages_for_summary = make_conversation(5)
+
+        result = await mgr.update_after_turn(2000)
+
+        # checkpoint advances 0 -> 4. summarized_turns counts cutoffs in (0, 4]: {2, 4} = 2.
+        assert result is not None
+        assert result.previous_checkpoint == 0
+        assert result.new_checkpoint == 4
+        assert result.summarized_turns == 2
+        assert result.input_tokens == 2000
+        assert mgr.compaction_state.total_summarized_turns == 2
+
+    @pytest.mark.asyncio
+    async def test_total_summarized_turns_accumulates_across_events(
+        self, make_session_manager, compaction_config
+    ):
+        """
+        Two threshold-crossing turns in the same session should both add their
+        delta to total_summarized_turns. Regression guard: earlier drafts
+        clobbered the running total when the agent reset between turns.
+        """
+        mgr = make_session_manager(compaction_config=compaction_config)
+        mgr.compaction_state = CompactionState()
+        mgr._compaction_state_loaded = True
+        mgr._save_compaction_state = MagicMock()
+        mgr._retrieve_session_summaries = MagicMock(return_value=[])
+
+        # First compaction: 5 turns, checkpoint advances 0 -> 4 (2 turns rolled up)
+        mgr._valid_cutoff_indices = [0, 2, 4, 6, 8]
+        mgr._all_messages_for_summary = make_conversation(5)
+        first = await mgr.update_after_turn(2000)
+        assert first is not None
+        assert first.summarized_turns == 2
+        assert mgr.compaction_state.total_summarized_turns == 2
+
+        # Second compaction: session grew to 7 turns, checkpoint advances 4 -> 8 (2 more turns)
+        mgr._valid_cutoff_indices = [0, 2, 4, 6, 8, 10, 12]
+        mgr._all_messages_for_summary = make_conversation(7)
+        second = await mgr.update_after_turn(2500)
+        assert second is not None
+        assert second.previous_checkpoint == 4
+        assert second.new_checkpoint == 8
+        assert second.summarized_turns == 2
+        # Cumulative total is the SUM of deltas, not the latest delta.
+        assert mgr.compaction_state.total_summarized_turns == 4
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_does_not_change_total_summarized_turns(
+        self, make_session_manager, compaction_config
+    ):
+        """A sub-threshold turn must not reset or increment the running total."""
+        mgr = make_session_manager(compaction_config=compaction_config)
+        mgr.compaction_state = CompactionState(checkpoint=4, total_summarized_turns=7)
+        mgr._compaction_state_loaded = True
+        mgr._save_compaction_state = MagicMock()
+
+        result = await mgr.update_after_turn(500)  # below 1000 threshold
+
+        assert result is None
+        assert mgr.compaction_state.total_summarized_turns == 7
+
+    # -----------------------------------------------------------------------
+    # Lazy-load: AgentCoreMemory empty-messages init path
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_lazy_loads_persisted_state_when_init_skipped(
+        self, make_session_manager, compaction_config
+    ):
+        """
+        On the AgentCoreMemory existing-session path, `initialize()` runs with
+        `agent.messages` empty and skips `_load_compaction_state`. The first
+        sub-threshold `update_after_turn` must lazy-load so the persisted
+        `total_summarized_turns` and `checkpoint` are not overwritten with
+        defaults when state is saved.
+        """
+        mgr = make_session_manager(compaction_config=compaction_config)
+        # Simulate post-init state on the empty-messages path: defaults, no load.
+        mgr.compaction_state = CompactionState()
+        assert mgr._compaction_state_loaded is False
+
+        persisted = CompactionState(
+            checkpoint=8,
+            summary="prior summary",
+            last_input_tokens=12000,
+            total_summarized_turns=5,
+        )
+        mgr._load_compaction_state = MagicMock(return_value=persisted)
+        mgr._save_compaction_state = MagicMock()
+
+        await mgr.update_after_turn(500)  # below threshold — early-save path
+
+        mgr._load_compaction_state.assert_called_once()
+        assert mgr._compaction_state_loaded is True
+        # Persisted fields preserved through the save (and last_input_tokens updated).
+        assert mgr.compaction_state.checkpoint == 8
+        assert mgr.compaction_state.summary == "prior summary"
+        assert mgr.compaction_state.total_summarized_turns == 5
+        assert mgr.compaction_state.last_input_tokens == 500
+        # The save would have written the persisted total back, not 0.
+        saved_state = mgr._save_compaction_state.call_args.args[0]
+        assert saved_state.total_summarized_turns == 5
+
+    @pytest.mark.asyncio
+    async def test_lazy_load_skipped_when_already_loaded(
+        self, make_session_manager, compaction_config
+    ):
+        """When init loaded the state, `update_after_turn` must not re-load."""
+        mgr = make_session_manager(compaction_config=compaction_config)
+        mgr.compaction_state = CompactionState(checkpoint=2, total_summarized_turns=1)
+        mgr._compaction_state_loaded = True
+        mgr._load_compaction_state = MagicMock()
+        mgr._save_compaction_state = MagicMock()
+
+        await mgr.update_after_turn(500)
+
+        mgr._load_compaction_state.assert_not_called()
+        assert mgr.compaction_state.total_summarized_turns == 1
+
+    @pytest.mark.asyncio
+    async def test_lazy_load_preserves_total_across_threshold_crossing(
+        self, make_session_manager, compaction_config
+    ):
+        """
+        After lazy-load, a threshold-crossing turn should ADD to the persisted
+        total, not start from 0. This is the user-visible scenario the
+        end-of-conversation indicator depends on.
+        """
+        mgr = make_session_manager(compaction_config=compaction_config)
+        mgr.compaction_state = CompactionState()
+        assert mgr._compaction_state_loaded is False
+
+        persisted = CompactionState(checkpoint=4, total_summarized_turns=2)
+        mgr._load_compaction_state = MagicMock(return_value=persisted)
+        mgr._save_compaction_state = MagicMock()
+        mgr._retrieve_session_summaries = MagicMock(return_value=[])
+
+        # 7 turns now — checkpoint advances from persisted 4 to 8 (2 more turns)
+        mgr._valid_cutoff_indices = [0, 2, 4, 6, 8, 10, 12]
+        mgr._all_messages_for_summary = make_conversation(7)
+
+        result = await mgr.update_after_turn(2500)
+
+        assert result is not None
+        assert result.previous_checkpoint == 4
+        assert result.new_checkpoint == 8
+        assert result.summarized_turns == 2
+        # 2 (persisted) + 2 (this event) — NOT 0 + 2.
+        assert mgr.compaction_state.total_summarized_turns == 4
 
 
 # ===========================================================================

--- a/frontend/ai.client/src/app/session/components/message-list/components/compaction-summary/compaction-summary.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/compaction-summary/compaction-summary.component.ts
@@ -1,0 +1,103 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArchiveBoxArrowDown } from '@ng-icons/heroicons/outline';
+
+/**
+ * Single subtle indicator rendered at the end of the conversation when
+ * any context compaction has happened in this session. Replaces the
+ * earlier per-message inline divider, which caused jarring layout shifts
+ * when it dropped between messages mid-conversation. Hover/focus reveals
+ * the cumulative turn count in a tooltip.
+ *
+ * `animate` plays a one-shot fade-in only on the first appearance
+ * (0 → >0 transition). Subsequent updates to `summarizedTurns` change
+ * the tooltip in place with no animation.
+ */
+@Component({
+  selector: 'app-compaction-summary',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroArchiveBoxArrowDown })],
+  styles: `
+    :host {
+      display: block;
+    }
+    @keyframes compactionFadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(2px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    .compaction-enter {
+      animation: compactionFadeIn 350ms ease-out backwards;
+    }
+  `,
+  template: `
+    <div
+      role="status"
+      [attr.aria-label]="ariaLabel()"
+      class="mt-2 flex justify-start text-[11px] text-gray-400 dark:text-gray-500"
+      [class.compaction-enter]="animate()"
+    >
+      <span
+        class="group relative inline-flex items-center gap-1 rounded-sm px-1 py-0.5 outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
+        tabindex="0"
+      >
+        <ng-icon
+          name="heroArchiveBoxArrowDown"
+          class="text-xs text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <span>Earlier messages summarized</span>
+
+        <!-- Hover/focus tooltip -->
+        <span
+          role="tooltip"
+          class="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-64 -translate-x-1/2 rounded-md border border-gray-200 bg-white p-3 text-left opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 dark:border-gray-700 dark:bg-gray-800"
+        >
+          <span
+            class="block text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+          >
+            Context summarized
+          </span>
+          <span class="mt-1 block text-xs text-gray-700 dark:text-gray-300">
+            {{ summaryDetail() }}
+          </span>
+          <span
+            class="mt-2 block text-[11px] leading-snug text-gray-500 dark:text-gray-400"
+          >
+            Older turns were condensed into a summary so the model can keep
+            responding without losing track of the conversation.
+          </span>
+        </span>
+      </span>
+    </div>
+  `,
+})
+export class CompactionSummaryComponent {
+  /** Cumulative count of turns summarized across all compaction events
+   *  in this session. */
+  summarizedTurns = input.required<number>();
+
+  /** Whether to play the one-shot fade-in animation on first render. */
+  animate = input<boolean>(false);
+
+  protected readonly summaryDetail = computed(() => {
+    const turns = this.summarizedTurns();
+    return `${turns.toLocaleString()} earlier ${turns === 1 ? 'turn has' : 'turns have'} been summarized to keep context manageable.`;
+  });
+
+  protected readonly ariaLabel = computed(() => {
+    const turns = this.summarizedTurns();
+    return `${turns} earlier ${turns === 1 ? 'turn' : 'turns'} summarized to save context`;
+  });
+}

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -31,6 +31,18 @@
             </div>
         </div>
     }
+
+  }
+
+  <!-- Single subtle compaction summary at the end of the conversation,
+       shown when the backend has rolled older turns into a summary. The
+       inline-divider variant of this was dropped because it caused
+       layout shifts mid-conversation; this lives in one fixed spot. -->
+  @if (hasCompaction()) {
+    <app-compaction-summary
+      [summarizedTurns]="totalSummarizedTurns()"
+      [animate]="animateCompaction()"
+    />
   }
 
   <!-- OAuth consent prompts not anchored to a loaded message — usually

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -9,6 +9,7 @@ import { CitationDisplayComponent } from '../citation-display/citation-display.c
 import { PulsatingLoaderComponent } from '../../../components/pulsating-loader.component';
 import { OAuthConsentPromptComponent } from './components/oauth-consent-prompt/oauth-consent-prompt.component';
 import { ToolApprovalPromptComponent } from './components/tool-approval-prompt/tool-approval-prompt.component';
+import { CompactionSummaryComponent } from './components/compaction-summary/compaction-summary.component';
 import {
   OAuthConsentRequest,
   OAuthConsentService,
@@ -17,6 +18,7 @@ import {
   ToolApprovalRequest,
   ToolApprovalService,
 } from '../../../services/tool-approval/tool-approval.service';
+import { CompactionSummaryService } from '../../services/chat/compaction-summary.service';
 
 @Component({
   selector: 'app-message-list',
@@ -29,6 +31,7 @@ import {
     PulsatingLoaderComponent,
     OAuthConsentPromptComponent,
     ToolApprovalPromptComponent,
+    CompactionSummaryComponent,
   ],
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
@@ -49,6 +52,17 @@ export class MessageListComponent implements OnDestroy {
 
   private consentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
+  private compactionSummary = inject(CompactionSummaryService);
+
+  /** Single end-of-conversation compaction summary inputs. Sourced from
+   *  live SSE events plus session-metadata hydration on load. The fade-in
+   *  animation only fires on live events; reload-hydrated totals appear
+   *  in place. */
+  protected hasCompaction = this.compactionSummary.hasCompaction;
+  protected totalSummarizedTurns = this.compactionSummary.totalSummarizedTurns;
+  protected animateCompaction = computed(
+    () => this.compactionSummary.hasCompaction() && !this.compactionSummary.wasHydrated(),
+  );
 
   /** Pending consent prompts whose anchor message id isn't in the loaded
    *  message list — typically the case when an interrupt fires on a turn

--- a/frontend/ai.client/src/app/session/services/chat/compaction-summary.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/compaction-summary.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, computed, signal } from '@angular/core';
+import type { CompactionEvent } from '../../../shared/utils/stream-parser';
+
+/**
+ * Aggregate compaction state for the current session view. Earlier
+ * iterations of this work tracked per-message-index dividers; that was
+ * dropped because the inline placement caused jarring layout shifts when
+ * the divider dropped between messages mid-conversation. The new shape
+ * is a single end-of-conversation summary, so we only need totals.
+ *
+ * `totalSummarizedTurns` is the running sum of `summarizedTurns` across
+ * every `compaction` SSE event received this session. On session load the
+ * persisted cumulative count is replayed via `seedFromHydration`, which
+ * also flips `wasHydrated` so the indicator renders without re-playing
+ * the one-shot fade-in.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CompactionSummaryService {
+  private readonly turnsSignal = signal<number>(0);
+  private readonly hydratedSignal = signal<boolean>(false);
+
+  readonly totalSummarizedTurns = this.turnsSignal.asReadonly();
+
+  /** True when the current total came from session-metadata hydration and
+   *  no live `compaction` event has fired since. The component reads this
+   *  to suppress the fade-in animation on reload. */
+  readonly wasHydrated = this.hydratedSignal.asReadonly();
+
+  /** Whether the summary should render at all in the UI. */
+  readonly hasCompaction = computed(() => this.turnsSignal() > 0);
+
+  /**
+   * Record a live `compaction` SSE event. Adds to the running total and
+   * clears the hydrated flag so the indicator animates in.
+   */
+  recordLive(event: CompactionEvent): void {
+    this.turnsSignal.update((total) => total + event.summarizedTurns);
+    this.hydratedSignal.set(false);
+  }
+
+  /**
+   * Replay a persisted cumulative total on session load. Idempotent and
+   * non-clobbering: a stale hydration call that arrives after a live
+   * event has already incremented the total is dropped.
+   */
+  seedFromHydration(total: number): void {
+    if (total <= 0) return;
+    if (this.turnsSignal() > 0 || this.hydratedSignal()) return;
+    this.turnsSignal.set(total);
+    this.hydratedSignal.set(true);
+  }
+
+  /** Clear all state — called on session change. */
+  reset(): void {
+    this.turnsSignal.set(0);
+    this.hydratedSignal.set(false);
+  }
+}

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -16,9 +16,11 @@ import {
 } from '../../../services/quota/quota-warning.service';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
 import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
+import { CompactionSummaryService } from './compaction-summary.service';
 import type {
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
+  CompactionEvent,
 } from '../../../shared/utils/stream-parser';
 import {
   processStreamEvent,
@@ -56,6 +58,7 @@ export class StreamParserService {
   private quotaWarningService = inject(QuotaWarningService);
   private oauthConsentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
+  private compactionSummary = inject(CompactionSummaryService);
 
   // =========================================================================
   // State Signals
@@ -321,6 +324,8 @@ export class StreamParserService {
           this.sessionId ?? undefined,
         );
       },
+
+      onCompaction: (data: CompactionEvent) => this.compactionSummary.recordLive(data),
 
       onToolApprovalRequired: (data: ToolApprovalRequiredEvent) => {
         const messages = this.allMessages();

--- a/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
@@ -40,6 +40,10 @@ export interface SessionMetadata {
   lastContextTokens?: number;
   /** Model context window (max input tokens) at the time of the most recent turn. */
   contextWindow?: number;
+  /** Cumulative count of turns the backend has rolled into a compaction
+   *  summary in this session. Drives the end-of-conversation summary
+   *  indicator after a refresh. */
+  totalSummarizedTurns?: number;
 }
 
 // Request model for updating session metadata

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -14,6 +14,7 @@ import { ModelSettings } from '../components/model-settings/model-settings';
 import { UserService } from '../auth/user.service';
 import { ChatHttpService } from './services/chat/chat-http.service';
 import { StreamParserService } from './services/chat/stream-parser.service';
+import { CompactionSummaryService } from './services/chat/compaction-summary.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
 import { Assistant } from '../assistants/models/assistant.model';
@@ -42,6 +43,7 @@ export class ConversationPage implements OnDestroy {
   private userService = inject(UserService);
   private chatHttpService = inject(ChatHttpService);
   private streamParserService = inject(StreamParserService);
+  private compactionSummary = inject(CompactionSummaryService);
   private assistantService = inject(AssistantService);
   private router = inject(Router);
   private dialog = inject(Dialog);
@@ -185,6 +187,21 @@ export class ConversationPage implements OnDestroy {
       });
     });
 
+    // Hydrate the compaction summary indicator from persisted session
+    // metadata. `seedFromHydration` is idempotent and won't clobber live
+    // increments, so re-runs of this effect (e.g. when other fields on
+    // currentSession update) are harmless. The route subscription resets
+    // the service before triggering the metadata fetch, so cross-session
+    // bleed is impossible.
+    effect(() => {
+      const session = this.sessionConversation();
+      if (!session?.sessionId || session.sessionId !== this.sessionId()) return;
+      const total = session.totalSummarizedTurns ?? 0;
+      if (total > 0) {
+        this.compactionSummary.seedFromHydration(total);
+      }
+    });
+
     // Priority-based assistant loading: URL query param first, then session preferences
     effect(() => {
       const queryAssistantId = this.assistantIdFromQuery();
@@ -231,6 +248,12 @@ export class ConversationPage implements OnDestroy {
       // metadata loads — otherwise the previous session's totals briefly
       // flash on the badge while the new metadata is in flight.
       this.chatStateService.seedSessionAggregates({});
+
+      // Compaction summary is session-scoped — clear before loading the
+      // next session's metadata so the previous session's totals don't
+      // bleed in. The hydration effect above will reseed from
+      // currentSession.totalSummarizedTurns once the metadata fetch lands.
+      this.compactionSummary.reset();
 
       if (id) {
         // Update the messages signal reference (this triggers reactivity)

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -57,6 +57,7 @@ export {
   validateCitation,
   validateOAuthRequiredEvent,
   validateToolApprovalRequiredEvent,
+  validateCompactionEvent,
 } from './stream-parser-core';
 
 // Types
@@ -78,6 +79,7 @@ export type {
   ConversationalStreamErrorEvent,
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
+  CompactionEvent,
   StreamEventType,
   StreamEventData,
   ParsedStreamEvent,

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -38,6 +38,7 @@ import type {
   ConversationalStreamErrorEvent,
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
+  CompactionEvent,
   ToolProgress,
 } from './stream-parser-types';
 import type { MetadataEvent } from '../../../session/services/models/content-types';
@@ -82,6 +83,9 @@ export interface StreamParserCallbacks {
 
   // Tool approval required (catalog flagged this MCP tool needs_approval)
   onToolApprovalRequired?: (data: ToolApprovalRequiredEvent) => void;
+
+  // Compaction (backend rolled older turns into a summary on this turn)
+  onCompaction?: (data: CompactionEvent) => void;
 
   // Error handling
   onError?: (data: StreamErrorEvent | ConversationalStreamErrorEvent | string) => void;
@@ -369,6 +373,27 @@ export function validateToolApprovalRequiredEvent(
 }
 
 /**
+ * Validate CompactionEvent structure
+ */
+export function validateCompactionEvent(data: unknown): data is CompactionEvent {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const event = data as Partial<CompactionEvent>;
+
+  return (
+    event.type === 'compaction' &&
+    typeof event.previousCheckpoint === 'number' &&
+    typeof event.newCheckpoint === 'number' &&
+    typeof event.summarizedTurns === 'number' &&
+    event.summarizedTurns >= 0 &&
+    typeof event.inputTokens === 'number' &&
+    event.newCheckpoint > event.previousCheckpoint
+  );
+}
+
+/**
  * Validate Citation structure
  */
 export function validateCitation(data: unknown): data is Citation {
@@ -546,6 +571,14 @@ export function processStreamEvent(
           callbacks.onToolApprovalRequired?.(data);
         } else {
           callbacks.onParseError?.('tool_approval_required: invalid data structure');
+        }
+        break;
+
+      case 'compaction':
+        if (validateCompactionEvent(data)) {
+          callbacks.onCompaction?.(data);
+        } else {
+          callbacks.onParseError?.('compaction: invalid data structure');
         }
         break;
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -120,6 +120,26 @@ export interface ToolApprovalRequiredEvent {
 }
 
 /**
+ * Compaction event — emitted after the final `metadata` event (so the badge
+ * updates first) and before `done` when the backend rolls older turns into
+ * a summary on this turn. The frontend uses it to drop an inline divider in
+ * the conversation marking where the checkpoint advanced.
+ *
+ * `newCheckpoint` is the message index the checkpoint moved to, and acts as
+ * the divider's anchor — the divider renders above the message at that
+ * index. `summarizedTurns` is the *delta* count of turns rolled up at this
+ * compaction event, not the cumulative total across prior compactions, so
+ * each divider stands on its own.
+ */
+export interface CompactionEvent {
+  type: 'compaction';
+  previousCheckpoint: number;
+  newCheckpoint: number;
+  summarizedTurns: number;
+  inputTokens: number;
+}
+
+/**
  * Tool result event data structure
  */
 export interface ToolResultEventData {
@@ -157,7 +177,8 @@ export type StreamEventType =
   | 'quota_exceeded'
   | 'stream_error'
   | 'citation'
-  | 'oauth_required';
+  | 'oauth_required'
+  | 'compaction';
 
 /**
  * Union type of all possible event data types
@@ -178,6 +199,7 @@ export type StreamEventData =
   | ConversationalStreamErrorEvent
   | Citation
   | OAuthRequiredEvent
+  | CompactionEvent
   | null
   | undefined;
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -122,14 +122,18 @@ export interface ToolApprovalRequiredEvent {
 /**
  * Compaction event — emitted after the final `metadata` event (so the badge
  * updates first) and before `done` when the backend rolls older turns into
- * a summary on this turn. The frontend uses it to drop an inline divider in
- * the conversation marking where the checkpoint advanced.
+ * a summary on this turn. The frontend feeds it to `CompactionSummaryService`,
+ * which increments a running total and renders a single end-of-conversation
+ * "Earlier messages summarized" indicator. (An earlier draft of this work
+ * placed inline dividers anchored at `newCheckpoint`; that variant was
+ * dropped because the mid-conversation drop-in caused jarring layout shifts.)
  *
- * `newCheckpoint` is the message index the checkpoint moved to, and acts as
- * the divider's anchor — the divider renders above the message at that
- * index. `summarizedTurns` is the *delta* count of turns rolled up at this
- * compaction event, not the cumulative total across prior compactions, so
- * each divider stands on its own.
+ * `summarizedTurns` is the *delta* count of turns rolled up at this
+ * compaction event, not the cumulative total across prior compactions —
+ * the service sums these deltas to keep its own running total, which is
+ * also persisted on the backend as `totalSummarizedTurns` for refresh
+ * survival. `previousCheckpoint` / `newCheckpoint` are kept on the wire
+ * for diagnostics and possible future per-event UI.
  */
 export interface CompactionEvent {
   type: 'compaction';


### PR DESCRIPTION
Closes #244

## Summary
- New `compaction` SSE event + end-of-conversation "Earlier messages summarized" indicator so users understand the sudden context-window % drops on the cost badge.
- `totalSummarizedTurns` is persisted alongside the existing compaction state in DynamoDB and surfaced on the session-metadata GET, so the indicator survives a page refresh.
- Animation only plays on live SSE events; reload-hydrated totals appear in place via a `wasHydrated` flag in `CompactionSummaryService`.

## Test plan
- [ ] Local: send several turns until input crosses the threshold; confirm a `compaction` event arrives in the SSE stream after the final `metadata` and the indicator appears with a fade-in.
- [ ] Refresh the page; confirm the indicator reappears immediately with the same turn count and **without** the fade-in animation.
- [ ] Switch to a different session that has not compacted; confirm the indicator does not bleed in.
- [ ] Switch to another session that has compacted; confirm the new total hydrates without animation.
- [ ] Verify the cost-badge context-window % updates *before* the indicator changes during a live compaction (event ordering: metadata → compaction → done).
- [ ] Backend tests: `uv run python -m pytest tests/agents/main_agent/session/ tests/shared/test_sessions_metadata.py tests/routes/test_sessions.py -q` (already green locally).
- [ ] Frontend parser tests: `npx vitest run src/app/shared/utils/stream-parser/stream-parser-core.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)