### PR TITLE
fix(token-accounting): correct per-message cost and context-window semantics

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -180,13 +180,26 @@ class StreamCoordinator:
                     if "metrics" in event_data:
                         accumulated_metadata["metrics"].update(event_data["metrics"])
 
-                # Collect metadata_summary event (don't send to client as-is)
+                # Collect metadata_summary event (don't send to client as-is).
+                #
+                # NOTE: metadata_summary carries Strands' EventLoopMetrics
+                # `accumulated_usage`, which sums each LLM call's full
+                # context-size across the turn (and across the agent's
+                # whole lifetime, per Strands' docs). For a 2-call tool
+                # turn with call_1.input=1000 and call_2.input=2500,
+                # accumulated_usage.inputTokens=3500 — but the *current*
+                # context occupancy is 2500, not 3500. We deliberately do
+                # NOT update accumulated_metadata["usage"] / ["metrics"]
+                # from this event: stream_coordinator's accumulated_metadata
+                # drives (a) the final SSE `usage` the frontend uses for
+                # the context-% badge and (b) the compaction trigger —
+                # both want "current context size", which the per-call
+                # `metadata` events already provide via last-write-wins
+                # `.update()`. Per-message cost attribution rides
+                # per_message_metadata (per-call) and is unaffected.
+                # We only keep the first_token_time backstop.
                 if event.get("type") == "metadata_summary":
                     event_data = event.get("data", {})
-                    if "usage" in event_data:
-                        accumulated_metadata["usage"].update(event_data["usage"])
-                    if "metrics" in event_data:
-                        accumulated_metadata["metrics"].update(event_data["metrics"])
                     if "first_token_time" in event_data:
                         first_token_time = event_data["first_token_time"]
                         # Associate first_token_time with first assistant message if we have one
@@ -327,6 +340,16 @@ class StreamCoordinator:
                     # checkpoint advanced on this turn, emit a `compaction` SSE
                     # so the frontend can place an inline "earlier messages
                     # summarized" divider. Fires after metadata, before done.
