### PR TITLE
feat(attachments): server-rendered PDF page-1 thumbnails

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,10 @@ dependencies = [
     "cryptography==47.0.0",
     "python-multipart==0.0.27",
     "aiohttp==3.13.5",
+
+    # PDF page-1 rasterization for attachment thumbnails (Apache 2.0 / BSD).
+    # Bundles PDFium (no system poppler/ghostscript needed).
+    "pypdfium2==4.30.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -18,6 +18,7 @@ from apis.shared.files.models import (
     CompleteUploadResponse,
     PreviewUrlResponse,
     TextSnippetResponse,
+    ThumbnailResponse,
     FileListResponse,
     QuotaResponse,
     QuotaExceededError as QuotaExceededModel,
@@ -32,6 +33,7 @@ from .service import (
     FileNotFoundError,
     FileUploadError,
 )
+from .thumbnails import ThumbnailRenderError, ThumbnailUnsupportedError
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +182,46 @@ async def get_text_snippet(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File {upload_id} not found or not owned by you",
+        )
+
+
+@router.get("/{upload_id}/thumbnail", response_model=ThumbnailResponse)
+async def get_thumbnail(
+    upload_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: FileUploadService = Depends(get_file_upload_service),
+):
+    """
+    Return a presigned URL for a PNG thumbnail of the file's first page.
+
+    Lazy-renders on first request and caches the resulting `_thumb.png`
+    sibling object next to the original. Subsequent calls hit the cache and
+    return immediately.
+
+    Status codes:
+    - 200: Thumbnail available (response body indicates `cached`).
+    - 404: File not found or not owned by the caller.
+    - 415: MIME type has no thumbnail renderer (UI should fall back to its
+           skeleton card).
+    - 422: File present but unrenderable (corrupt, encrypted, empty PDF, ...).
+    """
+    try:
+        return await service.get_or_create_thumbnail(user.user_id, upload_id)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"File {upload_id} not found or not owned by you",
+        )
+    except ThumbnailUnsupportedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=str(e),
+        )
+    except ThumbnailRenderError as e:
+        logger.warning(f"Thumbnail render failed for {upload_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Could not render a thumbnail for this file",
         )
 
 

--- a/backend/src/apis/app_api/files/service.py
+++ b/backend/src/apis/app_api/files/service.py
@@ -4,6 +4,7 @@ File Upload Service
 Business logic for file uploads with S3 pre-signed URLs and quota management.
 """
 
+import asyncio
 import os
 import logging
 import uuid
@@ -22,11 +23,19 @@ from apis.shared.files.models import (
     CompleteUploadResponse,
     PreviewUrlResponse,
     TextSnippetResponse,
+    ThumbnailResponse,
+    THUMBNAIL_SUPPORTED_MIME_TYPES,
     FileResponse,
     FileListResponse,
     QuotaResponse,
     is_allowed_mime_type,
     ALLOWED_MIME_TYPES,
+)
+from .thumbnails import (
+    ThumbnailRenderer,
+    ThumbnailRenderError,
+    ThumbnailUnsupportedError,
+    get_thumbnail_renderer,
 )
 
 
@@ -103,6 +112,10 @@ class FileUploadService:
     - File listing and deletion
     """
 
+    # Sibling key, in the same per-upload S3 "folder" as the original.
+    # Stored alongside the original so cleanup happens with the file.
+    THUMBNAIL_KEY_NAME = "_thumb.png"
+
     def __init__(
         self,
         repository: Optional[FileUploadRepository] = None,
@@ -111,9 +124,11 @@ class FileUploadService:
         max_file_size: Optional[int] = None,
         max_files_per_message: Optional[int] = None,
         user_quota_bytes: Optional[int] = None,
+        thumbnail_renderer: Optional[ThumbnailRenderer] = None,
     ):
         """Initialize with dependencies."""
         self.repository = repository or get_file_upload_repository()
+        self._thumbnail_renderer = thumbnail_renderer or get_thumbnail_renderer()
 
         # S3 configuration
         # Use region from AWS_REGION env var to ensure presigned URLs use regional endpoint
@@ -446,6 +461,155 @@ class FileUploadService:
         )
 
     # =========================================================================
