### PR TITLE
feat(sidebar): denser session list with skeleton and entry animation

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.css
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.css
@@ -17,3 +17,25 @@
     transform: scale(1);
   }
 }
+
+/* Loaded-state entry animation */
+.session-list-enter {
+  animation: session-list-enter 280ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes session-list-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-list-enter {
+    animation: none;
+  }
+}

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
@@ -1,24 +1,39 @@
 <nav class="flex h-full flex-col">
     @if (isLoading()) {
-        <div class="flex items-center justify-center py-8">
-            <span class="text-sm text-gray-500 dark:text-gray-400">Loading sessions...</span>
+        <!-- Loading skeleton: mirrors the real list's group + row layout -->
+        <div class="flex flex-col gap-y-3" aria-hidden="true">
+            @for (group of skeletonGroups; track $index) {
+                <section>
+                    <div class="px-2 pb-0.5">
+                        <div class="h-3 w-12 rounded-sm bg-gray-200 animate-pulse motion-reduce:animate-none dark:bg-white/5"></div>
+                    </div>
+                    <ul role="list" class="flex flex-col gap-y-0.5">
+                        @for (width of group; track $index) {
+                            <li class="px-2 py-1.5">
+                                <div class="h-4 rounded-md bg-gray-200 animate-pulse motion-reduce:animate-none dark:bg-white/5" [style.width]="width"></div>
+                            </li>
+                        }
+                    </ul>
+                </section>
+            }
         </div>
+        <span class="sr-only" role="status">Loading sessions</span>
     } @else if (error()) {
         <div class="flex items-center justify-center py-8">
             <span class="text-sm text-red-500 dark:text-red-400">Failed to load sessions</span>
         </div>
     } @else {
         @if (groupedSessions().length > 0) {
-            <div class="flex flex-col gap-y-4">
+            <div class="session-list-enter flex flex-col gap-y-3">
                 @for (group of groupedSessions(); track group.label) {
                     <section>
-                        <h3 class="px-2 pb-1 text-[11px]/5 font-medium text-gray-400 dark:text-gray-500">{{ group.label }}</h3>
-                        <ul role="list" class="flex flex-col gap-y-1">
+                        <h3 class="px-2 pb-0.5 text-[11px]/5 font-medium text-gray-400 dark:text-gray-500">{{ group.label }}</h3>
+                        <ul role="list" class="flex flex-col gap-y-0.5">
                             @for (session of group.sessions; track session.sessionId) {
                                 <li class="group relative">
                                     @if (renamingSessionId() === session.sessionId) {
                                         <!-- Inline rename input -->
-                                        <div class="flex items-center gap-1 rounded-md px-2 py-1.5">
+                                        <div class="flex items-center gap-1 rounded-md px-2 py-1">
                                             <input
                                                 #renameInput
                                                 type="text"
@@ -26,7 +41,7 @@
                                                 (input)="renameValue.set(renameInput.value)"
                                                 (keydown)="onRenameKeydown($event, session)"
                                                 (blur)="onRenameSubmit(session)"
-                                                class="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-sm/6 font-medium text-gray-900 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-primary-400 dark:focus:ring-primary-400"
+                                                class="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-sm/5 font-medium text-gray-900 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-primary-400 dark:focus:ring-primary-400"
                                                 aria-label="Rename conversation"
                                             />
                                         </div>
@@ -34,15 +49,11 @@
                                         <a
                                             [routerLink]="['/s', getSessionId(session.sessionId)]"
                                             [queryParams]="getSessionQueryParams(session)"
-                                            routerLinkActive="bg-gray-200 !text-secondary-500 dark:bg-white/5 dark:!text-white"
+                                            routerLinkActive="bg-gray-200 !font-medium !text-secondary-500 dark:bg-white/5 dark:!text-white"
                                             (click)="onSessionClick()"
-                                            class="flex gap-x-3 rounded-md px-2 py-2 pr-10 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 hover:text-secondary-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+                                            class="block truncate rounded-md px-2 py-1.5 pr-10 text-sm/5 font-normal text-gray-700 hover:bg-gray-50 hover:text-secondary-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
                                         >
-                                            <div class="flex min-w-0 flex-1 flex-col gap-y-1">
-                                                <div class="min-w-0 flex-auto truncate">
-                                                    <span>{{ getSessionTitle(session) }}</span>
-                                                </div>
-                                            </div>
+                                            {{ getSessionTitle(session) }}
                                         </a>
                                         <!-- Ellipsis menu button - visible on hover with fade-in animation -->
                                         <button

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -50,6 +50,16 @@ export class SessionList {
   protected renameValue = signal('');
 
   /**
+   * Placeholder row widths used by the loading skeleton.
+   * Each inner array is a "group" (e.g. Today, Yesterday) and each string
+   * is the width of one row, varied to mimic real session-title lengths.
+   */
+  protected readonly skeletonGroups: readonly (readonly string[])[] = [
+    ['78%', '52%', '64%'],
+    ['70%', '58%'],
+  ];
+
+  /**
    * Reactive resource for fetching sessions (base API data).
    */
   readonly sessionsResource = this.sessionService.sessionsResource;


### PR DESCRIPTION
## Summary

- **Denser rows** — session list items go from ~40px to ~32px tall (`py-2` → `py-1.5`, `text-sm/6` → `text-sm/5`); group gaps tighten too. ~25% shorter list overall.
- **Lighter weight** — inactive items drop to `font-normal`; the active row picks up `!font-medium` via `routerLinkActive` so it still anchors visually. Matches the idiom of modern sidebars (ChatGPT, Linear, Notion).
- **Better loading skeleton** — replaces the "Loading sessions..." text with a shimmer skeleton mirroring the real layout (group label placeholder + varied-width row placeholders, `animate-pulse`).
- **Entry animation** — when the loaded branch first mounts, the list does a single 280ms fade + 4px slide-up. Honors `prefers-reduced-motion`.

## What changed

**`session-list.html`**
- Loading branch: replaced single centered label with skeleton (2 groups: 3 + 2 rows). Visually `aria-hidden`; an `sr-only role="status"` element carries the loading message for assistive tech.
- Loaded branch: outer container picks up `session-list-enter` class for the entry animation.
- Each session link: `flex gap-x-3 ... py-2 ... text-sm/6 font-medium` + two nested flex wrappers → `block truncate ... py-1.5 ... text-sm/5 font-normal`. Single-line title sits directly on the `<a>`.
- Active state: added `!font-medium` to `routerLinkActive` (matches the existing `!text-secondary-500` override pattern).
- Group spacing: `gap-y-4` → `gap-y-3`, header `pb-1` → `pb-0.5`, row gap `gap-y-1` → `gap-y-0.5`.

**`session-list.css`**
- New `@keyframes session-list-enter` (opacity 0→1, `translateY(4px)` → 0).
- `.session-list-enter { animation: session-list-enter 280ms cubic-bezier(0.16, 1, 0.3, 1); }`
- `@media (prefers-reduced-motion: reduce) { .session-list-enter { animation: none; } }`

**`session-list.ts`**
- New readonly `skeletonGroups: readonly (readonly string[])[]` — placeholder row widths, varied (78% / 52% / 64% / 70% / 58%) so the skeleton doesn't look like a perfect grid.

## Test plan

- [ ] Open the app. Session list rows are noticeably tighter than before. Single-line titles truncate with ellipsis as expected.
- [ ] Active session row: title is bolder than the others; bg tint is present; color shifts to secondary.
- [ ] Hover state on inactive rows: bg tint appears; ellipsis menu button fades in.
- [ ] Throttle network (Slow 3G) + hard refresh → skeleton renders with shimmer in both light and dark mode. Rows have varied widths; group label placeholder above each batch.
- [ ] When sessions load, the list fades + slides up subtly (280ms). Adding/renaming/deleting a session afterward does **not** re-trigger the animation.
- [ ] Enable "Reduce motion" in OS preferences → both the shimmer and the entry animation are stilled.
- [ ] Screen reader announces "Loading sessions" while loading (via `sr-only role="status"`); does not read the skeleton shapes.
- [ ] `npx tsc --noEmit -p tsconfig.app.json` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)