### PR TITLE
fix(admin): distinguish links in user-menu-link modal and preview

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
@@ -143,7 +143,7 @@ const URL_PATTERN = /^https?:\/\/.+/i;
                 ></textarea>
                 <div class="rounded-sm border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
                   <p class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Preview</p>
-                  <div class="prose prose-sm max-w-none dark:prose-invert">
+                  <div class="markdown-body prose prose-sm max-w-none dark:prose-invert">
                     <markdown [data]="previewMarkdown()" />
                   </div>
                 </div>
@@ -181,6 +181,30 @@ const URL_PATTERN = /^https?:\/\/.+/i;
         </form>
       </div>
     </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .markdown-body ::ng-deep a {
+      color: var(--color-primary-500);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .markdown-body ::ng-deep a:hover {
+      color: var(--color-primary-700);
+    }
+    .markdown-body ::ng-deep a:focus-visible {
+      outline: 2px solid var(--color-primary-500);
+      outline-offset: 2px;
+      border-radius: 0.125rem;
+    }
+    :host-context(.dark) .markdown-body ::ng-deep a {
+      color: var(--color-primary-400);
+    }
+    :host-context(.dark) .markdown-body ::ng-deep a:hover {
+      color: var(--color-primary-300);
+    }
   `,
 })
 export class UserMenuLinkFormPage implements OnInit {

--- a/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/user-menu-link-modal/user-menu-link-modal.component.ts
@@ -52,7 +52,7 @@ export interface UserMenuLinkModalData {
         </div>
 
         <div class="max-h-[70vh] overflow-y-auto px-6 py-5">
-          <div class="prose prose-sm max-w-none dark:prose-invert">
+          <div class="markdown-body prose prose-sm max-w-none dark:prose-invert">
             <markdown [data]="data.bodyMarkdown" />
           </div>
         </div>
@@ -86,6 +86,26 @@ export interface UserMenuLinkModalData {
     @keyframes dialog-fade-in-up {
       from { opacity: 0; transform: translateY(1rem) scale(0.98); }
       to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    .markdown-body ::ng-deep a {
+      color: var(--color-primary-500);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .markdown-body ::ng-deep a:hover {
+      color: var(--color-primary-700);
+    }
+    .markdown-body ::ng-deep a:focus-visible {
+      outline: 2px solid var(--color-primary-500);
+      outline-offset: 2px;
+      border-radius: 0.125rem;
+    }
+    :host-context(.dark) .markdown-body ::ng-deep a {
+      color: var(--color-primary-400);
+    }
+    :host-context(.dark) .markdown-body ::ng-deep a:hover {
+      color: var(--color-primary-300);
     }
   `,
 })


### PR DESCRIPTION
## Summary
- The user-menu link modal and the admin form's live Preview pane wrapped markdown in `prose prose-sm dark:prose-invert`, but the Tailwind Typography plugin isn't installed in this project, so links rendered indistinguishable from surrounding text.
- Added scoped `::ng-deep` link styles to both surfaces, matching the chat `.message-block` treatment (primary color, underline, hover/focus-visible, dark-mode shade).

## Test plan
- [ ] Admin → User Menu Links → New, set Type = **In-app modal**, body contains `[Boise State](https://boisestate.edu)`; confirm the Preview pane renders the link in primary blue with underline and visible focus ring on Tab
- [ ] Save the link, open it from the user-menu; same link styling appears in the modal
- [ ] Toggle dark mode on both surfaces — links use the lighter primary shade and remain legible
- [ ] Non-link prose text is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)