+                    #
+                    # CAUTION: do NOT replace this with Strands'
+                    # AgentResult.context_size / EventLoopMetrics.latest_context_size.
+                    # Both return ONLY `inputTokens` from the last cycle —
+                    # under Bedrock prompt caching that's the uncached
+                    # suffix only, so a 50k-token fully-cached context
+                    # reports ~50 (inputTokens) and hides ~49,950 in
+                    # cacheReadInputTokens. Summing all three buckets
+                    # below is the only correct "current context size"
+                    # under caching.
                     if hasattr(session_manager, "update_after_turn"):
                         usage = accumulated_metadata.get("usage", {})
                         total_input_tokens = (
@@ -1165,27 +1188,25 @@ class StreamCoordinator:
                 end_to_end_latency_ms = int((stream_end_time - stream_start_time) * 1000)
                 logger.info(f"📊 Calculated E2E latency: {end_to_end_latency_ms}ms")
 
-            # Get time to first token
-            # PRIORITY 1: Use provider's timeToFirstByteMs if available (most accurate)
+            # Get time to first token. We persist `None` (not 0) when the
+            # provider didn't emit `timeToFirstByteMs` and we couldn't
+            # measure it locally — a real TTFT can never be 0ms, and any
+            # downstream aggregation (averages, percentiles) needs to
+            # distinguish "not measured" from a real value to avoid
+            # pulling stats toward zero.
             if accumulated_metadata.get("metrics", {}).get("timeToFirstByteMs"):
                 time_to_first_token_ms = int(accumulated_metadata["metrics"]["timeToFirstByteMs"])
                 logger.info(f"📊 Using provider timeToFirstByteMs: {time_to_first_token_ms}ms")
-            # PRIORITY 2: Estimate TTFT as a portion of latency if we don't have it
-            # This is a rough estimate but better than 0 or None
-            # For most LLM calls, TTFT is typically 20-40% of total latency
-            elif end_to_end_latency_ms and end_to_end_latency_ms > 100:
-                # If E2E latency is available and substantial, estimate TTFT
-                # We don't have actual TTFT so we can't store it accurately
-                # Instead, log that we're missing it
-                logger.info(f"📊 No TTFT available - provider did not send timeToFirstByteMs for this message")
-                # Still create latency metrics with just E2E, using a placeholder of 0 for TTFT
-                # This is better than losing all latency data
-                time_to_first_token_ms = 0  # Indicates "not measured"
+            else:
+                logger.info("📊 No TTFT available - provider did not send timeToFirstByteMs for this message")
 
-            # Create latency metrics if we have at least E2E latency
+            # Create latency metrics if we have at least E2E latency.
+            # `time_to_first_token_ms` may be None — LatencyMetrics.time_to_first_token
+            # is Optional, so this serializes as JSON null.
             if end_to_end_latency_ms is not None:
                 latency_metrics = LatencyMetrics(
-                    time_to_first_token=time_to_first_token_ms if time_to_first_token_ms is not None else 0, end_to_end_latency=end_to_end_latency_ms
+                    time_to_first_token=time_to_first_token_ms,
+                    end_to_end_latency=end_to_end_latency_ms,
                 )
                 logger.info(f"📊 Created LatencyMetrics: TTFT={time_to_first_token_ms}ms, E2E={end_to_end_latency_ms}ms")
             else:

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -1092,7 +1092,16 @@ def _handle_metadata_events(event: RawEvent) -> List[ProcessedEvent]:
                     metadata_data["metrics"] = metrics_data
             
             if metadata_data:
-                metadata_event = _create_event("metadata", metadata_data)
+                # Emit on the turn-summary track, NOT the per-message track.
+                # `result.metrics.accumulated_usage` is summed across every
+                # LLM call in the turn (Strands' EventLoopMetrics). If we
+                # emitted this as a `metadata` event, the stream coordinator
+                # would route it into per_message_metadata[last] and clobber
+                # that message's per-call usage — pricing each entry would
+                # then double-count earlier messages' input tokens. The
+                # main loop also accumulates `metadata_summary` events
+                # (see below), so the final summary stays cumulative.
+                metadata_event = _create_event("metadata_summary", metadata_data)
                 events.append(metadata_event)
 
     # Check for metadata in nested event structure (like content blocks)
@@ -1311,8 +1320,14 @@ async def process_agent_stream(
             # NOTE: timeToFirstByteMs from provider will be stored in metrics
             # and the coordinator can use it as a fallback if first_token_time is not set
             for processed_event in _handle_metadata_events(event):
-                # Accumulate metadata for summary
-                if processed_event.get("type") == "metadata":
+                # Accumulate metadata for the final summary. Both per-call
+                # `metadata` events (each LLM call's usage) and the
+                # turn-cumulative `metadata_summary` event (extracted from
+                # AgentResult.metrics.accumulated_usage) feed this dict —
+                # the cumulative event arrives last and `update()` makes it
+                # last-write-wins, so accumulated_metadata ends the turn
+                # carrying true totals.
+                if processed_event.get("type") in ("metadata", "metadata_summary"):
                     event_data = processed_event.get("data", {})
                     if "usage" in event_data:
                         accumulated_metadata["usage"].update(event_data["usage"])
@@ -1336,8 +1351,11 @@ async def process_agent_stream(
                 # Check one more time for metadata in case result came with complete
                 metadata_events_after_complete = _handle_metadata_events(event)
                 for processed_event in metadata_events_after_complete:
-                    # Accumulate metadata for summary
-                    if processed_event.get("type") == "metadata":
+                    # Accumulate metadata for summary — see note on the main
+                    # loop's accumulator above. Both `metadata` (per-call)
+                    # and `metadata_summary` (turn-cumulative from result)
+                    # feed accumulated_metadata so the final emit is total.
+                    if processed_event.get("type") in ("metadata", "metadata_summary"):
                         event_data = processed_event.get("data", {})
                         if "usage" in event_data:
                             accumulated_metadata["usage"].update(event_data["usage"])

--- a/backend/src/apis/app_api/messages/models.py
+++ b/backend/src/apis/app_api/messages/models.py
@@ -31,11 +31,22 @@ class MessageContent(BaseModel):
 
 
 class LatencyMetrics(BaseModel):
-    """Latency measurements in milliseconds"""
+    """Latency measurements in milliseconds.
+
+    ``time_to_first_token`` is ``None`` when the provider did not emit
+    ``timeToFirstByteMs`` and we couldn't compute it locally — distinct from
+    a measured value of 0ms (which is physically impossible). Aggregations
+    over TTFT must filter ``None`` so a missing measurement doesn't pull
+    averages toward zero.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    time_to_first_token: int = Field(..., alias="timeToFirstToken", description="Time from request start to first token received (ms)")
+    time_to_first_token: Optional[int] = Field(
+        None,
+        alias="timeToFirstToken",
+        description="Time from request start to first token (ms); None if not measured",
+    )
     end_to_end_latency: int = Field(..., alias="endToEndLatency", description="Total time from request start to completion (ms)")
 
 

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -332,11 +332,22 @@ class MessageContent(BaseModel):
 
 
 class LatencyMetrics(BaseModel):
-    """Latency measurements in milliseconds"""
+    """Latency measurements in milliseconds.
+
+    ``time_to_first_token`` is ``None`` when the provider did not emit
+    ``timeToFirstByteMs`` and we couldn't compute it locally — distinct from
+    a measured value of 0ms (which is physically impossible). Aggregations
+    over TTFT must filter ``None`` so a missing measurement doesn't pull
+    averages toward zero.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    time_to_first_token: int = Field(..., alias="timeToFirstToken", description="Time from request start to first token received (ms)")
+    time_to_first_token: Optional[int] = Field(
+        None,
+        alias="timeToFirstToken",
+        description="Time from request start to first token (ms); None if not measured",
+    )
     end_to_end_latency: int = Field(..., alias="endToEndLatency", description="Total time from request start to completion (ms)")
 
 

--- a/backend/tests/agents/main_agent/streaming/test_per_message_cost_attribution.py
+++ b/backend/tests/agents/main_agent/streaming/test_per_message_cost_attribution.py
@@ -1,0 +1,310 @@
+"""Regression test for per-message cost attribution on multi-LLM-call turns.
+
+Strands emits two sources of usage during a tool-use turn:
+  1. Per-LLM-call metadata via ``ModelStreamChunkEvent`` (one per assistant
+     message), carrying just that call's tokens.
+  2. A final ``AgentResultEvent`` whose ``AgentResult.metrics`` is an
+     ``EventLoopMetrics`` with ``accumulated_usage`` summed across every call
+     in the turn.
+
+``stream_processor._handle_metadata_events`` extracts both. The stream
+coordinator routes any ``metadata`` event into
+``per_message_metadata[current_assistant_message_index]["usage"].update(...)``.
+Because the AgentResult event arrives *after* every ``message_stop`` (so the
+index still points at the last assistant message), a naive ``.update()`` on
+the same key overwrites the last message's per-call usage with the
+turn-cumulative usage. Pricing each per-message entry and summing then
+double-counts every earlier message's input tokens.
+
+This module locks the contract:
+  - The per-call metadata events stay typed ``metadata`` (per-message track).
+  - The result-extracted cumulative metadata is typed ``metadata_summary``
+    (turn-summary track), so it never lands in per_message_metadata.
+
+If the contract regresses, simulating the dispatch loop will reproduce the
+double-count and these assertions will fail.
+"""
+
+from typing import Any, Dict, List
+
+from agents.main_agent.streaming.stream_processor import _handle_metadata_events
+
+
+# Realistic per-call metadata chunk shape: Bedrock's `metadata` chunk wrapped
+# inside Strands' ModelStreamChunkEvent (`{"event": chunk}`).
+def _per_call_metadata_event(usage: Dict[str, int]) -> Dict[str, Any]:
+    return {"event": {"metadata": {"usage": usage, "metrics": {"latencyMs": 100}}}}
+
+
+# Realistic AgentResultEvent shape. EventLoopMetrics has accumulated_usage
+# summed across all calls; _handle_metadata_events extracts it via __dict__.
+class _FakeEventLoopMetrics:
+    def __init__(self, accumulated_usage: Dict[str, int]) -> None:
+        self.accumulated_usage = accumulated_usage
+        self.accumulated_metrics = {"latencyMs": 250}
+
+
+class _FakeAgentResult:
+    def __init__(self, accumulated_usage: Dict[str, int]) -> None:
+        self.metrics = _FakeEventLoopMetrics(accumulated_usage)
+
+
+def _agent_result_event(accumulated_usage: Dict[str, int]) -> Dict[str, Any]:
+    return {"result": _FakeAgentResult(accumulated_usage)}
+
+
+def _dispatch_to_per_message(
+    processed_events: List[Dict[str, Any]],
+    per_message_metadata: List[Dict[str, Any]],
+    current_index: int,
+) -> None:
+    """Mimic stream_coordinator's per-message routing for a single source event.
+
+    Only ``metadata`` events flow into ``per_message_metadata`` — the
+    ``metadata_summary`` track is for the turn-level accumulator and is
+    intentionally not routed here.
+    """
+    for processed in processed_events:
+        if processed.get("type") != "metadata":
+            continue
+        usage = processed.get("data", {}).get("usage")
+        if not usage:
+            continue
+        per_message_metadata[current_index]["usage"].update(usage)
+
+
+class TestPerMessageAttributionTwoCallTurn:
+    """Reproduce the dispatch sequence of a 2-call tool-use turn."""
+
+    CALL_0_USAGE = {"inputTokens": 1000, "outputTokens": 50, "totalTokens": 1050}
+    CALL_1_USAGE = {"inputTokens": 1300, "outputTokens": 80, "totalTokens": 1380}
+    TURN_CUMULATIVE = {
+        "inputTokens": CALL_0_USAGE["inputTokens"] + CALL_1_USAGE["inputTokens"],
+        "outputTokens": CALL_0_USAGE["outputTokens"] + CALL_1_USAGE["outputTokens"],
+        "totalTokens": CALL_0_USAGE["totalTokens"] + CALL_1_USAGE["totalTokens"],
+    }
+
+    def test_per_call_metadata_routes_to_per_message_track(self):
+        """Each per-call metadata event carries one message's tokens, no more."""
+        events = _handle_metadata_events(_per_call_metadata_event(self.CALL_0_USAGE))
+        metadata_events = [e for e in events if e["type"] == "metadata"]
+        assert len(metadata_events) == 1
+        assert metadata_events[0]["data"]["usage"] == self.CALL_0_USAGE
+
+    def test_result_cumulative_does_not_route_to_per_message_track(self):
+        """The AgentResult cumulative must not be a `metadata` event.
+
+        If it is, the dispatch loop overwrites the last per-message entry
+        with cumulative usage, double-counting earlier messages' input
+        tokens at pricing time.
+        """
+        events = _handle_metadata_events(_agent_result_event(self.TURN_CUMULATIVE))
+        per_message_typed = [e for e in events if e["type"] == "metadata"]
+        assert per_message_typed == [], (
+            "AgentResult cumulative usage was emitted as a `metadata` event; "
+            "it would clobber the last per-message entry. Expected "
+            "`metadata_summary` so it stays on the turn-summary track only."
+        )
+
+    def test_result_cumulative_emitted_on_summary_track(self):
+        """Result-extracted cumulative is still emitted — just on metadata_summary."""
+        events = _handle_metadata_events(_agent_result_event(self.TURN_CUMULATIVE))
+        summary_events = [e for e in events if e["type"] == "metadata_summary"]
+        assert len(summary_events) == 1
+        assert summary_events[0]["data"]["usage"] == self.TURN_CUMULATIVE
+
+    def test_full_turn_dispatch_preserves_per_call_attribution(self):
+        """Drive the full event sequence and assert no double-counting."""
+        per_message_metadata = [
+            {"usage": {}, "metrics": {}},
+            {"usage": {}, "metrics": {}},
+        ]
+
+        # Message 0's per-call metadata fires while index = 0.
+        _dispatch_to_per_message(
+            _handle_metadata_events(_per_call_metadata_event(self.CALL_0_USAGE)),
+            per_message_metadata,
+            current_index=0,
+        )
+        # Message 1's per-call metadata fires while index = 1.
+        _dispatch_to_per_message(
+            _handle_metadata_events(_per_call_metadata_event(self.CALL_1_USAGE)),
+            per_message_metadata,
+            current_index=1,
+        )
+        # AgentResult cumulative fires last, with index still at 1. If this
+        # leaks onto the `metadata` track, msg 1's usage gets clobbered with
+        # the turn cumulative — input tokens for msg 0 would be summed twice
+        # when pricing each entry independently.
+        _dispatch_to_per_message(
+            _handle_metadata_events(_agent_result_event(self.TURN_CUMULATIVE)),
+            per_message_metadata,
+            current_index=1,
+        )
+
+        assert per_message_metadata[0]["usage"] == self.CALL_0_USAGE
+        assert per_message_metadata[1]["usage"] == self.CALL_1_USAGE
+
+        # Pricing each entry independently must equal the cumulative input,
+        # not 2× msg 0's input + msg 1's input.
+        summed_input = (
+            per_message_metadata[0]["usage"]["inputTokens"]
+            + per_message_metadata[1]["usage"]["inputTokens"]
+        )
+        assert summed_input == self.TURN_CUMULATIVE["inputTokens"]
+
+
+class TestSummaryAccumulatorAcceptsBothTracks:
+    """The stream_processor main loop must keep `accumulated_metadata` cumulative.
+
+    Per-call events accumulate via ``.update()`` (last-write-wins), so before
+    the cumulative arrives the accumulator only holds the last call's usage —
+    which is *not* cumulative. The accumulator must therefore consume both
+    `metadata` and `metadata_summary` events for the final summary emission
+    to carry true turn totals.
+    """
+
+    def test_accumulator_processes_both_tracks(self):
+        """Walk the same sequence the main loop does and check the final state."""
+        accumulated: Dict[str, Any] = {"usage": {}, "metrics": {}}
+
+        sequence = [
+            _per_call_metadata_event(TestPerMessageAttributionTwoCallTurn.CALL_0_USAGE),
+            _per_call_metadata_event(TestPerMessageAttributionTwoCallTurn.CALL_1_USAGE),
+            _agent_result_event(TestPerMessageAttributionTwoCallTurn.TURN_CUMULATIVE),
+        ]
+
+        for raw in sequence:
+            for processed in _handle_metadata_events(raw):
+                if processed.get("type") in ("metadata", "metadata_summary"):
+                    data = processed.get("data", {})
+                    if "usage" in data:
+                        accumulated["usage"].update(data["usage"])
+                    if "metrics" in data:
+                        accumulated["metrics"].update(data["metrics"])
+
+        assert accumulated["usage"] == TestPerMessageAttributionTwoCallTurn.TURN_CUMULATIVE
+
+
+class TestStreamCoordinatorContextOccupancy:
+    """The final SSE `usage` field must reflect current context, not sums.
+
+    Bedrock reports each LLM call's `inputTokens` as the FULL context size
+    sent on that call. For a 2-call tool turn:
+        call_1.input  = 1000  (system + user_msg)
+        call_2.input  = 2500  (system + user_msg + tool_use + tool_result)
+
+    Strands' EventLoopMetrics.accumulated_usage sums these into 3500 — but
+    the actual context occupancy is 2500, the size of the most recent call.
+    The frontend uses the SSE metadata `usage` to drive the context-%
+    badge, and the backend uses it to decide whether to trigger
+    compaction; both need "current context size", not the cross-call sum.
+
+    This locks in the contract that stream_coordinator's accumulated_metadata
+    (which feeds the final SSE metadata) takes per-call values via
+    last-write-wins from `metadata` events and IGNORES the cross-call
+    cumulative carried on `metadata_summary`.
+    """
+
+    CALL_0_USAGE = {"inputTokens": 1000, "outputTokens": 50, "totalTokens": 1050}
+    CALL_1_USAGE = {"inputTokens": 2500, "outputTokens": 100, "totalTokens": 2600}
+    TURN_CUMULATIVE = {
+        "inputTokens": 3500,   # 1000 + 2500 — Strands' accumulated_usage
+        "outputTokens": 150,
+        "totalTokens": 3650,
+    }
+
+    def _simulate_stream_coordinator_accumulator(
+        self, events: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Mirror stream_coordinator's accumulator branches for a sequence of
+        already-processed events. Returns the resulting accumulated_metadata.
+
+        - `metadata` events → update accumulated_metadata.usage/metrics.
+        - `metadata_summary` events → first_token_time only; usage/metrics ignored.
+        """
+        accumulated: Dict[str, Any] = {"usage": {}, "metrics": {}}
+        for processed in events:
+            event_type = processed.get("type")
+            event_data = processed.get("data", {})
+            if event_type == "metadata":
+                if "usage" in event_data:
+                    accumulated["usage"].update(event_data["usage"])
+                if "metrics" in event_data:
+                    accumulated["metrics"].update(event_data["metrics"])
+            # metadata_summary intentionally does NOT touch usage/metrics here
+        return accumulated
+
+    def test_final_usage_reflects_last_call_not_sum(self):
+        """End of a 2-call tool turn — usage should be call_2's, not the sum."""
+        # Drive the realistic event order through _handle_metadata_events
+        # exactly as stream_processor would, then through the coordinator's
+        # accumulator branches.
+        raw_events = [
+            _per_call_metadata_event(self.CALL_0_USAGE),
+            _per_call_metadata_event(self.CALL_1_USAGE),
+            _agent_result_event(self.TURN_CUMULATIVE),
+        ]
+        processed: List[Dict[str, Any]] = []
+        for raw in raw_events:
+            processed.extend(_handle_metadata_events(raw))
+
+        result = self._simulate_stream_coordinator_accumulator(processed)
+
+        assert result["usage"] == self.CALL_1_USAGE, (
+            "Final accumulated usage must equal the last per-call's full input "
+            "(current context size), not Strands' summed-across-calls value. "
+            "If this regresses, the context-% badge and compaction trigger "
+            "will inflate by ~the size of every prior call in the turn."
+        )
+
+    def test_compaction_input_tokens_match_current_context(self):
+        """The trigger threshold computation in stream_coordinator uses
+        `usage.inputTokens + cacheReadInputTokens + cacheWriteInputTokens`."""
+        call_with_cache = {
+            "inputTokens": 200,
+            "outputTokens": 80,
+            "totalTokens": 280,
+            "cacheReadInputTokens": 2000,
+            "cacheWriteInputTokens": 300,
+        }
+        prior_call = {
+            "inputTokens": 100,
+            "outputTokens": 40,
+            "totalTokens": 140,
+            "cacheReadInputTokens": 0,
+            "cacheWriteInputTokens": 800,
+        }
+        cumulative_after_two_calls = {
+            "inputTokens": 300,            # would be summed by Strands
+            "outputTokens": 120,
+            "totalTokens": 420,
+            "cacheReadInputTokens": 2000,
+            "cacheWriteInputTokens": 1100, # would be summed by Strands
+        }
+
+        raw_events = [
+            _per_call_metadata_event(prior_call),
+            _per_call_metadata_event(call_with_cache),
+            _agent_result_event(cumulative_after_two_calls),
+        ]
+        processed: List[Dict[str, Any]] = []
+        for raw in raw_events:
+            processed.extend(_handle_metadata_events(raw))
+
+        result = self._simulate_stream_coordinator_accumulator(processed)
+        usage = result["usage"]
+
+        # Compaction sums all three input buckets — must equal call_with_cache's
+        # totals (current context), not the summed-across-calls totals.
+        compaction_input = (
+            usage.get("inputTokens", 0)
+            + usage.get("cacheReadInputTokens", 0)
+            + usage.get("cacheWriteInputTokens", 0)
+        )
+        expected_current_context = (
+            call_with_cache["inputTokens"]
+            + call_with_cache["cacheReadInputTokens"]
+            + call_with_cache["cacheWriteInputTokens"]
+        )
+        assert compaction_input == expected_current_context

--- a/backend/tests/agents/main_agent/streaming/test_stream_processor.py
+++ b/backend/tests/agents/main_agent/streaming/test_stream_processor.py
@@ -608,7 +608,13 @@ class TestHandleMetadataEvents:
         assert _handle_metadata_events({}) == []
 
     def test_result_with_accumulated_usage(self):
-        """result.metrics.accumulated_usage produces a metadata event."""
+        """result.metrics.accumulated_usage rides the metadata_summary track.
+
+        It must NOT be emitted as a `metadata` event — those land in
+        per_message_metadata in the stream coordinator and would clobber
+        the last assistant message's per-call usage with a turn-cumulative
+        value, double-counting earlier messages at pricing time.
+        """
         raw = {
             "result": {
                 "metrics": {
@@ -621,9 +627,11 @@ class TestHandleMetadataEvents:
             }
         }
         events = _handle_metadata_events(raw)
-        m = [e for e in events if e["type"] == "metadata"]
-        assert len(m) >= 1
-        assert m[0]["data"]["usage"]["inputTokens"] == 500
+        per_message_typed = [e for e in events if e["type"] == "metadata"]
+        summary_typed = [e for e in events if e["type"] == "metadata_summary"]
+        assert per_message_typed == []
+        assert len(summary_typed) == 1
+        assert summary_typed[0]["data"]["usage"]["inputTokens"] == 500
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/costs/test_calculator.py
+++ b/backend/tests/costs/test_calculator.py
@@ -1,0 +1,282 @@
+"""Unit tests for CostCalculator — the source-of-truth for all USD math.
+
+These tests pin the per-bucket pricing formula, the cache-savings derivation,
+and the input-validation predicates. The aggregator and storage tests cover
+this code transitively, but only through mocks; this module is the only
+place the math itself is asserted directly.
+
+Conventions for cases:
+  - "Sonnet 4.5 pricing" reflects Bedrock's published rates so a regression
+    in the formula would be visible in dollar terms a reader can sanity-check.
+  - Floats are compared with ``pytest.approx`` to avoid 1e-15 drift.
+"""
+
+import pytest
+
+from apis.shared.costs.calculator import CostCalculator
+from apis.shared.costs.models import CostBreakdown
+
+
+# Bedrock rates for Claude Sonnet 4.5 ($/Mtok). Used as the "realistic"
+# baseline so dollar amounts in tests can be compared to a published source.
+SONNET_45_PRICING = {
+    "inputPricePerMtok": 3.0,
+    "outputPricePerMtok": 15.0,
+    "cacheWritePricePerMtok": 3.75,
+    "cacheReadPricePerMtok": 0.30,
+}
+
+
+class TestCalculateMessageCostBasic:
+    """Core formula: per-bucket pricing summed into total."""
+
+    def test_input_only(self):
+        usage = {"inputTokens": 1_000_000, "outputTokens": 0}
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        assert total == pytest.approx(3.0)
+        assert breakdown.input_cost == pytest.approx(3.0)
+        assert breakdown.output_cost == 0.0
+        assert breakdown.cache_read_cost == 0.0
+        assert breakdown.cache_write_cost == 0.0
+
+    def test_output_only(self):
+        usage = {"inputTokens": 0, "outputTokens": 1_000_000}
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        assert total == pytest.approx(15.0)
+        assert breakdown.output_cost == pytest.approx(15.0)
+        assert breakdown.input_cost == 0.0
+
+    def test_input_and_output_no_cache(self):
+        """Realistic short turn: 1k input + 500 output on Sonnet 4.5."""
+        usage = {"inputTokens": 1_000, "outputTokens": 500}
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        # 1000/1M * 3.00 + 500/1M * 15.00 = 0.003 + 0.0075 = 0.0105
+        assert total == pytest.approx(0.0105)
+        assert breakdown.input_cost == pytest.approx(0.003)
+        assert breakdown.output_cost == pytest.approx(0.0075)
+
+    def test_breakdown_components_sum_to_total(self):
+        """The total in the breakdown must equal the sum of its parts."""
+        usage = {
+            "inputTokens": 1_234,
+            "outputTokens": 567,
+            "cacheReadInputTokens": 8_910,
+            "cacheWriteInputTokens": 2_345,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        component_sum = (
+            breakdown.input_cost
+            + breakdown.output_cost
+            + breakdown.cache_read_cost
+            + breakdown.cache_write_cost
+        )
+        assert breakdown.total_cost == pytest.approx(component_sum)
+        assert total == pytest.approx(component_sum)
+
+
+class TestCalculateMessageCostWithCache:
+    """Cache buckets price separately and add to the total."""
+
+    def test_cache_read_only(self):
+        """A subsequent turn hitting the prompt cache."""
+        usage = {
+            "inputTokens": 100,            # uncached suffix
+            "outputTokens": 200,
+            "cacheReadInputTokens": 5_000, # cached prefix
+            "cacheWriteInputTokens": 0,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        # input: 100/1M * 3 = 0.0003
+        # output: 200/1M * 15 = 0.003
+        # cache_read: 5000/1M * 0.30 = 0.0015
+        assert breakdown.input_cost == pytest.approx(0.0003)
+        assert breakdown.output_cost == pytest.approx(0.003)
+        assert breakdown.cache_read_cost == pytest.approx(0.0015)
+        assert breakdown.cache_write_cost == 0.0
+        assert total == pytest.approx(0.0048)
+
+    def test_cache_write_only(self):
+        """The first turn that establishes the cache pays the write premium."""
+        usage = {
+            "inputTokens": 0,
+            "outputTokens": 100,
+            "cacheReadInputTokens": 0,
+            "cacheWriteInputTokens": 5_000,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        # cache_write: 5000/1M * 3.75 = 0.01875
+        # output: 100/1M * 15 = 0.0015
+        assert breakdown.cache_write_cost == pytest.approx(0.01875)
+        assert breakdown.output_cost == pytest.approx(0.0015)
+        assert breakdown.cache_read_cost == 0.0
+        assert total == pytest.approx(0.02025)
+
+    def test_cache_read_and_write_mixed(self):
+        """A turn that hits part of the cache and writes a new section."""
+        usage = {
+            "inputTokens": 200,
+            "outputTokens": 300,
+            "cacheReadInputTokens": 10_000,
+            "cacheWriteInputTokens": 2_000,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        assert breakdown.input_cost == pytest.approx(200 / 1_000_000 * 3.0)
+        assert breakdown.output_cost == pytest.approx(300 / 1_000_000 * 15.0)
+        assert breakdown.cache_read_cost == pytest.approx(10_000 / 1_000_000 * 0.30)
+        assert breakdown.cache_write_cost == pytest.approx(2_000 / 1_000_000 * 3.75)
+        assert total == pytest.approx(
+            breakdown.input_cost
+            + breakdown.output_cost
+            + breakdown.cache_read_cost
+            + breakdown.cache_write_cost
+        )
+
+    def test_docstring_example_holds(self):
+        """The docstring example must match the implementation."""
+        usage = {
+            "inputTokens": 1_000,
+            "outputTokens": 500,
+            "cacheReadInputTokens": 200,
+            "cacheWriteInputTokens": 100,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        assert breakdown.input_cost == pytest.approx(0.003)
+        assert breakdown.output_cost == pytest.approx(0.0075)
+        assert breakdown.cache_read_cost == pytest.approx(0.00006)
+        assert breakdown.cache_write_cost == pytest.approx(0.000375)
+        assert total == pytest.approx(0.010935)
+
+
+class TestCalculateMessageCostDefensive:
+    """Missing or None fields should degrade to 0, never raise."""
+
+    def test_missing_pricing_fields_default_to_zero(self):
+        """Cache prices may be absent for non-Bedrock providers."""
+        pricing = {"inputPricePerMtok": 1.0, "outputPricePerMtok": 2.0}
+        usage = {
+            "inputTokens": 1_000_000,
+            "outputTokens": 1_000_000,
+            "cacheReadInputTokens": 1_000_000,
+            "cacheWriteInputTokens": 1_000_000,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, pricing)
+        assert breakdown.input_cost == pytest.approx(1.0)
+        assert breakdown.output_cost == pytest.approx(2.0)
+        assert breakdown.cache_read_cost == 0.0
+        assert breakdown.cache_write_cost == 0.0
+        assert total == pytest.approx(3.0)
+
+    def test_none_pricing_values_default_to_zero(self):
+        """A managed-model row with explicit None for cache prices must not raise."""
+        pricing = {
+            "inputPricePerMtok": 3.0,
+            "outputPricePerMtok": 15.0,
+            "cacheReadPricePerMtok": None,
+            "cacheWritePricePerMtok": None,
+        }
+        usage = {
+            "inputTokens": 1_000,
+            "outputTokens": 500,
+            "cacheReadInputTokens": 1_000,
+            "cacheWriteInputTokens": 1_000,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, pricing)
+        assert breakdown.cache_read_cost == 0.0
+        assert breakdown.cache_write_cost == 0.0
+
+    def test_none_usage_values_default_to_zero(self):
+        usage = {
+            "inputTokens": None,
+            "outputTokens": None,
+            "cacheReadInputTokens": None,
+            "cacheWriteInputTokens": None,
+        }
+        total, breakdown = CostCalculator.calculate_message_cost(usage, SONNET_45_PRICING)
+        assert total == 0.0
+        assert breakdown.input_cost == 0.0
+        assert breakdown.output_cost == 0.0
+        assert breakdown.cache_read_cost == 0.0
+        assert breakdown.cache_write_cost == 0.0
+
+    def test_empty_usage_and_pricing(self):
+        total, breakdown = CostCalculator.calculate_message_cost({}, {})
+        assert total == 0.0
+        assert isinstance(breakdown, CostBreakdown)
+
+
+class TestCalculateCacheSavings:
+    """Cache savings = (input_price - cache_read_price) * read_tokens / 1M."""
+
+    def test_typical_savings(self):
+        """200 read tokens at Sonnet 4.5 rates."""
+        savings = CostCalculator.calculate_cache_savings(200, 3.0, 0.30)
+        # standard: 200/1M * 3 = 0.0006; cached: 200/1M * 0.30 = 0.00006
+        assert savings == pytest.approx(0.00054)
+
+    def test_zero_reads_returns_zero(self):
+        assert CostCalculator.calculate_cache_savings(0, 3.0, 0.30) == 0.0
+
+    def test_none_reads_returns_zero(self):
+        """``None`` is the realistic shape from a model that didn't hit cache."""
+        assert CostCalculator.calculate_cache_savings(None, 3.0, 0.30) == 0.0
+
+    def test_none_prices_default_to_zero(self):
+        """None prices must not raise — the formula collapses cleanly to 0."""
+        assert CostCalculator.calculate_cache_savings(1_000, None, None) == 0.0
+
+    def test_savings_equals_full_input_cost_when_cache_is_free(self):
+        """If cache reads are priced at 0, savings is the full input cost."""
+        savings = CostCalculator.calculate_cache_savings(1_000_000, 3.0, 0.0)
+        assert savings == pytest.approx(3.0)
+
+
+class TestValidatePricing:
+    """validate_pricing requires inputPricePerMtok and outputPricePerMtok with non-None values."""
+
+    def test_complete_pricing_is_valid(self):
+        assert CostCalculator.validate_pricing(SONNET_45_PRICING) is True
+
+    def test_minimal_pricing_is_valid(self):
+        """Cache fields are not required."""
+        assert CostCalculator.validate_pricing({
+            "inputPricePerMtok": 1.0,
+            "outputPricePerMtok": 2.0,
+        }) is True
+
+    def test_missing_input_price_is_invalid(self):
+        assert CostCalculator.validate_pricing({"outputPricePerMtok": 2.0}) is False
+
+    def test_missing_output_price_is_invalid(self):
+        assert CostCalculator.validate_pricing({"inputPricePerMtok": 1.0}) is False
+
+    def test_none_value_is_invalid(self):
+        assert CostCalculator.validate_pricing({
+            "inputPricePerMtok": None,
+            "outputPricePerMtok": 2.0,
+        }) is False
+
+
+class TestValidateUsage:
+    """validate_usage requires inputTokens and outputTokens with non-None values."""
+
+    def test_complete_usage_is_valid(self):
+        assert CostCalculator.validate_usage({
+            "inputTokens": 100,
+            "outputTokens": 50,
+        }) is True
+
+    def test_zero_values_are_valid(self):
+        """Zero is a real measurement, not an absence."""
+        assert CostCalculator.validate_usage({
+            "inputTokens": 0,
+            "outputTokens": 0,
+        }) is True
+
+    def test_missing_input_tokens_is_invalid(self):
+        assert CostCalculator.validate_usage({"outputTokens": 50}) is False
+
+    def test_none_value_is_invalid(self):
+        assert CostCalculator.validate_usage({
+            "inputTokens": None,
+            "outputTokens": 50,
+        }) is False

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
@@ -17,7 +17,11 @@ interface CostBreakdown {
 
 interface MessageMetadata {
     latency?: {
-        timeToFirstToken?: number;
+        // null = not measured (provider didn't emit timeToFirstByteMs and
+        // we couldn't compute it locally). Distinct from 0, which is
+        // physically impossible — keep them separate so any future
+        // analytics can filter unmeasured samples cleanly.
+        timeToFirstToken?: number | null;
         endToEndLatency?: number;
     };
     tokenUsage?: {

--- a/frontend/ai.client/src/app/session/components/session-cost-badge/session-cost-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/session-cost-badge/session-cost-badge.component.ts
@@ -119,7 +119,7 @@ const RING_FILL_DELAY_MS = 750;
                 {{ tokensTotalLabel() }} tokens
               </span>
               <span class="mt-2 block text-[11px] leading-snug text-gray-500 dark:text-gray-400">
-                Includes system prompt and tool definitions.
+                Reflects the most recent turn (includes system prompt and tool definitions). May shrink after a context compaction.
               </span>
             </span>
           </span>
@@ -246,6 +246,6 @@ export class SessionCostBadgeComponent {
   protected readonly contextAriaLabel = computed(() => {
     const tokens = this.contextTokens().toLocaleString();
     const window = this.contextWindow().toLocaleString();
-    return `Context window: ${this.contextLabel()} used (${tokens} of ${window} tokens, includes system prompt and tools)`;
+    return `Context window: ${this.contextLabel()} used by the most recent turn (${tokens} of ${window} tokens, includes system prompt and tools)`;
   });
 }

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -805,7 +805,7 @@ export class StreamParserService {
 
     // Check if we need to update
     const existingMetadata = lastMessage.metadata as Record<string, unknown>;
-    const existingLatency = existingMetadata['latency'] as { timeToFirstToken?: number } | undefined;
+    const existingLatency = existingMetadata['latency'] as { timeToFirstToken?: number | null } | undefined;
     const existingTTFT = existingLatency?.timeToFirstToken;
     const existingCost = existingMetadata['cost'] as number | undefined;
     const existingTokenUsage = existingMetadata['tokenUsage'] as {
@@ -813,7 +813,7 @@ export class StreamParserService {
       cacheWriteInputTokens?: number;
     } | undefined;
 
-    const newLatency = newMetadata['latency'] as { timeToFirstToken?: number } | undefined;
+    const newLatency = newMetadata['latency'] as { timeToFirstToken?: number | null } | undefined;
     const newTTFT = newLatency?.timeToFirstToken;
     const newCost = newMetadata['cost'] as number | undefined;
     const newTokenUsage = newMetadata['tokenUsage'] as {
@@ -901,8 +901,11 @@ export class StreamParserService {
     }
 
     if (metadataEvent.metrics) {
+      // Preserve `null` for unmeasured TTFT instead of coercing to 0 — a
+      // real time-to-first-token can never be 0ms, and the badge below
+      // already hides itself for null/undefined/0 via a truthy check.
       result['latency'] = {
-        timeToFirstToken: metadataEvent.metrics.timeToFirstByteMs ?? 0,
+        timeToFirstToken: metadataEvent.metrics.timeToFirstByteMs ?? null,
         endToEndLatency: metadataEvent.metrics.latencyMs,
       };
     }


### PR DESCRIPTION
## Summary

Audit of token accounting and context-window tracking surfaced two bugs that inflate cost and context-% reporting on tool-use turns. Both fixes ride on the same Strands event-routing change.

- **Per-message cost double-count** on tool turns. Strands' `AgentResultEvent.metrics.accumulated_usage` is summed across every LLM call in the turn. It was being routed onto the per-message `metadata` track and overwriting the last assistant message's per-call usage via `dict.update()` — pricing each entry and summing then double-counted every earlier message's input tokens.
- **Context-% inflation** within a tool turn. Bedrock reports each call's `inputTokens` as the FULL context size sent on that call. For a 2-call tool turn (call_1=1000, call_2=2500), Strands' `accumulated_usage` reports 3500 — but actual current context is 2500. The final SSE `usage` field (driving the badge and the compaction trigger) was inheriting the inflated value.

Also folded into this PR: TTFT placeholder of `0` → `null` (a real time-to-first-token can never be 0ms; aggregations need to distinguish absence from a real value), tooltip clarifies "most recent turn", and a new direct unit-test file for `CostCalculator` math (was only tested transitively through mocks before).

## Approach

- **Bug #1** — re-route the result-extracted cumulative onto the existing `metadata_summary` (turn-summary) track instead of `metadata`. Stream processor's main loop now consumes both event types into `accumulated_metadata` so the final summary still carries true totals.
- **Bug #2** — stream coordinator no longer accumulates `metadata_summary` into its `accumulated_metadata`. Per-call `metadata` events last-write-wins via `.update()`, so the final SSE `usage` equals the most recent call's full input = current context size.
- A `CAUTION` block at the compaction-input computation explains why we don't use `AgentResult.context_size` / `EventLoopMetrics.latest_context_size` — both return only `inputTokens` (uncached suffix only) and would under-report by 99%+ under prompt caching.

## Test plan

- [x] `pytest tests/agents/main_agent/streaming/` — 118 pass (5 new cases)
- [x] `pytest tests/costs/` — 26 new `CostCalculator` cases pass
- [x] `pytest tests/routes/test_converse_cost_accounting.py` — passes
- [x] Frontend `tsc --noEmit` — clean
- [x] Full `pytest tests/` — only 76 unrelated `test_oauth_repositories.py` failures (pre-existing test-isolation bug; passes 10/10 in isolation)
- [ ] **Manual UI verification:**
  1. Send a single-turn message — TTFT badge renders with non-zero ms.
  2. Open a session with older messages that previously showed "TTFT: 0ms" — badge now hidden for those.
  3. **Most important:** Send a tool-using turn (e.g., web search). Open DevTools → Network → SSE response → final `metadata` event. `cost.total` should be lower than before for tool turns; `usage.inputTokens` should reflect the most recent call's input, not summed-across-calls.
  4. Hover the context-% ring above the composer — tooltip reads "Reflects the most recent turn ... May shrink after a context compaction."
  5. Send a no-tool turn — cost badge unchanged from prior behavior.
  6. Multi-tool turn vs. single-call turn at similar conversation size — context-% should now be roughly comparable, not ~2× inflated for the tool turn.

## Regression tests

`backend/tests/agents/main_agent/streaming/test_per_message_cost_attribution.py` (new):
- `TestPerMessageAttributionTwoCallTurn` — locks the `metadata` vs `metadata_summary` event-type contract. Without the fix, `per_message_metadata[1].usage = (2300, 130, 2430)` instead of expected per-call `(1300, 80, 1380)`.
- `TestStreamCoordinatorContextOccupancy` — pins "current context size" semantic and verifies the all-three-bucket sum (`inputTokens + cacheReadInputTokens + cacheWriteInputTokens`) matches the most recent call.

`backend/tests/costs/test_calculator.py` (new): 26 cases covering per-bucket pricing, cache scenarios, defensive None handling, and validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)