### PR TITLE
fix(bff): tighten cross-task refresh-lock release + absolute-lifetime guard

### DIFF
--- a/backend/src/apis/shared/middleware/session_refresh.py
+++ b/backend/src/apis/shared/middleware/session_refresh.py
@@ -442,6 +442,23 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                     self._cache.set(current)
                     return current, False
 
+                # Past absolute lifetime — terminal. Don't burn a Cognito
+                # refresh-token rotation on a session we'd just write a
+                # past-dated TTL onto (which would instantly TTL-evict the
+                # row right after we wrote tokens). Mirrors the slide path
+                # in `_maybe_slide`, which also short-circuits at the cap.
+                if (
+                    current.created_at + self._config.absolute_lifetime_seconds
+                    <= int(time.time())
+                ):
+                    logger.info(
+                        "BFF session %s past absolute lifetime — clearing cookie "
+                        "rather than refreshing.",
+                        session_id,
+                    )
+                    self._cache.invalidate(session_id)
+                    return None, True
+
                 lock_owner = secrets.token_hex(16)
                 lock_acquired = await self._repository.try_acquire_refresh_lock(
                     session_id=session_id,
@@ -462,6 +479,14 @@ class SessionRefreshMiddleware(BaseHTTPMiddleware):
                         # will get to retry. Fail closed for *this* request.
                         self._cache.invalidate(session_id)
                         return None, True
+                    # Cross-task adoption succeeded — peer's refresh is
+                    # authoritative. Log at INFO so CloudWatch can answer
+                    # "how often is cross-task coalescing actually firing?"
+                    logger.info(
+                        "BFF session %s adopted peer task's refreshed tokens "
+                        "(cross-task lock follower path).",
+                        session_id,
+                    )
                     self._cache.set(peer)
                     return peer, False
 

--- a/backend/src/apis/shared/sessions_bff/repository.py
+++ b/backend/src/apis/shared/sessions_bff/repository.py
@@ -173,13 +173,19 @@ class SessionRepository:
         should slide alongside it.
 
         When `expected_lock_owner` is supplied, the write is conditional on
-        the row's `refresh_lock_owner` attribute matching (or being absent).
-        The lock attributes are also REMOVED in the same write, releasing
-        the cross-task lock alongside the token rotation. If the condition
-        fails (a peer has acquired the lock — implies our lock had expired
-        and someone else owns the refresh now), `ConditionalCheckFailedException`
-        is raised so the caller can re-read the row and adopt the peer's
-        tokens instead of stomping on them.
+        the row's `refresh_lock_owner` attribute strictly matching. The lock
+        attributes are also REMOVED in the same write, releasing the
+        cross-task lock alongside the token rotation. The condition fires
+        on two distinct stale-leader cases that both must NOT stomp:
+
+        1. A peer holds the lock right now (their owner != ours) — we never
+           had it or our acquisition was stale.
+        2. A peer held the lock, completed the refresh, and `REMOVE`d the
+           attrs — the row has no lock owner at all but our tokens are
+           now older than the row's persisted state.
+
+        Both surface as `ConditionalCheckFailedException`; the caller
+        re-reads the row and adopts the peer's tokens instead of stomping.
         """
         if not self._enabled:
             return
@@ -212,17 +218,22 @@ class SessionRepository:
 
         if expected_lock_owner is not None:
             # Atomically release the cross-task refresh lock alongside the
-            # token write. The condition guards against a stale leader
-            # (whose lock TTL'd while another task took over) overwriting
-            # the new leader's freshly persisted tokens.
+            # token write. The condition is strict — `refresh_lock_owner`
+            # MUST equal our owner. We don't accept "lock attrs absent"
+            # because that's exactly the stale-leader stomp case: a peer
+            # whose lock TTL'd, took over, refreshed, and persisted (which
+            # REMOVEs the lock attrs) — letting `attribute_not_exists`
+            # match here would let our stale tokens overwrite the peer's
+            # freshly rotated ones, silently logging the user out on the
+            # next request when Cognito rejects our (now-revoked) refresh
+            # token. The leader always set these attrs in
+            # `try_acquire_refresh_lock`, so the strict form is correct
+            # in every legitimate flow.
             kwargs["UpdateExpression"] = (
                 update_expr + " REMOVE refresh_lock_owner, refresh_lock_until"
             )
             expr_values[":owner"] = expected_lock_owner
-            kwargs["ConditionExpression"] = (
-                "attribute_not_exists(refresh_lock_owner) "
-                "OR refresh_lock_owner = :owner"
-            )
+            kwargs["ConditionExpression"] = "refresh_lock_owner = :owner"
 
         def _call() -> None:
             self._table.update_item(**kwargs)
@@ -259,9 +270,17 @@ class SessionRepository:
                 "SET refresh_lock_owner = :owner, "
                 "refresh_lock_until = :until"
             ),
+            # `attribute_exists(PK)` guards against UpdateItem's
+            # upsert-by-default behavior — without it, a logout that races
+            # the refresh path (deletes the row between `repository.get()`
+            # and this call) would let us create a phantom row containing
+            # only the lock attrs and no `ttl`, which DDB TTL would never
+            # reap. With it, lock acquisition on a missing row fails
+            # cleanly via ConditionalCheckFailedException → False.
             "ConditionExpression": (
+                "attribute_exists(PK) AND ("
                 "attribute_not_exists(refresh_lock_until) "
-                "OR refresh_lock_until < :now"
+                "OR refresh_lock_until < :now)"
             ),
             "ExpressionAttributeValues": {
                 ":owner": owner,

--- a/backend/tests/apis/shared/sessions_bff/test_repository.py
+++ b/backend/tests/apis/shared/sessions_bff/test_repository.py
@@ -277,3 +277,102 @@ async def test_update_tokens_rejects_persist_when_peer_owns_the_lock(
         exc_info.value.response.get("Error", {}).get("Code")
         == "ConditionalCheckFailedException"
     )
+
+
+@pytest.mark.asyncio
+async def test_update_tokens_rejects_persist_when_peer_already_cleared_the_lock(
+    repository, sample_record
+) -> None:
+    """The other half of the stale-leader guard: a peer whose lock TTL'd,
+    took over, refreshed, and successfully persisted (which atomically
+    REMOVEs the lock attrs) — the row now has NO lock attributes at all.
+    A stale leader trying to persist with `expected_lock_owner=our-task`
+    must still fail closed; otherwise our older Cognito tokens would
+    silently overwrite the peer's freshly rotated ones, and the next
+    request would get NotAuthorizedException from Cognito (our refresh
+    token was revoked when the peer's rotation was issued).
+
+    Sequence:
+        1. Task A acquires lock at T0.
+        2. Task A's Cognito call hangs.
+        3. Task B sees lock TTL'd, acquires, refreshes, persists (clears).
+        4. Task A's Cognito finally returns; A tries to persist.
+        => MUST fail with ConditionalCheckFailedException.
+    """
+    from botocore.exceptions import ClientError
+
+    record = sample_record()
+    await repository.put(record)
+
+    # Peer acquired the lock and successfully persisted (clearing it).
+    await repository.try_acquire_refresh_lock(
+        session_id=record.session_id, owner="peer-task", lock_ttl_seconds=30
+    )
+    await repository.update_tokens(
+        session_id=record.session_id,
+        access_token="access.peer-fresh",
+        refresh_token="refresh.peer-rotated",
+        id_token="id.peer",
+        access_token_exp=int(time.time()) + 3600,
+        last_seen_at=int(time.time()),
+        expected_lock_owner="peer-task",
+    )
+
+    # Stale leader (our-task) — never owned a lock that's still on the
+    # row, but holds an old `lock_owner` from before the TTL. Must fail.
+    with pytest.raises(ClientError) as exc_info:
+        await repository.update_tokens(
+            session_id=record.session_id,
+            access_token="access.stale-leader",
+            refresh_token="refresh.stale-leader",
+            id_token="id.stale-leader",
+            access_token_exp=int(time.time()) + 3600,
+            last_seen_at=int(time.time()),
+            expected_lock_owner="our-task",
+        )
+    assert (
+        exc_info.value.response.get("Error", {}).get("Code")
+        == "ConditionalCheckFailedException"
+    )
+
+    # Peer's tokens are still intact on the row.
+    fetched = await repository.get(record.session_id)
+    assert fetched is not None
+    assert fetched.cognito_access_token == "access.peer-fresh"
+    assert fetched.cognito_refresh_token == "refresh.peer-rotated"
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_refresh_lock_does_not_create_phantom_row(
+    repository, moto_bff_dynamodb
+) -> None:
+    """Logout-during-refresh guard: if the session row was deleted between
+    `repository.get()` and `try_acquire_refresh_lock`, UpdateItem would
+    upsert a phantom row containing only the lock attrs (and crucially no
+    `ttl`, so DDB TTL would never reap it). The `attribute_exists(PK)`
+    guard turns that into a clean False return.
+
+    Asserts via raw DDB get_item — `repository.get` would mask a phantom
+    behind its post-read TTL check (a row with no `ttl` attribute reads
+    as `int(item.get("ttl", 0)) <= now`, treated as missing), so we
+    bypass that and look at the raw item.
+    """
+    # Session row never existed (or was just deleted by a logout from
+    # another task between this request's repository.get() and here).
+    acquired = await repository.try_acquire_refresh_lock(
+        session_id="never-existed",
+        owner="task-A",
+        lock_ttl_seconds=30,
+    )
+    assert acquired is False
+
+    # No phantom row was created — check the raw table, since
+    # repository.get() would also return None for a phantom (no `ttl`).
+    table = moto_bff_dynamodb.Table("test-bff-sessions")
+    response = table.get_item(
+        Key={"PK": "SESSION#never-existed", "SK": "META"}
+    )
+    assert "Item" not in response, (
+        "try_acquire_refresh_lock created a phantom row with no `ttl` — "
+        "DDB TTL would never reap it"
+    )

--- a/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
+++ b/backend/tests/apis/shared/sessions_bff/test_session_refresh_middleware.py
@@ -496,6 +496,44 @@ def test_slide_max_age_capped_by_remaining_absolute_lifetime() -> None:
     assert 350 <= max_age <= 400
 
 
+def test_refresh_path_past_absolute_cap_clears_cookie_without_calling_cognito() -> None:
+    """The refresh path must mirror the slide path's absolute-cap behavior:
+    once `created_at + absolute_lifetime` has passed, do NOT mint fresh
+    tokens. Persisting them would also write a past-dated `ttl`
+    (`min(now + session_ttl_seconds, absolute_cap)` is `< now` past the
+    cap), which would instantly TTL-evict the row right after the write
+    and silently log the user out one request later. Failing closed up
+    front avoids burning a Cognito refresh-token rotation we'd just
+    throw away."""
+    record = _make_record(access_token_exp=int(time.time()) + 5)  # within leeway
+    record.created_at = int(time.time()) - 200  # past 100s absolute cap
+    repo = AsyncMock()
+    repo.get.return_value = record
+    codec = _make_codec()
+    refresh = MagicMock()
+    refresh.refresh = AsyncMock(
+        side_effect=AssertionError(
+            "Cognito refresh MUST NOT be called past absolute lifetime"
+        )
+    )
+    app = _build_app(
+        config=_enabled_config(absolute_lifetime_seconds=100),
+        repository=repo,
+        codec=codec,
+        refresh_client=refresh,
+    )
+
+    sealed = codec.seal(CookiePayload(session_id=record.session_id))
+    response = TestClient(app).get("/echo", cookies={SESSION_COOKIE_NAME: sealed})
+
+    assert response.status_code == 200
+    assert response.json()["has_session"] is False
+    refresh.refresh.assert_not_called()
+    repo.update_tokens.assert_not_called()
+    cleared = " ".join(response.headers.get_list("set-cookie"))
+    assert SESSION_COOKIE_NAME in cleared and "Max-Age=0" in cleared
+
+
 def test_refresh_path_bumps_ttl_when_persisting_tokens() -> None:
     """The token-rotation write must also slide the row's ttl forward —
     otherwise a session that just refreshed could still expire moments


### PR DESCRIPTION
## Summary

Two correctness improvements layered on top of [#273](https://github.com/Boise-State-Development/agentcore-public-stack/pull/273)'s cross-task refresh-lock work. Independent of [#274](https://github.com/Boise-State-Development/agentcore-public-stack/pull/274) — different files, no merge order required.

### 1. Strict-owner lock release (`repository.py`)

The post-#273 release condition had a stale-leader stomp bug. With:

```
attribute_not_exists(refresh_lock_owner) OR refresh_lock_owner = :owner
```

…the following race silently logs the user out:

```
Task A acquires the lock.
Task A's lock TTLs (slow Cognito refresh / ECS eviction / etc.).
Task B acquires the lock, refreshes, persists tokens — REMOVEing
  the lock attrs in the same write.
Task A returns from Cognito and calls update_tokens.
attribute_not_exists(refresh_lock_owner) matches → Task A's stale
  tokens overwrite Task B's freshly rotated ones.
Next request: Cognito rejects Task A's now-revoked refresh token →
  user logged out.
```

Fix: tighten to **strictly** `refresh_lock_owner = :owner`. The leader always sets the attrs in `try_acquire_refresh_lock`, so the strict form is correct in every legitimate flow and surfaces every stale-leader case as `ConditionalCheckFailedException` for the caller to re-read and adopt the peer's tokens.

### 2. Absolute-lifetime guard before refresh (`session_refresh.py`)

Mirrors the existing `_maybe_slide` short-circuit. If a session is past `created_at + absolute_lifetime_seconds`, don't burn a Cognito refresh-token rotation on a session whose row would TTL-evict immediately after the write — clear the cookie instead.

Also adds INFO logging on cross-task adoption success so CloudWatch can answer "how often is cross-task coalescing actually firing?" without needing a debug deploy.

## Test plan

- [x] `test_update_tokens_rejects_persist_when_peer_already_cleared_the_lock` — pins the strict-owner condition.
- [x] `test_try_acquire_refresh_lock_does_not_create_phantom_row` — pins the acquire-path `attribute_exists(PK)` guard.
- [x] `test_refresh_path_past_absolute_cap_clears_cookie_without_calling_cognito` — pins the lifetime guard ahead of lock acquisition.
- [x] Full `tests/apis/shared/sessions_bff/` + `tests/apis/shared/middleware/` suites pass standalone (without #274 applied) — 68 tests.
- [ ] Deploy to dev; tail app-api logs for the new "adopted peer task's refreshed tokens" INFO line under cross-task contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)