### PR TITLE
chore(kaizen): scope refinement — remove security lens, add Agentic UI/UX lens

### DIFF
--- a/.claude/skills/kaizen-research/SKILL.md
+++ b/.claude/skills/kaizen-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kaizen-research
-description: Weekly Friday early-morning external + internal scan for ways to improve the AgentCore Public Stack repo. Tracks AWS Bedrock + AgentCore announcements, Strands Agents releases, FastMCP (used by externally hosted MCP servers), the aws-samples/sample-strands-agent-with-agentcore reference repo, the MCP ecosystem, frontier model announcements, and agent-harness patterns. Audits internal signals (recent commits, open PRs, CI failures, version-pin lag, dormant skills) AND security posture (open Dependabot + CodeQL alerts, auth-surface churn). Outputs a dated research doc + queues ideas in `docs/kaizen/review-queue.md` for that same morning's `kaizen-review-prep` (runs ~2 hours later) to rank into decisions. Opens a PR into `develop`. Triggers: "kaizen research", "weekly research scan", "external scan", "what should we look at this week".
+description: Weekly Friday early-morning external + internal scan for emerging functionality, agentic trends, tools, and feature/UX improvements in the AgentCore Public Stack repo. Tracks AWS Bedrock + AgentCore announcements, Strands Agents releases, FastMCP (used by externally hosted MCP servers), the aws-samples/sample-strands-agent-with-agentcore reference repo, the MCP ecosystem (including MCP Apps + extensions), frontier model announcements, agent-harness patterns, and agentic UI/UX patterns (MCP Apps, Vercel AI SDK, assistant-ui, NN/g AI research, Linear/Cursor/Anthropic product blogs). Audits internal signals (recent commits, open PRs, CI failures, version-pin lag, dormant skills). Outputs a dated research doc + queues ideas in `docs/kaizen/review-queue.md` for that same morning's `kaizen-review-prep` (runs ~2 hours later) to rank into decisions. Opens a PR into `develop`. **Out of scope**: security advisories / Dependabot / CodeQL — those have dedicated tooling and don't need a weekly kaizen lens. Triggers: "kaizen research", "weekly research scan", "external scan", "what should we look at this week".
 ---
 
 # Kaizen Research
@@ -52,6 +52,15 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
    - https://pypi.org/project/fastmcp/ (for latest version + release date)
    - Identify: breaking changes, new server-side primitives (resources/prompts/tool decorators, lifespan, auth helpers), transport changes (especially relevant if MCP SEP-2567 sessionless transport lands), and Lambda/runtime adapter changes.
 
+4b. **Agentic UI/UX patterns** — emerging UI and UX conventions for AI/agentic apps. We're Angular + Tailwind, so React-specific libraries are **pattern-only** references (extract the idea, implement in signals). Focus on functionality + interaction + visual conventions, not generic "good chat UX".
+   - **MCP Apps + extensions** (priority): https://modelcontextprotocol.io/extensions/apps/overview, https://github.com/modelcontextprotocol/ext-apps, https://blog.modelcontextprotocol.io. The "MCP server returns an interactive UI inline with the chat" standard. Track host adoption (Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman) and new MCP extension SEPs.
+   - **AI SDK / Generative UI** (Vercel): https://ai-sdk.dev/docs/ai-sdk-ui, https://ai-sdk.dev/cookbook. Canonical reference for tool-call rendering, multi-step UI, generative UI, streaming state patterns. React, but the patterns port.
+   - **assistant-ui**: https://www.assistant-ui.com/docs, https://github.com/Yonom/assistant-ui/releases. React component library purpose-built for AI chat UI. Tracks attachment UX, threading, tool-call rendering primitives.
+   - **Vendor product-blog UX writeups**: https://linear.app/blog (Linear Agent), https://www.cursor.com/blog (canvas, agent harness), https://www.anthropic.com/news filtered for `artifact`/`ui`/`design`. Where in-app agentic patterns get documented by the teams shipping them.
+   - **OpenAI Canvas + ChatGPT UI**: https://openai.com/blog filtered for `canvas`, `chatgpt`, agent UI updates.
+   - **Nielsen Norman Group AI articles**: https://www.nngroup.com/topic/artificial-intelligence/. UX-research perspective; evidence-based; slow cadence — surfaces in ~1 of 4 weekly runs but high signal when it does.
+   - Identify: new agentic UI standards (especially MCP Apps + adjacent SEPs), tool-result rendering patterns, attachment/preview UX, multi-agent attribution patterns, consent/elicitation UX, evidence-based usability findings.
+
 5. **Frontier model announcements**
    - https://www.anthropic.com/news
    - https://openai.com/blog (filter: API, agents, tools)
@@ -77,16 +86,12 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
    - HN search: `site:news.ycombinator.com bedrock OR agentcore OR strands OR "claude code"` (last 7 days)
    - r/LocalLLaMA, r/MachineLearning — agent-harness critiques and patterns surface here before vendor blogs.
 
-10. **Security advisories**
-    - https://github.com/advisories — filter for `boto3`, `strands-agents`, `fastapi`, `mcp`, `@angular`, `aws-cdk-lib`, `pydantic`.
-    - Cross-reference against pinned versions in this repo.
-
-11. **Anthropic cookbook + courses**
+10. **Anthropic cookbook + courses**
     - https://github.com/anthropics/anthropic-cookbook
     - https://github.com/anthropics/courses
     - Worked examples often outpace docs — especially for caching, tool use, and agent loops.
 
-12. **Seasonal sources** (only when in window)
+11. **Seasonal sources** (only when in window)
     - AWS re:Invent (typically late Nov / early Dec) — Bedrock/AgentCore announcements.
     - NeurIPS / ICLR / EMNLP agent tracks (when proceedings drop).
     - If today's date is not in a known window, skip with "no seasonal sources this week".
@@ -104,14 +109,6 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 17. **Recent CHANGELOG.md / RELEASE_NOTES.md entries** (last 14 days). Used as the "don't re-propose what we just shipped" filter.
 
 18. **Skill inventory.** `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`. Skills not modified in 60+ days and not visibly referenced in recent PRs are retirement candidates.
