### PR TITLE
fix(bff): cross-task cookie-codec & refresh-lock correctness

### DIFF
--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import secrets
 import time
 from typing import Optional
+
+from botocore.exceptions import ClientError
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -65,6 +68,7 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
         cookie_codec: Optional[CookieCodec] = None,
         refresh_client: Optional[CognitoRefreshClient] = None,
         cache: Optional[SessionCache] = None,
+        refresh_lock_ttl_seconds: int = 30,
     ) -> None:
         super().__init__(app)
         self._config = config
@@ -72,6 +76,12 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
         self._cookie_codec = cookie_codec
         self._refresh_client = refresh_client
         self._cache = cache
+        # Cross-task refresh lock TTL. A leader that crashes mid-refresh
+        # strands the lock for at most this many seconds, after which any
+        # peer can re-acquire and retry. Followers poll for at most this
+        # long before falling back to terminal. 30s is a safety cushion
+        # over the worst-case (Cognito + DDB + retries) refresh latency.
+        self._refresh_lock_ttl_seconds = refresh_lock_ttl_seconds
         # Strong-reference set for fire-and-forget slide-write tasks.
         # Without keeping a reference, `asyncio.create_task(...)` can be
         # garbage-collected mid-execution — Python's docs explicitly warn
@@ -241,18 +251,26 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
         last_seen_at: int,
         ttl: int,
         rotated: bool,
+        lock_owner: str,
     ) -> bool:
         """Write refreshed tokens to DDB. Retry when rotation makes it critical.
 
         Returns True on success or on a benign (non-rotation) failure. Returns
         False only when rotation happened *and* every retry failed — caller
         should treat that as session-unrecoverable.
+
+        The write also clears the cross-task refresh lock (atomic with the
+        token rotation), conditional on `lock_owner` matching. A
+        `ConditionalCheckFailedException` here means a peer task acquired
+        the lock after ours expired — we abandon the persist and the caller
+        should re-read DDB to adopt the peer's tokens.
         """
         # Three attempts on rotation (≈350ms total worst-case), single shot
         # otherwise. boto3 already retries below us for transient API errors;
         # this layer handles longer blips and validation/throttling errors
         # that boto3 lets through.
         attempts = 3 if rotated else 1
+        last_exc: Optional[Exception] = None
         for attempt in range(attempts):
             try:
                 await self._repository.update_tokens(
@@ -263,8 +281,26 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                     access_token_exp=refreshed.access_token_exp,
                     last_seen_at=last_seen_at,
                     ttl=ttl,
+                    expected_lock_owner=lock_owner,
                 )
                 return True
+            except ClientError as exc:
+                # Lock-ownership condition failed — a peer task took over.
+                # Don't retry: their refresh is authoritative now. Caller
+                # adopts their tokens via the post-failure DDB re-read.
+                if (
+                    exc.response.get("Error", {}).get("Code")
+                    == "ConditionalCheckFailedException"
+                ):
+                    logger.info(
+                        "BFF refresh persist for %s lost lock to a peer task — "
+                        "deferring to peer's tokens.",
+                        session_id,
+                    )
+                    return False
+                last_exc = exc
+                if attempt + 1 < attempts:
+                    await asyncio.sleep(0.05 * (2**attempt))  # 50ms, 100ms
             except Exception as exc:
                 last_exc = exc
                 if attempt + 1 < attempts:
@@ -287,6 +323,48 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
             last_exc,
         )
         return True
+
+    async def _wait_for_peer_refresh(
+        self,
+        *,
+        session_id: str,
+        previous: SessionRecord,
+        max_wait_seconds: float,
+    ) -> Optional[SessionRecord]:
+        """Poll DDB for a peer task's freshly persisted tokens.
+
+        Called when we lost the cross-task refresh lock to a peer. Polls
+        the session row with bounded backoff (50ms → 500ms) until we
+        observe tokens that differ from `previous` — at which point we
+        adopt them — or `max_wait_seconds` elapses.
+
+        Returns the peer's record on success, or `None` if we timed out
+        (peer crashed mid-refresh). The caller treats `None` as terminal
+        and clears the cookie; the lock TTL ensures the next request can
+        re-acquire and retry without waiting for a stuck row.
+        """
+        deadline = time.monotonic() + max_wait_seconds
+        sleep_for = 0.05
+        while time.monotonic() < deadline:
+            await asyncio.sleep(sleep_for)
+            peer = await self._repository.get(session_id)
+            if peer is None:
+                # Row gone (delete or TTL eviction) — terminal.
+                return None
+            # Refresh-token rotation: peer issued a new refresh token, ours
+            # is now revoked. Adopt their record.
+            if peer.cognito_refresh_token != previous.cognito_refresh_token:
+                return peer
+            # No rotation but a fresh access token landed: peer refreshed
+            # successfully, we can use the new access token.
+            if (
+                peer.cognito_access_token != previous.cognito_access_token
+                and peer.access_token_exp
+                > int(time.time()) + self._config.refresh_leeway_seconds
+            ):
+                return peer
+            sleep_for = min(sleep_for * 1.5, 0.5)
+        return None
 
     async def _resolve_session(
         self, cookie_value: str
@@ -337,10 +415,24 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                 self._cache.set(record)
                 return record, False
 
-            # Coalesce concurrent refreshes for the same session id.
+            # Two-tier coalescing:
+            #
+            # 1. `get_session_lock` (in-process): collapses N concurrent
+            #    same-session callers within ONE task to a single refresh
+            #    contender.
+            # 2. `try_acquire_refresh_lock` (cross-process, DDB conditional
+            #    write): one of those contenders, across all tasks, becomes
+            #    the leader and actually calls Cognito. Followers poll DDB
+            #    for the leader's persisted tokens.
+            #
+            # Without the cross-process lock, two tasks under desiredCount: 2
+            # would each call `cognito-idp:initiate_auth` with the same refresh
+            # token — Cognito rotates on the first; the second fails
+            # `NotAuthorizedException` and the loser's middleware clears the
+            # user's cookie. The DDB lock turns that race into a leader/
+            # follower handoff so exactly one Cognito refresh happens per
+            # session per leeway window across the entire fleet.
             async with get_session_lock(session_id):
-                # Re-check after acquiring the lock — another waiter may have
-                # already refreshed, in which case we serve the fresh row.
                 current = await self._repository.get(session_id)
                 if current is None:
                     return None, True
@@ -350,13 +442,42 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                     self._cache.set(current)
                     return current, False
 
+                lock_owner = secrets.token_hex(16)
+                lock_acquired = await self._repository.try_acquire_refresh_lock(
+                    session_id=session_id,
+                    owner=lock_owner,
+                    lock_ttl_seconds=self._refresh_lock_ttl_seconds,
+                )
+                if not lock_acquired:
+                    # FOLLOWER: a peer task is doing the Cognito refresh.
+                    # Wait for their tokens to land on the row, then adopt.
+                    peer = await self._wait_for_peer_refresh(
+                        session_id=session_id,
+                        previous=current,
+                        max_wait_seconds=self._refresh_lock_ttl_seconds,
+                    )
+                    if peer is None:
+                        # Peer never wrote — likely crashed or hit a Cognito
+                        # error. Lock will TTL out; the user's next request
+                        # will get to retry. Fail closed for *this* request.
+                        self._cache.invalidate(session_id)
+                        return None, True
+                    self._cache.set(peer)
+                    return peer, False
+
+                # LEADER: do the Cognito refresh and persist.
                 try:
                     refreshed = await self._refresh_client.refresh(
                         username=current.username,
                         refresh_token=current.cognito_refresh_token,
                     )
                 except CognitoRefreshError:
-                    # Refresh refused — treat as terminal, force re-login.
+                    # Refresh refused — release the lock so a peer can retry
+                    # the next request without waiting for the full lock TTL,
+                    # then treat as terminal for this request.
+                    await self._repository.release_refresh_lock(
+                        session_id, lock_owner
+                    )
                     self._cache.invalidate(session_id)
                     return None, True
 
@@ -387,8 +508,25 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                     last_seen_at=now,
                     ttl=new_ttl,
                     rotated=rotated,
+                    lock_owner=lock_owner,
                 )
                 if not persist_ok:
