### PR TITLE
chore(kaizen): add FastMCP source + security posture lens + library-native subtraction

### DIFF
--- a/.claude/skills/kaizen-research/SKILL.md
+++ b/.claude/skills/kaizen-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kaizen-research
-description: Weekly Friday early-morning external + internal scan for ways to improve the AgentCore Public Stack repo. Tracks AWS Bedrock + AgentCore announcements, Strands Agents releases, the aws-samples/sample-strands-agent-with-agentcore reference repo, the MCP ecosystem, frontier model announcements, and agent-harness patterns. Audits internal signals (recent commits, open PRs, CI failures, version-pin lag, dormant skills). Outputs a dated research doc + queues ideas in `docs/kaizen/review-queue.md` for that same morning's `kaizen-review-prep` (runs ~2 hours later) to rank into decisions. Opens a PR into `develop`. Triggers: "kaizen research", "weekly research scan", "external scan", "what should we look at this week".
+description: Weekly Friday early-morning external + internal scan for ways to improve the AgentCore Public Stack repo. Tracks AWS Bedrock + AgentCore announcements, Strands Agents releases, FastMCP (used by externally hosted MCP servers), the aws-samples/sample-strands-agent-with-agentcore reference repo, the MCP ecosystem, frontier model announcements, and agent-harness patterns. Audits internal signals (recent commits, open PRs, CI failures, version-pin lag, dormant skills) AND security posture (open Dependabot + CodeQL alerts, auth-surface churn). Outputs a dated research doc + queues ideas in `docs/kaizen/review-queue.md` for that same morning's `kaizen-review-prep` (runs ~2 hours later) to rank into decisions. Opens a PR into `develop`. Triggers: "kaizen research", "weekly research scan", "external scan", "what should we look at this week".
 ---
 
 # Kaizen Research
@@ -9,7 +9,7 @@ Friday early morning. The "what's the rest of the world learning that we should 
 
 ## Philosophy
 
-- **Subtraction first.** Every research run should propose at least as many things to *remove or simplify* as to add. A smaller stack you trust beats a bigger one you route around.
+- **Subtraction first.** Every research run should propose at least as many things to *remove or simplify* as to add. A smaller stack you trust beats a bigger one you route around. **Subtraction explicitly includes replacing custom code with library-native equivalents** — when an upstream release (Strands, AgentCore SDK, FastMCP, MCP, etc.) ships a capability we'd already built or filed an issue for, the win is closing our version and adopting upstream. Example: the 2026-05-10 bootstrap run found that Strands v1.37/v1.38 silently closed our open issues #266 and #267 — the codebase surface area shrinks even though we "added" a dep bump.
 - **Subagent fan-out.** External sources are independent — fan them out to parallel subagents and synthesize. Keeps the main context clean and runs faster.
 - **Web budget soft cap.** Target ≤50 web requests. If a source is exhausted, unreachable, or rate-limited, list it as "not scanned this week" — don't skip silently. Going modestly over the cap (say, to 60) is fine if the extra requests are surfacing real signal; document the overage in the Web Budget block. Don't pad — if 30 requests covered every source meaningfully, stop at 30.
 - **Cite everything.** Every external claim gets a URL + access date in the Sources Scanned appendix. Web findings rot fast and you'll re-read them next week.
@@ -44,6 +44,13 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
    - https://modelcontextprotocol.io (blog, spec changes)
    - https://github.com/modelcontextprotocol/servers (new servers, retired servers)
    - MCP registry / awesome-mcp lists for new servers relevant to the stack (Bedrock, AWS, GitHub, Slack, observability).
+
+4a. **FastMCP** — used by our externally hosted MCP servers (Lambda-backed, behind AgentCore Gateway). FastMCP is **not** pinned in this repo's `pyproject.toml`; it lives in the MCP server repos this stack consumes via Gateway. Track upstream releases because changes affect server behavior we depend on.
+   - https://github.com/jlowin/fastmcp/releases
+   - https://github.com/jlowin/fastmcp/blob/main/CHANGELOG.md
+   - https://github.com/jlowin/fastmcp/issues?q=is%3Aissue+sort%3Aupdated-desc
+   - https://pypi.org/project/fastmcp/ (for latest version + release date)
+   - Identify: breaking changes, new server-side primitives (resources/prompts/tool decorators, lifespan, auth helpers), transport changes (especially relevant if MCP SEP-2567 sessionless transport lands), and Lambda/runtime adapter changes.
 
 5. **Frontier model announcements**
    - https://www.anthropic.com/news
@@ -98,6 +105,14 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 
 18. **Skill inventory.** `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`. Skills not modified in 60+ days and not visibly referenced in recent PRs are retirement candidates.
 
