### PR TITLE
fix(auth): dark-mode lava-lamp backdrop on login & first-boot

### DIFF
--- a/frontend/ai.client/src/app/app.config.ts
+++ b/frontend/ai.client/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { errorInterceptor } from './auth/error.interceptor';
 import { withCredentialsInterceptor } from './auth/with-credentials.interceptor';
 import { MARKED_OPTIONS, MarkedOptions, MarkedRenderer, provideMarkdown } from 'ngx-markdown';
 import { SessionService } from './auth/session.service';
+import { ThemeService } from './components/topnav/components/theme-toggle/theme.service';
 
 function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -47,5 +48,13 @@ export const appConfig: ApplicationConfig = {
     // the user can pick a provider. Transport errors leave the SPA in a clean
     // unauthenticated state without redirecting.
     provideAppInitializer(() => inject(SessionService).bootstrap()),
+
+    // ThemeService applies the persisted/system theme to <html> in its
+    // constructor. It's providedIn:'root' but only injected by the topnav
+    // and authed pages, so on a cold load to /auth/login or /auth/first-boot
+    // it would never run and the dark-mode CSS on those screens would sit
+    // dormant. Inject it at bootstrap so the lava-lamp backdrop honors the
+    // user's preference (and prefers-color-scheme) on every route.
+    provideAppInitializer(() => { inject(ThemeService); }),
   ]
 };

--- a/frontend/ai.client/src/app/auth/first-boot/first-boot.page.css
+++ b/frontend/ai.client/src/app/auth/first-boot/first-boot.page.css
@@ -15,7 +15,7 @@
     var(--color-gray-50);
 }
 
