### PR TITLE
feat(attachments): rich previews for file attachments in user messages

### DIFF
--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -16,6 +16,8 @@ from apis.shared.files.models import (
     PresignRequest,
     PresignResponse,
     CompleteUploadResponse,
+    PreviewUrlResponse,
+    TextSnippetResponse,
     FileListResponse,
     QuotaResponse,
     QuotaExceededError as QuotaExceededModel,
@@ -133,6 +135,51 @@ async def complete_upload(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(e),
+        )
+
+
+@router.get("/{upload_id}/preview-url", response_model=PreviewUrlResponse)
+async def get_preview_url(
+    upload_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: FileUploadService = Depends(get_file_upload_service),
+):
+    """
+    Generate a short-lived presigned GET URL for an uploaded file.
+
+    Used by the UI to render image previews inline and to open files in a
+    lightbox. The URL is scoped to the file owner and expires after a few
+    minutes.
+    """
+    try:
+        return await service.get_preview_url(user.user_id, upload_id)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"File {upload_id} not found or not owned by you",
+        )
+
+
+@router.get("/{upload_id}/text-snippet", response_model=TextSnippetResponse)
+async def get_text_snippet(
+    upload_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: FileUploadService = Depends(get_file_upload_service),
+):
+    """
+    Return a short UTF-8 text excerpt from the start of a file.
+
+    Used by the UI to render a content peek inside the document-style
+    attachment card for text-based files (txt, md, csv, html). Returns an
+    empty snippet for non-text MIME types so the UI can fall back to a
+    skeleton mockup.
+    """
+    try:
+        return await service.get_text_snippet(user.user_id, upload_id)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"File {upload_id} not found or not owned by you",
         )
 
 

--- a/backend/src/apis/app_api/files/service.py
+++ b/backend/src/apis/app_api/files/service.py
@@ -20,12 +20,26 @@ from apis.shared.files.models import (
     PresignRequest,
     PresignResponse,
     CompleteUploadResponse,
+    PreviewUrlResponse,
+    TextSnippetResponse,
     FileResponse,
     FileListResponse,
     QuotaResponse,
     is_allowed_mime_type,
     ALLOWED_MIME_TYPES,
 )
+
+
+# MIME types that are safe to decode as UTF-8 text for inline previews.
+TEXT_PREVIEW_MIME_TYPES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/html",
+    }
+)
+TEXT_SNIPPET_MAX_BYTES = 2048
 from apis.shared.files.repository import FileUploadRepository, get_file_upload_repository
 
 logger = logging.getLogger(__name__)
@@ -133,6 +147,7 @@ class FileUploadService:
 
         # Pre-signed URL expiration
         self.presign_expiration = 15 * 60  # 15 minutes
+        self.preview_url_expiration = 10 * 60  # 10 minutes for GET previews
 
     # =========================================================================
     # Pre-signed URL Flow
@@ -299,6 +314,135 @@ class FileUploadService:
             s3_uri=file_meta.s3_uri,
             filename=file_meta.filename,
             size_bytes=file_meta.size_bytes,
+        )
+
+    # =========================================================================
+    # Preview URL
+    # =========================================================================
+
+    async def get_preview_url(
+        self, user_id: str, upload_id: str
+    ) -> PreviewUrlResponse:
+        """
+        Generate a short-lived presigned GET URL for displaying a file.
+
+        Used by the UI to render image thumbnails inline and to power the
+        full-size lightbox. Only owners can generate preview URLs for their
+        own files. Files must be in READY state.
+
+        Args:
+            user_id: The owner's user ID
+            upload_id: The upload identifier
+
+        Returns:
+            PreviewUrlResponse with a presigned GET URL
+
+        Raises:
+            FileNotFoundError: If file not found, not owned by user, or not ready
+        """
+        file_meta = await self.repository.get_file(user_id, upload_id)
+        if not file_meta:
+            raise FileNotFoundError(f"File {upload_id} not found")
+
+        if file_meta.status != FileStatus.READY:
+            raise FileNotFoundError(
+                f"File {upload_id} is not ready (status: {file_meta.status})"
+            )
+
+        try:
+            url = self._s3_client.generate_presigned_url(
+                "get_object",
+                Params={
+                    "Bucket": self.bucket_name,
+                    "Key": file_meta.s3_key,
+                    "ResponseContentType": file_meta.mime_type,
+                    "ResponseContentDisposition": f'inline; filename="{file_meta.filename}"',
+                },
+                ExpiresIn=self.preview_url_expiration,
+            )
+        except ClientError as e:
+            logger.error(f"Failed to generate preview URL: {e}")
+            raise
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=self.preview_url_expiration)
+        ).isoformat() + "Z"
+
+        return PreviewUrlResponse(
+            upload_id=upload_id,
+            url=url,
+            expires_at=expires_at,
+            mime_type=file_meta.mime_type,
+            filename=file_meta.filename,
+        )
+
+    async def get_text_snippet(
+        self, user_id: str, upload_id: str
+    ) -> TextSnippetResponse:
+        """
+        Return a short UTF-8 text excerpt from the start of a file.
+
+        Used by the UI to render a content peek inside the document-style
+        attachment card. Only text-based MIME types are supported; other
+        types return an empty snippet so the UI can fall back to a skeleton.
+
+        Args:
+            user_id: The owner's user ID
+            upload_id: The upload identifier
+
+        Returns:
+            TextSnippetResponse with the decoded snippet (possibly empty)
+
+        Raises:
+            FileNotFoundError: If file not found, not owned, or not ready
+        """
+        file_meta = await self.repository.get_file(user_id, upload_id)
+        if not file_meta:
+            raise FileNotFoundError(f"File {upload_id} not found")
+
+        if file_meta.status != FileStatus.READY:
+            raise FileNotFoundError(
+                f"File {upload_id} is not ready (status: {file_meta.status})"
+            )
+
+        if file_meta.mime_type not in TEXT_PREVIEW_MIME_TYPES:
+            return TextSnippetResponse(
+                upload_id=upload_id,
+                snippet="",
+                truncated=False,
+                mime_type=file_meta.mime_type,
+            )
+
+        # Read up to TEXT_SNIPPET_MAX_BYTES + 1 bytes so we can detect truncation.
+        try:
+            response = self._s3_client.get_object(
+                Bucket=self.bucket_name,
+                Key=file_meta.s3_key,
+                Range=f"bytes=0-{TEXT_SNIPPET_MAX_BYTES}",
+            )
+            body = response["Body"].read()
+        except ClientError as e:
+            logger.warning(f"Failed to read snippet for {upload_id}: {e}")
+            return TextSnippetResponse(
+                upload_id=upload_id,
+                snippet="",
+                truncated=False,
+                mime_type=file_meta.mime_type,
+            )
+
+        truncated = file_meta.size_bytes > TEXT_SNIPPET_MAX_BYTES
+        excerpt = body[:TEXT_SNIPPET_MAX_BYTES]
+        try:
+            text = excerpt.decode("utf-8")
+        except UnicodeDecodeError:
+            # Trim trailing partial multi-byte sequence and retry; fall back to replace.
+            text = excerpt.decode("utf-8", errors="replace")
+
+        return TextSnippetResponse(
+            upload_id=upload_id,
+            snippet=text,
+            truncated=truncated,
+            mime_type=file_meta.mime_type,
         )
 
     # =========================================================================