+                    # Two reasons this lands here:
+                    #   (a) Rotation persist exhausted retries — session is
+                    #       unrecoverable; clear cookie and force re-auth.
+                    #   (b) Lock-owner condition failed (peer took over) —
+                    #       re-read DDB and adopt the peer's tokens rather
+                    #       than logging the user out.
+                    peer = await self._repository.get(session_id)
+                    if (
+                        peer is not None
+                        and not peer.needs_refresh(
+                            int(time.time()),
+                            self._config.refresh_leeway_seconds,
+                        )
+                    ):
+                        self._cache.set(peer)
+                        return peer, False
                     self._cache.invalidate(session_id)
                     return None, True
                 updated = SessionRecord(

--- a/backend/src/apis/shared/sessions_bff/cookie.py
+++ b/backend/src/apis/shared/sessions_bff/cookie.py
@@ -1,16 +1,33 @@
 """Cookie codec — AES-GCM-sealed session id with a KMS-wrapped data key.
 
-Phase 1 CDK provisioned `BFFCookieSigningKey` as a symmetric KMS key. We
-follow the envelope-encryption pattern from the CDK comment:
+The CDK provisions two collaborating resources:
 
-    1. At first use, call `kms:GenerateDataKey(KeyId=...)` to get a 256-bit
-       AES key. The plaintext key is held in process memory; the wrapped
-       blob is discarded.
-    2. Cookie value = base64url( version || nonce || AES-GCM(payload) ).
-       The KMS key is *not* embedded — rotation requires a task restart,
-       which is fine for Phase 2 (rotation is on the Phase 7 hardening list).
-    3. `unseal` is constant-time on failure: any decode/auth-tag error maps
-       to `CookieDecodeError` so callers can't time-distinguish failure modes.
+    - `BFFCookieSigningKey` — symmetric KMS CMK (envelope key).
+    - `BFFCookieDataKeySecret` — Secrets Manager secret holding the wrapped
+      AES-256 data key, generated **once at deploy time** by a CDK custom
+      resource (`kms:GenerateDataKey` -> `secretsmanager:PutSecretValue`).
+
+Every app-api task on first use:
+
+    1. Reads the wrapped blob from `BFFCookieDataKeySecret`.
+    2. Calls `kms:Decrypt(KeyId=BFFCookieSigningKey, CiphertextBlob=blob)`
+       to recover the plaintext AES key — `KeyId` is pinned so a substituted
+       blob wrapped under a different CMK is rejected.
+    3. Caches the resulting `AESGCM` cipher as the process-wide singleton.
+
+This shared-blob design replaces the prior pattern of each task calling
+`kms:GenerateDataKey` directly: that produced a fresh random key per
+process, so under `desiredCount > 1` cookies sealed by Task A unsealed as
+`bad seal` on Task B (every page-load fan-out became a 401 storm). The
+shape of the singleton is unchanged — only the source of the key material.
+
+    - Cookie value = base64url( version || nonce || AES-GCM(payload) ).
+    - The KMS key is *not* embedded — rotation requires regenerating the
+      wrapped secret AND restarting all tasks; in-flight cookies sealed
+      under the old key fail to unseal (Phase 7 hardening: kid-versioned
+      cookies enable hot rotation).
+    - `unseal` is constant-time on failure: any decode/auth-tag error maps
+      to `CookieDecodeError` so callers can't time-distinguish failure modes.
 
 Payload is JSON-encoded so we can extend `CookiePayload` later without
 breaking format compatibility (the version byte gates that). The whole
@@ -20,6 +37,7 @@ sealed cookie fits comfortably under 256 bytes for a 36-char session id.
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import logging
 import os
@@ -49,30 +67,53 @@ class CookieDecodeError(Exception):
     """
 
 
+class CookieDataKeyUnavailable(Exception):
+    """Raised when the wrapped data key can't be fetched/unwrapped at startup.
+
+    Distinct from `CookieDecodeError` so callers can return 5xx (transient
+    infra problem — Secrets Manager unreachable, KMS down, secret empty)
+    rather than silently clearing every active user's cookie.
+    """
+
+
 class CookieCodec:
-    """Stateful seal/unseal pair backed by a process-cached KMS data key.
+    """Stateful seal/unseal pair backed by a process-cached AES-GCM cipher.
 
     Construct one per process. The first `seal()` or `unseal()` call lazily
-    fetches the data key via `kms:GenerateDataKey`; subsequent calls reuse
-    the cached cipher. Thread-safe on the lazy-init path.
+    fetches the **shared** wrapped data key from Secrets Manager and
+    unwraps it via KMS; subsequent calls reuse the cached cipher.
+    Thread-safe on the lazy-init path.
+
+    Across multiple ECS tasks (`desiredCount > 1`), every task's codec
+    decrypts to the **same** plaintext key, so cookies sealed by any task
+    unseal on any other task. This is the property that the prior
+    `kms:GenerateDataKey`-per-process design lacked.
     """
 
     def __init__(
         self,
         kms_key_arn: Optional[str] = None,
         *,
+        data_key_secret_arn: Optional[str] = None,
         kms_client: Optional[object] = None,
+        secrets_manager_client: Optional[object] = None,
     ) -> None:
         if kms_key_arn is None:
             kms_key_arn = os.environ.get("BFF_COOKIE_SIGNING_KEY_ARN") or ""
+        if data_key_secret_arn is None:
+            data_key_secret_arn = (
+                os.environ.get("BFF_COOKIE_DATA_KEY_SECRET_ARN") or ""
+            )
         self._kms_key_arn = kms_key_arn
+        self._data_key_secret_arn = data_key_secret_arn
         self._kms_client = kms_client
+        self._secrets_manager_client = secrets_manager_client
         self._cipher: Optional[AESGCM] = None
         self._init_lock = Lock()
 
     @property
     def enabled(self) -> bool:
-        return bool(self._kms_key_arn)
+        return bool(self._kms_key_arn) and bool(self._data_key_secret_arn)
 
     def _ensure_cipher(self) -> AESGCM:
         if self._cipher is not None:
@@ -80,16 +121,59 @@ class CookieCodec:
         with self._init_lock:
             if self._cipher is not None:
                 return self._cipher
-            if not self._kms_key_arn:
+            # Configuration missing — surface as decode error so the
+            # middleware path stays the same as for a `bad seal` and clears
+            # the cookie. (This branch is normally only hit in tests or in
+            # a misconfigured deploy; the env vars are populated by CDK.)
+            if not self._kms_key_arn or not self._data_key_secret_arn:
                 raise CookieDecodeError()
+
+            sm = self._secrets_manager_client or boto3.client("secretsmanager")
+            try:
+                secret = sm.get_secret_value(SecretId=self._data_key_secret_arn)
+            except Exception as exc:
+                # Infra failure — propagate so the request returns 5xx
+                # rather than silently invalidating sessions.
+                raise CookieDataKeyUnavailable(
+                    f"Failed to fetch wrapped BFF data key from Secrets Manager: {exc}"
+                ) from exc
+            wrapped_b64 = secret.get("SecretString") or ""
+            if not wrapped_b64:
+                raise CookieDataKeyUnavailable(
+                    "BFF cookie data key secret is empty — bootstrap missing"
+                )
+            try:
+                wrapped_blob = base64.b64decode(wrapped_b64, validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise CookieDataKeyUnavailable(
+                    f"BFF cookie data key secret is not valid base64: {exc}"
+                ) from exc
+
             kms = self._kms_client or boto3.client("kms")
-            response = kms.generate_data_key(
-                KeyId=self._kms_key_arn,
-                KeySpec="AES_256",
-            )
-            plaintext_key = response["Plaintext"]
+            try:
+                # Pin KeyId: KMS will reject a blob wrapped under any other
+                # key, defending against blob substitution if the secret is
+                # ever tampered with. Without KeyId, KMS auto-selects the
+                # wrapping key, which is the substitution oracle we don't want.
+                response = kms.decrypt(
+                    CiphertextBlob=wrapped_blob,
+                    KeyId=self._kms_key_arn,
+                )
+            except Exception as exc:
+                raise CookieDataKeyUnavailable(
+                    f"Failed to unwrap BFF data key via KMS: {exc}"
+                ) from exc
+            plaintext_key = response.get("Plaintext")
+            if not plaintext_key or len(plaintext_key) != 32:
+                raise CookieDataKeyUnavailable(
+                    "BFF data key after KMS unwrap is not a 32-byte AES-256 key"
+                )
+
             self._cipher = AESGCM(plaintext_key)
-            logger.info("BFF cookie codec initialized (KMS data key fetched)")
+            logger.info(
+                "BFF cookie codec initialized "
+                "(wrapped data key fetched from Secrets Manager + KMS unwrap)"
+            )
             return self._cipher
 
     def seal(self, payload: CookiePayload) -> str:
@@ -162,11 +246,15 @@ class CookieCodec:
             raise CookieDecodeError()
 
 
-# Process-wide singleton. Every codec instance pulls a fresh random data key
-# from KMS, so two codecs in one process can never decrypt each other's
-# output — the seal happens in the auth/callback route, the unseal happens
-# in `SessionRefreshMiddleware`, and they MUST share a cipher. Treat this as
-# the only construction path in production code.
+# Process-wide singleton. The first `seal` or `unseal` call fetches the
+# shared wrapped data key from Secrets Manager and unwraps it via KMS;
+# subsequent calls reuse the same `AESGCM` cipher. Across processes (e.g.
+# multiple ECS tasks under `desiredCount > 1`), every task's singleton
+# decrypts to the **same** plaintext key — so a cookie sealed by any task
+# unseals on any other task, including across rolling deploys where two
+# task revisions briefly coexist. The seal happens in the auth/callback
+# route, the unseal happens in `SessionRefreshMiddleware` and the voice
+# WebSocket route, and they all MUST go through this singleton.
 _default_codec: Optional[CookieCodec] = None
 _default_codec_lock = Lock()
 

--- a/backend/src/apis/shared/sessions_bff/repository.py
+++ b/backend/src/apis/shared/sessions_bff/repository.py
@@ -8,9 +8,23 @@ Schema (single-table, fits the `BFFSessionsTable` provisioned in Phase 1):
     Attrs: user_id, cognito_access_token, cognito_refresh_token, id_token,
            access_token_exp, csrf_secret, created_at, last_seen_at, ttl
 
+    Cross-task refresh-lock attrs (added at runtime, never on the initial
+    write — both default to "absent" until a refresh contender writes them):
+       refresh_lock_owner: short opaque token identifying the leader
+       refresh_lock_until: epoch seconds; lock is considered expired past this
+
 The `ttl` attribute is wired to DynamoDB TTL so absolute session lifetime is
 enforced by the table itself — even if a session row is somehow leaked from
 the cleanup paths, DynamoDB will eventually evict it.
+
+The refresh-lock attrs coordinate the Cognito refresh exchange across tasks:
+the per-process `get_session_lock` and `single_flight` only coalesce within
+a single Python process, so under `desiredCount > 1` two tasks can otherwise
+issue parallel `cognito-idp:initiate_auth` calls with the same refresh token —
+Cognito rotates on the first; the second fails `NotAuthorizedException` and
+the loser unilaterally clears the user's cookie. The lock turns this into a
+leader/follower handoff: one task does the refresh, the other reads the
+freshly persisted tokens off the row.
 """
 
 from __future__ import annotations
@@ -147,6 +161,7 @@ class SessionRepository:
         access_token_exp: int,
         last_seen_at: int,
         ttl: Optional[int] = None,
+        expected_lock_owner: Optional[str] = None,
     ) -> None:
         """Atomically replace the Cognito tokens after a refresh.
 
@@ -156,6 +171,15 @@ class SessionRepository:
         is supplied, the row's DynamoDB TTL slides forward in the same write
         — a refresh proves the user is active, so the session row's expiry
         should slide alongside it.
+
+        When `expected_lock_owner` is supplied, the write is conditional on
+        the row's `refresh_lock_owner` attribute matching (or being absent).
+        The lock attributes are also REMOVED in the same write, releasing
+        the cross-task lock alongside the token rotation. If the condition
+        fails (a peer has acquired the lock — implies our lock had expired
+        and someone else owns the refresh now), `ConditionalCheckFailedException`
+        is raised so the caller can re-read the row and adopt the peer's
+        tokens instead of stomping on them.
         """
         if not self._enabled:
             return
@@ -186,8 +210,114 @@ class SessionRepository:
             # `ttl` is a reserved word in DynamoDB expressions.
             kwargs["ExpressionAttributeNames"] = {"#ttl": "ttl"}
 
+        if expected_lock_owner is not None:
+            # Atomically release the cross-task refresh lock alongside the
+            # token write. The condition guards against a stale leader
+            # (whose lock TTL'd while another task took over) overwriting
+            # the new leader's freshly persisted tokens.
+            kwargs["UpdateExpression"] = (
+                update_expr + " REMOVE refresh_lock_owner, refresh_lock_until"
+            )
+            expr_values[":owner"] = expected_lock_owner
+            kwargs["ConditionExpression"] = (
+                "attribute_not_exists(refresh_lock_owner) "
+                "OR refresh_lock_owner = :owner"
+            )
+
         def _call() -> None:
             self._table.update_item(**kwargs)
+
+        await asyncio.to_thread(_call)
+
+    async def try_acquire_refresh_lock(
+        self,
+        session_id: str,
+        owner: str,
+        lock_ttl_seconds: int,
+    ) -> bool:
+        """Atomically claim leadership of a cross-task Cognito refresh.
+
+        Conditional `UpdateItem` on the session row: succeeds (returns True)
+        only if no peer holds the lock OR the holder's lock has expired
+        (`refresh_lock_until < now`). On contention returns False — the
+        caller should poll the row for the leader's persisted tokens.
+
+        Lock TTL bounds the worst case: a leader that crashes mid-refresh
+        strands the lock for at most `lock_ttl_seconds` (we use 30s in the
+        middleware), after which any peer can re-acquire and retry.
+
+        Returns False on `ConditionalCheckFailedException`. Other DDB
+        errors propagate so the caller can surface them as 5xx — silently
+        suppressing them would create a "neither leader nor follower" gap.
+        """
+        if not self._enabled:
+            return False
+        now = int(time.time())
+        kwargs: dict = {
+            "Key": self._key(session_id),
+            "UpdateExpression": (
+                "SET refresh_lock_owner = :owner, "
+                "refresh_lock_until = :until"
+            ),
+            "ConditionExpression": (
+                "attribute_not_exists(refresh_lock_until) "
+                "OR refresh_lock_until < :now"
+            ),
+            "ExpressionAttributeValues": {
+                ":owner": owner,
+                ":until": now + lock_ttl_seconds,
+                ":now": now,
+            },
+        }
+
+        def _call() -> bool:
+            try:
+                self._table.update_item(**kwargs)
+                return True
+            except ClientError as exc:
+                if (
+                    exc.response.get("Error", {}).get("Code")
+                    == "ConditionalCheckFailedException"
+                ):
+                    return False
+                raise
+
+        return await asyncio.to_thread(_call)
+
+    async def release_refresh_lock(self, session_id: str, owner: str) -> None:
+        """Release the cross-task refresh lock if `owner` still holds it.
+
+        Used when the leader's Cognito refresh fails terminally and we want
+        a peer to be able to retry without waiting for the full lock TTL.
+        Best-effort: a `ConditionalCheckFailedException` (lock TTL'd or
+        re-acquired) is treated as a no-op.
+
+        `update_tokens` clears the lock attributes atomically with a
+        successful refresh, so this is only for the failure path.
+        """
+        if not self._enabled:
+            return
+        kwargs: dict = {
+            "Key": self._key(session_id),
+            "UpdateExpression": (
+                "REMOVE refresh_lock_owner, refresh_lock_until"
+            ),
+            "ConditionExpression": "refresh_lock_owner = :owner",
+            "ExpressionAttributeValues": {":owner": owner},
+        }
+
+        def _call() -> None:
+            try:
+                self._table.update_item(**kwargs)
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code")
+                if code == "ConditionalCheckFailedException":
+                    return  # peer re-acquired or lock TTL'd — fine
+                logger.warning(
+                    "BFF refresh lock release failed for %s: %s",
+                    session_id,
+                    exc,
+                )
 
         await asyncio.to_thread(_call)
 