-
-18a. **Security posture audit.** Snapshot the active security signal against the repo. Run in parallel with the other internal Bash calls:
-   - `gh api repos/:owner/:repo/dependabot/alerts --paginate` — open count + severity breakdown (critical / high / medium / low). Cluster by ecosystem (npm / pip / etc.) and package. Cross-reference against the external "Security advisories" scan — overlap is the "what we already know is hitting us" signal.
-   - `gh api repos/:owner/:repo/code-scanning/alerts --paginate` — open CodeQL findings with severity, rule id, file path. Group by rule (e.g., `py/log-injection × N`). Note `error`-severity findings in real backend paths separately from `note`-severity hygiene findings.
-   - `gh api repos/:owner/:repo/secret-scanning/alerts --paginate` — open leaked-secret alerts (this endpoint may 404 if secret scanning isn't enabled; record the gap).
-   - `gh issue list --state open --label security` — human-filed security tickets.
-   - `git log develop --since="7 days ago" -- '*auth*' '*oauth*' '*cookie*' '*jwt*' '*secret*' '*token*'` — recent commits touching the auth/secrets surface. High churn here is a defensive-review prompt (consider asking: is the surface stabilized or still in flux?).
-   - Most recent `CHANGELOG.md` `### 🔒 Security` block — what was just shipped.
 
 19. **Version-pin lag.** For each tracked dep, fetch latest release version and compute lag:
     - Backend: `strands-agents`, `boto3`, `botocore`, `fastapi`, `pydantic`, `bedrock-agentcore`, `mcp`
@@ -159,6 +156,9 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 #### FastMCP
 - **[Release / change]** — [URL] — *implications for our MCP servers*: [breaking change? new primitive worth adopting?]
 
+#### Agentic UI/UX patterns
+- **[Pattern / release]** — [URL] — *what it is*: [1-2 sentences] — *fit for our stack*: [direct port / pattern-only (Angular equivalent: …) / not applicable] — *where it'd land*: [SSE event / component / route]
+
 #### Frontier model announcements
 - …
 
@@ -169,9 +169,6 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 - …
 
 #### Community + GitHub issues
-- …
-
-#### Security advisories
 - …
 
 #### Cookbook / courses
@@ -204,26 +201,6 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 | Dep | Pinned | Latest | Lag | Notes |
 |---|---|---|---|---|
 | strands-agents | x.y.z | a.b.c | N releases / N days | [breaking? new feature relevant to us?] |
-
-### Security posture
-
-**Open Dependabot alerts**: N total ([N critical / N high / N medium / N low])
-| # | Severity | Ecosystem / Package | Summary | Same vuln in last week's external advisories scan? |
-|---|---|---|---|---|
-| #N | high | npm / fast-uri | host confusion | yes — appeared as "adjacent" advisory last week |
-
-**Open CodeQL alerts**: N total (N error, N warning, N note)
-| # | Severity | Rule | Path | Real surface or hygiene? |
-|---|---|---|---|---|
-| #N | error | py/log-injection | backend/src/.../service.py | real (user-controlled input → log) |
-
-**Open security-labeled issues**: N — [link]
-
-**Auth-surface churn (last 7 days)**: N commits touching `*auth*` / `*oauth*` / `*cookie*` / `*jwt*` / `*secret*` / `*token*`. Cluster: [BFF / Cognito / MCP auth / ...]. *Read*: [stabilizing / still in flux / suspicious].
-
-**Last-shipped security work**: link to most recent `🔒 Security` block in `CHANGELOG.md`.
-
-**Net read**: [1-2 sentences. Is the security posture trending tightening, drifting, or steady?]
 
 ### Retirement candidates
 - **[Skill / file / config]** — [evidence: not modified in N days, replaced by X, never referenced]
@@ -316,14 +293,8 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
    - `gh run list --status=failure --limit 30`
    - `find .claude/skills -name SKILL.md -exec stat -f "%Sm %N" {} \;`
    - Read pinned versions from the three manifest files.
-   - **Security posture** (parallel with the above):
-     - `gh api repos/:owner/:repo/dependabot/alerts --paginate` (filter `state==open`)
-     - `gh api repos/:owner/:repo/code-scanning/alerts --paginate` (filter `state==open`)
-     - `gh api repos/:owner/:repo/secret-scanning/alerts --paginate` (note 404 if disabled)
-     - `gh issue list --state open --label security`
-     - `git log develop --since="7 days ago" -- '*auth*' '*oauth*' '*cookie*' '*jwt*' '*secret*' '*token*'`
 
-4. **Fan out external scan** — spawn parallel `general-purpose` subagents (or `Explore` for sources requiring multiple targeted lookups). One subagent per source category 1–12 above (12 categories including FastMCP). Each subagent receives:
+4. **Fan out external scan** — spawn parallel `general-purpose` subagents (or `Explore` for sources requiring multiple targeted lookups). One subagent per source category 1–11 above (13 categories total including 4a FastMCP and 4b Agentic UI/UX). Each subagent receives:
    - The exact URLs to scan
    - Scope: last 7 days
    - Web budget for that subagent (3–5 requests soft target)
@@ -334,9 +305,7 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 5. **Version-pin diff.** For each tracked dep, fetch latest release version (WebFetch on the release page or registry equivalent — counts toward budget). Compute lag in releases and days. If a budget hit prevents a check, list the dep under "Skipped".
 
-5a. **Security cross-reference.** For each open Dependabot alert, mark whether the same vulnerability appeared in the external "Security advisories" subagent report (yes = "we already know it's hitting us" — escalate priority). For each high-severity CodeQL finding, note whether the path is real backend code or hygiene-only.
-
-6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself. **Top 5 weighting**: high-severity security findings on real surfaces get a priority boost; library-native subtraction opportunities (where upstream closed a custom-code need) get a subtraction boost.
+6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself. **Top 5 weighting**: library-native subtraction opportunities (where upstream closed a custom-code need) get a subtraction boost; UI/UX patterns that match an existing surface (tool-call rendering, attachments, A2A attribution, consent flows) get a "concrete fit" boost over generic "interesting trend" items.
 
 7. **Update review queue.** For each Top 5 idea, prepend a new entry under `## Open` in `docs/kaizen/review-queue.md`. Never touch `## Resolved`.
 
@@ -363,7 +332,7 @@ gh pr create --base develop --head "$BRANCH" \
   --title "chore(kaizen): weekly research scan ${DATE}" \
   --body "$(cat <<'EOF'
 ## Summary
-- External scan: AWS Bedrock/AgentCore, Strands Agents, reference repo, MCP, frontier models, agent-harness patterns, pricing, security advisories.
+- External scan: AWS Bedrock/AgentCore, Strands Agents, FastMCP, reference repo, MCP, agentic UI/UX patterns, frontier models, agent-harness patterns, pricing.
 - Internal audit: recent commits, open PRs, GitHub issues, CI failures, version-pin lag, retirement candidates.
 - Top 5 ideas in the dated research doc and queued in `docs/kaizen/review-queue.md`.
 

--- a/docs/kaizen/research/2026-05-10.md
+++ b/docs/kaizen/research/2026-05-10.md
@@ -1,16 +1,16 @@
 # Kaizen Research — Sunday, May 10, 2026
-> Scan window: May 3 – May 10, 2026 (7 days; reference repo extended to 30 days for first-run baseline)
-> Web budget: 54/50 used (target). Frontier-models scan went over by 5 due to two OpenAI WebFetch 403s; rest within sub-budget.
-> **Bootstrap run** — first execution of the kaizen-research skill. Subsequent runs cover only the prior 7 days for the reference repo too.
+> Scan window: May 3 – May 10, 2026 (7 days; reference repo + UI/UX scan extended to 30 days for first-run baseline)
+> Web budget: 64/50 used (target — UX-lens scan added 10 requests post-initial-run). Frontier-models also went over the sub-budget by ~5 due to two OpenAI WebFetch 403s.
+> **Bootstrap run** — first execution of the kaizen-research skill. Subsequent runs cover only the prior 7 days for the reference repo + UX sources too.
 
 ## TL;DR
 
 Three converging signals this week:
-1. **Security posture has known issues sitting open**: 4 high-severity `fast-uri` Dependabot alerts (host confusion + path traversal — confirmed real by our external scan) and 3 error-severity `py/log-injection` CodeQL findings in `chat/service.py`, `agent_types.py`, `connectors/routes.py`. Catching ≠ fixing; these have been open without movement.
+1. **MCP Apps is now the de-facto agentic UI standard**, and we don't host it yet. The spec (SEP-1865) is production-ready: tool results can declare a `ui://` resource that the host renders in a sandboxed iframe alongside the chat. Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman all ship support. Every third-party MCP server we connect could be shipping richer UX than text+JSON; we're leaving that on the table.
 2. **Upstream is shrinking our backlog for free**: our open issues #266/#267 were quietly solved in Strands v1.37/v1.38 (now in our 1.39 pin from #265); `bedrock-agentcore` is 3 minor versions behind (1.6.4 → 1.9.0, latest published May 7 — inside the scan window) with likely fixes for two open SDK issues we feel.
 3. **CI is broken**: 9 Nightly Build & Test failures + 6+ Deploy failures in 7 days, untriaged.
 
-**Recommended #1**: patch the 4 high-severity `fast-uri` Dependabot alerts (npm transitive of Hono). Free fix; everything else can stack on top.
+**Recommended #1**: scope an MCP Apps host renderer in our chat (multi-PR initiative). It's the highest-leverage agentic-UX investment this week per the scan. **Recommended quick-win**: bump `bedrock-agentcore` 1.6.4 → 1.9.0.
 
 ## External Scan
 
@@ -64,6 +64,21 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Latest release: 3.2.4** — published 2026-04-14 (~26 days ago) — https://pypi.org/project/fastmcp/ — *applicability*: cross-reference against our MCP server repos' pinned FastMCP version; if any are behind 3.x, evaluate the migration path.
 - **Bootstrap-run note**: FastMCP source category was added mid-bootstrap based on follow-up feedback. Full release-notes + issues scan (https://github.com/jlowin/fastmcp) deferred to the first regular Friday run (2026-05-15). For this bootstrap, only the PyPI version snapshot is captured.
 
+#### Agentic UI/UX patterns (30-day baseline scan for bootstrap)
+
+- **MCP Apps extension is production-ready (SEP-1865)** — https://modelcontextprotocol.io/extensions/apps/overview | https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/ — *what it is*: spec letting MCP tools return a `_meta.ui.resourceUri` pointing to a `ui://` resource; host fetches the HTML and renders it in a sandboxed iframe alongside the chat with bidirectional `ui/`-prefixed JSON-RPC via `postMessage`. Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman, MCPJam already ship support. — *fit*: **direct port (high impact, high effort)** — this is the standard our chat is going to be measured against in 2026. — *where it'd land*: new SSE event (`ui_resource` carrying `{resourceUri, csp, permissions}`), Angular `<mcp-app-frame>` sandboxed-iframe component implementing the `ui/` host bridge, branch in tool-result rendering pipeline.
+- **MCP Apps host security model — sandboxed iframe + opt-in capabilities** — https://modelcontextprotocol.io/extensions/apps/overview — *what it is*: hosts declare capabilities (`sendOpenLink`, mic, camera) a given app can request; tool-call proxying goes through the host with user consent. — *fit*: **direct port** — maps cleanly onto our existing `oauth_required` consent pattern. — *where it'd land*: extend `oauth_required` SSE event family with `ui_consent_required`; reuse per-provider consent badge UI.
+- **MCP Apps example servers** — https://github.com/modelcontextprotocol/ext-apps/tree/main/examples — *what it is*: starter servers for data exploration (cohort heatmap, customer segmentation), forms (scenario modeler, budget allocator), media (PDF, video, sheet music), 3D (Cesium, Three.js). — *fit*: pattern-only — templates are React/Vue/Svelte but the protocol is framework-agnostic. — *informs*: the kinds of internal tools we'd expose as MCP Apps once we host.
+- **AI SDK "Render Visual Interface in Chat" recipe** — https://ai-sdk.dev/cookbook — *what it is*: pattern where tool results map to specific UI components on the client, model drives which component renders. — *fit*: pattern-only (React hook). — *Angular equivalent*: a `toolRenderers` registry keyed by tool name, with a signal-driven `<tool-result>` component doing `@switch (toolName())` over registered renderers. We do a coarse version today; the pattern argues for making it a first-class extension point so per-tool components live next to the tool definition rather than in a god-switch.
+- **AI SDK "Call Tools in Multiple Steps" / `streamText` multi-step** — https://ai-sdk.dev/cookbook — *fit*: pattern-only. — *Angular equivalent*: keep `signal()`-backed tool-call state mutable across the conversation (don't freeze at `tool_result`), so prior tool-call cards stay interactive as new steps stream in.
+- **assistant-ui @0.14.0 (2026-05-07)** — https://github.com/Yonom/assistant-ui/releases — API consolidation (`useAui` replaces deprecated naming). Also: `mcp-app-studio` package updated alongside — assistant-ui is shipping first-party MCP Apps authoring/preview tooling. — *signal*: **MCP Apps is the assumed UI surface** for serious agentic chat shells going forward.
+- **"Output isn't design" — Karri Saarinen, Linear (2026-04-17)** — https://linear.app/now/output-isn-t-design — *takeaway*: pointed pushback on generative-UI hype. "Plausible-looking generated interfaces unravel the moment you actually use them" because the work of resolving tensions and edge cases hasn't happened. — *implication for us*: when we add MCP Apps, treat the iframe as a vehicle for *purpose-built* UIs (forms, viewers), not as a "let the model generate a UI" shortcut.
+- **"Interact with agent-created visualizations in canvases" — Cursor (2026-04-15)** — https://www.cursor.com/blog/canvas — *takeaway*: agent output that's interactive (charts you can drill into, plots you can re-parameterize) is now table stakes in agentic IDEs. Maps to our PDF/markdown/spreadsheet preview surface — direction is "previews become interactive viewers," not static thumbnails.
+- **Linear Agent as named participant** — https://linear.app/now/how-we-use-linear-agent-at-linear (2026-04-10) + https://linear.app/changelog/2026-04-23-linear-agent-mcp-support — *pattern*: Linear's agent reads context via MCP and posts back as a structured agent identity in the issue thread (not as a chat message). **Agents as named participants with distinct affordances**, not just a stream of assistant text. — *fit for us*: worth considering for our multi-agent A2A flows — A2A sub-agents could render as distinct attributed turns rather than nested tool calls.
+- **"Claude Design by Anthropic Labs" (2026-04-17)** — https://www.anthropic.com/news/claude-design-anthropic-labs — *takeaway*: "collaborate with Claude to produce polished visual work" as a first-class output type. Validates investing in artifact-style rendering surfaces beyond plain markdown.
+- **NN/g "Designing AI Agents: 4 Lessons from China's Qwen Agent" (2026-05-08)** — https://www.nngroup.com/articles/designing-ai-agents/ — *evidence-based principles*: support discoverability, reuse familiar patterns, handle personal data carefully, protect user autonomy. — *applicability*: **discoverability** — tool-call rendering should surface available tools *before* the user has to phrase the right prompt (slash menu, suggestions from `enabled_tools`). **Autonomy** — our `oauth_required` consent event is on-pattern; extend the same explicit-consent model to MCP-Apps-initiated tool calls.
+- **OpenAI AgentKit / Agent Builder visual canvas** — https://openai.com/index/introducing-agentkit/ — *takeaway*: agent *authoring* is moving to visual node-graphs. Not directly applicable to our runtime chat, but a signal that **agent-state visibility** (which agent is running, which tool, what step) is increasingly expected at runtime too — relevant to how we render A2A and multi-step tool flows.
+
 #### Frontier model announcements
 - **Anthropic — higher Opus rate limits (May 6)** — https://www.anthropic.com/news/higher-limits-spacex — informational; we use Bedrock-hosted, not first-party
 - **Anthropic — finance-agents pack (May 5)** — https://www.anthropic.com/news/finance-agents — Moody's MCP server is a concrete public MCP we could register in Gateway if a finance use case emerges
@@ -86,10 +101,6 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 #### Community + GitHub issues
 - HN: 0 hits for stack keywords (`bedrock`, `agentcore`, `strands`, `mcp`, `claude code`) in the 7-day window — quiet
 - Reddit: blocked from WebFetch in this environment — gap to address (`.rss` or Reddit MCP)
-
-#### Security advisories
-- **0 advisories affect our pinned versions** — clean week
-- Adjacent (transitive risk to verify with `uv pip tree` / `npm ls`): GitPython newline injection (CVE-2026-42215 patch bypass), `fast-uri` host confusion, `@babel/plugin-transform-modules-systemjs` codegen issue
 
 #### Cookbook / courses
 - 4 new managed-agent cookbooks landed May 5–8 (vulnerability detection, coordinator/specialists, outcome grading, registry category)
@@ -132,38 +143,6 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 | `fastapi` | 0.136.1 | 0.136.1 | current | — |
 | `mcp` | (transitive) | 1.27.1 | n/a | Watch for SEP-2567 adoption |
 
-### Security posture
-
-**Open Dependabot alerts: 9** (4 high, 4 medium, 1 low) — all npm ecosystem
-
-| # | Severity | Package | Summary | Same vuln in this week's external advisories scan? |
-|---|---|---|---|---|
-| #122, #121 | high | `fast-uri` | Host confusion via percent-encoded authority delimiters | **YES** — flagged "adjacent" by our security-advisories subagent this run. We now know it's hitting us. |
-| #117, #116 | high | `fast-uri` | Path traversal via percent-encoded dot segments | **YES** — same package |
-| #120 | medium | `hono` | CSS Declaration Injection in JSX SSR | no |
-| #118 | medium | `hono` | Cache Middleware ignores `Vary: Authorization` / `Vary: Cookie` → cross-user cache poisoning | no |
-| #115 | medium | `hono` | Unvalidated JSX Tag Names → HTML injection | no |
-| #113 | medium | `ip-address` | XSS in `Address6` HTML-emitting methods | no |
-| #119 | low | `hono` | Improper validation of NumericDate claims in JWT verify() | no |
-
-**Open CodeQL alerts: 10** (3 error, 2 note `empty-except`, 5 note hygiene)
-
-| # | Severity | Rule | Path | Real surface or hygiene? |
-|---|---|---|---|---|
-| #631 | **error** | `py/log-injection` | `backend/src/apis/inference_api/chat/service.py` | **real** — user-controlled input into logs |
-| #625 | **error** | `py/log-injection` | `backend/src/agents/main_agent/agent_types.py` | **real** |
-| #624, #623 | **error** | `py/log-injection` | `backend/src/apis/app_api/connectors/routes.py` | **real** |
-| #627, #626 | note | `py/empty-except` | `backend/src/apis/app_api/documents/ingestion/processors/xlsx_chunker.py` | code smell — silent failure path |
-| #634, #633, #621, #637 | note | unused-import / unused-local / ineffectual-statement / unused-global | various backend paths | hygiene |
-
-**Open security-labeled issues**: 0 (no issues currently tagged `security`)
-
-**Auth-surface churn (last 7 days)**: 7 commits (#270, #271, #272, #273, #274, #275, #277) — concentrated on BFF cookie-codec, refresh-lock release, session bootstrap. *Read*: still in flux. Patches landing every 1-2 days. Defensive review window not closed; treat any new BFF code as suspect-by-default for another 1-2 weeks.
-
-**Last-shipped security work**: beta.24 (May 6) `🔒 Security` block — BFF `return_to` control-byte bypass closed (#221), AES-GCM codec version-byte AAD binding (#213), Pygments 2.19.2 → 2.20.0 ReDoS, multiple Dependabot resolutions (#199, #247). The pace says we've been actively tightening, not letting things drift.
-
-**Net read**: Posture is **mixed**. The 4 `fast-uri` high-severity Dependabot alerts and 3 `py/log-injection` error-severity CodeQL findings are *known and not patched* — those are the immediate action items. Auth-surface churn says the BFF migration is still v1; expect another round of follow-ups. The good news: nothing in this snapshot is invisible — Dependabot and CodeQL are catching things; the system isn't drifting silently. The bad news: **catching ≠ fixing**, and these have been open without recorded movement.
-
 ### Retirement candidates
 
 - **`enabled_tools` whitelist debug guidance in `CLAUDE.md`** — Reference repo abandoned this pattern May 3 (`092aa33`) for `disabled_skills` blacklist. Not urgent retirement, but worth a re-evaluation if we touch tool-enablement code.
@@ -179,27 +158,26 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Strands #2266 — `BedrockModel.stream` leaks inner task on outer cancellation** — we cancel SSE streams on client disconnect. *What breaks if ignored*: orphaned tasks, "Task exception was never retrieved" log noise, possible memory pressure under churn. — https://github.com/strands-agents/sdk-python/issues/2266
 - **Reddit blocked from WebFetch** in the kaizen-research environment — community-signal scan is half-blind. — *Fix*: switch to `https://www.reddit.com/r/<sub>/.rss` or a configured Reddit MCP server.
 
-## Ideas — Top 7 (ranked)
+## Ideas — Top 6 (ranked)
 
-> Bootstrap exceptionally lists 7 (vs the skill's nominal 5) because the security lens was added mid-run and surfaced 2 immediate action items. Regular runs target 5.
+> Bootstrap exceptionally lists 6 (vs the skill's nominal 5) because the UI/UX lens was added mid-run and surfaced an MCP Apps initiative worth ranking. Regular runs target 5.
 
 | # | Idea | Surface | Effort | Impact | Subtracts? |
 |---|---|---|---|---|---|
-| 1 | Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122) | frontend | L | H | no — security fix; required hygiene |
+| 1 | Scope an MCP Apps host renderer in our chat (multi-PR initiative) | frontend + backend (SSE event + component) | H | H | no — additive, but unlocks every future MCP server shipping a UI |
 | 2 | Bump `bedrock-agentcore` 1.6.4 → 1.9.0; verify SDK issues #456/#452 are addressed | backend | L | M | no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window) |
-| 3 | Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631) | backend | L-M | M-H | no — security fix |
+| 3 | Promote tool-result rendering to a per-tool renderer registry (signal-backed) | frontend | M | M-H | partial — replaces an implicit switch with an explicit registry; bridges toward MCP Apps |
 | 4 | Audit `BedrockModel.stream` cancellation path against Strands #2266 | backend | L | M-H | no — defensive; SSE-disconnect path is hot |
-| 5 | Close issues #266 and #267 — features already in our Strands 1.39 pin; replace with smaller "wire upstream feature" tasks | cross-cutting | L | M | **yes — retires 2 build-from-scratch tickets** |
-| 6 | Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling | backend | M | H | no — defensive; mid-conversation OAuth failure is a real UX risk |
-| 7 | Triage Nightly Build & Test failure cluster (9× since May 6) | cross-cutting / CI | L-M | M-H | possibly — if root is issue #220, fixing it simplifies suite |
+| 5 | Close issues #266 and #267 — features already in our Strands 1.39 pin; replace with smaller "wire upstream feature" tasks | cross-cutting | L | M | **yes — retires 2 build-from-scratch tickets (library-native subtraction)** |
+| 6 | Triage Nightly Build & Test failure cluster (9× since May 6) | cross-cutting / CI | L-M | M-H | possibly — if root is issue #220, fixing it simplifies suite |
 
-### 1. Patch high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
-- **Source**: GitHub Dependabot alerts dashboard; cross-confirmed by this run's security-advisories subagent
-- **Surface area**: `frontend/ai.client/package.json` overrides (fast-uri is npm transitive — likely via Hono)
-- **Change**: identify the import chain (`npm ls fast-uri`); add an `overrides` entry pinning `fast-uri` to a patched version (advisories cite the affected and fixed ranges); rebuild + Vitest sweep; deploy through normal cycle.
-- **Subtracts**: addition only — security fix
-- **Effort × Impact**: Low × High (4 alerts at once; same package; the override approach already exists in the file)
-- **Verdict**: Worth trying
+### 1. Scope an MCP Apps host renderer in our chat
+- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ MCP Apps (SEP-1865, production-ready); cross-confirmed by assistant-ui's `mcp-app-studio` direction
+- **Surface area**: frontend (new `<mcp-app-frame>` Angular component, tool-result rendering pipeline branch) + backend (new SSE event `ui_resource`; possibly extend `oauth_required` family with `ui_consent_required`)
+- **Change**: implement the host side of the MCP Apps spec — sandboxed iframe rendering `ui://` resources returned by MCP tools, with the `ui/`-prefixed JSON-RPC dialect over `postMessage`. Consent UX reuses the existing `oauth_required` pattern. Treat as a multi-PR initiative: (a) SSE event + plumbing, (b) iframe component + postMessage bridge, (c) consent UI, (d) end-to-end with one example MCP App from `ext-apps/examples`.
+- **Subtracts**: no — pure addition. Justified because: every major host already ships this; without it, third-party MCP servers we connect can't deliver UI beyond text+JSON. We become the platform less-than the rest of the ecosystem.
+- **Effort × Impact**: High × High
+- **Verdict**: Worth scoping (formal scoping doc before any code). Could comfortably be a 3-4 week initiative spanning multiple sprints.
 
 ### 2. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
 - **Source**: PyPI (https://pypi.org/project/bedrock-agentcore/) + open SDK issues #456, #452
@@ -209,13 +187,13 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 - **Effort × Impact**: Low × Medium
 - **Verdict**: Worth trying
 
-### 3. Fix 3 `py/log-injection` error-severity CodeQL findings
-- **Source**: GitHub Code Scanning alerts #623, #624, #625, #631
-- **Surface area**: `backend/src/apis/inference_api/chat/service.py` (#631), `backend/src/agents/main_agent/agent_types.py` (#625), `backend/src/apis/app_api/connectors/routes.py` (#623, #624)
-- **Change**: locate the user-controlled input → logger calls; either sanitize via `repr()` / regex, or use parameterized logging (`logger.info("got %s", user_input)`) which CodeQL doesn't flag. Cross-check that this isn't a regression of the #247 log-injection fix (only `model_id` was sanitized then; these may be different inputs added in subsequent PRs).
-- **Subtracts**: addition only — security fix
-- **Effort × Impact**: Low-Medium × Medium-High (3 separate files, but the fix pattern is uniform)
-- **Verdict**: Worth trying
+### 3. Promote tool-result rendering to a per-tool renderer registry
+- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ AI SDK generative-UI recipes + Cursor canvases
+- **Surface area**: frontend (`<tool-result>` component or equivalent, plus a new `ToolRendererRegistry` service)
+- **Change**: today our tool-result rendering is (implicitly) a switch in one place. Promote to a signal-backed registry keyed by tool name; per-tool renderers live next to the tool definition. Bridges naturally toward MCP Apps (which would just be "another registered renderer that emits an iframe"). Lifts a chunk of switch-like code into a declarative table.
+- **Subtracts**: partial — replaces an implicit switch with an explicit registry; the registry's existence is more code, but it absorbs scattered tool-specific UI logic into one place.
+- **Effort × Impact**: Medium × Medium-High
+- **Verdict**: Worth trying — independently valuable AND pre-work for proposal #1.
 
 ### 4. Audit `BedrockModel.stream` cancellation path
 - **Source**: Strands open issue #2266 (filed May 9)
@@ -251,7 +229,7 @@ The MCP spec is heading toward stateless transport (SEP-2567 sessionless MCP mer
 
 ## Take
 
-Three themes braid together this week. **First**, security: known-and-unpatched is the worst posture state, and we're sitting in it on `fast-uri` + log-injection. **Second**, library-native subtraction: Strands 1.37/1.38 closes #266/#267 with library-native plumbing, AgentCore Memory metadata replaces ad-hoc tagging, `agent.cancel()` + `agent.state` (per the reference repo) replace custom cancellation/state code. **Third**, the BFF migration is v1 (still being patched daily) and CI is unreliable. The single most valuable change this week is **proposal #1** (patch `fast-uri`) — it's a free fix on a known-real vulnerability surface. After that, **#2** (`bedrock-agentcore` bump) and **#5** (close #266/#267) keep harvesting upstream gains.
+Two big themes this week. **First, agentic UI/UX has shifted under us.** MCP Apps shipped to production with adoption from Claude Desktop, ChatGPT, VS Code Copilot, Goose, and Postman; assistant-ui is building first-party MCP Apps tooling; the design conversation has moved from "what should an agent chat look like" to "how do we host other people's UIs in our chat." Our text+JSON tool-result rendering is now the baseline competitors are extending past. **Second, library-native subtraction is the kaizen loop's clearest win** — Strands 1.37/1.38 quietly closes our open issues #266/#267, and `bedrock-agentcore` 1.6.4 → 1.9.0 likely closes two open SDK issues we already feel. The single change that would matter most this week if scoped is **proposal #1 (MCP Apps host renderer)** — high effort, but the right strategic investment. Quick wins: **#2 (`bedrock-agentcore` bump)** and **#5 (close #266/#267)**. **#3 (renderer registry)** is the natural mid-ground that delivers value standalone AND pre-paves proposal #1.
 
 ---
 
@@ -264,24 +242,24 @@ Three themes braid together this week. **First**, security: known-and-unpatched 
 | 3 | Reference repo | github.com/aws-samples/sample-strands-agent-with-agentcore | 2026-05-10 | 12 commits in 30-day window |
 | 4 | MCP ecosystem | modelcontextprotocol.io / github.com/modelcontextprotocol | 2026-05-10 | 4 spec items + 3 discussions |
 | 4a | FastMCP (bootstrap: PyPI snapshot only — full scan deferred to 2026-05-15) | pypi.org/project/fastmcp + github.com/jlowin/fastmcp | 2026-05-10 | latest 3.2.4 |
+| 4b | Agentic UI/UX (MCP Apps, AI SDK, assistant-ui, Linear/Cursor/Anthropic, NN/g) — 30-day baseline | modelcontextprotocol.io + ai-sdk.dev + assistant-ui.com + linear.app + cursor.com + anthropic.com + nngroup.com | 2026-05-10 | 11 items across MCP Apps spec, AI SDK patterns, assistant-ui, vendor product blogs, NN/g research |
 | 5 | Frontier models (Anthropic, OpenAI, Google, Meta) | anthropic.com / openai.com / blog.google / ai.meta.com | 2026-05-10 | 3 Anthropic + 1 OpenAI + 0 others |
 | 6 | Agent harness | github.com/anthropics + langchain.com + pydantic.dev | 2026-05-10 | 3 CC releases + 4 cookbook items |
 | 7 | Community (HN Algolia + Reddit) | hn.algolia.com + reddit.com | 2026-05-10 | 0 HN hits, Reddit blocked |
-| 8 | Security advisories | github.com/advisories | 2026-05-10 | 0 affecting our pins (external); but cross-confirmed `fast-uri` advisories match open Dependabot alerts |
-| 9 | Version-pin diff | pypi.org / npmjs.com | 2026-05-10 | 8 deps checked, 4 lag |
-| 10 | Internal security posture (Dependabot, CodeQL, auth-surface churn) | gh api dependabot/alerts + code-scanning/alerts + git log | 2026-05-10 | 9 open Dependabot (4 high), 10 open CodeQL (3 error), 7-commit BFF churn |
+| 8 | Version-pin diff | pypi.org / npmjs.com | 2026-05-10 | 8 deps checked, 4 lag |
 
 ## Web Budget
 
-Used: 54 / 50 requests (target).
+Used: 64 / 50 requests (target — UX-lens scan added 10 to the original 54).
 
 Skipped (unreachable / rate-limited):
 - Reddit (`r/LocalLLaMA`, `r/MachineLearning`) — WebFetch blocked from this environment. Switch to `.rss` endpoint or configured Reddit MCP next run.
 - `https://aws.amazon.com/bedrock/whats-new/` — 404 (page appears retired). Drop or replace.
 - `https://docs.claude.com/en/docs/claude-code/release-notes` — 301→404. Replace with `github.com/anthropics/claude-code/blob/main/CHANGELOG.md`.
+- OpenAI blog returned 403 twice; backfilled via search.
 
-Skipped (other): none.
+Skipped (other): Security advisories (external) and Internal security posture (Dependabot + CodeQL) sources were initially included in this bootstrap run but **removed per scope refinement** — security signals are handled by Dependabot and CodeQL directly and don't need a weekly kaizen lens. Future runs won't scan them.
 
 Notes:
-- Frontier-models sub-budget exceeded (11 vs ~6 target) due to two OpenAI WebFetch 403s requiring search backfill and two Anthropic drilldowns. Within total cap.
-- This is a **bootstrap run**: reference-repo scope extended to 30 days for baseline; Carried Over and prior-decisions sections in the review-prep doc are necessarily empty.
+- Frontier-models sub-budget exceeded (11 vs ~6 target) due to two OpenAI WebFetch 403s requiring search backfill.
+- This is a **bootstrap run**: reference-repo + UX-lens scope extended to 30 days for baseline; Carried Over and prior-decisions sections in the review-prep doc are necessarily empty.

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -4,53 +4,60 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 ## Open
 
-### [2026-05-10] Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
-- **Source**: research/2026-05-10.md ▸ Top 7 #1 ▸ Security posture
-- **Surface**: frontend (`frontend/ai.client/package.json` overrides)
-- **Effort × Impact**: L × H
-- **Subtracts**: no — security fix
+### [2026-05-10] Scope an MCP Apps host renderer in our chat (multi-PR initiative)
+- **Source**: research/2026-05-10.md ▸ Top 6 #1 ▸ Agentic UI/UX
+- **Surface**: frontend + backend (new SSE event `ui_resource`; `<mcp-app-frame>` Angular component; consent UX)
+- **Effort × Impact**: H × H
+- **Subtracts**: no — pure addition. Justified: every major host (Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman) ships this; without it, third-party MCP servers we connect can only deliver text+JSON
 - **Status**: open
 
 ### [2026-05-10] Bump `bedrock-agentcore` 1.6.4 → 1.9.0
-- **Source**: research/2026-05-10.md ▸ Top 7 #2
+- **Source**: research/2026-05-10.md ▸ Top 6 #2
 - **Surface**: backend
 - **Effort × Impact**: L × M
 - **Subtracts**: no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window)
 - **Status**: open
 
-### [2026-05-10] Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)
-- **Source**: research/2026-05-10.md ▸ Top 7 #3 ▸ Security posture
-- **Surface**: backend (`chat/service.py`, `agent_types.py`, `connectors/routes.py`)
-- **Effort × Impact**: L-M × M-H
-- **Subtracts**: no — security fix
+### [2026-05-10] Promote tool-result rendering to a per-tool renderer registry (signal-backed)
+- **Source**: research/2026-05-10.md ▸ Top 6 #3 ▸ Agentic UI/UX (AI SDK + Cursor)
+- **Surface**: frontend (`<tool-result>` component + new `ToolRendererRegistry` service)
+- **Effort × Impact**: M × M-H
+- **Subtracts**: partial — replaces implicit switch with explicit registry; absorbs scattered tool-specific UI logic. Pre-paves MCP Apps proposal #1.
 - **Status**: open
 
 ### [2026-05-10] Audit `BedrockModel.stream` cancellation path against Strands #2266
-- **Source**: research/2026-05-10.md ▸ Top 7 #4
+- **Source**: research/2026-05-10.md ▸ Top 6 #4
 - **Surface**: backend
 - **Effort × Impact**: L × M-H
 - **Subtracts**: no — defensive (SSE-disconnect path is hot)
 - **Status**: open
 
 ### [2026-05-10] Close issues #266 and #267 — features already in our Strands 1.39 pin
-- **Source**: research/2026-05-10.md ▸ Top 7 #5
+- **Source**: research/2026-05-10.md ▸ Top 6 #5
 - **Surface**: cross-cutting
 - **Effort × Impact**: L × M
 - **Subtracts**: **yes — library-native subtraction; retires 2 build-from-scratch issues**
 - **Status**: open
 
-### [2026-05-10] Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
-- **Source**: research/2026-05-10.md ▸ Top 7 #6
-- **Surface**: backend
-- **Effort × Impact**: M × H
-- **Subtracts**: no — defensive
-- **Status**: open
-
 ### [2026-05-10] Triage Nightly Build & Test failure cluster (9× since May 6)
-- **Source**: research/2026-05-10.md ▸ Top 7 #7
+- **Source**: research/2026-05-10.md ▸ Top 6 #6
 - **Surface**: cross-cutting / CI
 - **Effort × Impact**: L-M × M-H
 - **Subtracts**: possibly — if root is issue #220 (test isolation)
+- **Status**: open
+
+### [2026-05-10] Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: research/2026-05-10.md ▸ Risks
+- **Surface**: backend
+- **Effort × Impact**: M × H
+- **Subtracts**: no — defensive
+- **Status**: open (deferred 2 weeks per prior review — surface again on 2026-05-24)
+
+### [2026-05-10] Named A2A agent participants in the chat UI
+- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ Linear Agent pattern
+- **Surface**: frontend (extend message model with `agent_identity`, distinct avatar/name/styling)
+- **Effort × Impact**: L-M × M
+- **Subtracts**: no — additive but pattern-validated across Linear/ChatGPT/Cursor
 - **Status**: open
 
 ### [2026-05-10] Replace dead source URLs in `kaizen-research` skill

--- a/docs/kaizen/reviews/2026-05-10.md
+++ b/docs/kaizen/reviews/2026-05-10.md
@@ -1,21 +1,13 @@
 # Kaizen Review — Sunday, May 10, 2026
 > Prepared 11:00am MT. Review window: May 3 – May 10, 2026 (7 days).
-> Source: research/2026-05-10.md + review-queue.md (9 open items).
-> **Bootstrap run** — no prior reviews, no prior-week POC findings, no Carried Over items. Mid-bootstrap added: FastMCP source category, library-native subtraction lens, and security posture lens (added 2 immediate-action items).
+> Source: research/2026-05-10.md + review-queue.md (8 open items).
+> **Bootstrap run** — no prior reviews, no prior-week POC findings, no Carried Over items. Scope evolved mid-bootstrap: added FastMCP, library-native subtraction lens, and Agentic UI/UX lens; removed security posture lens (security is handled by Dependabot/CodeQL and doesn't need a weekly kaizen pass).
 
 ## Week in Review
 
-Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high — all `fast-uri`) and 10 open CodeQL alerts (3 error-severity `py/log-injection` in real backend paths) are catching things — but **caught ≠ patched**, and these have been sitting open. **Upstream-shrinks-our-backlog**: Strands v1.37/v1.38 quietly closed our open issues #266 and #267, and `bedrock-agentcore` is 3 minor versions behind with likely fixes for two SDK issues we feel. **BFF still v1**: 5 of 8 commits this week are auth follow-ups; CI is unreliable. Net read: a "patch the known things, harvest the upstream gains, don't start anything new" week.
+Two themes braid this week. **Agentic UI/UX has shifted under us**: MCP Apps shipped to production with adoption from Claude Desktop, ChatGPT, VS Code Copilot, Goose, and Postman; the design conversation has moved from "what should an agent chat look like" to "how do we host other people's UIs in our chat." Our text+JSON tool-result rendering is now the baseline competitors are extending past. **Upstream-shrinks-our-backlog**: Strands v1.37/v1.38 quietly closed our open issues #266 and #267, `bedrock-agentcore` is 3 minor versions behind with likely fixes for two SDK issues we feel. The BFF migration is still v1 (5 of 8 commits this week are auth follow-ups), CI is unreliable. Net read: a "scope the big UX investment, harvest the upstream gains, stabilize hygiene" week.
 
 ## Friction — the week's signal
-
-### Security signals — known and unpatched
-- **4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)** — host confusion + path traversal. Cross-confirmed by this week's external advisories scan. Same package, two distinct CVEs.
-  - *Hypothesis*: transitive npm dep, probably via Hono (already in `overrides`). Override-pin pattern is established; just needs the patched version.
-  - *Candidate fix*: see proposal #1.
-- **3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)** — user-controlled inputs into `logger` calls in `chat/service.py`, `agent_types.py`, `connectors/routes.py`.
-  - *Hypothesis*: #247 sanitized `model_id` log injection but newer code paths added since then weren't scoped in. Pattern is the same; fix is uniform.
-  - *Candidate fix*: see proposal #3.
 
 ### Repeated patterns (≥2 occurrences)
 - **CI deploy failures (6+ since May 6)** across Inference API, App API, and Frontend deploys.
@@ -25,8 +17,8 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
   - *Hypothesis*: known flakiness from issue #220 (`test_cognito_idp_service`, `test_oauth_repositories`, `test_auth_providers*` order-dependent) compounding under the BFF-heavy week's churn.
   - *Candidate fix*: triage one failure log end-to-end. Either the root is #220 (then #220 needs to land) or it's a real regression masked by the noise.
 - **BFF/auth fix churn (5 of 8 commits this week)** — #270, #271, #273, #274, #275, #277.
-  - *Hypothesis*: BFF migration is a v1, not a v1.1; expect 1–2 more weeks of follow-ups before declaring beta.25. Concurrent with the still-open security CodeQL alerts in `connectors/routes.py` and `inference_api/chat/service.py`, the auth surface needs both a security-fix pass AND a stabilization wait.
-  - *Candidate fix*: not a fix per se — adjust release-cut timing for beta.25 to wait for the churn + security alerts to settle.
+  - *Hypothesis*: BFF migration is a v1, not a v1.1; expect 1–2 more weeks of follow-ups before declaring beta.25.
+  - *Candidate fix*: not a fix per se — adjust release-cut timing for beta.25 to wait for the churn to settle.
 
 ### One-offs worth watching
 - **`bedrock-agentcore` 1.6.4 → 1.9.0 lag** with a release published *inside* the scan window (May 7) — see proposal #1.
@@ -40,20 +32,20 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 
 ## Proposals — ranked
 
-### 1. Patch 4 high-severity `fast-uri` Dependabot alerts (#116, #117, #121, #122)
-- **Source**: research/2026-05-10.md ▸ Top 7 #1 ▸ Security posture | review-queue.md (open)
-- **Surface area**: frontend (`frontend/ai.client/package.json` overrides)
-- **Change**: `npm ls fast-uri` to find the import chain; add an `overrides` entry pinning `fast-uri` to the patched version; rebuild + Vitest sweep; deploy through normal cycle.
-- **Subtracts**: addition only — security fix
-- **Effort**: Low
-- **Impact**: High (4 high-severity alerts at once)
+### 1. Scope an MCP Apps host renderer in our chat (multi-PR initiative)
+- **Source**: research/2026-05-10.md ▸ Top 6 #1 ▸ Agentic UI/UX | review-queue.md (open)
+- **Surface area**: frontend (new `<mcp-app-frame>` Angular component, tool-result rendering pipeline) + backend (new SSE event `ui_resource`; likely a `ui_consent_required` cousin of `oauth_required`)
+- **Change**: implement the host side of MCP Apps (SEP-1865) — sandboxed iframe rendering `ui://` resources returned by MCP tools, with the `ui/`-prefixed JSON-RPC dialect over `postMessage`. Treat as a multi-PR initiative: (a) scoping/architecture doc + spec checklist, (b) SSE event + plumbing, (c) iframe component + postMessage bridge, (d) consent UX, (e) end-to-end demo with one example from `ext-apps/examples`.
+- **Subtracts**: no — pure addition. Justified: Claude Desktop, ChatGPT, VS Code Copilot, Goose, and Postman ship this. Every third-party MCP server we connect could be shipping UIs richer than text+JSON; without a host, we leave that on the table.
+- **Effort**: High (multi-PR; new SSE protocol event; sandboxed-iframe component; consent UX)
+- **Impact**: High (strategic — agentic UI standard our chat is being measured against)
 - **POC findings**: not POCed.
-- **Ship means**: small PR; 4 alerts close at once.
-- **Decline means**: alerts continue accumulating; eventually someone will exploit them or audit-fail us.
-- **Recommendation**: **Ship.** Highest priority this week. Free fix on a known-real vulnerability surface; the override pattern is already established in `package.json` so this is mechanical.
+- **Ship means**: **scope this week, build over 3-4 weeks.** Open a scoping issue + architecture doc this week — not a code PR yet. Code PRs follow in subsequent sprints.
+- **Decline means**: stay on text+JSON tool results; revisit when a third-party MCP server we connect ships an MCP App and we can't render it (the forcing function).
+- **Recommendation**: **Ship (scope this week).** Highest strategic value of any item. Pre-paves with proposal #3.
 
 ### 2. Bump `bedrock-agentcore` 1.6.4 → 1.9.0
-- **Source**: research/2026-05-10.md ▸ Top 7 #2 | review-queue.md (open)
+- **Source**: research/2026-05-10.md ▸ Top 6 #2 | review-queue.md (open)
 - **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
 - **Change**: pin update + smoke-test memory + identity flows in dev; verify upstream CHANGELOG between 1.6 and 1.9 for any breaking changes; close out open SDK issues #456 (OTEL trace detach) and #452 (event-loop blocking) if 1.9 addresses them.
 - **Subtracts**: addition only — justified by 3 versions of upstream fixes including likely-relevant ones to OTEL trace detach and AgentCoreMemorySessionManager event-loop blocking.
@@ -62,22 +54,22 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **POC findings**: not POCed — bootstrap run.
 - **Ship means**: open a PR updating `pyproject.toml` and `uv.lock`; smoke-test memory write/read + identity OAuth flows in dev; if smoke passes, merge.
 - **Decline means**: keep at 1.6.4 for another week; revisit after 1.10 ships or after we observe a memory/identity issue.
-- **Recommendation**: **Ship.** Highest signal among non-security items; do this immediately after proposal #1.
+- **Recommendation**: **Ship.** Lowest effort × medium impact; clean upstream-harvest win.
 
-### 3. Fix 3 `py/log-injection` error-severity CodeQL findings (#623, #624, #625, #631)
-- **Source**: research/2026-05-10.md ▸ Top 7 #3 ▸ Security posture | review-queue.md (open)
-- **Surface area**: backend — `apis/inference_api/chat/service.py` (#631), `agents/main_agent/agent_types.py` (#625), `apis/app_api/connectors/routes.py` (#623, #624)
-- **Change**: locate the user-controlled input → logger calls; switch to parameterized logging (`logger.info("got %s", user_input)`) or sanitize via `repr()` / regex strip. Cross-check that this isn't a regression of the #247 `model_id` log-injection fix — these are likely different inputs added after #247.
-- **Subtracts**: addition only — security fix
-- **Effort**: Low-Medium (3 files, uniform fix pattern)
-- **Impact**: Medium-High (log injection enables log forgery and downstream log-pipeline poisoning)
+### 3. Promote tool-result rendering to a per-tool renderer registry (signal-backed)
+- **Source**: research/2026-05-10.md ▸ Top 6 #3 ▸ Agentic UI/UX (AI SDK + Cursor canvases) | review-queue.md (open)
+- **Surface area**: frontend (`<tool-result>` component + new `ToolRendererRegistry` service)
+- **Change**: today our tool-result rendering is (implicitly) a switch in one place. Promote to a signal-backed registry keyed by tool name; per-tool renderers live next to the tool definition. Independently valuable AND the natural extension point for proposal #1 (MCP Apps becomes "just another registered renderer that emits an iframe").
+- **Subtracts**: partial — replaces an implicit switch with an explicit registry; the registry itself is new code, but it absorbs scattered tool-specific UI logic into one declarative table.
+- **Effort**: Medium
+- **Impact**: Medium-High (improves current tool-result UX AND pre-paves MCP Apps host)
 - **POC findings**: not POCed.
-- **Ship means**: a single PR touching the 3 files; close the 4 CodeQL alerts.
-- **Decline means**: alerts continue accumulating; same audit-risk story as #1.
-- **Recommendation**: **Ship.** Bundle with proposal #1 in a "security-posture sweep" PR if convenient — or ship separately, both are small.
+- **Ship means**: open a PR that introduces the registry service + migrates 2-3 current tool renderers as a proof point.
+- **Decline means**: keep the implicit switch; pay the cost when proposal #1 lands.
+- **Recommendation**: **Ship.** Best risk-adjusted UX investment — value standalone AND scaffolding for proposal #1.
 
 ### 4. Audit `BedrockModel.stream` cancellation path against Strands #2266
-- **Source**: research/2026-05-10.md ▸ Top 7 #4 | review-queue.md (open)
+- **Source**: research/2026-05-10.md ▸ Top 6 #4 | review-queue.md (open)
 - **Surface area**: backend (`backend/src/agents/main_agent/` stream coordinator + SSE handler)
 - **Change**: locate every `BedrockModel.stream` cancellation path; ensure each `await`s the inner task on cancel so it doesn't orphan; add a dev-only assertion / log filter to detect "Task exception was never retrieved" before it reaches prod.
 - **Subtracts**: addition only — defensive.
@@ -89,7 +81,7 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **Recommendation**: **Ship.** Pairs naturally with proposal #2 (same backend area, same week's Strands signal). Cheap insurance.
 
 ### 5. Close issues #266 and #267 — features already in our Strands 1.39 pin
-- **Source**: research/2026-05-10.md ▸ Top 7 #5 | review-queue.md (open)
+- **Source**: research/2026-05-10.md ▸ Top 6 #5 | review-queue.md (open)
 - **Surface area**: cross-cutting — GitHub issues + small wiring in `stream_coordinator` and Code Interpreter / spreadsheet tool-result handling
 - **Change**:
   1. Comment on #266 + #267 pointing at upstream PRs (Strands #2249 for context-window lookup; v1.38.0 release notes for large tool result offload).
@@ -101,22 +93,10 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **POC findings**: not POCed.
 - **Ship means**: 30-minute issue-grooming pass; comment + close + (if needed) file 2 smaller follow-ups.
 - **Decline means**: leave #266 + #267 open; future kaizen runs will re-flag them.
-- **Recommendation**: **Ship.** Highest *subtraction* yield this week. The clearest demonstration of the kaizen loop earning its keep: surface what upstream already did for us.
+- **Recommendation**: **Ship.** Highest *subtraction* yield this week. The clearest demonstration of the kaizen loop earning its keep.
 
-### 6. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
-- **Source**: research/2026-05-10.md ▸ Top 7 #6 | review-queue.md (open)
-- **Surface area**: backend (`apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers)
-- **Change**: walk through the code paths where an external OAuth provider (Google etc.) returns 401/403 mid-stream; confirm the response is `oauth_required` SSE re-emission (consent-resume), not a streamed tool error to the user. Add a regression test if missing.
-- **Subtracts**: addition only — defensive; closes a real UX gap when upstream tokens revoke.
-- **Effort**: Medium (audit + likely 1-2 small fixes)
-- **Impact**: High (user-visible UX; OAuth token revocation does happen)
-- **POC findings**: not POCed.
-- **Ship means**: open a tech-debt issue with the audit findings; fix in a follow-up PR if anything is broken; otherwise add the regression test and close.
-- **Decline means**: assume current behavior is correct; revisit if a user reports a stuck-OAuth conversation.
-- **Recommendation**: **Defer 2 weeks.** This is the highest-impact proposal but also the highest-effort, and BFF auth is still settling — landing this in the middle of the BFF patch parade risks compounding the churn. Better to wait until BFF stabilizes (likely beta.25 territory), then audit cleanly.
-
-### 7. Triage Nightly Build & Test failure cluster (9× since May 6)
-- **Source**: research/2026-05-10.md ▸ Top 7 #7 | review-queue.md (open)
+### 6. Triage Nightly Build & Test failure cluster (9× since May 6)
+- **Source**: research/2026-05-10.md ▸ Top 6 #6 | review-queue.md (open)
 - **Surface area**: cross-cutting / CI (`.github/workflows/nightly-*.yml`, possibly `tests/shared/test_cognito_idp_service.py` per issue #220)
 - **Change**: pull the most recent failure log; trace to root cause; if root is issue #220 (test isolation), bump #220 to blocking and land it; if it's a different cause, file and resolve.
 - **Subtracts**: possibly — if root is #220, fixing it materially simplifies the suite (removes a tech-debt entry).
@@ -127,7 +107,31 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **Decline means**: continue ignoring nightly failures; eventually a real regression will hide here.
 - **Recommendation**: **Ship.** This is independent of the kaizen-loop work above; it's hygiene. If the kaizen review is the venue that finally surfaces it, that's a kaizen win.
 
-### 8. Replace dead source URLs in `kaizen-research` skill + drop `anthropics/courses`
+### 7. Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
+- **Source**: research/2026-05-10.md ▸ Risks | review-queue.md (open, deferred)
+- **Surface area**: backend (`apis/shared/oauth/agentcore_identity.py`, SSE event emission in `inference-api`, MCP/A2A tool wrappers)
+- **Change**: walk through the code paths where an external OAuth provider (Google etc.) returns 401/403 mid-stream; confirm the response is `oauth_required` SSE re-emission (consent-resume), not a streamed tool error to the user. Add a regression test if missing.
+- **Subtracts**: addition only — defensive; closes a real UX gap when upstream tokens revoke.
+- **Effort**: Medium (audit + likely 1-2 small fixes)
+- **Impact**: High (user-visible UX; OAuth token revocation does happen)
+- **POC findings**: not POCed.
+- **Ship means**: open a tech-debt issue with the audit findings; fix in a follow-up PR if anything is broken.
+- **Decline means**: assume current behavior is correct; revisit if a user reports a stuck-OAuth conversation.
+- **Recommendation**: **Defer 2 weeks (revisit 2026-05-24).** Highest-impact backend proposal but BFF auth is still settling — landing this in the middle of the BFF patch parade risks compounding the churn. Wait for BFF to stabilize (likely beta.25), then audit cleanly.
+
+### 8. Named A2A agent participants in the chat UI
+- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ Linear Agent pattern | review-queue.md (open)
+- **Surface area**: frontend (extend message model with `agent_identity`; distinct avatar / name / styling for A2A sub-agent turns instead of nesting under generic `tool_use` cards)
+- **Change**: when an A2A sub-agent produces output, render it as a distinctly attributed turn (named, avatar'd) rather than as a nested tool result. SSE already carries enough information; this is mostly a rendering change.
+- **Subtracts**: no — additive but pattern-validated across Linear, ChatGPT agents, and Cursor multi-agent flows.
+- **Effort**: Low-Medium
+- **Impact**: Medium (legibility of multi-agent runs; user understanding of "who did what")
+- **POC findings**: not POCed.
+- **Ship means**: small PR extending the message model + a `<agent-turn>` Angular component variant.
+- **Decline means**: A2A sub-agent activity continues to be nested under tool cards; users can't easily tell when a different "actor" is responding.
+- **Recommendation**: **Ship.** Low-effort UX win that future-proofs the chat for the A2A direction we're already heading.
+
+### 9. Replace dead source URLs in `kaizen-research` skill + drop `anthropics/courses`
 - **Source**: research/2026-05-10.md ▸ Retirement candidates | review-queue.md (open)
 - **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Change**:
@@ -140,9 +144,9 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **POC findings**: not POCed.
 - **Ship means**: 5-minute edit to `kaizen-research/SKILL.md`.
 - **Decline means**: leave dead URLs; future runs waste budget on them.
-- **Recommendation**: **Ship.** Trivial, pure subtraction. Bundle with proposal #9 in one skill-update PR.
+- **Recommendation**: **Ship.** Trivial, pure subtraction. Bundle with proposal #10 in one skill-update PR.
 
-### 9. Add Reddit `.rss` or Reddit MCP to `kaizen-research`
+### 10. Add Reddit `.rss` or Reddit MCP to `kaizen-research`
 - **Source**: research/2026-05-10.md ▸ Risks ▸ "Reddit blocked from WebFetch" | review-queue.md (open)
 - **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Change**: switch the community-signal subagent from raw `reddit.com` URLs to `https://www.reddit.com/r/<sub>/.rss` (try first — `.rss` may be allowed where the HTML page isn't), or wire a Reddit MCP server if available.
@@ -152,7 +156,7 @@ Three themes braid this week. **Security**: 9 open Dependabot alerts (4 high —
 - **POC findings**: not POCed.
 - **Ship means**: edit the skill's source list.
 - **Decline means**: keep accepting "Reddit blocked" as a known gap.
-- **Recommendation**: **Ship.** Bundle with proposal #8 in a single skill-update PR.
+- **Recommendation**: **Ship.** Bundle with proposal #9 in a single skill-update PR.
 
 ## Carried Over From Prior Reviews
 
@@ -166,8 +170,7 @@ Bootstrap run — none.
 ## Risks Acknowledged But Not Acted On
 
 - **OpenAI GPT-5.3 → 5.5 Instant displacement** — https://openai.com/index/gpt-5-5-instant/ — *what breaks if ignored*: customers using a 5.3 default may hit a deprecation window. **Recommendation**: **Watch until 2026-06-01.** Quick check next week to confirm whether OpenAI is publishing a deprecation date for 5.3; if yes, file a model-selector audit.
-- **`fast-uri` was on this list last cycle as an "adjacent" transitive — now confirmed real** (4 open high-severity Dependabot alerts). Promoted to proposal #1. The lesson for the kaizen loop: adjacent-CVE flags warrant a Dependabot cross-check, not a "we'll see" defer. Skill philosophy updated to cross-reference Dependabot + external advisories explicitly.
-- **`@babel/plugin-transform-modules-systemjs`, `gitpython` adjacent CVEs** (transitives, not on Dependabot alert list) — *what breaks if ignored*: maybe nothing; we don't know without `uv pip tree` / `npm ls` against the lockfiles. **Recommendation**: **Address now (Low effort)**: 5-minute lockfile audit; if any are present, file an upgrade issue. Bundle with proposal #1 if convenient.
+- **MCP Apps adoption window** — every major host shipped support in Q1 2026. The longer we wait, the more we're shaping our tool-result UI in a direction that doesn't compose with where the ecosystem is going. **Recommendation**: scope this week (proposal #1); first code PR by 2026-05-31.
 
 ## What Shipped This Week
 
@@ -182,16 +185,16 @@ Bootstrap run — none.
 
 ## Take
 
-The week's most valuable shipping is the strands-agents 1.39.0 bump (#265) — the team probably doesn't yet know it closed two of our open issues. That's the kaizen loop earning its keep on the upstream-harvest side. The new security lens — added mid-bootstrap — earned its keep too: it surfaced 4 high-severity `fast-uri` Dependabot alerts the external scan only flagged as "adjacent". The single most valuable change this week would be **proposal #1 (patch `fast-uri`)** — known-real vulnerability, free fix. After that: **#2 (`bedrock-agentcore` bump)** and **#5 (close #266/#267)** demonstrate library-native subtraction. CI (proposal #7) is the loudest non-kaizen problem; surface it here but fix it as hygiene.
+The week's most valuable shipping is the strands-agents 1.39.0 bump (#265) — the team probably doesn't yet know it closed two of our open issues. That's the kaizen loop earning its keep on the upstream-harvest side. The new UI/UX lens — added mid-bootstrap — earned its keep too: it surfaced **MCP Apps** as a production-ready agentic UI standard that every major host already ships, and that our chat doesn't. The most consequential change this week if scoped is **proposal #1 (MCP Apps host renderer)** — high effort but high strategic value. The best risk-adjusted move is **proposal #3 (per-tool renderer registry)** — independently valuable AND pre-paves #1. Quick wins: **#2 (`bedrock-agentcore` bump)** and **#5 (close #266/#267)** demonstrate library-native subtraction. CI (proposal #6) is the loudest non-kaizen problem; surface it here but fix it as hygiene.
 
 ---
 
 ## Review Protocol (for Phil)
 
-1. Read Friction — especially the new "Security signals — known and unpatched" block (3 min).
-2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **9 proposals**; my recommendations: 8 Ship, 1 Defer, 0 Decline (proposal #6 is the defer).
+1. Read Friction (2 min).
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **10 proposals**; my recommendations: 9 Ship, 1 Defer, 0 Decline (proposal #7 — `oauth_required` audit — is the defer until 2026-05-24).
 3. Same for Risks Acknowledged.
-4. Pick 1-3 to ship this week. Suggested if you only do 3: **#1 (`fast-uri` Dependabot patch), #2 (bedrock-agentcore bump), #5 (close #266/#267)** — covers the security win, an upstream-harvest win, and a subtraction. If 4: add **#3 (log-injection)** to bundle with #1 as a security-posture sweep.
+4. Pick 1-3 to ship this week. Suggested if you only do 3: **#1 (scope MCP Apps host — scoping doc only this week), #2 (bedrock-agentcore bump), #5 (close #266/#267)** — covers strategic, quick-win, and subtraction. If 4: add **#3 (renderer registry)** as the bridge investment.
 
 Target: 12-17 minutes (slightly more than the nominal 10-15 because the bootstrap is larger than a normal weekly review).
 


### PR DESCRIPTION
## Summary

Scope refinement to `kaizen-research` based on feedback. The kaizen loop is for **emerging functionality, agentic trends, tools, and feature/UX improvements** — security has dedicated tooling (Dependabot + CodeQL) and doesn't need a parallel weekly kaizen pass.

### Removed
- External source #10 "Security advisories"
- Internal source #18a "Security posture audit"
- Bootstrap proposals around `fast-uri` Dependabot alerts and `py/log-injection` CodeQL findings — these belong on the security tracker, not the kaizen agenda
- Output template's "Security posture" section + "Security advisories" subsection
- Step 5a security cross-reference + step 6 security weighting

### Added (Agentic UI/UX lens — new source #4b)
- **MCP Apps + extensions** (priority) — https://modelcontextprotocol.io/extensions/apps/overview. The "MCP server returns an interactive UI inline with the chat" standard, now production-ready (SEP-1865). Adopted by Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman.
- **AI SDK / Generative UI** (Vercel) — https://ai-sdk.dev/cookbook. Patterns for tool-call rendering, multi-step UI, streaming generative UI. React-based but the patterns port.
- **assistant-ui** — https://github.com/Yonom/assistant-ui. Most active React component library for AI chat UI. Tracks attachment UX, threading, tool-call primitives. (Also shipping `mcp-app-studio` — strong signal.)
- **Vendor product-blog UX writeups** — Linear, Cursor, Anthropic news filtered for `artifact`/`ui`/`design`.
- **OpenAI Canvas + ChatGPT UI** — https://openai.com/blog filtered for canvas / agents UI updates.
- **Nielsen Norman Group AI articles** — https://www.nngroup.com/topic/artificial-intelligence/. Evidence-based UX research.

Top-5 weighting now boosts UI/UX patterns that match an existing surface (tool-call rendering, attachments, A2A attribution, consent flows) over generic "interesting trend" items.

## What this changes in the 2026-05-10 bootstrap output

The UX lens re-walk reshuffled the Top-N significantly. New highest-priority proposal:

- **#1: Scope an MCP Apps host renderer in our chat** — multi-PR initiative. Every major host already ships this; without it, third-party MCP servers we connect can only deliver text+JSON. Strategic. (H × H)
- **#3: Promote tool-result rendering to a per-tool renderer registry (signal-backed)** — independently valuable AND pre-paves #1. Best risk-adjusted UX investment. (M × M-H)
- **#8: Named A2A agent participants** — Linear Agent pattern; A2A sub-agents render as distinctly attributed turns instead of nested tool cards. (L-M × M)

Plus the carryovers that survived the refactor:
- #2: Bump `bedrock-agentcore` 1.6.4 → 1.9.0
- #4: Audit `BedrockModel.stream` cancel path against Strands #2266
- #5: Close issues #266/#267 (library-native subtraction)
- #6: Triage Nightly Build & Test cluster
- #7: Audit `oauth_required` SSE flow (deferred 2 weeks)
- #9, #10: Skill-update items (replace dead URLs, add Reddit RSS)

The two security-driven proposals (`fast-uri` Dependabot patch, `py/log-injection` CodeQL fixes) are not in this PR — they should be tracked separately on the security board if you want to actually patch them.

## Review

- New skill definition takes effect for the Fri 2026-05-15 scheduled run.
- Bootstrap output (`docs/kaizen/research/2026-05-10.md` + `reviews/2026-05-10.md` + `review-queue.md`) is updated to match.

## Decision

Ship to `develop`. Next scheduled Friday run (2026-05-15) will exercise the UX lens fully — full FastMCP scan, full MCP Apps + AI SDK + assistant-ui + vendor blog + NN/g scan, no security pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)