--- a/backend/src/apis/shared/files/models.py
+++ b/backend/src/apis/shared/files/models.py
@@ -250,6 +250,29 @@ class CompleteUploadResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class PreviewUrlResponse(BaseModel):
+    """Response for GET /api/files/{uploadId}/preview-url."""
+
+    upload_id: str = Field(..., alias="uploadId")
+    url: str = Field(..., description="Short-lived presigned GET URL")
+    expires_at: str = Field(..., alias="expiresAt", description="ISO8601 expiration time")
+    mime_type: str = Field(..., alias="mimeType")
+    filename: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TextSnippetResponse(BaseModel):
+    """Response for GET /api/files/{uploadId}/text-snippet."""
+
+    upload_id: str = Field(..., alias="uploadId")
+    snippet: str = Field(..., description="UTF-8 decoded text from the start of the file")
+    truncated: bool = Field(..., description="True if the file was longer than the snippet limit")
+    mime_type: str = Field(..., alias="mimeType")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class FileResponse(BaseModel):
     """Single file in list response."""
 

--- a/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
+++ b/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
@@ -78,6 +78,27 @@ export interface CompleteUploadResponse {
 }
 
 /**
+ * Response from GET /files/{uploadId}/preview-url
+ */
+export interface PreviewUrlResponse {
+  uploadId: string;
+  url: string;
+  expiresAt: string;
+  mimeType: string;
+  filename: string;
+}
+
+/**
+ * Response from GET /files/{uploadId}/text-snippet
+ */
+export interface TextSnippetResponse {
+  uploadId: string;
+  snippet: string;
+  truncated: boolean;
+  mimeType: string;
+}
+
+/**
  * File metadata from list/get operations
  */
 export interface FileMetadata {
@@ -548,6 +569,38 @@ export class FileUploadService {
     }
 
     return results;
+  }
+
+  /**
+   * Fetch a short-lived presigned GET URL for a file.
+   *
+   * Used by the UI to render inline image previews and the lightbox.
+   * The URL expires after a few minutes; refetch on expiry.
+   */
+  async getPreviewUrl(uploadId: string): Promise<PreviewUrlResponse> {
+    try {
+      return await firstValueFrom(
+        this.http.get<PreviewUrlResponse>(`${this.baseUrl()}/${uploadId}/preview-url`)
+      );
+    } catch (err) {
+      throw this.handleApiError(err, 'Failed to get preview URL');
+    }
+  }
+
+  /**
+   * Fetch a UTF-8 text snippet from the start of a file.
+   *
+   * Returns an empty snippet for non-text MIME types so the UI can fall
+   * back to a skeleton mockup.
+   */
+  async getTextSnippet(uploadId: string): Promise<TextSnippetResponse> {
+    try {
+      return await firstValueFrom(
+        this.http.get<TextSnippetResponse>(`${this.baseUrl()}/${uploadId}/text-snippet`)
+      );
+    } catch (err) {
+      throw this.handleApiError(err, 'Failed to get text snippet');
+    }
   }
 
   /**

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input, computed } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, effect, inject, input, signal } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroDocument,
@@ -6,120 +6,116 @@ import {
   heroTableCells,
   heroCodeBracket,
   heroPhoto,
+  heroArrowTopRightOnSquare,
 } from '@ng-icons/heroicons/outline';
-import { formatBytes } from '../../../../../services/file-upload';
+import { formatBytes, FileUploadService } from '../../../../../services/file-upload';
 import { FileAttachmentData } from '../../../../services/models/message.model';
 
-/**
- * Check if MIME type is an image
- */
-function isImageMimeType(mimeType: string): boolean {
-  return mimeType.startsWith('image/');
+interface FileTypeStyle {
+  icon: string;
+  label: string;
+  /** Accent color used for the type chip and the icon */
+  accent_text: string;
+  /** Header strip background tint (subtle) */
+  header_bg: string;
 }
 
-/**
- * File type to icon mapping
- */
-const FILE_TYPE_ICONS: Record<string, string> = {
-  'application/pdf': 'heroDocument',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'heroDocumentText',
-  'text/plain': 'heroDocumentText',
-  'text/html': 'heroCodeBracket',
-  'text/csv': 'heroTableCells',
-  'application/vnd.ms-excel': 'heroTableCells',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'heroTableCells',
-  'text/markdown': 'heroDocumentText',
-  'image/png': 'heroPhoto',
-  'image/jpeg': 'heroPhoto',
-  'image/gif': 'heroPhoto',
-  'image/webp': 'heroPhoto',
+const DEFAULT_STYLE: FileTypeStyle = {
+  icon: 'heroDocument',
+  label: 'FILE',
+  accent_text: 'text-gray-600 dark:text-gray-300',
+  header_bg: 'bg-gray-50 dark:bg-gray-700/50',
 };
 
-/**
- * File type to color mapping for icon container
- */
-const FILE_TYPE_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+const FILE_TYPE_STYLES: Record<string, FileTypeStyle> = {
   'application/pdf': {
-    bg: 'bg-rose-100 dark:bg-rose-900/60',
-    text: 'text-rose-600 dark:text-rose-300',
-    border: 'border-rose-300 dark:border-rose-700'
+    icon: 'heroDocument',
+    label: 'PDF',
+    accent_text: 'text-rose-600 dark:text-rose-300',
+    header_bg: 'bg-rose-50 dark:bg-rose-950/40',
   },
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
-    bg: 'bg-blue-100 dark:bg-blue-900/60',
-    text: 'text-blue-600 dark:text-blue-300',
-    border: 'border-blue-300 dark:border-blue-700'
+    icon: 'heroDocumentText',
+    label: 'DOCX',
+    accent_text: 'text-blue-600 dark:text-blue-300',
+    header_bg: 'bg-blue-50 dark:bg-blue-950/40',
   },
   'text/plain': {
-    bg: 'bg-gray-100 dark:bg-gray-600',
-    text: 'text-gray-600 dark:text-gray-200',
-    border: 'border-gray-300 dark:border-gray-500'
+    icon: 'heroDocumentText',
+    label: 'TXT',
+    accent_text: 'text-gray-600 dark:text-gray-300',
+    header_bg: 'bg-gray-50 dark:bg-gray-700/50',
   },
   'text/html': {
-    bg: 'bg-orange-100 dark:bg-orange-900/60',
-    text: 'text-orange-600 dark:text-orange-300',
-    border: 'border-orange-300 dark:border-orange-700'
+    icon: 'heroCodeBracket',
+    label: 'HTML',
+    accent_text: 'text-orange-600 dark:text-orange-300',
+    header_bg: 'bg-orange-50 dark:bg-orange-950/40',
   },
   'text/csv': {
-    bg: 'bg-green-100 dark:bg-green-900/60',
-    text: 'text-green-600 dark:text-green-300',
-    border: 'border-green-300 dark:border-green-700'
+    icon: 'heroTableCells',
+    label: 'CSV',
+    accent_text: 'text-green-600 dark:text-green-300',
+    header_bg: 'bg-green-50 dark:bg-green-950/40',
   },
   'application/vnd.ms-excel': {
-    bg: 'bg-green-100 dark:bg-green-900/60',
-    text: 'text-green-600 dark:text-green-300',
-    border: 'border-green-300 dark:border-green-700'
+    icon: 'heroTableCells',
+    label: 'XLS',
+    accent_text: 'text-green-600 dark:text-green-300',
+    header_bg: 'bg-green-50 dark:bg-green-950/40',
   },
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
-    bg: 'bg-green-100 dark:bg-green-900/60',
-    text: 'text-green-600 dark:text-green-300',
-    border: 'border-green-300 dark:border-green-700'
+    icon: 'heroTableCells',
+    label: 'XLSX',
+    accent_text: 'text-green-600 dark:text-green-300',
+    header_bg: 'bg-green-50 dark:bg-green-950/40',
   },
   'text/markdown': {
-    bg: 'bg-purple-100 dark:bg-purple-900/60',
-    text: 'text-purple-600 dark:text-purple-300',
-    border: 'border-purple-300 dark:border-purple-700'
+    icon: 'heroDocumentText',
+    label: 'MD',
+    accent_text: 'text-purple-600 dark:text-purple-300',
+    header_bg: 'bg-purple-50 dark:bg-purple-950/40',
   },
   'image/png': {
-    bg: 'bg-indigo-100 dark:bg-indigo-900/60',
-    text: 'text-indigo-600 dark:text-indigo-300',
-    border: 'border-indigo-300 dark:border-indigo-700'
+    icon: 'heroPhoto',
+    label: 'PNG',
+    accent_text: 'text-indigo-600 dark:text-indigo-300',
+    header_bg: 'bg-indigo-50 dark:bg-indigo-950/40',
   },
   'image/jpeg': {
-    bg: 'bg-indigo-100 dark:bg-indigo-900/60',
-    text: 'text-indigo-600 dark:text-indigo-300',
-    border: 'border-indigo-300 dark:border-indigo-700'
+    icon: 'heroPhoto',
+    label: 'JPG',
+    accent_text: 'text-indigo-600 dark:text-indigo-300',
+    header_bg: 'bg-indigo-50 dark:bg-indigo-950/40',
   },
   'image/gif': {
-    bg: 'bg-indigo-100 dark:bg-indigo-900/60',
-    text: 'text-indigo-600 dark:text-indigo-300',
-    border: 'border-indigo-300 dark:border-indigo-700'
+    icon: 'heroPhoto',
+    label: 'GIF',
+    accent_text: 'text-indigo-600 dark:text-indigo-300',
+    header_bg: 'bg-indigo-50 dark:bg-indigo-950/40',
   },
   'image/webp': {
-    bg: 'bg-indigo-100 dark:bg-indigo-900/60',
-    text: 'text-indigo-600 dark:text-indigo-300',
-    border: 'border-indigo-300 dark:border-indigo-700'
+    icon: 'heroPhoto',
+    label: 'WEBP',
+    accent_text: 'text-indigo-600 dark:text-indigo-300',
+    header_bg: 'bg-indigo-50 dark:bg-indigo-950/40',
   },
 };
 