+18a. **Security posture audit.** Snapshot the active security signal against the repo. Run in parallel with the other internal Bash calls:
+   - `gh api repos/:owner/:repo/dependabot/alerts --paginate` — open count + severity breakdown (critical / high / medium / low). Cluster by ecosystem (npm / pip / etc.) and package. Cross-reference against the external "Security advisories" scan — overlap is the "what we already know is hitting us" signal.
+   - `gh api repos/:owner/:repo/code-scanning/alerts --paginate` — open CodeQL findings with severity, rule id, file path. Group by rule (e.g., `py/log-injection × N`). Note `error`-severity findings in real backend paths separately from `note`-severity hygiene findings.
+   - `gh api repos/:owner/:repo/secret-scanning/alerts --paginate` — open leaked-secret alerts (this endpoint may 404 if secret scanning isn't enabled; record the gap).
+   - `gh issue list --state open --label security` — human-filed security tickets.
+   - `git log develop --since="7 days ago" -- '*auth*' '*oauth*' '*cookie*' '*jwt*' '*secret*' '*token*'` — recent commits touching the auth/secrets surface. High churn here is a defensive-review prompt (consider asking: is the surface stabilized or still in flux?).
+   - Most recent `CHANGELOG.md` `### 🔒 Security` block — what was just shipped.
+
 19. **Version-pin lag.** For each tracked dep, fetch latest release version and compute lag:
     - Backend: `strands-agents`, `boto3`, `botocore`, `fastapi`, `pydantic`, `bedrock-agentcore`, `mcp`
     - Frontend: `@angular/core`, `@analogjs/platform`, `vitest`
@@ -140,6 +155,9 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 
 #### MCP ecosystem
 - …
+
+#### FastMCP
+- **[Release / change]** — [URL] — *implications for our MCP servers*: [breaking change? new primitive worth adopting?]
 
 #### Frontier model announcements
 - …
@@ -186,6 +204,26 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 | Dep | Pinned | Latest | Lag | Notes |
 |---|---|---|---|---|
 | strands-agents | x.y.z | a.b.c | N releases / N days | [breaking? new feature relevant to us?] |
+
+### Security posture
+
+**Open Dependabot alerts**: N total ([N critical / N high / N medium / N low])
+| # | Severity | Ecosystem / Package | Summary | Same vuln in last week's external advisories scan? |
+|---|---|---|---|---|
+| #N | high | npm / fast-uri | host confusion | yes — appeared as "adjacent" advisory last week |
+
+**Open CodeQL alerts**: N total (N error, N warning, N note)
+| # | Severity | Rule | Path | Real surface or hygiene? |
+|---|---|---|---|---|
+| #N | error | py/log-injection | backend/src/.../service.py | real (user-controlled input → log) |
+
+**Open security-labeled issues**: N — [link]
+
+**Auth-surface churn (last 7 days)**: N commits touching `*auth*` / `*oauth*` / `*cookie*` / `*jwt*` / `*secret*` / `*token*`. Cluster: [BFF / Cognito / MCP auth / ...]. *Read*: [stabilizing / still in flux / suspicious].
+
+**Last-shipped security work**: link to most recent `🔒 Security` block in `CHANGELOG.md`.
+
+**Net read**: [1-2 sentences. Is the security posture trending tightening, drifting, or steady?]
 
 ### Retirement candidates
 - **[Skill / file / config]** — [evidence: not modified in N days, replaced by X, never referenced]
@@ -278,8 +316,14 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
    - `gh run list --status=failure --limit 30`
    - `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`
    - Read pinned versions from the three manifest files.
+   - **Security posture** (parallel with the above):
+     - `gh api repos/:owner/:repo/dependabot/alerts --paginate` (filter `state==open`)
+     - `gh api repos/:owner/:repo/code-scanning/alerts --paginate` (filter `state==open`)
+     - `gh api repos/:owner/:repo/secret-scanning/alerts --paginate` (note 404 if disabled)
+     - `gh issue list --state open --label security`
+     - `git log develop --since="7 days ago" -- '*auth*' '*oauth*' '*cookie*' '*jwt*' '*secret*' '*token*'`
 
-4. **Fan out external scan** — spawn parallel `general-purpose` subagents (or `Explore` for sources requiring multiple targeted lookups). One subagent per source category 1–11 above. Each subagent receives:
+4. **Fan out external scan** — spawn parallel `general-purpose` subagents (or `Explore` for sources requiring multiple targeted lookups). One subagent per source category 1–12 above (12 categories including FastMCP). Each subagent receives:
    - The exact URLs to scan
    - Scope: last 7 days
    - Web budget for that subagent (3–5 requests soft target)
@@ -290,7 +334,9 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 5. **Version-pin diff.** For each tracked dep, fetch latest release version (WebFetch on the release page or registry equivalent — counts toward budget). Compute lag in releases and days. If a budget hit prevents a check, list the dep under "Skipped".
 
-6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself.
+5a. **Security cross-reference.** For each open Dependabot alert, mark whether the same vulnerability appeared in the external "Security advisories" subagent report (yes = "we already know it's hitting us" — escalate priority). For each high-severity CodeQL finding, note whether the path is real backend code or hygiene-only.
+
+6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself. **Top 5 weighting**: high-severity security findings on real surfaces get a priority boost; library-native subtraction opportunities (where upstream closed a custom-code need) get a subtraction boost.
 
 7. **Update review queue.** For each Top 5 idea, prepend a new entry under `## Open` in `docs/kaizen/review-queue.md`. Never touch `## Resolved`.
 

--- a/docs/kaizen/research/2026-05-10.md
+++ b/docs/kaizen/research/2026-05-10.md
@@ -5,7 +5,12 @@
 
 ## TL;DR
 
-The week's biggest external signal is that **`bedrock-agentcore` is now three minor versions behind** (1.6.4 → 1.9.0, latest published May 7), and our two highest-impact open issues (#266 large tool result offload, #267 context-window lookup table) **were quietly solved upstream in Strands v1.37/v1.38** — we just need to wire them in. The biggest internal signal is **CI is broken**: 9 Nightly Build & Test failures and 6+ Deploy failures in the last 7 days. Recommended #1: bump `bedrock-agentcore` to 1.9.0 and verify our Strands `BedrockModel.stream` cancel path against the just-filed #2266 leak.
+Three converging signals this week:
+1. **Security posture has known issues sitting open**: 4 high-severity `fast-uri` Dependabot alerts (host confusion + path traversal — confirmed real by our external scan) and 3 error-severity `py/log-injection` CodeQL findings in `chat/service.py`, `agent_types.py`, `connectors/routes.py`. Catching ≠ fixing; these have been open without movement.
+2. **Upstream is shrinking our backlog for free**: our open issues #266/#267 were quietly solved in Strands v1.37/v1.38 (now in our 1.39 pin from #265); `bedrock-agentcore` is 3 minor versions behind (1.6.4 → 1.9.0, latest published May 7 — inside the scan window) with likely fixes for two open SDK issues we feel.
+3. **CI is broken**: 9 Nightly Build & Test failures + 6+ Deploy failures in 7 days, untriaged.
+
+**Recommended #1**: patch the 4 high-severity `fast-uri` Dependabot alerts (npm transitive of Hono). Free fix; everything else can stack on top.
 
 ## External Scan
 
@@ -54,6 +59,10 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Schema rename: `IncompleteResult` → `InputRequiredResult`** — typed-API break on next `mcp` lib bump
 - **MCPSafe — security scanner for MCP servers** — https://github.com/orgs/modelcontextprotocol/discussions — could scan our Gateway-hosted servers
 - **MCP servers repo (no new servers this week)** — discovery has moved to `registry.modelcontextprotocol.io`
+
+#### FastMCP (used by our externally hosted MCP servers, behind AgentCore Gateway)
+- **Latest release: 3.2.4** — published 2026-04-14 (~26 days ago) — https://pypi.org/project/fastmcp/ — *applicability*: cross-reference against our MCP server repos' pinned FastMCP version; if any are behind 3.x, evaluate the migration path.
+- **Bootstrap-run note**: FastMCP source category was added mid-bootstrap based on follow-up feedback. Full release-notes + issues scan (https://github.com/jlowin/fastmcp) deferred to the first regular Friday run (2026-05-15). For this bootstrap, only the PyPI version snapshot is captured.
 
 #### Frontier model announcements
 - **Anthropic — higher Opus rate limits (May 6)** — https://www.anthropic.com/news/higher-limits-spacex — informational; we use Bedrock-hosted, not first-party
@@ -123,6 +132,38 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 | `fastapi` | 0.136.1 | 0.136.1 | current | — |
 | `mcp` | (transitive) | 1.27.1 | n/a | Watch for SEP-2567 adoption |
 
+### Security posture
+
+**Open Dependabot alerts: 9** (4 high, 4 medium, 1 low) — all npm ecosystem
+
+| # | Severity | Package | Summary | Same vuln in this week's external advisories scan? |
+|---|---|---|---|---|
+| #122, #121 | high | `fast-uri` | Host confusion via percent-encoded authority delimiters | **YES** — flagged "adjacent" by our security-advisories subagent this run. We now know it's hitting us. |
+| #117, #116 | high | `fast-uri` | Path traversal via percent-encoded dot segments | **YES** — same package |
+| #120 | medium | `hono` | CSS Declaration Injection in JSX SSR | no |
+| #118 | medium | `hono` | Cache Middleware ignores `Vary: Authorization` / `Vary: Cookie` → cross-user cache poisoning | no |
+| #115 | medium | `hono` | Unvalidated JSX Tag Names → HTML injection | no |
+| #113 | medium | `ip-address` | XSS in `Address6` HTML-emitting methods | no |
+| #119 | low | `hono` | Improper validation of NumericDate claims in JWT verify() | no |
+
+**Open CodeQL alerts: 10** (3 error, 2 note `empty-except`, 5 note hygiene)
+
+| # | Severity | Rule | Path | Real surface or hygiene? |
+|---|---|---|---|---|
+| #631 | **error** | `py/log-injection` | `backend/src/apis/inference_api/chat/service.py` | **real** — user-controlled input into logs |
+| #625 | **error** | `py/log-injection` | `backend/src/agents/main_agent/agent_types.py` | **real** |
+| #624, #623 | **error** | `py/log-injection` | `backend/src/apis/app_api/connectors/routes.py` | **real** |
+| #627, #626 | note | `py/empty-except` | `backend/src/apis/app_api/documents/ingestion/processors/xlsx_chunker.py` | code smell — silent failure path |
+| #634, #633, #621, #637 | note | unused-import / unused-local / ineffectual-statement / unused-global | various backend paths | hygiene |
+
+**Open security-labeled issues**: 0 (no issues currently tagged `security`)
+
+**Auth-surface churn (last 7 days)**: 7 commits (#270, #271, #272, #273, #274, #275, #277) — concentrated on BFF cookie-codec, refresh-lock release, session bootstrap. *Read*: still in flux. Patches landing every 1-2 days. Defensive review window not closed; treat any new BFF code as suspect-by-default for another 1-2 weeks.
+
+**Last-shipped security work**: beta.24 (May 6) `🔒 Security` block — BFF `return_to` control-byte bypass closed (#221), AES-GCM codec version-byte AAD binding (#213), Pygments 2.19.2 → 2.20.0 ReDoS, multiple Dependabot resolutions (#199, #247). The pace says we've been actively tightening, not letting things drift.
+
+**Net read**: Posture is **mixed**. The 4 `fast-uri` high-severity Dependabot alerts and 3 `py/log-injection` error-severity CodeQL findings are *known and not patched* — those are the immediate action items. Auth-surface churn says the BFF migration is still v1; expect another round of follow-ups. The good news: nothing in this snapshot is invisible — Dependabot and CodeQL are catching things; the system isn't drifting silently. The bad news: **catching ≠ fixing**, and these have been open without recorded movement.
+
 ### Retirement candidates
 
 - **`enabled_tools` whitelist debug guidance in `CLAUDE.md`** — Reference repo abandoned this pattern May 3 (`092aa33`) for `disabled_skills` blacklist. Not urgent retirement, but worth a re-evaluation if we touch tool-enablement code.
@@ -138,17 +179,29 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Strands #2266 — `BedrockModel.stream` leaks inner task on outer cancellation** — we cancel SSE streams on client disconnect. *What breaks if ignored*: orphaned tasks, "Task exception was never retrieved" log noise, possible memory pressure under churn. — https://github.com/strands-agents/sdk-python/issues/2266
 - **Reddit blocked from WebFetch** in the kaizen-research environment — community-signal scan is half-blind. — *Fix*: switch to `https://www.reddit.com/r/<sub>/.rss` or a configured Reddit MCP server.
 
-## Ideas — Top 5 (ranked)
+## Ideas — Top 7 (ranked)
+
+> Bootstrap exceptionally lists 7 (vs the skill's nominal 5) because the security lens was added mid-run and surfaced 2 immediate action items. Regular runs target 5.
 
 | # | Idea | Surface | Effort | Impact | Subtracts? |
 |---|---|---|---|---|---|
-| 1 | Bump `bedrock-agentcore` 1.6.4 → 1.9.0; verify SDK issues #456/#452 are addressed | backend | L | M | no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window) |
-| 2 | Audit `BedrockModel.stream` cancellation path against Strands #2266 | backend | L | M-H | no — defensive; SSE-disconnect path is hot |
-| 3 | Close issues #266 and #267 — features already in our Strands 1.39 pin; replace with smaller "wire upstream feature" tasks | cross-cutting | L | M | **yes — retires 2 build-from-scratch tickets** |
-| 4 | Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling | backend | M | H | no — defensive; mid-conversation OAuth failure is a real UX risk |
-| 5 | Triage Nightly Build & Test failure cluster (9× since May 6) | cross-cutting / CI | L-M | M-H | possibly — if root is issue #220, fixing it simplifies suite |
+| 1 | Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122) | frontend | L | H | no — security fix; required hygiene |
+| 2 | Bump `bedrock-agentcore` 1.6.4 → 1.9.0; verify SDK issues #456/#452 are addressed | backend | L | M | no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window) |
+| 3 | Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631) | backend | L-M | M-H | no — security fix |
+| 4 | Audit `BedrockModel.stream` cancellation path against Strands #2266 | backend | L | M-H | no — defensive; SSE-disconnect path is hot |
+| 5 | Close issues #266 and #267 — features already in our Strands 1.39 pin; replace with smaller "wire upstream feature" tasks | cross-cutting | L | M | **yes — retires 2 build-from-scratch tickets** |
+| 6 | Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling | backend | M | H | no — defensive; mid-conversation OAuth failure is a real UX risk |
+| 7 | Triage Nightly Build & Test failure cluster (9× since May 6) | cross-cutting / CI | L-M | M-H | possibly — if root is issue #220, fixing it simplifies suite |
 
-### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
+### 1. Patch high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
+- **Source**: GitHub Dependabot alerts dashboard; cross-confirmed by this run's security-advisories subagent
+- **Surface area**: `frontend/ai.client/package.json` overrides (fast-uri is npm transitive — likely via Hono)
+- **Change**: identify the import chain (`npm ls fast-uri`); add an `overrides` entry pinning `fast-uri` to a patched version (advisories cite the affected and fixed ranges); rebuild + Vitest sweep; deploy through normal cycle.
+- **Subtracts**: addition only — security fix
+- **Effort × Impact**: Low × High (4 alerts at once; same package; the override approach already exists in the file)
+- **Verdict**: Worth trying
+
+### 2. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
 - **Source**: PyPI (https://pypi.org/project/bedrock-agentcore/) + open SDK issues #456, #452
 - **Surface area**: `backend/pyproject.toml`, `backend/uv.lock`
 - **Change**: pin update + smoke-test memory + identity flows in dev; verify CHANGELOG between 1.6 and 1.9 for any breaking changes
@@ -156,7 +209,15 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Effort × Impact**: Low × Medium
 - **Verdict**: Worth trying
 
-### 2. Audit `BedrockModel.stream` cancellation path
+### 3. Fix 3 `py/log-injection` error-severity CodeQL findings
+- **Source**: GitHub Code Scanning alerts #623, #624, #625, #631
+- **Surface area**: `backend/src/apis/inference_api/chat/service.py` (#631), `backend/src/agents/main_agent/agent_types.py` (#625), `backend/src/apis/app_api/connectors/routes.py` (#623, #624)
+- **Change**: locate the user-controlled input → logger calls; either sanitize via `repr()` / regex, or use parameterized logging (`logger.info("got %s", user_input)`) which CodeQL doesn't flag. Cross-check that this isn't a regression of the #247 log-injection fix (only `model_id` was sanitized then; these may be different inputs added in subsequent PRs).
+- **Subtracts**: addition only — security fix
+- **Effort × Impact**: Low-Medium × Medium-High (3 separate files, but the fix pattern is uniform)
+- **Verdict**: Worth trying
+
+### 4. Audit `BedrockModel.stream` cancellation path
 - **Source**: Strands open issue #2266 (filed May 9)
 - **Surface area**: `backend/src/agents/main_agent/` stream coordinator + SSE handler
 - **Change**: locate where we cancel `BedrockModel.stream`; ensure we `await task` on cancel paths so tasks don't orphan; add a log assertion in dev to detect "Task exception was never retrieved"
@@ -164,15 +225,15 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Effort × Impact**: Low × Medium-High
 - **Verdict**: Worth trying
 
-### 3. Close issues #266 and #267 — features already in our Strands 1.39 pin
+### 5. Close issues #266 and #267 — features already in our Strands 1.39 pin
 - **Source**: Strands v1.37 (PR #2249, context-window lookup) + v1.38 (large tool result offload)
 - **Surface area**: GitHub issues + small wiring in `stream_coordinator` and tool-result handling for spreadsheet/Code Interpreter outputs
 - **Change**: close #266 and #267 with comments pointing at upstream PRs; replace with smaller "wire context-window lookup" and "wire large tool result offload" tasks if the wiring isn't automatic
-- **Subtracts**: **yes — retires 2 "build from scratch" issues; replaces with at-most 2 "use upstream feature" tasks**
+- **Subtracts**: **yes — retires 2 "build from scratch" issues; replaces with at-most 2 "use upstream feature" tasks. Library-native subtraction.**
 - **Effort × Impact**: Low × Medium
 - **Verdict**: Worth trying
 
-### 4. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+### 6. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
 - **Source**: aws-samples/sample-strands-agent-with-agentcore commit `9fcdb4c`
 - **Surface area**: `backend/src/apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers
 - **Change**: ensure mid-conversation 401/403 from Google/external OAuth providers re-emits `oauth_required` (consent-resume) rather than streaming a tool error to the user
@@ -180,7 +241,7 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Effort × Impact**: Medium × High
 - **Verdict**: Worth trying
 
-### 5. Triage Nightly Build & Test failure cluster
+### 7. Triage Nightly Build & Test failure cluster
 - **Source**: 9 failures since May 6 in `gh run list --status=failure`
 - **Surface area**: `.github/workflows/nightly-*.yml`, possibly `tests/shared/test_cognito_idp_service.py` + adjacent (per issue #220)
 - **Change**: pull the most recent failure log; trace to root cause; fix flakiness OR document why it's failing if it's a real regression; promote to blocking issue
@@ -190,7 +251,7 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 
 ## Take
 
-The ecosystem and our own week converged on the same theme: **stop maintaining things that upstream now does for us**. Strands 1.37/1.38 closes our open issues #266/#267 with library-native plumbing; AgentCore Memory metadata replaces ad-hoc tagging; `agent.cancel()` and `agent.state` (per the reference repo) replace custom cancellation/state code. The single most valuable change this week would be bumping `bedrock-agentcore` to 1.9.0 — it's free, it's a clean signal (3 versions of upstream fixes, including likely-relevant ones to issues we've filed), and it's the prerequisite to most of the upstream-leaning work. The CI failure cluster is a separate concern and probably shouldn't wait for kaizen.
+Three themes braid together this week. **First**, security: known-and-unpatched is the worst posture state, and we're sitting in it on `fast-uri` + log-injection. **Second**, library-native subtraction: Strands 1.37/1.38 closes #266/#267 with library-native plumbing, AgentCore Memory metadata replaces ad-hoc tagging, `agent.cancel()` + `agent.state` (per the reference repo) replace custom cancellation/state code. **Third**, the BFF migration is v1 (still being patched daily) and CI is unreliable. The single most valuable change this week is **proposal #1** (patch `fast-uri`) — it's a free fix on a known-real vulnerability surface. After that, **#2** (`bedrock-agentcore` bump) and **#5** (close #266/#267) keep harvesting upstream gains.
 
 ---
 
@@ -202,11 +263,13 @@ The ecosystem and our own week converged on the same theme: **stop maintaining t
 | 2 | Strands Agents (releases, issues, PRs) | github.com/strands-agents/sdk-python | 2026-05-10 | 3 releases + 5 issues |
 | 3 | Reference repo | github.com/aws-samples/sample-strands-agent-with-agentcore | 2026-05-10 | 12 commits in 30-day window |
 | 4 | MCP ecosystem | modelcontextprotocol.io / github.com/modelcontextprotocol | 2026-05-10 | 4 spec items + 3 discussions |
+| 4a | FastMCP (bootstrap: PyPI snapshot only — full scan deferred to 2026-05-15) | pypi.org/project/fastmcp + github.com/jlowin/fastmcp | 2026-05-10 | latest 3.2.4 |
 | 5 | Frontier models (Anthropic, OpenAI, Google, Meta) | anthropic.com / openai.com / blog.google / ai.meta.com | 2026-05-10 | 3 Anthropic + 1 OpenAI + 0 others |
 | 6 | Agent harness | github.com/anthropics + langchain.com + pydantic.dev | 2026-05-10 | 3 CC releases + 4 cookbook items |
 | 7 | Community (HN Algolia + Reddit) | hn.algolia.com + reddit.com | 2026-05-10 | 0 HN hits, Reddit blocked |
-| 8 | Security advisories | github.com/advisories | 2026-05-10 | 0 affecting our pins |
+| 8 | Security advisories | github.com/advisories | 2026-05-10 | 0 affecting our pins (external); but cross-confirmed `fast-uri` advisories match open Dependabot alerts |
 | 9 | Version-pin diff | pypi.org / npmjs.com | 2026-05-10 | 8 deps checked, 4 lag |
+| 10 | Internal security posture (Dependabot, CodeQL, auth-surface churn) | gh api dependabot/alerts + code-scanning/alerts + git log | 2026-05-10 | 9 open Dependabot (4 high), 10 open CodeQL (3 error), 7-commit BFF churn |
 
 ## Web Budget
 

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -4,36 +4,50 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 ## Open
 
+### [2026-05-10] Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
+- **Source**: research/2026-05-10.md ▸ Top 7 #1 ▸ Security posture
+- **Surface**: frontend (`frontend/ai.client/package.json` overrides)
+- **Effort × Impact**: L × H
+- **Subtracts**: no — security fix
+- **Status**: open
+
 ### [2026-05-10] Bump `bedrock-agentcore` 1.6.4 → 1.9.0
-- **Source**: research/2026-05-10.md ▸ Top 5 #1
+- **Source**: research/2026-05-10.md ▸ Top 7 #2
 - **Surface**: backend
 - **Effort × Impact**: L × M
 - **Subtracts**: no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window)
 - **Status**: open
 
+### [2026-05-10] Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)
+- **Source**: research/2026-05-10.md ▸ Top 7 #3 ▸ Security posture
+- **Surface**: backend (`chat/service.py`, `agent_types.py`, `connectors/routes.py`)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: no — security fix
+- **Status**: open
+
 ### [2026-05-10] Audit `BedrockModel.stream` cancellation path against Strands #2266
-- **Source**: research/2026-05-10.md ▸ Top 5 #2
+- **Source**: research/2026-05-10.md ▸ Top 7 #4
 - **Surface**: backend
 - **Effort × Impact**: L × M-H
 - **Subtracts**: no — defensive (SSE-disconnect path is hot)
 - **Status**: open
 
 ### [2026-05-10] Close issues #266 and #267 — features already in our Strands 1.39 pin
-- **Source**: research/2026-05-10.md ▸ Top 5 #3
+- **Source**: research/2026-05-10.md ▸ Top 7 #5
 - **Surface**: cross-cutting
 - **Effort × Impact**: L × M
-- **Subtracts**: yes — retires 2 build-from-scratch issues; replaces with at-most 2 "wire upstream feature" tasks
+- **Subtracts**: **yes — library-native subtraction; retires 2 build-from-scratch issues**
 - **Status**: open
 
 ### [2026-05-10] Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
-- **Source**: research/2026-05-10.md ▸ Top 5 #4
+- **Source**: research/2026-05-10.md ▸ Top 7 #6
 - **Surface**: backend
 - **Effort × Impact**: M × H
 - **Subtracts**: no — defensive
 - **Status**: open
 
 ### [2026-05-10] Triage Nightly Build & Test failure cluster (9× since May 6)
-- **Source**: research/2026-05-10.md ▸ Top 5 #5
+- **Source**: research/2026-05-10.md ▸ Top 7 #7
 - **Surface**: cross-cutting / CI
 - **Effort × Impact**: L-M × M-H
 - **Subtracts**: possibly — if root is issue #220 (test isolation)

--- a/docs/kaizen/reviews/2026-05-10.md
+++ b/docs/kaizen/reviews/2026-05-10.md
@@ -1,13 +1,21 @@
 # Kaizen Review — Sunday, May 10, 2026
 > Prepared 11:00am MT. Review window: May 3 – May 10, 2026 (7 days).
-> Source: research/2026-05-10.md + review-queue.md (7 open items).
-> **Bootstrap run** — no prior reviews, no prior-week POC findings, no Carried Over items.
+> Source: research/2026-05-10.md + review-queue.md (9 open items).
+> **Bootstrap run** — no prior reviews, no prior-week POC findings, no Carried Over items. Mid-bootstrap added: FastMCP source category, library-native subtraction lens, and security posture lens (added 2 immediate-action items).
 
 ## Week in Review
 
-The BFF Token Handler migration that shipped in beta.24 (May 6) is still being patched — 5 of 8 commits this week are BFF/auth follow-ups. CI is hot: 9 Nightly Build & Test failures and 6+ Deploy failures since May 6, none visibly triaged. The bigger external story is that the upstream agent ecosystem moved while we were heads-down on auth — `bedrock-agentcore` is 3 minor versions behind, and two of our own open issues (#266, #267) were quietly closed by Strands releases we just upgraded into. Net read: this is a "harvest the upstream changes you already paid for" week, not a "build something new" week.
+Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high — all `fast-uri`) and 10 open CodeQL alerts (3 error-severity `py/log-injection` in real backend paths) are catching things — but **caught ≠ patched**, and these have been sitting open. **Upstream-shrinks-our-backlog**: Strands v1.37/v1.38 quietly closed our open issues #266 and #267, and `bedrock-agentcore` is 3 minor versions behind with likely fixes for two SDK issues we feel. **BFF still v1**: 5 of 8 commits this week are auth follow-ups; CI is unreliable. Net read: a "patch the known things, harvest the upstream gains, don't start anything new" week.
 
 ## Friction — the week's signal
+
+### Security signals — known and unpatched
+- **4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)** — host confusion + path traversal. Cross-confirmed by this week's external advisories scan. Same package, two distinct CVEs.
+  - *Hypothesis*: transitive npm dep, probably via Hono (already in `overrides`). Override-pin pattern is established; just needs the patched version.
+  - *Candidate fix*: see proposal #1.
+- **3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)** — user-controlled inputs into `logger` calls in `chat/service.py`, `agent_types.py`, `connectors/routes.py`.
+  - *Hypothesis*: #247 sanitized `model_id` log injection but newer code paths added since then weren't scoped in. Pattern is the same; fix is uniform.
+  - *Candidate fix*: see proposal #3.
 
 ### Repeated patterns (≥2 occurrences)
 - **CI deploy failures (6+ since May 6)** across Inference API, App API, and Frontend deploys.
@@ -17,8 +25,8 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
   - *Hypothesis*: known flakiness from issue #220 (`test_cognito_idp_service`, `test_oauth_repositories`, `test_auth_providers*` order-dependent) compounding under the BFF-heavy week's churn.
   - *Candidate fix*: triage one failure log end-to-end. Either the root is #220 (then #220 needs to land) or it's a real regression masked by the noise.
 - **BFF/auth fix churn (5 of 8 commits this week)** — #270, #271, #273, #274, #275, #277.
-  - *Hypothesis*: BFF migration is a v1, not a v1.1; expect 1–2 more weeks of follow-ups before declaring beta.25.
-  - *Candidate fix*: not a fix per se — adjust release-cut timing for beta.25 to wait for the churn to settle.
+  - *Hypothesis*: BFF migration is a v1, not a v1.1; expect 1–2 more weeks of follow-ups before declaring beta.25. Concurrent with the still-open security CodeQL alerts in `connectors/routes.py` and `inference_api/chat/service.py`, the auth surface needs both a security-fix pass AND a stabilization wait.
+  - *Candidate fix*: not a fix per se — adjust release-cut timing for beta.25 to wait for the churn + security alerts to settle.
 
 ### One-offs worth watching
 - **`bedrock-agentcore` 1.6.4 → 1.9.0 lag** with a release published *inside* the scan window (May 7) — see proposal #1.
@@ -32,8 +40,20 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 
 ## Proposals — ranked
 
-### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
-- **Source**: research/2026-05-10.md ▸ Top 5 #1 | review-queue.md (open)
+### 1. Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
+- **Source**: research/2026-05-10.md ▸ Top 7 #1 ▸ Security posture | review-queue.md (open)
+- **Surface area**: frontend (`frontend/ai.client/package.json` overrides)
+- **Change**: `npm ls fast-uri` to find the import chain; add an `overrides` entry pinning `fast-uri` to the patched version; rebuild + Vitest sweep; deploy through normal cycle.
+- **Subtracts**: addition only — security fix
+- **Effort**: Low
+- **Impact**: High (4 high-severity alerts at once)
+- **POC findings**: not POCed.
+- **Ship means**: small PR; 4 alerts close at once.
+- **Decline means**: alerts continue accumulating; eventually someone will exploit them or audit-fail us.
+- **Recommendation**: **Ship.** Highest priority this week. Free fix on a known-real vulnerability surface; the override pattern is already established in `package.json` so this is mechanical.
+
+### 2. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
+- **Source**: research/2026-05-10.md ▸ Top 7 #2 | review-queue.md (open)
 - **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
 - **Change**: pin update + smoke-test memory + identity flows in dev; verify upstream CHANGELOG between 1.6 and 1.9 for any breaking changes; close out open SDK issues #456 (OTEL trace detach) and #452 (event-loop blocking) if 1.9 addresses them.
 - **Subtracts**: addition only — justified by 3 versions of upstream fixes including likely-relevant ones to OTEL trace detach and AgentCoreMemorySessionManager event-loop blocking.
@@ -42,10 +62,22 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **POC findings**: not POCed — bootstrap run.
 - **Ship means**: open a PR updating `pyproject.toml` and `uv.lock`; smoke-test memory write/read + identity OAuth flows in dev; if smoke passes, merge.
 - **Decline means**: keep at 1.6.4 for another week; revisit after 1.10 ships or after we observe a memory/identity issue.
-- **Recommendation**: **Ship.** Lowest effort × highest signal of any proposal this week. Do this first.
+- **Recommendation**: **Ship.** Highest signal among non-security items; do this immediately after proposal #1.
 
-### 2. Audit `BedrockModel.stream` cancellation path against Strands #2266
-- **Source**: research/2026-05-10.md ▸ Top 5 #2 | review-queue.md (open)
+### 3. Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)
+- **Source**: research/2026-05-10.md ▸ Top 7 #3 ▸ Security posture | review-queue.md (open)
+- **Surface area**: backend — `apis/inference_api/chat/service.py` (#631), `agents/main_agent/agent_types.py` (#625), `apis/app_api/connectors/routes.py` (#623, #624)
+- **Change**: locate the user-controlled input → logger calls; switch to parameterized logging (`logger.info("got %s", user_input)`) or sanitize via `repr()` / regex strip. Cross-check that this isn't a regression of the #247 `model_id` log-injection fix — these are likely different inputs added after #247.
+- **Subtracts**: addition only — security fix
+- **Effort**: Low-Medium (3 files, uniform fix pattern)
+- **Impact**: Medium-High (log injection enables log forgery and downstream log-pipeline poisoning)
+- **POC findings**: not POCed.
+- **Ship means**: a single PR touching the 3 files; close the 4 CodeQL alerts.
+- **Decline means**: alerts continue accumulating; same audit-risk story as #1.
+- **Recommendation**: **Ship.** Bundle with proposal #1 in a "security-posture sweep" PR if convenient — or ship separately, both are small.
+
+### 4. Audit `BedrockModel.stream` cancellation path against Strands #2266
+- **Source**: research/2026-05-10.md ▸ Top 7 #4 | review-queue.md (open)
 - **Surface area**: backend (`backend/src/agents/main_agent/` stream coordinator + SSE handler)
 - **Change**: locate every `BedrockModel.stream` cancellation path; ensure each `await`s the inner task on cancel so it doesn't orphan; add a dev-only assertion / log filter to detect "Task exception was never retrieved" before it reaches prod.
 - **Subtracts**: addition only — defensive.
@@ -54,25 +86,25 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **POC findings**: not POCed.
 - **Ship means**: open a PR with the audit + fixes + a regression test that triggers cancel + asserts no orphan tasks.
 - **Decline means**: log a tech-debt issue; revisit if "Task exception was never retrieved" appears in CloudWatch.
-- **Recommendation**: **Ship.** Pairs naturally with #1 — same backend area, same week's signal. Cheap insurance.
+- **Recommendation**: **Ship.** Pairs naturally with proposal #2 (same backend area, same week's Strands signal). Cheap insurance.
 
-### 3. Close issues #266 and #267 — features already in our Strands 1.39 pin
-- **Source**: research/2026-05-10.md ▸ Top 5 #3 | review-queue.md (open)
+### 5. Close issues #266 and #267 — features already in our Strands 1.39 pin
+- **Source**: research/2026-05-10.md ▸ Top 7 #5 | review-queue.md (open)
 - **Surface area**: cross-cutting — GitHub issues + small wiring in `stream_coordinator` and Code Interpreter / spreadsheet tool-result handling
 - **Change**:
   1. Comment on #266 + #267 pointing at upstream PRs (Strands #2249 for context-window lookup; v1.38.0 release notes for large tool result offload).
   2. Verify the upstream features are *automatically* active under our 1.39 pin — if not, file replacement issues for the wiring work and link them.
   3. Close #266 + #267.
-- **Subtracts**: **yes — retires 2 "build from scratch" tickets; replaces with at-most 2 "wire upstream feature" tasks.**
+- **Subtracts**: **yes — library-native subtraction. Retires 2 "build from scratch" tickets; replaces with at-most 2 "wire upstream feature" tasks.**
 - **Effort**: Low
 - **Impact**: Medium (closes phantom tech debt; clears the issue list)
 - **POC findings**: not POCed.
 - **Ship means**: 30-minute issue-grooming pass; comment + close + (if needed) file 2 smaller follow-ups.
 - **Decline means**: leave #266 + #267 open; future kaizen runs will re-flag them.
-- **Recommendation**: **Ship.** Highest *subtraction* yield this week. Costs nothing, removes two stale tickets, communicates "we're tracking upstream" to the team.
+- **Recommendation**: **Ship.** Highest *subtraction* yield this week. The clearest demonstration of the kaizen loop earning its keep: surface what upstream already did for us.
 
-### 4. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
-- **Source**: research/2026-05-10.md ▸ Top 5 #4 | review-queue.md (open)
+### 6. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: research/2026-05-10.md ▸ Top 7 #6 | review-queue.md (open)
 - **Surface area**: backend (`apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers)
 - **Change**: walk through the code paths where an external OAuth provider (Google etc.) returns 401/403 mid-stream; confirm the response is `oauth_required` SSE re-emission (consent-resume), not a streamed tool error to the user. Add a regression test if missing.
 - **Subtracts**: addition only — defensive; closes a real UX gap when upstream tokens revoke.
@@ -83,8 +115,8 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **Decline means**: assume current behavior is correct; revisit if a user reports a stuck-OAuth conversation.
 - **Recommendation**: **Defer 2 weeks.** This is the highest-impact proposal but also the highest-effort, and BFF auth is still settling — landing this in the middle of the BFF patch parade risks compounding the churn. Better to wait until BFF stabilizes (likely beta.25 territory), then audit cleanly.
 
-### 5. Triage Nightly Build & Test failure cluster (9× since May 6)
-- **Source**: research/2026-05-10.md ▸ Top 5 #5 | review-queue.md (open)
+### 7. Triage Nightly Build & Test failure cluster (9× since May 6)
+- **Source**: research/2026-05-10.md ▸ Top 7 #7 | review-queue.md (open)
 - **Surface area**: cross-cutting / CI (`.github/workflows/nightly-*.yml`, possibly `tests/shared/test_cognito_idp_service.py` per issue #220)
 - **Change**: pull the most recent failure log; trace to root cause; if root is issue #220 (test isolation), bump #220 to blocking and land it; if it's a different cause, file and resolve.
 - **Subtracts**: possibly — if root is #220, fixing it materially simplifies the suite (removes a tech-debt entry).
@@ -95,7 +127,7 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **Decline means**: continue ignoring nightly failures; eventually a real regression will hide here.
 - **Recommendation**: **Ship.** This is independent of the kaizen-loop work above; it's hygiene. If the kaizen review is the venue that finally surfaces it, that's a kaizen win.
 
-### 6. Replace dead source URLs in `kaizen-research` skill + drop `anthropics/courses`
+### 8. Replace dead source URLs in `kaizen-research` skill + drop `anthropics/courses`
 - **Source**: research/2026-05-10.md ▸ Retirement candidates | review-queue.md (open)
 - **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Change**:
@@ -108,9 +140,9 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **POC findings**: not POCed.
 - **Ship means**: 5-minute edit to `kaizen-research/SKILL.md`.
 - **Decline means**: leave dead URLs; future runs waste budget on them.
-- **Recommendation**: **Ship.** Trivial, pure subtraction. Bundle with proposal #7 in one skill-update PR.
+- **Recommendation**: **Ship.** Trivial, pure subtraction. Bundle with proposal #9 in one skill-update PR.
 
-### 7. Add Reddit `.rss` or Reddit MCP to `kaizen-research`
+### 9. Add Reddit `.rss` or Reddit MCP to `kaizen-research`
 - **Source**: research/2026-05-10.md ▸ Risks ▸ "Reddit blocked from WebFetch" | review-queue.md (open)
 - **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Change**: switch the community-signal subagent from raw `reddit.com` URLs to `https://www.reddit.com/r/<sub>/.rss` (try first — `.rss` may be allowed where the HTML page isn't), or wire a Reddit MCP server if available.
@@ -120,7 +152,7 @@ The BFF Token Handler migration that shipped in beta.24 (May 6) is still being p
 - **POC findings**: not POCed.
 - **Ship means**: edit the skill's source list.
 - **Decline means**: keep accepting "Reddit blocked" as a known gap.
-- **Recommendation**: **Ship.** Bundle with proposal #6 in a single skill-update PR.
+- **Recommendation**: **Ship.** Bundle with proposal #8 in a single skill-update PR.
 
 ## Carried Over From Prior Reviews
 
@@ -134,7 +166,8 @@ Bootstrap run — none.
 ## Risks Acknowledged But Not Acted On
 
 - **OpenAI GPT-5.3 → 5.5 Instant displacement** — https://openai.com/index/gpt-5-5-instant/ — *what breaks if ignored*: customers using a 5.3 default may hit a deprecation window. **Recommendation**: **Watch until 2026-06-01.** Quick check next week to confirm whether OpenAI is publishing a deprecation date for 5.3; if yes, file a model-selector audit.
-- **`fast-uri`, `@babel/plugin-transform-modules-systemjs`, `gitpython` adjacent CVEs** (high-severity transitives, not direct deps) — *what breaks if ignored*: maybe nothing; we don't know without `uv pip tree` / `npm ls` against the lockfiles. **Recommendation**: **Address now (Low effort)**: 5-minute lockfile audit; if any are present, file an upgrade issue. Bundle with proposal #1 if convenient.
+- **`fast-uri` was on this list last cycle as an "adjacent" transitive — now confirmed real** (4 open high-severity Dependabot alerts). Promoted to proposal #1. The lesson for the kaizen loop: adjacent-CVE flags warrant a Dependabot cross-check, not a "we'll see" defer. Skill philosophy updated to cross-reference Dependabot + external advisories explicitly.
+- **`@babel/plugin-transform-modules-systemjs`, `gitpython` adjacent CVEs** (transitives, not on Dependabot alert list) — *what breaks if ignored*: maybe nothing; we don't know without `uv pip tree` / `npm ls` against the lockfiles. **Recommendation**: **Address now (Low effort)**: 5-minute lockfile audit; if any are present, file an upgrade issue. Bundle with proposal #1 if convenient.
 
 ## What Shipped This Week
 
@@ -149,18 +182,18 @@ Bootstrap run — none.
 
 ## Take
 
-The week's most valuable shipping is the strands-agents 1.39.0 bump (#265) — and the team probably doesn't yet know it closed two of our open issues. That's the kaizen loop earning its keep: surface the latent value before it gets re-built. The single change that would matter most this week if shipped is **proposal #1 (bump bedrock-agentcore)** — it's free, it likely fixes two open SDK issues we already feel, and it sets up everything else upstream-related. CI is the loudest non-kaizen problem on the board; proposal #5 is the right venue to surface it but the fix is hygiene, not strategy.
+The week's most valuable shipping is the strands-agents 1.39.0 bump (#265) — the team probably doesn't yet know it closed two of our open issues. That's the kaizen loop earning its keep on the upstream-harvest side. The new security lens — added mid-bootstrap — earned its keep too: it surfaced 4 high-severity `fast-uri` Dependabot alerts the external scan only flagged as "adjacent". The single most valuable change this week would be **proposal #1 (patch `fast-uri`)** — known-real vulnerability, free fix. After that: **#2 (`bedrock-agentcore` bump)** and **#5 (close #266/#267)** demonstrate library-native subtraction. CI (proposal #7) is the loudest non-kaizen problem; surface it here but fix it as hygiene.
 
 ---
 
 ## Review Protocol (for Phil)
 
-1. Read Friction (2 min).
-2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (3-5 min). 7 proposals; my recommendations: 5 Ship, 1 Defer, 0 Decline (proposal #4 is the defer).
+1. Read Friction — especially the new "Security signals — known and unpatched" block (3 min).
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **9 proposals**; my recommendations: 8 Ship, 1 Defer, 0 Decline (proposal #6 is the defer).
 3. Same for Risks Acknowledged.
-4. Pick 1-3 to ship this week. Suggested if you only do 3: **#1 (bedrock-agentcore bump), #3 (close #266/#267), #5 (CI triage)** — covers a quick win, a subtraction, and a hygiene fix.
+4. Pick 1-3 to ship this week. Suggested if you only do 3: **#1 (`fast-uri` Dependabot patch), #2 (bedrock-agentcore bump), #5 (close #266/#267)** — covers the security win, an upstream-harvest win, and a subtraction. If 4: add **#3 (log-injection)** to bundle with #1 as a security-posture sweep.
 
-Target: 10-15 minutes.
+Target: 12-17 minutes (slightly more than the nominal 10-15 because the bootstrap is larger than a normal weekly review).
 
 ## Post-review (separate PRs)
 


### PR DESCRIPTION
## Summary

Follow-up to [#278](https://github.com/Boise-State-Development/agentcore-public-stack/pull/278) (the bootstrap). Three feedback-driven additions to the `kaizen-research` skill, plus a re-walk of the 2026-05-10 bootstrap output through the new lenses.

### 1. FastMCP added as a tracked source (`source 4a`)
Tracks upstream releases for the externally hosted MCP servers this stack consumes via AgentCore Gateway. FastMCP is **not** pinned in this repo (it lives in the MCP server repos) — so it's tracked as an external library, not via the version-pin diff. Latest is `3.2.4` (2026-04-14).

### 2. Library-native subtraction explicitly named in the philosophy
Existing "Subtraction first" rule expanded to call out that **replacing custom code with library-native equivalents counts as subtraction**. Canonical example from this week: Strands v1.37/v1.38 silently closed our open issues #266 and #267 — the codebase surface shrinks even though we "added" a dep bump.

### 3. Security posture audit added (`source 18a` + new doc section)
Snapshots active security signal against the repo every Friday:
- `gh api dependabot/alerts` → open count + severity breakdown
- `gh api code-scanning/alerts` → CodeQL findings with severity + rule + path
- `gh issue list --label security`
- Auth-surface commit churn (`*auth*`, `*oauth*`, `*cookie*`, `*jwt*`, `*secret*`, `*token*`)
- Cross-references open Dependabot alerts against the external "Security advisories" subagent scan — overlap = "we already know it's hitting us"

Surfaces in the research doc as a new **Security Posture** section between Version-pin lag and Retirement candidates.

## What this changes in the 2026-05-10 bootstrap output

The lens re-walk found two known-and-unpatched security issues that were *not* in the original bootstrap proposals:

- **4 high-severity `fast-uri` Dependabot alerts** (#116, #117, #121, #122) — same package, host confusion + path traversal. Last week's external advisories scan flagged `fast-uri` as "adjacent / not in our pins" — but we now see Dependabot has it open against us. Confirmed real.
- **3 error-severity `py/log-injection` CodeQL findings** (#623, #624, #625, #631) in `chat/service.py`, `agent_types.py`, `connectors/routes.py` — user-controlled inputs into `logger` calls. Likely added in PRs after #247 sanitized `model_id`; same pattern, same fix.

These become Top-7 #1 and #3 in the updated research doc; the queue + review-prep doc are renumbered accordingly. **Recommendation**: ship #1 (`fast-uri` patch) this week — free fix, known-real vulnerability surface, 4 alerts close at once.

## Review

- New skill rules + sources land going forward (next scheduled run: Fri 2026-05-15).
- The 2026-05-10 bootstrap output has been re-walked through the new lenses — `docs/kaizen/research/2026-05-10.md` now has the Security Posture section; `review-queue.md` has 2 new entries; `reviews/2026-05-10.md` has 9 proposals instead of 7.

## Decision

Ship to `develop`. The next scheduled Friday run will exercise the new lenses fully (full FastMCP scan, security cross-reference, library-native flagging in the Top 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)