### PR TITLE
chore: restrict contributions and disable Dependabot version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+# Version-update PRs are disabled across all ecosystems
+# (open-pull-requests-limit: 0). We handle dependency upgrades manually on a
+# weekly cadence. Security updates are unaffected and will still be raised by
+# Dependabot when a CVE is published against a dependency.
 updates:
   # ── Python backend ──
   - package-ecosystem: "pip"
@@ -9,7 +13,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Boise"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: "increase-if-necessary"
     commit-message:
       prefix: "chore(deps)"
@@ -33,7 +37,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Boise"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: "increase-if-necessary"
     commit-message:
       prefix: "chore(deps)"
@@ -58,7 +62,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Boise"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     versioning-strategy: "increase-if-necessary"
     commit-message:
       prefix: "chore(deps)"
@@ -83,7 +87,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Boise"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"
       include: "scope"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,39 @@
 # Contributing to AgentCore Public Stack
 
+## Contribution Policy
+
+AgentCore Public Stack is maintained by Boise State University as a reference
+implementation for academic and public-sector AgentCore deployments. It is
+source-available under the PolyForm Noncommercial License 1.0.0 (see
+[`LICENSE`](./LICENSE)).
+
+### Pull requests are restricted to approved collaborators
+
+To keep the reference architecture coherent and to let downstream deployments
+stay in sync with a single, well-known upstream, this repository uses GitHub's
+**"Collaborators only"** pull request setting. Only users with Write access or
+higher can open a pull request.
+
+### Reporting issues and proposing changes
+
+If you are deploying this stack and find a bug, regression, or documentation
+gap, please open a GitHub issue — issues are open to everyone. A maintainer
+will triage the report, and if the change belongs upstream we will either
+implement it or coordinate with the reporter on next steps.
+
+### For collaborators
+
+- Link the tracking issue in the PR description so changes stay discoverable.
+- Keep each PR focused on a single logical change.
+- Sign off your commits with `git commit -s` (Developer Certificate of Origin).
+- Make sure CI is green before requesting review.
+- Respect the backend import boundaries enforced by
+  `backend/tests/architecture/test_import_boundaries.py` — `app_api`,
+  `inference_api`, and `agents/` are independent consumers of `apis.shared`
+  and must not import from each other.
+
+---
+
 ## Prerequisites
 
 - **Node.js** 20+ (for frontend and infrastructure)


### PR DESCRIPTION
## Summary

Two related housekeeping changes to reduce drive-by PR noise on this public reference stack:

1. **`CONTRIBUTING.md`** — Document that PRs are restricted to approved collaborators (GitHub "Collaborators only" setting). Issues remain open to everyone for bug reports and proposed changes; maintainers triage and either implement upstream or coordinate next steps. Adds a brief checklist for collaborators (link tracking issue, single logical change per PR, DCO sign-off, green CI, respect backend import boundaries).
2. **`.github/dependabot.yml`** — Set `open-pull-requests-limit: 0` across all four ecosystems (pip, frontend npm, infrastructure npm, github-actions). Stops scheduled version-update PRs while leaving Dependabot security updates intact (CVE-driven PRs will still be raised). Existing groups, labels, `versioning-strategy`, and schedules are retained so the previous behavior can be restored by raising the limit.

## Manual follow-up (outside this PR)

These config changes describe the policy; the enforcement is a repo setting:

- **Settings → General → Pull Requests → Collaborators only.** Without this flip, the policy in `CONTRIBUTING.md` is just words.
- Verify **Settings → Code security → Dependabot security updates** is **enabled** (we explicitly want CVE-driven PRs to keep flowing).

## Tested

No code changes; YAML and Markdown only. Dependabot config is validated by GitHub on push.