-const DEFAULT_COLORS = {
-  bg: 'bg-gray-100 dark:bg-gray-600',
-  text: 'text-gray-600 dark:text-gray-200',
-  border: 'border-gray-300 dark:border-gray-500'
-};
+const TEXT_PREVIEW_MIMES = new Set(['text/plain', 'text/markdown', 'text/csv', 'text/html']);
+
+/** Skeleton "lines of text" widths (percent), tuned to look like a paragraph. */
+const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
 
 /**
- * Compact file attachment badge for displaying in user messages.
+ * Document-style preview card for a non-image file attachment.
  *
- * This is a read-only display component (no remove/retry actions)
- * used for showing files that were attached to historical messages.
- * Styled consistently with the FileCardComponent.
+ * Renders an iMessage-inspired "paper" mockup: a tinted header strip with the
+ * type chip and accent icon, a white page area showing either a real text
+ * excerpt (for txt/md/csv/html) or skeleton lines (for binary docs), a
+ * folded top-right corner detail, and a footer with filename + size.
  *
- * @example
- * ```html
- * <app-file-attachment-badge
- *   [attachment]="fileAttachment"
- * />
- * ```
+ * Clicking opens the file in a new tab via a short-lived presigned URL.
  */
 @Component({
   selector: 'app-file-attachment-badge',
@@ -132,25 +128,86 @@ const DEFAULT_COLORS = {
       heroTableCells,
       heroCodeBracket,
       heroPhoto,
-    })
+      heroArrowTopRightOnSquare,
+    }),
   ],
