### PR TITLE
feat(attachments): markdown preview rendering and modal viewer

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
@@ -8,8 +8,10 @@ import {
   heroPhoto,
   heroArrowTopRightOnSquare,
 } from '@ng-icons/heroicons/outline';
+import { MarkdownComponent } from 'ngx-markdown';
 import { formatBytes, FileUploadService } from '../../../../../services/file-upload';
 import { FileAttachmentData } from '../../../../services/models/message.model';
+import { MarkdownPreviewModalComponent } from './markdown-preview-modal.component';
 
 interface FileTypeStyle {
   icon: string;
@@ -120,7 +122,7 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
 @Component({
   selector: 'app-file-attachment-badge',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon],
+  imports: [NgIcon, MarkdownComponent, MarkdownPreviewModalComponent],
   providers: [
     provideIcons({
       heroDocument,
@@ -141,6 +143,70 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
     }
     :host-context(.dark) .corner-fold {
       --corner-bg: #374151;
+    }
+
+    /* Compact markdown styling for the small in-card preview. The card body
+       is only ~128px tall so we shrink everything aggressively and strip the
+       margins that the global .message-block prose styles add. */
+    .md-card-preview {
+      font-size: 9px;
+      line-height: 1.45;
+      color: rgb(55 65 81);
+    }
+    :host-context(.dark) .md-card-preview {
+      color: rgb(209 213 219);
+    }
+    .md-card-preview :is(h1, h2, h3, h4, h5, h6) {
+      font-weight: 700;
+      line-height: 1.25;
+      margin: 0 0 2px;
+      color: rgb(17 24 39);
+    }
+    :host-context(.dark) .md-card-preview :is(h1, h2, h3, h4, h5, h6) {
+      color: rgb(243 244 246);
+    }
+    .md-card-preview h1 { font-size: 12px; }
+    .md-card-preview h2 { font-size: 11px; }
+    .md-card-preview h3,
+    .md-card-preview h4,
+    .md-card-preview h5,
+    .md-card-preview h6 { font-size: 10px; }
+    .md-card-preview p { margin: 0 0 4px; }
+    .md-card-preview ul,
+    .md-card-preview ol {
+      margin: 0 0 4px;
+      padding-left: 14px;
+    }
+    .md-card-preview li { margin: 0 0 1px; }
+    .md-card-preview code {
+      font-size: 8.5px;
+      background: rgb(243 244 246);
+      padding: 0 2px;
+      border-radius: 2px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    .md-card-preview pre {
+      font-size: 8.5px;
+      background: rgb(243 244 246);
+      padding: 4px;
+      border-radius: 4px;
+      overflow: hidden;
+      margin: 0 0 4px;
+    }
+    :host-context(.dark) .md-card-preview code,
+    :host-context(.dark) .md-card-preview pre {
+      background: rgb(31 41 55);
+    }
+    .md-card-preview a {
+      color: rgb(99 102 241);
+      text-decoration: underline;
+    }
+    .md-card-preview strong { font-weight: 600; }
+    .md-card-preview blockquote {
+      border-left: 2px solid rgb(209 213 219);
+      padding-left: 6px;
+      margin: 0 0 4px;
+      color: rgb(107 114 128);
     }
   `,
   template: `
@@ -185,9 +251,15 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
         ></div>
 
         @if (snippetState() === 'ready' && hasSnippet()) {
-          <pre
-            class="m-0 max-h-full overflow-hidden whitespace-pre-wrap break-words px-3 py-2 font-mono text-[9px] leading-snug text-gray-700 dark:text-gray-300"
-          >{{ truncatedSnippet() }}</pre>
+          @if (isMarkdown()) {
+            <div class="md-card-preview h-full overflow-hidden px-3 py-2">
+              <markdown [data]="truncatedSnippet()" />
+            </div>
+          } @else {
+            <pre
+              class="m-0 max-h-full overflow-hidden whitespace-pre-wrap break-words px-3 py-2 font-mono text-[9px] leading-snug text-gray-700 dark:text-gray-300"
+            >{{ truncatedSnippet() }}</pre>
+          }
         } @else {
           <div class="space-y-1.5 px-3 py-2.5" aria-hidden="true">
             @for (width of skeletonWidths; track $index) {
@@ -216,6 +288,14 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
         </p>
       </div>
     </button>
+
+    @if (markdownModalOpen()) {
+      <app-markdown-preview-modal
+        [uploadId]="attachment().uploadId"
+        [filename]="attachment().filename"
+        (close)="markdownModalOpen.set(false)"
+      />
+    }
   `,
 })
 export class FileAttachmentBadgeComponent {
@@ -227,6 +307,7 @@ export class FileAttachmentBadgeComponent {
 
   protected readonly snippetState = signal<'idle' | 'loading' | 'ready' | 'error'>('idle');
   private readonly snippet = signal<string>('');
+  protected readonly markdownModalOpen = signal(false);
 
   protected readonly formattedSize = computed(() => formatBytes(this.attachment().sizeBytes));
 
@@ -235,6 +316,8 @@ export class FileAttachmentBadgeComponent {
   );
 
   protected readonly hasSnippet = computed(() => this.snippet().trim().length > 0);
+
+  protected readonly isMarkdown = computed(() => this.attachment().mimeType === 'text/markdown');
 
   /** Cap chars so very long unbroken lines don't blow out the card. */
   protected readonly truncatedSnippet = computed(() => {
@@ -263,6 +346,10 @@ export class FileAttachmentBadgeComponent {
   }
 
   protected async openFile(): Promise<void> {
+    if (this.isMarkdown()) {
+      this.markdownModalOpen.set(true);
+      return;
+    }
     try {
       const response = await this.fileUploadService.getPreviewUrl(this.attachment().uploadId);
       window.open(response.url, '_blank', 'noopener,noreferrer');

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/index.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/index.ts
@@ -2,3 +2,4 @@ export { FileAttachmentBadgeComponent } from './file-attachment-badge.component'
 export { ImageAttachmentGroupComponent } from './image-attachment-group.component';
 export { ImageLightboxComponent } from './image-lightbox.component';
 export type { LightboxImage } from './image-lightbox.component';
+export { MarkdownPreviewModalComponent } from './markdown-preview-modal.component';

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/markdown-preview-modal.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/markdown-preview-modal.component.ts
@@ -1,0 +1,183 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroArrowTopRightOnSquare } from '@ng-icons/heroicons/outline';
+import { MarkdownComponent } from 'ngx-markdown';
+import { FileUploadService } from '../../../../../services/file-upload';
+
+/** Hard cap on how much of the file we render in the modal. */
+const MAX_PREVIEW_BYTES = 1024 * 1024;
+
+/**
+ * Full-screen modal that fetches a markdown file via a short-lived presigned
+ * URL and renders it through ngx-markdown. Used in place of opening the raw
+ * source in a new tab when a user clicks a `.md` attachment card.
+ */
+@Component({
+  selector: 'app-markdown-preview-modal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, MarkdownComponent],
+  providers: [provideIcons({ heroXMark, heroArrowTopRightOnSquare })],
+  host: {
+    '(document:keydown)': 'onKeydown($event)',
+  },
+  template: `
+    <div
+      class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      [attr.aria-label]="'Markdown preview: ' + filename()"
+      (click)="onBackdropClick($event)"
+    >
+      <div
+        class="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-900"
+        (click)="$event.stopPropagation()"
+      >
+        <!-- Header -->
+        <div
+          class="flex items-center justify-between gap-3 border-b border-gray-200 px-5 py-3 dark:border-gray-700"
+        >
+          <h2
+            class="min-w-0 truncate text-sm font-semibold text-gray-900 dark:text-white"
+            [title]="filename()"
+          >
+            {{ filename() }}
+          </h2>
+          <div class="flex items-center gap-1">
+            @if (sourceUrl()) {
+              <a
+                [href]="sourceUrl()!"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex size-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                aria-label="Open raw markdown in a new tab"
+              >
+                <ng-icon
+                  name="heroArrowTopRightOnSquare"
+                  class="size-5"
+                  aria-hidden="true"
+                />
+              </a>
+            }
+            <button
+              type="button"
+              class="flex size-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              (click)="close.emit()"
+              aria-label="Close preview"
+            >
+              <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="message-block min-h-0 flex-1 overflow-auto px-6 py-5">
+          @switch (state()) {
+            @case ('loading') {
+              <div
+                class="flex h-full min-h-[200px] items-center justify-center text-sm text-gray-500 dark:text-gray-400"
+                role="status"
+              >
+                <span
+                  class="size-5 animate-spin rounded-full border-2 border-gray-300 border-t-primary-500"
+                  aria-hidden="true"
+                ></span>
+                <span class="ml-3">Loading preview…</span>
+              </div>
+            }
+            @case ('error') {
+              <div
+                class="flex h-full min-h-[200px] items-center justify-center text-sm text-red-600 dark:text-red-400"
+                role="alert"
+              >
+                Couldn't load the markdown preview.
+              </div>
+            }
+            @case ('ready') {
+              @if (truncated()) {
+                <p
+                  class="mb-4 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+                >
+                  Showing the first {{ formattedLimit }} of this file. Open in a
+                  new tab for the full source.
+                </p>
+              }
+              <markdown [data]="content()" />
+            }
+          }
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+  `,
+})
+export class MarkdownPreviewModalComponent {
+  readonly uploadId = input.required<string>();
+  readonly filename = input.required<string>();
+  readonly close = output<void>();
+
+  private readonly fileUploadService = inject(FileUploadService);
+
+  protected readonly state = signal<'loading' | 'ready' | 'error'>('loading');
+  protected readonly content = signal<string>('');
+  protected readonly sourceUrl = signal<string | null>(null);
+  protected readonly truncated = signal(false);
+
+  protected readonly formattedLimit = computed(() => {
+    const kb = MAX_PREVIEW_BYTES / 1024;
+    return kb >= 1024 ? `${kb / 1024} MB` : `${kb} KB`;
+  })();
+
+  constructor() {
+    effect(() => {
+      const id = this.uploadId();
+      if (id) this.load(id);
+    });
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close.emit();
+    }
+  }
+
+  protected onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.close.emit();
+    }
+  }
+
+  private async load(uploadId: string): Promise<void> {
+    this.state.set('loading');
+    try {
+      const presigned = await this.fileUploadService.getPreviewUrl(uploadId);
+      this.sourceUrl.set(presigned.url);
+
+      const response = await fetch(presigned.url);
+      if (!response.ok) {
+        throw new Error(`Fetch failed: ${response.status}`);
+      }
+
+      const text = await response.text();
+      const isTruncated = text.length > MAX_PREVIEW_BYTES;
+      this.content.set(isTruncated ? text.slice(0, MAX_PREVIEW_BYTES) : text);
+      this.truncated.set(isTruncated);
+      this.state.set('ready');
+    } catch {
+      this.state.set('error');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Render parsed markdown (headers, lists, code, links) inside the in-card excerpt for `.md` attachments instead of raw text — reuses the `ngx-markdown` instance already provided in `app.config.ts`.
- Replace the new-tab behavior with a full-screen modal viewer when a user clicks a `.md` card. The modal fetches the full file via the existing presigned preview-url, renders it through `<markdown>`, and falls back to "open raw" for content over 1 MB.
- Other file types (txt/csv/pdf/docx/xls/xlsx) keep their existing new-tab behavior.

## Test plan
- [ ] `cd frontend/ai.client && npm run start`
- [ ] Attach a `.md` file with headers, lists, inline code, and links — confirm the card excerpt renders formatting (not raw `#`/`-`/backticks).
- [ ] Click the `.md` card — modal opens with the full file rendered as markdown using the same `.message-block` prose styling as assistant messages.
- [ ] Dismiss with Escape, backdrop click, and the X button.
- [ ] Click the top-right "open raw" icon — opens the presigned URL in a new tab.
- [ ] Attach a `.txt`, `.csv`, `.pdf`, or `.docx` — confirm clicking still opens in a new tab (unchanged behavior).
- [ ] Toggle dark mode and re-verify card preview legibility and modal contrast.
- [ ] Attach a `.md` over 1 MB — confirm the truncation banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)