--- a/backend/tests/apis/shared/middleware/test_session_refresh_preservation.py
+++ b/backend/tests/apis/shared/middleware/test_session_refresh_preservation.py
@@ -83,6 +83,20 @@ class InstrumentedTable:
     Records call counts so preservation tests can assert "zero AWS calls"
     for dormant / no-cookie pass-through paths, and "exactly one get_item"
     for the refresh-storm coalescing contract.
+
+    `update_item` writes are classified into three kinds by inspecting the
+    `UpdateExpression`:
+      - `lock_acquire_calls`: cross-task refresh-lock acquisition (writes
+        `refresh_lock_owner` + `refresh_lock_until`, no token columns).
+      - `token_persist_calls`: token rotation write (sets
+        `cognito_access_token` etc., usually also REMOVE-ing the lock).
+      - `slide_calls`: sliding-renewal touch (writes only `last_seen_at`
+        and optionally `ttl`).
+    `update_item_calls` remains the total (sum) so existing assertions on
+    "any update_item issued" continue to hold. The injected side-effect is
+    applied only to the token-persist path so tests that simulate "DDB
+    throttled during persist" don't accidentally fail at the lock-acquire
+    write — that's a different code path with different recovery semantics.
     """
 
     def __init__(
@@ -97,6 +111,9 @@ class InstrumentedTable:
         self._update_item_side_effect = update_item_side_effect
         self.get_item_calls = 0
         self.update_item_calls = 0
+        self.lock_acquire_calls = 0
+        self.token_persist_calls = 0
+        self.slide_calls = 0
         self.put_item_calls = 0
         self.delete_item_calls = 0
 
@@ -111,10 +128,34 @@ class InstrumentedTable:
             return {}
         return {"Item": _record_to_item(self._record)}
 
+    @staticmethod
+    def _classify_update(update_expr: str) -> str:
+        """Classify which middleware path issued this update_item.
+
+        Token persist writes always set `cognito_access_token`. Pure lock
+        acquires write `refresh_lock_owner` without touching tokens. Slide
+        writes touch only `last_seen_at` (+ optionally `ttl`).
+        """
+        if "cognito_access_token" in update_expr:
+            return "token_persist"
+        if "refresh_lock_owner" in update_expr:
+            return "lock_acquire"
+        return "slide"
+
     def update_item(self, **kwargs: Any) -> dict:
         self.update_item_calls += 1
+        kind = self._classify_update(kwargs.get("UpdateExpression", ""))
+        if kind == "token_persist":
+            self.token_persist_calls += 1
+        elif kind == "lock_acquire":
+            self.lock_acquire_calls += 1
+        else:
+            self.slide_calls += 1
         self._sleep()
-        if self._update_item_side_effect is not None:
+        # Side-effect injection applies only to the token-persist path —
+        # tests that simulate "rotation persist exhausted" mean exactly
+        # that write, not the upstream lock-acquire.
+        if self._update_item_side_effect is not None and kind == "token_persist":
             raise self._update_item_side_effect
         return {}
 
@@ -1094,10 +1135,12 @@ def test_3_10_rotation_persist_exhausts_invalidates_cache_and_clears_cookies() -
     _assert_clear_cookie_attrs(session_clears[0])
     _assert_clear_cookie_attrs(csrf_clears[0])
 
-    # Sanity: update_tokens was retried 3 times on rotation.
-    assert table.update_item_calls == 3, (
+    # Sanity: update_tokens was retried 3 times on rotation. Use the
+    # token_persist sub-counter so we measure persist attempts only,
+    # not the (also-incrementing) lock_acquire write that precedes them.
+    assert table.token_persist_calls == 3, (
         f"[3.10] rotation must retry update_tokens 3 times; got "
-        f"{table.update_item_calls}"
+        f"{table.token_persist_calls}"
     )
 
 

--- a/backend/tests/apis/shared/middleware/test_session_refresh_preservation.py
+++ b/backend/tests/apis/shared/middleware/test_session_refresh_preservation.py
@@ -30,6 +30,7 @@ Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 from __future__ import annotations
 
 import asyncio
+import base64
 import secrets
 import time
 from typing import Any, Optional
@@ -791,19 +792,28 @@ async def test_3_5_refresh_storm_coalesces_to_single_initiate_auth() -> None:
 def test_3_6_get_default_codec_is_singleton_with_no_per_request_kms() -> None:
     """(3.6) Codec singleton.
 
-    `get_default_codec()` returns the same instance across calls; the
-    KMS `generate_data_key` call happens at most once per process.
-    """
-    kms_client = MagicMock()
-    kms_client.generate_data_key.return_value = {
-        "Plaintext": secrets.token_bytes(32),
-        "CiphertextBlob": b"wrapped-key-blob",
-    }
+    `get_default_codec()` returns the same instance across calls. The
+    *underlying* AWS calls — `secretsmanager:GetSecretValue` to fetch the
+    wrapped data key and `kms:Decrypt` to unwrap it — happen at most once
+    per process. Hot seal/unseal traffic must not re-fetch.
 
-    # Build a codec with an injected KMS client and install it as the
-    # process-wide default. Then call get_default_codec() many times and
-    # assert identity and KMS call count.
-    codec = CookieCodec(kms_key_arn="arn:aws:kms:fake-3.6", kms_client=kms_client)
+    (This contract held under the original `kms:GenerateDataKey`-per-process
+    design too; only the underlying AWS APIs changed when the codec was
+    moved to a shared wrapped data key for cross-task seal/unseal.)
+    """
+    plaintext_key = secrets.token_bytes(32)
+    wrapped_b64 = base64.b64encode(b"wrapped-blob:" + plaintext_key).decode("ascii")
+    sm_client = MagicMock()
+    sm_client.get_secret_value.return_value = {"SecretString": wrapped_b64}
+    kms_client = MagicMock()
+    kms_client.decrypt.return_value = {"Plaintext": plaintext_key}
+
+    codec = CookieCodec(
+        kms_key_arn="arn:aws:kms:fake-3.6",
+        data_key_secret_arn="arn:aws:secretsmanager:fake-3.6",
+        kms_client=kms_client,
+        secrets_manager_client=sm_client,
+    )
     cookie_module._set_default_codec_for_tests(codec)
 
     first = get_default_codec()
@@ -813,19 +823,28 @@ def test_3_6_get_default_codec_is_singleton_with_no_per_request_kms() -> None:
             "[3.6] get_default_codec() must return the same instance each call"
         )
 
-    # Exercise the codec many times — each seal/unseal round-trip must NOT
-    # generate a new data key.
     payload = CookiePayload(session_id="sess-3-6")
     for _ in range(20):
         sealed = first.seal(payload)
         roundtripped = first.unseal(sealed)
         assert roundtripped.session_id == "sess-3-6"
 