-html.dark .login-shell {
+:host-context(html.dark) .login-shell {
   background:
     radial-gradient(120% 80% at 0% 0%, color-mix(in oklab, var(--color-primary-900) 50%, black) 0%, transparent 60%),
     radial-gradient(120% 80% at 100% 100%, color-mix(in oklab, var(--color-primary-800) 35%, black) 0%, transparent 55%),
@@ -134,12 +134,12 @@ html.dark .login-shell {
     login-morph-c 9s ease-in-out infinite alternate -2s;
 }
 
-html.dark .login-blob--a { opacity: 0.32; }
-html.dark .login-blob--b { opacity: 0.28; }
-html.dark .login-blob--c { opacity: 0.38; }
-html.dark .login-blob--d { opacity: 0.42; }
-html.dark .login-blob--e { opacity: 0.5; }
-html.dark .login-blob--f { opacity: 0.55; }
+:host-context(html.dark) .login-blob--a { opacity: 0.32; }
+:host-context(html.dark) .login-blob--b { opacity: 0.28; }
+:host-context(html.dark) .login-blob--c { opacity: 0.38; }
+:host-context(html.dark) .login-blob--d { opacity: 0.42; }
+:host-context(html.dark) .login-blob--e { opacity: 0.5; }
+:host-context(html.dark) .login-blob--f { opacity: 0.55; }
 
 .login-grid {
   position: absolute;
@@ -153,7 +153,7 @@ html.dark .login-blob--f { opacity: 0.55; }
   opacity: 0.6;
 }
 
-html.dark .login-grid {
+:host-context(html.dark) .login-grid {
   background-image:
     linear-gradient(to right, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px),
     linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px);
@@ -237,7 +237,7 @@ html.dark .login-grid {
     0 8px 24px -12px rgba(0, 0, 0, 0.15);
 }
 
-html.dark .login-card {
+:host-context(html.dark) .login-card {
   background: color-mix(in oklab, var(--color-gray-900) 55%, transparent);
   border-color: color-mix(in oklab, white 12%, transparent);
   box-shadow:

--- a/frontend/ai.client/src/app/auth/login/login.page.css
+++ b/frontend/ai.client/src/app/auth/login/login.page.css
@@ -10,7 +10,7 @@
     var(--color-gray-50);
 }
 
-html.dark .login-shell {
+:host-context(html.dark) .login-shell {
   background:
     radial-gradient(120% 80% at 0% 0%, color-mix(in oklab, var(--color-primary-900) 50%, black) 0%, transparent 60%),
     radial-gradient(120% 80% at 100% 100%, color-mix(in oklab, var(--color-primary-800) 35%, black) 0%, transparent 55%),
@@ -134,12 +134,12 @@ html.dark .login-shell {
     login-morph-c 9s ease-in-out infinite alternate -2s;
 }
 
-html.dark .login-blob--a { opacity: 0.32; }
-html.dark .login-blob--b { opacity: 0.28; }
-html.dark .login-blob--c { opacity: 0.38; }
-html.dark .login-blob--d { opacity: 0.42; }
-html.dark .login-blob--e { opacity: 0.5; }
-html.dark .login-blob--f { opacity: 0.55; }
+:host-context(html.dark) .login-blob--a { opacity: 0.32; }
+:host-context(html.dark) .login-blob--b { opacity: 0.28; }
+:host-context(html.dark) .login-blob--c { opacity: 0.38; }
+:host-context(html.dark) .login-blob--d { opacity: 0.42; }
+:host-context(html.dark) .login-blob--e { opacity: 0.5; }
+:host-context(html.dark) .login-blob--f { opacity: 0.55; }
 
 .login-grid {
   position: absolute;
@@ -153,7 +153,7 @@ html.dark .login-blob--f { opacity: 0.55; }
   opacity: 0.6;
 }
 
-html.dark .login-grid {
+:host-context(html.dark) .login-grid {
   background-image:
     linear-gradient(to right, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px),
     linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-300) 6%, transparent) 1px, transparent 1px);
@@ -243,7 +243,7 @@ html.dark .login-grid {
     0 8px 24px -12px rgba(0, 0, 0, 0.15);
 }
 
-html.dark .login-card {
+:host-context(html.dark) .login-card {
   background: color-mix(in oklab, var(--color-gray-900) 55%, transparent);
   border-color: color-mix(in oklab, white 12%, transparent);
   box-shadow:
@@ -260,6 +260,6 @@ html.dark .login-card {
   border-radius: 9999px;
 }
 
-html.dark .login-divider-text {
+:host-context(html.dark) .login-divider-text {
   background: color-mix(in oklab, var(--color-gray-900) 70%, transparent);
 }


### PR DESCRIPTION
## Summary
- Auth-page lava-lamp backdrop and frosted-glass card now render correctly in dark mode.
- Two bugs fixed: a CSS-encapsulation mismatch and a missing theme-bootstrap.

## What was broken
The `dark:` Tailwind utilities (text colors, logo swap) flipped fine, but the hand-written canvas/blob/card backgrounds stayed light even with `<html class="dark">`. Two compounding issues:

1. **CSS scoping** — selectors written as `html.dark .login-shell` don't match under Angular's emulated view encapsulation. The rest of the codebase already uses `:host-context(html.dark) .X` for the same purpose; the auth pages just didn't.
2. **Theme not initialized on cold load** — `ThemeService` is `providedIn: 'root'` and applies the `dark` class in its constructor, but nothing in the pre-auth tree injects it. A first-time visit to `/auth/login` or `/auth/first-boot` would never apply the persisted/system preference.

## Changes
- `login.page.css` / `first-boot.page.css` — `html.dark .X` → `:host-context(html.dark) .X` (canvas, 6 blob opacities, grid, card, divider).
- `app.config.ts` — `provideAppInitializer(() => { inject(ThemeService); })` so the theme lands on `<html>` before the first route renders.

## Test plan
- [ ] OS in dark mode + cleared localStorage → `/auth/login` renders with deep-blue/black canvas and dark frosted card; "Sign In" header readable white-on-dark.
- [ ] Settings → Appearance → Light, log out → login screen renders light (white card, light blue canvas).
- [ ] `/auth/first-boot` (fresh-DB env) follows OS dark mode same as login.
- [ ] With `theme-preference = system`, flip OS dark↔light on the login page → page updates without reload.
- [ ] DevTools: with dark active, computed `.login-card` background resolves to the `color-mix(... gray-900 ...)` rule, not the white one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)