### PR TITLE
fix(oauth): always send prompt=consent on Google initiate-consent

### DIFF
--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -228,10 +228,19 @@ async def initiate_consent(
             scopes=provider.scopes,
             user_id=current_user.user_id,
             force_authentication=force_auth,
+            # initiate_consent is by definition a "walk me through consent"
+            # path — the user clicked Connect/Reconnect after seeing they
+            # were not connected. For Google this means we must send
+            # `prompt=consent`, otherwise Google sees a previously-consented
+            # user, skips the consent screen, and re-issues an access_token
+            # WITHOUT a refresh_token. Vault then expires after ~1h and the
+            # user is back here. Decoupled from `force_auth` (which only
+            # toggles the SDK's vault-bypass) so the silent-refresh fast
+            # path elsewhere is unaffected.
             custom_parameters=custom_parameters_for(
                 provider.provider_type.value,
                 provider.custom_parameters,
-                force_authentication=force_auth,
+                force_authentication=True,
             ),
             # No custom_state: AgentCore appears to treat its presence as a
             # signal to start a fresh flow, never short-circuiting to the

--- a/backend/tests/apis/app_api/test_connectors_routes.py
+++ b/backend/tests/apis/app_api/test_connectors_routes.py
@@ -418,7 +418,14 @@ class TestForceReauthLifecycle:
             "access_type": "offline",
         }
 
-    def test_initiate_consent_forwards_google_access_type_offline(self, app_with_deps):
+    def test_initiate_consent_forwards_google_access_type_offline_and_prompt_consent(
+        self, app_with_deps
+    ):
+        # initiate_consent is a "walk me through consent" path, so for Google
+        # we always send `prompt=consent` (in addition to `access_type=offline`).
+        # Without it, Google sees a previously-consented user, skips the consent
+        # screen, and re-issues an access_token without a refresh_token —
+        # putting the user back in the hourly-reconsent loop.
         app, identity, _ = app_with_deps(
             "alice",
             provider=_make_provider(),
@@ -429,6 +436,7 @@ class TestForceReauthLifecycle:
         identity.get_token_for_user.assert_called_once()
         assert identity.get_token_for_user.call_args.kwargs["custom_parameters"] == {
             "access_type": "offline",
+            "prompt": "consent",
         }
 
     def test_admin_custom_parameters_merge_with_google_baseline(self, app_with_deps):


### PR DESCRIPTION
## Summary

- Google reconsent loop returns: when AgentCore's vault loses a refresh token via any path other than the explicit Disconnect button (testing-mode refresh-token expiry, user revocation at Google, etc.), the next initiate-consent call sent the user to Google without `prompt=consent`. Google saw a previously-consented user, skipped the consent screen, and re-issued an access_token only — putting the user back in the hourly-reconsent loop.
- `initiate_consent` is by definition a "walk me through consent" path, so always pass `force_authentication=True` to `custom_parameters_for` here. Decoupled from the SDK's vault-bypass flag, so the silent-refresh fast path on `/status` and the agent-side gate is unaffected.
- Affects Google providers only — the vendor baseline returns `{}` for every other provider regardless of the flag.
- Builds on #210, which introduced the `prompt=consent`-on-force_auth wiring but only triggered it from the explicit disconnect path.

## Test plan

- [x] `tests/apis/app_api/test_connectors_routes.py` — updated `test_initiate_consent_forwards_google_access_type_offline_and_prompt_consent` to encode the new contract; all 63 tests in `tests/apis/app_api/test_connectors_routes.py`, `tests/apis/shared/oauth/`, and `tests/shared/test_oauth_disconnect_repository.py` pass.
- [ ] Manual: Disconnect a Google connector → Reconnect → verify https://myaccount.google.com/permissions shows "Has offline access" for the app.
- [ ] Manual: wait an hour after reconnect, run a Google-backed tool, confirm silent refresh works (no consent prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)