-    assert kms_client.generate_data_key.call_count <= 1, (
-        f"[3.6] KMS generate_data_key invoked "
-        f"{kms_client.generate_data_key.call_count} times — must be at most "
+    assert sm_client.get_secret_value.call_count <= 1, (
+        f"[3.6] Secrets Manager get_secret_value invoked "
+        f"{sm_client.get_secret_value.call_count} times — must be at most "
         "one per process."
     )
+    assert kms_client.decrypt.call_count <= 1, (
+        f"[3.6] KMS decrypt invoked {kms_client.decrypt.call_count} times "
+        "— must be at most one per process."
+    )
+    # Defense against blob substitution: KeyId must be pinned on Decrypt.
+    if kms_client.decrypt.call_count == 1:
+        kwargs = kms_client.decrypt.call_args.kwargs
+        assert kwargs.get("KeyId") == "arn:aws:kms:fake-3.6", (
+            "[3.6] kms:Decrypt must pin KeyId so a substituted blob wrapped "
+            "under a different CMK is rejected."
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/backend/tests/apis/shared/sessions_bff/test_cookie.py
+++ b/backend/tests/apis/shared/sessions_bff/test_cookie.py
@@ -1,8 +1,17 @@
 """Tests for the AES-GCM cookie codec.
 
-Uses an injected `AESGCM` cipher to avoid mocking KMS — `CookieCodec` exposes
-the `_cipher` attribute which we set directly. (Production callers always go
-through `_ensure_cipher`, which is what the KMS-integration test exercises.)
+Two layers of coverage:
+
+  1. Round-trip / decode tests — use an injected `AESGCM` cipher (set on
+     `_cipher` directly) so we don't need to mock Secrets Manager or KMS.
+  2. `_ensure_cipher` path — exercises the deploy-time-bootstrapped wrapped
+     data key flow (`secretsmanager:GetSecretValue` ->
+     `kms:Decrypt(KeyId=...)` -> AESGCM cipher) with mock clients. This is
+     the path that runs in production every time a task starts.
+
+The cross-task seal/unseal regression — a cookie sealed by one process
+unsealing on a *different* process — is locked in by
+`test_two_codecs_with_same_wrapped_blob_decrypt_to_the_same_cipher`.
 """
 
 from __future__ import annotations
@@ -10,12 +19,14 @@ from __future__ import annotations
 import base64
 import os
 import secrets
+from unittest.mock import MagicMock
 
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from apis.shared.sessions_bff.cookie import (
     CookieCodec,
+    CookieDataKeyUnavailable,
     CookieDecodeError,
     _reset_default_codec_for_tests,
     _set_default_codec_for_tests,
@@ -110,17 +121,24 @@ def test_seal_preserves_extras() -> None:
 def test_default_codec_is_a_singleton() -> None:
     """The auth/callback route seals with this codec and the
     `SessionRefreshMiddleware` unseals with it on the next request — they
-    must be the *same* instance, since each `CookieCodec` derives its own
-    random AES key. A second instance would fail every unseal as 'bad seal'.
+    must be the *same* instance within a process so we don't refetch the
+    wrapped data key from Secrets Manager + KMS on every cookie operation.
+
+    Cross-process consistency (Task A's seal unsealing on Task B) is locked
+    in by `test_two_codecs_with_same_wrapped_blob_decrypt_to_the_same_cipher`.
     """
     _reset_default_codec_for_tests()
     try:
         os.environ["BFF_COOKIE_SIGNING_KEY_ARN"] = "arn:aws:kms:fake"
+        os.environ["BFF_COOKIE_DATA_KEY_SECRET_ARN"] = (
+            "arn:aws:secretsmanager:us-east-1:0:secret:bff-data-key"
+        )
         first = get_default_codec()
         second = get_default_codec()
         assert first is second
     finally:
         os.environ.pop("BFF_COOKIE_SIGNING_KEY_ARN", None)
+        os.environ.pop("BFF_COOKIE_DATA_KEY_SECRET_ARN", None)
         _reset_default_codec_for_tests()
 
 
@@ -142,14 +160,179 @@ def test_default_codec_round_trip_seals_and_unseals() -> None:
         _reset_default_codec_for_tests()
 
 
-def test_unseal_propagates_kms_infrastructure_errors() -> None:
-    """KMS unavailable is not a decode error — it must surface so the caller
-    can return 5xx instead of clearing the cookie and forcing re-login."""
-    from unittest.mock import MagicMock
+# =====================================================================
+# `_ensure_cipher` — wrapped data key fetch + KMS unwrap path.
+# =====================================================================
 
-    fake_kms = MagicMock()
-    fake_kms.generate_data_key.side_effect = RuntimeError("KMS unreachable")
+KMS_KEY_ARN = "arn:aws:kms:us-east-1:0:key/test"
+DATA_KEY_SECRET_ARN = "arn:aws:secretsmanager:us-east-1:0:secret:bff-data-key"
 
-    codec = CookieCodec(kms_key_arn="arn:aws:kms:fake", kms_client=fake_kms)
-    with pytest.raises(RuntimeError, match="KMS unreachable"):
-        codec.unseal("doesnt-matter")
+
+def _wrap_plaintext_key_for_test(plaintext: bytes) -> tuple[bytes, str]:
+    """Stand-in for `kms:GenerateDataKey`'s ciphertext — opaque bytes in,
+    base64 string out (matches what CDK's AwsCustomResource stores in
+    Secrets Manager)."""
+    fake_wrapped = b"fake-wrapped:" + plaintext
+    return fake_wrapped, base64.b64encode(fake_wrapped).decode("ascii")
+
+
+def _make_mocks_for(plaintext_key: bytes) -> tuple[MagicMock, MagicMock, str]:
+    fake_wrapped, b64 = _wrap_plaintext_key_for_test(plaintext_key)
+    sm = MagicMock()
+    sm.get_secret_value.return_value = {"SecretString": b64}
+    kms = MagicMock()
+    kms.decrypt.return_value = {"Plaintext": plaintext_key}
+    return sm, kms, b64
+
+
+def test_ensure_cipher_fetches_wrapped_blob_and_unwraps() -> None:
+    """Happy path: codec fetches the wrapped blob from Secrets Manager and
+    unwraps it via KMS, then seals/unseals successfully."""
+    plaintext = secrets.token_bytes(32)
+    sm, kms, _ = _make_mocks_for(plaintext)
+
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms,
+        secrets_manager_client=sm,
+    )
+    sealed = codec.seal(CookiePayload(session_id="sess-bootstrapped"))
+    assert codec.unseal(sealed).session_id == "sess-bootstrapped"
+
+    sm.get_secret_value.assert_called_once_with(SecretId=DATA_KEY_SECRET_ARN)
+    kms.decrypt.assert_called_once()
+    # Defense against blob substitution: KeyId MUST be pinned on Decrypt.
+    kwargs = kms.decrypt.call_args.kwargs
+    assert kwargs["KeyId"] == KMS_KEY_ARN
+    assert kwargs["CiphertextBlob"] == b"fake-wrapped:" + plaintext
+
+
+def test_ensure_cipher_caches_after_first_call() -> None:
+    """Hot-path requirement: only one Secrets Manager + KMS call per process."""
+    sm, kms, _ = _make_mocks_for(secrets.token_bytes(32))
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms,
+        secrets_manager_client=sm,
+    )
+    for _ in range(5):
+        codec.seal(CookiePayload(session_id="x"))
+    assert sm.get_secret_value.call_count == 1
+    assert kms.decrypt.call_count == 1
+
+
+def test_two_codecs_with_same_wrapped_blob_decrypt_to_the_same_cipher() -> None:
+    """Regression lock for the dev `bad seal` 401 storm.
+
+    Two independent `CookieCodec` instances simulate two ECS tasks. Both
+    fetch the SAME wrapped blob from Secrets Manager and unwrap it with
+    the same CMK. A cookie sealed on `task_a` MUST unseal on `task_b`.
+    Pre-fix, each task generated its own random data key and this failed.
+    """
+    plaintext = secrets.token_bytes(32)
+    sm_a, kms_a, _ = _make_mocks_for(plaintext)
+    sm_b, kms_b, _ = _make_mocks_for(plaintext)
+
+    task_a = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms_a,
+        secrets_manager_client=sm_a,
+    )
+    task_b = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms_b,
+        secrets_manager_client=sm_b,
+    )
+
+    sealed_on_a = task_a.seal(CookiePayload(session_id="sess-cross-task"))
+    decoded_on_b = task_b.unseal(sealed_on_a)
+    assert decoded_on_b.session_id == "sess-cross-task"
+
+
+def test_ensure_cipher_propagates_secrets_manager_failure() -> None:
+    """Secrets Manager unreachable must surface as `CookieDataKeyUnavailable`
+    so the request returns 5xx — never as a decode error that clears the
+    user's cookie."""
+    sm = MagicMock()
+    sm.get_secret_value.side_effect = RuntimeError("Secrets Manager unreachable")
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=MagicMock(),
+        secrets_manager_client=sm,
+    )
+    with pytest.raises(CookieDataKeyUnavailable):
+        codec.unseal("anything")
+
+
+def test_ensure_cipher_propagates_kms_decrypt_failure() -> None:
+    sm, _, _ = _make_mocks_for(secrets.token_bytes(32))
+    kms = MagicMock()
+    kms.decrypt.side_effect = RuntimeError("KMS unreachable")
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms,
+        secrets_manager_client=sm,
+    )
+    with pytest.raises(CookieDataKeyUnavailable):
+        codec.unseal("anything")
+
+
+def test_ensure_cipher_rejects_empty_secret_string() -> None:
+    """Bootstrap not yet completed (or secret manually wiped) — fail loud
+    rather than silently invalidate every active session."""
+    sm = MagicMock()
+    sm.get_secret_value.return_value = {"SecretString": ""}
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=MagicMock(),
+        secrets_manager_client=sm,
+    )
+    with pytest.raises(CookieDataKeyUnavailable, match="bootstrap missing"):
+        codec.unseal("anything")
+
+
+def test_ensure_cipher_rejects_non_base64_secret() -> None:
+    sm = MagicMock()
+    sm.get_secret_value.return_value = {"SecretString": "!!! not base64 !!!"}
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=MagicMock(),
+        secrets_manager_client=sm,
+    )
+    with pytest.raises(CookieDataKeyUnavailable, match="not valid base64"):
+        codec.unseal("anything")
+
+
+def test_ensure_cipher_rejects_wrong_size_plaintext_key() -> None:
+    """KMS returned something, but it's not a 32-byte AES-256 key. Bail
+    rather than constructing an invalid `AESGCM` cipher."""
+    sm = MagicMock()
+    sm.get_secret_value.return_value = {
+        "SecretString": base64.b64encode(b"wrapped").decode("ascii")
+    }
+    kms = MagicMock()
+    kms.decrypt.return_value = {"Plaintext": b"too-short"}
+    codec = CookieCodec(
+        kms_key_arn=KMS_KEY_ARN,
+        data_key_secret_arn=DATA_KEY_SECRET_ARN,
+        kms_client=kms,
+        secrets_manager_client=sm,
+    )
+    with pytest.raises(CookieDataKeyUnavailable, match="32-byte"):
+        codec.unseal("anything")
+
+
+def test_ensure_cipher_missing_config_surfaces_as_decode_error() -> None:
+    """No KMS ARN or no secret ARN — same shape as today's "BFF disabled"
+    path. Treated as `bad seal` so the middleware clears the cookie."""
+    codec = CookieCodec(kms_key_arn="", data_key_secret_arn="")
+    with pytest.raises(CookieDecodeError):
+        codec.unseal("anything")

--- a/backend/tests/apis/shared/sessions_bff/test_repository.py
+++ b/backend/tests/apis/shared/sessions_bff/test_repository.py
@@ -77,3 +77,203 @@ async def test_disabled_repository_is_inert() -> None:
     # All ops succeed silently — no exceptions, no AWS calls.
     assert await repo.get("any") is None
     await repo.delete("any")
