### PR TITLE
feat(auth): add SKIP_AUTH=true local-dev bypass with allowlist guard

### DIFF
--- a/.github/workflows/skip-auth-guard.yml
+++ b/.github/workflows/skip-auth-guard.yml
@@ -17,9 +17,9 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Scan for SKIP_AUTH=true in deployable config
         run: |

--- a/.github/workflows/skip-auth-guard.yml
+++ b/.github/workflows/skip-auth-guard.yml
@@ -1,0 +1,49 @@
+name: "Guard: SKIP_AUTH must not appear in deployed config"
+
+# Refuses any PR or push that lets the local-dev SKIP_AUTH=true bypass
+# leak into deployed configuration. The bypass itself is implemented in
+# backend/src/apis/shared/auth/dependencies.py and gated at boot in
+# backend/src/apis/app_api/main.py — both of those legitimately reference
+# the string and are excluded from the scan. Anywhere else is a leak.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for SKIP_AUTH=true in deployable config
+        run: |
+          set -euo pipefail
+          # Look in CDK, GitHub Actions, Dockerfiles, and any task definitions.
+          # Exclude the two files that legitimately reference the variable
+          # (the bypass implementation + its startup guard) and this workflow.
+          # Catches `SKIP_AUTH=true`, `SKIP_AUTH: true`, `SKIP_AUTH: "true"`, etc.
+          # Covers shell, Dockerfile, YAML, and CDK TypeScript object-literal styles.
+          PATTERN='SKIP_AUTH[[:space:]]*[:=][[:space:]]*["'\'']*true'
+          MATCHES=$(grep -RInE "$PATTERN" \
+            infrastructure/lib \
+            infrastructure/bin \
+            scripts \
+            .github/workflows \
+            backend/Dockerfile.app-api \
+            backend/Dockerfile.inference-api \
+            2>/dev/null \
+            | grep -v '^.github/workflows/skip-auth-guard.yml:' \
+            || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::SKIP_AUTH=true is a local-dev bypass and must never appear in deployed config."
+            echo "Found in:"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "OK — no SKIP_AUTH=true in deployable config."

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -69,6 +69,41 @@ AGENTCORE_CODE_INTERPRETER_ID=
 # DEVELOPMENT SETTINGS
 # =============================================================================
 
+# Local-dev auth bypass (OPTIONAL — LOCAL DEV ONLY)
+# Purpose: Skip the Cognito redirect and return a fake admin user from
+# the three auth dependencies (get_current_user,
+# get_current_user_from_session, get_current_user_trusted). Lets an
+# unattended agent or a dev with no IdP access hit protected app-api
+# routes without the OAuth round-trip.
+# Default: unset (auth enforced)
+# Guard rails:
+#   - app-api refuses to boot when SKIP_AUTH=true unless every entry in
+#     CORS_ORIGINS is a localhost URL (localhost, 127.0.0.1, ::1,
+#     0.0.0.0). This is the allowlist that keeps the bypass off
+#     deployed environments.
+#   - A CI workflow (.github/workflows/skip-auth-guard.yml) refuses any
+#     PR that puts SKIP_AUTH=true into Dockerfiles, CDK, scripts, or
+#     other workflows.
+#   - Inference-api is NOT bypassed — SPA traffic flows through app-api
+#     so a single chokepoint suffices.
+# DO NOT enable in any deployed environment.
+SKIP_AUTH=
+
+# Roles to assign the fake user (OPTIONAL — only read when SKIP_AUTH=true)
+# Purpose: Comma-separated list of roles for the bypass user. Drives
+# RBAC filtering (model visibility, admin endpoints, etc.).
+# Default: admin
+# Example: DotNetDevelopers,QA
+SKIP_AUTH_ROLES=admin
+
+# User ID to assign the fake user (OPTIONAL — only read when SKIP_AUTH=true)
+# Default: local-dev
+SKIP_AUTH_USER_ID=local-dev
+
+# Email to assign the fake user (OPTIONAL — only read when SKIP_AUTH=true)
+# Default: dev@local
+SKIP_AUTH_EMAIL=dev@local
+
 # Enable quota enforcement (OPTIONAL)
 # Purpose: Enforce user quota limits on chat requests
 # If true (default), checks user quota before processing each request

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -28,6 +28,40 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Refuse to boot unless SKIP_AUTH is paired with a positive local-dev
+# signal. Allowlist over blocklist: every CORS_ORIGINS entry must be a
+# localhost URL. Any deployed origin (or empty config) trips this — far
+# safer than enumerating every env var a deployed runtime might set, and
+# fails closed for new deploy targets we haven't met yet.
+if os.environ.get("SKIP_AUTH", "").lower() == "true":
+    from urllib.parse import urlparse
+
+    _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+    _skip_auth_origins = [
+        o.strip()
+        for o in os.environ.get("CORS_ORIGINS", "").split(",")
+        if o.strip()
+    ]
+
+    def _is_local_origin(origin: str) -> bool:
+        try:
+            return (urlparse(origin).hostname or "") in _LOCAL_HOSTS
+        except Exception:
+            return False
+
+    if not _skip_auth_origins or not all(
+        _is_local_origin(o) for o in _skip_auth_origins
+    ):
+        raise RuntimeError(
+            "SKIP_AUTH=true requires CORS_ORIGINS to contain only localhost "
+            "origins (localhost, 127.0.0.1, ::1, 0.0.0.0). Refusing to start "
+            "— this bypass is local-dev only."
+        )
+    logger.warning(
+        "SKIP_AUTH=true — auth dependencies will return a fake admin user. "
+        "DO NOT enable this in any deployed environment."
+    )
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -34,25 +34,37 @@ logger = logging.getLogger(__name__)
 # localhost URL. Any deployed origin (or empty config) trips this — far
 # safer than enumerating every env var a deployed runtime might set, and
 # fails closed for new deploy targets we haven't met yet.
-if os.environ.get("SKIP_AUTH", "").lower() == "true":
+#
+# Runs from `lifespan()` rather than at import time so tests that import
+# this module (e.g. tests/routes/test_pbt_auth_sweep.py) don't trip the
+# check on environments where SKIP_AUTH=true is set globally.
+_SKIP_AUTH_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+
+
+def _validate_skip_auth_or_raise() -> None:
+    """Raise RuntimeError if SKIP_AUTH=true is paired with non-local CORS_ORIGINS.
+
+    No-op when SKIP_AUTH is unset/false. When set, every CORS_ORIGINS entry
+    must resolve to a localhost host or boot is refused.
+    """
+    if os.environ.get("SKIP_AUTH", "").lower() != "true":
+        return
+
     from urllib.parse import urlparse
 
-    _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
-    _skip_auth_origins = [
+    origins = [
         o.strip()
         for o in os.environ.get("CORS_ORIGINS", "").split(",")
         if o.strip()
     ]
 
-    def _is_local_origin(origin: str) -> bool:
+    def _is_local(origin: str) -> bool:
         try:
-            return (urlparse(origin).hostname or "") in _LOCAL_HOSTS
+            return (urlparse(origin).hostname or "") in _SKIP_AUTH_LOCAL_HOSTS
         except Exception:
             return False
 
-    if not _skip_auth_origins or not all(
-        _is_local_origin(o) for o in _skip_auth_origins
-    ):
+    if not origins or not all(_is_local(o) for o in origins):
         raise RuntimeError(
             "SKIP_AUTH=true requires CORS_ORIGINS to contain only localhost "
             "origins (localhost, 127.0.0.1, ::1, 0.0.0.0). Refusing to start "
@@ -62,9 +74,12 @@ if os.environ.get("SKIP_AUTH", "").lower() == "true":
         "SKIP_AUTH=true — auth dependencies will return a fake admin user. "
         "DO NOT enable this in any deployed environment."
     )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
+    _validate_skip_auth_or_raise()
     logger.info("=== AgentCore Public Stack API Starting ===")
     logger.info("Agent execution engine initialized")
 

--- a/backend/src/apis/shared/auth/dependencies.py
+++ b/backend/src/apis/shared/auth/dependencies.py
@@ -227,6 +227,29 @@ def _get_bff_cognito_validator():
     return _bff_cognito_validator
 
 
+def _skip_auth_user() -> Optional[User]:
+    """Return a fake admin user when SKIP_AUTH=true, else None.
+
+    Local-dev-only bypass so an unattended agent (or a dev with no IdP
+    access) can hit protected routes without the OAuth round-trip. The
+    startup check in `app_api/main.py` refuses to boot when this is
+    combined with deployed-environment indicators.
+    """
+    if os.environ.get("SKIP_AUTH", "").lower() != "true":
+        return None
+    roles = [
+        r.strip()
+        for r in os.environ.get("SKIP_AUTH_ROLES", "admin").split(",")
+        if r.strip()
+    ]
+    return User(
+        user_id=os.environ.get("SKIP_AUTH_USER_ID", "local-dev"),
+        email=os.environ.get("SKIP_AUTH_EMAIL", "dev@local"),
+        name="Local Dev",
+        roles=roles,
+    )
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)
 ) -> User:
