### PR TITLE
chore(kaizen): add capability-unlock lens + AgentCore BYO filesystem queue item

### DIFF
--- a/.claude/skills/kaizen-research/SKILL.md
+++ b/.claude/skills/kaizen-research/SKILL.md
@@ -10,6 +10,7 @@ Friday early morning. The "what's the rest of the world learning that we should 
 ## Philosophy
 
 - **Subtraction first.** Every research run should propose at least as many things to *remove or simplify* as to add. A smaller stack you trust beats a bigger one you route around. **Subtraction explicitly includes replacing custom code with library-native equivalents** — when an upstream release (Strands, AgentCore SDK, FastMCP, MCP, etc.) ships a capability we'd already built or filed an issue for, the win is closing our version and adopting upstream. Example: the 2026-05-10 bootstrap run found that Strands v1.37/v1.38 silently closed our open issues #266 and #267 — the codebase surface area shrinks even though we "added" a dep bump.
+- **Dual lens — impact + capability-unlock.** Evaluate every upstream feature through *two* lenses, not one: (a) **impact on existing code** (does it change, simplify, or obsolete something we already have?) and (b) **capability unlock** (what *new* product capability, UX pattern, or enhancement does this make possible that we couldn't easily do before?). Subtraction-first still applies to the first lens. But capability-unlock items — features that enable net-new product surface — must be evaluated on their strategic merit, *not* hedged into "replaces future glue we haven't written." Example: the 2026-05-10 AgentCore Runtime BYO filesystem was first framed only as "could replace future filesystem-staging glue" — under-weighting the real story (code-interpreter sandboxes, cross-session uploads, shared skill hot-swap, persistent vector indexes). A dep-bump's win is usually subtraction; a *new* platform primitive's win is usually capability unlock. Don't mis-classify.
 - **Subagent fan-out.** External sources are independent — fan them out to parallel subagents and synthesize. Keeps the main context clean and runs faster.
 - **Web budget soft cap.** Target ≤50 web requests. If a source is exhausted, unreachable, or rate-limited, list it as "not scanned this week" — don't skip silently. Going modestly over the cap (say, to 60) is fine if the extra requests are surfacing real signal; document the overage in the Web Budget block. Don't pad — if 30 requests covered every source meaningfully, stop at 30.
 - **Cite everything.** Every external claim gets a URL + access date in the Sources Scanned appendix. Web findings rot fast and you'll re-read them next week.
@@ -141,8 +142,14 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 
 ### Notable items by source
 
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens. What construct/file does this affect? What does it replace, simplify, or obsolete?
+> - `*unlocks*:` — capability-unlock lens (use when applicable, especially for *new* platform primitives, SDK hooks, or UX patterns). What net-new product capability or enhancement does this make possible? What could we now build that we couldn't before?
+>
+> Bug-fixes and incremental dep-bumps usually only need `*relevance*`. New platform features, new SDK primitives, new spec capabilities, and new UX patterns usually deserve both.
+
 #### AWS Bedrock / AgentCore
-- **[Item]** — [1-2 sentence summary] — [URL] — *relevance*: [specific construct/file]
+- **[Item]** — [1-2 sentence summary] — [URL] — *relevance*: [specific construct/file] — *unlocks* (if applicable): [net-new capability or enhancement this enables]
 
 #### Strands Agents
 - **[Item]** — …
@@ -211,16 +218,17 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 
 ## Ideas — Top 5 (ranked)
 
-| # | Idea | Surface | Effort | Impact | Subtracts? |
-|---|---|---|---|---|---|
-| 1 | [Title] | backend / frontend / infra / cross-cutting | L/M/H | L/M/H | [what it retires, or "addition only — justified because…"] |
-| 2 | … | | | | |
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | [Title] | backend / frontend / infra / cross-cutting | L/M/H | L/M/H | [what it retires, or "addition only — justified because…"] | [net-new capability, or "—" if not applicable] |
+| 2 | … | | | | | |
 
 ### 1. [Idea title]
 - **Source**: [external item / internal signal — URL or commit SHA]
 - **Surface area**: [paths affected]
 - **Change**: [what specifically would change]
 - **Subtracts**: [what this retires/simplifies, or explicitly: "addition only — justified because…"]
+- **Unlocks** (if applicable): [net-new product capability, UX pattern, or enhancement this enables — bulleted if multiple. Omit field when not a capability-unlock item.]
 - **Effort × Impact**: [Low/Med/High] × [Low/Med/High]
 - **Verdict**: [Worth trying / Not a fit / Monitor]
 
@@ -263,6 +271,7 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Surface**: backend | frontend | infrastructure | cross-cutting
 - **Effort × Impact**: L/M/H × L/M/H
 - **Subtracts**: [yes — what / no — justification]
+- **Unlocks** (if applicable): [net-new capability, UX pattern, or enhancement this enables; bulleted if multiple. Omit when not a capability-unlock item.]
 - **Status**: open
 
 ## Resolved
@@ -305,7 +314,10 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 5. **Version-pin diff.** For each tracked dep, fetch latest release version (WebFetch on the release page or registry equivalent — counts toward budget). Compute lag in releases and days. If a budget hit prevents a check, list the dep under "Skipped".
 
-6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself. **Top 5 weighting**: library-native subtraction opportunities (where upstream closed a custom-code need) get a subtraction boost; UI/UX patterns that match an existing surface (tool-call rendering, attachments, A2A attribution, consent flows) get a "concrete fit" boost over generic "interesting trend" items.
+6. **Synthesize.** Write the research doc per the shape above. Pull subagent reports verbatim into source sections; write the gestalt narrative (TL;DR, "What's moving", Take) yourself. **Top 5 weighting**:
+   - **Library-native subtraction** opportunities (where upstream closed a custom-code need) get a subtraction boost.
+   - **Capability-unlock** items — new platform primitives, SDK hooks, spec capabilities, or UX patterns that enable net-new product surface we couldn't easily build before — rank on their strategic merit, *not* deprioritized just because they don't intersect existing code. Apply the dual lens from Philosophy: if a feature genuinely unlocks new capability (code-interpreter, persistent agent state, multi-agent UI attribution, etc.), rank it like a fit item, not like a "monitor" item. Resist the temptation to hedge unlock items into "replaces future glue we haven't written" — that under-weights the real story.
+   - **Concrete fit** UI/UX patterns that match an existing surface (tool-call rendering, attachments, A2A attribution, consent flows) get a fit boost over generic "interesting trend" items.
 
 7. **Update review queue.** For each Top 5 idea, prepend a new entry under `## Open` in `docs/kaizen/review-queue.md`. Never touch `## Resolved`.
 

--- a/.claude/skills/kaizen-review-prep/SKILL.md
+++ b/.claude/skills/kaizen-review-prep/SKILL.md
@@ -11,6 +11,7 @@ Friday late morning, after `kaizen-research` ran earlier the same morning. This 
 
 - **Review is a decision forum, not a status update.** Everything that lands in the output should be either: (a) actionable this week, (b) explicitly deferred with a reason and revisit date, or (c) declined. Nothing is "noted." Noted-and-forgotten is how systems accumulate friction.
 - **Subtraction first.** Every proposal ranks against "do nothing" and "retire something instead." If a proposal adds anything, it must explain what existing thing it either replaces or simplifies.
+- **Dual lens — impact + capability-unlock.** Rank proposals through *two* lenses, not one: (a) **impact on existing code** (does this change, simplify, or obsolete something we already have?) and (b) **capability unlock** (what *new* product capability or UX enhancement does this enable that we couldn't easily build before?). Subtraction-first applies to lens (a). But proposals that genuinely unlock new product surface — code-interpreter sandboxes, persistent agent state, multi-agent UI attribution, new SSE event types that enable inline UI, etc. — must be evaluated on their strategic merit, *not* auto-deferred because they don't intersect existing code. A proposal with no `Subtracts` value but a substantive `Unlocks` value can rank above a low-impact dep-bump. Don't penalize net-new capability for not being a cleanup.
 - **Multiple cycles.** Kaizen is small changes, weekly, compounding. If this week's review touches 3 things, next week's will touch 3 different things. Phil doesn't need a grand plan — he needs a reliable weekly cadence.
 - **One-week feedback lag is intentional.** Phil reviews Friday → POCs over the weekend → those POC findings surface in the *next* Friday's review-prep as Carried Over items. Don't try to fold same-day POC findings in — they don't exist yet.
 - **No edits outside `docs/kaizen/`.** This skill writes one Markdown file under `docs/kaizen/reviews/` and updates `docs/kaizen/review-queue.md` (moves Open → Resolved post-review). It never touches source code, `CLAUDE.md`, or skill files. Those changes happen in separate PRs after the review.
@@ -74,6 +75,7 @@ check before decisions.]
 - **Surface area**: backend / frontend / infrastructure / cross-cutting / docs / skills
 - **Change**: [concrete description — what files change, what the new behavior is]
 - **Subtracts**: [required field — what this retires, simplifies, or replaces. Or explicitly "addition only — justified because…"]
+- **Unlocks** (if applicable): [net-new product capability, UX pattern, or enhancement this enables — bulleted if multiple. Required for proposals where `Subtracts: no — addition only`; the unlock is the justification. Omit when purely a cleanup/dep-bump and not applicable.]
 - **Effort**: Low / Med / High
 - **Impact**: Low / Med / High
 - **POC findings (if Phil tried it)**: [summary or "not POCed"]
@@ -177,7 +179,11 @@ After Phil reviews and the decisions are logged in the review doc, this skill (o
    - All `## Open` entries in `review-queue.md` (the primary source)
    - Any new friction patterns surfaced from PR comments / merged PRs / CI that weren't already in the queue
    - Carried Over items
-   Rank: Low-effort × High-impact first; retirement candidates get a +1 boost (subtraction bias); items with POC findings rank above untested items at the same effort/impact.
+   Rank:
+   - Low-effort × High-impact first.
+   - **Retirement candidates** get a +1 boost (subtraction bias).
+   - **Capability-unlock items** (proposals with a substantive `Unlocks` field — new product capability, UX surface, or platform primitive adoption) rank on their strategic merit. Do not auto-defer just because `Subtracts: no`. A High-impact unlock can rank above a Low-impact subtraction.
+   - Items with **POC findings** rank above untested items at the same effort/impact.
 
 8. **Cap the proposal count at 10.** If more than 10 candidates, defer the lowest-ranked to next week with a note. The review is supposed to take 10-15 minutes, not be exhaustive.
 

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -4,6 +4,20 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 ## Open
 
+### [2026-05-10] Scope AgentCore Runtime BYO filesystem (S3 Files / EFS) for persistent agent workspaces
+- **Source**: research/2026-05-10.md ▸ AWS Bedrock / AgentCore (re-evaluated 2026-05-10 via strategic-lens follow-up — original framing under-weighted the capability-unlock angle)
+- **Surface**: backend (`inference-api` invocation handler reads/writes mount) + infrastructure (VPC config, IAM mount permissions, S3 Files or EFS access points, per-user prefix/access-point layout for RBAC); ADR-worthy
+- **Effort × Impact**: H × H
+- **Subtracts**: no — pure capability addition
+- **Unlocks**:
+  - Code-interpreter / persistent agent workspace (artifacts survive turn and session boundaries)
+  - Cross-session file uploads — PDFs/spreadsheets persist between conversations instead of re-staging per session
+  - Shared skill/template/prompt hot-swap without redeploying the runtime container
+  - A2A multi-agent intermediate-result handoff via shared mount
+  - Persistent vector indexes / embedding caches — avoids cold-start rebuild
+- **Open questions**: GA vs preview status (March 2026 managed session storage was preview; May 2026 BYO needs verification); VPC requirement is a new architectural surface for the runtime; multi-tenancy isolation strategy (per-user S3 prefix vs per-user EFS access point); RBAC mount-path layout; runtime data plane still only proxies `/invocations` + `/ping` so this doesn't unlock new HTTP routes
+- **Status**: open
+
 ### [2026-05-10] Scope an MCP Apps host renderer in our chat (multi-PR initiative)
 - **Source**: research/2026-05-10.md ▸ Top 6 #1 ▸ Agentic UI/UX
 - **Surface**: frontend + backend (new SSE event `ui_resource`; `<mcp-app-frame>` Angular component; consent UX)


### PR DESCRIPTION
## Summary
- Adapts `kaizen-research` and `kaizen-review-prep` to evaluate upstream features through a **dual lens** — *impact on existing code* AND *capability unlock* — rather than only asking what each feature replaces.
- Triggered by the 2026-05-10 AgentCore Runtime BYO filesystem (S3 Files / EFS) item, which the bootstrap research doc framed only as "could replace future filesystem-staging glue" — under-weighting the actual story (code-interpreter sandboxes, cross-session uploads, shared skill hot-swap, persistent vector indexes).
- Queues the BYO filesystem item at the top of `docs/kaizen/review-queue.md`, framed correctly as a capability unlock with explicit open questions.

## Changes

### Skills
- **New Philosophy bullet** on the dual lens in both skill files, with the BYO-filesystem mis-framing called out as the cautionary example.
- **kaizen-research source-item template** gains an `*unlocks*:` annotation alongside `*relevance*:`. Bug-fixes and dep-bumps usually only need `*relevance*`; new platform primitives, SDK hooks, spec capabilities, and UX patterns usually deserve both.
- **Top 5 table** gains an `Unlocks?` column; per-idea block gains an `Unlocks` field.
- **review-queue entry template** and **kaizen-review-prep Proposal template** both gain an `Unlocks` field (required when `Subtracts: no — addition only` — the unlock becomes the justification).
- **Ranking guidance** in both skills updated: capability-unlock items rank on strategic merit, not auto-deferred for lacking an existing-code intersection. A high-impact unlock can rank above a low-impact subtraction.

### Queue
- **New entry** at the top of `## Open`: *Scope AgentCore Runtime BYO filesystem (S3 Files / EFS) for persistent agent workspaces*. H × H. `Subtracts: no — pure capability addition`. Five concrete `Unlocks` bullets (code-interpreter, cross-session uploads, hot-swap, A2A handoff, persistent indexes). Open questions cover GA-vs-preview status, the VPC architectural commitment, multi-tenancy isolation strategy, and the `/invocations`-only data-plane constraint.

## Why this matters
The bootstrap kaizen run treated every upstream feature through a single lens: *does this change something we already wrote?* That systematically under-weights net-new platform primitives — features whose value is what they let us build *next*, not what they let us delete. The dual lens makes capability-unlock items a first-class signal in both the weekly research scan and the ranking pass.

## Test plan
- [ ] Read both updated skill files; confirm the Philosophy / template / ranking edits read consistently and don't undermine the subtraction-first principle.
- [ ] Read `docs/kaizen/review-queue.md`; confirm the new BYO entry uses the new `Unlocks` schema and the existing entries still parse cleanly under the updated review-prep Proposal template.
- [ ] Next Friday's `kaizen-research` run will be the first live test — confirm `*unlocks*` annotations appear on at least one item and the Top 5 table renders the new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)