### PR TITLE
feat(frontend): copy-to-clipboard button on chat code blocks

### DIFF
--- a/frontend/ai.client/angular.json
+++ b/frontend/ai.client/angular.json
@@ -41,6 +41,10 @@
             "scripts": [
               "node_modules/prismjs/prism.js",
               "node_modules/prismjs/components/prism-csharp.min.js",
+              "node_modules/prismjs/components/prism-javascript.min.js",
+              "node_modules/prismjs/components/prism-typescript.min.js",
+              "node_modules/prismjs/components/prism-python.min.js",
+              "node_modules/prismjs/components/prism-sql.min.js",
               "node_modules/prismjs/components/prism-css.min.js",
               "node_modules/mermaid/dist/mermaid.min.js",
               "node_modules/katex/dist/katex.min.js",

--- a/frontend/ai.client/src/app/session/components/message-list/components/code-block-clipboard-button.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/code-block-clipboard-button.component.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroSquare2Stack, heroCheck } from '@ng-icons/heroicons/outline';
+import { TooltipDirective } from '../../../../components/tooltip';
+
+/**
+ * Custom button rendered by ngx-markdown for the copy-to-clipboard toolbar
+ * that wraps each `<pre>` code block. ngx-markdown attaches ClipboardJS to
+ * the rendered button's root node — this component only owns the visual
+ * "Copied" feedback state.
+ */
+@Component({
+  selector: 'app-code-block-clipboard-button',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [provideIcons({ heroSquare2Stack, heroCheck })],
+  template: `
+    <button
+      type="button"
+      class="inline-flex items-center justify-center rounded-md bg-gray-100/80 p-1.5 text-gray-500 backdrop-blur-sm transition-colors hover:bg-gray-200 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-gray-800/80 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+      [appTooltip]="copied() ? 'Copied' : 'Copy code'"
+      appTooltipPosition="top"
+      [attr.aria-label]="copied() ? 'Copied to clipboard' : 'Copy code'"
+      (click)="onClick()"
+    >
+      @if (copied()) {
+        <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+      } @else {
+        <ng-icon name="heroSquare2Stack" class="size-4" aria-hidden="true" />
+      }
+    </button>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+  `,
+})
+export class CodeBlockClipboardButtonComponent implements OnDestroy {
+  protected copied = signal(false);
+  private resetTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  protected onClick(): void {
+    this.copied.set(true);
+    if (this.resetTimeout) {
+      clearTimeout(this.resetTimeout);
+    }
+    this.resetTimeout = setTimeout(() => {
+      this.copied.set(false);
+      this.resetTimeout = null;
+    }, 2000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.resetTimeout) {
+      clearTimeout(this.resetTimeout);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/streaming-text.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/streaming-text.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { MarkdownComponent } from 'ngx-markdown';
+import { CodeBlockClipboardButtonComponent } from './code-block-clipboard-button.component';
 
 /**
  * StreamingTextComponent provides smooth character-by-character typing animation
@@ -27,7 +28,8 @@ import { MarkdownComponent } from 'ngx-markdown';
   template: `
     <markdown
       class="min-w-0 max-w-full overflow-hidden"
-      clipboard
+      [clipboard]="!isStreaming()"
+      [clipboardButtonComponent]="ClipboardButton"
       mermaid
       katex
       [data]="displayedText()"
@@ -42,6 +44,8 @@ import { MarkdownComponent } from 'ngx-markdown';
 export class StreamingTextComponent implements OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private isBrowser = isPlatformBrowser(this.platformId);
+
+  protected readonly ClipboardButton = CodeBlockClipboardButtonComponent;
 
   /** The full text content to display */
   text = input.required<string>();


### PR DESCRIPTION
## Summary

- Wires a custom, app-styled copy button into ngx-markdown's clipboard directive on the chat streaming-text component. Previously the `clipboard` attribute was already on the `<markdown>` tag, but it fell back to the library's default unstyled `<button>Copy</button>` and was effectively invisible.
- Gates clipboard processing on `!isStreaming()` so the directive doesn't re-wrap every `<pre>` element on each character batch during the typing animation.
- Adds Prism language bundles for JavaScript, TypeScript, Python, and SQL so code blocks in those languages get syntax-highlighted (separate commit).

## What changed

**New component** — `code-block-clipboard-button.component.ts`
- Standalone, OnPush, uses the same `heroSquare2Stack` / `heroCheck` icons as the existing message-level copy button in `message-actions.component.ts`.
- ngx-markdown's clipboard directive attaches ClipboardJS to the rendered button's root node automatically; this component only owns the "copied" visual-feedback state (2s timeout).
- Tooltip via the project's `TooltipDirective` (`"Copy code"` → `"Copied"`), `aria-label` mirrors it for screen readers, focus-visible ring, dark-mode variants.

**Updated** — `streaming-text.component.ts`
- `clipboard` → `[clipboard]="!isStreaming()"` to skip clipboard wrapping during the character-by-character animation.
- `[clipboardButtonComponent]="ClipboardButton"` wires in the custom button.

**Updated** — `angular.json`
- Adds `prism-javascript`, `prism-typescript`, `prism-python`, `prism-sql` minified bundles alongside the existing csharp/css ones.

## Why

The clipboard directive was technically enabled but the default button was unstyled (plain text in a default browser button at the top-right of every `<pre>`), so users couldn't reliably see or use it. The custom button matches the rest of the chat UI and only renders once a code block has fully streamed in, avoiding wasted re-wrapping work during animation.

## Reviewer notes

- ngx-markdown handles the actual copy via ClipboardJS (already loaded via `angular.json` scripts). The button's click handler only toggles visual state — no clipboard API call from our code.
- The existing message-level copy button (in `message-actions.component.ts`, copies the whole assistant message as rich + plain text) is unchanged. The new button copies only the contents of an individual `<pre>` block.
- Verified: `tsc --noEmit -p tsconfig.app.json` passes; `ng serve` builds cleanly.

## Test plan

- [ ] Open a chat session and ask for a response with a fenced code block (e.g. "show me a Python hello world").
- [ ] **During streaming:** code blocks render normally; **no** copy button while text is animating in.
- [ ] **After streaming completes:** copy icon (two stacked squares) appears top-right of each `<pre>` with a translucent backdrop-blur background.
- [ ] Hover the button: background darkens; tooltip "Copy code" appears above it.
- [ ] Click it: icon swaps to checkmark for ~2s, tooltip switches to "Copied", paste somewhere — should be the code block's text only.
- [ ] Tab to focus the button: blue focus ring appears.
- [ ] Repeat in dark mode: button readable against gray-800 code background.
- [ ] Existing message-level copy button (bottom of each assistant message) still works unchanged.
- [ ] Multi-language code blocks (JS, TS, Python, SQL) are syntax-highlighted via Prism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)