@@ -247,6 +270,9 @@ async def get_current_user(
             - 401 if token is missing or invalid
             - 500 if no JWT validator is available
     """
+    if (fake := _skip_auth_user()) is not None:
+        return fake
+
     # Check if credentials are missing
     if credentials is None:
         raise HTTPException(
@@ -308,6 +334,9 @@ async def get_current_user_from_session(request: Request) -> User:
         HTTPException 401 if no session was resolved by the upstream
         middleware (cookie missing, malformed, or session record gone).
     """
+    if (fake := _skip_auth_user()) is not None:
+        return fake
+
     record = getattr(request.state, "bff_session", None)
     if record is None:
         raise HTTPException(
@@ -394,6 +423,9 @@ async def get_current_user_trusted(
             - 401 if token is missing or malformed
     """
     logger.debug("[get_current_user_trusted] Trusted auth extraction started")
+
+    if (fake := _skip_auth_user()) is not None:
+        return fake
 
     # Check if credentials are missing
     if credentials is None:

--- a/backend/tests/auth/test_skip_auth.py
+++ b/backend/tests/auth/test_skip_auth.py
@@ -1,0 +1,263 @@
+"""Tests for the SKIP_AUTH=true local-dev bypass.
+
+Covers:
+- `_skip_auth_user()` returns None when disabled, fake User when enabled
+- All three auth dependencies bypass when SKIP_AUTH=true
+- `_validate_skip_auth_or_raise()` accepts localhost-only CORS_ORIGINS,
+  rejects empty CORS_ORIGINS, rejects any non-localhost origin
+- The CI-guard regex matches realistic leak strings and skips the
+  legitimate references in dependencies.py / main.py
+"""
+
+import importlib
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from apis.shared.auth.dependencies import (
+    _skip_auth_user,
+    get_current_user,
+    get_current_user_from_session,
+    get_current_user_trusted,
+)
+from apis.shared.auth.models import User
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clean_skip_auth_env(monkeypatch):
+    """Clear all SKIP_AUTH_* env vars so each test starts from a known state."""
+    for key in (
+        "SKIP_AUTH",
+        "SKIP_AUTH_ROLES",
+        "SKIP_AUTH_USER_ID",
+        "SKIP_AUTH_EMAIL",
+        "CORS_ORIGINS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _skip_auth_user
+# ---------------------------------------------------------------------------
+
+
+class TestSkipAuthUser:
+    """Tests for the `_skip_auth_user()` helper."""
+
+    def test_returns_none_when_unset(self, clean_skip_auth_env):
+        assert _skip_auth_user() is None
+
+    @pytest.mark.parametrize("value", ["false", "0", "", "no", "FALSE"])
+    def test_returns_none_when_falsey(self, clean_skip_auth_env, monkeypatch, value):
+        monkeypatch.setenv("SKIP_AUTH", value)
+        assert _skip_auth_user() is None
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "True"])
+    def test_returns_user_when_true(self, clean_skip_auth_env, monkeypatch, value):
+        monkeypatch.setenv("SKIP_AUTH", value)
+        user = _skip_auth_user()
+        assert isinstance(user, User)
+        assert user.user_id == "local-dev"
+        assert user.email == "dev@local"
+        assert user.name == "Local Dev"
+        assert user.roles == ["admin"]
+
+    def test_overrides_via_env(self, clean_skip_auth_env, monkeypatch):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        monkeypatch.setenv("SKIP_AUTH_USER_ID", "phil")
+        monkeypatch.setenv("SKIP_AUTH_EMAIL", "phil@example.com")
+        monkeypatch.setenv("SKIP_AUTH_ROLES", "admin,DotNetDevelopers, ,QA ")
+
+        user = _skip_auth_user()
+        assert user is not None
+        assert user.user_id == "phil"
+        assert user.email == "phil@example.com"
+        # whitespace-only entries filtered, surrounding whitespace stripped
+        assert user.roles == ["admin", "DotNetDevelopers", "QA"]
+
+
+# ---------------------------------------------------------------------------
+# Dependency bypass
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyBypass:
+    """Tests that the bypass short-circuits each auth dependency."""
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_bypassed(self, clean_skip_auth_env, monkeypatch):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        # Patch the validator to assert it's never consulted.
+        with patch(
+            "apis.shared.auth.dependencies._get_cognito_validator"
+        ) as mock_get:
+            user = await get_current_user(credentials=None)
+            assert mock_get.call_count == 0
+        assert user.user_id == "local-dev"
+        assert user.roles == ["admin"]
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_from_session_bypassed(
+        self, clean_skip_auth_env, monkeypatch
+    ):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        # Build a request whose state.bff_session is unset; without the
+        # bypass this would 401, with the bypass we get the fake user.
+        request = MagicMock()
+        request.state = MagicMock(spec=[])  # no bff_session attr
+
+        user = await get_current_user_from_session(request)
+        assert user.user_id == "local-dev"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_trusted_bypassed(
+        self, clean_skip_auth_env, monkeypatch
+    ):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        # No credentials supplied — without the bypass this 401s.
+        user = await get_current_user_trusted(credentials=None)
+        assert user.user_id == "local-dev"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_still_401_when_disabled(
+        self, clean_skip_auth_env
+    ):
+        """Sanity check: with SKIP_AUTH unset, missing credentials still 401."""
+        with pytest.raises(HTTPException) as exc:
+            await get_current_user(credentials=None)
+        assert exc.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Startup guard
+# ---------------------------------------------------------------------------
+
+
+def _import_main_module():
+    """Import (and reload) apis.app_api.main so it picks up current env.
+
+    The module calls `load_dotenv(..., override=True)` at import time,
+    which would clobber monkeypatched env vars on reload. Patch the
+    upstream symbol so the `from dotenv import load_dotenv` re-binding
+    inside the module reload also picks up the no-op.
+    """
+    with patch("dotenv.load_dotenv", lambda *a, **kw: None):
+        import apis.app_api.main as m
+        return importlib.reload(m)
+
+
+class TestStartupGuard:
+    """Tests for `_validate_skip_auth_or_raise()` in app_api/main.py."""
+
+    def test_noop_when_skip_auth_off(self, clean_skip_auth_env):
+        m = _import_main_module()
+        # Doesn't raise even with no CORS_ORIGINS — guard is a no-op.
+        m._validate_skip_auth_or_raise()
+
+    @pytest.mark.parametrize(
+        "origins",
+        [
+            "http://localhost:4200",
+            "http://localhost:4200,http://127.0.0.1:8000",
+            "http://[::1]:4200",
+            "http://0.0.0.0:4200",
+            "http://localhost:4200, http://127.0.0.1:8000 ",  # whitespace tolerated
+        ],
+    )
+    def test_accepts_localhost_origins(
+        self, clean_skip_auth_env, monkeypatch, origins
+    ):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        monkeypatch.setenv("CORS_ORIGINS", origins)
+        m = _import_main_module()
+        m._validate_skip_auth_or_raise()  # no raise
+
+    def test_rejects_empty_cors_origins(self, clean_skip_auth_env, monkeypatch):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        monkeypatch.setenv("CORS_ORIGINS", "")
+        m = _import_main_module()
+        with pytest.raises(RuntimeError, match="localhost"):
+            m._validate_skip_auth_or_raise()
+
+    def test_rejects_unset_cors_origins(self, clean_skip_auth_env, monkeypatch):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        # CORS_ORIGINS deliberately unset
+        m = _import_main_module()
+        with pytest.raises(RuntimeError, match="localhost"):
+            m._validate_skip_auth_or_raise()
+
+    @pytest.mark.parametrize(
+        "origins",
+        [
+            "https://app.example.com",
+            "http://localhost:4200,https://app.example.com",  # one bad apple
+            "https://prod.boisestate.edu",
+        ],
+    )
+    def test_rejects_non_localhost(
+        self, clean_skip_auth_env, monkeypatch, origins
+    ):
+        monkeypatch.setenv("SKIP_AUTH", "true")
+        monkeypatch.setenv("CORS_ORIGINS", origins)
+        m = _import_main_module()
+        with pytest.raises(RuntimeError, match="localhost"):
+            m._validate_skip_auth_or_raise()
+
+
+# ---------------------------------------------------------------------------
+# CI-guard regex
+# ---------------------------------------------------------------------------
+
+
+class TestCIGuardPattern:
+    """Tests that mirror the grep pattern in skip-auth-guard.yml.
+
+    The CI workflow uses `grep -E` with this pattern; we validate the
+    same regex against representative leak strings and the legitimate
+    references in our own source so a future refactor of the workflow
+    has a behavioral spec to test against.
+    """
+
+    # Mirrors the PATTERN in .github/workflows/skip-auth-guard.yml
+    PATTERN = re.compile(r"""SKIP_AUTH[ \t]*[:=][ \t]*["']*true""")
+
+    @pytest.mark.parametrize(
+        "leak",
+        [
+            "SKIP_AUTH=true",
+            'SKIP_AUTH: "true"',
+            "SKIP_AUTH: true",
+            "SKIP_AUTH:true",
+            "SKIP_AUTH: 'true'",
+            "  SKIP_AUTH = true",
+            'SKIP_AUTH="true"',
+            "ENV SKIP_AUTH=true",  # Dockerfile
+            "      SKIP_AUTH: 'true'  # in some yaml",
+        ],
+    )
+    def test_matches_leak_strings(self, leak):
+        assert self.PATTERN.search(leak) is not None, f"missed leak: {leak!r}"
+
+    @pytest.mark.parametrize(
+        "benign",
+        [
+            'SKIP_AUTH = "false"',
+            "SKIP_AUTH=false",
+            "# Document SKIP_AUTH behaviour",
+            'os.environ.get("SKIP_AUTH", "")',
+            'if os.environ.get("SKIP_AUTH", "").lower() == "true":',
+        ],
+    )
+    def test_skips_benign_strings(self, benign):
+        # The legitimate dependencies.py / main.py references compare against
+        # "true" but don't *assign* SKIP_AUTH=true, so they shouldn't match.
+        # The one exception is the inline comparison string "== \"true\"" —
+        # which the workflow excludes via path-based filtering, not regex.
+        # We only assert the pattern itself doesn't trip on these forms.
+        assert self.PATTERN.search(benign) is None, f"false positive: {benign!r}"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure AWS region is set so that module-level boto3 calls don't fail
 # during import (e.g. agents.main_agent.quota -> boto3.resource('dynamodb'))
 os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
@@ -15,4 +17,22 @@ SRC_DIR = BACKEND_DIR / "src"
 
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+
+# Scrub SKIP_AUTH bleed from local .env. Some tests reload
+# `apis.app_api.main`, which calls `load_dotenv(override=True)` and
+# clobbers process env with whatever `backend/src/.env` has set —
+# typically `SKIP_AUTH=true` for local dev. Without this fixture every
+# auth-aware test downstream of that reload returns the fake bypass
+# user. Tests that need SKIP_AUTH on can still set it via monkeypatch
+# (test-local setenv runs after this autouse delenv).
+@pytest.fixture(autouse=True)
+def _clear_skip_auth_env(monkeypatch):
+    for key in (
+        "SKIP_AUTH",
+        "SKIP_AUTH_ROLES",
+        "SKIP_AUTH_USER_ID",
+        "SKIP_AUTH_EMAIL",
+    ):
+        monkeypatch.delenv(key, raising=False)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,13 +26,28 @@ if str(SRC_DIR) not in sys.path:
 # auth-aware test downstream of that reload returns the fake bypass
 # user. Tests that need SKIP_AUTH on can still set it via monkeypatch
 # (test-local setenv runs after this autouse delenv).
+#
+# Manages os.environ directly rather than depending on monkeypatch so
+# this autouse fixture doesn't perturb fixture-teardown ordering for
+# tests that already use monkeypatch + their own autouse fixtures
+# (e.g. tests/apis/app_api/test_connectors_routes.py).
+_SKIP_AUTH_ENV_KEYS = (
+    "SKIP_AUTH",
+    "SKIP_AUTH_ROLES",
+    "SKIP_AUTH_USER_ID",
+    "SKIP_AUTH_EMAIL",
+)
+
+
 @pytest.fixture(autouse=True)
-def _clear_skip_auth_env(monkeypatch):
-    for key in (
-        "SKIP_AUTH",
-        "SKIP_AUTH_ROLES",
-        "SKIP_AUTH_USER_ID",
-        "SKIP_AUTH_EMAIL",
-    ):
-        monkeypatch.delenv(key, raising=False)
+def _clear_skip_auth_env():
+    saved = {k: os.environ.pop(k, None) for k in _SKIP_AUTH_ENV_KEYS}
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 


### PR DESCRIPTION
## Summary
- Add a `SKIP_AUTH=true` env-var bypass in `apis.shared.auth.dependencies` so local dev (and unattended agents) can hit protected routes without the external-IdP redirect.
- Gate the bypass at app-api startup with an **allowlist** check: refuse to boot unless every `CORS_ORIGINS` entry is localhost.
- Add a CI workflow (`skip-auth-guard.yml`) that greps CDK source, workflows, and Dockerfiles for any `SKIP_AUTH=true` / `SKIP_AUTH: true` leak into deployed config.

## Rationale
The Cognito redirect blocks unattended local dev. The bypass returns a fake admin user from the three auth dependencies (`get_current_user`, `get_current_user_from_session`, `get_current_user_trusted`); CSRF middleware, RBAC, and profile-cache flows all behave naturally because `request.state.bff_session` is never set.

`get_current_user_id` wraps `get_current_user_from_session`, so it inherits the bypass for free.

Inference-api is intentionally **not** bypassed — all SPA traffic flows through app-api per the BFF pattern, so a single chokepoint suffices.

## Why allowlist instead of blocklist
The earlier draft refused to boot when AWS Lambda / ECS env vars were set. That's a blocklist — every new deploy target (EKS, App Runner, AgentCore Runtime, EC2, …) becomes a fresh hole. Flipping to "every `CORS_ORIGINS` entry must be localhost" fails closed for deploy targets we haven't anticipated, since `CORS_ORIGINS` must be set correctly per environment for the app to function.

## Usage
```
# backend/src/.env (gitignored)
SKIP_AUTH=true
SKIP_AUTH_ROLES=admin            # optional, default "admin"
SKIP_AUTH_USER_ID=local-dev      # optional
SKIP_AUTH_EMAIL=dev@local        # optional
```

## Test plan
- [x] `/auth/session` returns 200 with the fake user — verified locally.
- [x] SPA bootstraps authenticated as Local Dev, no redirect to `/auth/login` — verified end-to-end via preview tools.
- [x] Full chat round-trip works (Bedrock invoke → SSE stream → assistant reply) — verified with a "pong" prompt.
- [x] RBAC honored: `SKIP_AUTH_ROLES=DotNetDevelopers` filters models correctly (6 of 7 visible).
- [x] Allowlist guard refuses on non-localhost CORS origin — verified.
- [x] Allowlist guard refuses on empty CORS_ORIGINS — verified.
- [x] Allowlist guard accepts localhost-only CORS — verified.
- [x] CI grep catches `SKIP_AUTH=true`, `SKIP_AUTH: true`, `SKIP_AUTH: "true"` in TS / YAML / Dockerfile / shell styles — verified locally with synthetic leaks.
- [x] CI grep does not false-positive on the clean repo — verified.
- [ ] Reviewer to confirm `skip-auth-guard.yml` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)