+    # Thumbnails
+    # =========================================================================
+
+    def _thumbnail_s3_key(self, file_meta: FileMetadata) -> str:
+        """
+        Derive the sibling thumbnail key for an original file.
+
+        Originals live at ``user-files/{user}/{session}/{upload_id}/{filename}``,
+        thumbnails at ``user-files/{user}/{session}/{upload_id}/_thumb.png`` —
+        same parent prefix so cleanup paths can find both.
+        """
+        base, _, _ = file_meta.s3_key.rpartition("/")
+        return f"{base}/{self.THUMBNAIL_KEY_NAME}"
+
+    async def get_or_create_thumbnail(
+        self, user_id: str, upload_id: str
+    ) -> ThumbnailResponse:
+        """
+        Return a presigned URL for a PNG thumbnail of the file's first page.
+
+        Lazy-renders on first request: checks for a cached ``_thumb.png``
+        sibling object in S3, generates one synchronously if missing, then
+        returns a short-lived presigned URL. Subsequent calls hit the cache.
+
+        Args:
+            user_id: The owner's user ID.
+            upload_id: The upload identifier.
+
+        Returns:
+            ThumbnailResponse with a presigned GET URL and ``cached`` flag.
+
+        Raises:
+            FileNotFoundError: File not found, not owned, or not ready.
+            ThumbnailUnsupportedError: MIME type has no registered renderer.
+            ThumbnailRenderError: The file was unreadable / corrupt / encrypted.
+        """
+        file_meta = await self.repository.get_file(user_id, upload_id)
+        if not file_meta:
+            raise FileNotFoundError(f"File {upload_id} not found")
+
+        if file_meta.status != FileStatus.READY:
+            raise FileNotFoundError(
+                f"File {upload_id} is not ready (status: {file_meta.status})"
+            )
+
+        if file_meta.mime_type not in THUMBNAIL_SUPPORTED_MIME_TYPES:
+            raise ThumbnailUnsupportedError(
+                f"No thumbnail renderer for {file_meta.mime_type}"
+            )
+
+        thumb_key = self._thumbnail_s3_key(file_meta)
+
+        # Cache check via HEAD — cheap, no body transfer.
+        cached = True
+        try:
+            self._s3_client.head_object(Bucket=self.bucket_name, Key=thumb_key)
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                cached = False
+            else:
+                logger.error(f"HEAD failed for thumbnail {thumb_key}: {e}")
+                raise
+
+        if not cached:
+            await self._render_and_store_thumbnail(file_meta, thumb_key)
+
+        # Generate the presigned URL for the thumbnail. Use the same
+        # expiration window as preview URLs so the UI's caching expectations
+        # line up.
+        try:
+            url = self._s3_client.generate_presigned_url(
+                "get_object",
+                Params={
+                    "Bucket": self.bucket_name,
+                    "Key": thumb_key,
+                    "ResponseContentType": "image/png",
+                },
+                ExpiresIn=self.preview_url_expiration,
+            )
+        except ClientError as e:
+            logger.error(f"Failed to generate thumbnail presigned URL: {e}")
+            raise
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=self.preview_url_expiration)
+        ).isoformat() + "Z"
+
+        return ThumbnailResponse(
+            upload_id=upload_id,
+            url=url,
+            expires_at=expires_at,
+            cached=cached,
+        )
+
+    async def _render_and_store_thumbnail(
+        self, file_meta: FileMetadata, thumb_key: str
+    ) -> None:
+        """Stream the original from S3, rasterize page 1, store the PNG."""
+        try:
+            response = self._s3_client.get_object(
+                Bucket=self.bucket_name,
+                Key=file_meta.s3_key,
+            )
+            raw = response["Body"].read()
+        except ClientError as e:
+            logger.error(f"Failed to read source for thumbnail {file_meta.upload_id}: {e}")
+            raise ThumbnailRenderError(f"Failed to read source: {e}") from e
+
+        # Run the CPU-bound render off the event loop so we don't stall the
+        # request worker. pypdfium2 releases the GIL for the heavy bits.
+        loop = asyncio.get_event_loop()
+        png_bytes = await loop.run_in_executor(
+            None,
+            self._thumbnail_renderer.render,
+            file_meta.mime_type,
+            raw,
+        )
+
+        try:
+            self._s3_client.put_object(
+                Bucket=self.bucket_name,
+                Key=thumb_key,
+                Body=png_bytes,
+                ContentType="image/png",
+            )
+        except ClientError as e:
+            logger.error(f"Failed to write thumbnail {thumb_key}: {e}")
+            raise
+
+        logger.info(
+            f"Rendered thumbnail for upload {file_meta.upload_id} "
+            f"({len(png_bytes)} bytes)"
+        )
+
+    def _delete_thumbnail_object(self, file_meta: FileMetadata) -> None:
+        """
+        Best-effort delete of the thumbnail sibling.
+
+        S3 ``delete_object`` is idempotent — a missing key is not an error.
+        We swallow other errors so a broken thumbnail never blocks deletion
+        of the underlying file.
+        """
+        thumb_key = self._thumbnail_s3_key(file_meta)
+        try:
+            self._s3_client.delete_object(Bucket=self.bucket_name, Key=thumb_key)
+        except ClientError as e:
+            logger.warning(f"Failed to delete thumbnail {thumb_key}: {e}")
+
+    # =========================================================================
     # File Management
     # =========================================================================
 
