### PR TITLE
feat(auth): centralize 401 redirect + proactive session detection

### DIFF
--- a/frontend/ai.client/src/app/app.ts
+++ b/frontend/ai.client/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { Sidenav } from './components/sidenav/sidenav';
 import { ErrorToastComponent } from './components/error-toast/error-toast.component';
@@ -6,14 +6,15 @@ import { ToastComponent } from './components/toast';
 import { SidenavService } from './services/sidenav/sidenav.service';
 import { HeaderService } from './services/header/header.service';
 import { TooltipDirective } from './components/tooltip/tooltip.directive';
+import { SessionService } from './auth/session.service';
 
 @Component({
   selector: 'app-root',
   imports: [
-    RouterOutlet, 
-    Sidenav, 
-    ErrorToastComponent, 
-    ToastComponent, 
+    RouterOutlet,
+    Sidenav,
+    ErrorToastComponent,
+    ToastComponent,
     TooltipDirective
   ],
   templateUrl: './app.html',
@@ -24,6 +25,24 @@ export class App {
   protected sidenavService = inject(SidenavService);
   protected headerService = inject(HeaderService);
   private router = inject(Router);
+  private session = inject(SessionService);
+
+  constructor() {
+    // Re-probe the BFF session whenever the tab regains focus. A session
+    // that expired while the tab was backgrounded surfaces immediately
+    // (redirect to /auth/login) instead of waiting for the next user
+    // action to 401. SSR-safe via the document guard.
+    if (typeof document !== 'undefined') {
+      const destroyRef = inject(DestroyRef);
+      const handler = () => {
+        if (document.visibilityState === 'visible') {
+          this.session.recheck();
+        }
+      };
+      document.addEventListener('visibilitychange', handler);
+      destroyRef.onDestroy(() => document.removeEventListener('visibilitychange', handler));
+    }
+  }
 
   newChat() {
     this.router.navigate(['']);

--- a/frontend/ai.client/src/app/auth/error.interceptor.spec.ts
+++ b/frontend/ai.client/src/app/auth/error.interceptor.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpRequest, HttpResponse, HttpErrorResponse, HttpHandlerFn } from '@angular/common/http';
 import { errorInterceptor } from './error.interceptor';
 import { ErrorService } from '../services/error/error.service';
+import { SessionService } from './session.service';
 import { of, throwError } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -9,16 +10,23 @@ describe('errorInterceptor', () => {
   let errorService: {
     handleHttpError: ReturnType<typeof vi.fn>;
   };
+  let sessionService: {
+    handleUnauthorized: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     TestBed.resetTestingModule();
     errorService = {
       handleHttpError: vi.fn(),
     };
+    sessionService = {
+      handleUnauthorized: vi.fn(),
+    };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: ErrorService, useValue: errorService },
+        { provide: SessionService, useValue: sessionService },
       ],
     });
   });
