### PR TITLE
feat(admin): admin-managed user-menu links

### DIFF
--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -727,6 +727,11 @@ from .auth_providers.routes import router as auth_providers_router
 
 router.include_router(auth_providers_router)
 
+# ========== Include User Menu Links Admin Subrouter ==========
+from .user_menu_links.routes import router as user_menu_links_admin_router
+
+router.include_router(user_menu_links_admin_router)
+
 # ========== Include Fine-Tuning Admin Subrouter (conditional) ==========
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":
     from .fine_tuning.routes import router as fine_tuning_admin_router

--- a/backend/src/apis/app_api/admin/user_menu_links/routes.py
+++ b/backend/src/apis/app_api/admin/user_menu_links/routes.py
@@ -1,0 +1,125 @@
+"""Admin API routes for user-menu link management.
+
+All endpoints require admin role. Non-admin users hit the public
+``GET /user-menu-links`` endpoint (registered under ``app_api.user_menu_links``)
+which returns only enabled links and strips admin-only metadata.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from apis.shared.auth import User, require_admin
+from apis.shared.user_menu_links.models import (
+    UserMenuLinkCreate,
+    UserMenuLinkListResponse,
+    UserMenuLinkResponse,
+    UserMenuLinkUpdate,
+)
+from apis.shared.user_menu_links.service import get_user_menu_links_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/user-menu-links", tags=["admin-user-menu-links"])
+
+
+@router.get(
+    "/",
+    response_model=UserMenuLinkListResponse,
+    summary="List all user-menu links",
+)
+async def list_user_menu_links(
+    enabled_only: bool = Query(False, description="Filter to enabled links only"),
+    admin_user: User = Depends(require_admin),
+) -> UserMenuLinkListResponse:
+    """List all user-menu links (admin sees disabled ones too)."""
+    service = get_user_menu_links_service()
+    links = await service.list_links(enabled_only=enabled_only)
+    return UserMenuLinkListResponse(
+        links=[UserMenuLinkResponse.from_link(link) for link in links],
+        total=len(links),
+    )
+
+
+@router.get(
+    "/{link_id}",
+    response_model=UserMenuLinkResponse,
+    summary="Get a user-menu link",
+)
+async def get_user_menu_link(
+    link_id: str,
+    admin_user: User = Depends(require_admin),
+) -> UserMenuLinkResponse:
+    service = get_user_menu_links_service()
+    link = await service.get_link(link_id)
+    if not link:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User-menu link '{link_id}' not found",
+        )
+    return UserMenuLinkResponse.from_link(link)
+
+
+@router.post(
+    "/",
+    response_model=UserMenuLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a user-menu link",
+)
+async def create_user_menu_link(
+    data: UserMenuLinkCreate,
+    admin_user: User = Depends(require_admin),
+) -> UserMenuLinkResponse:
+    try:
+        service = get_user_menu_links_service()
+        link = await service.create_link(data, created_by=admin_user.email)
+        return UserMenuLinkResponse.from_link(link)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.patch(
+    "/{link_id}",
+    response_model=UserMenuLinkResponse,
+    summary="Update a user-menu link",
+)
+async def update_user_menu_link(
+    link_id: str,
+    updates: UserMenuLinkUpdate,
+    admin_user: User = Depends(require_admin),
+) -> UserMenuLinkResponse:
+    try:
+        service = get_user_menu_links_service()
+        link = await service.update_link(link_id, updates)
+        if not link:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User-menu link '{link_id}' not found",
+            )
+        return UserMenuLinkResponse.from_link(link)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.delete(
+    "/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a user-menu link",
+)
+async def delete_user_menu_link(
+    link_id: str,
+    admin_user: User = Depends(require_admin),
+) -> None:
+    service = get_user_menu_links_service()
+    deleted = await service.delete_link(link_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User-menu link '{link_id}' not found",
+        )

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -181,6 +181,7 @@ from apis.app_api.connectors.routes import router as connectors_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
 from apis.app_api.voice import router as voice_router
+from apis.app_api.user_menu_links.routes import router as user_menu_links_router
 
 # Include routers
 app.include_router(health_router)
@@ -207,6 +208,7 @@ app.include_router(conversations_share_router)  # Share conversations endpoints
 app.include_router(shares_router)  # Share management (update, revoke, export)
 app.include_router(shared_view_router)  # Shared conversation read-only view
 app.include_router(voice_router)  # Cookie-authenticated WS proxy for Nova Sonic voice mode (#211)
+app.include_router(user_menu_links_router)  # Public read of admin-managed user-menu links
 
 # Conditionally register fine-tuning routes
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":

--- a/backend/src/apis/app_api/user_menu_links/routes.py
+++ b/backend/src/apis/app_api/user_menu_links/routes.py
@@ -1,0 +1,37 @@
+"""Public read endpoint for user-menu links.
+
+Signed-in users (any role) fetch enabled links to render in the user menu.
+Admin writes go through ``/admin/user-menu-links``.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.user_menu_links.models import (
+    UserMenuLinkListResponse,
+    UserMenuLinkResponse,
+)
+from apis.shared.user_menu_links.service import get_user_menu_links_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/user-menu-links", tags=["user-menu-links"])
+
+
+@router.get(
+    "/",
+    response_model=UserMenuLinkListResponse,
+    summary="List enabled user-menu links",
+)
+async def list_enabled_user_menu_links(
+    current_user: User = Depends(get_current_user_from_session),
+) -> UserMenuLinkListResponse:
+    """Return all enabled links for rendering in the SPA user menu."""
+    service = get_user_menu_links_service()
+    links = await service.list_links(enabled_only=True)
+    return UserMenuLinkListResponse(
+        links=[UserMenuLinkResponse.from_link(link) for link in links],
+        total=len(links),
+    )

--- a/backend/src/apis/shared/user_menu_links/__init__.py
+++ b/backend/src/apis/shared/user_menu_links/__init__.py
@@ -1,0 +1,1 @@
+"""User-menu links: admin-managed links shown in the SPA user menu."""