@@ -487,6 +651,9 @@ class FileUploadService:
         except ClientError as e:
             logger.warning("Failed to delete S3 object", exc_info=True)
             # Continue with metadata deletion even if S3 fails
+
+        # Best-effort delete of the thumbnail sibling, if one exists.
+        self._delete_thumbnail_object(file_meta)
 
         # Delete metadata
         deleted = await self.repository.delete_file(user_id, upload_id)
@@ -631,6 +798,9 @@ class FileUploadService:
                 except ClientError as e:
                     logger.warning(f"Failed to delete S3 object for {file_meta.upload_id}: {e}")
                     # Continue with metadata deletion
+
+                # Best-effort delete of the thumbnail sibling, if one exists.
+                self._delete_thumbnail_object(file_meta)
 
                 # Delete metadata
                 deleted = await self.repository.delete_file(

--- a/backend/src/apis/app_api/files/thumbnails.py
+++ b/backend/src/apis/app_api/files/thumbnails.py
@@ -1,0 +1,147 @@
+"""
+Thumbnail rendering for non-image file attachments.
+
+Currently supports PDF (page 1) via pypdfium2. Office formats (.docx, .xlsx)
+are intentionally not implemented here — see ThumbnailRenderer.render() for
+guidance on how to extend this.
+"""
+
+import io
+import logging
+from typing import Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+
+# Bounded box for the longest dimension of a generated thumbnail. The UI's
+# attachment card body is ~240x128 logical pixels, so 256 covers retina
+# without being wasteful on storage / CPU.
+THUMBNAIL_MAX_DIMENSION = 256
+
+
+class ThumbnailUnsupportedError(Exception):
+    """Raised when no renderer is registered for a given MIME type."""
+
+
+class ThumbnailRenderError(Exception):
+    """Raised when rendering ran but the source file was unreadable."""
+
+
+class ThumbnailRenderer:
+    """
+    MIME-type-dispatching renderer that produces a PNG of a file's first page.
+
+    Today this is PDF-only. The dispatcher exists so that callers (the file
+    upload service, the route layer) speak a single API: hand it a MIME type
+    plus bytes, get back a PNG or a typed error. New formats plug in by
+    adding an entry to ``_renderers``.
+
+    ----- Future formats: .docx and .xlsx -----
+
+    Office formats are deliberately out of scope for this in-process renderer.
+    The standard rasterization path requires LibreOffice (``soffice --headless
+    --convert-to pdf``) to first convert the document to PDF, which can then be
+    handed to the existing PDF path. LibreOffice adds roughly 500 MB to a
+    container image, pulls in ~20 system packages, and noticeably increases
+    cold start time — costs that are inappropriate for the app-api request
+    path, which today serves chat traffic with a tight latency budget.
+
+    Recommendation when those formats are needed:
+
+    1. Build a separate **thumbnail render service**. A small Fargate task or
+       a dedicated Lambda using a pre-baked LibreOffice container image is a
+       clean fit. Either flavor can stay scaled to zero when idle.
+    2. Have app-api enqueue render requests (SQS or a synchronous HTTPS call
+       behind an internal ALB) instead of importing the converter. The render
+       service writes the resulting PNG to the same `_thumb.png` sibling key
+       the PDF path uses, so the cache-and-serve flow on this side is
+       unchanged.
+    3. Keep the dispatcher's public API stable: callers should still get a PNG
+       back, and the cache layout in S3 should not change. The only difference
+       is *where* the bytes are produced.
+
+    Until that service exists, callers are expected to filter on
+    ``THUMBNAIL_SUPPORTED_MIME_TYPES`` from ``apis.shared.files.models`` and
+    return a 415 for unsupported types so the UI can fall back to the
+    existing skeleton card.
+    """
+
+    def __init__(self) -> None:
+        self._renderers: Dict[str, Callable[[bytes], bytes]] = {
+            "application/pdf": self._render_pdf,
+            # Future entries plug in here. See class docstring for the
+            # recommended out-of-process design for .docx and .xlsx.
+        }
+
+    def render(self, mime_type: str, raw: bytes) -> bytes:
+        """
+        Render a thumbnail PNG for the given file bytes.
+
+        Args:
+            mime_type: The source file's MIME type.
+            raw: The raw file bytes.
+
+        Returns:
+            PNG-encoded bytes for a thumbnail bounded by
+            THUMBNAIL_MAX_DIMENSION on its longest side.
+
+        Raises:
+            ThumbnailUnsupportedError: No renderer is registered for mime_type.
+            ThumbnailRenderError: The renderer ran but the file was unreadable.
+        """
+        renderer = self._renderers.get(mime_type)
+        if renderer is None:
+            raise ThumbnailUnsupportedError(
+                f"No thumbnail renderer registered for {mime_type}"
+            )
+        return renderer(raw)
+
+    def _render_pdf(self, raw: bytes) -> bytes:
+        # Imported lazily so unit tests that don't touch the renderer don't
+        # need the native lib loaded.
+        try:
+            import pypdfium2 as pdfium
+        except ImportError as e:
+            raise ThumbnailRenderError(
+                "pypdfium2 is not installed; PDF thumbnails are unavailable"
+            ) from e
+
+        try:
+            pdf = pdfium.PdfDocument(io.BytesIO(raw))
+        except Exception as e:
+            raise ThumbnailRenderError(f"Failed to open PDF: {e}") from e
+
+        try:
+            if len(pdf) == 0:
+                raise ThumbnailRenderError("PDF has no pages")
+
+            page = pdf[0]
+            try:
+                width, height = page.get_size()
+                longest = max(width, height)
+                if longest <= 0:
+                    raise ThumbnailRenderError("PDF page has zero dimensions")
+
+                # Scale so the longest side lands at THUMBNAIL_MAX_DIMENSION.
+                scale = THUMBNAIL_MAX_DIMENSION / longest
+                bitmap = page.render(scale=scale)
+                pil_image = bitmap.to_pil()
+            finally:
+                page.close()
+        finally:
+            pdf.close()
+
+        buffer = io.BytesIO()
+        pil_image.save(buffer, format="PNG", optimize=True)
+        return buffer.getvalue()
+
+
+_renderer_instance: ThumbnailRenderer | None = None
+
+
+def get_thumbnail_renderer() -> ThumbnailRenderer:
+    """Get or create the singleton ThumbnailRenderer."""
+    global _renderer_instance
+    if _renderer_instance is None:
+        _renderer_instance = ThumbnailRenderer()
+    return _renderer_instance

--- a/backend/src/apis/shared/files/models.py
+++ b/backend/src/apis/shared/files/models.py
@@ -273,6 +273,25 @@ class TextSnippetResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+# MIME types the thumbnail renderer can currently produce a preview image for.
+# Callers should consult this set before invoking the thumbnail endpoint to
+# avoid hammering the service for unsupported types.
+THUMBNAIL_SUPPORTED_MIME_TYPES = frozenset({
+    "application/pdf",
+})
+
+
+class ThumbnailResponse(BaseModel):
+    """Response for GET /api/files/{uploadId}/thumbnail."""
+
+    upload_id: str = Field(..., alias="uploadId")
+    url: str = Field(..., description="Short-lived presigned GET URL for a PNG thumbnail")
+    expires_at: str = Field(..., alias="expiresAt", description="ISO8601 expiration time")
+    cached: bool = Field(..., description="True if served from cache, False if newly rendered")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class FileResponse(BaseModel):
     """Single file in list response."""
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -25,6 +25,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pillow" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pypdfium2" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "starlette" },
@@ -98,6 +99,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'agentcore'", specifier = "==2.32.0" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
+    { name = "pypdfium2", specifier = "==4.30.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
@@ -109,7 +111,7 @@ requires-dist = [
     { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.37.0" },
     { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.5.1" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
-    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20251011" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260409" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
 ]
 provides-extras = ["agentcore", "bidi", "dev", "all"]
@@ -3669,6 +3671,26 @@ crypto = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "4.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/14/838b3ba247a0ba92e4df5d23f2bea9478edcfd72b78a39d6ca36ccd84ad2/pypdfium2-4.30.0.tar.gz", hash = "sha256:48b5b7e5566665bc1015b9d69c1ebabe21f6aee468b509531c3c8318eeee2e16", size = 140239, upload-time = "2024-05-09T18:33:17.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9a/c8ff5cc352c1b60b0b97642ae734f51edbab6e28b45b4fcdfe5306ee3c83/pypdfium2-4.30.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:b33ceded0b6ff5b2b93bc1fe0ad4b71aa6b7e7bd5875f1ca0cdfb6ba6ac01aab", size = 2837254, upload-time = "2024-05-09T18:32:48.653Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8b/27d4d5409f3c76b985f4ee4afe147b606594411e15ac4dc1c3363c9a9810/pypdfium2-4.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4e55689f4b06e2d2406203e771f78789bd4f190731b5d57383d05cf611d829de", size = 2707624, upload-time = "2024-05-09T18:32:51.458Z" },
+    { url = "https://files.pythonhosted.org/packages/11/63/28a73ca17c24b41a205d658e177d68e198d7dde65a8c99c821d231b6ee3d/pypdfium2-4.30.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e6e50f5ce7f65a40a33d7c9edc39f23140c57e37144c2d6d9e9262a2a854854", size = 2793126, upload-time = "2024-05-09T18:32:53.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/53b3ebf0955edbd02ac6da16a818ecc65c939e98fdeb4e0958362bd385c8/pypdfium2-4.30.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d0dd3ecaffd0b6dbda3da663220e705cb563918249bda26058c6036752ba3a2", size = 2591077, upload-time = "2024-05-09T18:32:55.99Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/0394e56e7cab8b5b21f744d988400948ef71a9a892cbeb0b200d324ab2c7/pypdfium2-4.30.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc3bf29b0db8c76cdfaac1ec1cde8edf211a7de7390fbf8934ad2aa9b4d6dfad", size = 2864431, upload-time = "2024-05-09T18:32:57.911Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cd/3f1edf20a0ef4a212a5e20a5900e64942c5a374473671ac0780eaa08ea80/pypdfium2-4.30.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1f78d2189e0ddf9ac2b7a9b9bd4f0c66f54d1389ff6c17e9fd9dc034d06eb3f", size = 2812008, upload-time = "2024-05-09T18:32:59.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/91/2d517db61845698f41a2a974de90762e50faeb529201c6b3574935969045/pypdfium2-4.30.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5eda3641a2da7a7a0b2f4dbd71d706401a656fea521b6b6faa0675b15d31a163", size = 6181543, upload-time = "2024-05-09T18:33:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c4/ed1315143a7a84b2c7616569dfb472473968d628f17c231c39e29ae9d780/pypdfium2-4.30.0-py3-none-musllinux_1_1_i686.whl", hash = "sha256:0dfa61421b5eb68e1188b0b2231e7ba35735aef2d867d86e48ee6cab6975195e", size = 6175911, upload-time = "2024-05-09T18:33:05.376Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c4/9e62d03f414e0e3051c56d5943c3bf42aa9608ede4e19dc96438364e9e03/pypdfium2-4.30.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:f33bd79e7a09d5f7acca3b0b69ff6c8a488869a7fab48fdf400fec6e20b9c8be", size = 6267430, upload-time = "2024-05-09T18:33:08.067Z" },
+    { url = "https://files.pythonhosted.org/packages/90/47/eda4904f715fb98561e34012826e883816945934a851745570521ec89520/pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e", size = 2775951, upload-time = "2024-05-09T18:33:10.567Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bd/56d9ec6b9f0fc4e0d95288759f3179f0fcd34b1a1526b75673d2f6d5196f/pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c", size = 2892098, upload-time = "2024-05-09T18:33:13.107Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7a/097801205b991bc3115e8af1edb850d30aeaf0118520b016354cf5ccd3f6/pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29", size = 2752118, upload-time = "2024-05-09T18:33:15.489Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4567,11 +4589,11 @@ wheels = [
 
 [[package]]
 name = "types-aiofiles"
-version = "25.1.0.20251011"
+version = "25.1.0.20260409"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6c/6d23908a8217e36704aa9c79d99a620f2fdd388b66a4b7f72fbc6b6ff6c6/types_aiofiles-25.1.0.20251011.tar.gz", hash = "sha256:1c2b8ab260cb3cd40c15f9d10efdc05a6e1e6b02899304d80dfa0410e028d3ff", size = 14535, upload-time = "2025-10-11T02:44:51.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/66/9e62a2692792bc96c0f423f478149f4a7b84720704c546c8960b0a047c89/types_aiofiles-25.1.0.20260409.tar.gz", hash = "sha256:49e67d72bdcf9fe406f5815758a78dc34a1249bb5aa2adba78a80aec0a775435", size = 14812, upload-time = "2026-04-09T04:22:35.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/0f/76917bab27e270bb6c32addd5968d69e558e5b6f7fb4ac4cbfa282996a96/types_aiofiles-25.1.0.20251011-py3-none-any.whl", hash = "sha256:8ff8de7f9d42739d8f0dadcceeb781ce27cd8d8c4152d4a7c52f6b20edb8149c", size = 14338, upload-time = "2025-10-11T02:44:50.054Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d0/28236f869ba4dfb223ecdbc267eb2bdb634b81a561dd992230a4f9ec48fa/types_aiofiles-25.1.0.20260409-py3-none-any.whl", hash = "sha256:923fedb532c772cc0f62e0ce4282725afa82ca5b41cabd9857f06b55e5eee8de", size = 14372, upload-time = "2026-04-09T04:22:34.328Z" },
 ]
 
 [[package]]

--- a/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
+++ b/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
@@ -99,6 +99,26 @@ export interface TextSnippetResponse {
 }
 
 /**
+ * Response from GET /files/{uploadId}/thumbnail
+ */
+export interface ThumbnailResponse {
+  uploadId: string;
+  url: string;
+  expiresAt: string;
+  cached: boolean;
+}
+
+/**
+ * Outcome of a thumbnail fetch — `unsupported` (415) and `unavailable`
+ * (404/422/network) collapse into typed states the UI can switch on
+ * without parsing HTTP errors at the call site.
+ */
+export type ThumbnailFetchResult =
+  | { status: 'ready'; response: ThumbnailResponse }
+  | { status: 'unsupported' }
+  | { status: 'unavailable' };
+
+/**
  * File metadata from list/get operations
  */
 export interface FileMetadata {
@@ -600,6 +620,29 @@ export class FileUploadService {
       );
     } catch (err) {
       throw this.handleApiError(err, 'Failed to get text snippet');
+    }
+  }
+
+  /**
+   * Fetch a presigned URL for a PNG thumbnail of the file's first page.
+   *
+   * Backend lazy-renders on first call and caches the result, so subsequent
+   * calls return instantly. Distinguishes between "this file type can never
+   * have a thumbnail" (415 → `unsupported`) and "we tried but it didn't
+   * work" (404/422/network → `unavailable`) so the UI can decide whether
+   * to retry or give up.
+   */
+  async getThumbnail(uploadId: string): Promise<ThumbnailFetchResult> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<ThumbnailResponse>(`${this.baseUrl()}/${uploadId}/thumbnail`)
+      );
+      return { status: 'ready', response };
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 415) {
+        return { status: 'unsupported' };
+      }
+      return { status: 'unavailable' };
     }
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
@@ -106,6 +106,9 @@ const FILE_TYPE_STYLES: Record<string, FileTypeStyle> = {
 
 const TEXT_PREVIEW_MIMES = new Set(['text/plain', 'text/markdown', 'text/csv', 'text/html']);
 
+/** MIME types where the backend can produce a real first-page thumbnail. */
+const THUMBNAIL_PREVIEW_MIMES = new Set(['application/pdf']);
+
 /** Skeleton "lines of text" widths (percent), tuned to look like a paragraph. */
 const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
 
@@ -250,7 +253,15 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
           aria-hidden="true"
         ></div>
 
-        @if (snippetState() === 'ready' && hasSnippet()) {
+        @if (thumbnailUrl(); as url) {
+          <img
+            [src]="url"
+            [alt]="'First page of ' + attachment().filename"
+            class="size-full object-cover object-top"
+            loading="lazy"
+            decoding="async"
+          />
+        } @else if (snippetState() === 'ready' && hasSnippet()) {
           @if (isMarkdown()) {
             <div class="md-card-preview h-full overflow-hidden px-3 py-2">
               <markdown [data]="truncatedSnippet()" />
@@ -271,11 +282,14 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
           </div>
         }
 
-        <!-- Bottom fade for long text -->
-        <div
-          class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-white to-transparent dark:from-gray-900/40"
-          aria-hidden="true"
-        ></div>
+        <!-- Bottom fade for long text. Suppressed when a thumbnail is shown
+             so the rendered page edge stays crisp. -->
+        @if (!thumbnailUrl()) {
+          <div
+            class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-white to-transparent dark:from-gray-900/40"
+            aria-hidden="true"
+          ></div>
+        }
       </div>
 
       <!-- Footer -->
@@ -309,6 +323,10 @@ export class FileAttachmentBadgeComponent {
   private readonly snippet = signal<string>('');
   protected readonly markdownModalOpen = signal(false);
 
+  /** Presigned URL for a real first-page thumbnail (PDFs today). null on
+      unsupported types or render failure — caller falls back to skeleton. */
+  protected readonly thumbnailUrl = signal<string | null>(null);
+
   protected readonly formattedSize = computed(() => formatBytes(this.attachment().sizeBytes));
 
   protected readonly style = computed<FileTypeStyle>(
@@ -331,6 +349,9 @@ export class FileAttachmentBadgeComponent {
       if (TEXT_PREVIEW_MIMES.has(att.mimeType)) {
         this.loadSnippet(att.uploadId);
       }
+      if (THUMBNAIL_PREVIEW_MIMES.has(att.mimeType)) {
+        this.loadThumbnail(att.uploadId);
+      }
     });
   }
 
@@ -343,6 +364,11 @@ export class FileAttachmentBadgeComponent {
     } catch {
       this.snippetState.set('error');
     }
+  }
+
+  private async loadThumbnail(uploadId: string): Promise<void> {
+    const result = await this.fileUploadService.getThumbnail(uploadId);
+    this.thumbnailUrl.set(result.status === 'ready' ? result.response.url : null);
   }
 
   protected async openFile(): Promise<void> {


### PR DESCRIPTION
## Summary
- Render real first-page thumbnails for PDF attachments instead of the skeleton mockup. Rasterization happens server-side in app-api via [`pypdfium2`](https://pypi.org/project/pypdfium2/) — Apache 2.0 / BSD, bundles the PDFium binary, no system `poppler` or `ghostscript` deps.
- New `GET /files/{upload_id}/thumbnail` endpoint. Lazy + cached: HEAD-checks for a `_thumb.png` sibling next to the original, renders + stores on miss, returns a short-lived presigned GET URL. Subsequent calls hit the cache and return immediately.
- Render runs in `loop.run_in_executor()` so request workers aren't blocked. Returns 415 for unsupported MIME types, 422 for corrupt / encrypted / empty PDFs — UI silently falls back to its existing skeleton card.
- `ThumbnailRenderer` is a MIME-type dispatcher with PDF as the only registered format today. The class docstring spells out why `.docx` / `.xlsx` are deferred and recommends a separate render service (LibreOffice headless on Fargate or in a pre-baked Lambda image) rather than bundling LibreOffice into app-api.
- Single-file delete and session cascade delete now also clean up the `_thumb.png` sibling. Thumbs share the lifecycle of the original file.

## Test plan
- [ ] `cd backend/src/apis/app_api && uv run python main.py`; `cd frontend/ai.client && npm run start`.
- [ ] Attach a PDF — confirm the card body shows a real first-page thumbnail. First load takes ~1–3s; re-attaching the same `upload_id` is instant (cache hit, response body has `cached: true`).
- [ ] Attach a `.docx` / `.xlsx` — confirm the card still shows the skeleton (415 → silent fallback, no console errors).
- [ ] Attach a `.md` / `.txt` / `.csv` — confirm the existing text-snippet preview is unchanged.
- [ ] Toggle dark mode — confirm thumbnail readability and the corner-fold detail still reads.
- [ ] Delete a PDF that's been thumbnailed; verify in S3 (or via re-fetch) that both the original and `_thumb.png` are gone.
- [ ] Delete a session containing PDFs — confirm the cascade also removes thumbnails.
- [ ] Try a corrupt or encrypted PDF — confirm the card falls back to the skeleton (422 in the network tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)