+
+
+# =====================================================================
+# Cross-task refresh lock — try_acquire_refresh_lock / release_refresh_lock
+# =====================================================================
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_refresh_lock_succeeds_on_unlocked_row(
+    repository, sample_record
+) -> None:
+    """The first contender claims the lock when no peer is holding one."""
+    record = sample_record()
+    await repository.put(record)
+
+    acquired = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id,
+        owner="task-A",
+        lock_ttl_seconds=30,
+    )
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_refresh_lock_blocks_concurrent_peer(
+    repository, sample_record
+) -> None:
+    """While task-A's lock is fresh, task-B's acquisition MUST fail.
+
+    This is the cross-task coalescing primitive — without it, two tasks
+    would each call cognito-idp:initiate_auth with the same refresh token
+    under desiredCount > 1.
+    """
+    record = sample_record()
+    await repository.put(record)
+
+    a = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id,
+        owner="task-A",
+        lock_ttl_seconds=30,
+    )
+    b = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id,
+        owner="task-B",
+        lock_ttl_seconds=30,
+    )
+    assert a is True
+    assert b is False
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_refresh_lock_takes_over_after_ttl_expires(
+    repository, sample_record
+) -> None:
+    """A leader that crashed mid-refresh strands the lock for at most
+    `lock_ttl_seconds`. After that, any peer can re-acquire — no manual
+    cleanup required, no permanent stuck state."""
+    record = sample_record()
+    await repository.put(record)
+
+    # task-A acquires with a 0-second TTL → lock_until = now, so any
+    # contender at a later second sees `refresh_lock_until < :now`.
+    a = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id,
+        owner="task-A",
+        lock_ttl_seconds=0,
+    )
+    assert a is True
+
+    # Sleep 1s so the next contender's :now is strictly greater.
+    time.sleep(1)
+
+    b = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id,
+        owner="task-B",
+        lock_ttl_seconds=30,
+    )
+    assert b is True
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_refresh_lock_distinct_sessions_dont_block(
+    repository, sample_record
+) -> None:
+    rec_a = sample_record(session_id="sess-A")
+    rec_b = sample_record(session_id="sess-B")
+    await repository.put(rec_a)
+    await repository.put(rec_b)
+
+    a = await repository.try_acquire_refresh_lock(
+        session_id=rec_a.session_id, owner="task-1", lock_ttl_seconds=30
+    )
+    b = await repository.try_acquire_refresh_lock(
+        session_id=rec_b.session_id, owner="task-1", lock_ttl_seconds=30
+    )
+    assert a is True
+    assert b is True
+
+
+@pytest.mark.asyncio
+async def test_release_refresh_lock_clears_attrs_for_owner(
+    repository, sample_record
+) -> None:
+    record = sample_record()
+    await repository.put(record)
+    await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-A", lock_ttl_seconds=30
+    )
+
+    await repository.release_refresh_lock(record.session_id, owner="task-A")
+
+    # After release a peer can immediately acquire.
+    b = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-B", lock_ttl_seconds=30
+    )
+    assert b is True
+
+
+@pytest.mark.asyncio
+async def test_release_refresh_lock_is_no_op_for_non_owner(
+    repository, sample_record
+) -> None:
+    """Best-effort release: if a peer has already taken over the lock
+    (because ours TTL'd), the release MUST NOT clear their lock attrs."""
+    record = sample_record()
+    await repository.put(record)
+    await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-A", lock_ttl_seconds=30
+    )
+
+    # task-B (who never held the lock) calls release — must not blow away
+    # task-A's lock.
+    await repository.release_refresh_lock(record.session_id, owner="task-B")
+
+    # task-A's lock is still in force; a third contender can't acquire.
+    c = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-C", lock_ttl_seconds=30
+    )
+    assert c is False
+
+
+@pytest.mark.asyncio
+async def test_update_tokens_with_lock_owner_clears_lock_atomically(
+    repository, sample_record
+) -> None:
+    """Successful refresh persist clears the lock attributes in the same
+    write so peers don't have to wait for the TTL to retry."""
+    record = sample_record()
+    await repository.put(record)
+    await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-A", lock_ttl_seconds=30
+    )
+
+    await repository.update_tokens(
+        session_id=record.session_id,
+        access_token="access.fresh",
+        refresh_token="refresh.rotated",
+        id_token="id.fresh",
+        access_token_exp=int(time.time()) + 3600,
+        last_seen_at=int(time.time()),
+        expected_lock_owner="task-A",
+    )
+
+    # Lock cleared → another contender can acquire immediately.
+    b = await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="task-B", lock_ttl_seconds=30
+    )
+    assert b is True
+
+
+@pytest.mark.asyncio
+async def test_update_tokens_rejects_persist_when_peer_owns_the_lock(
+    repository, sample_record
+) -> None:
+    """Stale-leader guard: if our lock TTL'd and a peer took over, we must
+    NOT overwrite their freshly persisted tokens. ConditionalCheckFailed
+    propagates so the caller can re-read DDB and adopt the peer's state."""
+    from botocore.exceptions import ClientError
+
+    record = sample_record()
+    await repository.put(record)
+    # Peer task acquired the lock.
+    await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="peer-task", lock_ttl_seconds=30
+    )
+
+    with pytest.raises(ClientError) as exc_info:
+        await repository.update_tokens(
+            session_id=record.session_id,
+            access_token="access.stale",
+            refresh_token="refresh.stale",
+            id_token="id.stale",
+            access_token_exp=int(time.time()) + 3600,
+            last_seen_at=int(time.time()),
+            expected_lock_owner="our-task",  # ≠ peer-task
+        )
+    assert (
+        exc_info.value.response.get("Error", {}).get("Code")
+        == "ConditionalCheckFailedException"
+    )

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_cross_task.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_cross_task.py
@@ -1,0 +1,480 @@
+"""Cross-task refresh-coalescing tests for SessionRefreshMiddleware.
+
+Locks in the regression that PR #264 created and the cookie-codec fix would
+*expose* once dev started working again: with `desiredCount: 2`, two
+`SessionRefreshMiddleware` instances running in two ECS tasks would each
+see a cookie crossing the refresh-leeway boundary, each call
+`cognito-idp:initiate_auth` with the same refresh token, and one of them
+would lose the rotation race — Cognito revokes the original token on the
+winner's exchange, the loser gets `NotAuthorizedException`, the loser's
+middleware clears the user's cookie. Page-load fan-outs become routine
+silent logouts.
+
+The fix coalesces the refresh exchange across tasks via a DynamoDB
+conditional-write lock (`refresh_lock_owner` + `refresh_lock_until` on
+the session row). These tests instantiate two repository + middleware
+pairs against ONE moto-backed DDB table so we can drive the leader and
+follower paths deterministically without spinning real ECS tasks.
+
+What's covered:
+    - Leader-only Cognito refresh under same-time contention from two tasks
+    - Follower adoption of the leader's persisted tokens (no Cognito call)
+    - Leader crash (Cognito error) releases the lock so peers can retry
+    - Lock TTL recovery: a crashed leader's lock unblocks peers after TTL
+    - Refresh-token rotation: peer's rotated tokens propagate to follower
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import boto3
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.shared.middleware.session_refresh import SessionRefreshMiddleware
+from apis.shared.sessions_bff import lock as lock_module
+from apis.shared.sessions_bff import single_flight as single_flight_module
+from apis.shared.sessions_bff.cache import SessionCache
+from apis.shared.sessions_bff.config import (
+    BFFConfig,
+    SESSION_COOKIE_NAME,
+)
+from apis.shared.sessions_bff.cookie import CookieCodec
+from apis.shared.sessions_bff.models import CookiePayload, SessionRecord
+from apis.shared.sessions_bff.refresh import (
+    CognitoRefreshError,
+    RefreshResult,
+)
+from apis.shared.sessions_bff.repository import SessionRepository
+
+# Single shared DDB table — both "tasks" attach to the same backing store,
+# matching production where two ECS tasks read/write one BFFSessionsTable.
+TABLE_NAME = "test-bff-sessions"
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Drop process-wide locks + single-flight registries between tests so
+    a leftover Future or asyncio lock from one test can't influence the
+    next case's contention behavior."""
+    lock_module._reset_for_tests()
+    single_flight_module._reset_for_tests()
+    yield
+    lock_module._reset_for_tests()
+    single_flight_module._reset_for_tests()
+
+
+@pytest.fixture
+def two_task_setup(monkeypatch):
+    """Spin up two `SessionRefreshMiddleware` instances over one moto DDB
+    table so each represents a distinct ECS task in the same fleet."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName=TABLE_NAME,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # Both tasks share the wrapped data key (otherwise the cookie sealed
+        # by Task A would unseal as `bad seal` on Task B — that's the OTHER
+        # bug in this branch, exercised by test_cookie). We pre-inject one
+        # AES key here to keep the test focused on the refresh-lock path.
+        shared_aes_key = secrets.token_bytes(32)
+
+        def _make_codec() -> CookieCodec:
+            codec = CookieCodec(
+                kms_key_arn="arn:aws:kms:fake",
+                data_key_secret_arn="arn:aws:secretsmanager:fake",
+            )
+            codec._cipher = AESGCM(shared_aes_key)
+            return codec
+
+        def _make_task(*, refresh_client) -> dict:
+            repo = SessionRepository(table_name=TABLE_NAME)
+            codec = _make_codec()
+            cache = SessionCache(ttl_seconds=60)
+            config = _enabled_config()
+
+            app = FastAPI()
+            app.add_middleware(
+                SessionRefreshMiddleware,
+                config=config,
+                repository=repo,
+                cookie_codec=codec,
+                refresh_client=refresh_client,
+                cache=cache,
+                refresh_lock_ttl_seconds=2,  # short for tests
+            )
+
+            @app.get("/echo")
+            async def echo(request: Request):
+                record = getattr(request.state, "bff_session", None)
+                return {
+                    "has_session": record is not None,
+                    "access_token": (
+                        record.cognito_access_token if record else None
+                    ),
+                    "refresh_token": (
+                        record.cognito_refresh_token if record else None
+                    ),
+                }
+
+            return {
+                "app": app,
+                "repository": repo,
+                "codec": codec,
+                "cache": cache,
+                "refresh_client": refresh_client,
+            }
+
+        yield {
+            "make_task": _make_task,
+            "table_name": TABLE_NAME,
+            "shared_aes_key": shared_aes_key,
+            "make_codec": _make_codec,
+        }
+
+
+def _enabled_config() -> BFFConfig:
+    return BFFConfig(
+        sessions_table_name="tbl",
+        cookie_signing_key_arn="arn:aws:kms:fake",
+        session_ttl_seconds=28800,
+        refresh_leeway_seconds=60,
+        cognito_bff_app_client_id="client-id",
+        cognito_bff_app_client_secret_arn="arn:secret",
+        inference_api_url=None,
+        absolute_lifetime_seconds=30 * 24 * 3600,
+        sliding_renewal_throttle_seconds=300,
+    )
+
+
+def _seed_session_in_refresh_window(repository: SessionRepository) -> SessionRecord:
+    """Persist a session whose access token is inside the refresh leeway,
+    so the middleware MUST hit the refresh path."""
+    now = int(time.time())
+    record = SessionRecord(
+        session_id="sess-cross-task",
+        user_id="user-001",
+        username="alice",
+        cognito_access_token="access.original",
+        cognito_refresh_token="refresh.original",
+        id_token="id.original",
+        access_token_exp=now + 5,  # within 60s leeway
+        csrf_secret="csrf-secret",
+        created_at=now,
+        last_seen_at=now,
+        ttl=now + 28800,
+    )
+    asyncio.run(repository.put(record))
+    return record
+
+
+def test_only_the_leader_calls_cognito_under_cross_task_contention(
+    two_task_setup,
+) -> None:
+    """Two tasks see the same cookie in the refresh window. Exactly one
+    calls Cognito (the leader). The other adopts the leader's tokens
+    from DDB without ever calling Cognito.
+
+    Pre-fix: BOTH tasks would call Cognito with the same refresh token,
+    and the loser would get NotAuthorizedException → clear cookie → 401.
+    """
+    # Refresh client A is the leader's; refresh client B simulates the
+    # follower's. We assert that B is NEVER called.
+    leader_refresh = AsyncMock(
+        return_value=RefreshResult(
+            access_token="access.fresh-from-leader",
+            refresh_token="refresh.rotated-by-leader",
+            id_token="id.fresh",
+            access_token_exp=int(time.time()) + 3600,
+        )
+    )
+    follower_refresh = AsyncMock(
+        side_effect=AssertionError(
+            "Follower MUST NOT call Cognito — peer holds the refresh lock"
+        )
+    )
+
+    task_a = two_task_setup["make_task"](refresh_client=MagicMock(refresh=leader_refresh))
+    task_b = two_task_setup["make_task"](refresh_client=MagicMock(refresh=follower_refresh))
+
+    record = _seed_session_in_refresh_window(task_a["repository"])
+    sealed = task_a["codec"].seal(CookiePayload(session_id=record.session_id))
+
+    # Drive task_a first (it'll grab the lock and refresh). Then drive
+    # task_b — it must observe the lock as held (or just released, with
+    # tokens already rotated on the row) and adopt rather than refresh.
+    with TestClient(task_a["app"]) as client_a:
+        response_a = client_a.get(
+            "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+        )
+    with TestClient(task_b["app"]) as client_b:
+        response_b = client_b.get(
+            "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+        )
+
+    assert response_a.status_code == 200
+    assert response_b.status_code == 200
+    assert response_a.json()["has_session"] is True
+    assert response_b.json()["has_session"] is True
+    # Both tasks see the leader's freshly rotated tokens.
+    assert response_a.json()["access_token"] == "access.fresh-from-leader"
+    assert response_b.json()["access_token"] == "access.fresh-from-leader"
+    assert response_b.json()["refresh_token"] == "refresh.rotated-by-leader"
+
+    leader_refresh.assert_called_once()
+    follower_refresh.assert_not_called()
+
+
+def test_follower_polls_until_leader_persists_then_adopts(
+    two_task_setup,
+) -> None:
+    """Simulates near-simultaneous arrival: task_a gets the lock just
+    before task_b runs. Task_b's `_wait_for_peer_refresh` polls DDB
+    and adopts task_a's tokens once they land.
+
+    To force the follower to actually poll (rather than fall through
+    a fully-completed leader path), we make the leader's Cognito refresh
+    take a measurable amount of time and start the follower while the
+    leader is still in flight.
+    """
+    leader_done = asyncio.Event()
+    follower_started = asyncio.Event()
+
+    async def slow_leader_refresh(*args, **kwargs) -> RefreshResult:
+        # Wait for the follower to be inside its poll loop, then complete.
+        await follower_started.wait()
+        await asyncio.sleep(0.05)
+        leader_done.set()
+        return RefreshResult(
+            access_token="access.fresh-leader",
+            refresh_token="refresh.rotated-leader",
+            id_token="id.fresh",
+            access_token_exp=int(time.time()) + 3600,
+        )
+
+    leader_refresh = AsyncMock(side_effect=slow_leader_refresh)
+    follower_refresh = AsyncMock(
+        side_effect=AssertionError("Follower must NOT call Cognito")
+    )
+
+    task_a = two_task_setup["make_task"](refresh_client=MagicMock(refresh=leader_refresh))
+    task_b = two_task_setup["make_task"](refresh_client=MagicMock(refresh=follower_refresh))
+    record = _seed_session_in_refresh_window(task_a["repository"])
+    sealed = task_a["codec"].seal(CookiePayload(session_id=record.session_id))
+
+    async def drive_both() -> tuple[dict, dict]:
+        async def hit(client_app):
+            from httpx import ASGITransport, AsyncClient
+
+            async with AsyncClient(
+                transport=ASGITransport(app=client_app), base_url="http://t"
+            ) as client:
+                response = await client.get(
+                    "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+                )
+                return response.json()
+
+        async def driven_follower():
+            # Start the follower a tick later, so the leader has the lock.
+            await asyncio.sleep(0.02)
+            follower_started.set()
+            return await hit(task_b["app"])
+
+        a, b = await asyncio.gather(hit(task_a["app"]), driven_follower())
+        return a, b
+
+    a_body, b_body = asyncio.run(drive_both())
+
+    assert a_body["has_session"] is True
+    assert b_body["has_session"] is True
+    assert a_body["access_token"] == "access.fresh-leader"
+    assert b_body["access_token"] == "access.fresh-leader"
+    leader_refresh.assert_called_once()
+    follower_refresh.assert_not_called()
+
+
+def test_lock_ttl_lets_a_peer_retry_after_a_dead_leader(
+    two_task_setup,
+) -> None:
+    """Leader's Cognito call fails → lock is released → peer can refresh
+    on its next request without waiting for the full TTL.
+
+    This guards against the worst case where a leader crashes mid-refresh
+    and never persists tokens. We don't want every subsequent request to
+    fail closed for the duration of the lock TTL.
+    """
+    leader_refresh = AsyncMock(side_effect=CognitoRefreshError("Cognito down"))
+    follower_refresh = AsyncMock(
+        return_value=RefreshResult(
+            access_token="access.peer-fresh",
+            refresh_token="refresh.peer-rotated",
+            id_token="id.peer",
+            access_token_exp=int(time.time()) + 3600,
+        )
+    )
+
+    task_a = two_task_setup["make_task"](
+        refresh_client=MagicMock(refresh=leader_refresh)
+    )
+    task_b = two_task_setup["make_task"](
+        refresh_client=MagicMock(refresh=follower_refresh)
+    )
+    record = _seed_session_in_refresh_window(task_a["repository"])
+    sealed = task_a["codec"].seal(CookiePayload(session_id=record.session_id))
+
+    # Task A: leader fails. The middleware clears its cookie for THIS
+    # request but releases the lock (so a peer can retry).
+    with TestClient(task_a["app"]) as client_a:
+        response_a = client_a.get(
+            "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+        )
+    assert response_a.status_code == 200
+    assert response_a.json()["has_session"] is False
+    set_cookies_a = response_a.headers.get_list("set-cookie")
+    assert any(
+        "__Host-bff_session=" in c and "Max-Age=0" in c for c in set_cookies_a
+    ), "Task A must clear cookie after its own refresh failed"
+
+    # Task B (different request): lock is released; peer becomes the new
+    # leader and refreshes successfully.
+    with TestClient(task_b["app"]) as client_b:
+        response_b = client_b.get(
+            "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+        )
+    assert response_b.status_code == 200
+    assert response_b.json()["has_session"] is True
+    assert response_b.json()["access_token"] == "access.peer-fresh"
+    leader_refresh.assert_called_once()
+    follower_refresh.assert_called_once()
+
+
+def test_follower_falls_back_terminal_when_leader_disappears_mid_refresh(
+    two_task_setup,
+) -> None:
+    """Pathological case: leader holds the lock but never persists tokens
+    AND never releases (e.g. process killed). The follower's poll deadline
+    is bounded by `refresh_lock_ttl_seconds`; after that, this request
+    fails closed (clear cookie). The user re-auths.
+
+    The next request after this one will see the lock TTL'd and can
+    re-acquire — that path is covered by
+    `test_lock_ttl_lets_a_peer_retry_after_a_dead_leader`.
+    """
+    follower_refresh = AsyncMock(
+        side_effect=AssertionError("Follower must NOT call Cognito while a peer holds the lock")
+    )
+    task_b = two_task_setup["make_task"](
+        refresh_client=MagicMock(refresh=follower_refresh)
+    )
+    record = _seed_session_in_refresh_window(task_b["repository"])
+
+    # Manually park a lock on the row as if some other task is mid-refresh
+    # but hasn't persisted yet (and won't, for the duration of this test).
+    asyncio.run(
+        task_b["repository"].try_acquire_refresh_lock(
+            session_id=record.session_id,
+            owner="ghost-task",
+            lock_ttl_seconds=2,  # matches make_task's middleware TTL
+        )
+    )
+
+    sealed = task_b["codec"].seal(CookiePayload(session_id=record.session_id))
+    with TestClient(task_b["app"]) as client_b:
+        response = client_b.get(
+            "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    set_cookies = response.headers.get_list("set-cookie")
+    assert any(
+        "__Host-bff_session=" in c and "Max-Age=0" in c for c in set_cookies
+    ), "Follower must clear cookie after polling timed out on a stuck leader"
+    follower_refresh.assert_not_called()
+
+
+def test_two_tasks_in_parallel_call_cognito_at_most_once(
+    two_task_setup,
+) -> None:
+    """Pure asyncio gather of one request per task at the same instant.
+    Whichever wins the conditional UpdateItem becomes the leader; the
+    other adopts. Combined Cognito call count must be exactly 1.
+
+    This is the closest analogue to the page-load fan-out behavior we
+    care about in production — two tasks each receive their share of
+    the 8-endpoint fan-out at the moment the cookie crosses the leeway
+    window.
+    """
+    refresh_count = {"calls": 0}
+
+    async def counted_refresh(*args, **kwargs):
+        refresh_count["calls"] += 1
+        await asyncio.sleep(0.05)
+        return RefreshResult(
+            access_token="access.fresh",
+            refresh_token="refresh.rotated",
+            id_token="id.fresh",
+            access_token_exp=int(time.time()) + 3600,
+        )
+
+    refresh_a = AsyncMock(side_effect=counted_refresh)
+    refresh_b = AsyncMock(side_effect=counted_refresh)
+
+    task_a = two_task_setup["make_task"](
+        refresh_client=MagicMock(refresh=refresh_a)
+    )
+    task_b = two_task_setup["make_task"](
+        refresh_client=MagicMock(refresh=refresh_b)
+    )
+    record = _seed_session_in_refresh_window(task_a["repository"])
+    sealed = task_a["codec"].seal(CookiePayload(session_id=record.session_id))
+
+    async def drive() -> tuple[dict, dict]:
+        from httpx import ASGITransport, AsyncClient
+
+        async def hit(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://t"
+            ) as client:
+                response = await client.get(
+                    "/echo", cookies={SESSION_COOKIE_NAME: sealed}
+                )
+                return response.json()
+
+        return await asyncio.gather(hit(task_a["app"]), hit(task_b["app"]))
+
+    a_body, b_body = asyncio.run(drive())
+
+    # Both succeeded.
+    assert a_body["has_session"] is True
+    assert b_body["has_session"] is True
+    # Both got the same fresh tokens (one set, sourced from the leader).
+    assert a_body["access_token"] == b_body["access_token"] == "access.fresh"
+    assert a_body["refresh_token"] == b_body["refresh_token"] == "refresh.rotated"
+    # CRITICAL: across BOTH tasks, Cognito refresh was called at most once.
+    assert refresh_count["calls"] == 1, (
+        f"Cross-task coalescing violated — Cognito refresh was called "
+        f"{refresh_count['calls']} times across two tasks"
+    )

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -367,6 +367,10 @@ export class AppApiStack extends cdk.Stack {
       this,
       `/${config.projectPrefix}/auth/bff-cookie-signing-key-arn`
     );
+    const bffCookieDataKeySecretArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/auth/bff-cookie-data-key-secret-arn`
+    );
     const cognitoBFFAppClientId = ssm.StringParameter.valueForStringParameter(
       this,
       `/${config.projectPrefix}/auth/cognito/bff-app-client-id`
@@ -533,6 +537,12 @@ export class AppApiStack extends cdk.Stack {
         // BFF Token Handler — wired in Phase 1, used starting Phase 2.
         BFF_SESSIONS_TABLE_NAME: bffSessionsTableName,
         BFF_COOKIE_SIGNING_KEY_ARN: bffCookieSigningKeyArn,
+        // Wrapped AES-256 data key — fetched once at task startup, decrypted
+        // via kms:Decrypt against BFF_COOKIE_SIGNING_KEY_ARN, cached as the
+        // CookieCodec singleton's cipher. Bootstrapped at deploy time by the
+        // BFFCookieDataKey* AwsCustomResources in infrastructure-stack.ts so
+        // every app-api task shares one plaintext key.
+        BFF_COOKIE_DATA_KEY_SECRET_ARN: bffCookieDataKeySecretArn,
         BFF_SESSION_TTL_SECONDS: '28800',
         BFF_SESSION_REFRESH_LEEWAY_SECONDS: '60',
         COGNITO_BFF_APP_CLIENT_ID: cognitoBFFAppClientId,
@@ -1035,9 +1045,26 @@ export class AppApiStack extends cdk.Stack {
       new iam.PolicyStatement({
         sid: 'BFFCookieSigningKeyAccess',
         effect: iam.Effect.ALLOW,
-        // GenerateDataKey at startup; Decrypt is reserved for future key rotation.
-        actions: ['kms:GenerateDataKey', 'kms:Decrypt', 'kms:DescribeKey'],
+        // The wrapped data key is generated once at deploy time by the
+        // BFFCookieDataKey* AwsCustomResources; runtime only needs Decrypt
+        // (against BFFCookieSigningKey) to unwrap the blob fetched from
+        // Secrets Manager. kms:GenerateDataKey is intentionally NOT granted
+        // to the runtime — least privilege; a compromised task can no longer
+        // mint a parallel data key and seal cookies under it.
+        actions: ['kms:Decrypt', 'kms:DescribeKey'],
         resources: [bffCookieSigningKeyArn],
+      })
+    );
+
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'BFFCookieDataKeySecretAccess',
+        effect: iam.Effect.ALLOW,
+        // Read-only on the wrapped data key. PutSecretValue is held only by
+        // the deploy-time bootstrap custom resource — runtime cannot rotate
+        // or substitute the blob.
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: [`${bffCookieDataKeySecretArn}*`], // Wildcard for random suffix
       })
     );
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -6,12 +6,14 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { AppConfig, getResourceName, applyStandardTags, getRemovalPolicy, getAutoDeleteObjects, buildCorsOrigins } from './config';
 
@@ -689,6 +691,87 @@ export class InfrastructureStack extends cdk.Stack {
       parameterName: `/${config.projectPrefix}/auth/bff-cookie-signing-key-arn`,
       stringValue: bffCookieSigningKey.keyArn,
       description: "KMS key ARN for BFF session cookie sealing",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    // Wrapped (KMS-encrypted) AES-256 data key for cookie sealing. Persisted
+    // once at deploy time so every app-api task — across desiredCount > 1 and
+    // across rolling deploys where two task revisions briefly coexist —
+    // decrypts to the same plaintext key. Without this, each task's
+    // process-wide CookieCodec singleton calls kms:GenerateDataKey at first
+    // use and gets its own random AES key, so any cookie sealed by one task
+    // unseals as `bad seal` on another task — every page-load fan-out
+    // becomes a 401 storm under the desiredCount: 2 deployment shape.
+    const bffCookieDataKeySecret = new secretsmanager.Secret(this, "BFFCookieDataKeySecret", {
+      secretName: getResourceName(config, "bff-cookie-data-key"),
+      description:
+        "KMS-wrapped AES-256 data key (base64) for sealing BFF session cookies. " +
+        "Generated once at deploy time; rotation invalidates active cookies (no kid versioning yet).",
+      encryptionKey: bffCookieSigningKey,
+      removalPolicy: getRemovalPolicy(config),
+    });
+
+    // One-shot bootstrap. AwsCustomResource invokes one API per resource, so
+    // we chain two: (a) kms:GenerateDataKey, (b) secretsmanager:PutSecretValue
+    // threading the ciphertext through getResponseField. Both run on Create
+    // only; rotation is deliberately not wired here because we don't yet
+    // version cookies with a key id (Phase 7 hardening).
+    //
+    // CRITICAL: outputPaths whitelists CiphertextBlob so the response Plaintext
+    // (the AES key itself) never enters the AwsCustomResource Lambda's CFN
+    // response payload — it stays inside that Lambda's request-scoped memory
+    // and is dropped before the response is written to CloudFormation state.
+    const generateBffDataKey = new cr.AwsCustomResource(this, "BFFCookieDataKeyGenerate", {
+      onCreate: {
+        service: "KMS",
+        action: "generateDataKey",
+        parameters: {
+          KeyId: bffCookieSigningKey.keyArn,
+          KeySpec: "AES_256",
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(
+          `${this.stackName}-bff-cookie-data-key-generate`,
+        ),
+        outputPaths: ["CiphertextBlob"],
+      },
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ["kms:GenerateDataKey"],
+          resources: [bffCookieSigningKey.keyArn],
+        }),
+      ]),
+      installLatestAwsSdk: false,
+    });
+
+    const wrappedDataKeyBase64 = generateBffDataKey.getResponseField("CiphertextBlob");
+
+    const storeBffDataKey = new cr.AwsCustomResource(this, "BFFCookieDataKeyStore", {
+      onCreate: {
+        service: "SecretsManager",
+        action: "putSecretValue",
+        parameters: {
+          SecretId: bffCookieDataKeySecret.secretArn,
+          SecretString: wrappedDataKeyBase64,
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(
+          `${this.stackName}-bff-cookie-data-key-store`,
+        ),
+      },
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ["secretsmanager:PutSecretValue"],
+          resources: [bffCookieDataKeySecret.secretArn],
+        }),
+      ]),
+      installLatestAwsSdk: false,
+    });
+    storeBffDataKey.node.addDependency(bffCookieDataKeySecret);
+    storeBffDataKey.node.addDependency(generateBffDataKey);
+
+    new ssm.StringParameter(this, "BFFCookieDataKeySecretArnParameter", {
+      parameterName: `/${config.projectPrefix}/auth/bff-cookie-data-key-secret-arn`,
+      stringValue: bffCookieDataKeySecret.secretArn,
+      description: "Secrets Manager ARN for the BFF cookie wrapped AES-256 data key",
       tier: ssm.ParameterTier.STANDARD,
     });
 

--- a/infrastructure/test/app-api-stack.test.ts
+++ b/infrastructure/test/app-api-stack.test.ts
@@ -3,6 +3,28 @@ import { Template, Match } from 'aws-cdk-lib/assertions';
 import { AppApiStack } from '../lib/app-api-stack';
 import { createMockConfig, createMockApp, mockEnv } from './helpers/mock-config';
 
+/**
+ * CDK splits a task role's policy across an inline AWS::IAM::Policy and one
+ * or more AWS::IAM::ManagedPolicy "overflow" attachments once the IAM inline
+ * policy size limit is exceeded. Match.arrayWith on a single resource type
+ * misses statements that landed in the overflow. Walk both types and return
+ * every statement carrying the requested Sid.
+ */
+function _findStatementsBySid(template: Template, sid: string): any[] {
+  const found: any[] = [];
+  for (const resourceType of ['AWS::IAM::Policy', 'AWS::IAM::ManagedPolicy']) {
+    const policies = template.findResources(resourceType);
+    for (const policy of Object.values(policies)) {
+      const stmts =
+        (policy as any).Properties?.PolicyDocument?.Statement || [];
+      for (const stmt of stmts) {
+        if (stmt.Sid === sid) found.push(stmt);
+      }
+    }
+  }
+  return found;
+}
+
 describe('AppApiStack', () => {
   let template: Template;
   let config: ReturnType<typeof createMockConfig>;
@@ -254,6 +276,55 @@ describe('AppApiStack', () => {
             }),
           ]),
         }),
+      });
+    });
+
+    test('BFFCookieSigningKey grant is Decrypt-only — kms:GenerateDataKey is NOT granted to the runtime', () => {
+      // Least privilege: the wrapped data key is generated once at deploy
+      // time by the BFFCookieDataKey* AwsCustomResources in
+      // InfrastructureStack. The runtime only needs kms:Decrypt to unwrap
+      // it. A GenerateDataKey grant here would let a compromised app-api
+      // task mint a parallel data key and seal cookies under it.
+      const bffCookieGrants = _findStatementsBySid(template, 'BFFCookieSigningKeyAccess');
+      expect(bffCookieGrants.length).toBeGreaterThan(0);
+      for (const stmt of bffCookieGrants) {
+        const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        expect(actions).not.toContain('kms:GenerateDataKey');
+        expect(actions).toContain('kms:Decrypt');
+      }
+    });
+
+    test('task role can read the BFF cookie data key secret (GetSecretValue)', () => {
+      const grants = _findStatementsBySid(template, 'BFFCookieDataKeySecretAccess');
+      expect(grants.length).toBeGreaterThan(0);
+      for (const stmt of grants) {
+        expect(stmt.Effect).toBe('Allow');
+        const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        expect(actions).toContain('secretsmanager:GetSecretValue');
+        expect(actions).toContain('secretsmanager:DescribeSecret');
+      }
+    });
+  });
+
+  // ============================================================
+  // BFF Cookie Data Key — env var wiring
+  // ============================================================
+
+  describe('BFF Cookie Data Key', () => {
+    test('container env includes BFF_COOKIE_DATA_KEY_SECRET_ARN sourced from SSM', () => {
+      // Without this env var the CookieCodec falls back to "BFF disabled"
+      // and every cookie-bearing request unseals as bad seal — auth flow
+      // breaks across every app-api task.
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Environment: Match.arrayWith([
+              Match.objectLike({
+                Name: 'BFF_COOKIE_DATA_KEY_SECRET_ARN',
+              }),
+            ]),
+          }),
+        ]),
       });
     });
   });

--- a/infrastructure/test/infrastructure-stack.test.ts
+++ b/infrastructure/test/infrastructure-stack.test.ts
@@ -4,6 +4,36 @@ import { InfrastructureStack } from '../lib/infrastructure-stack';
 import { createMockConfig, mockEnv } from './helpers/mock-config';
 
 /**
+ * Concatenate the literal string fragments of an Fn::Join payload, ignoring
+ * intrinsic refs ({Fn::GetAtt: ...} / {Ref: ...}). Used to assert on the
+ * AwsCustomResource `Create` payload, which CDK emits as a Join over the
+ * SDK call's parameter JSON with cross-resource references spliced in.
+ */
+function _joinLiterals(value: any): string {
+  if (typeof value === 'string') return value;
+  if (value && value['Fn::Join']) {
+    const [_sep, parts] = value['Fn::Join'];
+    return (parts as any[])
+      .map((p) => (typeof p === 'string' ? p : ''))
+      .join('');
+  }
+  return '';
+}
+
+function _findCustomResourceCreate(
+  template: Template,
+  actionSubstring: string,
+): string | null {
+  const customResources = template.findResources('Custom::AWS');
+  for (const r of Object.values(customResources)) {
+    const create = (r as any).Properties?.Create;
+    const text = _joinLiterals(create);
+    if (text.includes(`"action":"${actionSubstring}"`)) return text;
+  }
+  return null;
+}
+
+/**
  * Unit tests for InfrastructureStack — the foundation layer.
  *
  * Validates VPC, ALB, ECS Cluster, Security Groups, DynamoDB tables,
@@ -110,8 +140,15 @@ describe('InfrastructureStack', () => {
   // ------------------------------------------------------------------
   // 6. All DynamoDB tables are created (count)
   // ------------------------------------------------------------------
-  test('creates all 16 DynamoDB tables', () => {
-    template.resourceCountIs('AWS::DynamoDB::Table', 16);
+  test('creates all 18 DynamoDB tables', () => {
+    // The hard-coded count drifts as tables are added — bump it when you
+    // intentionally provision a new table; investigate if it changed
+    // unexpectedly. Today: oidc_state, bff_sessions, voice_ticket_replay,
+    // users, app_roles, api_keys, oauth_providers, oauth_user_tokens,
+    // user_quotas, quota_events, sessions_metadata, user_cost_summary,
+    // system_cost_rollup, managed_models, user_settings, auth_providers,
+    // user_files, shared_conversations.
+    template.resourceCountIs('AWS::DynamoDB::Table', 18);
   });
 
   // ------------------------------------------------------------------
@@ -268,8 +305,12 @@ describe('InfrastructureStack', () => {
   // ------------------------------------------------------------------
   // 8. Secrets Manager Secrets exist
   // ------------------------------------------------------------------
-  test('creates 3 Secrets Manager secrets', () => {
-    template.resourceCountIs('AWS::SecretsManager::Secret', 3);
+  test('creates 6 Secrets Manager secrets', () => {
+    // Today: AuthenticationSecret, VoiceTicketSigningSecret,
+    // BFFCookieDataKeySecret (deploy-time wrapped AES-256 data key for
+    // cross-task cookie seal/unseal), OAuthClientSecretsSecret,
+    // AuthProviderSecretsSecret, CognitoBFFAppClientSecret.
+    template.resourceCountIs('AWS::SecretsManager::Secret', 6);
   });
 
   test('authentication secret generates a 64-char random string', () => {
@@ -446,6 +487,78 @@ describe('InfrastructureStack', () => {
         Description: Match.stringLikeRegexp('OIDC authentication provider client secrets'),
       }),
       DeletionPolicy: 'Delete',
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // BFF Cookie Data Key — shared wrapped data key for cross-task seal/unseal
+  // ------------------------------------------------------------------
+  describe('BFF Cookie Data Key', () => {
+    test('provisions a Secrets Manager secret for the wrapped data key, encrypted with the BFFCookieSigningKey CMK', () => {
+      template.hasResource('AWS::SecretsManager::Secret', {
+        Properties: Match.objectLike({
+          Description: Match.stringLikeRegexp('KMS-wrapped AES-256 data key'),
+          KmsKeyId: Match.anyValue(),
+        }),
+      });
+    });
+
+    test('publishes the data key secret ARN to SSM for app-api to consume', () => {
+      template.hasResourceProperties('AWS::SSM::Parameter', {
+        Name: `/${config.projectPrefix}/auth/bff-cookie-data-key-secret-arn`,
+      });
+    });
+
+    test('bootstrap custom resource calls kms:generateDataKey with KeySpec AES_256 + outputPaths CiphertextBlob', () => {
+      // The `Create` payload of an AwsCustomResource is emitted as an
+      // Fn::Join over [literal-fragments, intrinsic-refs, literal-fragments].
+      // Concatenate the literal string fragments to assert on the embedded
+      // service/action/parameters JSON.
+      const create = _findCustomResourceCreate(template, 'generateDataKey');
+      expect(create).not.toBeNull();
+      expect(create).toContain('"service":"KMS"');
+      expect(create).toContain('"action":"generateDataKey"');
+      expect(create).toContain('"KeySpec":"AES_256"');
+      // CRITICAL: outputPaths whitelists CiphertextBlob so the response
+      // Plaintext (the AES key itself) never enters CFN state.
+      expect(create).toContain('"outputPaths":["CiphertextBlob"]');
+    });
+
+    test('bootstrap custom resource calls secretsmanager:putSecretValue with the wrapped blob', () => {
+      const create = _findCustomResourceCreate(template, 'putSecretValue');
+      expect(create).not.toBeNull();
+      expect(create).toContain('"service":"SecretsManager"');
+      expect(create).toContain('"action":"putSecretValue"');
+    });
+
+    test('bootstrap custom resource has narrow IAM (kms:GenerateDataKey + secretsmanager:PutSecretValue only)', () => {
+      // The bootstrap Lambda's role must NOT carry broad KMS or Secrets
+      // Manager permissions — those would be a privilege-escalation path
+      // for anyone who can invoke the custom resource.
+      const policies = template.findResources('AWS::IAM::Policy');
+      const customResourcePolicies = Object.values(policies).filter((p: any) =>
+        JSON.stringify(p).includes('AWS679f53fac002430cb0da5b7982bd2287'),
+      );
+      // We don't assert on counts (CDK may share policies); we assert that
+      // anywhere the bootstrap policies appear, the actions are exactly the
+      // two we granted — no wildcards.
+      const actionsInUse = new Set<string>();
+      for (const policy of customResourcePolicies) {
+        const stmts =
+          (policy as any).Properties?.PolicyDocument?.Statement || [];
+        for (const stmt of stmts) {
+          const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+          for (const a of actions) actionsInUse.add(a);
+        }
+      }
+      // We expect at minimum these two actions; CDK adds Lambda invoke etc.
+      // The negative assertion is what matters: no wildcards and no broad
+      // kms:* or secretsmanager:*.
+      for (const action of actionsInUse) {
+        expect(action).not.toBe('*');
+        expect(action).not.toBe('kms:*');
+        expect(action).not.toBe('secretsmanager:*');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes the cross-task correctness gap that PR #264 left behind when it bumped `appApi.desiredCount` from 1 → 2 without auditing the in-process singletons that the bump exposed. Two coordinated commits:

- **Phase 1 — `fix(bff): share AES-256 cookie data key across tasks via Secrets Manager`.** The dev-blocking bug. The `CookieCodec` singleton called `kms:GenerateDataKey` once per process, so each ECS task minted its own random AES key and a cookie sealed by Task A unsealed as `bad seal` on Task B. Page-load fan-outs become routine 401 storms (visible today: `/sessions` 200 from one task, `/permissions` `/models` `/tools` `/quota` `/connectors` 401 from the other). Fix: bootstrap the wrapped data key once at deploy time via two chained `AwsCustomResource`s (`kms:GenerateDataKey` → `secretsmanager:PutSecretValue`, with `outputPaths: [\"CiphertextBlob\"]` so the response Plaintext never enters CFN state). Each task fetches the same wrapped blob from Secrets Manager and unwraps it via `kms:Decrypt(KeyId=..., CiphertextBlob=...)` once at startup; identical AESGCM cipher across the fleet.
- **Phase 2 — `fix(bff): coalesce Cognito refresh across tasks via DDB conditional-write lock`.** The next regression that would surface once Phase 1 starts working. The `single_flight` and `get_session_lock` introduced in PR #264 are both in-process; under `desiredCount: 2` two tasks each call `cognito-idp:initiate_auth` with the same refresh token, Cognito rotates on the winner, and the loser's middleware clears the user's cookie. Fix: a DDB conditional-write lock (`refresh_lock_owner` + `refresh_lock_until` on the session row) elects exactly one leader across the fleet. Followers poll the row via `_wait_for_peer_refresh` and adopt the leader's tokens without ever calling Cognito. Persist is conditional on still-being-leader so a stale leader can't stomp on a successor's writes.

Together these mean: the cookie codec's plaintext key is consistent across tasks; exactly one Cognito refresh per session per leeway window happens across the fleet; users no longer get silent 401s on page-load fan-outs.

## What changed

### Phase 1 — cross-task cookie codec ([77031f11](https://github.com/Boise-State-Development/agentcore-public-stack/commit/77031f11))

**Infrastructure (CDK):**
- New `BFFCookieDataKeySecret` (Secrets Manager), encrypted at rest with the existing `BFFCookieSigningKey` CMK.
- Two chained `AwsCustomResource`s in `infrastructure-stack.ts` bootstrap the wrapped blob on Create only. **`outputPaths: [\"CiphertextBlob\"]` whitelists the response field returned to CFN so the Plaintext data key never enters CloudFormation state.**
- New SSM parameter publishes the secret ARN.
- `app-api-stack.ts`: new env var `BFF_COOKIE_DATA_KEY_SECRET_ARN`, new `BFFCookieDataKeySecretAccess` IAM grant (`GetSecretValue` only — `PutSecretValue` is held only by the deploy-time bootstrap), and **`kms:GenerateDataKey` removed from the runtime task role** (least privilege).

**App-api (`backend/src/apis/shared/sessions_bff/cookie.py`):**
- `_ensure_cipher` reads the wrapped blob from Secrets Manager → calls `kms:Decrypt(KeyId=BFFCookieSigningKey, ...)` to unwrap → caches the AESGCM cipher. **`KeyId` is pinned on Decrypt** so a substituted blob wrapped under a different CMK is rejected (defense against blob substitution if the secret is ever tampered).
- New `CookieDataKeyUnavailable` exception distinguishes infra failure (→ 5xx, never silently invalidate sessions) from decode failure (→ clear cookie). Empty / non-base64 / wrong-size key all surface as infra errors.

### Phase 2 — cross-task refresh lock ([0838eeac](https://github.com/Boise-State-Development/agentcore-public-stack/commit/0838eeac))

**Repository (`repository.py`):**
- `try_acquire_refresh_lock(session_id, owner, lock_ttl_seconds) -> bool`: conditional `UpdateItem` that succeeds iff `attribute_not_exists(refresh_lock_until) OR refresh_lock_until < :now`. Loser returns False; non-condition errors propagate.
- `update_tokens` gains `expected_lock_owner=...` — when supplied, the write conditionally requires `refresh_lock_owner = :owner` and atomically REMOVE-es the lock attrs in the same write. `ConditionalCheckFailed` propagates so a stale leader can't stomp on a successor's tokens.
- `release_refresh_lock(session_id, owner)`: best-effort cleanup for the leader-failed path.

**Middleware (`session_refresh.py`):**
- Two-tier coalescing inside `_resolve_session._loader`: existing in-process `get_session_lock` collapses N callers to one contender per task; the **new DDB lock elects exactly one leader across the fleet**.
- Leader path: `_persist_refresh` threads `lock_owner` through; `ConditionalCheckFailed` on persist → re-read DDB and adopt the peer's tokens rather than invalidating.
- Cognito refresh failure on leader path: lock is released eagerly so peer requests don't have to wait the full TTL.
- New `_wait_for_peer_refresh` polls DDB with bounded backoff (50ms → 500ms) for the leader's tokens. Detects rotation by `refresh_token` mismatch and non-rotation by `access_token` change + future-dated exp.
- New `refresh_lock_ttl_seconds` middleware param (default 30s).

No IAM change required — the runtime task role already had `dynamodb:UpdateItem` on the BFF sessions table.

## Why these changes

- **PR #264's hidden assumption.** The design doc explicitly enumerated the in-process singletons that would prevent `--workers > 1` (`cache.py`, `refresh.py`) and chose ECS task scaling as the alternative. **`cookie.py` has the same shape with worse blast radius** but wasn't on the audit list. Bumping `desiredCount` to 2 implicitly added a cross-process correctness requirement that the codec didn't meet — and that the lock didn't meet either.
- **The trade-off in PR #264 was real but oversold.** The `to_thread` offload, throttle/leeway de-alignment, and fire-and-forget slide-write are good hygiene that should stay. The single-flight is fine. The `desiredCount: 2` bump is the right direction — but it can't ship safely without the cross-task correctness work in this branch.
- **Locks the regression in.** The new tests assert the cross-task contracts directly so this can't quietly regress again.

## Test plan

- [x] `tests/apis/` (full backend `apis/` tree): **307 passed**
- [x] `tests/apis/shared/sessions_bff/` + `middleware/` + `app_api/auth/` + `app_api/voice/`: **184 passed** (171 baseline → +13 new)
- [x] `tests/apis/shared/sessions_bff/test_repository.py`: 14 (+8 new for the lock)
- [x] `tests/apis/shared/sessions_bff/test_session_refresh_cross_task.py`: 5 (new file — leader/follower/dead-leader/lock-TTL/parallel-coalesced-Cognito-call)
- [x] Infrastructure `npx jest`: **312 passed** (added BFF Cookie Data Key resource + IAM tests; fixed two pre-existing stale resource counts)
- [x] `npx cdk synth` — green; new resources land in InfrastructureStack + AppApiStack templates
- [ ] Deploy to dev and verify the page-load fan-out (`/sessions` + `/permissions` + `/models` + `/tools/` + `/quota` + `/connectors/`) returns 200 across the desiredCount: 2 ECS service.
- [ ] Verify the bootstrap custom resource ran successfully (CloudFormation stack events) and the `bff-cookie-data-key` Secret has a non-empty value.
- [ ] Manually exercise a refresh window: confirm exactly one `cognito-idp:initiate_auth` per session per leeway window across both tasks (CloudTrail).

## Notable for reviewers

- **CFN state and the AES key.** The `outputPaths: [\"CiphertextBlob\"]` on the `kms:generateDataKey` AwsCustomResource is **load-bearing** for not leaking the plaintext AES key into CFN state. Don't drop it.
- **`KeyId` pin on `kms:Decrypt`.** Without it, KMS auto-selects the wrapping key from the blob, which is a substitution oracle if anyone gets `secretsmanager:PutSecretValue` on the secret. Runtime IAM does not grant that, but the pin is free defense-in-depth.
- **Key rotation story.** This commit doesn't add `kid`-versioned cookies, so rotating the data key still invalidates every active session. Same as today's behavior — the constraint moves from \"per task restart\" to \"per intentional secret rotation.\" Phase 7 hardening (separate work) is where versioned rotation lives.
- **Refresh-lock TTL.** Default 30s is a safety cushion over Cognito + DDB + retries. Tune via `SessionRefreshMiddleware(refresh_lock_ttl_seconds=...)` if you ever observe followers timing out.
- **Pre-existing test pollution.** The full `tests/` sweep reports 76 failures in `tests/shared/test_oauth_repositories.py` and `tests/shared/test_cognito_idp_service.py`. Both pass cleanly in isolation — fixture/env leakage from another file. Reproduces on `develop` without this branch's changes; not introduced here. Worth a separate cleanup task.
- **CDK test deltas.** While here I bumped two stale hard-coded resource counts in `infrastructure-stack.test.ts` (`16 → 18` DynamoDB tables, `3 → 6` Secrets Manager secrets) so the assertions match what the stack actually emits today. Counted via `template.findResources` — these were already failing on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)