--- a/backend/src/apis/shared/user_menu_links/models.py
+++ b/backend/src/apis/shared/user_menu_links/models.py
@@ -1,0 +1,160 @@
+"""Models for admin-managed user-menu links.
+
+A link is either:
+  - ``external``: opens ``url`` in a new tab
+  - ``modal``:    opens an in-app modal that renders ``body_markdown``
+
+Storage uses single-table design with a fixed partition (``USER_MENU_LINKS``)
+since the data is global / single-tenant. When per-org scoping is needed, the
+PK becomes ``USER_MENU_LINKS#<org_id>`` without touching the SK shape.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+LinkKind = Literal["external", "modal"]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+@dataclass
+class UserMenuLink:
+    """Admin-managed user-menu link stored in DynamoDB."""
+
+    link_id: str
+    label: str
+    kind: LinkKind
+    enabled: bool = True
+    order: int = 0
+    icon: Optional[str] = None
+    url: Optional[str] = None  # external kind only
+    body_markdown: Optional[str] = None  # modal kind only
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    created_by: Optional[str] = None
+
+    def to_dynamo_item(self) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "PK": "USER_MENU_LINKS",
+            "SK": f"LINK#{self.link_id}",
+            "linkId": self.link_id,
+            "label": self.label,
+            "kind": self.kind,
+            "enabled": self.enabled,
+            "order": self.order,
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+        if self.icon:
+            item["icon"] = self.icon
+        if self.url:
+            item["url"] = self.url
+        if self.body_markdown:
+            item["bodyMarkdown"] = self.body_markdown
+        if self.created_by:
+            item["createdBy"] = self.created_by
+        return item
+
+    @classmethod
+    def from_dynamo_item(cls, item: Dict[str, Any]) -> "UserMenuLink":
+        return cls(
+            link_id=item["linkId"],
+            label=item["label"],
+            kind=item["kind"],
+            enabled=item.get("enabled", True),
+            order=int(item.get("order", 0)),
+            icon=item.get("icon"),
+            url=item.get("url"),
+            body_markdown=item.get("bodyMarkdown"),
+            created_at=item.get("createdAt", _utc_now()),
+            updated_at=item.get("updatedAt", _utc_now()),
+            created_by=item.get("createdBy"),
+        )
+
+
+# =============================================================================
+# Pydantic request/response models
+# =============================================================================
+
+
+class _LinkFieldsMixin(BaseModel):
+    """Field validation shared by Create + Update."""
+
+    @model_validator(mode="after")
+    def _validate_kind_fields(self) -> "_LinkFieldsMixin":
+        kind = getattr(self, "kind", None)
+        url = getattr(self, "url", None)
+        body = getattr(self, "body_markdown", None)
+        if kind == "external" and not url:
+            raise ValueError("external links require url")
+        if kind == "modal" and not body:
+            raise ValueError("modal links require body_markdown")
+        # On a partial update, kind may be None — that's fine; downstream
+        # service merges with existing values before persisting.
+        return self
+
+
+class UserMenuLinkCreate(_LinkFieldsMixin):
+    label: str = Field(..., min_length=1, max_length=64)
+    kind: LinkKind
+    enabled: bool = True
+    order: int = Field(default=0, ge=0, le=10_000)
+    icon: Optional[str] = Field(
+        None, max_length=64, description="ng-icons name (e.g., 'heroDocumentText')"
+    )
+    url: Optional[str] = Field(None, max_length=2048)
+    body_markdown: Optional[str] = Field(None, max_length=50_000)
+
+
+class UserMenuLinkUpdate(BaseModel):
+    """Partial update — all fields optional. Validation runs after merge."""
+
+    label: Optional[str] = Field(None, min_length=1, max_length=64)
+    kind: Optional[LinkKind] = None
+    enabled: Optional[bool] = None
+    order: Optional[int] = Field(None, ge=0, le=10_000)
+    icon: Optional[str] = Field(None, max_length=64)
+    url: Optional[str] = Field(None, max_length=2048)
+    body_markdown: Optional[str] = Field(None, max_length=50_000)
+
+
+class UserMenuLinkResponse(BaseModel):
+    """API response shape (camelCase via field aliases on read sites)."""
+
+    link_id: str
+    label: str
+    kind: LinkKind
+    enabled: bool
+    order: int
+    icon: Optional[str] = None
+    url: Optional[str] = None
+    body_markdown: Optional[str] = None
+    created_at: str
+    updated_at: str
+    created_by: Optional[str] = None
+
+    @classmethod
+    def from_link(cls, link: UserMenuLink) -> "UserMenuLinkResponse":
+        return cls(
+            link_id=link.link_id,
+            label=link.label,
+            kind=link.kind,
+            enabled=link.enabled,
+            order=link.order,
+            icon=link.icon,
+            url=link.url,
+            body_markdown=link.body_markdown,
+            created_at=link.created_at,
+            updated_at=link.updated_at,
+            created_by=link.created_by,
+        )
+
+
+class UserMenuLinkListResponse(BaseModel):
+    links: List[UserMenuLinkResponse]
+    total: int

--- a/backend/src/apis/shared/user_menu_links/models.py
+++ b/backend/src/apis/shared/user_menu_links/models.py
@@ -13,13 +13,25 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 LinkKind = Literal["external", "modal"]
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _validate_http_url(value: Optional[str]) -> Optional[str]:
+    """Reject non-http(s) URLs. Defense-in-depth — Angular's DomSanitizer
+    also strips ``javascript:`` URLs from ``[href]``, but anyone hitting the
+    API directly (curl, scripts, a malicious admin) bypasses the SPA form."""
+    if value is None or value == "":
+        return value
+    lowered = value.strip().lower()
+    if not (lowered.startswith("http://") or lowered.startswith("https://")):
+        raise ValueError("url must start with http:// or https://")
+    return value
 
 
 @dataclass
@@ -29,13 +41,12 @@ class UserMenuLink:
     link_id: str
     label: str
     kind: LinkKind
+    created_at: str
+    updated_at: str
     enabled: bool = True
     order: int = 0
-    icon: Optional[str] = None
     url: Optional[str] = None  # external kind only
     body_markdown: Optional[str] = None  # modal kind only
-    created_at: str = field(default_factory=_utc_now)
-    updated_at: str = field(default_factory=_utc_now)
     created_by: Optional[str] = None
 
     def to_dynamo_item(self) -> Dict[str, Any]:
@@ -50,8 +61,6 @@ class UserMenuLink:
             "createdAt": self.created_at,
             "updatedAt": self.updated_at,
         }
-        if self.icon:
-            item["icon"] = self.icon
         if self.url:
             item["url"] = self.url
         if self.body_markdown:
@@ -62,17 +71,24 @@ class UserMenuLink:
 
     @classmethod
     def from_dynamo_item(cls, item: Dict[str, Any]) -> "UserMenuLink":
+        try:
+            created_at = item["createdAt"]
+            updated_at = item["updatedAt"]
+        except KeyError as e:
+            raise ValueError(
+                f"User-menu link item {item.get('SK', '?')} is missing required "
+                f"timestamp field: {e.args[0]}"
+            ) from e
         return cls(
             link_id=item["linkId"],
             label=item["label"],
             kind=item["kind"],
             enabled=item.get("enabled", True),
             order=int(item.get("order", 0)),
-            icon=item.get("icon"),
             url=item.get("url"),
             body_markdown=item.get("bodyMarkdown"),
-            created_at=item.get("createdAt", _utc_now()),
-            updated_at=item.get("updatedAt", _utc_now()),
+            created_at=created_at,
+            updated_at=updated_at,
             created_by=item.get("createdBy"),
         )
 
@@ -104,11 +120,13 @@ class UserMenuLinkCreate(_LinkFieldsMixin):
     kind: LinkKind
     enabled: bool = True
     order: int = Field(default=0, ge=0, le=10_000)
-    icon: Optional[str] = Field(
-        None, max_length=64, description="ng-icons name (e.g., 'heroDocumentText')"
-    )
     url: Optional[str] = Field(None, max_length=2048)
     body_markdown: Optional[str] = Field(None, max_length=50_000)
+
+    @field_validator("url")
+    @classmethod
+    def _check_url_scheme(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_http_url(v)
 
 
 class UserMenuLinkUpdate(BaseModel):
@@ -118,9 +136,13 @@ class UserMenuLinkUpdate(BaseModel):
     kind: Optional[LinkKind] = None
     enabled: Optional[bool] = None
     order: Optional[int] = Field(None, ge=0, le=10_000)
-    icon: Optional[str] = Field(None, max_length=64)
     url: Optional[str] = Field(None, max_length=2048)
     body_markdown: Optional[str] = Field(None, max_length=50_000)
+
+    @field_validator("url")
+    @classmethod
+    def _check_url_scheme(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_http_url(v)
 
 
 class UserMenuLinkResponse(BaseModel):
@@ -131,7 +153,6 @@ class UserMenuLinkResponse(BaseModel):
     kind: LinkKind
     enabled: bool
     order: int
-    icon: Optional[str] = None
     url: Optional[str] = None
     body_markdown: Optional[str] = None
     created_at: str
@@ -146,7 +167,6 @@ class UserMenuLinkResponse(BaseModel):
             kind=link.kind,
             enabled=link.enabled,
             order=link.order,
-            icon=link.icon,
             url=link.url,
             body_markdown=link.body_markdown,
             created_at=link.created_at,

--- a/backend/src/apis/shared/user_menu_links/repository.py
+++ b/backend/src/apis/shared/user_menu_links/repository.py
@@ -1,0 +1,178 @@
+"""DynamoDB repository for admin-managed user-menu links."""
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import UserMenuLink, UserMenuLinkCreate, UserMenuLinkUpdate
+
+logger = logging.getLogger(__name__)
+
+
+class UserMenuLinksRepository:
+    """CRUD for user-menu links in DynamoDB.
+
+    Single-table design, fixed PK ``USER_MENU_LINKS``. All items are queried
+    with a single ``query`` by PK; no GSI needed.
+    """
+
+    def __init__(self, table_name: Optional[str] = None, region: Optional[str] = None):
+        self._table_name = table_name or os.getenv("DYNAMODB_USER_MENU_LINKS_TABLE_NAME")
+        self._region = region or os.getenv("AWS_REGION", "us-west-2")
+        self._enabled = bool(self._table_name)
+
+        if not self._enabled:
+            logger.warning(
+                "DYNAMODB_USER_MENU_LINKS_TABLE_NAME not set. "
+                "User menu links repository is disabled."
+            )
+            return
+
+        profile = os.getenv("AWS_PROFILE")
+        if profile:
+            session = boto3.Session(profile_name=profile)
+            self._dynamodb = session.resource("dynamodb", region_name=self._region)
+        else:
+            self._dynamodb = boto3.resource("dynamodb", region_name=self._region)
+        self._table = self._dynamodb.Table(self._table_name)
+        logger.info(f"Initialized user-menu links repository: table={self._table_name}")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def list_links(self, enabled_only: bool = False) -> List[UserMenuLink]:
+        if not self._enabled:
+            return []
+
+        try:
+            response = self._table.query(
+                KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+                ExpressionAttributeValues={":pk": "USER_MENU_LINKS", ":sk": "LINK#"},
+            )
+            items = response.get("Items", [])
+            while "LastEvaluatedKey" in response:
+                response = self._table.query(
+                    KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+                    ExpressionAttributeValues={":pk": "USER_MENU_LINKS", ":sk": "LINK#"},
+                    ExclusiveStartKey=response["LastEvaluatedKey"],
+                )
+                items.extend(response.get("Items", []))
+        except ClientError:
+            logger.error("Error listing user-menu links", exc_info=True)
+            raise
+
+        links = [UserMenuLink.from_dynamo_item(item) for item in items]
+        if enabled_only:
+            links = [link for link in links if link.enabled]
+        links.sort(key=lambda link: (link.order, link.label.lower()))
+        return links
+
+    async def get_link(self, link_id: str) -> Optional[UserMenuLink]:
+        if not self._enabled:
+            return None
+        try:
+            response = self._table.get_item(
+                Key={"PK": "USER_MENU_LINKS", "SK": f"LINK#{link_id}"}
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return UserMenuLink.from_dynamo_item(item)
+        except ClientError:
+            logger.error("Error getting user-menu link", exc_info=True)
+            raise
+
+    async def create_link(
+        self, data: UserMenuLinkCreate, created_by: Optional[str] = None
+    ) -> UserMenuLink:
+        if not self._enabled:
+            raise RuntimeError("User-menu links repository is not enabled")
+
+        now = datetime.now(timezone.utc).isoformat() + "Z"
+        link = UserMenuLink(
+            link_id=str(uuid.uuid4()),
+            label=data.label,
+            kind=data.kind,
+            enabled=data.enabled,
+            order=data.order,
+            icon=data.icon,
+            url=data.url,
+            body_markdown=data.body_markdown,
+            created_at=now,
+            updated_at=now,
+            created_by=created_by,
+        )
+
+        try:
+            self._table.put_item(
+                Item=link.to_dynamo_item(),
+                ConditionExpression="attribute_not_exists(PK)",
+            )
+        except ClientError:
+            logger.error("Error creating user-menu link", exc_info=True)
+            raise
+
+        logger.info(f"Created user-menu link: {link.link_id}")
+        return link
+
+    async def update_link(
+        self, link_id: str, updates: UserMenuLinkUpdate
+    ) -> Optional[UserMenuLink]:
+        if not self._enabled:
+            return None
+
+        existing = await self.get_link(link_id)
+        if not existing:
+            return None
+
+        update_fields = updates.model_dump(exclude_none=True)
+        for field_name, value in update_fields.items():
+            setattr(existing, field_name, value)
+        existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+
+        # Re-validate the merged kind/url/body_markdown invariant before persist.
+        if existing.kind == "external" and not existing.url:
+            raise ValueError("external links require url")
+        if existing.kind == "modal" and not existing.body_markdown:
+            raise ValueError("modal links require body_markdown")
+
+        try:
+            self._table.put_item(Item=existing.to_dynamo_item())
+        except ClientError:
+            logger.error("Error updating user-menu link", exc_info=True)
+            raise
+
+        logger.info(f"Updated user-menu link: {link_id}")
+        return existing
+
+    async def delete_link(self, link_id: str) -> bool:
+        if not self._enabled:
+            return False
+        existing = await self.get_link(link_id)
+        if not existing:
+            return False
+        try:
+            self._table.delete_item(
+                Key={"PK": "USER_MENU_LINKS", "SK": f"LINK#{link_id}"}
+            )
+        except ClientError:
+            logger.error("Error deleting user-menu link", exc_info=True)
+            raise
+        logger.info(f"Deleted user-menu link: {link_id}")
+        return True
+
+
+_repository: Optional[UserMenuLinksRepository] = None
+
+
+def get_user_menu_links_repository() -> UserMenuLinksRepository:
+    global _repository
+    if _repository is None:
+        _repository = UserMenuLinksRepository()
+    return _repository

--- a/backend/src/apis/shared/user_menu_links/repository.py
+++ b/backend/src/apis/shared/user_menu_links/repository.py
@@ -101,7 +101,6 @@ class UserMenuLinksRepository:
             kind=data.kind,
             enabled=data.enabled,
             order=data.order,
-            icon=data.icon,
             url=data.url,
             body_markdown=data.body_markdown,
             created_at=now,
@@ -141,6 +140,10 @@ class UserMenuLinksRepository:
             raise ValueError("external links require url")
         if existing.kind == "modal" and not existing.body_markdown:
             raise ValueError("modal links require body_markdown")
+        if existing.url:
+            lowered = existing.url.strip().lower()
+            if not (lowered.startswith("http://") or lowered.startswith("https://")):
+                raise ValueError("url must start with http:// or https://")
 
         try:
             self._table.put_item(Item=existing.to_dynamo_item())

--- a/backend/src/apis/shared/user_menu_links/service.py
+++ b/backend/src/apis/shared/user_menu_links/service.py
@@ -1,0 +1,40 @@
+"""Service layer for user-menu links."""
+
+from typing import List, Optional
+
+from .models import UserMenuLink, UserMenuLinkCreate, UserMenuLinkUpdate
+from .repository import UserMenuLinksRepository, get_user_menu_links_repository
+
+
+class UserMenuLinksService:
+    def __init__(self, repository: UserMenuLinksRepository):
+        self._repo = repository
+
+    async def list_links(self, enabled_only: bool = False) -> List[UserMenuLink]:
+        return await self._repo.list_links(enabled_only=enabled_only)
+
+    async def get_link(self, link_id: str) -> Optional[UserMenuLink]:
+        return await self._repo.get_link(link_id)
+
+    async def create_link(
+        self, data: UserMenuLinkCreate, created_by: Optional[str] = None
+    ) -> UserMenuLink:
+        return await self._repo.create_link(data, created_by=created_by)
+
+    async def update_link(
+        self, link_id: str, updates: UserMenuLinkUpdate
+    ) -> Optional[UserMenuLink]:
+        return await self._repo.update_link(link_id, updates)
+
+    async def delete_link(self, link_id: str) -> bool:
+        return await self._repo.delete_link(link_id)
+
+
+_service: Optional[UserMenuLinksService] = None
+
+
+def get_user_menu_links_service() -> UserMenuLinksService:
+    global _service
+    if _service is None:
+        _service = UserMenuLinksService(get_user_menu_links_repository())
+    return _service

--- a/backend/tests/shared/test_user_menu_links.py
+++ b/backend/tests/shared/test_user_menu_links.py
@@ -1,0 +1,208 @@
+"""Tests for the user-menu links shared module (repository + service)."""
+
+import boto3
+import pytest
+from pydantic import ValidationError
+
+from apis.shared.user_menu_links.models import (
+    UserMenuLink,
+    UserMenuLinkCreate,
+    UserMenuLinkUpdate,
+)
+from apis.shared.user_menu_links.repository import UserMenuLinksRepository
+from apis.shared.user_menu_links.service import UserMenuLinksService
+
+AWS_REGION = "us-west-2"
+
+
+@pytest.fixture()
+def user_menu_links_table(aws, monkeypatch):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    name = "test-user-menu-links"
+    ddb.create_table(
+        TableName=name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    monkeypatch.setenv("DYNAMODB_USER_MENU_LINKS_TABLE_NAME", name)
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(name)
+
+
+@pytest.fixture()
+def repo(user_menu_links_table):
+    return UserMenuLinksRepository(table_name="test-user-menu-links", region=AWS_REGION)
+
+
+@pytest.fixture()
+def service(repo):
+    return UserMenuLinksService(repo)
+
+
+def _external(**kw):
+    defaults = dict(label="Privacy policy", kind="external", url="https://x.example/p")
+    defaults.update(kw)
+    return UserMenuLinkCreate(**defaults)
+
+
+def _modal(**kw):
+    defaults = dict(label="About", kind="modal", body_markdown="# Hi")
+    defaults.update(kw)
+    return UserMenuLinkCreate(**defaults)
+
+
+# ----------------------------------------------------------------------
+# Pydantic validation
+# ----------------------------------------------------------------------
+
+
+class TestCreateValidation:
+    def test_external_requires_url(self):
+        with pytest.raises(ValidationError):
+            UserMenuLinkCreate(label="X", kind="external")
+
+    def test_modal_requires_body_markdown(self):
+        with pytest.raises(ValidationError):
+            UserMenuLinkCreate(label="X", kind="modal")
+
+    def test_external_ok_with_url(self):
+        link = UserMenuLinkCreate(label="X", kind="external", url="https://x.example")
+        assert link.kind == "external"
+
+    def test_modal_ok_with_body(self):
+        link = UserMenuLinkCreate(label="X", kind="modal", body_markdown="hi")
+        assert link.kind == "modal"
+
+    def test_order_bounds(self):
+        with pytest.raises(ValidationError):
+            UserMenuLinkCreate(label="X", kind="external", url="https://x.example", order=-1)
+        with pytest.raises(ValidationError):
+            UserMenuLinkCreate(label="X", kind="external", url="https://x.example", order=10_001)
+
+
+# ----------------------------------------------------------------------
+# Repository
+# ----------------------------------------------------------------------
+
+
+class TestRepository:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, repo):
+        created = await repo.create_link(_external(), created_by="admin@x")
+        assert created.link_id
+        fetched = await repo.get_link(created.link_id)
+        assert fetched is not None
+        assert fetched.label == "Privacy policy"
+        assert fetched.created_by == "admin@x"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, repo):
+        assert await repo.get_link("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_list_returns_all_then_enabled_only(self, repo):
+        a = await repo.create_link(_external(label="A", order=2))
+        b = await repo.create_link(_modal(label="B", order=1, enabled=False))
+        all_links = await repo.list_links()
+        assert {link.link_id for link in all_links} == {a.link_id, b.link_id}
+        enabled = await repo.list_links(enabled_only=True)
+        assert [link.link_id for link in enabled] == [a.link_id]
+
+    @pytest.mark.asyncio
+    async def test_list_sorted_by_order_then_label(self, repo):
+        await repo.create_link(_external(label="Beta", order=10))
+        await repo.create_link(_external(label="Alpha", order=10))
+        await repo.create_link(_external(label="First", order=0))
+        labels = [link.label for link in await repo.list_links()]
+        assert labels == ["First", "Alpha", "Beta"]
+
+    @pytest.mark.asyncio
+    async def test_update_partial_merges(self, repo):
+        created = await repo.create_link(_external())
+        updated = await repo.update_link(
+            created.link_id, UserMenuLinkUpdate(label="Renamed")
+        )
+        assert updated is not None
+        assert updated.label == "Renamed"
+        assert updated.url == "https://x.example/p"  # untouched
+
+    @pytest.mark.asyncio
+    async def test_update_to_modal_requires_body(self, repo):
+        created = await repo.create_link(_external())
+        # Switching to modal without supplying body_markdown should raise:
+        # the merged record has kind=modal but no body.
+        with pytest.raises(ValueError, match="modal links require body_markdown"):
+            await repo.update_link(created.link_id, UserMenuLinkUpdate(kind="modal"))
+
+    @pytest.mark.asyncio
+    async def test_update_to_modal_with_body_succeeds(self, repo):
+        created = await repo.create_link(_external())
+        updated = await repo.update_link(
+            created.link_id,
+            UserMenuLinkUpdate(kind="modal", body_markdown="hi"),
+        )
+        assert updated is not None
+        assert updated.kind == "modal"
+        assert updated.body_markdown == "hi"
+
+    @pytest.mark.asyncio
+    async def test_update_missing_returns_none(self, repo):
+        assert await repo.update_link("nope", UserMenuLinkUpdate(label="x")) is None
+
+    @pytest.mark.asyncio
+    async def test_delete(self, repo):
+        created = await repo.create_link(_external())
+        assert await repo.delete_link(created.link_id) is True
+        assert await repo.get_link(created.link_id) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_returns_false(self, repo):
+        assert await repo.delete_link("nope") is False
+
+
+# ----------------------------------------------------------------------
+# Service
+# ----------------------------------------------------------------------
+
+
+class TestService:
+    @pytest.mark.asyncio
+    async def test_create_then_list(self, service):
+        await service.create_link(_external())
+        links = await service.list_links()
+        assert len(links) == 1
+
+    @pytest.mark.asyncio
+    async def test_enabled_only_filter(self, service):
+        await service.create_link(_external(label="A"))
+        await service.create_link(_external(label="B", enabled=False))
+        enabled = await service.list_links(enabled_only=True)
+        labels = [link.label for link in enabled]
+        assert labels == ["A"]
+
+
+# ----------------------------------------------------------------------
+# Dataclass round-trip
+# ----------------------------------------------------------------------
+
+
+class TestDynamoRoundTrip:
+    def test_to_and_from_dynamo_item(self):
+        original = UserMenuLink(
+            link_id="abc",
+            label="Test",
+            kind="modal",
+            enabled=True,
+            order=5,
+            icon="heroDocumentText",
+            body_markdown="# Hi",
+        )
+        item = original.to_dynamo_item()
+        round_tripped = UserMenuLink.from_dynamo_item(item)
+        assert round_tripped == original

--- a/backend/tests/shared/test_user_menu_links.py
+++ b/backend/tests/shared/test_user_menu_links.py
@@ -85,6 +85,29 @@ class TestCreateValidation:
         with pytest.raises(ValidationError):
             UserMenuLinkCreate(label="X", kind="external", url="https://x.example", order=10_001)
 
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "//example.com/x",
+            "example.com/x",
+        ],
+    )
+    def test_external_rejects_non_http_url(self, bad_url):
+        with pytest.raises(ValidationError):
+            UserMenuLinkCreate(label="X", kind="external", url=bad_url)
+
+    def test_external_accepts_http_and_https(self):
+        UserMenuLinkCreate(label="X", kind="external", url="http://x.example")
+        UserMenuLinkCreate(label="X", kind="external", url="HTTPS://X.example")
+
+    def test_update_rejects_non_http_url(self):
+        with pytest.raises(ValidationError):
+            UserMenuLinkUpdate(url="javascript:alert(1)")
+
 
 # ----------------------------------------------------------------------
 # Repository
@@ -165,6 +188,25 @@ class TestRepository:
     async def test_delete_missing_returns_false(self, repo):
         assert await repo.delete_link("nope") is False
 
+    @pytest.mark.asyncio
+    async def test_update_rejects_non_http_url_on_merge(self, repo):
+        """Defense-in-depth: even if a bypass somehow stored a bad URL,
+        an update that merges it back through the repo must reject it.
+        We bypass Pydantic by mutating the existing record directly."""
+        created = await repo.create_link(_external())
+        # Force a bad URL into the persisted item to simulate corruption /
+        # an out-of-band write.
+        repo._table.update_item(
+            Key={"PK": "USER_MENU_LINKS", "SK": f"LINK#{created.link_id}"},
+            UpdateExpression="SET #u = :u",
+            ExpressionAttributeNames={"#u": "url"},
+            ExpressionAttributeValues={":u": "javascript:alert(1)"},
+        )
+        with pytest.raises(ValueError, match="url must start with"):
+            await repo.update_link(
+                created.link_id, UserMenuLinkUpdate(label="Renamed")
+            )
+
 
 # ----------------------------------------------------------------------
 # Service
@@ -200,9 +242,18 @@ class TestDynamoRoundTrip:
             kind="modal",
             enabled=True,
             order=5,
-            icon="heroDocumentText",
             body_markdown="# Hi",
+            created_at="2026-05-14T00:00:00Z",
+            updated_at="2026-05-14T00:00:00Z",
         )
         item = original.to_dynamo_item()
         round_tripped = UserMenuLink.from_dynamo_item(item)
         assert round_tripped == original
+
+    def test_from_dynamo_item_requires_timestamps(self):
+        # Corrupted records (missing createdAt/updatedAt) should raise rather
+        # than silently substituting "now".
+        with pytest.raises(ValueError, match="missing required timestamp"):
+            UserMenuLink.from_dynamo_item(
+                {"linkId": "x", "label": "x", "kind": "external", "url": "https://x.example"}
+            )

--- a/backend/tests/shared/test_user_menu_links_routes.py
+++ b/backend/tests/shared/test_user_menu_links_routes.py
@@ -1,0 +1,229 @@
+"""Route tests for user-menu links endpoints (admin CRUD + public read)."""
+
+import boto3
+import pytest
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import get_current_user_from_session, require_admin
+from apis.shared.auth.models import User
+from apis.shared.user_menu_links import repository as repo_module
+from apis.shared.user_menu_links import service as service_module
+
+AWS_REGION = "us-east-1"
+TABLE_NAME = "test-user-menu-links-routes"
+
+
+def _make_user(email: str = "user@example.com", roles=None) -> User:
+    return User(
+        email=email,
+        user_id="user-001",
+        name="Test User",
+        roles=roles if roles is not None else ["User"],
+    )
+
+
+@pytest.fixture()
+def user_menu_links_table(aws, monkeypatch):
+    """Moto-backed DynamoDB table + module-singleton reset so the routes pick
+    up this fresh table on first call inside each test."""
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    ddb.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    monkeypatch.setenv("DYNAMODB_USER_MENU_LINKS_TABLE_NAME", TABLE_NAME)
+    monkeypatch.setenv("AWS_REGION", AWS_REGION)
+    # The service + repo are module-level singletons; reset them so the
+    # next get_*() call constructs a fresh instance against the moto table.
+    monkeypatch.setattr(repo_module, "_repository", None)
+    monkeypatch.setattr(service_module, "_service", None)
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE_NAME)
+
+
+def _build_admin_app() -> FastAPI:
+    """Mount the admin router under /admin to mirror the real app."""
+    from apis.app_api.admin.user_menu_links.routes import router as admin_router
+
+    app = FastAPI()
+    parent = APIRouter(prefix="/admin")
+    parent.include_router(admin_router)
+    app.include_router(parent)
+    return app
+
+
+def _build_public_app() -> FastAPI:
+    from apis.app_api.user_menu_links.routes import router as public_router
+
+    app = FastAPI()
+    app.include_router(public_router)
+    return app
+
+
+# ----------------------------------------------------------------------
+# Admin routes
+# ----------------------------------------------------------------------
+
+
+class TestAdminRoutes:
+    def test_create_returns_201(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        resp = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "Privacy", "kind": "external", "url": "https://x.example"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["label"] == "Privacy"
+        assert body["created_by"] == "admin@example.com"
+
+    def test_create_rejects_non_http_url_with_422(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        resp = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "Bad", "kind": "external", "url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_missing_url_for_external_returns_422(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        resp = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "X", "kind": "external"},
+        )
+        assert resp.status_code == 422
+
+    def test_non_admin_gets_403(self, user_menu_links_table):
+        app = _build_admin_app()
+
+        def _forbid():
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        app.dependency_overrides[require_admin] = _forbid
+
+        client = TestClient(app)
+        resp = client.get("/admin/user-menu-links/")
+        assert resp.status_code == 403
+
+    def test_list_then_get_round_trips(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        created = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "About", "kind": "modal", "body_markdown": "# Hi"},
+        ).json()
+
+        list_resp = client.get("/admin/user-menu-links/")
+        assert list_resp.status_code == 200
+        assert list_resp.json()["total"] == 1
+
+        get_resp = client.get(f"/admin/user-menu-links/{created['link_id']}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["label"] == "About"
+
+    def test_get_missing_returns_404(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        resp = client.get("/admin/user-menu-links/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_update_returns_400_on_invariant_violation(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        created = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "Privacy", "kind": "external", "url": "https://x.example"},
+        ).json()
+
+        # PATCH kind=modal without supplying body_markdown — the merged record
+        # fails the kind/body invariant in the repository, which raises
+        # ValueError → mapped to 400 by the handler.
+        resp = client.patch(
+            f"/admin/user-menu-links/{created['link_id']}",
+            json={"kind": "modal"},
+        )
+        assert resp.status_code == 400
+
+    def test_delete_returns_204_then_404(self, user_menu_links_table):
+        app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        app.dependency_overrides[require_admin] = lambda: admin
+
+        client = TestClient(app)
+        created = client.post(
+            "/admin/user-menu-links/",
+            json={"label": "X", "kind": "external", "url": "https://x.example"},
+        ).json()
+
+        del_resp = client.delete(f"/admin/user-menu-links/{created['link_id']}")
+        assert del_resp.status_code == 204
+
+        again = client.delete(f"/admin/user-menu-links/{created['link_id']}")
+        assert again.status_code == 404
+
+
+# ----------------------------------------------------------------------
+# Public read route
+# ----------------------------------------------------------------------
+
+
+class TestPublicRoute:
+    def test_returns_only_enabled_links(self, user_menu_links_table):
+        admin_app = _build_admin_app()
+        admin = _make_user(email="admin@example.com", roles=["system_admin"])
+        admin_app.dependency_overrides[require_admin] = lambda: admin
+        admin_client = TestClient(admin_app)
+
+        # Seed one enabled + one disabled link via the admin API.
+        admin_client.post(
+            "/admin/user-menu-links/",
+            json={"label": "Visible", "kind": "external", "url": "https://x.example"},
+        )
+        admin_client.post(
+            "/admin/user-menu-links/",
+            json={
+                "label": "Hidden",
+                "kind": "external",
+                "url": "https://y.example",
+                "enabled": False,
+            },
+        )
+
+        public_app = _build_public_app()
+        public_app.dependency_overrides[get_current_user_from_session] = (
+            lambda: _make_user()
+        )
+        public_client = TestClient(public_app)
+        resp = public_client.get("/user-menu-links/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [link["label"] for link in body["links"]] == ["Visible"]

--- a/frontend/ai.client/src/app/admin/admin.page.ts
+++ b/frontend/ai.client/src/app/admin/admin.page.ts
@@ -116,6 +116,12 @@ export class AdminPage {
       route: '/admin/connectors',
     },
     {
+      title: 'User Menu Links',
+      description: 'Manage links shown in the user menu. External URLs open in a new tab; modal links show rich Markdown content in-app.',
+      icon: 'heroLink',
+      route: '/admin/manage-user-menu-links',
+    },
+    {
       title: 'Fine-Tuning Access',
       description: 'Manage which users can access fine-tuning. Grant or revoke access, set monthly compute hour quotas, and monitor usage.',
       icon: 'heroAcademicCap',

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
@@ -1,0 +1,154 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroPencil,
+  heroTrash,
+  heroPlus,
+  heroArrowTopRightOnSquare,
+  heroDocumentText,
+} from '@ng-icons/heroicons/outline';
+import { UserMenuLinksService } from './services/user-menu-links.service';
+import { UserMenuLink } from './models/user-menu-link.model';
+
+@Component({
+  selector: 'app-manage-user-menu-links-page',
+  imports: [RouterLink, NgIcon],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPencil,
+      heroTrash,
+      heroPlus,
+      heroArrowTopRightOnSquare,
+      heroDocumentText,
+    }),
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <a
+          routerLink="/admin"
+          class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" />
+          Back to Admin
+        </a>
+
+        <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">User Menu Links</h1>
+            <p class="mt-1 text-gray-600 dark:text-gray-400">
+              Manage links rendered in the user menu. Each link opens an external URL or an in-app modal with rich text.
+            </p>
+          </div>
+          <a
+            routerLink="/admin/manage-user-menu-links/new"
+            class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-5" />
+            New link
+          </a>
+        </div>
+
+        @if (loadError()) {
+          <div class="mb-4 rounded-sm border border-red-300 bg-red-50 p-4 text-sm/6 text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+            Failed to load links. {{ loadError() }}
+          </div>
+        }
+
+        @if (links().length === 0 && !isLoading()) {
+          <div class="rounded-sm border border-gray-300 bg-white p-12 text-center dark:border-gray-600 dark:bg-gray-800">
+            <p class="text-base/7 text-gray-500 dark:text-gray-400">No user-menu links yet.</p>
+            <a
+              routerLink="/admin/manage-user-menu-links/new"
+              class="mt-4 inline-flex items-center gap-2 text-sm/6 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              Add the first one →
+            </a>
+          </div>
+        } @else {
+          <div class="space-y-3">
+            @for (link of links(); track link.link_id) {
+              <div class="flex items-center justify-between gap-4 rounded-sm border border-gray-300 bg-white p-4 dark:border-gray-600 dark:bg-gray-800">
+                <div class="flex flex-1 items-center gap-3 min-w-0">
+                  <ng-icon
+                    [name]="link.kind === 'external' ? 'heroArrowTopRightOnSquare' : 'heroDocumentText'"
+                    class="size-5 shrink-0 text-gray-400 dark:text-gray-500"
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">{{ link.label }}</span>
+                      @if (!link.enabled) {
+                        <span class="shrink-0 rounded-sm bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">Disabled</span>
+                      }
+                      <span class="shrink-0 rounded-sm bg-blue-100 px-2 py-0.5 text-xs/5 font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                        {{ link.kind === 'external' ? 'External' : 'Modal' }}
+                      </span>
+                    </div>
+                    @if (link.kind === 'external') {
+                      <p class="mt-0.5 truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ link.url }}</p>
+                    } @else {
+                      <p class="mt-0.5 truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ summarize(link.body_markdown) }}</p>
+                    }
+                  </div>
+                </div>
+                <div class="flex shrink-0 items-center gap-2">
+                  <span class="hidden text-xs text-gray-400 sm:inline dark:text-gray-500" [title]="'Order: ' + link.order">#{{ link.order }}</span>
+                  <a
+                    [routerLink]="['/admin/manage-user-menu-links/edit', link.link_id]"
+                    class="inline-flex items-center gap-1 rounded-sm border border-gray-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                    [attr.aria-label]="'Edit ' + link.label"
+                  >
+                    <ng-icon name="heroPencil" class="size-4" />
+                    <span class="sr-only sm:not-sr-only">Edit</span>
+                  </a>
+                  <button
+                    type="button"
+                    (click)="onDelete(link)"
+                    class="inline-flex items-center gap-1 rounded-sm border border-red-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-400 dark:hover:bg-red-900/20"
+                    [attr.aria-label]="'Delete ' + link.label"
+                  >
+                    <ng-icon name="heroTrash" class="size-4" />
+                    <span class="sr-only sm:not-sr-only">Delete</span>
+                  </button>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class ManageUserMenuLinksPage {
+  private readonly service = inject(UserMenuLinksService);
+
+  protected readonly links = computed<UserMenuLink[]>(
+    () => this.service.adminLinksResource.value()?.links ?? [],
+  );
+  protected readonly isLoading = computed(() => this.service.adminLinksResource.isLoading());
+  protected readonly loadError = computed(() => {
+    const err = this.service.adminLinksResource.error();
+    if (!err) return null;
+    return err instanceof Error ? err.message : String(err);
+  });
+
+  protected summarize(markdown: string | null | undefined): string {
+    if (!markdown) return '(empty)';
+    const stripped = markdown.replace(/[#*_`>\-]/g, '').replace(/\s+/g, ' ').trim();
+    return stripped.length > 120 ? stripped.slice(0, 120) + '…' : stripped;
+  }
+
+  protected async onDelete(link: UserMenuLink): Promise<void> {
+    if (!confirm(`Delete "${link.label}"?`)) return;
+    try {
+      await this.service.deleteLink(link.link_id);
+    } catch (err) {
+      console.error('Failed to delete user-menu link', err);
+      alert('Failed to delete the link. Please try again.');
+    }
+  }
+}

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/models/user-menu-link.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/models/user-menu-link.model.ts
@@ -1,0 +1,29 @@
+export type UserMenuLinkKind = 'external' | 'modal';
+
+export interface UserMenuLink {
+  link_id: string;
+  label: string;
+  kind: UserMenuLinkKind;
+  enabled: boolean;
+  order: number;
+  icon?: string | null;
+  url?: string | null;
+  body_markdown?: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+}
+
+export interface UserMenuLinksListResponse {
+  links: UserMenuLink[];
+  total: number;
+}
+
+export interface UserMenuLinkFormData {
+  label: string;
+  kind: UserMenuLinkKind;
+  enabled: boolean;
+  order: number;
+  url?: string | null;
+  body_markdown?: string | null;
+}

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/models/user-menu-link.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/models/user-menu-link.model.ts
@@ -6,7 +6,6 @@ export interface UserMenuLink {
   kind: UserMenuLinkKind;
   enabled: boolean;
   order: number;
-  icon?: string | null;
   url?: string | null;
   body_markdown?: string | null;
   created_at: string;

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, inject, computed, resource } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import {
+  UserMenuLink,
+  UserMenuLinkFormData,
+  UserMenuLinksListResponse,
+} from '../models/user-menu-link.model';
+
+/**
+ * Service for admin-managed user-menu links.
+ *
+ * Two API surfaces:
+ *  - Admin: `/admin/user-menu-links` (CRUD, includes disabled links)
+ *  - Public: `/user-menu-links` (enabled-only, used by `enabledLinksResource`)
+ *
+ * The public resource is what the user-dropdown component consumes. It is
+ * lazy by design: callers must call `.reload()` after auth lands (the
+ * dropdown does this in an effect that watches the user signal).
+ */
+@Injectable({ providedIn: 'root' })
+export class UserMenuLinksService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly adminBaseUrl = computed(
+    () => `${this.config.appApiUrl()}/admin/user-menu-links`,
+  );
+  private readonly publicBaseUrl = computed(
+    () => `${this.config.appApiUrl()}/user-menu-links`,
+  );
+
+  readonly adminLinksResource = resource({
+    loader: async () => this.fetchAdminLinks(),
+  });
+
+  readonly enabledLinksResource = resource({
+    loader: async () => this.fetchEnabledLinks(),
+  });
+
+  async fetchAdminLinks(): Promise<UserMenuLinksListResponse> {
+    return await firstValueFrom(
+      this.http.get<UserMenuLinksListResponse>(`${this.adminBaseUrl()}/`),
+    );
+  }
+
+  async fetchEnabledLinks(): Promise<UserMenuLinksListResponse> {
+    return await firstValueFrom(
+      this.http.get<UserMenuLinksListResponse>(`${this.publicBaseUrl()}/`),
+    );
+  }
+
+  async getLink(linkId: string): Promise<UserMenuLink> {
+    return await firstValueFrom(
+      this.http.get<UserMenuLink>(`${this.adminBaseUrl()}/${linkId}`),
+    );
+  }
+
+  async createLink(data: UserMenuLinkFormData): Promise<UserMenuLink> {
+    const created = await firstValueFrom(
+      this.http.post<UserMenuLink>(`${this.adminBaseUrl()}/`, data),
+    );
+    this.adminLinksResource.reload();
+    this.enabledLinksResource.reload();
+    return created;
+  }
+
+  async updateLink(
+    linkId: string,
+    updates: Partial<UserMenuLinkFormData>,
+  ): Promise<UserMenuLink> {
+    const updated = await firstValueFrom(
+      this.http.patch<UserMenuLink>(`${this.adminBaseUrl()}/${linkId}`, updates),
+    );
+    this.adminLinksResource.reload();
+    this.enabledLinksResource.reload();
+    return updated;
+  }
+
+  async deleteLink(linkId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.delete<void>(`${this.adminBaseUrl()}/${linkId}`),
+    );
+    this.adminLinksResource.reload();
+    this.enabledLinksResource.reload();
+  }
+}

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
@@ -15,9 +15,10 @@ import {
  *  - Admin: `/admin/user-menu-links` (CRUD, includes disabled links)
  *  - Public: `/user-menu-links` (enabled-only, used by `enabledLinksResource`)
  *
- * The public resource is what the user-dropdown component consumes. It is
- * lazy by design: callers must call `.reload()` after auth lands (the
- * dropdown does this in an effect that watches the user signal).
+ * The public resource is what the user-dropdown component consumes. The
+ * dropdown takes a `User` as a required input and is only rendered by the
+ * topnav once the session bootstrap has resolved, so the resource's loader
+ * fires post-auth on first read — no explicit reload needed.
  */
 @Injectable({ providedIn: 'root' })
 export class UserMenuLinksService {

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
@@ -1,0 +1,305 @@
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MarkdownComponent } from 'ngx-markdown';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import { UserMenuLinksService } from './services/user-menu-links.service';
+import {
+  UserMenuLinkFormData,
+  UserMenuLinkKind,
+} from './models/user-menu-link.model';
+
+const URL_PATTERN = /^https?:\/\/.+/i;
+
+@Component({
+  selector: 'app-user-menu-link-form-page',
+  imports: [RouterLink, ReactiveFormsModule, MarkdownComponent, NgIcon],
+  providers: [provideIcons({ heroArrowLeft })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <a
+          routerLink="/admin/manage-user-menu-links"
+          class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" />
+          Back to User Menu Links
+        </a>
+
+        <h1 class="mb-6 text-3xl/9 font-bold text-gray-900 dark:text-white">
+          {{ isEdit() ? 'Edit user-menu link' : 'New user-menu link' }}
+        </h1>
+
+        @if (loadError()) {
+          <div class="mb-4 rounded-sm border border-red-300 bg-red-50 p-4 text-sm/6 text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+            {{ loadError() }}
+          </div>
+        }
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6">
+          <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div class="md:col-span-2">
+                <label for="label" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                  Label <span class="text-red-600">*</span>
+                </label>
+                <input
+                  id="label"
+                  type="text"
+                  formControlName="label"
+                  maxlength="64"
+                  class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="e.g. Privacy policy"
+                />
+                @if (showError('label')) {
+                  <p class="mt-1 text-xs text-red-600 dark:text-red-400">Label is required.</p>
+                }
+              </div>
+
+              <div>
+                <label for="kind" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                  Type
+                </label>
+                <select
+                  id="kind"
+                  formControlName="kind"
+                  class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value="external">External URL (new tab)</option>
+                  <option value="modal">In-app modal (rich text)</option>
+                </select>
+              </div>
+
+              <div>
+                <label for="order" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                  Order
+                </label>
+                <input
+                  id="order"
+                  type="number"
+                  min="0"
+                  max="10000"
+                  formControlName="order"
+                  class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Lower numbers appear first.</p>
+              </div>
+
+              <div class="md:col-span-2 flex items-center gap-2">
+                <input
+                  id="enabled"
+                  type="checkbox"
+                  formControlName="enabled"
+                  class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <label for="enabled" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                  Visible to users
+                </label>
+              </div>
+            </div>
+          </div>
+
+          @if (kindValue() === 'external') {
+            <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+              <label for="url" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                URL <span class="text-red-600">*</span>
+              </label>
+              <input
+                id="url"
+                type="url"
+                formControlName="url"
+                maxlength="2048"
+                placeholder="https://example.com/privacy"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              />
+              @if (showError('url')) {
+                <p class="mt-1 text-xs text-red-600 dark:text-red-400">A valid http(s) URL is required.</p>
+              }
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Opens in a new tab with <code>rel="noopener noreferrer"</code>.</p>
+            </div>
+          } @else {
+            <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+              <label for="body_markdown" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Body (Markdown) <span class="text-red-600">*</span>
+              </label>
+              <p class="mt-1 mb-3 text-xs text-gray-500 dark:text-gray-400">
+                Supports CommonMark: headings, lists, links, code, emphasis. Links open in a new tab.
+              </p>
+              <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <textarea
+                  id="body_markdown"
+                  formControlName="body_markdown"
+                  rows="14"
+                  maxlength="50000"
+                  class="block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                  placeholder="# Welcome&#10;&#10;Some **rich** text..."
+                ></textarea>
+                <div class="rounded-sm border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+                  <p class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Preview</p>
+                  <div class="prose prose-sm max-w-none dark:prose-invert">
+                    <markdown [data]="previewMarkdown()" />
+                  </div>
+                </div>
+              </div>
+              @if (showError('body_markdown')) {
+                <p class="mt-1 text-xs text-red-600 dark:text-red-400">Body is required for modal links.</p>
+              }
+            </div>
+          }
+
+          @if (submitError()) {
+            <div class="rounded-sm border border-red-300 bg-red-50 p-4 text-sm/6 text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+              {{ submitError() }}
+            </div>
+          }
+
+          <div class="flex justify-end gap-3">
+            <a
+              routerLink="/admin/manage-user-menu-links"
+              class="rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Cancel
+            </a>
+            <button
+              type="submit"
+              [disabled]="form.invalid || isSubmitting()"
+              class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              @if (isSubmitting()) {
+                <span class="size-4 animate-spin rounded-full border-2 border-white border-t-transparent" aria-hidden="true"></span>
+              }
+              {{ isEdit() ? 'Save changes' : 'Create link' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `,
+})
+export class UserMenuLinkFormPage implements OnInit {
+  private readonly service = inject(UserMenuLinksService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  protected readonly form = new FormGroup({
+    label: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(64)],
+    }),
+    kind: new FormControl<UserMenuLinkKind>('external', { nonNullable: true }),
+    enabled: new FormControl<boolean>(true, { nonNullable: true }),
+    order: new FormControl<number>(0, {
+      nonNullable: true,
+      validators: [Validators.min(0), Validators.max(10_000)],
+    }),
+    url: new FormControl<string>('', { nonNullable: true }),
+    body_markdown: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  protected readonly isSubmitting = signal(false);
+  protected readonly submitError = signal<string | null>(null);
+  protected readonly loadError = signal<string | null>(null);
+  private readonly editingId = signal<string | null>(null);
+  protected readonly isEdit = computed(() => this.editingId() !== null);
+
+  // Mirrored signals for reactive template (FormControl.valueChanges is rxjs).
+  private readonly kindSig = signal<UserMenuLinkKind>('external');
+  private readonly bodySig = signal<string>('');
+  protected readonly kindValue = this.kindSig.asReadonly();
+  protected readonly previewMarkdown = computed(() => this.bodySig() || '*(empty preview)*');
+
+  async ngOnInit(): Promise<void> {
+    this.form.controls.kind.valueChanges.subscribe(value => {
+      this.kindSig.set(value);
+      this.syncKindValidators(value);
+    });
+    this.form.controls.body_markdown.valueChanges.subscribe(value => {
+      this.bodySig.set(value);
+    });
+    this.syncKindValidators(this.form.controls.kind.value);
+
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.editingId.set(id);
+      try {
+        const link = await this.service.getLink(id);
+        this.form.patchValue({
+          label: link.label,
+          kind: link.kind,
+          enabled: link.enabled,
+          order: link.order,
+          url: link.url ?? '',
+          body_markdown: link.body_markdown ?? '',
+        });
+        this.kindSig.set(link.kind);
+        this.bodySig.set(link.body_markdown ?? '');
+      } catch (err) {
+        this.loadError.set(
+          err instanceof Error ? err.message : 'Failed to load link.',
+        );
+      }
+    }
+  }
+
+  private syncKindValidators(kind: UserMenuLinkKind): void {
+    const url = this.form.controls.url;
+    const body = this.form.controls.body_markdown;
+    if (kind === 'external') {
+      url.setValidators([Validators.required, Validators.pattern(URL_PATTERN)]);
+      body.clearValidators();
+    } else {
+      body.setValidators([Validators.required]);
+      url.clearValidators();
+    }
+    url.updateValueAndValidity({ emitEvent: false });
+    body.updateValueAndValidity({ emitEvent: false });
+  }
+
+  protected showError(name: 'label' | 'url' | 'body_markdown'): boolean {
+    const c = this.form.get(name);
+    return !!c && c.invalid && (c.touched || c.dirty);
+  }
+
+  protected async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+
+    const raw = this.form.getRawValue();
+    const data: UserMenuLinkFormData = {
+      label: raw.label.trim(),
+      kind: raw.kind,
+      enabled: raw.enabled,
+      order: Number(raw.order ?? 0),
+      url: raw.kind === 'external' ? raw.url.trim() : null,
+      body_markdown: raw.kind === 'modal' ? raw.body_markdown : null,
+    };
+
+    try {
+      const id = this.editingId();
+      if (id) {
+        await this.service.updateLink(id, data);
+      } else {
+        await this.service.createLink(data);
+      }
+      this.router.navigate(['/admin/manage-user-menu-links']);
+    } catch (err: unknown) {
+      const detail = (err as { error?: { detail?: string }; message?: string })?.error?.detail
+        ?? (err as Error)?.message
+        ?? 'Failed to save link.';
+      this.submitError.set(detail);
+    } finally {
+      this.isSubmitting.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -64,6 +64,21 @@ export const routes: Routes = [
         canActivate: [adminGuard],
     },
     {
+        path: 'admin/manage-user-menu-links',
+        loadComponent: () => import('./admin/manage-user-menu-links/manage-user-menu-links.page').then(m => m.ManageUserMenuLinksPage),
+        canActivate: [adminGuard],
+    },
+    {
+        path: 'admin/manage-user-menu-links/new',
+        loadComponent: () => import('./admin/manage-user-menu-links/user-menu-link-form.page').then(m => m.UserMenuLinkFormPage),
+        canActivate: [adminGuard],
+    },
+    {
+        path: 'admin/manage-user-menu-links/edit/:id',
+        loadComponent: () => import('./admin/manage-user-menu-links/user-menu-link-form.page').then(m => m.UserMenuLinkFormPage),
+        canActivate: [adminGuard],
+    },
+    {
         path: 'assistants/new',
         loadComponent: () => import('./assistants/assistant-form/assistant-form.page').then(m => m.AssistantFormPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/components/topnav/components/user-dropdown.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/user-dropdown.component.ts
@@ -3,6 +3,7 @@ import { Component, input, output, ChangeDetectionStrategy, computed, inject } f
 import { RouterLink } from '@angular/router';
 import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
+import { Dialog } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroChevronUpDown,
@@ -16,9 +17,17 @@ import {
   heroDocument,
   heroBriefcase,
   heroCog6Tooth,
+  heroArrowTopRightOnSquare,
+  heroDocumentText,
 } from '@ng-icons/heroicons/outline';
 import { ThemeService, ThemePreference } from './theme-toggle/theme.service';
 import { VERSION } from '../../../../version';
+import { UserMenuLinksService } from '../../../admin/manage-user-menu-links/services/user-menu-links.service';
+import { UserMenuLink } from '../../../admin/manage-user-menu-links/models/user-menu-link.model';
+import {
+  UserMenuLinkModalComponent,
+  UserMenuLinkModalData,
+} from './user-menu-link-modal/user-menu-link-modal.component';
 
 export interface User {
   firstName: string;
@@ -45,6 +54,8 @@ export interface User {
       heroChatBubbleLeftRight,
       heroDocument,
       heroCog6Tooth,
+      heroArrowTopRightOnSquare,
+      heroDocumentText,
     })
   ],
   template: `
@@ -135,6 +146,44 @@ export interface User {
               </a>
             </div>
 
+            <!-- Admin-managed custom links -->
+            @if (customLinks().length > 0) {
+              <div class="border-t border-gray-200 py-1 dark:border-gray-700">
+                @for (link of customLinks(); track link.link_id) {
+                  @if (link.kind === 'external') {
+                    <a
+                      cdkMenuItem
+                      [href]="link.url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex w-full items-center gap-3 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700 rounded-xs outline-hidden"
+                      role="menuitem"
+                    >
+                      <ng-icon
+                        name="heroArrowTopRightOnSquare"
+                        class="size-5 text-gray-400 dark:text-gray-500"
+                      />
+                      <span class="flex-1 truncate">{{ link.label }}</span>
+                    </a>
+                  } @else {
+                    <button
+                      cdkMenuItem
+                      type="button"
+                      (click)="openLinkModal(link)"
+                      class="flex w-full items-center gap-3 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700 rounded-xs outline-hidden text-left"
+                      role="menuitem"
+                    >
+                      <ng-icon
+                        name="heroDocumentText"
+                        class="size-5 text-gray-400 dark:text-gray-500"
+                      />
+                      <span class="flex-1 truncate">{{ link.label }}</span>
+                    </button>
+                  }
+                }
+              </div>
+            }
+
             <!-- Logout section -->
             <div class="border-t border-gray-200 py-1 dark:border-gray-700">
               <button
@@ -198,10 +247,28 @@ export interface User {
 })
 export class UserDropdownComponent {
   private readonly themeService = inject(ThemeService);
+  private readonly userMenuLinksService = inject(UserMenuLinksService);
+  private readonly dialog = inject(Dialog);
 
   // Inputs
   user = input.required<User>();
   isAdmin = input.required<boolean>();
+
+  // Admin-managed custom links (already enabled-filtered + ordered by backend).
+  protected readonly customLinks = computed<UserMenuLink[]>(
+    () => this.userMenuLinksService.enabledLinksResource.value()?.links ?? [],
+  );
+
+  protected openLinkModal(link: UserMenuLink): void {
+    this.dialog.open<void, UserMenuLinkModalData>(UserMenuLinkModalComponent, {
+      data: {
+        label: link.label,
+        bodyMarkdown: link.body_markdown ?? '',
+      },
+      hasBackdrop: false, // dialog component owns its own backdrop
+      panelClass: 'user-menu-link-modal-panel',
+    });
+  }
 
   // Outputs
   logout = output<void>();

--- a/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
@@ -1,0 +1,100 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { MarkdownComponent } from 'ngx-markdown';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+
+export interface UserMenuLinkModalData {
+  label: string;
+  bodyMarkdown: string;
+}
+
+/**
+ * Generic rich-text modal opened from admin-managed user-menu links.
+ * Renders markdown via ngx-markdown (same renderer used for assistant
+ * messages, so heading/list/link styling is consistent).
+ */
+@Component({
+  selector: 'app-user-menu-link-modal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MarkdownComponent, NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onClose()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+      aria-hidden="true"
+      (click)="onClose()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative w-full transform overflow-hidden rounded-lg bg-white text-left shadow-xl sm:my-8 sm:max-w-2xl dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="titleId"
+      >
+        <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <h3 [id]="titleId" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+            {{ data.label }}
+          </h3>
+          <button
+            type="button"
+            (click)="onClose()"
+            class="rounded-md text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-[var(--color-primary)] dark:hover:text-gray-300"
+            aria-label="Close dialog"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="max-h-[70vh] overflow-y-auto px-6 py-5">
+          <div class="prose prose-sm max-w-none dark:prose-invert">
+            <markdown [data]="data.bodyMarkdown" />
+          </div>
+        </div>
+
+        <div class="flex justify-end border-t border-gray-200 px-6 py-3 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onClose()"
+            class="rounded-md bg-white px-3 py-2 text-sm/6 font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.98); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class UserMenuLinkModalComponent {
+  private dialogRef = inject(DialogRef<void>);
+  protected data = inject<UserMenuLinkModalData>(DIALOG_DATA);
+  protected readonly titleId = `user-menu-link-modal-title-${Math.random().toString(36).slice(2, 8)}`;
+
+  protected onClose(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
@@ -92,7 +92,7 @@ export interface UserMenuLinkModalData {
 export class UserMenuLinkModalComponent {
   private dialogRef = inject(DialogRef<void>);
   protected data = inject<UserMenuLinkModalData>(DIALOG_DATA);
-  protected readonly titleId = `user-menu-link-modal-title-${Math.random().toString(36).slice(2, 8)}`;
+  protected readonly titleId = `user-menu-link-modal-title-${crypto.randomUUID()}`;
 
   protected onClose(): void {
     this.dialogRef.close();

--- a/infrastructure/lib/app-api-stack.ts
+++ b/infrastructure/lib/app-api-stack.ts
@@ -314,6 +314,14 @@ export class AppApiStack extends cdk.Stack {
       this,
       `/${config.projectPrefix}/auth/auth-providers-table-arn`
     );
+    const userMenuLinksTableName = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/admin/user-menu-links-table-name`
+    );
+    const userMenuLinksTableArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/${config.projectPrefix}/admin/user-menu-links-table-arn`
+    );
     const authProviderSecretsArn = ssm.StringParameter.valueForStringParameter(
       this,
       `/${config.projectPrefix}/auth/auth-provider-secrets-arn`
@@ -524,6 +532,7 @@ export class AppApiStack extends cdk.Stack {
         DYNAMODB_AUTH_PROVIDERS_TABLE_NAME: authProvidersTableName,
         AUTH_PROVIDER_SECRETS_ARN: authProviderSecretsArn,
         DYNAMODB_USER_SETTINGS_TABLE_NAME: userSettingsTableName,
+        DYNAMODB_USER_MENU_LINKS_TABLE_NAME: userMenuLinksTableName,
         // Cognito configuration (imported from Infrastructure Stack)
         COGNITO_USER_POOL_ID: cognitoUserPoolId,
         COGNITO_APP_CLIENT_ID: cognitoAppClientId,
@@ -1250,6 +1259,22 @@ export class AppApiStack extends cdk.Stack {
         effect: iam.Effect.ALLOW,
         actions: ['secretsmanager:GetSecretValue', 'secretsmanager:PutSecretValue', 'secretsmanager:DescribeSecret'],
         resources: [`${authProviderSecretsArn}*`], // Wildcard for random suffix
+      })
+    );
+
+    // Grant CRUD on the user-menu links table (admin-managed)
+    taskDefinition.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        sid: 'UserMenuLinksTableAccess',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:UpdateItem',
+          'dynamodb:DeleteItem',
+          'dynamodb:Query',
+        ],
+        resources: [userMenuLinksTableArn],
       })
     );
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -1209,6 +1209,35 @@ export class InfrastructureStack extends cdk.Stack {
       tier: ssm.ParameterTier.STANDARD,
     });
 
+    // ============================================================
+    // User Menu Links Table
+    // Admin-managed links rendered in the SPA user menu.
+    // Fixed PK ``USER_MENU_LINKS``, SK ``LINK#<uuid>``.
+    // ============================================================
+    const userMenuLinksTable = new dynamodb.Table(this, "UserMenuLinksTable", {
+      tableName: getResourceName(config, "user-menu-links"),
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
+      removalPolicy: getRemovalPolicy(config),
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    new ssm.StringParameter(this, "UserMenuLinksTableNameParameter", {
+      parameterName: `/${config.projectPrefix}/admin/user-menu-links-table-name`,
+      stringValue: userMenuLinksTable.tableName,
+      description: "User-menu links DynamoDB table name",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, "UserMenuLinksTableArnParameter", {
+      parameterName: `/${config.projectPrefix}/admin/user-menu-links-table-arn`,
+      stringValue: userMenuLinksTable.tableArn,
+      description: "User-menu links DynamoDB table ARN",
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
     // AuthProviders Table - OIDC authentication provider configuration
     const authProvidersTable = new dynamodb.Table(this, "AuthProvidersTable", {
       tableName: getResourceName(config, "auth-providers"),


### PR DESCRIPTION
## Summary

- New admin domain so org admins can curate the links shown in the SPA user menu without code changes
- Each link is either an **external URL** (opens in a new tab) or an **in-app modal** that renders admin-authored Markdown — covers policy pages, feedback forms, and embedded org-specific notices
- Dedicated `UserMenuLinksTable` (single-tenant flat config for now; per-org PK scoping can be added later without changing the SK shape)
- Admin CRUD at `/admin/user-menu-links` (gated by `require_admin`) + public enabled-only read at `/user-menu-links` (cookie-aware `get_current_user_from_session`)
- Admin UI mirrors the `manage-models` pattern: list page + form page with live Markdown preview for the modal body
- User dropdown renders custom links between Settings and Logout — external links use ↗ icon and `rel="noopener noreferrer"`, modal links open a CDK Dialog with `<markdown>` body

## Infrastructure changes

- `InfrastructureStack`: new `UserMenuLinksTable` (PK/SK, pay-per-request, AWS-managed encryption) + SSM params
- `AppApiStack`: imports the table ARN, sets `DYNAMODB_USER_MENU_LINKS_TABLE_NAME` env var, grants CRUD IAM
- **Deploy order**: `InfrastructureStack` → `AppApiStack` so the env var resolves before app-api task restarts

## Tests

- 18 new backend tests in `tests/shared/test_user_menu_links.py` covering Pydantic validation, repository CRUD, DynamoDB round-trip, and service-layer enabled-only filtering
- Existing `tests/architecture/test_import_boundaries.py` still passes (shared module is consumed only by `app_api`, no cross-service leakage)
- Frontend `ng build --configuration=development` is clean (zero warnings)

## Test plan

- [ ] `cd backend && uv run python -m pytest tests/shared/test_user_menu_links.py tests/architecture/ -v` — all green
- [ ] `cd infrastructure && npx cdk diff InfrastructureStack AppApiStack` — review table + IAM diff, then `cdk deploy`
- [ ] After app-api task restarts: sign in as admin → admin dashboard → **User Menu Links** card
- [ ] Create one of each kind (external + modal); verify the modal form's live Markdown preview
- [ ] Open user menu — both items appear between Settings and Logout; external opens new tab; modal opens CDK Dialog (Esc / backdrop closes)
- [ ] Toggle a link's **Visible to users** off — disappears from user menu, still listed in admin with `Disabled` chip
- [ ] Delete a link — disappears from both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)