### PR TITLE
chore(kaizen): weekly research scan 2026-05-15

### DIFF
--- a/docs/kaizen/research/2026-05-15.md
+++ b/docs/kaizen/research/2026-05-15.md
@@ -1,0 +1,253 @@
+# Kaizen Research — Friday, May 15, 2026
+> Scan window: May 8 – May 15, 2026 (7 days).
+> Web budget: ~46/50 used (target). Modest overshoot only on the frontier-models sub-budget (OpenAI 403 backfilled via search).
+> First regular run after the 2026-05-10 bootstrap.
+
+## TL;DR
+
+Quiet external week with two outsized upstream events: **Strands v1.40.0 shipped (proactive context compression PR #2239 landed)** and carries a **breaking default flip** (`use_native_token_count` true → false) that affects our token accounting; and **`bedrock-agentcore` is now 4 releases behind** (1.6.4 → 1.9.1, latest May 12) with PR #478 in flight that directly resolves last week's flagged issue #452 (AgentCoreMemorySessionManager event-loop blocking). Internally the BFF parade settled into the beta.25 + beta.26 release pair, but **#293 disabled Dependabot version-update PRs on May 13** — the kaizen loop is now the *only* mechanism catching version-pin lag. **Recommended #1**: re-prioritize the `bedrock-agentcore` bump from last week's queue — it's stale and the lag is widening.
+
+## External Scan
+
+### What's moving this week
+
+Two ecosystem currents converged. **First, the upstream-shrinks-our-backlog pattern continued** but with a wrinkle: Strands v1.40 (May 14) lands the proactive context compression we'd noted as PR #2239, but it also flips `use_native_token_count` from `true` to `false` per PR #2284 — a silent latency regression fix for multimodal, but a behavior change for anyone reading Bedrock-native input-token counts. We'd need to audit our token-metric reads (recall last week's #270 bugfix touched per-message-cost + context-% semantics) before promoting. **Second, the MCP "stateless" track keeps consolidating**: SEP-2575 merged May 11 paired with SEP-2567 from last week's window — together they remove `Mcp-Session-Id` and the mandatory `initialize` handshake. Python `mcp` SDK 1.27.1 is patch-only and doesn't adopt either yet, so the watch-and-wait posture from last week stands.
+
+The reference repo (`aws-samples/sample-strands-agent-with-agentcore`) had 12 commits in window. The architecturally interesting cluster is around a Progressive-Disclosure "skill_executor" SSE wire-name unwrap (which doesn't map to us — we don't have a wrapper-tool layer) and two defensive fixes that *do* generalize: (a) `tool_use` SSE was being emitted twice per call (empty-args then populated-args), and (b) A2A AgentCard needed an explicit `capabilities={"streaming": True}` or the SDK silently fell back to non-streaming → 40-minute timeouts. Both are 30-second checks for us with non-trivial silent-failure modes.
+
+AgentCore SDK shipped **1.9.1 (May 12)** with a runtime parse-error fix and an entrypoint registration fix; **PR #478** adds the long-requested `async_mode` to `MemorySessionManager` — the fix for issue #452 we flagged HIGH last week. Likely lands in 1.10.0. Anthropic shipped the **`/goal` command + per-tool `duration_ms` on PostToolUse hooks** in Claude Code 2.1.139/141 — both directly inspire pieces of work we already have on deck (the planned context-attribution prototype + a long-arc-objective UX). Frontier-model side was quiet: only OpenAI's GPT-5.2/5.3 snapshot deprecation notice (no Anthropic / Google / Meta model releases). Agentic UI/UX was a lean week — only Linear Code Intelligence (validating the named-participant pattern with a 5× growth datapoint) and Cursor's pre-run elicitation wizard (informs MCP elicitation UX whenever we tackle it). HN and Reddit yielded nothing in window; Reddit `.rss` confirmed blocked at the domain level via WebFetch, not just the HTML path.
+
+### Notable items by source
+
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens. What construct/file does this affect? What does it replace, simplify, or obsolete?
+> - `*unlocks*:` — capability-unlock lens (where applicable). What net-new capability or enhancement does this make possible?
+
+#### AWS Bedrock / AgentCore
+- **AgentCore Browser + Code Interpreter — Chrome enterprise policies + custom root CA certificates** — `BrowserClient.create_browser(enterprise_policies=...)` and `CodeInterpreter.create_code_interpreter(certificates=[Certificate.from_secret_arn(...)])` for governed/corporate-proxy scenarios. — https://aws.amazon.com/blogs/machine-learning/control-where-your-ai-agents-can-browse-with-chrome-enterprise-policies-on-amazon-bedrock-agentcore/ — *relevance*: informational; we don't use AgentCore Browser or Code Interpreter primitives today (tool layer is direct-call + AWS-SDK + Gateway-MCP + A2A) — *unlocks*: domain-restricted browser agents (e.g. `*.boisestate.edu`) and code-exec tools that reach internal HTTPS endpoints behind a corporate CA without disabling cert verification — parking-lot for whenever we add a browsing or sandboxed-exec tool
+- **Bedrock advanced prompt optimizer + migration tool** — console feature that refines a prompt across multiple models and shows comparative perf + cost. — https://aws.amazon.com/about-aws/whats-new/2026/05/amazon-bedrock-advanced-prompt-optimization-migration-tool/ — *relevance*: informational; we author agent prompts in `backend/src/agents/main_agent/` (version-controlled), not Bedrock console. Could be a one-off tuning aid for the main-agent system prompt against a candidate model swap. No code impact.
+- **Real-time voice agents with Stream Vision Agents + Nova 2 Sonic** — integration walkthrough for Nova 2 Sonic on Bedrock. — https://aws.amazon.com/blogs/machine-learning/real-time-voice-agents-with-stream-vision-agents-and-amazon-nova-2-sonic/ — *relevance*: informational; we already have a voice mode (`apis/app_api/voice/` with voice-ticket cookie auth). Useful comp point if we ever evaluate Nova 2 Sonic.
+- **No AgentCore platform-level GA/preview announcements this week.** No movement on BYO filesystem, Memory metadata, Identity-on-ECS, or Payments (all flagged last week as new). Quietest AgentCore week in recent memory.
+
+#### Strands Agents
+- **v1.40.0 released 2026-05-14** — *applicability*: HIGH — touches `backend/src/agents/main_agent/` agent setup and our custom `TurnBasedSessionManager`. — https://github.com/strands-agents/sdk-python/releases/tag/v1.40.0
+  - Proactive context compression (PR #2239) landed — adjacent to our compaction-surfacing SSE path (`compaction` event). Verify it doesn't double-fire with our existing flush.
+  - Bedrock `count_tokens` AccessDenied caching (PR #2279).
+  - Swarm OTel context-detach fix (PR #2281) — same family as bedrock-agentcore SDK issue #456 we flagged last week.
+- **BREAKING — `use_native_token_count` default flipped to `false` (PR #2284, in v1.40.0)** — fixes #2277 silent-latency regression for image/multimodal workloads; previous default added a per-turn Bedrock `count_tokens` call. — *applicability*: HIGH — if we read native input-token counts anywhere in `apis/shared/` token metrics or compaction triggers, we now get heuristic counts unless we explicitly set `BedrockModel(use_native_token_count=True)`. Audit before bumping. — https://github.com/strands-agents/sdk-python/pull/2284 — *closes our issues?* no, but interacts with last week's #270 per-message-cost fix.
+- **Issue #2266 still open** — `BedrockModel.stream` cancel leak ("Task exception was never retrieved"); last updated 2026-05-09, no PR linked yet. — *applicability*: MEDIUM-HIGH (this is the same item we already queued as last week's #4 audit). — https://github.com/strands-agents/sdk-python/issues/2266
+- **PR #2290 — MCP progress notifications in MCPClient (open, updated 2026-05-14)** — adds `notifications/progress` to `MCPClient`. — *applicability*: MEDIUM — once merged, long-running MCP tools (Gateway-SigV4 + external OAuth servers) can stream progress to the user; would slot into our SSE event stream as a new event type. — *unlocks*: long-running-tool progress UX, e.g. for spreadsheet-analysis or future browsing tools. — https://github.com/strands-agents/sdk-python/pull/2290
+- **Issue #2286 — Strands SDK repos consolidating into a monorepo** — maintainer announcement opened 2026-05-12. — *applicability*: LOW today, HIGH later — import paths may move in a future major; pin and watch for v2.x messaging. — https://github.com/strands-agents/sdk-python/issues/2286
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **fix(a2a): enable streaming capability on AgentCard** (`50c9112`) — one-line fix: `capabilities={"streaming": True}` on the A2A AgentCard. Without it, the A2A SDK client silently falls back to non-streaming and never receives the completed event → ~40-minute timeouts. — *applicability*: HIGH if we have any A2A AgentCard config. **Defensive 30-second check on our A2A construct(s)** (likely `backend/src/agents/` or infra). Failure mode is silent — exactly the kind of bug we don't want to discover in prod. — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/50c9112cbc83a4517462d9e77d73e2239b22a004
+- **refactor(sse): emit TOOL_CALL_START once per tool_use, after unwrap** (`d668685`) — they discovered Strands' tool-use processor was firing `_format_tool_use` twice per call (registration with empty input, then again with populated args). They gated START until the populated call. — *applicability*: MEDIUM — quick audit of our SSE `tool_use` emission. If we emit twice (empty + populated), the frontend tool chip may flicker or render an "unknown args" intermediate state. — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/d668685ddfd2e6164093ca2cca0e91852ad19876
+- **fix(skill): filter disabled skills out of the L1 catalog** (`a0753dc`) — generalizes to: *if a tool is filtered at execution, it must also be filtered out of any catalog/listing that gets injected into the system prompt*. Otherwise the model hallucinates availability. — *applicability*: MEDIUM — our system-prompt tool list should derive from the same post-RBAC filtered set the executor uses. Quick consistency check. — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/a0753dca5ade0e613f44608c3824e002dc02bc03
+- **test(e2e): add L4 protocol-path integration suite** (`8d111d9`) — 13 protocol paths (local/builtin/gateway/a2a/skill/memory) tested via deployed BFF with event-based SSE assertions. — *applicability*: MEDIUM — we have unit + architecture tests but limited deployed-BFF e2e of the multi-protocol matrix. Event-based assertions sidestep LLM flakiness. — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commit/8d111d9bb79b7b1d88cc03cfb223ef23e037a32e
+
+#### MCP ecosystem
+- **SEP-2575 "Make MCP Stateless" merged 2026-05-11** — companion to SEP-2567 (sessionless transport, last week). Removes the mandatory `initialize` handshake; replaces with per-request `MCP-Protocol-Version` header + `_meta` capability bits, a new optional `server/discover` RPC, and `messages/listen` for client-initiated streaming. — *implications*: directly affects our Lambda+Gateway servers. Combined with SEP-2567 this formalizes the "stateless wire protocol" direction. **No action yet** — wait for python `mcp` SDK adoption. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
+- **python-sdk v1.27.1 released 2026-05-08 — NO SEP-2567/2575 adoption** — patch release only (pydantic 2.13 compat, OAuth client-metadata coercion, `httpx<1.0.0` pin, SSEError import refactor). — *implications*: safe transitive bump from 1.27.0; the `httpx<1.0.0` pin is worth noting if anything in `backend/pyproject.toml` is reaching toward httpx 1.x. — https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.27.1
+- **awslabs/mcp PR #3491 — auth-conflict detection + structured recovery (merged May 13)** — multi-tenant OAuth/MCP pattern. — *implications*: worth reading before our next Gateway-SigV4/OAuth bridging round in `backend/src/apis/shared/oauth/agentcore_identity.py` — same problem space (token vault + multiple identities). Reference pattern, not a blocker. — https://github.com/awslabs/mcp/pull/3491
+- **SEP-2577 "Deprecate Roots, Sampling, and Logging" still open** (active May 13) — signal the spec is consolidating around tools+prompts+resources only. — *implications*: informational; our Lambda servers don't implement those client-side features. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577
+
+#### FastMCP
+- **v3.3.0 "Slim Reaper" released 2026-05-15** — headline: `fastmcp-slim`, a client-only distribution that drops Starlette/Uvicorn for installs that only consume MCP. Import namespace unchanged. — https://github.com/PrefectHQ/fastmcp/releases/tag/v3.3.0 — *implications for our MCP servers*: **informational, not breaking**. Our externally-hosted MCP servers are servers, so they stay on the full `fastmcp`. But anything in `apis.shared` that acts as a *client*, or future scripts/agents that just consume MCP, could shrink their install footprint by switching to `fastmcp-slim[client]`. No API changes.
+- **No transport / SEP-2567 / Lambda-adapter changes this week.** Active PRs are server hardening (docstring caching #4136, proactive token refresh #4142, event-store eviction crash #4144, cancelled-tool-call forwarding #4145) — nothing protocol-level. — https://github.com/PrefectHQ/fastmcp/pulls
+- **Latest FastMCP pin moved 3.2.4 → 3.3.0.** Update the kaizen tracker.
+
+#### Agentic UI/UX patterns
+- **Linear Agent — Code Intelligence (May 14)** — Linear Agent can now read codebases and answer technical questions; invoked via `@Linear` mention. **Usage jumped ~5× Feb→May (1,055 → ~5,200 queries/mo)** — strong validation of the named-participant pattern flagged last week. — https://linear.app/now/code-intelligence-for-linear-agent — *what it is*: agent-as-mention pattern, addressable by `@`, scoped to a thread, inline answers. — *fit*: pattern-only (Angular equivalent: render assistant turns with a distinct avatar + handle; support `@mention` addressing when multi-agent lands). — *where it'd land*: `chat-message` component (agent identity slot + mention-token renderer); no SSE change needed yet. **Strengthens the existing queue item for named A2A participants.**
+- **Cursor — Cloud Agent Development Environments (May 12)** — pre-run setup wizard where the agent gathers config/secrets via structured prompts before any task runs. — https://www.cursor.com/blog/cloud-agent-development-environments — *what it is*: productized elicitation flow, distinct from in-conversation tool consent. — *fit*: pattern-only; closest MCP analog is SEP-elicitation. Bookmark for whenever we tackle MCP elicitation UX. Not on the near-term roadmap.
+- **assistant-ui 0.14.2 (May 13)** — CI plumbing only (disable OIDC pre-flight verification). The substantive 0.14.0 release fell May 7 (one day outside window). — *fit*: not applicable this week; watch for an `mcp-app-studio` follow-up.
+- **blog.modelcontextprotocol.io — quiet (no new posts in window).** Last MCP-blog post was April 8.
+- **NN/Group AI topic URL 404'd** — try `/articles/?topic=ai` or a search path next week.
+
+#### Frontier model announcements
+- **OpenAI — deprecation notice for `gpt-5.2-chat-latest` and `gpt-5.3-chat-latest` snapshots (May 8)** — pairs with last week's GPT-5.5 Instant displacing 5.3 flag. — https://community.openai.com/t/deprecation-notice-upcoming-model-shutdowns-in-2026/1379553 — *relevance*: informational (we don't ship OpenAI in the selector); useful as a comp pattern for our own model-lifecycle UX in the model-selector. — *risk*: low; only material if we proxy OpenAI.
+- **OpenAI — Realtime API Beta removed (May 12)**, **DALL·E 2/3 snapshots removed (May 12)** — informational; no impact on `backend/src/apis/app_api/voice/` (own ticket flow) or any of our image paths.
+- **Anthropic — Claude for Small Business (May 13)** — packaging/connectors announcement; QuickBooks, PayPal, HubSpot, Canva, DocuSign, Google Workspace, Microsoft 365. — https://www.anthropic.com/news/claude-for-small-business — *relevance*: informational; foreshadows which integrations Anthropic considers "table stakes." Hints at first-party MCP tools we might otherwise build.
+- **Anthropic — $200M Gates Foundation partnership (May 14)** — non-technical; no capability deltas. — https://www.anthropic.com/news/gates-foundation-partnership
+- **Google DeepMind + Meta — quiet (two weeks running).** No Gemini or Llama posts in window. Frontier signal is now coming exclusively from Anthropic + OpenAI.
+
+#### Agent harness patterns
+- **Claude Code 2.1.139 — `/goal` command + persistent agent view** — sets a turn-spanning completion condition with live overlay (elapsed time / turns / tokens). Hooks declared in agent frontmatter fire when that agent runs as the main thread via `--agent`. — *applicability*: HIGH — maps cleanly onto our SSE pipeline (we already stream `metadata` tokens and emit `compaction`). *Inspires*: a `goal` SSE event + sidebar overlay showing user-declared objective + turn count + token-budget burn-down, particularly useful for long agentic threads. — https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- **Claude Code 2.1.141 — `duration_ms` on PostToolUse hooks** — per-tool wall-clock cost without instrumenting each tool. — *applicability*: HIGH — Strands has a hook system we already lean on (planned context-attribution prototype is hook-based per our memory). *Inspires*: emit per-tool `duration_ms` in our `tool_result` SSE payload + a faint inline timing badge on tool blocks. Feeds the planned context-attribution work by separating tool latency from token cost.
+- **Claude Code 2.1.142 — `MCP_TOOL_TIMEOUT` per-request override** — removes the hardcoded 60s ceiling on remote MCP. — *applicability*: MEDIUM — our Gateway-MCP path has the 15-min Lambda cap as the real ceiling, but our app_api → inference_api SSE has its own 600s timeout. *Inspires*: per-MCP-target timeout in our Gateway target registry (today one global) + surfacing remaining-time in the `tool_use` event so the UI can show a progress hint on slow MCP calls.
+- **Anthropic engineering blog — no posts in window.**
+
+#### Pricing / quota
+- **AgentCore Payments launch (May 11)** — preview only; AWS charges $0 for the service, wallet-provider passes through (Coinbase CDP ~$0.005/wallet op). — *impact*: none on inference_api model selection or cost-badge values today; relevant only if we wire an agent to autonomously pay for external APIs/MCP servers. — https://aws.amazon.com/blogs/aws/aws-weekly-roundup-amazon-bedrock-agentcore-payments-agent-toolkit-for-aws-and-more-may-11-2026/
+- **AgentCore base pricing unchanged.** Runtime/Browser/Code-Interpreter still $0.0895/vCPU-hr + $0.00945/GB-hr; Memory $0.25/1K events; Identity $0.010/1K token requests (free via Runtime/Gateway); Gateway $0.005/1K invocations.
+- **Bedrock model pricing page** — WebFetch extraction returned only Claude 3.5 entries (same limitation as last week). No model-pricing announcements detected. Worth a manual eyeball or direct curl next week. — https://aws.amazon.com/bedrock/pricing/
+
+#### Open AgentCore SDK issues affecting us
+- **PR #478 — feat: add async support to MemorySessionManager** — opt-in `async_mode: bool` on `AgentCoreMemoryConfig`; when true, wraps sync methods in `asyncio.to_thread()`. **Directly resolves last week's #452**. Likely lands in 1.10.0. — https://github.com/aws/bedrock-agentcore-sdk-python/pull/478 — *applicability*: HIGH
+- **Issue #471 — docs: `/ping` response requires undocumented `time_of_last_update` field** — without that field, AgentCore's idle reaper kills microVMs even while `/ping` returns `HealthyBusy`; AWS docs only show `{"status": "HealthyBusy"}`. — *applicability*: HIGH — we run long-running streaming responses on the inference-api runtime. If our `/ping` doesn't emit `time_of_last_update`, we may be experiencing silent microVM reaping on long generations. **Grep our ping handler today.** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/471
+- **Issue #468 — BedrockAgentCoreApp SDK needs update for expanded Request Header Allowlist** — AgentCore CP now allows arbitrary HTTP headers; SDK doesn't yet surface them to the handler. — *applicability*: MEDIUM — unlocks passing trace IDs / tenant hints from BFF/app-api into inference-api without the `X-Amzn-...-Custom-` prefix dance. Not blocking. — https://github.com/aws/bedrock-agentcore-sdk-python/issues/468
+- **Issue #467 — Multi-agent (Graph) session support missing from AgentCoreMemorySessionManager** — `create_multi_agent` / `read_multi_agent` / `update_multi_agent` on Strands `SessionRepository` aren't implemented; Strands `Graph`-based flows fail at graph creation when paired with AgentCore Memory. — *applicability*: LOW-MEDIUM today (single-agent), HIGH if/when we adopt Strands Graph for sub-agent decomposition. — https://github.com/aws/bedrock-agentcore-sdk-python/issues/467
+
+#### Cookbook / courses
+- **Linear ↔ Managed Agents stateless webhook bridge** (May 13, `9644291`) — TS/Bun template: no held SSE, no session-map DB. `session.metadata` carries `linear_session_id` + `org_id`; uses `beta.webhooks.unwrap` with retrieve-then-filter and 10s ack. — https://github.com/anthropics/claude-cookbooks/commit/96442914bfee9842faa97b1d45ee7b43317f7391 — *what we'd borrow*: the stateless-bridge pattern is the cleanest pattern we've seen for wrapping streaming backends behind webhook-style async callers. Worth comparing to how `apis.shared` correlates async tool callbacks today. *Inspires*: stash external correlation IDs in `session.metadata` instead of a session-map table; future Slack/Teams entry points slot in cheaply.
+- **CMA Sessions API as an MCP server (stdio + HTTP)** (May 13, `a090206`) — thin MCP wrapper with two entrypoints: `server.ts` for Claude Desktop stdio, `server-http.ts` for Streamable HTTP + bearer auth (claude.ai Connectors). `wait_for_idle` is an SSE→request/response shim. Authoring/destructive endpoints deliberately omitted. — *what we'd borrow*: the `wait_for_idle` SSE-to-request/response shim is a clean template for wrapping streaming backends as MCP tools — relevant if we ever expose our Strands agent loop as an MCP tool another agent can call. Also: deliberate-omission stance (no authoring/secrets) is a good template for our admin-endpoint MCP boundaries.
+- **Registry: "Claude Managed Agents" category** (May 13, `c8b30f3`) — schema addition + retag of managed_agents notebooks under a new top-level category. — *takeaway*: Anthropic is consolidating CMA as a first-class product surface. Strategic data point on whether to keep building bridges *to* CMA vs. treat it as a peer to Bedrock AgentCore.
+
+#### Community + GitHub issues
+- **HN Algolia (May 8–15) — 0 in-window hits** for `bedrock`, `agentcore`, `strands`, `mcp`, `claude code`. Index is functioning — `agentcore` returns 1,490 lifetime results, with the most recent (Payments) at May 7, one day before window. Quiet week confirmed.
+- **Reddit `.rss` blocked at the domain level via WebFetch** (not just the HTML path). Last week's open queue item to "add Reddit `.rss`" is **infeasible via WebFetch** — needs a different transport (`curl` with UA header via Bash, or an RSS-fetching MCP). Recommend closing the queue item as infeasible.
+
+#### Seasonal
+- Out of window — no re:Invent / NeurIPS / ICLR / EMNLP items.
+
+### Patterns worth considering
+
+- **Per-tool timing as a first-class hook output** (Claude Code 2.1.141) — directly enables our planned context-attribution prototype to separate tool latency from token cost. Cheap, mechanical, signal-rich.
+- **`session.metadata` correlation-id pattern** (Linear↔CMA cookbook) — replaces dedicated session-map tables with a JSON blob the external system writes. Lifts a future infra ask (Slack/Teams entry points → schema work) to a zero-table approach.
+- **Stateless MCP transport** (SEP-2567 + SEP-2575) — direct fit for our SigV4 Gateway model. Watch python `mcp` SDK for adoption; act when 1.28.0+ ships with the changes.
+- **Tool-catalog ↔ executor consistency** (ref repo `a0753dc`) — generalizes the principle: any tool list emitted to the model must derive from the same post-RBAC filtered set the executor uses. Worth a quick audit on our system-prompt assembly.
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: 33 (across multiple squash-merged PRs and direct release/develop merges)
+- **PRs merged into develop in window**: 8 user-facing (#290, #293, #296, #297, #298, #299, #300, #301) + 2 release back-merges (beta.25, beta.26) + 1 docs (#276 — pre-existing branch)
+- **PRs opened**: 1 (#301 — session-list polish; the working branch this run is on)
+- **PRs reverted**: 0
+- **Issues opened**: 1 (#288 — inference-api deploy: new images reach ECR but live AgentCore Runtime isn't rolled)
+- **Releases**: beta.25 (May 12), beta.26 (May 14)
+- **CI failures (workflow → count, last 7 days)**:
+  - Version Check: 7 (all Dependabot — see below)
+  - Deploy App API: 5
+  - Deploy Inference API: 3
+  - Deploy Infrastructure: 2
+  - **Nightly Build & Test: 0** (last week's #6 idea — fixed via #290 on May 12)
+
+### Repeated friction signals
+- **Inference API deploy not rolling new Runtime versions** (issue #288, May 12) — new container images reach ECR but the live AgentCore Runtime isn't picked up. Correlates with the 3 Deploy Inference API failures this week. *Hypothesis*: deploy step is publishing the image but not bumping the Runtime version pointer or invoking `update_agent_runtime`. *Fix candidate*: trace the deploy workflow against the AgentCore Runtime versioning model — verify it calls the SDK's `update_agent_runtime` (or equivalent) after the ECR push.
+- **Deploy App API failures clustered (5 in 7 days)** — three on the `feature/fix-default-model-persistence` branch on May 12, two on `feature/skip-auth-local-bypass` on May 9 (pre-`#272` merge). Branch-level, not a `develop` regression — most are pre-merge breakages getting resolved by the author.
+- **Nightly Build & Test cluster from last week — RESOLVED.** Last failure was May 8; PR #290 landed May 12 and the cluster has been silent since. *Last week's #6 worked.*
+
+### Version-pin lag
+
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| `bedrock-agentcore` | 1.6.4 | **1.9.1** | 4 minor+patch / latest 2026-05-12 | **Widening from last week (was 3).** PR #478 in flight adds `async_mode` to `MemorySessionManager` — directly resolves last week's flagged #452. |
+| `strands-agents` | 1.39.0 | **1.40.0** | 1 minor / latest 2026-05-14 | **New release in window.** Headline: proactive context compression (PR #2239). **Carries breaking default flip on `use_native_token_count` (true → false)** — audit token-metric reads before bumping. |
+| `fastmcp` (transitive on external MCP servers) | n/a in this repo | **3.3.0** | n/a | New `fastmcp-slim` client distribution. Informational. |
+| `mcp` (transitive) | (transitive) | 1.27.1 | 1 patch | Patch-only release. NO SEP-2567/2575 adoption — watch 1.28.0. |
+| `boto3` | 1.42.96 | (not re-fetched this week) | — | Last week 1.43.6 was latest; routine bumps continue. |
+| `aws-cdk-lib` | 2.251.0 | (not re-fetched this week) | — | Routine. |
+| `@angular/core` | 21.2.11 | (not re-fetched this week) | — | Routine. |
+
+> **Note**: #293 disabled Dependabot version-update PRs on 2026-05-13. The kaizen loop is now the only mechanism catching version-pin lag — version-pin diff has been promoted from "routine" to "load-bearing."
+
+### Retirement candidates
+- **Last week's queue item "Add Reddit `.rss` or Reddit MCP to `kaizen-research`"** — confirmed Reddit is blocked at the domain level via WebFetch (not just the HTML path). Close the queue item as **infeasible via WebFetch**; revisit only if a different transport becomes available (Reddit MCP, or `curl`-via-Bash with UA header).
+- **`kaizen-research/SKILL.md` AgentCore starter-toolkit URL is wrong** — current URL references `aws/amazon-bedrock-agentcore-starter-toolkit`; correct slug is `aws/bedrock-agentcore-starter-toolkit` (no `amazon-` prefix). Fold into the existing queue item "Replace dead source URLs in `kaizen-research` skill."
+- **`anthropics/courses` source** — already queued for removal last week; confirmed quiet again this week. Leave queued.
+
+### Risks introduced this week
+- **Dependabot version-update PRs disabled (#293, May 13)** — no automated bump pressure. Kaizen loop is now the *only* mechanism catching version-pin lag. *What breaks if ignored*: version-pin lag silently widens; security patches in transitive deps may not arrive until something else surfaces them. — *mitigation*: tighten the version-pin diff section of this skill (already in scope); add direct fetches for `boto3`, `aws-cdk-lib`, `@angular/core`, `pydantic` every run.
+- **`bedrock-agentcore` now 4 releases behind, with a release in the scan window** (1.9.1, May 12) — *what breaks if ignored*: still-open OTEL trace detach (#456), event-loop blocking (#452 — fix in PR #478 likely 1.10.0). Same risk as last week but worse — 3rd week of carry-over would be embarrassing.
+- **Strands v1.40 `use_native_token_count` default flip** — if we bump without auditing, token-accounting code reading native counts gets heuristic values instead. — https://github.com/strands-agents/sdk-python/pull/2284
+- **AgentCore `/ping` may not emit `time_of_last_update`** (SDK issue #471) — silent microVM reaping on long generations. — *what breaks if ignored*: long agent turns get killed by the idle reaper even while we're streaming. **Grep our ping handler.** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/471
+- **Inference-api deploy doesn't roll the live AgentCore Runtime** (our #288) — manual-redeploy band-aid; eventually a security patch or model-version bump will need to ship and won't.
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | Bump `bedrock-agentcore` 1.6.4 → 1.9.1 (now 4 releases behind — re-prioritized from last week) | backend | L | M-H | no — addition only, but retires open queue carry-over; sets up adoption of PR #478 / `async_mode` once 1.10.0 ships | — |
+| 2 | Audit and fix `/ping` to emit `time_of_last_update` per AgentCore SDK issue #471 | backend (inference-api `/ping`) | L | M-H | no — defensive against silent microVM reaping on long generations | — |
+| 3 | Strands 1.39 → 1.40 bump, gated on `use_native_token_count` audit + proactive-compression double-fire check | backend | M | M-H | **yes — adopting upstream proactive context compression (PR #2239) reduces our custom compaction surface area** | — |
+| 4 | Defensive A2A AgentCard `capabilities={"streaming": True}` check (ref repo `50c9112`) | backend (A2A construct) | L | M | no — defensive; silent-failure mode is 40-min timeouts | — |
+| 5 | Wire per-tool `duration_ms` into our `tool_result` SSE payload (Claude Code 2.1.141 pattern) | backend (Strands hook) + frontend (faint inline badge) | L-M | M-H | partial — replaces ad-hoc per-tool timing with a single hook-driven field; pre-paves the planned context-attribution prototype | per-tool timing visibility in the UI; the data substrate for context-attribution that separates latency from token cost |
+
+### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.1
+- **Source**: PyPI (https://pypi.org/project/bedrock-agentcore/) + open SDK issues #456, #452, #471. *Re-prioritized from last week's queue — lag widened 3 → 4 releases and Dependabot version-updates are now disabled (#293), so this won't get there on its own.*
+- **Surface area**: `backend/pyproject.toml`, `backend/uv.lock`
+- **Change**: pin update + smoke-test memory + identity flows in dev. Verify CHANGELOG between 1.6.4 and 1.9.1 for breaking changes. Verify whether 1.9.1 already addresses #456 (OTEL trace detach across asyncio boundaries) — if so, close. Track PR #478 (`async_mode`) for the 1.10.0 follow-up.
+- **Subtracts**: addition only — justified by 4 versions of upstream fixes and the kaizen-loop accountability for catching version-pin lag now that Dependabot is off
+- **Effort × Impact**: Low × Medium-High
+- **Verdict**: Worth trying. *This is a re-prioritization, not a new idea — the bootstrap-week version is still open in the queue and is now stale.*
+
+### 2. Audit and fix `/ping` to emit `time_of_last_update`
+- **Source**: AgentCore SDK issue #471 (https://github.com/aws/bedrock-agentcore-sdk-python/issues/471)
+- **Surface area**: `backend/src/apis/inference_api/` (the `/ping` handler) — this is one of the two routes the AgentCore Runtime data plane actually serves (per CLAUDE.md inference-api boundary section).
+- **Change**: grep our ping response shape; if it's just `{"status": "Healthy" | "HealthyBusy"}`, extend it to also emit `{"time_of_last_update": <iso-ts>}`. Without that field AgentCore's idle reaper can kill microVMs mid-long-generation even while we're streaming.
+- **Subtracts**: addition only — defensive; silent failure mode
+- **Effort × Impact**: Low × Medium-High
+- **Verdict**: Worth trying — cheap, surface area is tiny, failure mode is silent and bad
+
+### 3. Strands 1.39 → 1.40 bump
+- **Source**: Strands v1.40.0 release notes + PR #2284 (breaking)
+- **Surface area**: `backend/pyproject.toml`, `backend/uv.lock`, our compaction-surfacing SSE path, any code reading native Bedrock input-token counts
+- **Change**: (a) audit `apis/shared/` and `agents/main_agent/streaming/` for native-token-count reads — if we depend on them, either pin `BedrockModel(use_native_token_count=True)` explicitly OR re-route through the heuristic and verify our cost-badge math (recall last week's #270 already touched this); (b) bump pin; (c) verify proactive context compression (PR #2239) doesn't double-fire with our existing `TurnBasedSessionManager` flush — our compaction SSE event should still emit cleanly. (d) Smoke-test cost-badge values across a tool turn before promoting.
+- **Subtracts**: **yes — library-native subtraction.** Strands' proactive context compression replaces compaction logic we'd otherwise grow. Reduces the surface area in our custom session manager.
+- **Effort × Impact**: Medium × Medium-High
+- **Verdict**: Worth trying. The bump is straightforward; the audit is the careful part.
+
+### 4. Defensive A2A AgentCard `capabilities={"streaming": True}` check
+- **Source**: aws-samples/sample-strands-agent-with-agentcore commit `50c9112`
+- **Surface area**: wherever we construct A2A AgentCards in this repo (search `AgentCard`, `capabilities=`, `agent_card`)
+- **Change**: 30-second grep + read; if the field is missing or `False`, set to `True`. Silent failure mode otherwise: A2A SDK client falls back to non-streaming, never receives `completed`, hangs 40 minutes.
+- **Subtracts**: addition only — defensive
+- **Effort × Impact**: Low × Medium
+- **Verdict**: Worth trying. Cheapest item in the list with a real silent-failure mode.
+
+### 5. Wire per-tool `duration_ms` into `tool_result` SSE
+- **Source**: Claude Code 2.1.141 hook pattern (https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
+- **Surface area**: backend Strands hook (PostToolUse equivalent) emitting into our SSE `tool_result` payload; frontend `<tool-result>` component renders a faint inline timing badge
+- **Change**: register a Strands `AfterToolCall` hook that captures `(end - start)` wall-clock per tool invocation; emit on the existing `tool_result` SSE event as `duration_ms`. Frontend renders inline timing only if `> 250ms` (avoid noise).
+- **Subtracts**: partial — replaces ad-hoc per-tool timing (if any) with a single hook-driven field; *more importantly, it's the data substrate for the planned context-attribution prototype* (per our memory) — separating tool latency from token cost
+- **Unlocks**: per-tool timing visibility in the UI (which slow tool is the bottleneck on this turn?); the data substrate for context-attribution that distinguishes latency from token cost
+- **Effort × Impact**: Low-Medium × Medium-High
+- **Verdict**: Worth trying. Pairs naturally with the planned context-attribution work — landing this first means the prototype starts with cleaner inputs.
+
+## Take
+
+Two patterns are quietly reshaping the kaizen loop. **First, the upstream-shrinks-our-backlog play keeps paying off**: this week Strands shipped the proactive compression we'd flagged, AgentCore SDK has the `async_mode` fix for our #452 in flight, and the ref repo's `50c9112` A2A streaming-capability fix is a 30-second port. **Second, #293 disabled Dependabot version-update PRs** — the kaizen loop is now the only mechanism catching version-pin lag, which makes the *re-prioritization* of last week's bedrock-agentcore bump (now 4 releases behind, not 3) the single most important change this week. The agentic-UI/MCP-Apps storyline that dominated bootstrap week has gone quiet — slow week on UX, normal noise on ecosystem. Idea #1 is a carry-over but earns its #1 by being stale; idea #2 (the `/ping` fix) is the most consequential silent-failure mitigation we can land cheaply. If Phil ships only two this week, those are the two.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock + AgentCore (RSS, blog, AWS weekly roundup) | aws.amazon.com / github.com/aws/bedrock-agentcore-* | 2026-05-15 | 3 announcements + 4 SDK items (PR #478, issues #467/#468/#471) |
+| 2 | Strands Agents (releases, issues, PRs) | github.com/strands-agents/sdk-python | 2026-05-15 | 1 release (v1.40.0) + 4 issues/PRs (#2266, #2284, #2286, #2290) |
+| 3 | Reference repo (12 commits in window) | github.com/aws-samples/sample-strands-agent-with-agentcore | 2026-05-15 | 4 architecturally relevant commits (50c9112, d668685, a0753dc, 8d111d9) |
+| 4 | MCP ecosystem (SEPs, python-sdk, awslabs/mcp) | modelcontextprotocol.io / github.com/modelcontextprotocol / github.com/awslabs/mcp | 2026-05-15 | SEP-2575 merge + python-sdk v1.27.1 + 2 awslabs PRs + SEP-2577 |
+| 4a | FastMCP (v3.3.0 + active PRs) | github.com/PrefectHQ/fastmcp + pypi.org/project/fastmcp | 2026-05-15 | 1 release (3.3.0) + 4 active PRs |
+| 4b | Agentic UI/UX (MCP blog, assistant-ui, Linear, Cursor, Anthropic, NN/g) | blog.modelcontextprotocol.io + linear.app + cursor.com + anthropic.com + nngroup.com | 2026-05-15 | 2 in-window posts (Linear Code Intelligence, Cursor cloud envs) + 1 assistant-ui CI release + NN/g 404 noted |
+| 5 | Frontier models (Anthropic, OpenAI, Google, Meta) | anthropic.com / openai.com / blog.google / ai.meta.com | 2026-05-15 | 2 Anthropic non-technical + 3 OpenAI deprecations + 0 Google/Meta |
+| 6 | Agent harness (Claude Code CHANGELOG, claude-cookbooks, Anthropic engineering) | github.com/anthropics/* | 2026-05-15 | 3 Claude Code releases (2.1.139/141/142) + 3 new cookbook artifacts |
+| 7 | AWS Bedrock pricing + quota | aws.amazon.com/bedrock/pricing | 2026-05-15 | 0 detected changes; AgentCore Payments launch context only |
+| 8 | Community (HN Algolia + Reddit) | hn.algolia.com + reddit.com | 2026-05-15 | 0 HN in-window; Reddit `.rss` confirmed domain-blocked via WebFetch |
+
+## Web Budget
+
+Used: ~46 / 50 requests (target).
+- AWS Bedrock/AgentCore: 4–5 (one 404 on a `/whats-new/2026/05/` aggregator)
+- Strands: 4 (mostly `gh api`)
+- Reference repo: 4 (`gh api`)
+- MCP ecosystem: 4 (mostly `gh api`, 1 web)
+- FastMCP: 2 `gh api`
+- Agentic UI/UX: 6 (one 404 on NN/g topic URL)
+- Frontier models: 6 (1 over sub-budget — OpenAI 403 backfilled via search)
+- Agent harness: 4
+- Pricing: 3
+- AgentCore SDK: 4 (mostly `gh api`)
+- Community: 3 (HN + 2 Reddit attempts that failed fast)
+- Cookbook: 2 `gh api` (no web)
+
+Skipped (unreachable):
+- Reddit `.rss` — domain-blocked via WebFetch (confirmed). Closing the existing queue item as infeasible-via-WebFetch.
+- NN/Group AI topic URL `https://www.nngroup.com/topic/artificial-intelligence/` 404'd. Try `/articles/?topic=ai` or search next week.
+- `https://aws.amazon.com/about-aws/whats-new/2026/05/` 404'd. RSS feed covers this anyway.
+
+Skipped (other): seasonal sources (out of window).
+
+Notes:
+- Frontier-models sub-budget overshot by 1 (OpenAI 403 required search backfill — same failure mode as bootstrap).
+- Bedrock pricing-page extraction returned only Claude 3.5 entries for the second week running. If a third scan misses, switch to `curl` + grep instead of WebFetch summarization.

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -4,6 +4,43 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 ## Open
 
+### [2026-05-15] Bump `bedrock-agentcore` 1.6.4 → 1.9.1 (re-prioritized — lag widened 3 → 4)
+- **Source**: research/2026-05-15.md ▸ Top 5 #1. Re-surfacing of the 2026-05-10 queue item — lag widened and Dependabot version-updates were disabled in #293 (May 13), so this won't get there on its own.
+- **Surface**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
+- **Effort × Impact**: L × M-H
+- **Subtracts**: no — pure dep bump (justified: 4 versions of upstream fixes, latest 2026-05-12; sets up adoption of PR #478 `async_mode` once 1.10.0 ships)
+- **Status**: open (supersedes the 2026-05-10 queue entry — that one can be closed during review)
+
+### [2026-05-15] Audit and fix `/ping` to emit `time_of_last_update` (AgentCore SDK issue #471)
+- **Source**: research/2026-05-15.md ▸ Top 5 #2 — https://github.com/aws/bedrock-agentcore-sdk-python/issues/471
+- **Surface**: backend (`backend/src/apis/inference_api/` `/ping` handler — one of the two routes the AgentCore Runtime data plane actually serves)
+- **Effort × Impact**: L × M-H
+- **Subtracts**: no — defensive against silent microVM reaping on long generations
+- **Status**: open
+
+### [2026-05-15] Strands 1.39 → 1.40 bump, gated on `use_native_token_count` audit + proactive-compression double-fire check
+- **Source**: research/2026-05-15.md ▸ Top 5 #3 — Strands v1.40.0 release notes + breaking PR #2284
+- **Surface**: backend (`backend/pyproject.toml`, `apis/shared/` token-metric reads, `agents/main_agent/streaming/`, `TurnBasedSessionManager`)
+- **Effort × Impact**: M × M-H
+- **Subtracts**: **yes — library-native subtraction.** Strands' proactive context compression (PR #2239) reduces the surface area of our custom session-manager compaction logic.
+- **Status**: open
+
+### [2026-05-15] Defensive A2A AgentCard `capabilities={"streaming": True}` check
+- **Source**: research/2026-05-15.md ▸ Top 5 #4 — aws-samples/sample-strands-agent-with-agentcore commit `50c9112`
+- **Surface**: backend (A2A AgentCard construction sites)
+- **Effort × Impact**: L × M
+- **Subtracts**: no — defensive against silent 40-min A2A-client timeouts
+- **Status**: open
+
+### [2026-05-15] Wire per-tool `duration_ms` into `tool_result` SSE
+- **Source**: research/2026-05-15.md ▸ Top 5 #5 — Claude Code 2.1.141 hook pattern
+- **Surface**: backend (Strands `AfterToolCall` hook) + frontend (`<tool-result>` component — inline timing badge for `> 250ms`)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: partial — single hook-driven field replaces any ad-hoc per-tool timing; pre-paves the planned context-attribution prototype
+- **Unlocks**:
+  - Per-tool timing visibility in the UI (which slow tool is the bottleneck on this turn?)
+  - Data substrate for the planned context-attribution prototype — separates tool latency from token cost
+
 ### [2026-05-10] Scope AgentCore Runtime BYO filesystem (S3 Files / EFS) for persistent agent workspaces
 - **Source**: research/2026-05-10.md ▸ AWS Bedrock / AgentCore (re-evaluated 2026-05-10 via strategic-lens follow-up — original framing under-weighted the capability-unlock angle)
 - **Surface**: backend (`inference-api` invocation handler reads/writes mount) + infrastructure (VPC config, IAM mount permissions, S3 Files or EFS access points, per-user prefix/access-point layout for RBAC); ADR-worthy


### PR DESCRIPTION
## Summary
- External scan: AWS Bedrock/AgentCore, Strands Agents (v1.40.0 + breaking default flip), FastMCP (3.3.0), reference repo (12 commits, 3 generalizable fixes), MCP (SEP-2575 merged), agentic UI/UX, frontier models, agent harness (Claude Code 2.1.139/141/142), AgentCore SDK (1.9.1).
- Internal audit: 33 commits / 8+2 release PRs on develop, 1 new issue (#288), beta.25 + beta.26 shipped, **Dependabot version-update PRs disabled in #293** (May 13).
- Top 5 ideas in `docs/kaizen/research/2026-05-15.md` and queued in `docs/kaizen/review-queue.md`.

**Top 1**: bump `bedrock-agentcore` 1.6.4 → 1.9.1 (re-prioritized — lag widened 3 → 4, and #293 removed the safety net). **Top 2**: audit and fix `/ping` to emit `time_of_last_update` per AgentCore SDK #471 — silent microVM reaping on long generations.

## Review
- Read the research doc.
- Comment on the PR with reactions and any weekend POC findings — these become first-class signal for *next* Friday's `kaizen-review-prep`.
- POC promising ideas over the weekend.

## Decision
Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)