-  host: {
-    'class': 'contents'
-  },
+  host: { class: 'contents' },
+  styles: `
+    .corner-fold {
+      width: 18px;
+      height: 18px;
+      background: linear-gradient(225deg, var(--corner-bg, #f3f4f6) 50%, transparent 50%);
+      box-shadow: -1px 1px 1px rgb(0 0 0 / 0.05);
+    }
+    :host-context(.dark) .corner-fold {
+      --corner-bg: #374151;
+    }
+  `,
   template: `
-    <div
-      class="flex w-48 shrink-0 items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-600 dark:bg-gray-800"
+    <button
+      type="button"
+      (click)="openFile()"
+      class="group flex w-60 shrink-0 flex-col overflow-hidden rounded-xl border border-gray-200 bg-white text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800"
+      [attr.aria-label]="'Open ' + attachment().filename"
     >
-      <!-- File icon -->
+      <!-- Header strip -->
       <div
-        class="flex size-8 shrink-0 items-center justify-center rounded-md border"
-        [class]="iconContainerClass()"
+        class="flex items-center justify-between border-b border-gray-200 px-3 py-2 dark:border-gray-700"
+        [class]="style().header_bg"
       >
-        <ng-icon [name]="iconName()" class="size-5" [class]="iconClass()" aria-hidden="true" />
+        <div class="flex items-center gap-2">
+          <ng-icon
+            [name]="style().icon"
+            class="size-4"
+            [class]="style().accent_text"
+            aria-hidden="true"
+          />
+          <span
+            class="text-[10px] font-bold tracking-wider"
+            [class]="style().accent_text"
+          >
+            {{ style().label }}
+          </span>
+        </div>
+        <ng-icon
+          name="heroArrowTopRightOnSquare"
+          class="size-4 text-gray-400 opacity-0 transition-opacity group-hover:opacity-100"
+          aria-hidden="true"
+        />
       </div>
 
-      <!-- File info -->
-      <div class="min-w-0 flex-1">
+      <!-- Paper page area -->
+      <div class="relative h-32 overflow-hidden bg-white dark:bg-gray-900/40">
+        <!-- Folded corner -->
+        <div
+          class="corner-fold absolute right-0 top-0"
+          aria-hidden="true"
+        ></div>
+
+        @if (snippetState() === 'ready' && hasSnippet()) {
+          <pre
+            class="m-0 max-h-full overflow-hidden whitespace-pre-wrap break-words px-3 py-2 font-mono text-[9px] leading-snug text-gray-700 dark:text-gray-300"
+          >{{ truncatedSnippet() }}</pre>
+        } @else {
+          <div class="space-y-1.5 px-3 py-2.5" aria-hidden="true">
+            @for (width of skeletonWidths; track $index) {
+              <div
+                class="h-1.5 rounded-full bg-gray-200 dark:bg-gray-700"
+                [style.width.%]="width"
+              ></div>
+            }
+          </div>
+        }
+
+        <!-- Bottom fade for long text -->
+        <div
+          class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-white to-transparent dark:from-gray-900/40"
+          aria-hidden="true"
+        ></div>
+      </div>
+
+      <!-- Footer -->
+      <div class="min-w-0 border-t border-gray-100 px-3 py-2 dark:border-gray-700/60">
         <p class="truncate text-sm font-medium text-gray-900 dark:text-white">
           {{ attachment().filename }}
         </p>
@@ -158,37 +215,60 @@ const DEFAULT_COLORS = {
           {{ formattedSize() }}
         </p>
       </div>
-    </div>
+    </button>
   `,
 })
 export class FileAttachmentBadgeComponent {
-  /** File attachment data */
   readonly attachment = input.required<FileAttachmentData>();
 
-  protected readonly formattedSize = computed(() =>
-    formatBytes(this.attachment().sizeBytes)
+  private readonly fileUploadService = inject(FileUploadService);
+
+  protected readonly skeletonWidths = SKELETON_LINE_WIDTHS;
+
+  protected readonly snippetState = signal<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  private readonly snippet = signal<string>('');
+
+  protected readonly formattedSize = computed(() => formatBytes(this.attachment().sizeBytes));
+
+  protected readonly style = computed<FileTypeStyle>(
+    () => FILE_TYPE_STYLES[this.attachment().mimeType] ?? DEFAULT_STYLE,
   );
 
-  protected readonly isImage = computed(() =>
-    isImageMimeType(this.attachment().mimeType)
-  );
+  protected readonly hasSnippet = computed(() => this.snippet().trim().length > 0);
 
-  protected readonly iconName = computed(() => {
-    const mime = this.attachment().mimeType;
-    return FILE_TYPE_ICONS[mime] ?? 'heroDocument';
+  /** Cap chars so very long unbroken lines don't blow out the card. */
+  protected readonly truncatedSnippet = computed(() => {
+    const raw = this.snippet();
+    return raw.length > 600 ? raw.slice(0, 600) : raw;
   });
 
-  protected readonly colors = computed(() => {
-    const mime = this.attachment().mimeType;
-    return FILE_TYPE_COLORS[mime] ?? DEFAULT_COLORS;
-  });
+  constructor() {
+    effect(() => {
+      const att = this.attachment();
+      if (TEXT_PREVIEW_MIMES.has(att.mimeType)) {
+        this.loadSnippet(att.uploadId);
+      }
+    });
+  }
 
-  protected readonly iconContainerClass = computed(() => {
-    const colors = this.colors();
-    return `${colors.bg} ${colors.border}`;
-  });
+  private async loadSnippet(uploadId: string): Promise<void> {
+    this.snippetState.set('loading');
+    try {
+      const response = await this.fileUploadService.getTextSnippet(uploadId);
+      this.snippet.set(response.snippet);
+      this.snippetState.set('ready');
+    } catch {
+      this.snippetState.set('error');
+    }
+  }
 
-  protected readonly iconClass = computed(() => {
-    return this.colors().text;
-  });
+  protected async openFile(): Promise<void> {
+    try {
+      const response = await this.fileUploadService.getPreviewUrl(this.attachment().uploadId);
+      window.open(response.url, '_blank', 'noopener,noreferrer');
+    } catch {
+      // Silent failure — the broken link state is rare and the message stream
+      // surfaces backend errors separately.
+    }
+  }
 }

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.ts
@@ -1,0 +1,214 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroPhoto, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { FileAttachmentData } from '../../../../services/models/message.model';
+import { FileUploadService } from '../../../../../services/file-upload';
+import { ImageLightboxComponent, LightboxImage } from './image-lightbox.component';
+
+interface PreviewState {
+  url: string | null;
+  status: 'idle' | 'loading' | 'ready' | 'error';
+}
+
+/**
+ * iMessage-style group renderer for one or more image attachments.
+ *
+ * Layouts:
+ * - 1 image: large bubble (max 280px tall), aspect preserved
+ * - 2 images: side-by-side equal columns
+ * - 3 images: 1 large + 2 stacked column on the right
+ * - 4 images: 2x2 grid
+ * - 5+ images: 2x2 grid with "+N" overlay on the last tile
+ *
+ * Each image lazy-fetches a presigned GET URL on first render. Clicking any
+ * tile opens a full-screen lightbox with arrow-key navigation.
+ */
+@Component({
+  selector: 'app-image-attachment-group',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, ImageLightboxComponent],
+  providers: [provideIcons({ heroPhoto, heroExclamationTriangle })],
+  host: { class: 'contents' },
+  template: `
+    <div
+      class="overflow-hidden rounded-2xl"
+      [class]="layoutClass()"
+      [style.max-width.px]="maxWidthPx()"
+    >
+      @for (item of visibleImages(); track item.attachment.uploadId; let i = $index) {
+        <button
+          type="button"
+          class="group relative block overflow-hidden bg-gray-100 dark:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          [class]="tileClass(i)"
+          (click)="openLightbox(i)"
+          [attr.aria-label]="'Open ' + item.attachment.filename"
+        >
+          @if (item.state.status === 'ready' && item.state.url) {
+            <img
+              [src]="item.state.url"
+              [alt]="item.attachment.filename"
+              class="size-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
+              loading="lazy"
+              decoding="async"
+            />
+          } @else if (item.state.status === 'error') {
+            <div
+              class="flex size-full flex-col items-center justify-center gap-1 bg-red-50 p-2 text-red-500 dark:bg-red-950/30 dark:text-red-400"
+            >
+              <ng-icon name="heroExclamationTriangle" class="size-6" aria-hidden="true" />
+              <span class="px-2 text-center text-xs">Preview unavailable</span>
+            </div>
+          } @else {
+            <div class="flex size-full items-center justify-center">
+              <div
+                class="size-8 animate-pulse rounded-full bg-gray-300 dark:bg-gray-600"
+                aria-hidden="true"
+              ></div>
+              <span class="sr-only">Loading {{ item.attachment.filename }}</span>
+            </div>
+          }
+
+          @if (showOverflowOnLast() && $last) {
+            <div
+              class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/50 text-2xl font-semibold text-white"
+            >
+              +{{ overflowCount() }}
+            </div>
+          }
+        </button>
+      }
+    </div>
+
+    @if (lightboxOpenAt() !== null) {
+      <app-image-lightbox
+        [images]="lightboxImages()"
+        [startIndex]="lightboxOpenAt() ?? 0"
+        (close)="closeLightbox()"
+      />
+    }
+  `,
+})
+export class ImageAttachmentGroupComponent {
+  readonly attachments = input.required<FileAttachmentData[]>();
+
+  private readonly fileUploadService = inject(FileUploadService);
+
+  /** Map of uploadId -> preview state. Signals updates trigger re-render. */
+  protected readonly previews = signal<Map<string, PreviewState>>(new Map());
+
+  protected readonly lightboxOpenAt = signal<number | null>(null);
+
+  /** All attachments are eligible for the lightbox; we cap visible tiles at 4. */
+  private readonly maxVisible = 4;
+
+  protected readonly visibleImages = computed(() => {
+    const all = this.attachments();
+    const visible = all.slice(0, this.maxVisible);
+    const map = this.previews();
+    return visible.map((attachment) => ({
+      attachment,
+      state: map.get(attachment.uploadId) ?? { url: null, status: 'idle' as const },
+    }));
+  });
+
+  protected readonly overflowCount = computed(() =>
+    Math.max(0, this.attachments().length - this.maxVisible),
+  );
+
+  protected readonly showOverflowOnLast = computed(() => this.overflowCount() > 0);
+
+  protected readonly lightboxImages = computed<LightboxImage[]>(() => {
+    const map = this.previews();
+    return this.attachments().map((a) => ({
+      url: map.get(a.uploadId)?.url ?? '',
+      filename: a.filename,
+    }));
+  });
+
+  protected readonly maxWidthPx = computed(() => {
+    const count = Math.min(this.attachments().length, this.maxVisible);
+    if (count === 1) return 320;
+    return 360;
+  });
+
+  protected readonly layoutClass = computed(() => {
+    const count = Math.min(this.attachments().length, this.maxVisible);
+    if (count === 1) return 'block';
+    if (count === 2) return 'grid grid-cols-2 gap-0.5';
+    if (count === 3) return 'grid grid-cols-2 grid-rows-2 gap-0.5';
+    return 'grid grid-cols-2 grid-rows-2 gap-0.5';
+  });
+
+  constructor() {
+    queueMicrotask(() => this.loadPreviews());
+  }
+
+  protected tileClass(index: number): string {
+    const count = Math.min(this.attachments().length, this.maxVisible);
+    if (count === 1) {
+      return 'aspect-[4/3] max-h-[280px] w-full';
+    }
+    if (count === 2) {
+      return 'aspect-square';
+    }
+    if (count === 3) {
+      // First tile spans 2 rows on left; tiles 2 and 3 stack on right
+      if (index === 0) return 'row-span-2 aspect-[3/4]';
+      return 'aspect-square';
+    }
+    // 4+
+    return 'aspect-square';
+  }
+
+  protected openLightbox(visibleIndex: number): void {
+    const map = this.previews();
+    const attachment = this.attachments()[visibleIndex];
+    if (!attachment) return;
+    const state = map.get(attachment.uploadId);
+    if (state?.status !== 'ready') return;
+    this.lightboxOpenAt.set(visibleIndex);
+  }
+
+  protected closeLightbox(): void {
+    this.lightboxOpenAt.set(null);
+  }
+
+  private async loadPreviews(): Promise<void> {
+    const all = this.attachments();
+    const current = this.previews();
+    const next = new Map(current);
+    for (const a of all) {
+      if (!next.has(a.uploadId)) {
+        next.set(a.uploadId, { url: null, status: 'loading' });
+      }
+    }
+    this.previews.set(next);
+
+    await Promise.all(
+      all.map(async (a) => {
+        if (current.get(a.uploadId)?.status === 'ready') return;
+        try {
+          const response = await this.fileUploadService.getPreviewUrl(a.uploadId);
+          this.updatePreview(a.uploadId, { url: response.url, status: 'ready' });
+        } catch {
+          this.updatePreview(a.uploadId, { url: null, status: 'error' });
+        }
+      }),
+    );
+  }
+
+  private updatePreview(uploadId: string, state: PreviewState): void {
+    this.previews.update((m) => {
+      const next = new Map(m);
+      next.set(uploadId, state);
+      return next;
+    });
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-lightbox.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-lightbox.component.ts
@@ -1,0 +1,138 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroArrowLeft, heroArrowRight } from '@ng-icons/heroicons/outline';
+
+export interface LightboxImage {
+  url: string;
+  filename: string;
+}
+
+/**
+ * Full-screen image lightbox with keyboard navigation.
+ *
+ * Renders a fixed overlay above the page when an image is selected.
+ * Supports left/right arrow keys to step through a group of images and
+ * Escape to dismiss.
+ */
+@Component({
+  selector: 'app-image-lightbox',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark, heroArrowLeft, heroArrowRight })],
+  host: {
+    '(document:keydown)': 'onKeydown($event)',
+  },
+  template: `
+    <div
+      class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/85 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      [attr.aria-label]="'Image preview: ' + currentImage().filename"
+      (click)="onBackdropClick($event)"
+    >
+      <button
+        type="button"
+        class="absolute right-4 top-4 flex size-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        (click)="close.emit()"
+        aria-label="Close preview"
+      >
+        <ng-icon name="heroXMark" class="size-6" aria-hidden="true" />
+      </button>
+
+      @if (hasMultiple()) {
+        <button
+          type="button"
+          class="absolute left-4 top-1/2 flex size-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          (click)="prev($event)"
+          aria-label="Previous image"
+        >
+          <ng-icon name="heroArrowLeft" class="size-6" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          class="absolute right-4 top-1/2 flex size-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          (click)="next($event)"
+          aria-label="Next image"
+        >
+          <ng-icon name="heroArrowRight" class="size-6" aria-hidden="true" />
+        </button>
+      }
+
+      <figure class="flex max-h-full max-w-full flex-col items-center gap-3">
+        <img
+          [src]="currentImage().url"
+          [alt]="currentImage().filename"
+          class="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+          (click)="$event.stopPropagation()"
+        />
+        <figcaption class="max-w-full truncate text-sm text-white/80">
+          {{ currentImage().filename }}
+          @if (hasMultiple()) {
+            <span class="ml-2 text-white/50">{{ activeIndex() + 1 }} / {{ images().length }}</span>
+          }
+        </figcaption>
+      </figure>
+    </div>
+  `,
+})
+export class ImageLightboxComponent {
+  readonly images = input.required<LightboxImage[]>();
+  readonly startIndex = input<number>(0);
+  readonly close = output<void>();
+
+  protected readonly activeIndex = signal(0);
+
+  protected readonly currentImage = computed(() => {
+    const list = this.images();
+    const idx = Math.min(Math.max(this.activeIndex(), 0), list.length - 1);
+    return list[idx];
+  });
+
+  protected readonly hasMultiple = computed(() => this.images().length > 1);
+
+  constructor() {
+    queueMicrotask(() => this.activeIndex.set(this.startIndex()));
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close.emit();
+    } else if (event.key === 'ArrowLeft' && this.hasMultiple()) {
+      event.preventDefault();
+      this.step(-1);
+    } else if (event.key === 'ArrowRight' && this.hasMultiple()) {
+      event.preventDefault();
+      this.step(1);
+    }
+  }
+
+  protected onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.close.emit();
+    }
+  }
+
+  protected prev(event: Event): void {
+    event.stopPropagation();
+    this.step(-1);
+  }
+
+  protected next(event: Event): void {
+    event.stopPropagation();
+    this.step(1);
+  }
+
+  private step(delta: number): void {
+    const len = this.images().length;
+    if (len === 0) return;
+    this.activeIndex.update((i) => (i + delta + len) % len);
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/index.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/index.ts
@@ -1,1 +1,4 @@
 export { FileAttachmentBadgeComponent } from './file-attachment-badge.component';
+export { ImageAttachmentGroupComponent } from './image-attachment-group.component';
+export { ImageLightboxComponent } from './image-lightbox.component';
+export type { LightboxImage } from './image-lightbox.component';

--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
@@ -10,15 +10,19 @@ import {
   inject,
 } from '@angular/core';
 import { ContentBlock, Message, FileAttachmentData } from '../../../services/models/message.model';
-import { FileAttachmentBadgeComponent } from './file-attachment';
+import { FileAttachmentBadgeComponent, ImageAttachmentGroupComponent } from './file-attachment';
 import { LocalSettingsService } from '../../../../services/local-settings.service';
+
+function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('image/');
+}
 
 const MAX_HEIGHT_PX = 200;
 
 @Component({
   selector: 'app-user-message',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FileAttachmentBadgeComponent],
+  imports: [FileAttachmentBadgeComponent, ImageAttachmentGroupComponent],
   template: `
     @if (hasTextContent() || hasFileAttachments()) {
       <div class="flex w-full flex-col items-end gap-2">
@@ -61,10 +65,17 @@ const MAX_HEIGHT_PX = 200;
           </div>
         }
 
-        <!-- File attachments (below message bubble) -->
-        @if (hasFileAttachments()) {
+        <!-- Image attachments (iMessage-style mosaic) -->
+        @if (imageAttachments().length > 0) {
+          <div class="flex max-w-[80%] justify-end">
+            <app-image-attachment-group [attachments]="imageAttachments()" />
+          </div>
+        }
+
+        <!-- Non-image file attachments (below message bubble) -->
+        @if (nonImageAttachments().length > 0) {
           <div class="flex max-w-[80%] flex-wrap justify-end gap-2">
-            @for (attachment of fileAttachments(); track attachment.uploadId) {
+            @for (attachment of nonImageAttachments(); track attachment.uploadId) {
               <app-file-attachment-badge [attachment]="attachment" />
             }
           </div>
@@ -118,6 +129,14 @@ export class UserMessageComponent implements AfterViewInit {
       .filter((block: ContentBlock) => block.type === 'fileAttachment' && block.fileAttachment)
       .map((block: ContentBlock) => block.fileAttachment as FileAttachmentData);
   });
+
+  imageAttachments = computed((): FileAttachmentData[] =>
+    this.fileAttachments().filter((a) => isImageMimeType(a.mimeType)),
+  );
+
+  nonImageAttachments = computed((): FileAttachmentData[] =>
+    this.fileAttachments().filter((a) => !isImageMimeType(a.mimeType)),
+  );
 
   ngAfterViewInit(): void {
     this.checkOverflow();


### PR DESCRIPTION
## Summary

Replaces the dense file attachment badge with a much richer preview renderer in user message history.

- **Images** render as an iMessage-style mosaic and open in a full-screen lightbox with arrow-key navigation.
- **Documents** render as a card that looks like a real document — tinted header with type chip, white "page" body with a folded corner, filename + size footer. Text-based files (txt, md, csv, html) show a real content excerpt; binary types (pdf, docx, xls/xlsx) get skeleton lines that suggest paragraph text.

## Backend additions

- `GET /files/{upload_id}/preview-url` — 10-minute presigned GET URL, scoped to the file owner. Powers inline images and the lightbox; sent with `Content-Disposition: inline` so documents render in the browser when opened in a new tab.
- `GET /files/{upload_id}/text-snippet` — first 2 KB of a text-based file decoded as UTF-8, used for the content peek on document cards. Returns an empty snippet for non-text MIMEs so the UI can fall back to skeleton lines.

Both endpoints require the user to own the file and the file to be in `READY` state.

## Frontend changes

- New `ImageLightboxComponent` — fullscreen overlay; ←/→ navigation, Esc to close, backdrop click dismisses, image counter for multi-image groups.
- New `ImageAttachmentGroupComponent` — iMessage-style mosaic:
  - 1 image: 4:3 bubble (max ~280px tall)
  - 2 images: side-by-side squares
  - 3 images: 1 large left + 2 stacked right
  - 4 images: 2×2 grid
  - 5+: 2×2 with `+N more` overlay on the last tile (lightbox still cycles through all)
- Refactored `FileAttachmentBadgeComponent` — full redesign as a paper-mockup card with optional text-content peek.
- `user-message.component.ts` — splits attachments into images (rendered via the group component) and files (rendered as flex-wrapped cards).
- `FileUploadService` — adds `getPreviewUrl()` and `getTextSnippet()` plus their response types.

All inline image previews and document opens go through the new presigned-URL endpoint, so private S3 files are never exposed beyond a short-lived window.

## Test plan

### Images
- [ ] Single image: rounded bubble, max ~280px tall, aspect preserved; click → lightbox; Esc closes
- [ ] 2 images: side-by-side squares, single rounded container
- [ ] 3 images: 1 large left + 2 stacked right
- [ ] 4 images: 2×2 grid
- [ ] 5+ images: 2×2 grid with `+N` overlay; lightbox cycles through ALL images via ←/→
- [ ] Backdrop click closes lightbox; clicking the image itself does not
- [ ] Image counter shows `1 / N` in lightbox

### Documents
- [ ] PDF: rose-tinted header, "PDF" chip, skeleton paragraph lines, folded corner, filename + size footer
- [ ] DOCX: blue-tinted header with skeleton lines
- [ ] XLSX / XLS / CSV: green-tinted header
- [ ] TXT / MD: real text content rendered in monospace excerpt
- [ ] CSV: real rows visible (header + first few rows)
- [ ] HTML: raw markup truncated, layout doesn't blow out (long lines wrap)
- [ ] Click a document card → opens in new tab via presigned URL, renders inline

### Mixed
- [ ] 2 images + 1 PDF + 1 CSV in one message: image mosaic above, document cards below

### Theme & a11y
- [ ] Dark mode: header tints, page body, folded corner, snippet text, and skeletons all readable
- [ ] AXE clean on a message with attachments
- [ ] Image tile buttons have `aria-label="Open <filename>"`
- [ ] Lightbox has `role=dialog aria-modal=true`
- [ ] Keyboard: Tab through close/prev/next buttons in lightbox shows focus rings

### Robustness
- [ ] Refreshing mid-conversation re-fetches preview URLs and re-renders attachments
- [ ] Deleting a file from the file browser, then refreshing a session that referenced it: image tile shows "Preview unavailable"; document card click silently no-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)