### PR TITLE
fix: resolve open CodeQL and Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # ── Python backend ──
   - package-ecosystem: "pip"
     directory: "/backend"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -27,7 +27,7 @@ updates:
   # ── Frontend npm ──
   - package-ecosystem: "npm"
     directory: "/frontend/ai.client"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -52,7 +52,7 @@ updates:
   # ── Infrastructure CDK ──
   - package-ecosystem: "npm"
     directory: "/infrastructure"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -77,7 +77,7 @@ updates:
   # ── GitHub Actions ──
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
     paths:
       - 'backend/src/**'
       - 'backend/lambda-functions/**'
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/**'
       - '.github/codeql/**'
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
     paths:
       - 'backend/src/**'
       - 'backend/lambda-functions/**'

--- a/backend/src/agents/builtin_tools/code_interpreter_diagram_tool.py
+++ b/backend/src/agents/builtin_tools/code_interpreter_diagram_tool.py
@@ -139,7 +139,6 @@ Please deploy AgentCore Runtime Stack to create Custom Code Interpreter."""
 
         # 4. Check for errors
         execution_success = False
-        execution_output = ""
 
         for event in response.get("stream", []):
             result = event.get("result", {})

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -1233,9 +1233,6 @@ async def process_agent_stream(
     current_block_index: Dict[str, int] = {"index": 0}
 
     try:
-        # Track if we've seen result to know when it's safe to break on complete
-        result_seen = False
-
         # Iterate through each raw event from the agent stream
         # The agent stream is an async generator that yields events as they occur
         async for event in agent_stream:

--- a/backend/src/apis/app_api/admin/costs/service.py
+++ b/backend/src/apis/app_api/admin/costs/service.py
@@ -248,7 +248,7 @@ class AdminCostService:
         Returns:
             List of TierUsageSummary (currently empty, placeholder).
         """
-        _period = period or self._get_current_period()  # TODO: use once tier aggregation is implemented
+        _ = period or self._get_current_period()  # TODO: use once tier aggregation is implemented
         logger.info("Getting tier usage for period")
 
         # TODO: Implement tier usage aggregation

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -566,7 +566,7 @@ async def dismiss_pending_interrupt_endpoint(
     """
     user_id = current_user.user_id
 
-    logger.info("DELETE /sessions/%s/pending-interrupts/%s", session_id, interrupt_id)
+    logger.info("DELETE /sessions/.../pending-interrupts/...")
 
     try:
         await remove_pending_interrupts(

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -687,10 +687,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
 
             snapshot = await get_paused_turn(input_data.session_id, user_id)
             if not snapshot:
-                logger.warning(
-                    "Resume rejected: no paused_turn snapshot for session %s",
-                    input_data.session_id,
-                )
+                logger.warning("Resume rejected: no paused_turn snapshot found")
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="No paused turn for this session; restart the turn.",
@@ -700,10 +697,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             except ValueError:
                 expires_at = None
             if expires_at and datetime.now(timezone.utc) > expires_at:
-                logger.warning(
-                    "Resume rejected: paused_turn snapshot expired for session %s",
-                    input_data.session_id,
-                )
+                logger.warning("Resume rejected: paused_turn snapshot expired")
                 await clear_paused_turn(input_data.session_id, user_id)
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -327,7 +327,7 @@ async def generate_conversation_title(
             }
         }
 
-        logger.info(f"🎯 Generating title for session {session_id} (input length: {len(truncated_input)} chars)")
+        logger.info("🎯 Generating title (input length: %d chars)", len(truncated_input))
 
         # Call Bedrock Nova Micro
         response = bedrock_client.converse(
@@ -343,9 +343,9 @@ async def generate_conversation_title(
         # Enforce 50 character limit (just in case model exceeds)
         if len(title) > 50:
             title = title[:47] + "..."
-            logger.warning(f"Title exceeded 50 chars, truncated to: {title}")
+            logger.warning("Title exceeded 50 chars, truncated")
 
-        logger.info(f"✅ Generated title: '{title}' for session {session_id}")
+        logger.info("✅ Generated title successfully")
 
         # Targeted update — only writes the title attribute. The post-stream
         # update_session_activity write is also targeted and disjoint, so the
@@ -358,6 +358,6 @@ async def generate_conversation_title(
         # Title generation is nice-to-have. Leave the existing "New Conversation"
         # placeholder in place rather than writing a fallback; the row already
         # exists from the pre-create.
-        logger.error(f"Failed to generate title for session {session_id}: {e}", exc_info=True)
+        logger.error("Failed to generate title: %s", e, exc_info=True)
         return "New Conversation"
 

--- a/backend/src/apis/shared/auth/cognito_jwt_validator.py
+++ b/backend/src/apis/shared/auth/cognito_jwt_validator.py
@@ -122,7 +122,7 @@ class CognitoJWTValidator:
                 if isinstance(parsed, list):
                     return [str(r).strip() for r in parsed if str(r).strip()]
             except (json.JSONDecodeError, TypeError):
-                pass
+                pass  # Fall through to comma-separated parsing below
             # Fall back to comma-separated
             return [r.strip() for r in custom_roles.split(",") if r.strip()]
 

--- a/backend/tests/supply_chain/test_dependabot_config.py
+++ b/backend/tests/supply_chain/test_dependabot_config.py
@@ -1,6 +1,6 @@
 """Property tests for Dependabot configuration.
 
-Feature: supply-chain-hardening, Property 8: Dependabot entries target develop with grouped updates
+Feature: supply-chain-hardening, Property 8: Dependabot entries target main with grouped updates
 Validates: Requirements 9.2, 9.3
 """
 
@@ -22,8 +22,8 @@ def _load_dependabot_config() -> dict:
         return yaml.safe_load(f)
 
 
-def test_all_ecosystems_target_develop():
-    """Property 8a: All Dependabot ecosystem entries target the develop branch.
+def test_all_ecosystems_target_main():
+    """Property 8a: All Dependabot ecosystem entries target the main branch.
 
     **Validates: Requirement 9.2**
     """
@@ -37,14 +37,14 @@ def test_all_ecosystems_target_develop():
         directory = entry.get("directory", "/")
         target = entry.get("target-branch")
 
-        if target != "develop":
+        if target != "main":
             violations.append(
                 f"  {ecosystem} ({directory}): target-branch = '{target}' "
-                f"(expected: 'develop')"
+                f"(expected: 'main')"
             )
 
     assert not violations, (
-        f"Found {len(violations)} ecosystem(s) not targeting develop:\n"
+        f"Found {len(violations)} ecosystem(s) not targeting main:\n"
         + "\n".join(violations)
     )
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3644,11 +3644,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -7,11 +7,7 @@ import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as logs from "aws-cdk-lib/aws-logs";
-import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as lambdaEventSources from "aws-cdk-lib/aws-lambda-event-sources";
-import * as sns from "aws-cdk-lib/aws-sns";
-import * as events from "aws-cdk-lib/aws-events";
-import * as targets from "aws-cdk-lib/aws-events-targets";
+
 import { Construct } from "constructs";
 import { AppConfig, getResourceName, applyStandardTags, getRemovalPolicy, buildCorsOrigins } from "./config";
 


### PR DESCRIPTION
## Summary

Resolves all open CodeQL alerts and one Dependabot alert, and retargets CodeQL/Dependabot automation to the \`main\` branch.

## CodeQL fixes (13 alerts)

- **Log Injection (\`py/log-injection\`)** — removed user-controlled values (session IDs, interrupt IDs, titles) from log statements in \`inference_api/chat/service.py\`, \`inference_api/chat/routes.py\`, and \`app_api/sessions/routes.py\`. Sanitization was considered but CodeQL continues to trace tainted flows through sanitizers, so the cleanest fix is to omit the user input from the log messages entirely.
- **Empty except (\`py/empty-except\`)** — added explanatory comment to the \`pass\` in \`cognito_jwt_validator.py\`.
- **Unused imports (\`js/unused-local-variable\`)** — removed 5 unused AWS CDK imports (\`lambda\`, \`lambdaEventSources\`, \`sns\`, \`events\`, \`targets\`) from \`app-api-stack.ts\`.
- **Unused variables (\`py/unused-local-variable\`)**:
  - Removed dead-code \`result_seen\` in \`stream_processor.py\` (dead \`break\` guard; TODO comment retained)
  - Removed \`execution_output\` in \`code_interpreter_diagram_tool.py\`
  - Renamed \`_period\` to \`_\` in \`admin/costs/service.py\` (intentionally unused placeholder)

## Dependabot fix (1 alert)

- Upgraded **Pygments** 2.19.2 → 2.20.0 (ReDoS in GUID regex, alert #71).
- The remaining 34 open Dependabot alerts target versions that are already satisfied in the lockfiles (pillow 12.2.0, aiohttp 3.13.5, cryptography 47.0.0, python-multipart 0.0.27, vite 8.0.10, postcss 8.5.12, dompurify 3.4.1, hono 4.12.15, @hono/node-server 2.0.0, lodash-es 4.18.1). These should auto-close on the next scan.

## CI config

- \`.github/workflows/codeql.yml\`: push/PR triggers changed from \`develop\` to \`main\`.
- \`.github/dependabot.yml\`: all four ecosystems (pip, npm frontend, npm infra, github-actions) now target \`main\`.

## Testing

- Diagnostics pass for all modified files (no compile or lint errors).
- Backend lockfile resolved cleanly via \`uv lock\` inside the \`agentcore-dev\` container.