### PR TITLE
feat(auth): lava-lamp parallax backdrop on login + first-boot

### DIFF
--- a/frontend/ai.client/src/app/auth/first-boot/first-boot.page.css
+++ b/frontend/ai.client/src/app/auth/first-boot/first-boot.page.css
@@ -1,5 +1,247 @@
-/* First-boot page specific styles */
+/* First-boot page styles — mirrors the login page's lava-lamp parallax
+   backdrop and frosted-glass card so the two auth screens feel like one
+   system. Class names are component-scoped (Emulated view encapsulation)
+   so they don't collide with the login page's identical names. */
 
 @import "tailwindcss";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* ---------- Background canvas ---------- */
+.login-shell {
+  background:
+    radial-gradient(120% 80% at 0% 0%, color-mix(in oklab, var(--color-primary-50) 70%, white) 0%, transparent 60%),
+    radial-gradient(120% 80% at 100% 100%, color-mix(in oklab, var(--color-primary-100) 60%, white) 0%, transparent 55%),
+    var(--color-gray-50);
+}
+
+html.dark .login-shell {
+  background:
+    radial-gradient(120% 80% at 0% 0%, color-mix(in oklab, var(--color-primary-900) 50%, black) 0%, transparent 60%),
+    radial-gradient(120% 80% at 100% 100%, color-mix(in oklab, var(--color-primary-800) 35%, black) 0%, transparent 55%),
+    var(--color-gray-900);
+}
+
+.login-bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.login-lava {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.login-blob {
+  position: absolute;
+  will-change: transform, border-radius;
+  border-radius: 58% 42% 60% 40% / 50% 55% 45% 50%;
+}
+
+/* ----- Far tier: huge, slow, heavy blur, low opacity ----- */
+.login-blob--a {
+  width: 70vw;
+  height: 86vw;
+  max-width: 880px;
+  max-height: 1080px;
+  bottom: -38vw;
+  left: -18vw;
+  filter: blur(110px);
+  opacity: 0.4;
+  background: radial-gradient(circle at 35% 35%, var(--color-primary-400), var(--color-primary-700) 60%, transparent 78%);
+  animation:
+    login-rise-a 52s ease-in-out infinite alternate,
+    login-morph-a 28s ease-in-out infinite alternate;
+}
+
+.login-blob--b {
+  width: 62vw;
+  height: 76vw;
+  max-width: 800px;
+  max-height: 960px;
+  top: -34vw;
+  right: -20vw;
+  filter: blur(100px);
+  opacity: 0.36;
+  background: radial-gradient(circle at 65% 65%, var(--color-primary-500), var(--color-primary-800) 65%, transparent 82%);
+  animation:
+    login-rise-b 60s ease-in-out infinite alternate,
+    login-morph-b 32s ease-in-out infinite alternate;
+}
+
+/* ----- Mid tier ----- */
+.login-blob--c {
+  width: 32vw;
+  height: 40vw;
+  max-width: 420px;
+  max-height: 520px;
+  top: 28%;
+  left: 42%;
+  filter: blur(60px);
+  opacity: 0.5;
+  background: radial-gradient(circle, color-mix(in oklab, var(--color-primary-300) 75%, white), transparent 72%);
+  animation:
+    login-rise-c 30s ease-in-out infinite alternate,
+    login-morph-c 18s ease-in-out infinite alternate;
+}
+
+.login-blob--d {
+  width: 28vw;
+  height: 36vw;
+  max-width: 360px;
+  max-height: 460px;
+  bottom: -12vw;
+  right: 18vw;
+  filter: blur(55px);
+  opacity: 0.55;
+  background: radial-gradient(circle at 50% 50%, var(--color-primary-300), var(--color-primary-500) 60%, transparent 80%);
+  animation:
+    login-rise-d 26s ease-in-out infinite alternate,
+    login-morph-a 16s ease-in-out infinite alternate -3s;
+}
+
+/* ----- Near tier ----- */
+.login-blob--e {
+  width: 16vw;
+  height: 22vw;
+  max-width: 220px;
+  max-height: 300px;
+  top: -6vw;
+  left: 32vw;
+  filter: blur(32px);
+  opacity: 0.65;
+  background: radial-gradient(circle at 50% 50%, var(--color-primary-400), var(--color-primary-700) 65%, transparent 82%);
+  animation:
+    login-rise-e 14s ease-in-out infinite alternate,
+    login-morph-b 11s ease-in-out infinite alternate -5s;
+}
+
+.login-blob--f {
+  width: 12vw;
+  height: 16vw;
+  max-width: 160px;
+  max-height: 220px;
+  bottom: -4vw;
+  left: 14vw;
+  filter: blur(26px);
+  opacity: 0.7;
+  background: radial-gradient(circle at 45% 45%, var(--color-primary-300), var(--color-primary-600) 65%, transparent 84%);
+  animation:
+    login-rise-f 11s ease-in-out infinite alternate,
+    login-morph-c 9s ease-in-out infinite alternate -2s;
+}
+
+html.dark .login-blob--a { opacity: 0.32; }
+html.dark .login-blob--b { opacity: 0.28; }
+html.dark .login-blob--c { opacity: 0.38; }
+html.dark .login-blob--d { opacity: 0.42; }
+html.dark .login-blob--e { opacity: 0.5; }
+html.dark .login-blob--f { opacity: 0.55; }
+
+.login-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--color-primary-500) 8%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-500) 8%, transparent) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(ellipse 70% 60% at 50% 45%, black 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 45%, black 30%, transparent 75%);
+  opacity: 0.6;
+}
+
+html.dark .login-grid {
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px);
+  opacity: 0.5;
+}
+
+/* Far: minimal travel, lazy sway */
+@keyframes login-rise-a {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(2vw, -12vh, 0) scale(1.04, 0.96) rotate(4deg); }
+  100% { transform: translate3d(-1vw, -22vh, 0) scale(0.97, 1.05) rotate(-3deg); }
+}
+@keyframes login-rise-b {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-2vw, 10vh, 0) scale(0.96, 1.05) rotate(-4deg); }
+  100% { transform: translate3d(1vw, 20vh, 0) scale(1.05, 0.96) rotate(3deg); }
+}
+
+/* Mid: moderate travel */
+@keyframes login-rise-c {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-5vw, -25vh, 0) scale(1.1, 0.94) rotate(-10deg); }
+  100% { transform: translate3d(4vw, -50vh, 0) scale(0.92, 1.1) rotate(8deg); }
+}
+@keyframes login-rise-d {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(6vw, -35vh, 0) scale(1.05, 0.95) rotate(12deg); }
+  100% { transform: translate3d(-3vw, -68vh, 0) scale(0.92, 1.08) rotate(-7deg); }
+}
+
+/* Near: dramatic travel */
+@keyframes login-rise-e {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(8vw, 55vh, 0) scale(0.88, 1.14) rotate(-18deg); }
+  100% { transform: translate3d(-6vw, 100vh, 0) scale(1.16, 0.86) rotate(14deg); }
+}
+@keyframes login-rise-f {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-9vw, -55vh, 0) scale(1.18, 0.84) rotate(20deg); }
+  100% { transform: translate3d(7vw, -105vh, 0) scale(0.85, 1.18) rotate(-16deg); }
+}
+
+/* Surface morph */
+@keyframes login-morph-a {
+  0%   { border-radius: 58% 42% 60% 40% / 50% 55% 45% 50%; }
+  50%  { border-radius: 42% 58% 38% 62% / 60% 40% 60% 40%; }
+  100% { border-radius: 50% 50% 65% 35% / 45% 55% 50% 50%; }
+}
+@keyframes login-morph-b {
+  0%   { border-radius: 50% 50% 40% 60% / 55% 45% 55% 45%; }
+  50%  { border-radius: 65% 35% 55% 45% / 40% 60% 40% 60%; }
+  100% { border-radius: 38% 62% 50% 50% / 60% 50% 50% 40%; }
+}
+@keyframes login-morph-c {
+  0%   { border-radius: 60% 40% 50% 50% / 45% 60% 40% 55%; }
+  50%  { border-radius: 40% 60% 65% 35% / 55% 40% 60% 45%; }
+  100% { border-radius: 55% 45% 38% 62% / 50% 55% 45% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-blob,
+  .login-blob--a,
+  .login-blob--b,
+  .login-blob--c,
+  .login-blob--d,
+  .login-blob--e,
+  .login-blob--f {
+    animation: none;
+  }
+}
+
+/* ---------- Frosted glass card ---------- */
+.login-card {
+  background: color-mix(in oklab, white 65%, transparent);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border: 1px solid color-mix(in oklab, white 70%, transparent);
+  box-shadow:
+    0 1px 0 0 rgba(255, 255, 255, 0.6) inset,
+    0 20px 50px -20px color-mix(in oklab, var(--color-primary-900) 35%, transparent),
+    0 8px 24px -12px rgba(0, 0, 0, 0.15);
+}
+
+html.dark .login-card {
+  background: color-mix(in oklab, var(--color-gray-900) 55%, transparent);
+  border-color: color-mix(in oklab, white 12%, transparent);
+  box-shadow:
+    0 1px 0 0 rgba(255, 255, 255, 0.06) inset,
+    0 20px 50px -20px rgba(0, 0, 0, 0.6),
+    0 8px 24px -12px rgba(0, 0, 0, 0.5);
+}

--- a/frontend/ai.client/src/app/auth/first-boot/first-boot.page.ts
+++ b/frontend/ai.client/src/app/auth/first-boot/first-boot.page.ts
@@ -11,8 +11,23 @@ import { SystemService, FirstBootError } from '../../services/system.service';
   styleUrl: './first-boot.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="fixed inset-0 flex items-center justify-center bg-gray-50 dark:bg-gray-900 overflow-y-auto">
-      <div class="w-full max-w-md px-4 py-12">
+    <div class="login-shell fixed inset-0 flex items-center justify-center overflow-y-auto">
+      <!-- Decorative background: lava-lamp blobs across three depth tiers
+           (far/mid/near) for parallax — size, blur, speed, and travel
+           distance all scale with depth. -->
+      <div class="login-bg" aria-hidden="true">
+        <div class="login-lava">
+          <div class="login-blob login-blob--a"></div>
+          <div class="login-blob login-blob--b"></div>
+          <div class="login-blob login-blob--c"></div>
+          <div class="login-blob login-blob--d"></div>
+          <div class="login-blob login-blob--e"></div>
+          <div class="login-blob login-blob--f"></div>
+        </div>
+        <div class="login-grid"></div>
+      </div>
+
+      <div class="relative w-full max-w-md px-4 py-12">
         <!-- Logo -->
         <div class="mb-8 flex justify-center">
           <img
@@ -25,13 +40,13 @@ import { SystemService, FirstBootError } from '../../services/system.service';
             class="hidden size-16 dark:block">
         </div>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8">
+        <div class="login-card rounded-2xl p-8">
           <div class="flex flex-col items-center gap-6">
             <div class="flex flex-col items-center gap-2">
-              <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-50">
                 Welcome
               </h1>
-              <p class="text-base/7 text-gray-600 dark:text-gray-400 text-center">
+              <p class="text-base/7 text-gray-700 dark:text-gray-300 text-center">
                 Create your admin account to get started
               </p>
             </div>

--- a/frontend/ai.client/src/app/auth/login/login.page.css
+++ b/frontend/ai.client/src/app/auth/login/login.page.css
@@ -35,88 +35,111 @@ html.dark .login-shell {
 
 .login-blob {
   position: absolute;
-  filter: blur(70px);
-  opacity: 0.55;
   will-change: transform, border-radius;
   /* Asymmetric border-radius gives an organic, non-circular blob silhouette;
      keyframes morph these values to make the surface "wobble" as it rises. */
   border-radius: 58% 42% 60% 40% / 50% 55% 45% 50%;
 }
 
+/* ----- Far tier: huge, slow, heavy blur, low opacity ----- */
 .login-blob--a {
-  width: 52vw;
-  height: 64vw;
-  max-width: 620px;
-  max-height: 760px;
-  bottom: -25vw;
-  left: -8vw;
-  background: radial-gradient(circle at 35% 35%, var(--color-primary-400), var(--color-primary-600) 60%, transparent 78%);
+  width: 70vw;
+  height: 86vw;
+  max-width: 880px;
+  max-height: 1080px;
+  bottom: -38vw;
+  left: -18vw;
+  filter: blur(110px);
+  opacity: 0.4;
+  background: radial-gradient(circle at 35% 35%, var(--color-primary-400), var(--color-primary-700) 60%, transparent 78%);
   animation:
-    login-rise-a 20s ease-in-out infinite alternate,
-    login-morph-a 14s ease-in-out infinite alternate;
+    login-rise-a 52s ease-in-out infinite alternate,
+    login-morph-a 28s ease-in-out infinite alternate;
 }
 
 .login-blob--b {
-  width: 46vw;
-  height: 58vw;
-  max-width: 560px;
-  max-height: 700px;
-  top: -22vw;
-  right: -10vw;
+  width: 62vw;
+  height: 76vw;
+  max-width: 800px;
+  max-height: 960px;
+  top: -34vw;
+  right: -20vw;
+  filter: blur(100px);
+  opacity: 0.36;
   background: radial-gradient(circle at 65% 65%, var(--color-primary-500), var(--color-primary-800) 65%, transparent 82%);
-  opacity: 0.5;
   animation:
-    login-rise-b 26s ease-in-out infinite alternate,
-    login-morph-b 17s ease-in-out infinite alternate;
+    login-rise-b 60s ease-in-out infinite alternate,
+    login-morph-b 32s ease-in-out infinite alternate;
 }
 
+/* ----- Mid tier: medium, moderate speed/blur ----- */
 .login-blob--c {
   width: 32vw;
   height: 40vw;
   max-width: 420px;
   max-height: 520px;
-  top: 30%;
-  left: 45%;
+  top: 28%;
+  left: 42%;
+  filter: blur(60px);
+  opacity: 0.5;
   background: radial-gradient(circle, color-mix(in oklab, var(--color-primary-300) 75%, white), transparent 72%);
-  opacity: 0.4;
   animation:
-    login-rise-c 32s ease-in-out infinite alternate,
-    login-morph-c 19s ease-in-out infinite alternate;
+    login-rise-c 30s ease-in-out infinite alternate,
+    login-morph-c 18s ease-in-out infinite alternate;
 }
 
 .login-blob--d {
-  width: 26vw;
-  height: 34vw;
-  max-width: 340px;
-  max-height: 440px;
-  bottom: -10vw;
+  width: 28vw;
+  height: 36vw;
+  max-width: 360px;
+  max-height: 460px;
+  bottom: -12vw;
   right: 18vw;
+  filter: blur(55px);
+  opacity: 0.55;
   background: radial-gradient(circle at 50% 50%, var(--color-primary-300), var(--color-primary-500) 60%, transparent 80%);
-  opacity: 0.45;
   animation:
-    login-rise-d 24s ease-in-out infinite alternate,
+    login-rise-d 26s ease-in-out infinite alternate,
     login-morph-a 16s ease-in-out infinite alternate -3s;
 }
 
+/* ----- Near tier: small, fast, sharper, more opaque ----- */
 .login-blob--e {
-  width: 22vw;
-  height: 30vw;
-  max-width: 300px;
-  max-height: 400px;
-  top: -8vw;
-  left: 28vw;
+  width: 16vw;
+  height: 22vw;
+  max-width: 220px;
+  max-height: 300px;
+  top: -6vw;
+  left: 32vw;
+  filter: blur(32px);
+  opacity: 0.65;
   background: radial-gradient(circle at 50% 50%, var(--color-primary-400), var(--color-primary-700) 65%, transparent 82%);
-  opacity: 0.4;
   animation:
-    login-rise-e 28s ease-in-out infinite alternate,
-    login-morph-b 21s ease-in-out infinite alternate -5s;
+    login-rise-e 14s ease-in-out infinite alternate,
+    login-morph-b 11s ease-in-out infinite alternate -5s;
 }
 
-html.dark .login-blob--a { opacity: 0.45; }
-html.dark .login-blob--b { opacity: 0.4; }
-html.dark .login-blob--c { opacity: 0.3; }
-html.dark .login-blob--d { opacity: 0.35; }
-html.dark .login-blob--e { opacity: 0.3; }
+.login-blob--f {
+  width: 12vw;
+  height: 16vw;
+  max-width: 160px;
+  max-height: 220px;
+  bottom: -4vw;
+  left: 14vw;
+  filter: blur(26px);
+  opacity: 0.7;
+  background: radial-gradient(circle at 45% 45%, var(--color-primary-300), var(--color-primary-600) 65%, transparent 84%);
+  animation:
+    login-rise-f 11s ease-in-out infinite alternate,
+    login-morph-c 9s ease-in-out infinite alternate -2s;
+}
+
+html.dark .login-blob--a { opacity: 0.32; }
+html.dark .login-blob--b { opacity: 0.28; }
+html.dark .login-blob--c { opacity: 0.38; }
+html.dark .login-blob--d { opacity: 0.42; }
+html.dark .login-blob--e { opacity: 0.5; }
+html.dark .login-blob--f { opacity: 0.55; }
 
 .login-grid {
   position: absolute;
@@ -138,32 +161,44 @@ html.dark .login-grid {
 }
 
 /* Rise/fall trajectories — primary motion is vertical with gentle horizontal
-   sway and squish/stretch via non-uniform scale, mimicking convection in a
-   lava lamp. */
+   sway and squish/stretch via non-uniform scale. Travel distance scales with
+   depth: far tier barely budges, mid tier drifts, near tier traverses most
+   of the viewport — that contrast is what sells the parallax effect. */
+
+/* Far: minimal travel, lazy sway */
 @keyframes login-rise-a {
   0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
-  50%  { transform: translate3d(3vw, -45vh, 0) scale(1.08, 0.92) rotate(8deg); }
-  100% { transform: translate3d(-2vw, -85vh, 0) scale(0.94, 1.1) rotate(-6deg); }
+  50%  { transform: translate3d(2vw, -12vh, 0) scale(1.04, 0.96) rotate(4deg); }
+  100% { transform: translate3d(-1vw, -22vh, 0) scale(0.97, 1.05) rotate(-3deg); }
 }
 @keyframes login-rise-b {
   0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
-  50%  { transform: translate3d(-4vw, 40vh, 0) scale(0.92, 1.1) rotate(-10deg); }
-  100% { transform: translate3d(2vw, 78vh, 0) scale(1.1, 0.9) rotate(7deg); }
+  50%  { transform: translate3d(-2vw, 10vh, 0) scale(0.96, 1.05) rotate(-4deg); }
+  100% { transform: translate3d(1vw, 20vh, 0) scale(1.05, 0.96) rotate(3deg); }
 }
+
+/* Mid: moderate travel */
 @keyframes login-rise-c {
   0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
-  50%  { transform: translate3d(-5vw, -8vh, 0) scale(1.12, 0.94) rotate(-12deg); }
-  100% { transform: translate3d(4vw, 6vh, 0) scale(0.9, 1.1) rotate(10deg); }
+  50%  { transform: translate3d(-5vw, -25vh, 0) scale(1.1, 0.94) rotate(-10deg); }
+  100% { transform: translate3d(4vw, -50vh, 0) scale(0.92, 1.1) rotate(8deg); }
 }
 @keyframes login-rise-d {
   0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
-  50%  { transform: translate3d(-6vw, -55vh, 0) scale(1.05, 0.95) rotate(15deg); }
-  100% { transform: translate3d(3vw, -90vh, 0) scale(0.92, 1.08) rotate(-8deg); }
+  50%  { transform: translate3d(6vw, -35vh, 0) scale(1.05, 0.95) rotate(12deg); }
+  100% { transform: translate3d(-3vw, -68vh, 0) scale(0.92, 1.08) rotate(-7deg); }
 }
+
+/* Near: dramatic travel, snappy squish/stretch */
 @keyframes login-rise-e {
   0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
-  50%  { transform: translate3d(5vw, 50vh, 0) scale(0.94, 1.08) rotate(-14deg); }
-  100% { transform: translate3d(-3vw, 88vh, 0) scale(1.1, 0.92) rotate(9deg); }
+  50%  { transform: translate3d(8vw, 55vh, 0) scale(0.88, 1.14) rotate(-18deg); }
+  100% { transform: translate3d(-6vw, 100vh, 0) scale(1.16, 0.86) rotate(14deg); }
+}
+@keyframes login-rise-f {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-9vw, -55vh, 0) scale(1.18, 0.84) rotate(20deg); }
+  100% { transform: translate3d(7vw, -105vh, 0) scale(0.85, 1.18) rotate(-16deg); }
 }
 
 /* Morphing border-radius makes each blob's surface wobble independently of
@@ -190,7 +225,8 @@ html.dark .login-grid {
   .login-blob--b,
   .login-blob--c,
   .login-blob--d,
-  .login-blob--e {
+  .login-blob--e,
+  .login-blob--f {
     animation: none;
   }
 }

--- a/frontend/ai.client/src/app/auth/login/login.page.css
+++ b/frontend/ai.client/src/app/auth/login/login.page.css
@@ -24,53 +24,99 @@ html.dark .login-shell {
   pointer-events: none;
 }
 
+/* The .login-lava wrapper holds the morphing blobs. Keeping it as a separate
+   layer lets us isolate transforms and (in the future) drop a goo SVG filter
+   on it without affecting the grid overlay. */
+.login-lava {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
 .login-blob {
   position: absolute;
-  border-radius: 9999px;
-  filter: blur(80px);
+  filter: blur(70px);
   opacity: 0.55;
-  will-change: transform;
+  will-change: transform, border-radius;
+  /* Asymmetric border-radius gives an organic, non-circular blob silhouette;
+     keyframes morph these values to make the surface "wobble" as it rises. */
+  border-radius: 58% 42% 60% 40% / 50% 55% 45% 50%;
 }
 
 .login-blob--a {
-  width: 60vw;
-  height: 60vw;
-  max-width: 720px;
-  max-height: 720px;
-  top: -15vw;
-  left: -10vw;
-  background: radial-gradient(circle at 30% 30%, var(--color-primary-400), var(--color-primary-600) 60%, transparent 75%);
-  animation: login-drift-a 18s ease-in-out infinite alternate;
+  width: 52vw;
+  height: 64vw;
+  max-width: 620px;
+  max-height: 760px;
+  bottom: -25vw;
+  left: -8vw;
+  background: radial-gradient(circle at 35% 35%, var(--color-primary-400), var(--color-primary-600) 60%, transparent 78%);
+  animation:
+    login-rise-a 20s ease-in-out infinite alternate,
+    login-morph-a 14s ease-in-out infinite alternate;
 }
 
 .login-blob--b {
-  width: 55vw;
-  height: 55vw;
-  max-width: 640px;
-  max-height: 640px;
-  bottom: -18vw;
-  right: -12vw;
-  background: radial-gradient(circle at 70% 70%, var(--color-primary-500), var(--color-primary-800) 65%, transparent 80%);
-  opacity: 0.45;
-  animation: login-drift-b 22s ease-in-out infinite alternate;
+  width: 46vw;
+  height: 58vw;
+  max-width: 560px;
+  max-height: 700px;
+  top: -22vw;
+  right: -10vw;
+  background: radial-gradient(circle at 65% 65%, var(--color-primary-500), var(--color-primary-800) 65%, transparent 82%);
+  opacity: 0.5;
+  animation:
+    login-rise-b 26s ease-in-out infinite alternate,
+    login-morph-b 17s ease-in-out infinite alternate;
 }
 
 .login-blob--c {
-  width: 38vw;
-  height: 38vw;
-  max-width: 480px;
-  max-height: 480px;
-  top: 35%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: radial-gradient(circle, color-mix(in oklab, var(--color-primary-300) 70%, white), transparent 70%);
-  opacity: 0.35;
-  animation: login-drift-c 26s ease-in-out infinite alternate;
+  width: 32vw;
+  height: 40vw;
+  max-width: 420px;
+  max-height: 520px;
+  top: 30%;
+  left: 45%;
+  background: radial-gradient(circle, color-mix(in oklab, var(--color-primary-300) 75%, white), transparent 72%);
+  opacity: 0.4;
+  animation:
+    login-rise-c 32s ease-in-out infinite alternate,
+    login-morph-c 19s ease-in-out infinite alternate;
+}
+
+.login-blob--d {
+  width: 26vw;
+  height: 34vw;
+  max-width: 340px;
+  max-height: 440px;
+  bottom: -10vw;
+  right: 18vw;
+  background: radial-gradient(circle at 50% 50%, var(--color-primary-300), var(--color-primary-500) 60%, transparent 80%);
+  opacity: 0.45;
+  animation:
+    login-rise-d 24s ease-in-out infinite alternate,
+    login-morph-a 16s ease-in-out infinite alternate -3s;
+}
+
+.login-blob--e {
+  width: 22vw;
+  height: 30vw;
+  max-width: 300px;
+  max-height: 400px;
+  top: -8vw;
+  left: 28vw;
+  background: radial-gradient(circle at 50% 50%, var(--color-primary-400), var(--color-primary-700) 65%, transparent 82%);
+  opacity: 0.4;
+  animation:
+    login-rise-e 28s ease-in-out infinite alternate,
+    login-morph-b 21s ease-in-out infinite alternate -5s;
 }
 
 html.dark .login-blob--a { opacity: 0.45; }
 html.dark .login-blob--b { opacity: 0.4; }
-html.dark .login-blob--c { opacity: 0.25; }
+html.dark .login-blob--c { opacity: 0.3; }
+html.dark .login-blob--d { opacity: 0.35; }
+html.dark .login-blob--e { opacity: 0.3; }
 
 .login-grid {
   position: absolute;
@@ -91,24 +137,60 @@ html.dark .login-grid {
   opacity: 0.5;
 }
 
-@keyframes login-drift-a {
-  from { transform: translate3d(0, 0, 0) scale(1); }
-  to   { transform: translate3d(4vw, 3vw, 0) scale(1.08); }
+/* Rise/fall trajectories — primary motion is vertical with gentle horizontal
+   sway and squish/stretch via non-uniform scale, mimicking convection in a
+   lava lamp. */
+@keyframes login-rise-a {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(3vw, -45vh, 0) scale(1.08, 0.92) rotate(8deg); }
+  100% { transform: translate3d(-2vw, -85vh, 0) scale(0.94, 1.1) rotate(-6deg); }
 }
-@keyframes login-drift-b {
-  from { transform: translate3d(0, 0, 0) scale(1); }
-  to   { transform: translate3d(-3vw, -4vw, 0) scale(1.1); }
+@keyframes login-rise-b {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-4vw, 40vh, 0) scale(0.92, 1.1) rotate(-10deg); }
+  100% { transform: translate3d(2vw, 78vh, 0) scale(1.1, 0.9) rotate(7deg); }
 }
-@keyframes login-drift-c {
-  from { transform: translate(-50%, -50%) scale(1); }
-  to   { transform: translate(-48%, -52%) scale(1.06); }
+@keyframes login-rise-c {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-5vw, -8vh, 0) scale(1.12, 0.94) rotate(-12deg); }
+  100% { transform: translate3d(4vw, 6vh, 0) scale(0.9, 1.1) rotate(10deg); }
+}
+@keyframes login-rise-d {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(-6vw, -55vh, 0) scale(1.05, 0.95) rotate(15deg); }
+  100% { transform: translate3d(3vw, -90vh, 0) scale(0.92, 1.08) rotate(-8deg); }
+}
+@keyframes login-rise-e {
+  0%   { transform: translate3d(0, 0, 0) scale(1, 1) rotate(0deg); }
+  50%  { transform: translate3d(5vw, 50vh, 0) scale(0.94, 1.08) rotate(-14deg); }
+  100% { transform: translate3d(-3vw, 88vh, 0) scale(1.1, 0.92) rotate(9deg); }
+}
+
+/* Morphing border-radius makes each blob's surface wobble independently of
+   its trajectory — the signature lava-lamp "skin" deformation. */
+@keyframes login-morph-a {
+  0%   { border-radius: 58% 42% 60% 40% / 50% 55% 45% 50%; }
+  50%  { border-radius: 42% 58% 38% 62% / 60% 40% 60% 40%; }
+  100% { border-radius: 50% 50% 65% 35% / 45% 55% 50% 50%; }
+}
+@keyframes login-morph-b {
+  0%   { border-radius: 50% 50% 40% 60% / 55% 45% 55% 45%; }
+  50%  { border-radius: 65% 35% 55% 45% / 40% 60% 40% 60%; }
+  100% { border-radius: 38% 62% 50% 50% / 60% 50% 50% 40%; }
+}
+@keyframes login-morph-c {
+  0%   { border-radius: 60% 40% 50% 50% / 45% 60% 40% 55%; }
+  50%  { border-radius: 40% 60% 65% 35% / 55% 40% 60% 45%; }
+  100% { border-radius: 55% 45% 38% 62% / 50% 55% 45% 50%; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .login-blob,
   .login-blob--a,
   .login-blob--b,
-  .login-blob--c {
+  .login-blob--c,
+  .login-blob--d,
+  .login-blob--e {
     animation: none;
   }
 }

--- a/frontend/ai.client/src/app/auth/login/login.page.ts
+++ b/frontend/ai.client/src/app/auth/login/login.page.ts
@@ -26,11 +26,15 @@ interface AuthProviderPublicListResponse {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="login-shell fixed inset-0 flex items-center justify-center overflow-y-auto">
-      <!-- Decorative background: large primary-color blobs with soft blur -->
+      <!-- Decorative background: lava-lamp blobs with organic morph + rise/fall -->
       <div class="login-bg" aria-hidden="true">
-        <div class="login-blob login-blob--a"></div>
-        <div class="login-blob login-blob--b"></div>
-        <div class="login-blob login-blob--c"></div>
+        <div class="login-lava">
+          <div class="login-blob login-blob--a"></div>
+          <div class="login-blob login-blob--b"></div>
+          <div class="login-blob login-blob--c"></div>
+          <div class="login-blob login-blob--d"></div>
+          <div class="login-blob login-blob--e"></div>
+        </div>
         <div class="login-grid"></div>
       </div>
 

--- a/frontend/ai.client/src/app/auth/login/login.page.ts
+++ b/frontend/ai.client/src/app/auth/login/login.page.ts
@@ -26,14 +26,20 @@ interface AuthProviderPublicListResponse {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="login-shell fixed inset-0 flex items-center justify-center overflow-y-auto">
-      <!-- Decorative background: lava-lamp blobs with organic morph + rise/fall -->
+      <!-- Decorative background: lava-lamp blobs across three depth tiers
+           (far/mid/near) for parallax — size, blur, speed, and travel
+           distance all scale with depth. -->
       <div class="login-bg" aria-hidden="true">
         <div class="login-lava">
+          <!-- Far layer: huge, slow, heavily blurred -->
           <div class="login-blob login-blob--a"></div>
           <div class="login-blob login-blob--b"></div>
+          <!-- Mid layer -->
           <div class="login-blob login-blob--c"></div>
           <div class="login-blob login-blob--d"></div>
+          <!-- Near layer: small, fast, sharper -->
           <div class="login-blob login-blob--e"></div>
+          <div class="login-blob login-blob--f"></div>
         </div>
         <div class="login-grid"></div>
       </div>


### PR DESCRIPTION
## Summary
- Replace static circular drift with organic morphing blob shapes that rise/fall vertically with squish-stretch and gentle rotation
- Restructure into three depth tiers (far/mid/near, 6 blobs total). Size, blur, opacity, duration, and travel distance all scale with depth → velocity contrast reads as parallax
- Apply the same shell (lava backdrop + frosted-glass card) to the first-boot page so the two auth screens feel like one system
- Honors `prefers-reduced-motion`

## Test plan
- [ ] Visit `/auth/login` — confirm 6 blobs across 3 visible depth tiers; small near blobs travel farther/faster than huge far blobs
- [ ] Watch ~30s — blobs morph (border-radius wobble) and squish/stretch via non-uniform scale; no two cycles in lockstep
- [ ] Visit `/auth/first-boot` (reset first-boot state if needed) — same backdrop + frosted card; form fields readable; password requirements list still updates green
- [ ] Toggle dark mode on both pages — backdrop dims, card switches to dark frosted glass, headings/labels/banners stay readable
- [ ] Submit success/error banners on first-boot remain readable over the moving backdrop
- [ ] Resize to ~375px wide — `vw`-based blobs scale; card not clipped
- [ ] Enable macOS Reduce Motion → reload both pages — animation halts, organic shapes remain
- [ ] No console errors; no jank during interactions

## Notes
The lava-lamp/frosted-card CSS is currently duplicated between `login.page.css` and `first-boot.page.css` (Angular view encapsulation scopes the classes per component). A shared partial would be a clean follow-up if this pattern lands on more auth pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)