@@ -139,6 +147,26 @@ describe('errorInterceptor', () => {
         errorInterceptor(req, nextFn).subscribe({
           error: (err: unknown) => {
             expect(errorService.handleHttpError).toHaveBeenCalled();
+            expect(err).toBe(error);
+            resolve();
+          },
+        });
+      });
+    });
+  });
+
+  it('should call sessionService.handleUnauthorized on 401 and skip the toast', async () => {
+    const error = new HttpErrorResponse({ status: 401, url: 'http://localhost:8000/api/sessions' });
+    const nextFn: HttpHandlerFn = vi.fn().mockReturnValue(throwError(() => error));
+    const req = new HttpRequest('GET', 'http://localhost:8000/api/sessions');
+
+    await new Promise<void>((resolve) => {
+      TestBed.runInInjectionContext(() => {
+        errorInterceptor(req, nextFn).subscribe({
+          error: (err: unknown) => {
+            expect(sessionService.handleUnauthorized).toHaveBeenCalledTimes(1);
+            expect(errorService.handleHttpError).not.toHaveBeenCalled();
+            // Caller still sees the error so any local cleanup runs.
             expect(err).toBe(error);
             resolve();
           },

--- a/frontend/ai.client/src/app/auth/error.interceptor.ts
+++ b/frontend/ai.client/src/app/auth/error.interceptor.ts
@@ -2,6 +2,7 @@ import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
 import { ErrorService } from '../services/error/error.service';
+import { SessionService } from './session.service';
 
 /**
  * HTTP interceptor that handles errors from non-streaming HTTP requests
@@ -17,6 +18,7 @@ import { ErrorService } from '../services/error/error.service';
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const errorService = inject(ErrorService);
+  const sessionService = inject(SessionService);
 
   // Skip error handling for SSE streaming endpoints
   // These are handled by fetchEventSource's onerror callback.
@@ -43,12 +45,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
           req.url.includes(endpoint)
         );
 
-        // 401s mean the BFF session is missing or expired. SessionService
-        // handles that by routing the user to /auth/login — a toast on top
-        // is just noise and tends to flash before the redirect lands.
-        const isUnauthorized = error.status === 401;
-
-        if (!isSilentEndpoint && !isUnauthorized) {
+        // 401s mean the BFF session is missing or expired. Route to the
+        // SPA login page (idempotent across concurrent 401s) and skip the
+        // toast — it just flashes before the redirect lands.
+        if (error.status === 401) {
+          sessionService.handleUnauthorized();
+        } else if (!isSilentEndpoint) {
           // Use ErrorService to display the error
           errorService.handleHttpError(error);
         }

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -21,8 +21,37 @@ describe('SessionService', () => {
     csrf_token: 'csrf-secret-abc',
   };
 
+  // Helpers — bootstrap takes the network path only when the JS-readable
+  // CSRF cookie is present; otherwise the fast-path bounces straight to
+  // login. Tests that exercise the network path set the cookie first.
+  //
+  // jsdom enforces `__Host-` cookie prefix rules (Secure required, no
+  // http://localhost), so a real `document.cookie` write is silently
+  // rejected. Install a minimal one-cookie shim per-test.
+  let cookieStore = '';
+  const installCookieShim = () => {
+    cookieStore = '';
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => cookieStore,
+      set: (input: string) => {
+        const [pair, ...attrs] = input.split(';');
+        const expired = attrs.some((a) => /expires=Thu, 01 Jan 1970/i.test(a));
+        cookieStore = expired ? '' : pair.trim();
+      },
+    });
+  };
+  const setCsrfCookie = (value = 'test-csrf-token') => {
+    document.cookie = `__Host-bff_csrf=${value}; path=/`;
+  };
+  const clearCsrfCookie = () => {
+    document.cookie =
+      '__Host-bff_csrf=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  };
+
   beforeEach(() => {
     TestBed.resetTestingModule();
+    installCookieShim();
 
     Object.defineProperty(window, 'location', {
       value: {
@@ -53,6 +82,7 @@ describe('SessionService', () => {
 
   afterEach(() => {
     httpMock.verify();
+    clearCsrfCookie();
     TestBed.resetTestingModule();
     vi.restoreAllMocks();
   });
@@ -68,6 +98,7 @@ describe('SessionService', () => {
 
   describe('bootstrap', () => {
     it('populates user and csrfToken on a successful 200', async () => {
+      setCsrfCookie();
       const promise = service.bootstrap();
 
       const req = httpMock.expectOne('http://localhost:8000/auth/session');
@@ -94,6 +125,7 @@ describe('SessionService', () => {
     });
 
     it('redirects to the SPA /auth/login page on 401 and clears state', async () => {
+      setCsrfCookie();
       window.location.pathname = '/admin/users';
       window.location.search = '?tab=roles';
 
@@ -120,6 +152,7 @@ describe('SessionService', () => {
     });
 
     it('does not redirect when the 401 lands on /auth/login itself', async () => {
+      setCsrfCookie();
       window.location.pathname = '/auth/login';
       window.location.search = '';
 
@@ -137,6 +170,7 @@ describe('SessionService', () => {
     });
 
     it('does not redirect on a non-401 transport error', async () => {
+      setCsrfCookie();
       const promise = service.bootstrap();
 
       const req = httpMock.expectOne('http://localhost:8000/auth/session');
@@ -151,6 +185,7 @@ describe('SessionService', () => {
     });
 
     it('uses same-origin path when appApiUrl is configured as /api', async () => {
+      setCsrfCookie();
       (configService.appApiUrl as any).set('/api');
 
       const promise = service.bootstrap();
@@ -164,6 +199,7 @@ describe('SessionService', () => {
     });
 
     it('strips a trailing slash from appApiUrl', async () => {
+      setCsrfCookie();
       (configService.appApiUrl as any).set('http://localhost:8000/');
 
       const promise = service.bootstrap();
@@ -175,6 +211,150 @@ describe('SessionService', () => {
 
       expect(service.isAuthenticated()).toBe(true);
     });
+
+    it('skips the /auth/session round-trip and redirects when no CSRF cookie is present', async () => {
+      window.location.pathname = '/files';
+      window.location.search = '';
+      // Cookie absent (cleared in beforeEach). The fast-path should
+      // detect this and bounce without making any HTTP request.
+      void service.bootstrap();
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      httpMock.expectNone('http://localhost:8000/auth/session');
+      expect(service.bootstrapped()).toBe(false);
+      expect(window.location.href).toBe(
+        `/auth/login?returnUrl=${encodeURIComponent('/files')}`,
+      );
+    });
+
+    it('still resolves on /auth/login when the CSRF cookie is absent', async () => {
+      window.location.pathname = '/auth/login';
+      window.location.search = '';
+      // No cookie — fast-path triggers, but handleUnauthorized returns
+      // false on /auth/login so bootstrap completes without hanging.
+      await service.bootstrap();
+
+      httpMock.expectNone('http://localhost:8000/auth/session');
+      expect(service.bootstrapped()).toBe(true);
+      expect(window.location.href).toBe('');
+    });
+  });
+
+  describe('handleUnauthorized', () => {
+    it('redirects to /auth/login with the current path as returnUrl', () => {
+      window.location.pathname = '/manage-sessions';
+      window.location.search = '?id=abc';
+
+      const navigated = service.handleUnauthorized();
+
+      expect(navigated).toBe(true);
+      expect(window.location.href).toBe(
+        `/auth/login?returnUrl=${encodeURIComponent('/manage-sessions?id=abc')}`,
+      );
+      expect(service.user()).toBeNull();
+      expect(service.csrfToken()).toBeNull();
+    });
+
+    it('is a no-op when already on /auth/login', () => {
+      window.location.pathname = '/auth/login';
+
+      const navigated = service.handleUnauthorized();
+
+      expect(navigated).toBe(false);
+      expect(window.location.href).toBe('');
+    });
+
+    it('dedupes concurrent calls — only the first navigates', () => {
+      window.location.pathname = '/files';
+
+      expect(service.handleUnauthorized()).toBe(true);
+
+      // Mid-burst 401s shouldn't queue more navigations.
+      window.location.href = ''; // simulate that nothing has actually navigated yet
+      expect(service.handleUnauthorized()).toBe(false);
+      expect(window.location.href).toBe('');
+    });
+  });
+
+  describe('hasSessionCookie', () => {
+    it('returns false when the cookie is absent', () => {
+      expect(service.hasSessionCookie()).toBe(false);
+    });
+
+    it('returns true when the cookie is present', () => {
+      setCsrfCookie();
+      expect(service.hasSessionCookie()).toBe(true);
+    });
+  });
+
+  describe('recheck', () => {
+    const bootstrapAuthenticated = async () => {
+      setCsrfCookie();
+      const promise = service.bootstrap();
+      httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
+      await promise;
+    };
+
+    it('is a no-op before bootstrap has resolved', async () => {
+      setCsrfCookie();
+      await service.recheck();
+      httpMock.expectNone('http://localhost:8000/auth/session');
+    });
+
+    it('refreshes session state on a successful 200', async () => {
+      await bootstrapAuthenticated();
+      window.location.pathname = '/files';
+
+      const promise = service.recheck();
+      const req = httpMock.expectOne('http://localhost:8000/auth/session');
+      req.flush({ ...sessionResponse, csrf_token: 'rotated-csrf' });
+      await promise;
+
+      expect(service.csrfToken()).toBe('rotated-csrf');
+      expect(service.isAuthenticated()).toBe(true);
+      expect(window.location.href).toBe('');
+    });
+
+    it('redirects when the BFF returns 401', async () => {
+      await bootstrapAuthenticated();
+      window.location.pathname = '/files';
+
+      const promise = service.recheck();
+      const req = httpMock.expectOne('http://localhost:8000/auth/session');
+      req.flush('unauthorized', { status: 401, statusText: 'Unauthorized' });
+      await promise;
+
+      expect(window.location.href).toBe(
+        `/auth/login?returnUrl=${encodeURIComponent('/files')}`,
+      );
+    });
+
+    it('redirects without a network call when the CSRF cookie is gone', async () => {
+      await bootstrapAuthenticated();
+      window.location.pathname = '/files';
+      clearCsrfCookie();
+
+      await service.recheck();
+
+      httpMock.expectNone('http://localhost:8000/auth/session');
+      expect(window.location.href).toBe(
+        `/auth/login?returnUrl=${encodeURIComponent('/files')}`,
+      );
+    });
+
+    it('stays silent on a transient network error', async () => {
+      await bootstrapAuthenticated();
+      window.location.pathname = '/files';
+
+      const promise = service.recheck();
+      const req = httpMock.expectOne('http://localhost:8000/auth/session');
+      req.error(new ProgressEvent('network'), { status: 0, statusText: '' });
+      await promise;
+
+      expect(window.location.href).toBe('');
+      expect(service.isAuthenticated()).toBe(true);
+    });
   });
 
   describe('csrfHeaders', () => {
@@ -183,6 +363,7 @@ describe('SessionService', () => {
     });
 
     it('returns X-CSRF-Token after a successful bootstrap', async () => {
+      setCsrfCookie();
       const promise = service.bootstrap();
       httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
       await promise;
@@ -239,6 +420,7 @@ describe('SessionService', () => {
 
   describe('logout', () => {
     it('POSTs /auth/logout, clears local state, and navigates to the Cognito logout URL', async () => {
+      setCsrfCookie();
       const bootPromise = service.bootstrap();
       httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
       await bootPromise;
@@ -264,6 +446,7 @@ describe('SessionService', () => {
     });
 
     it('does not navigate when post_logout_url is null', async () => {
+      setCsrfCookie();
       const bootPromise = service.bootstrap();
       httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
       await bootPromise;
@@ -279,6 +462,7 @@ describe('SessionService', () => {
     });
 
     it('clears local state even when /auth/logout fails', async () => {
+      setCsrfCookie();
       const bootPromise = service.bootstrap();
       httpMock.expectOne('http://localhost:8000/auth/session').flush(sessionResponse);
       await bootPromise;

--- a/frontend/ai.client/src/app/auth/session.service.ts
+++ b/frontend/ai.client/src/app/auth/session.service.ts
@@ -35,6 +35,12 @@ export class SessionService {
   private readonly _csrfToken = signal<string | null>(null);
   private readonly _bootstrapped = signal(false);
 
+  /**
+   * Latch flipped the first time we trigger a 401 redirect, so concurrent
+   * 401s from in-flight requests don't queue multiple navigations.
+   */
+  private redirecting = false;
+
   /** Current BFF session user, or null when no session is active. */
   readonly user = this._user.asReadonly();
 
@@ -55,11 +61,28 @@ export class SessionService {
    * to the SPA's `/auth/login` page (unless we're already there) so the
    * user can pick a provider before we hand off to Cognito Hosted UI.
    *
+   * Fast path: the JS-readable `__Host-bff_csrf` cookie shares its
+   * lifetime with the httpOnly session cookie (BFF sets and clears them
+   * together). If it's gone, the session is gone too — skip the round-trip
+   * and bounce straight to login.
+   *
    * Network errors leave the service in a clean unauthenticated state
    * without redirecting — a transient failure shouldn't kick the user
    * out.
    */
   async bootstrap(): Promise<void> {
+    if (!this.hasSessionCookie()) {
+      this._user.set(null);
+      this._csrfToken.set(null);
+      if (this.handleUnauthorized()) {
+        // Hang so APP_INITIALIZER blocks the SPA from rendering a route
+        // before the queued navigation tears the page down.
+        await new Promise<never>(() => {});
+      }
+      this._bootstrapped.set(true);
+      return;
+    }
+
     const url = `${this.baseUrl()}/auth/session`;
     try {
       const response = await firstValueFrom(
@@ -72,22 +95,86 @@ export class SessionService {
       this._user.set(null);
       this._csrfToken.set(null);
       if (error instanceof HttpErrorResponse && error.status === 401) {
-        if (window.location.pathname === '/auth/login') {
-          // Already on the SPA login page — let it render so the user
-          // can pick a provider.
-          return;
+        if (this.handleUnauthorized()) {
+          await new Promise<never>(() => {});
         }
-        const returnUrl = `${window.location.pathname}${window.location.search}`;
-        const params = new URLSearchParams({ returnUrl });
-        window.location.href = `/auth/login?${params.toString()}`;
-        // window.location.href only queues the navigation. Hang the promise
-        // so APP_INITIALIZER blocks the SPA from rendering a route before
-        // the browser tears the page down.
-        await new Promise<never>(() => {});
       }
     } finally {
       this._bootstrapped.set(true);
     }
+  }
+
+  /**
+   * Centralized 401 handler. Clears local session state and navigates the
+   * browser to the SPA's `/auth/login` page with a `returnUrl` so the user
+   * lands back where they were after re-auth.
+   *
+   * Idempotent — a concurrent burst of 401s from in-flight requests only
+   * queues a single navigation. Skipped (returns false) when we're already
+   * on `/auth/login` so the page can render.
+   *
+   * @returns true when a navigation was queued, false otherwise. Bootstrap
+   *   uses the boolean to decide whether to hang APP_INITIALIZER.
+   */
+  handleUnauthorized(): boolean {
+    if (this.redirecting) return false;
+    if (window.location.pathname === '/auth/login') return false;
+    this.redirecting = true;
+    this._user.set(null);
+    this._csrfToken.set(null);
+    const returnUrl = `${window.location.pathname}${window.location.search}`;
+    const params = new URLSearchParams({ returnUrl });
+    window.location.href = `/auth/login?${params.toString()}`;
+    return true;
+  }
+
+  /**
+   * Re-probe the session against the BFF. Called by the app shell on tab
+   * refocus so a session that expired while the tab was backgrounded
+   * surfaces immediately instead of on the next user action.
+   *
+   * Cookie-presence check first — if the JS-readable CSRF cookie is gone,
+   * the session cookie is gone too (they share lifetime), so we redirect
+   * without spending a round-trip. Otherwise hits `/auth/session` which has
+   * no side effects on the BFF (it neither slides nor refreshes).
+   *
+   * Network errors are silent — a transient failure mid-tab-focus is not a
+   * reason to bounce the user.
+   */
+  async recheck(): Promise<void> {
+    if (this.redirecting) return;
+    if (!this._bootstrapped()) return;
+    if (!this.hasSessionCookie()) {
+      this.handleUnauthorized();
+      return;
+    }
+    const url = `${this.baseUrl()}/auth/session`;
+    try {
+      const response = await firstValueFrom(
+        this.http.get<BffSessionResponse>(url, { withCredentials: true }),
+      );
+      const { csrf_token, ...user } = response;
+      this._user.set(user);
+      this._csrfToken.set(csrf_token);
+    } catch (error) {
+      if (error instanceof HttpErrorResponse && error.status === 401) {
+        this.handleUnauthorized();
+      }
+    }
+  }
+
+  /**
+   * True when the JS-readable `__Host-bff_csrf` cookie is present. The BFF
+   * sets and clears it alongside the httpOnly session cookie with the same
+   * `Max-Age`, so absence ⇒ session is also gone. Presence is a weak
+   * positive — server-side revocation can leave the cookie behind until
+   * its TTL elapses — so callers should still verify with the BFF.
+   */
+  hasSessionCookie(): boolean {
+    if (typeof document === 'undefined') return true;
+    return document.cookie
+      .split(';')
+      .some((entry) => entry.trim().startsWith('__Host-bff_csrf='));
   }
 
   /**

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
@@ -28,7 +28,7 @@ describe('ChatHttpService', () => {
         // Phase 6c: chat-http now reads CSRF from the BFF SessionService
         // and lets cookie auth ride along with the request rather than
         // attaching a Bearer manually.
-        { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}) } },
+        { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}), handleUnauthorized: vi.fn() } },
         { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn() } },
         { provide: StreamParserService, useValue: {} },
         { provide: ChatStateService, useValue: { isStreaming: signal(false), streamingSessionId: signal(null), abortCurrentRequest: vi.fn(), setChatLoading: vi.fn(), resetState: vi.fn(), getAbortController: vi.fn().mockReturnValue(new AbortController()) } },

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -22,6 +22,17 @@ class FatalError extends Error {
     this.name = 'FatalError';
   }
 }
+/**
+ * Thrown by the SSE `onopen` when the BFF returned 401. The session
+ * redirect is already in flight; `onerror` uses this marker to suppress
+ * the toast that would otherwise flash before the page tears down.
+ */
+class UnauthorizedError extends Error {
+  constructor() {
+    super('Session expired');
+    this.name = 'UnauthorizedError';
+  }
+}
 
 interface GenerateTitleRequest {
   session_id: string;
@@ -69,6 +80,10 @@ export class ChatHttpService {
     // an empty object before bootstrap or in the Bearer rollback path.
     const csrfHeaders = this.bffSession.csrfHeaders();
 
+    // Capture into a local so `onopen` (a method-shorthand on the config
+    // object, not a closure over `this`) can reach the BFF session.
+    const bffSession = this.bffSession;
+
     return fetchEventSource(`${baseUrl}/chat/stream`, {
       method: 'POST',
       // Send the BFF session cookie (`__Host-bff_session`) on cross-origin
@@ -88,6 +103,12 @@ export class ChatHttpService {
       async onopen(response) {
         if (response.ok && response.headers.get('content-type')?.includes('text/event-stream')) {
           return; // everything's good
+        } else if (response.status === 401) {
+          // BFF session is missing or expired. Bounce to /auth/login —
+          // `handleUnauthorized` is idempotent, so a 401 here that races
+          // with one from a parallel request only navigates once.
+          bffSession.handleUnauthorized();
+          throw new UnauthorizedError();
         } else if (response.status === 403) {
           // Handle forbidden (e.g., usage limit exceeded)
           let errorMessage = 'Access forbidden';
@@ -161,6 +182,12 @@ export class ChatHttpService {
       onerror: (err) => {
         this.messageMapService.endStreaming();
         this.chatStateService.setChatLoading(false);
+
+        // 401 already triggered the redirect — skip the toast so it
+        // doesn't flash before the page tears down.
+        if (err instanceof UnauthorizedError) {
+          throw err;
+        }
 
         // Display error message to user using ErrorService
         if (err instanceof FatalError) {


### PR DESCRIPTION
## Summary

Previously only `SessionService.bootstrap()` redirected on 401. A session that expired mid-use left the user stranded with a generic toast (CRUD endpoints) or no feedback at all (SSE chat stream).

This PR routes every 401 through a single `SessionService.handleUnauthorized()` and adds two proactive detection layers so a stale session surfaces *before* the user hits send.

## What changed

**Centralized 401 handling**
- `SessionService.handleUnauthorized()` — clears local state, navigates to `/auth/login?returnUrl=...`, idempotent latch dedupes concurrent calls, no-op when already on `/auth/login`.
- `errorInterceptor` — calls `handleUnauthorized()` on 401 (toast still suppressed since redirect is in flight).
- `ChatHttpService` SSE `onopen` — detects 401, calls `handleUnauthorized()`, throws `UnauthorizedError` so `onerror` skips the toast that would flash before tear-down.

**Proactive detection**
- Cookie-presence fast-path in `bootstrap()` and new `recheck()` — when `__Host-bff_csrf` is gone, the httpOnly session cookie is gone too (BFF sets/clears them with matching `Max-Age`), so we redirect without spending an `/auth/session` round-trip.
- Visibility re-probe in the app shell — `visibilitychange` listener calls `session.recheck()` on tab refocus so a session expired while the tab was backgrounded is caught immediately. `DestroyRef` cleanup, SSR-safe.

**Deferred to follow-up PRs**
- Cross-tab `BroadcastChannel` coordination.
- Draft preservation across the login redirect.
- Periodic background polling (only if server-side revocation cases show up in the wild).

## Test plan

Automated:
- [x] 925 unit tests pass (28 in `session.service.spec.ts`, including new coverage for `handleUnauthorized` dedupe, cookie fast-path, `recheck`, and 401 in `errorInterceptor`).
- [x] `ng build --configuration=development` clean.

Manual (against a real BFF — SKIP_AUTH bypasses the session path so it can't exercise these changes):
- [x] CRUD 401 redirect: delete `__Host-bff_session`, trigger any HTTP call → redirect to `/auth/login?returnUrl=...`, no 401 toast flash.
- [x] Cookie fast-path on cold load: delete both cookies, hard reload `/files` → instant redirect, no `/auth/session` request in network panel.
- [x] SSE 401 redirect: delete session cookie, send a chat message → redirect, no "Request failed with status 401" toast.
- [x] Visibility re-probe: shorten `BFF_SESSION_TTL_SECONDS` locally, background the tab past TTL, refocus → redirect within ~1s.
- [x] Already-on-login no-op: visit `/auth/login` directly with no cookies → page renders, no redirect loop.
- [ ] Concurrent 401 dedupe: covered by unit test; in-browser dedupe is invisible by design (page tears down on first navigation), so manual verification adds no signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)