### PR TITLE
chore(kaizen): scaffold kaizen-research + review-prep + bootstrap 2026-05-10

### DIFF
--- a/.claude/skills/kaizen-research/SKILL.md
+++ b/.claude/skills/kaizen-research/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: kaizen-research
+description: Weekly Friday early-morning external + internal scan for ways to improve the AgentCore Public Stack repo. Tracks AWS Bedrock + AgentCore announcements, Strands Agents releases, the aws-samples/sample-strands-agent-with-agentcore reference repo, the MCP ecosystem, frontier model announcements, and agent-harness patterns. Audits internal signals (recent commits, open PRs, CI failures, version-pin lag, dormant skills). Outputs a dated research doc + queues ideas in `docs/kaizen/review-queue.md` for that same morning's `kaizen-review-prep` (runs ~2 hours later) to rank into decisions. Opens a PR into `develop`. Triggers: "kaizen research", "weekly research scan", "external scan", "what should we look at this week".
+---
+
+# Kaizen Research
+
+Friday early morning. The "what's the rest of the world learning that we should consider, and what's our own week telling us?" scan. Pairs with `kaizen-review-prep` which runs ~2 hours later the same morning and ranks this skill's output into a decision agenda — both docs ready before Phil sits down to review Friday morning.
+
+## Philosophy
+
+- **Subtraction first.** Every research run should propose at least as many things to *remove or simplify* as to add. A smaller stack you trust beats a bigger one you route around.
+- **Subagent fan-out.** External sources are independent — fan them out to parallel subagents and synthesize. Keeps the main context clean and runs faster.
+- **Web budget soft cap.** Target ≤50 web requests. If a source is exhausted, unreachable, or rate-limited, list it as "not scanned this week" — don't skip silently. Going modestly over the cap (say, to 60) is fine if the extra requests are surfacing real signal; document the overage in the Web Budget block. Don't pad — if 30 requests covered every source meaningfully, stop at 30.
+- **Cite everything.** Every external claim gets a URL + access date in the Sources Scanned appendix. Web findings rot fast and you'll re-read them next week.
+- **No edits outside `docs/kaizen/`.** This skill writes a dated research doc and updates `review-queue.md`. It never touches `backend/`, `frontend/`, `infrastructure/`, `CLAUDE.md`, or skill files.
+
+## When to run
+
+Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am MT) so both docs are waiting when Phil sits down Friday morning. Phil reviews, picks 1–3 to ship over the coming week, and POCs additional items over the weekend. Last weekend's POC findings surface in *this* run's review-prep as Carried Over items (lifted from comments on the previous week's research PR).
+
+## Sources
+
+### External (web — last 7 days unless noted)
+
+1. **AWS Bedrock + AgentCore "What's New"**
+   - https://aws.amazon.com/about-aws/whats-new/recent/feed/
+   - https://aws.amazon.com/bedrock/whats-new/
+   - https://aws.amazon.com/blogs/machine-learning/ (filter: bedrock, agentcore)
+   - Filter to: Bedrock, AgentCore, Bedrock Agents, Knowledge Bases, Guardrails, model availability/region/quota changes.
+
+2. **Strands Agents SDK**
+   - https://github.com/strands-agents/sdk-python/releases
+   - https://github.com/strands-agents/sdk-python/blob/main/CHANGELOG.md
+   - https://github.com/strands-agents/sdk-python/issues?q=is%3Aissue+sort%3Aupdated-desc
+   - For each new release, identify: breaking changes, new hooks/features, fixes that map to current usage in `backend/src/agents/main_agent/`.
+
+3. **Reference repo — `aws-samples/sample-strands-agent-with-agentcore`**
+   - https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main
+   - Diff the last 7 days (or "since last research run" — whichever is longer). Identify new patterns, removed approaches, or fixes that map to constructs in this repo: agent setup, tool registration, AgentCore Identity flows, Memory configuration, Gateway/MCP wiring.
+   - This repo has historically informed our architecture; week-over-week deltas are first-class signal.
+
+4. **MCP ecosystem**
+   - https://modelcontextprotocol.io (blog, spec changes)
+   - https://github.com/modelcontextprotocol/servers (new servers, retired servers)
+   - MCP registry / awesome-mcp lists for new servers relevant to the stack (Bedrock, AWS, GitHub, Slack, observability).
+
+5. **Frontier model announcements**
+   - https://www.anthropic.com/news
+   - https://openai.com/blog (filter: API, agents, tools)
+   - https://blog.google/technology/google-deepmind/ (Gemini)
+   - https://ai.meta.com/blog/ (Llama)
+   - Focus on capability deltas affecting agent harness design: longer context, native tool use changes, prompt caching APIs, computer use, structured output, latency/cost shifts.
+
+6. **Agent harness patterns**
+   - https://www.anthropic.com/engineering (Claude Code, agent design posts)
+   - https://docs.claude.com/en/docs/claude-code/release-notes
+   - LangChain / LlamaIndex / Pydantic-AI release notes — for ideas, not adoption.
+
+7. **AWS Bedrock pricing + quota**
+   - https://aws.amazon.com/bedrock/pricing/
+   - Note any model price/quota changes that could shift architecture choices in this repo (e.g., model selection in `inference_api`).
+
+8. **AgentCore SDK / starter-toolkit issues**
+   - https://github.com/aws/amazon-bedrock-agentcore-sdk-python/issues
+   - https://github.com/aws/amazon-bedrock-agentcore-starter-toolkit/issues
+   - Early-signal bugs/limits other users hit before we do.
+
+9. **Community signal (filtered)**
+   - HN search: `site:news.ycombinator.com bedrock OR agentcore OR strands OR "claude code"` (last 7 days)
+   - r/LocalLLaMA, r/MachineLearning — agent-harness critiques and patterns surface here before vendor blogs.
+
+10. **Security advisories**
+    - https://github.com/advisories — filter for `boto3`, `strands-agents`, `fastapi`, `mcp`, `@angular`, `aws-cdk-lib`, `pydantic`.
+    - Cross-reference against pinned versions in this repo.
+
+11. **Anthropic cookbook + courses**
+    - https://github.com/anthropics/anthropic-cookbook
+    - https://github.com/anthropics/courses
+    - Worked examples often outpace docs — especially for caching, tool use, and agent loops.
+
+12. **Seasonal sources** (only when in window)
+    - AWS re:Invent (typically late Nov / early Dec) — Bedrock/AgentCore announcements.
+    - NeurIPS / ICLR / EMNLP agent tracks (when proceedings drop).
+    - If today's date is not in a known window, skip with "no seasonal sources this week".
+
+### Internal (this repo)
+
+13. **Recent commits.** `git log develop --since="7 days ago" --oneline --no-merges`. Cluster by area (`backend/`, `frontend/`, `infrastructure/`). Reverts and high-churn files signal pain points.
+
+14. **Open PRs + review comments.** `gh pr list --base develop --state open --limit 20`, then `gh pr view <n> --comments` on the top 3 by comment count. Repeated review feedback is a CLAUDE.md or skill-update signal.
+
+15. **GitHub issues opened in last 7 days.** `gh issue list --state open --search "created:>$(date -v-7d +%Y-%m-%d)"`. Bug clustering = refactor signal.
+
+16. **CI failures.** `gh run list --status=failure --limit 30`. Group by workflow + job. Flaky tests and recurring infra failures.
+
+17. **Recent CHANGELOG.md / RELEASE_NOTES.md entries** (last 14 days). Used as the "don't re-propose what we just shipped" filter.
+
+18. **Skill inventory.** `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`. Skills not modified in 60+ days and not visibly referenced in recent PRs are retirement candidates.
+
+19. **Version-pin lag.** For each tracked dep, fetch latest release version and compute lag:
+    - Backend: `strands-agents`, `boto3`, `botocore`, `fastapi`, `pydantic`, `bedrock-agentcore`, `mcp`
+    - Frontend: `@angular/core`, `@analogjs/platform`, `vitest`
+    - Infrastructure: `aws-cdk-lib`, `constructs`
+    - Source files: `backend/pyproject.toml`, `frontend/ai.client/package.json`, `infrastructure/package.json`.
+
+20. **Decisions log** — `docs/kaizen/decisions.md` (if it exists). Items previously declined; don't re-propose without materially new context.
+
+21. **Recent reviews** — `docs/kaizen/reviews/*.md` (last 1–2). Used to avoid duplicate proposals.
+
+## Output
+
+### 1. Primary doc — `docs/kaizen/research/YYYY-MM-DD.md`
+
+```markdown
+# Kaizen Research — [Day, Month D, YYYY]
+> Scan window: [Month D – Month D, YYYY] (7 days)
+> Web budget: N/50 used (target).
+
+## TL;DR
+
+[2-3 sentences. The single most important external move and the single most pressing internal signal. Name the recommended #1 idea here.]
+
+## External Scan
+
+### What's moving this week
+
+[1-2 paragraphs — gestalt. What's the shape of the week? Are vendors converging on a pattern? Anything surprise you?]
+
+### Notable items by source
+
+#### AWS Bedrock / AgentCore
+- **[Item]** — [1-2 sentence summary] — [URL] — *relevance*: [specific construct/file]
+
+#### Strands Agents
+- **[Item]** — …
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **[Commit / change]** — [diff summary] — [URL] — *applicability*: [does our equivalent code do this differently? worth porting?]
+
+#### MCP ecosystem
+- …
+
+#### Frontier model announcements
+- …
+
+#### Agent harness patterns
+- …
+
+#### Pricing / quota
+- …
+
+#### Community + GitHub issues
+- …
+
+#### Security advisories
+- …
+
+#### Cookbook / courses
+- …
+
+#### Seasonal
+- [content, or "Out of window — none scanned this week"]
+
+### Patterns worth considering
+
+- **[Pattern]** — [3 sentences: what it is, where it's appearing, fit for this repo]
+  - **Where**: [examples]
+  - **Fit**: [would this help? what does it replace? cost to adopt?]
+  - **Verdict**: [Worth trying / Not a fit / Monitor]
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: N (across N PRs)
+- **PRs opened**: N — **merged**: N — **reverted**: N
+- **Issues opened**: N — **closed**: N
+- **CI failures (workflow → count)**: …
+
+### Repeated friction signals
+- **[Pattern]** (N occurrences) — [evidence: commit SHAs, PR numbers, issue links]
+  - **Hypothesis**: [root cause]
+  - **Fix candidate**: [specific change — file + behavior]
+
+### Version-pin lag
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| strands-agents | x.y.z | a.b.c | N releases / N days | [breaking? new feature relevant to us?] |
+
+### Retirement candidates
+- **[Skill / file / config]** — [evidence: not modified in N days, replaced by X, never referenced]
+
+### Risks introduced this week
+<!-- Defensive scanning — things that could break us if ignored. -->
+- **[Risk]** — [source URL or PR] — *what breaks if we ignore this*
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? |
+|---|---|---|---|---|---|
+| 1 | [Title] | backend / frontend / infra / cross-cutting | L/M/H | L/M/H | [what it retires, or "addition only — justified because…"] |
+| 2 | … | | | | |
+
+### 1. [Idea title]
+- **Source**: [external item / internal signal — URL or commit SHA]
+- **Surface area**: [paths affected]
+- **Change**: [what specifically would change]
+- **Subtracts**: [what this retires/simplifies, or explicitly: "addition only — justified because…"]
+- **Effort × Impact**: [Low/Med/High] × [Low/Med/High]
+- **Verdict**: [Worth trying / Not a fit / Monitor]
+
+### 2. …
+
+## Take
+
+[2-4 sentences. Net read of the week. Is the system trending toward the ecosystem or away from it? One change that would matter most. What Phil would notice first if shipped.]
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock What's New | https://… | 2026-05-10 | 3 |
+
+## Web Budget
+
+Used: N / 50 requests (target).
+Skipped (unreachable / rate-limited): [list]
+Skipped (other): [list with reason]
+Notes: [if the cap was exceeded, name the source category that justified it]
+```
+
+### 2. Handoff — `docs/kaizen/review-queue.md` (rolling, not dated)
+
+The explicit contract with `kaizen-review-prep`. This skill **appends** new entries under `## Open`. It never edits `## Resolved` (review-prep does the move).
+
+```markdown
+# Kaizen Review Queue
+
+Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
+
+## Open
+<!-- Newest at top. -->
+
+### [YYYY-MM-DD] [Idea title]
+- **Source**: research/YYYY-MM-DD.md
+- **Surface**: backend | frontend | infrastructure | cross-cutting
+- **Effort × Impact**: L/M/H × L/M/H
+- **Subtracts**: [yes — what / no — justification]
+- **Status**: open
+
+## Resolved
+<!-- kaizen-review-prep moves entries here after a review. -->
+
+### [YYYY-MM-DD] [Idea title]
+- **Source**: research/YYYY-MM-DD.md
+- **Decision**: Ship | Decline | Defer until [date]
+- **Reasoning**: [Phil's reason, one sentence]
+- **Reviewed in**: reviews/YYYY-MM-DD.md
+```
+
+## How to run
+
+1. **Bootstrap.** If `docs/kaizen/`, `docs/kaizen/research/`, `docs/kaizen/reviews/`, or `docs/kaizen/review-queue.md` don't exist, create them. The queue starts with the headers above and empty sections.
+
+2. **Read recent context** (sequential — small reads):
+   - Last 1-2 files in `docs/kaizen/research/`
+   - Last 1-2 files in `docs/kaizen/reviews/`
+   - `docs/kaizen/decisions.md` if present
+   - `docs/kaizen/review-queue.md`
+   - Last 14 days of `CHANGELOG.md` and `RELEASE_NOTES.md`
+
+3. **Inventory internal signals** (parallel Bash calls):
+   - `git log develop --since="7 days ago" --oneline --no-merges`
+   - `gh pr list --base develop --state open --limit 20`
+   - `gh issue list --state open --search "created:>$(date -v-7d +%Y-%m-%d)"`
+   - `gh run list --status=failure --limit 30`
+   - `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`
+   - Read pinned versions from the three manifest files.
+
+4. **Fan out external scan** — spawn parallel `general-purpose` subagents (or `Explore` for sources requiring multiple targeted lookups). One subagent per source category 1–11 above. Each subagent receives:
+   - The exact URLs to scan
+   - Scope: last 7 days
+   - Web budget for that subagent (3–5 requests soft target)
+   - Required output: 3-5 bullet items max — title, 1-2 sentence summary, URL, "relevance to this repo" line.
+   - **Required**: cite URLs; never fabricate. If empty, return "no notable items this week".
+
+   Total budget across subagents targets ≤50. Track centrally; modest overage (~60) is acceptable when surfacing real signal — beyond that, stop and document the skip.
+
+5. **Version-pin diff.** For each tracked dep, fetch latest release version (WebFetch on the release page or registry equivalent — counts toward budget). Compute lag in releases and days. If a budget hit prevents a check, list the dep under "Skipped".
+
+6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself.
+
+7. **Update review queue.** For each Top 5 idea, prepend a new entry under `## Open` in `docs/kaizen/review-queue.md`. Never touch `## Resolved`.
+
+8. **Open a PR** — see "PR creation".
+
+## PR creation
+
+```bash
+DATE=$(TZ=America/Denver date +'%Y-%m-%d')
+BRANCH="kaizen/research-${DATE}"
+
+git checkout -b "$BRANCH" develop
+git add docs/kaizen/
+git commit -m "$(cat <<EOF
+chore(kaizen): weekly research scan ${DATE}
+
+Generated by the kaizen-research skill. Top 5 ideas appended to
+docs/kaizen/review-queue.md for the kaizen-review-prep run later this morning.
+EOF
+)"
+git push -u origin "$BRANCH"
+
+gh pr create --base develop --head "$BRANCH" \
+  --title "chore(kaizen): weekly research scan ${DATE}" \
+  --body "$(cat <<'EOF'
+## Summary
+- External scan: AWS Bedrock/AgentCore, Strands Agents, reference repo, MCP, frontier models, agent-harness patterns, pricing, security advisories.
+- Internal audit: recent commits, open PRs, GitHub issues, CI failures, version-pin lag, retirement candidates.
+- Top 5 ideas in the dated research doc and queued in `docs/kaizen/review-queue.md`.
+
+## Review
+- Read the research doc.
+- Comment on the PR with reactions and any weekend POC findings — these become first-class signal for *next* Friday's `kaizen-review-prep`.
+- POC promising ideas over the weekend.
+
+## Decision
+Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+The branch is one-shot — squash-merging the PR lands the doc on `develop` and the branch can be deleted.
+
+## Rules
+
+- **No fabrication.** If a source is rate-limited or empty, list it as "not scanned" — don't invent content. The Sources Scanned table is auditable.
+- **Web budget is a soft target, not a hard cap.** ≤50 requests is the goal. Overage is acceptable when justified by signal (document in the Web Budget block). Don't pad — if a source is empty after one fetch, move on.
+- **Subtraction first.** Top 5 should include at least 2 retire/simplify candidates if the system has been running >2 weeks.
+- **Concrete, not aspirational.** "Consider Strands hooks" is too vague. "Add a Strands `BeforeToolCall` hook in `backend/src/agents/main_agent/hooks/` to attribute tokens by tool" is actionable.
+- **No edits to source code.** This skill only writes under `docs/kaizen/`.
+- **Honest about dry weeks.** A quiet week produces a short doc, not a padded one.
+- **Don't re-propose declined ideas** without materially new context. Check `docs/kaizen/decisions.md` and recent reviews.
+- **Cite everything.** Every external claim has a URL + access date in the Sources Scanned appendix.
+- **Don't auto-merge the PR.** Phil reviews and merges Friday morning. Review-prep runs against the unmerged PR's docs — it reads the file from the working tree, not from `develop`.
+
+## Confirmation
+
+After the PR is opened, tell Phil:
+1. PR URL.
+2. Top 1-2 ideas (title + Effort×Impact).
+3. One-sentence Take.
+4. Web budget used (N/50 target) and any skipped sources.
+
+Brief. The full doc is on the PR.

--- a/.claude/skills/kaizen-review-prep/SKILL.md
+++ b/.claude/skills/kaizen-review-prep/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: kaizen-review-prep
+description: Friday late-morning synthesis. Runs ~2 hours after `kaizen-research` the same morning. Consumes this week's research doc, open items in `docs/kaizen/review-queue.md`, last weekend's POC findings (from comments on the previous week's research PR), and recent merges/reverts/CI signal — produces a ranked, decision-oriented agenda. Every item has a Ship / Decline / Defer recommendation. Opens a PR into `develop`. Triggers: "kaizen review prep", "weekly review prep", "friday review", "rank kaizen ideas".
+---
+
+# Kaizen Review Prep
+
+Friday late morning, after `kaizen-research` ran earlier the same morning. This skill consolidates this week's research + open queue items + last weekend's POC findings (lifted from PR comments on the previous week's research PR) + recent repo state into a ranked decision agenda. Phil reviews Friday morning, marks ✅/❌/⏸ on each item, ships 1–3 the following week, and POCs the next batch over the weekend.
+
+## Philosophy
+
+- **Review is a decision forum, not a status update.** Everything that lands in the output should be either: (a) actionable this week, (b) explicitly deferred with a reason and revisit date, or (c) declined. Nothing is "noted." Noted-and-forgotten is how systems accumulate friction.
+- **Subtraction first.** Every proposal ranks against "do nothing" and "retire something instead." If a proposal adds anything, it must explain what existing thing it either replaces or simplifies.
+- **Multiple cycles.** Kaizen is small changes, weekly, compounding. If this week's review touches 3 things, next week's will touch 3 different things. Phil doesn't need a grand plan — he needs a reliable weekly cadence.
+- **One-week feedback lag is intentional.** Phil reviews Friday → POCs over the weekend → those POC findings surface in the *next* Friday's review-prep as Carried Over items. Don't try to fold same-day POC findings in — they don't exist yet.
+- **No edits outside `docs/kaizen/`.** This skill writes one Markdown file under `docs/kaizen/reviews/` and updates `docs/kaizen/review-queue.md` (moves Open → Resolved post-review). It never touches source code, `CLAUDE.md`, or skill files. Those changes happen in separate PRs after the review.
+
+## When to run
+
+Friday late morning (~8am MT), ~2 hours after `kaizen-research` runs. Phil reviews both docs Friday morning, picks 1–3 to ship over the coming week, and POCs additional items over the weekend. POC findings from last weekend's POC session surface here as Carried Over items (lifted from PR comments on the *previous* week's research PR — not this week's, which Phil hasn't seen yet).
+
+## Inputs
+
+1. **Most recent `docs/kaizen/research/YYYY-MM-DD.md`** — Friday's scan. Its Top 5 ideas are the primary candidate list.
+2. **`docs/kaizen/review-queue.md`** — `## Open` entries. Includes both this week's ideas (just appended by `kaizen-research`) and any prior-week items that weren't resolved.
+3. **Last 1–2 `docs/kaizen/reviews/*.md`** — what was proposed before, what was decided, anything deferred to "revisit by [date]".
+4. **PR comments on the *previous* week's kaizen-research PR.** `gh pr view <n> --comments` — Phil's reactions and weekend POC findings are first-class signal. The PR opened *this* morning by `kaizen-research` is too fresh; comments accumulate over the week as Phil POCs ideas. Pick the research PR from one week ago (or the most recent merged/closed kaizen-research PR), not today's.
+5. **`docs/kaizen/decisions.md`** (if it exists) — declined items with reasons. Don't re-propose without materially new context.
+6. **Recent activity since last review:**
+   - `git log develop --since="<last review date>" --oneline --no-merges` — what shipped.
+   - `gh pr list --base develop --state merged --search "merged:>$(date -v-7d +%Y-%m-%d)"` — what landed.
+   - `gh run list --status=failure --limit 30` — fresh CI failures.
+7. **`CLAUDE.md` + skill inventory** — surface concerns only; never propose unilateral edits to these.
+8. **`CHANGELOG.md` / `RELEASE_NOTES.md`** — most recent ~14 days, for the "what shipped this week" celebration block + the don't-re-propose filter.
+
+## Output
+
+### 1. Review doc — `docs/kaizen/reviews/YYYY-MM-DD.md`
+
+```markdown
+# Kaizen Review — [Day, Month D, YYYY]
+> Prepared HH:MMam MT. Review window: [Month D – D] (7 days).
+> Source: research/YYYY-MM-DD.md + review-queue.md (N open items).
+
+## Week in Review
+
+[2-4 sentences. What did the week reveal about the system? Use concrete language —
+"The aws-samples reference repo introduced a new agent-loop pattern and we're 2
+Strands releases behind" beats "some external changes". This is Phil's pulse
+check before decisions.]
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **[Pattern]** (N times) — [concrete description; quote PR review comments or commit messages where helpful]
+  - *Hypothesis*: [root cause]
+  - *Candidate fix*: [specific change — file + behavior]
+
+### One-offs worth watching
+- **[Pattern]** (1 occurrence) — [context]
+
+### Silence that matters
+<!-- What WASN'T used: skills not referenced this week, features not invoked,
+     CI workflows that haven't run, etc. -->
+- **[Silence]** — [what wasn't used + what that might mean]
+
+## Proposals — ranked
+
+<!-- 5–10 items. Each is a DECISION for Phil, not a status. Every item has
+     a specific Ship option, a specific Decline option, and a recommendation. -->
+
+### 1. [Proposal title]
+- **Source**: research/YYYY-MM-DD.md ▸ Top 5 #N | review-queue.md (open since YYYY-MM-DD) | PR comment | direct observation
+- **Surface area**: backend / frontend / infrastructure / cross-cutting / docs / skills
+- **Change**: [concrete description — what files change, what the new behavior is]
+- **Subtracts**: [required field — what this retires, simplifies, or replaces. Or explicitly "addition only — justified because…"]
+- **Effort**: Low / Med / High
+- **Impact**: Low / Med / High
+- **POC findings (if Phil tried it)**: [summary or "not POCed"]
+- **Ship means**: [specific action — "open PR updating X to do Y" or "retire skill Z"]
+- **Decline means**: [what happens instead — usually "keep current behavior, revisit in N weeks"]
+- **Recommendation**: Ship / Decline / Defer N weeks — [one-sentence why]
+
+### 2. [Next proposal]
+…
+
+## Carried Over From Prior Reviews
+<!-- Items deferred in earlier review docs that have hit their revisit date.
+     Surfaced here for re-decision so nothing rots silently in "deferred" status. -->
+
+- **[Deferred item]** (deferred YYYY-MM-DD until YYYY-MM-DD) — [original context]. Now due.
+
+## Retirement Candidates
+
+<!-- Things currently in the scaffold that aren't earning their place.
+     Bias strongly toward subtraction. If you can't find anything, that's a
+     finding — flag it in the Take. -->
+
+- **[Candidate]** — [evidence: not modified in N days, not referenced, replaced by X]
+
+## Risks Acknowledged But Not Acted On
+<!-- From research's "Risks introduced this week" section. Surface so Phil
+     can decide: address now, defer with a watch date, or accept. -->
+
+- **[Risk]** — [source URL] — *what breaks if ignored* — recommendation: [Address now / Watch until [date] / Accept]
+
+## What Shipped This Week
+
+<!-- From CHANGELOG.md / merged PRs. Short list, one line each. Context for
+     "the system absorbed this much change recently — propose less if a lot." -->
+
+- [shipped item] — *why it mattered*
+
+## Take
+
+[2-4 sentences. Is the system trending toward trust or toward friction? Is the kaizen
+loop catching real signal or generating noise? What's the one change that would
+matter most this week if shipped? Don't sugarcoat — if a skill or pattern isn't
+pulling its weight, say so.]
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min).
+2. Scan Proposals — mark ✅ Ship / ❌ Decline / ⏸ Defer on each (3-5 min).
+3. Scan Retirement Candidates — same marks (1-2 min).
+4. Resolve Carried Over items (1-2 min).
+5. Resolve Risks block.
+6. Pick 1-3 to ship this week. Decline or defer the rest with a reason.
+
+Target: 10-15 minutes.
+
+## Post-review (for Phil — separate PRs)
+
+- ✅ Ship items → individual feature PRs over the week. The decision is logged in this doc; the implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with Phil's reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a "revisit by [date]"; surface again in the next review when due.
+
+This skill produces the agenda. Implementation never happens here.
+```
+
+### 2. Queue update — `docs/kaizen/review-queue.md`
+
+After Phil reviews and the decisions are logged in the review doc, this skill (or Phil himself, manually) **moves resolved items** from `## Open` to `## Resolved` with a Decision and Reasoning. On a fresh run before Phil has reviewed, the skill leaves Open as-is — only the *prior* review's outcomes get processed for queue movement.
+
+## How to run
+
+1. **Bootstrap.** Confirm `docs/kaizen/reviews/` exists; create it if not.
+
+2. **Read inputs** (sequential — small reads):
+   - Latest file in `docs/kaizen/research/`
+   - `docs/kaizen/review-queue.md` (full)
+   - Last 1–2 files in `docs/kaizen/reviews/`
+   - `docs/kaizen/decisions.md` if present
+   - Last ~14 days of `CHANGELOG.md` and `RELEASE_NOTES.md`
+   - `CLAUDE.md` (read-only — for context, not edits)
+
+3. **Pull PR comments on the latest research PR** (parallel with step 4):
+   ```
+   gh pr list --base develop --state all --search "kaizen/research" --limit 1 --json number,url
+   gh pr view <number> --comments
+   ```
+   Capture Phil's reactions. POC findings he mentions get folded into proposal entries.
+
+4. **Pull recent activity** (parallel Bash):
+   - `git log develop --since="<last review date>" --oneline --no-merges`
+   - `gh pr list --base develop --state merged --search "merged:>$(date -v-7d +%Y-%m-%d)" --limit 30`
+   - `gh run list --status=failure --limit 30`
+   - `gh issue list --state open --search "created:>$(date -v-7d +%Y-%m-%d)"`
+
+5. **Process prior-review queue movement.** For each entry in `## Open` that was resolved in the most recent review doc, move it to `## Resolved` with the Decision + Reasoning + Reviewed-in fields. Items with no decision in the prior review stay open.
+
+6. **Identify Carried Over items.** Scan prior review docs for `Defer N weeks` recommendations whose revisit date has hit. Add those to the new review's Carried Over section.
+
+7. **Synthesize the review doc** per the shape above. The Proposals list is built from:
+   - All `## Open` entries in `review-queue.md` (the primary source)
+   - Any new friction patterns surfaced from PR comments / merged PRs / CI that weren't already in the queue
+   - Carried Over items
+   Rank: Low-effort × High-impact first; retirement candidates get a +1 boost (subtraction bias); items with POC findings rank above untested items at the same effort/impact.
+
+8. **Cap the proposal count at 10.** If more than 10 candidates, defer the lowest-ranked to next week with a note. The review is supposed to take 10-15 minutes, not be exhaustive.
+
+9. **Open a PR** — see "PR creation".
+
+## PR creation
+
+```bash
+DATE=$(TZ=America/Denver date +'%Y-%m-%d')
+BRANCH="kaizen/review-${DATE}"
+
+git checkout -b "$BRANCH" develop
+git add docs/kaizen/
+git commit -m "$(cat <<EOF
+chore(kaizen): weekly review prep ${DATE}
+
+Generated by kaizen-review-prep. Ranked agenda for the 10-15 min decision pass;
+queue updated with prior-review outcomes.
+EOF
+)"
+git push -u origin "$BRANCH"
+
+gh pr create --base develop --head "$BRANCH" \
+  --title "chore(kaizen): weekly review prep ${DATE}" \
+  --body "$(cat <<'EOF'
+## Summary
+- N proposals ranked Effort × Impact (retirement candidates boosted).
+- Friction patterns from the week's commits, PRs, and CI surfaced.
+- Carried-over deferred items now due for re-decision.
+- POC findings (from kaizen-research PR comments) folded into proposals where Phil tried something.
+
+## Review
+1. Read Friction (2 min).
+2. Mark each Proposal: ✅ Ship / ❌ Decline / ⏸ Defer.
+3. Same for Retirement Candidates and Risks.
+4. Pick 1-3 to ship this week.
+
+Target: 10-15 minutes.
+
+## Decision
+Ship the doc to `develop`. Action on individual items happens in separate PRs over the week.
+Declined items go to `docs/kaizen/decisions.md`; deferred items stay open in `review-queue.md` with a revisit date.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Rules
+
+- **Every proposal is a decision.** No "consider X" or "we might want to." Each has Ship means / Decline means / Recommendation.
+- **Every proposal has a Subtracts field.** Required. If empty, ask: does it really need to be its own thing? Could an existing skill / construct be updated instead? If still pure addition, justify it explicitly.
+- **Retirement candidates are required.** If the section is empty and the system has been running >2 weeks, *that's* the finding — flag it in the Take.
+- **Don't re-propose declined items** without materially new context. Cross-check `docs/kaizen/decisions.md` and the last 1–2 reviews.
+- **Carried Over is not a graveyard.** Deferred items resurface on their revisit date. No silent deferrals.
+- **No fabrication.** If a week was quiet, the review is short. Length tracks signal, not target word count.
+- **Never edit `CLAUDE.md` or skill files unilaterally.** A proposal can recommend a change to them, but the change itself is always Phil-approved in review and shipped in a separate PR.
+- **Cap at 10 proposals.** A 15-item list defeats the 10-15 min target.
+
+## Confirmation
+
+After the PR is opened, tell Phil:
+1. PR URL.
+2. Top 1–2 proposals (title, Effort×Impact, recommendation).
+3. Top 1 retirement candidate if any.
+4. One-sentence Take.
+5. Estimated review time.
+
+Brief. Phil reads the full doc on the PR and marks decisions there or in a follow-up commit.

--- a/docs/kaizen/research/2026-05-10.md
+++ b/docs/kaizen/research/2026-05-10.md
@@ -1,0 +1,224 @@
+# Kaizen Research — Sunday, May 10, 2026
+> Scan window: May 3 – May 10, 2026 (7 days; reference repo extended to 30 days for first-run baseline)
+> Web budget: 54/50 used (target). Frontier-models scan went over by 5 due to two OpenAI WebFetch 403s; rest within sub-budget.
+> **Bootstrap run** — first execution of the kaizen-research skill. Subsequent runs cover only the prior 7 days for the reference repo too.
+
+## TL;DR
+
+The week's biggest external signal is that **`bedrock-agentcore` is now three minor versions behind** (1.6.4 → 1.9.0, latest published May 7), and our two highest-impact open issues (#266 large tool result offload, #267 context-window lookup table) **were quietly solved upstream in Strands v1.37/v1.38** — we just need to wire them in. The biggest internal signal is **CI is broken**: 9 Nightly Build & Test failures and 6+ Deploy failures in the last 7 days. Recommended #1: bump `bedrock-agentcore` to 1.9.0 and verify our Strands `BedrockModel.stream` cancel path against the just-filed #2266 leak.
+
+## External Scan
+
+### What's moving this week
+
+The week converged on two themes worth our attention. First, AWS shipped two AgentCore capabilities that map cleanly onto things we already do: **AgentCore Runtime BYO filesystem from S3/EFS** (cross-session filesystem persistence without custom mount code) and **AgentCore Memory metadata** (structured tags on long-term memory records for filtered retrieval). Both are direct value-adds to our `inference-api` and our `TurnBasedSessionManager` layer. Second, Strands has been cleaning up the long tail: v1.37 added a context-window lookup table (closes our open issue #267), v1.38 added large tool result offload (closes our open issue #266), and v1.39 — which we just pinned in #265 — added AWS-profile support for the OpenAI provider. We're caught up to the head, but we haven't yet *used* the v1.37/v1.38 features the upgrade unlocked.
+
+The reference repo (`aws-samples/sample-strands-agent-with-agentcore`) has diverged from us in one major direction (CDK → Terraform on Apr 19) and converged in several minor ones — most notably moving compaction state and per-message metadata onto Strands' own `agent.state` and `message.metadata` instead of a custom DynamoDB table. They also abandoned the `enabledTools` whitelist pattern that's still embedded in our CLAUDE.md, in favor of a `disabled_skills` blacklist read from DDB per-request. Those are architectural calls, not direct ports.
+
+The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP merged May 7), which is a strong fit for our SigV4 Gateway model — but our Python `mcp` library hasn't picked it up yet (current 1.27.1). Watch.
+
+### Notable items by source
+
+#### AWS Bedrock / AgentCore
+- **AgentCore Runtime BYO file system from S3 and EFS** — Attach S3/EFS to runtimes for cross-session persistence without custom mount code — https://aws.amazon.com/about-aws/whats-new/2026/05/amazon-bedrock-agentcore-runtime/ — *relevance*: directly applicable to `inference-api`; could replace future filesystem-staging glue
+- **AgentCore Memory adds metadata for long-term memory** — Long-term memory records now support structured metadata for filtered retrieval — https://aws.amazon.com/about-aws/whats-new/2026/05/agentcore-longterm-memory-metadata — *relevance*: `TurnBasedSessionManager` long-term flush could carry user/RBAC/conversation-type metadata for richer recall
+- **Secure AI agents with AgentCore Identity on Amazon ECS** — OAuth federation walkthrough for ECS-hosted agents — https://aws.amazon.com/blogs/machine-learning/secure-ai-agents-with-amazon-bedrock-agentcore-identity-on-amazon-ecs/ — *relevance*: useful reference; pattern mirrors our `apis/shared/oauth/agentcore_identity.py` mint-fallback
+- **OS-Level Actions in AgentCore Browser** — OS-level control for native UI agents — https://aws.amazon.com/blogs/machine-learning/introducing-os-level-actions-in-amazon-bedrock-agentcore-browser/ — *relevance*: informational; we don't use AgentCore Browser
+- **AgentCore Payments preview** — Wallet/auth/governance for transactional agents (Coinbase + Stripe partners) — https://aws.amazon.com/blogs/machine-learning/agents-that-transact-introducing-amazon-bedrock-agentcore-payments-built-with-coinbase-and-stripe/ — *relevance*: informational; no commerce path today
+
+**Open AgentCore SDK issues affecting us:**
+- **#456 — OTEL context detached across asyncio/thread boundaries in memory client + Strands session_manager** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/456 — *applicability*: HIGH — we use Strands 1.39 + AgentCore Memory + `TurnBasedSessionManager`; X-Ray/OTEL traces likely show broken spans on memory writes
+- **#452 — AgentCoreMemorySessionManager: add `async_mode` to prevent event-loop blocking** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/452 — *applicability*: HIGH — `inference-api` is FastAPI/async; sync flush on the loop could be hurting concurrency
+- **#453 — Auto-populate AgentCard.skills[] from ToolRegistry in serve_a2a** — *applicability*: medium; relevant if/when we expose A2A endpoints
+
+#### Strands Agents
+- **v1.39.0 (current pin)** — AWS profile support for OpenAI, MCP init error messaging, Bedrock token-counting enhancements, A2A task-lifecycle states — https://github.com/strands-agents/sdk-python/releases/tag/v1.39.0 — *informational*: just landed in #265
+- **v1.38.0 — large tool result offload + `CachePoint` TTL for prompt caching** — https://github.com/strands-agents/sdk-python/releases/tag/v1.38.0 — *closes our issue #266*
+- **v1.37.0 — context-window limit lookup tables + experimental checkpoint API** — https://github.com/strands-agents/sdk-python/releases/tag/v1.37.0 — *closes our issue #267*
+- **#2266 — `BedrockModel.stream` leaks inner task on outer cancellation (May 9, open)** — https://github.com/strands-agents/sdk-python/issues/2266 — *applicability*: HIGH — we cancel SSE streams on client disconnect; check for "Task exception was never retrieved" in stream_coordinator logs
+- **#2271 — Support dual cache prefixes in Bedrock auto caching strategy (May 10)** — https://github.com/strands-agents/sdk-python/issues/2271 — *applicability*: medium; pairs with issue #269 (prompt caching) if we move to Strands' built-in caching strategy
+- **#2243 — Tool-level suspend/resume for external async callbacks** — https://github.com/strands-agents/sdk-python/issues/2243 — *applicability*: medium; could simplify our `oauth_required` SSE handoff
+- **PR #2239 — Proactive Context Compression (merged May 8)** — https://github.com/strands-agents/sdk-python/pull/2239 — *applicability*: medium; could complement our SSE compaction surfacing
+
+#### Reference repo: aws-samples/sample-strands-agent-with-agentcore (last 30 days — bootstrap baseline)
+- **CDK → Terraform migration (Apr 19, c422fbf)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/c422fbf — *applicability*: NOT relevant for porting; we're CDK-native. **Implication**: the reference repo is no longer a usable CDK template going forward. Anything CDK-shaped historically pulled from them is frozen at pre-Apr-19 state.
+- **Compaction state + metrics moved from custom DynamoDB to SDK `agent.state` + `message.metadata` (Apr 27, 2b1a13d)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/2b1a13d — *applicability*: HIGH — our `TurnBasedSessionManager` could shed code by piggybacking on `agent.state` rather than maintaining parallel state; potential subtraction
+- **Force re-auth on OAuth 401/403 mid-tool-call (Apr 22, 9fcdb4c)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/9fcdb4c — *applicability*: HIGH — verify our `oauth_required` SSE flow handles mid-conversation 401/403 from Google etc. by re-emitting `oauth_required` rather than streaming an error
+- **Supersede stale executions instead of 409-rejecting (May 6, d6c9516)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/d6c9516 — *applicability*: medium; check how app-api handles concurrent submissions on the same conversation
+- **Use SDK `agent.cancel()` for stop-signal handling (May 6, fd9acec)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/fd9acec — *applicability*: medium; if we have custom cancellation code, may simplify
+- **`enabledTools` whitelist replaced with `disabled_skills` blacklist (May 3, 092aa33)** — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/092aa33 — *applicability*: monitor; our CLAUDE.md still mentions `enabled_tools` as a debug step. Inversion has UX upside but RBAC implications
+
+#### MCP ecosystem
+- **SEP-2567 Sessionless MCP merged (May 7)** — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567 — *implications*: drops `Mcp-Session-Id` and `session/create`; list endpoints become cacheable. Strong fit for our SigV4 Gateway model. Watch python `mcp` library for adoption.
+- **SEP-2575 init-removal track (companion)** — same thread — *implications*: stateless HTTP transport simplifies Lambda-backed Gateway servers
+- **Schema rename: `IncompleteResult` → `InputRequiredResult`** — typed-API break on next `mcp` lib bump
+- **MCPSafe — security scanner for MCP servers** — https://github.com/orgs/modelcontextprotocol/discussions — could scan our Gateway-hosted servers
+- **MCP servers repo (no new servers this week)** — discovery has moved to `registry.modelcontextprotocol.io`
+
+#### Frontier model announcements
+- **Anthropic — higher Opus rate limits (May 6)** — https://www.anthropic.com/news/higher-limits-spacex — informational; we use Bedrock-hosted, not first-party
+- **Anthropic — finance-agents pack (May 5)** — https://www.anthropic.com/news/finance-agents — Moody's MCP server is a concrete public MCP we could register in Gateway if a finance use case emerges
+- **OpenAI — GPT-5.5 Instant displaces GPT-5.3 Instant (May 5)** — https://openai.com/index/gpt-5-5-instant/ — *risk*: confirm our model selector doesn't expose a deprecation-path 5.3 ID
+- **Google / Gemini** — quiet week (no new model/API deltas)
+- **Meta / Llama** — quiet week
+
+#### Agent harness patterns
+- **Claude Code 2.1.136 — skills-under-plugins fix + MCP content-block fix** — https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md — *relevance*: skill loading + MCP tool result rendering
+- **Claude Code 2.1.133 — hooks receive `effort.level` + `worktree.baseRef` setting** — same URL — pattern worth mirroring in Strands hook payloads
+- **Claude Code 2.1.132 — `CLAUDE_CODE_SESSION_ID` env into Bash subprocess** — same URL — session-id-everywhere pattern we already do loosely
+- **CMA_coordinate_specialist_team.ipynb (May 6)** — https://github.com/anthropics/claude-cookbooks/tree/main/managed_agents — coordinator + 3 specialists with per-role tool scoping
+- **CMA_verify_with_outcome_grader.ipynb (May 6)** — same repo — writer/grader loop with `user.define_outcome` rubrics; could bolt onto SSE for tool-result fact-checking
+- **Agent Development Lifecycle (LangChain blog, May 9)** — https://www.langchain.com/blog/the-agent-development-lifecycle — our kaizen cadence already covers most of this; gap is "online evals"
+
+#### Pricing / quota
+- No detected Bedrock or AgentCore pricing changes this week
+- Note: `https://aws.amazon.com/bedrock/whats-new/` returned **404** — page appears retired. Skill source URL needs replacement.
+
+#### Community + GitHub issues
+- HN: 0 hits for stack keywords (`bedrock`, `agentcore`, `strands`, `mcp`, `claude code`) in the 7-day window — quiet
+- Reddit: blocked from WebFetch in this environment — gap to address (`.rss` or Reddit MCP)
+
+#### Security advisories
+- **0 advisories affect our pinned versions** — clean week
+- Adjacent (transitive risk to verify with `uv pip tree` / `npm ls`): GitPython newline injection (CVE-2026-42215 patch bypass), `fast-uri` host confusion, `@babel/plugin-transform-modules-systemjs` codegen issue
+
+#### Cookbook / courses
+- 4 new managed-agent cookbooks landed May 5–8 (vulnerability detection, coordinator/specialists, outcome grading, registry category)
+- `anthropics/courses` quiet (last commit Nov 2025) — candidate to drop from weekly scan
+
+#### Seasonal
+- Out of window — no re:Invent or NeurIPS items
+
+### Patterns worth considering
+
+- **Online evals via grader sub-agent** — sample N% of conversation turns, run a stateless grader, persist outcomes. Fits LangChain's Agent Development Lifecycle framing and the CMA outcome-grader cookbook. **Verdict**: monitor — interesting once we've shipped the core cleanups below.
+- **Brain/hands separation** (Anthropic Managed Agents direction) — push session/checkpoint store outside the agent process. We already do this via AgentCore Memory; fully aligned. **Verdict**: aligned, no action.
+- **Sessionless MCP** (SEP-2567) — list endpoints cacheable per (deployment, auth). Direct fit for SigV4 Gateway. **Verdict**: monitor; act when python `mcp` library adopts.
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: 8 (all from squash-merged PRs)
+- **PRs opened**: 5 (4 dependabot — #237/#239/#241 still open, plus #276 docs)
+- **PRs merged**: 8
+- **PRs reverted**: 0
+- **Issues opened**: 4 (#266, #267, #268, #269 on May 9 — Strands-features and prompt caching)
+- **CI failures (workflow → count)**: Nightly Build & Test 9, Deploy Inference API 5, Deploy App API 6, Deploy Frontend 1, Version Check 6, Deploy Infrastructure 2
+
+### Repeated friction signals
+- **Nightly Build & Test failing 9× since May 6** — concentrated cluster; no signal it's been investigated. Could be the test flakiness from issue #220 (order-dependent flakiness in `test_cognito_idp_service`, `test_oauth_repositories`, `test_auth_providers*`) compounding, or a different cause. *Hypothesis*: untriaged. *Fix candidate*: triage one failure end-to-end; promote to a blocking issue if not already on the board.
+- **Deploy workflows failing 6+ times May 6–9** — Inference API, App API, Frontend deploys all hit failures. *Hypothesis*: BFF migration shipped this week (#272–#277) introduced env-var or stack drift not caught in synth. *Fix candidate*: cross-check most recent failed deploy log against beta.24 ↔ post-beta.24 stack diff.
+- **5 of 8 commits this week are BFF/auth fixes** (#270, #271, #273, #274, #275, #277) — the BFF migration shipped in beta.24 is still being patched. Healthy iteration, but the pace says "treat BFF as not-done-yet" before declaring beta.25.
+
+### Version-pin lag
+
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| `bedrock-agentcore` | 1.6.4 | **1.9.0** | 3 minor / latest 2026-05-07 | Open issues #456 (OTEL detach) and #452 (event-loop blocking) may already be addressed |
+| `boto3` | 1.42.96 | 1.43.6 | 1 minor / ~10 patches | Routine bump |
+| `aws-cdk-lib` | 2.251.0 | 2.253.1 | 2 patch | Routine |
+| `aws-cdk` | 2.1120.0 | 2.1121.0 | 1 patch | Routine |
+| `@angular/core` | 21.2.11 | 21.2.12 | 1 patch | Routine |
+| `strands-agents` | 1.39.0 | 1.39.0 | current | Just upgraded in #265 |
+| `fastapi` | 0.136.1 | 0.136.1 | current | — |
+| `mcp` | (transitive) | 1.27.1 | n/a | Watch for SEP-2567 adoption |
+
+### Retirement candidates
+
+- **`enabled_tools` whitelist debug guidance in `CLAUDE.md`** — Reference repo abandoned this pattern May 3 (`092aa33`) for `disabled_skills` blacklist. Not urgent retirement, but worth a re-evaluation if we touch tool-enablement code.
+- **`anthropics/courses` source in `kaizen-research`** — Last commit Nov 2025; subagent reported "quiet". Drop from weekly scan list.
+- **`https://aws.amazon.com/bedrock/whats-new/` URL in `kaizen-research`** — 404'd on this run. Replace with the AWS What's New RSS feed only, or a different filtered URL.
+- **`https://docs.claude.com/en/docs/claude-code/release-notes` URL in `kaizen-research`** — 301→404. Replace with `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md`.
+- **6 of 9 skills not modified in 60+ days** (angualar-best-practices, tailwind-ui, frontend-design, cdk-infrastructure, versioning, cors-deployment) — modification freshness alone is a weak signal for skills since they encode stable conventions. **No retirement recommended without invocation telemetry.**
+
+### Risks introduced this week
+
+- **`bedrock-agentcore` 3 minor versions behind** with a release in the scan window — issues #456 (OTEL trace detach in Memory + Strands session_manager) and #452 (async-mode for AgentCoreMemorySessionManager) may be already-fixed in 1.7-1.9. *What breaks if ignored*: silent observability gaps (broken spans on memory writes); concurrency degradation under load. — https://pypi.org/project/bedrock-agentcore/
+- **OpenAI displaces GPT-5.3 Instant with GPT-5.5 Instant (May 5)** — our model selector exposes per-model IDs. *What breaks if ignored*: customers using a 5.3 default may hit a deprecation window. — https://openai.com/index/gpt-5-5-instant/
+- **Strands #2266 — `BedrockModel.stream` leaks inner task on outer cancellation** — we cancel SSE streams on client disconnect. *What breaks if ignored*: orphaned tasks, "Task exception was never retrieved" log noise, possible memory pressure under churn. — https://github.com/strands-agents/sdk-python/issues/2266
+- **Reddit blocked from WebFetch** in the kaizen-research environment — community-signal scan is half-blind. — *Fix*: switch to `https://www.reddit.com/r/<sub>/.rss` or a configured Reddit MCP server.
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? |
+|---|---|---|---|---|---|
+| 1 | Bump `bedrock-agentcore` 1.6.4 → 1.9.0; verify SDK issues #456/#452 are addressed | backend | L | M | no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window) |
+| 2 | Audit `BedrockModel.stream` cancellation path against Strands #2266 | backend | L | M-H | no — defensive; SSE-disconnect path is hot |
+| 3 | Close issues #266 and #267 — features already in our Strands 1.39 pin; replace with smaller "wire upstream feature" tasks | cross-cutting | L | M | **yes — retires 2 build-from-scratch tickets** |
+| 4 | Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling | backend | M | H | no — defensive; mid-conversation OAuth failure is a real UX risk |
+| 5 | Triage Nightly Build & Test failure cluster (9× since May 6) | cross-cutting / CI | L-M | M-H | possibly — if root is issue #220, fixing it simplifies suite |
+
+### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
+- **Source**: PyPI (https://pypi.org/project/bedrock-agentcore/) + open SDK issues #456, #452
+- **Surface area**: `backend/pyproject.toml`, `backend/uv.lock`
+- **Change**: pin update + smoke-test memory + identity flows in dev; verify CHANGELOG between 1.6 and 1.9 for any breaking changes
+- **Subtracts**: addition only — justified by 3 versions of upstream fixes including likely-relevant OTEL trace detach (#456) and event-loop blocking (#452)
+- **Effort × Impact**: Low × Medium
+- **Verdict**: Worth trying
+
+### 2. Audit `BedrockModel.stream` cancellation path
+- **Source**: Strands open issue #2266 (filed May 9)
+- **Surface area**: `backend/src/agents/main_agent/` stream coordinator + SSE handler
+- **Change**: locate where we cancel `BedrockModel.stream`; ensure we `await task` on cancel paths so tasks don't orphan; add a log assertion in dev to detect "Task exception was never retrieved"
+- **Subtracts**: addition only — defensive
+- **Effort × Impact**: Low × Medium-High
+- **Verdict**: Worth trying
+
+### 3. Close issues #266 and #267 — features already in our Strands 1.39 pin
+- **Source**: Strands v1.37 (PR #2249, context-window lookup) + v1.38 (large tool result offload)
+- **Surface area**: GitHub issues + small wiring in `stream_coordinator` and tool-result handling for spreadsheet/Code Interpreter outputs
+- **Change**: close #266 and #267 with comments pointing at upstream PRs; replace with smaller "wire context-window lookup" and "wire large tool result offload" tasks if the wiring isn't automatic
+- **Subtracts**: **yes — retires 2 "build from scratch" issues; replaces with at-most 2 "use upstream feature" tasks**
+- **Effort × Impact**: Low × Medium
+- **Verdict**: Worth trying
+
+### 4. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: aws-samples/sample-strands-agent-with-agentcore commit `9fcdb4c`
+- **Surface area**: `backend/src/apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers
+- **Change**: ensure mid-conversation 401/403 from Google/external OAuth providers re-emits `oauth_required` (consent-resume) rather than streaming a tool error to the user
+- **Subtracts**: addition only — defensive; closes a real UX gap when upstream tokens revoke mid-stream
+- **Effort × Impact**: Medium × High
+- **Verdict**: Worth trying
+
+### 5. Triage Nightly Build & Test failure cluster
+- **Source**: 9 failures since May 6 in `gh run list --status=failure`
+- **Surface area**: `.github/workflows/nightly-*.yml`, possibly `tests/shared/test_cognito_idp_service.py` + adjacent (per issue #220)
+- **Change**: pull the most recent failure log; trace to root cause; fix flakiness OR document why it's failing if it's a real regression; promote to blocking issue
+- **Subtracts**: possibly — if root is issue #220 (test isolation), fixing it materially simplifies the suite
+- **Effort × Impact**: Low-Medium × Medium-High
+- **Verdict**: Worth trying
+
+## Take
+
+The ecosystem and our own week converged on the same theme: **stop maintaining things that upstream now does for us**. Strands 1.37/1.38 closes our open issues #266/#267 with library-native plumbing; AgentCore Memory metadata replaces ad-hoc tagging; `agent.cancel()` and `agent.state` (per the reference repo) replace custom cancellation/state code. The single most valuable change this week would be bumping `bedrock-agentcore` to 1.9.0 — it's free, it's a clean signal (3 versions of upstream fixes, including likely-relevant ones to issues we've filed), and it's the prerequisite to most of the upstream-leaning work. The CI failure cluster is a separate concern and probably shouldn't wait for kaizen.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock + AgentCore (RSS, blog, pricing, SDK issues) | aws.amazon.com / github.com/aws/bedrock-agentcore-* | 2026-05-10 | 5 announcements + 5 issues |
+| 2 | Strands Agents (releases, issues, PRs) | github.com/strands-agents/sdk-python | 2026-05-10 | 3 releases + 5 issues |
+| 3 | Reference repo | github.com/aws-samples/sample-strands-agent-with-agentcore | 2026-05-10 | 12 commits in 30-day window |
+| 4 | MCP ecosystem | modelcontextprotocol.io / github.com/modelcontextprotocol | 2026-05-10 | 4 spec items + 3 discussions |
+| 5 | Frontier models (Anthropic, OpenAI, Google, Meta) | anthropic.com / openai.com / blog.google / ai.meta.com | 2026-05-10 | 3 Anthropic + 1 OpenAI + 0 others |
+| 6 | Agent harness | github.com/anthropics + langchain.com + pydantic.dev | 2026-05-10 | 3 CC releases + 4 cookbook items |
+| 7 | Community (HN Algolia + Reddit) | hn.algolia.com + reddit.com | 2026-05-10 | 0 HN hits, Reddit blocked |
+| 8 | Security advisories | github.com/advisories | 2026-05-10 | 0 affecting our pins |
+| 9 | Version-pin diff | pypi.org / npmjs.com | 2026-05-10 | 8 deps checked, 4 lag |
+
+## Web Budget
+
+Used: 54 / 50 requests (target).
+
+Skipped (unreachable / rate-limited):
+- Reddit (`r/LocalLLaMA`, `r/MachineLearning`) — WebFetch blocked from this environment. Switch to `.rss` endpoint or configured Reddit MCP next run.
+- `https://aws.amazon.com/bedrock/whats-new/` — 404 (page appears retired). Drop or replace.
+- `https://docs.claude.com/en/docs/claude-code/release-notes` — 301→404. Replace with `github.com/anthropics/claude-code/blob/main/CHANGELOG.md`.
+
+Skipped (other): none.
+
+Notes:
+- Frontier-models sub-budget exceeded (11 vs ~6 target) due to two OpenAI WebFetch 403s requiring search backfill and two Anthropic drilldowns. Within total cap.
+- This is a **bootstrap run**: reference-repo scope extended to 30 days for baseline; Carried Over and prior-decisions sections in the review-prep doc are necessarily empty.

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -1,0 +1,57 @@
+# Kaizen Review Queue
+
+Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
+
+## Open
+
+### [2026-05-10] Bump `bedrock-agentcore` 1.6.4 → 1.9.0
+- **Source**: research/2026-05-10.md ▸ Top 5 #1
+- **Surface**: backend
+- **Effort × Impact**: L × M
+- **Subtracts**: no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window)
+- **Status**: open
+
+### [2026-05-10] Audit `BedrockModel.stream` cancellation path against Strands #2266
+- **Source**: research/2026-05-10.md ▸ Top 5 #2
+- **Surface**: backend
+- **Effort × Impact**: L × M-H
+- **Subtracts**: no — defensive (SSE-disconnect path is hot)
+- **Status**: open
+
+### [2026-05-10] Close issues #266 and #267 — features already in our Strands 1.39 pin
+- **Source**: research/2026-05-10.md ▸ Top 5 #3
+- **Surface**: cross-cutting
+- **Effort × Impact**: L × M
+- **Subtracts**: yes — retires 2 build-from-scratch issues; replaces with at-most 2 "wire upstream feature" tasks
+- **Status**: open
+
+### [2026-05-10] Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: research/2026-05-10.md ▸ Top 5 #4
+- **Surface**: backend
+- **Effort × Impact**: M × H
+- **Subtracts**: no — defensive
+- **Status**: open
+
+### [2026-05-10] Triage Nightly Build & Test failure cluster (9× since May 6)
+- **Source**: research/2026-05-10.md ▸ Top 5 #5
+- **Surface**: cross-cutting / CI
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: possibly — if root is issue #220 (test isolation)
+- **Status**: open
+
+### [2026-05-10] Replace dead source URLs in `kaizen-research` skill
+- **Source**: research/2026-05-10.md ▸ Retirement candidates
+- **Surface**: skills (`.claude/skills/kaizen-research/SKILL.md`)
+- **Effort × Impact**: L × L
+- **Subtracts**: yes — replaces 2 broken URLs (`bedrock/whats-new/` 404, `docs.claude.com/.../release-notes` 404) with working ones; drops `anthropics/courses` (quiet since Nov 2025)
+- **Status**: open
+
+### [2026-05-10] Add Reddit `.rss` or Reddit MCP to `kaizen-research`
+- **Source**: research/2026-05-10.md ▸ Risks ▸ "Reddit blocked from WebFetch"
+- **Surface**: skills (`.claude/skills/kaizen-research/SKILL.md`)
+- **Effort × Impact**: L × L
+- **Subtracts**: no — restores a half-blind source
+- **Status**: open
+
+## Resolved
+<!-- kaizen-review-prep moves entries here after a review. Bootstrap run — empty. -->

--- a/docs/kaizen/reviews/2026-05-10.md
+++ b/docs/kaizen/reviews/2026-05-10.md
@@ -1,0 +1,171 @@
+# Kaizen Review — Sunday, May 10, 2026
+> Prepared 11:00am MT. Review window: May 3 – May 10, 2026 (7 days).
+> Source: research/2026-05-10.md + review-queue.md (7 open items).
+> **Bootstrap run** — no prior reviews, no prior-week POC findings, no Carried Over items.
+
+## Week in Review
+
+The BFF Token Handler migration that shipped in beta.24 (May 6) is still being patched — 5 of 8 commits this week are BFF/auth follow-ups. CI is hot: 9 Nightly Build & Test failures and 6+ Deploy failures since May 6, none visibly triaged. The bigger external story is that the upstream agent ecosystem moved while we were heads-down on auth — `bedrock-agentcore` is 3 minor versions behind, and two of our own open issues (#266, #267) were quietly closed by Strands releases we just upgraded into. Net read: this is a "harvest the upstream changes you already paid for" week, not a "build something new" week.
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **CI deploy failures (6+ since May 6)** across Inference API, App API, and Frontend deploys.
+  - *Hypothesis*: BFF migration introduced env-var or stack drift not caught in synth (most failures cluster around the same auth/config landscape that's still being patched).
+  - *Candidate fix*: cross-check the most recent failed deploy log against the beta.23 → beta.24 stack diff; the most likely suspects are missing/renamed SSM parameters from the public-PKCE-client decommission (`/auth/cognito/app-client-id` removed) or the new `BFF_*` env vars.
+- **Nightly Build & Test failures (9× since May 6)** — concentrated, untriaged.
+  - *Hypothesis*: known flakiness from issue #220 (`test_cognito_idp_service`, `test_oauth_repositories`, `test_auth_providers*` order-dependent) compounding under the BFF-heavy week's churn.
+  - *Candidate fix*: triage one failure log end-to-end. Either the root is #220 (then #220 needs to land) or it's a real regression masked by the noise.
+- **BFF/auth fix churn (5 of 8 commits this week)** — #270, #271, #273, #274, #275, #277.
+  - *Hypothesis*: BFF migration is a v1, not a v1.1; expect 1–2 more weeks of follow-ups before declaring beta.25.
+  - *Candidate fix*: not a fix per se — adjust release-cut timing for beta.25 to wait for the churn to settle.
+
+### One-offs worth watching
+- **`bedrock-agentcore` 1.6.4 → 1.9.0 lag** with a release published *inside* the scan window (May 7) — see proposal #1.
+- **OpenAI displaces GPT-5.3 Instant with GPT-5.5 Instant** — model selector audit needed (proposal #6 — declined-by-default below; check first then decide).
+- **Strands #2266 `BedrockModel.stream` cancel leak** — filed May 9; see proposal #2.
+
+### Silence that matters
+- **No invocations of 6 of 9 skills in 60+ days** (angualar-best-practices, tailwind-ui, frontend-design, cdk-infrastructure, versioning, cors-deployment) — modification freshness is a weak signal for skills since they encode stable conventions; **not enough to act**, but worth instrumenting invocation telemetry if we want to make this a reliable retirement signal in the future.
+- **HN was quiet on stack keywords this week** (0 hits in Algolia 7-day window) — not a problem; just a confirmation that this is an internal-momentum week, not a community-momentum week.
+- **`anthropics/courses` quiet since Nov 2025** — proposal #6 below proposes dropping it from the scan list.
+
+## Proposals — ranked
+
+### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
+- **Source**: research/2026-05-10.md ▸ Top 5 #1 | review-queue.md (open)
+- **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
+- **Change**: pin update + smoke-test memory + identity flows in dev; verify upstream CHANGELOG between 1.6 and 1.9 for any breaking changes; close out open SDK issues #456 (OTEL trace detach) and #452 (event-loop blocking) if 1.9 addresses them.
+- **Subtracts**: addition only — justified by 3 versions of upstream fixes including likely-relevant ones to OTEL trace detach and AgentCoreMemorySessionManager event-loop blocking.
+- **Effort**: Low
+- **Impact**: Medium (observability + concurrency)
+- **POC findings**: not POCed — bootstrap run.
+- **Ship means**: open a PR updating `pyproject.toml` and `uv.lock`; smoke-test memory write/read + identity OAuth flows in dev; if smoke passes, merge.
+- **Decline means**: keep at 1.6.4 for another week; revisit after 1.10 ships or after we observe a memory/identity issue.
+- **Recommendation**: **Ship.** Lowest effort × highest signal of any proposal this week. Do this first.
+
+### 2. Audit `BedrockModel.stream` cancellation path against Strands #2266
+- **Source**: research/2026-05-10.md ▸ Top 5 #2 | review-queue.md (open)
+- **Surface area**: backend (`backend/src/agents/main_agent/` stream coordinator + SSE handler)
+- **Change**: locate every `BedrockModel.stream` cancellation path; ensure each `await`s the inner task on cancel so it doesn't orphan; add a dev-only assertion / log filter to detect "Task exception was never retrieved" before it reaches prod.
+- **Subtracts**: addition only — defensive.
+- **Effort**: Low
+- **Impact**: Medium-High (SSE-disconnect path is hot; orphan-task pressure is silent until it isn't)
+- **POC findings**: not POCed.
+- **Ship means**: open a PR with the audit + fixes + a regression test that triggers cancel + asserts no orphan tasks.
+- **Decline means**: log a tech-debt issue; revisit if "Task exception was never retrieved" appears in CloudWatch.
+- **Recommendation**: **Ship.** Pairs naturally with #1 — same backend area, same week's signal. Cheap insurance.
+
+### 3. Close issues #266 and #267 — features already in our Strands 1.39 pin
+- **Source**: research/2026-05-10.md ▸ Top 5 #3 | review-queue.md (open)
+- **Surface area**: cross-cutting — GitHub issues + small wiring in `stream_coordinator` and Code Interpreter / spreadsheet tool-result handling
+- **Change**:
+  1. Comment on #266 + #267 pointing at upstream PRs (Strands #2249 for context-window lookup; v1.38.0 release notes for large tool result offload).
+  2. Verify the upstream features are *automatically* active under our 1.39 pin — if not, file replacement issues for the wiring work and link them.
+  3. Close #266 + #267.
+- **Subtracts**: **yes — retires 2 "build from scratch" tickets; replaces with at-most 2 "wire upstream feature" tasks.**
+- **Effort**: Low
+- **Impact**: Medium (closes phantom tech debt; clears the issue list)
+- **POC findings**: not POCed.
+- **Ship means**: 30-minute issue-grooming pass; comment + close + (if needed) file 2 smaller follow-ups.
+- **Decline means**: leave #266 + #267 open; future kaizen runs will re-flag them.
+- **Recommendation**: **Ship.** Highest *subtraction* yield this week. Costs nothing, removes two stale tickets, communicates "we're tracking upstream" to the team.
+
+### 4. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: research/2026-05-10.md ▸ Top 5 #4 | review-queue.md (open)
+- **Surface area**: backend (`apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers)
+- **Change**: walk through the code paths where an external OAuth provider (Google etc.) returns 401/403 mid-stream; confirm the response is `oauth_required` SSE re-emission (consent-resume), not a streamed tool error to the user. Add a regression test if missing.
+- **Subtracts**: addition only — defensive; closes a real UX gap when upstream tokens revoke.
+- **Effort**: Medium (audit + likely 1-2 small fixes)
+- **Impact**: High (user-visible UX; OAuth token revocation does happen)
+- **POC findings**: not POCed.
+- **Ship means**: open a tech-debt issue with the audit findings; fix in a follow-up PR if anything is broken; otherwise add the regression test and close.
+- **Decline means**: assume current behavior is correct; revisit if a user reports a stuck-OAuth conversation.
+- **Recommendation**: **Defer 2 weeks.** This is the highest-impact proposal but also the highest-effort, and BFF auth is still settling — landing this in the middle of the BFF patch parade risks compounding the churn. Better to wait until BFF stabilizes (likely beta.25 territory), then audit cleanly.
+
+### 5. Triage Nightly Build & Test failure cluster (9× since May 6)
+- **Source**: research/2026-05-10.md ▸ Top 5 #5 | review-queue.md (open)
+- **Surface area**: cross-cutting / CI (`.github/workflows/nightly-*.yml`, possibly `tests/shared/test_cognito_idp_service.py` per issue #220)
+- **Change**: pull the most recent failure log; trace to root cause; if root is issue #220 (test isolation), bump #220 to blocking and land it; if it's a different cause, file and resolve.
+- **Subtracts**: possibly — if root is #220, fixing it materially simplifies the suite (removes a tech-debt entry).
+- **Effort**: Low-Medium (worst case: a real regression hiding under the noise)
+- **Impact**: Medium-High (CI signal is currently unreliable; that affects *every* PR review)
+- **POC findings**: not POCed.
+- **Ship means**: 1-2 hour triage pass; either fix in a small PR or bump #220 to blocking.
+- **Decline means**: continue ignoring nightly failures; eventually a real regression will hide here.
+- **Recommendation**: **Ship.** This is independent of the kaizen-loop work above; it's hygiene. If the kaizen review is the venue that finally surfaces it, that's a kaizen win.
+
+### 6. Replace dead source URLs in `kaizen-research` skill + drop `anthropics/courses`
+- **Source**: research/2026-05-10.md ▸ Retirement candidates | review-queue.md (open)
+- **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
+- **Change**:
+  - Replace `https://aws.amazon.com/bedrock/whats-new/` (404) with the AWS What's New RSS feed (already in the skill — drop the dead URL).
+  - Replace `https://docs.claude.com/en/docs/claude-code/release-notes` (301→404) with `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md`.
+  - Drop `https://github.com/anthropics/courses` from the cookbook source (quiet since Nov 2025).
+- **Subtracts**: **yes — replaces 2 broken URLs with working ones; drops 1 stale source.**
+- **Effort**: Low
+- **Impact**: Low (skill quality)
+- **POC findings**: not POCed.
+- **Ship means**: 5-minute edit to `kaizen-research/SKILL.md`.
+- **Decline means**: leave dead URLs; future runs waste budget on them.
+- **Recommendation**: **Ship.** Trivial, pure subtraction. Bundle with proposal #7 in one skill-update PR.
+
+### 7. Add Reddit `.rss` or Reddit MCP to `kaizen-research`
+- **Source**: research/2026-05-10.md ▸ Risks ▸ "Reddit blocked from WebFetch" | review-queue.md (open)
+- **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
+- **Change**: switch the community-signal subagent from raw `reddit.com` URLs to `https://www.reddit.com/r/<sub>/.rss` (try first — `.rss` may be allowed where the HTML page isn't), or wire a Reddit MCP server if available.
+- **Subtracts**: no — restores a half-blind source.
+- **Effort**: Low (try `.rss` first; fall back to MCP if blocked)
+- **Impact**: Low-Medium (community signal is one of 11 sources; useful but not load-bearing)
+- **POC findings**: not POCed.
+- **Ship means**: edit the skill's source list.
+- **Decline means**: keep accepting "Reddit blocked" as a known gap.
+- **Recommendation**: **Ship.** Bundle with proposal #6 in a single skill-update PR.
+
+## Carried Over From Prior Reviews
+
+Bootstrap run — none.
+
+## Retirement Candidates
+
+- **`enabled_tools` whitelist debug guidance in `CLAUDE.md`** — Reference repo abandoned this pattern May 3; ours isn't *wrong*, just diverging from the reference. **Recommendation**: monitor; revisit if/when we touch tool-enablement code. Not retire-this-week.
+- **Skills not modified in 60+ days (6 of 9)** — modification freshness alone isn't enough signal to retire skills that encode stable conventions (e.g. `tailwind-ui`, `cdk-infrastructure`). **Recommendation**: **don't retire.** If we want this to be a reliable retirement signal, we'd need invocation telemetry — that's a separate proposal worth filing for a future week.
+
+## Risks Acknowledged But Not Acted On
+
+- **OpenAI GPT-5.3 → 5.5 Instant displacement** — https://openai.com/index/gpt-5-5-instant/ — *what breaks if ignored*: customers using a 5.3 default may hit a deprecation window. **Recommendation**: **Watch until 2026-06-01.** Quick check next week to confirm whether OpenAI is publishing a deprecation date for 5.3; if yes, file a model-selector audit.
+- **`fast-uri`, `@babel/plugin-transform-modules-systemjs`, `gitpython` adjacent CVEs** (high-severity transitives, not direct deps) — *what breaks if ignored*: maybe nothing; we don't know without `uv pip tree` / `npm ls` against the lockfiles. **Recommendation**: **Address now (Low effort)**: 5-minute lockfile audit; if any are present, file an upgrade issue. Bundle with proposal #1 if convenient.
+
+## What Shipped This Week
+
+- **#277 — feat(auth): centralize 401 redirect + proactive session detection** (May 10) — *closes a real refresh-edge UX hole*
+- **#275 — fix(bff): tighten cross-task refresh-lock release + absolute-lifetime guard** — *prevents zombie refresh attempts after lock release*
+- **#274 — fix(bff): replace KMS-wrap data-key bootstrap with Secrets-Manager-generated secret** — *removes a bootstrap race the AES-GCM codec couldn't recover from*
+- **#273 — fix(bff): cross-task cookie-codec & refresh-lock correctness** — *cleanup*
+- **#272 — feat(auth): add SKIP_AUTH=true local-dev bypass with allowlist guard** — *unblocks local dev when Cognito is offline*
+- **#271 — fix(auth): make lava-lamp backdrop dark-mode aware** — *visual polish*
+- **#270 — fix(token-accounting): correct per-message cost and context-window semantics** — *fixes the cost badge accuracy*
+- **#265 — chore(deps): upgrade strands-agents to 1.39.0** — *the upgrade that quietly closes #266 and #267*
+
+## Take
+
+The week's most valuable shipping is the strands-agents 1.39.0 bump (#265) — and the team probably doesn't yet know it closed two of our open issues. That's the kaizen loop earning its keep: surface the latent value before it gets re-built. The single change that would matter most this week if shipped is **proposal #1 (bump bedrock-agentcore)** — it's free, it likely fixes two open SDK issues we already feel, and it sets up everything else upstream-related. CI is the loudest non-kaizen problem on the board; proposal #5 is the right venue to surface it but the fix is hygiene, not strategy.
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min).
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (3-5 min). 7 proposals; my recommendations: 5 Ship, 1 Defer, 0 Decline (proposal #4 is the defer).
+3. Same for Risks Acknowledged.
+4. Pick 1-3 to ship this week. Suggested if you only do 3: **#1 (bedrock-agentcore bump), #3 (close #266/#267), #5 (CI triage)** — covers a quick win, a subtraction, and a hygiene fix.
+
+Target: 10-15 minutes.
+
+## Post-review (separate PRs)
+
+- ✅ Ship items → individual feature PRs over the week. The decision is logged in this doc; the implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a "revisit by" date; surface again in the next review when due.
+
+This skill produces the agenda. Implementation never happens here.


### PR DESCRIPTION
## Summary

Adds two new repo-level skills and the first kaizen run output. This is a **bootstrap PR** — going forward, the two skills will produce two separate PRs each Friday morning.

### New skills (`.claude/skills/`)
- **`kaizen-research`** — Friday ~6am MT external + internal scan. Sources: AWS Bedrock + AgentCore, Strands Agents, the aws-samples/sample-strands-agent-with-agentcore reference repo, MCP ecosystem, frontier model announcements, agent-harness patterns, AWS pricing, AgentCore SDK issues, community signal, security advisories, Anthropic cookbook + courses, version-pin lag, recent commits/PRs/issues/CI failures, skill inventory.
- **`kaizen-review-prep`** — Friday ~8am MT (~2hr after research). Ranked decision agenda. Consumes the research doc + open `review-queue.md` items + last week's POC findings (from the prior research PR's comments) + recent merges + CI signal. Every item has Ship / Decline / Defer recommendation, capped at 10 proposals.

Both skills open PRs into `develop` on `kaizen/*` branches. Soft web budget 50/run. Parallel subagent fan-out per source category.

### Bootstrap outputs (this PR)
- `docs/kaizen/research/2026-05-10.md` — first research doc
- `docs/kaizen/reviews/2026-05-10.md` — first review-prep doc with 7 ranked proposals
- `docs/kaizen/review-queue.md` — rolling handoff between the two skills

## Top findings (full detail in the docs)

1. **`bedrock-agentcore` is 3 minor versions behind** (1.6.4 → 1.9.0, released May 7). Open SDK issues #456 (OTEL trace detach) and #452 (event-loop blocking in `AgentCoreMemorySessionManager`) may already be fixed. Recommended: bump.
2. **Our open issues #266 and #267 were closed upstream** by Strands v1.37 (context-window lookup tables) and v1.38 (large tool result offload) — both shipped before our 1.39 pin (#265). Recommended: close + replace with smaller "wire feature" tasks.
3. **CI is unhealthy**: 9 Nightly Build & Test failures and 6+ Deploy failures since May 6, untriaged. Likely BFF migration drift + #220 test isolation flakiness compounding.
4. Reference repo (`aws-samples/sample-strands-agent-with-agentcore`) **migrated CDK → Terraform Apr 19** — no longer a CDK template for us. Their `disabled_skills` blacklist (replacing `enabledTools` whitelist) and SDK-native `agent.state` compaction are patterns to evaluate.
5. **MCP SEP-2567 (Sessionless MCP) merged May 7** — strong fit for our SigV4 Gateway. Watch for python `mcp` library adoption.

## Review

1. Read `docs/kaizen/reviews/2026-05-10.md`.
2. Mark each of the 7 proposals ✅ Ship / ❌ Decline / ⏸ Defer in a PR comment or follow-up commit.
3. If you only ship 3 this week: my recommendation is **#1 (bedrock-agentcore bump), #3 (close #266/#267), #5 (CI triage)**.

Target review time: 10–15 minutes.

## Scheduling

Two scheduled tasks will be created (or are being created in parallel with this PR) to run automatically:
- `kaizen-research` — Fridays 6:00 AM MT (`0 6 * * 5`)
- `kaizen-review-prep` — Fridays 8:00 AM MT (`0 8 * * 5`)

## Bootstrap notes

- This is the **first** run; `Carried Over` and `prior decisions` sections are necessarily empty.
- Reference-repo scan extended to 30 days for baseline; future runs cover 7 days.
- 2 dead source URLs identified (Bedrock What's New 404, Claude Code release notes 404) — proposal #6 in the review doc fixes these.
- Reddit blocked from WebFetch in this environment — proposal #7 switches to `.rss`/MCP.
- Note from the push: GitHub flags 9 dependabot vulnerabilities on the default branch (4 high, 4 moderate, 1 low) — separate from this scan but worth a look.

## Decision

Ship the doc + skills to `develop`. Action on individual ideas happens in separate PRs over the next week.
- Declined items will be appended to `docs/kaizen/decisions.md` (created on first decline).
- Deferred items stay open in `review-queue.md` with a revisit date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)