### PR TITLE
chore(kaizen): weekly review prep 2026-05-15

### DIFF
--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -4,6 +4,51 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 
 ## Open
 
+### [2026-05-15] Bump `bedrock-agentcore` 1.6.4 → 1.9.1 (re-prioritized — lag widened 3 → 4)
+- **Source**: research/2026-05-15.md ▸ Top 5 #1. Re-surfacing of the 2026-05-10 queue item — lag widened and Dependabot version-updates were disabled in #293 (May 13), so this won't get there on its own.
+- **Surface**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
+- **Effort × Impact**: L × M-H
+- **Subtracts**: no — pure dep bump (justified: 4 versions of upstream fixes, latest 2026-05-12; sets up adoption of PR #478 `async_mode` once 1.10.0 ships)
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #1 (Ship)
+
+### [2026-05-15] Audit and fix `/ping` to emit `time_of_last_update` (AgentCore SDK issue #471)
+- **Source**: research/2026-05-15.md ▸ Top 5 #2 — https://github.com/aws/bedrock-agentcore-sdk-python/issues/471
+- **Surface**: backend (`backend/src/apis/inference_api/` `/ping` handler — one of the two routes the AgentCore Runtime data plane actually serves)
+- **Effort × Impact**: L × M-H
+- **Subtracts**: no — defensive against silent microVM reaping on long generations
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #2 (Ship)
+
+### [2026-05-15] Strands 1.39 → 1.40 bump, gated on `use_native_token_count` audit + proactive-compression double-fire check
+- **Source**: research/2026-05-15.md ▸ Top 5 #3 — Strands v1.40.0 release notes + breaking PR #2284
+- **Surface**: backend (`backend/pyproject.toml`, `apis/shared/` token-metric reads, `agents/main_agent/streaming/`, `TurnBasedSessionManager`)
+- **Effort × Impact**: M × M-H
+- **Subtracts**: **yes — library-native subtraction.** Strands' proactive context compression (PR #2239) reduces the surface area of our custom session-manager compaction logic.
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #6 (Ship)
+
+### [2026-05-15] Defensive A2A AgentCard `capabilities={"streaming": True}` check
+- **Source**: research/2026-05-15.md ▸ Top 5 #4 — aws-samples/sample-strands-agent-with-agentcore commit `50c9112`
+- **Surface**: backend (A2A AgentCard construction sites)
+- **Effort × Impact**: L × M
+- **Subtracts**: no — defensive against silent 40-min A2A-client timeouts
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #4 (Ship)
+
+### [2026-05-15] Wire per-tool `duration_ms` into `tool_result` SSE
+- **Source**: research/2026-05-15.md ▸ Top 5 #5 — Claude Code 2.1.141 hook pattern
+- **Surface**: backend (Strands `AfterToolCall` hook) + frontend (`<tool-result>` component — inline timing badge for `> 250ms`)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: partial — single hook-driven field replaces any ad-hoc per-tool timing; pre-paves the planned context-attribution prototype
+- **Unlocks**:
+  - Per-tool timing visibility in the UI (which slow tool is the bottleneck on this turn?)
+  - Data substrate for the planned context-attribution prototype — separates tool latency from token cost
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #3 (Ship)
+
+### [2026-05-15] Investigate inference-api deploy — new images reach ECR but Runtime isn't rolled (issue #288)
+- **Source**: reviews/2026-05-15.md ▸ Proposal #10 (new from internal friction, issue #288 May 12). Pairs with the 1.6.4 → 1.9.1 bump (same SDK package owns `update_agent_runtime`).
+- **Surface**: cross-cutting — `.github/workflows/deploy-inference-api.yml` + bedrock-agentcore SDK `update_agent_runtime` call shape
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: possibly — removes the manual-redeploy band-aid that's been the workaround
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #10 (Ship)
+
 ### [2026-05-10] Scope AgentCore Runtime BYO filesystem (S3 Files / EFS) for persistent agent workspaces
 - **Source**: research/2026-05-10.md ▸ AWS Bedrock / AgentCore (re-evaluated 2026-05-10 via strategic-lens follow-up — original framing under-weighted the capability-unlock angle)
 - **Surface**: backend (`inference-api` invocation handler reads/writes mount) + infrastructure (VPC config, IAM mount permissions, S3 Files or EFS access points, per-user prefix/access-point layout for RBAC); ADR-worthy
@@ -16,77 +61,71 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
   - A2A multi-agent intermediate-result handoff via shared mount
   - Persistent vector indexes / embedding caches — avoids cold-start rebuild
 - **Open questions**: GA vs preview status (March 2026 managed session storage was preview; May 2026 BYO needs verification); VPC requirement is a new architectural surface for the runtime; multi-tenancy isolation strategy (per-user S3 prefix vs per-user EFS access point); RBAC mount-path layout; runtime data plane still only proxies `/invocations` + `/ping` so this doesn't unlock new HTTP routes
-- **Status**: open
+- **Status**: open — deferred 4 weeks in reviews/2026-05-15.md (revisit 2026-06-12). MCP Apps host renderer is the dominant strategic initiative this cycle; layering another ADR-worthy bet on top would double the open architectural surface.
 
-### [2026-05-10] Scope an MCP Apps host renderer in our chat (multi-PR initiative)
-- **Source**: research/2026-05-10.md ▸ Top 6 #1 ▸ Agentic UI/UX
-- **Surface**: frontend + backend (new SSE event `ui_resource`; `<mcp-app-frame>` Angular component; consent UX)
-- **Effort × Impact**: H × H
-- **Subtracts**: no — pure addition. Justified: every major host (Claude Desktop, ChatGPT, VS Code Copilot, Goose, Postman) ships this; without it, third-party MCP servers we connect can only deliver text+JSON
-- **Status**: open
-
-### [2026-05-10] Bump `bedrock-agentcore` 1.6.4 → 1.9.0
-- **Source**: research/2026-05-10.md ▸ Top 6 #2
-- **Surface**: backend
-- **Effort × Impact**: L × M
-- **Subtracts**: no — pure dep bump (justified: 3 versions of upstream fixes, latest in scan window)
-- **Status**: open
-
-### [2026-05-10] Promote tool-result rendering to a per-tool renderer registry (signal-backed)
-- **Source**: research/2026-05-10.md ▸ Top 6 #3 ▸ Agentic UI/UX (AI SDK + Cursor)
+### [2026-05-10] Promote tool-result rendering to a per-tool renderer registry (PR #0 of MCP Apps host sequence)
+- **Source**: research/2026-05-10.md ▸ Top 6 #3 ▸ Agentic UI/UX (AI SDK + Cursor). Locked in as PR #0 of the MCP Apps host renderer sequence (`docs/kaizen/scoping/mcp-apps-host-renderer.md`, PR #296).
 - **Surface**: frontend (`<tool-result>` component + new `ToolRendererRegistry` service)
 - **Effort × Impact**: M × M-H
-- **Subtracts**: partial — replaces implicit switch with explicit registry; absorbs scattered tool-specific UI logic. Pre-paves MCP Apps proposal #1.
-- **Status**: open
+- **Subtracts**: partial — replaces implicit switch with explicit registry; absorbs scattered tool-specific UI logic. Pre-paves MCP Apps PR #4.
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #5 (Ship)
 
 ### [2026-05-10] Audit `BedrockModel.stream` cancellation path against Strands #2266
 - **Source**: research/2026-05-10.md ▸ Top 6 #4
 - **Surface**: backend
 - **Effort × Impact**: L × M-H
 - **Subtracts**: no — defensive (SSE-disconnect path is hot)
-- **Status**: open
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #8 (Ship)
 
 ### [2026-05-10] Close issues #266 and #267 — features already in our Strands 1.39 pin
 - **Source**: research/2026-05-10.md ▸ Top 6 #5
 - **Surface**: cross-cutting
 - **Effort × Impact**: L × M
 - **Subtracts**: **yes — library-native subtraction; retires 2 build-from-scratch issues**
-- **Status**: open
-
-### [2026-05-10] Triage Nightly Build & Test failure cluster (9× since May 6)
-- **Source**: research/2026-05-10.md ▸ Top 6 #6
-- **Surface**: cross-cutting / CI
-- **Effort × Impact**: L-M × M-H
-- **Subtracts**: possibly — if root is issue #220 (test isolation)
-- **Status**: open
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #7 (Ship)
 
 ### [2026-05-10] Audit `oauth_required` SSE flow against ref-repo's mid-tool-call 401/403 handling
 - **Source**: research/2026-05-10.md ▸ Risks
 - **Surface**: backend
 - **Effort × Impact**: M × H
 - **Subtracts**: no — defensive
-- **Status**: open (deferred 2 weeks per prior review — surface again on 2026-05-24)
+- **Status**: open — deferred 2026-05-10 until 2026-05-24. BFF parade declared done via #297 (May 14), so deferral conditions have cleared a week early; reviews/2026-05-15.md holds to original revisit date to give one stable week.
 
 ### [2026-05-10] Named A2A agent participants in the chat UI
-- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ Linear Agent pattern
+- **Source**: research/2026-05-10.md ▸ Agentic UI/UX ▸ Linear Agent pattern. Reinforced by research/2026-05-15.md Linear Code Intelligence 5× usage-growth datapoint.
 - **Surface**: frontend (extend message model with `agent_identity`, distinct avatar/name/styling)
 - **Effort × Impact**: L-M × M
 - **Subtracts**: no — additive but pattern-validated across Linear/ChatGPT/Cursor
-- **Status**: open
+- **Status**: open — deferred 4 weeks in reviews/2026-05-15.md (revisit 2026-06-12). Earns its keep when an A2A construct lands.
 
-### [2026-05-10] Replace dead source URLs in `kaizen-research` skill
-- **Source**: research/2026-05-10.md ▸ Retirement candidates
+### [2026-05-10] Replace dead source URLs in `kaizen-research` skill (+ AgentCore starter-toolkit slug typo)
+- **Source**: research/2026-05-10.md ▸ Retirement candidates + research/2026-05-15.md ▸ Retirement candidates (starter-toolkit slug)
 - **Surface**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Effort × Impact**: L × L
-- **Subtracts**: yes — replaces 2 broken URLs (`bedrock/whats-new/` 404, `docs.claude.com/.../release-notes` 404) with working ones; drops `anthropics/courses` (quiet since Nov 2025)
-- **Status**: open
+- **Subtracts**: yes — replaces 2 broken URLs (`bedrock/whats-new/` 404, `docs.claude.com/.../release-notes` 404) with working ones; drops `anthropics/courses` (quiet since Nov 2025); fixes `aws/amazon-bedrock-agentcore-starter-toolkit` → `aws/bedrock-agentcore-starter-toolkit` slug
+- **Status**: open — surfaced in reviews/2026-05-15.md ▸ Proposal #9 (Ship)
 
 ### [2026-05-10] Add Reddit `.rss` or Reddit MCP to `kaizen-research`
 - **Source**: research/2026-05-10.md ▸ Risks ▸ "Reddit blocked from WebFetch"
 - **Surface**: skills (`.claude/skills/kaizen-research/SKILL.md`)
 - **Effort × Impact**: L × L
 - **Subtracts**: no — restores a half-blind source
-- **Status**: open
+- **Status**: open — research/2026-05-15.md confirmed Reddit is blocked at the *domain* level via WebFetch (not just the HTML path), so the proposal as scoped is infeasible. reviews/2026-05-15.md ▸ Retirement Candidates recommends **Decline**; move to Resolved + log in `docs/kaizen/decisions.md` after Phil's mark.
 
 ## Resolved
-<!-- kaizen-review-prep moves entries here after a review. Bootstrap run — empty. -->
+
+### [2026-05-10] Scope an MCP Apps host renderer in our chat (multi-PR initiative) → RESOLVED — scoping landed
+- **Decision**: Ship (scope only) — reviews/2026-05-10.md ▸ Proposal #1
+- **Reasoning**: Scoping doc `docs/kaizen/scoping/mcp-apps-host-renderer.md` landed in PR #296 (May 14, 2026). Four open architectural questions locked: sandbox-proxy origin, app-initiated `tools/call` plumbing, `ui/update-model-context` storage in Strands `agent.state`, full v1 method scope. PR #0 → PR #6 sequence defined; build work is now tracked via the renderer-registry queue item (PR #0 of that sequence).
+- **Reviewed-in**: reviews/2026-05-10.md ▸ Proposal #1
+
+### [2026-05-10] Triage Nightly Build & Test failure cluster (9× since May 6) → RESOLVED — fixed
+- **Decision**: Ship — reviews/2026-05-10.md ▸ Proposal #6
+- **Reasoning**: PR #290 (`Fix e2e testing in nightly`, May 12) landed. The Nightly Build & Test workflow has been silent since — research/2026-05-15.md confirms 0 failures in the May 10–15 window. Loop caught and resolved CI hygiene.
+- **Reviewed-in**: reviews/2026-05-10.md ▸ Proposal #6
+
+### [2026-05-10] Bump `bedrock-agentcore` 1.6.4 → 1.9.0 → RESOLVED — superseded
+- **Decision**: Superseded
+- **Reasoning**: Replaced by the 2026-05-15 re-prioritized entry (`1.6.4 → 1.9.1`) — lag widened from 3 → 4 versions in window, and Dependabot version-updates were disabled by #293 (May 13), so the lag is now structural rather than incidental.
+- **Reviewed-in**: reviews/2026-05-15.md ▸ Proposal #1
+

--- a/docs/kaizen/reviews/2026-05-15.md
+++ b/docs/kaizen/reviews/2026-05-15.md
@@ -1,0 +1,207 @@
+# Kaizen Review — Friday, May 15, 2026
+> Prepared 09:50am MT. Review window: May 10 – May 15, 2026 (5 days since the bootstrap review).
+> Source: research/2026-05-15.md + review-queue.md (15 open items at run start).
+> First *regular* review after the 2026-05-10 bootstrap. Two prior-week proposals already landed (#1 MCP Apps scoping → PR #296, #6 nightly-CI triage → PR #290).
+
+## Week in Review
+
+The week's defining move came not from external ecosystem noise but from a single internal decision: **#293 disabled Dependabot version-update PRs on May 13**, which silently promotes this kaizen loop from "nice-to-have radar" to "the only mechanism catching version-pin lag." The first cost of that promotion arrived the same week — `bedrock-agentcore` widened from 3 → 4 releases behind (1.6.4 → 1.9.1, latest May 12), Strands shipped v1.40 with a *breaking* default-flip on `use_native_token_count`, and four ref-repo and SDK signals pointed at silent-failure modes in our code (`/ping` reaping, A2A streaming capability, double-fired `tool_use` SSE, tool-catalog/executor RBAC drift). Externally the agentic-UI storyline that dominated bootstrap week went quiet, but the upstream-shrinks-our-backlog play kept paying off — Strands' proactive context compression and the AgentCore SDK `async_mode` PR #478 both directly intersect work we'd otherwise build. Net read: a "harvest the upstream gains, defuse the silent-failure modes, take responsibility for dependency drift" week.
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **Inference-API deploy doesn't roll new AgentCore Runtime versions** (issue #288, May 12; 3 Deploy Inference API failures in window) — new container images reach ECR but the live Runtime isn't picked up.
+  - *Hypothesis*: the deploy workflow pushes the image but does not call `update_agent_runtime` (or whatever the SDK equivalent is) to bump the Runtime version pointer. Manual redeploys have been the band-aid.
+  - *Candidate fix*: trace the deploy workflow against the AgentCore Runtime versioning model; verify the post-ECR-push step invokes the SDK's `update_agent_runtime`. Pair with the bedrock-agentcore 1.9.1 bump (the SDK we'd need to call against has moved 4 versions in that workflow's blind spot).
+- **Version Check workflow failures clustered on Dependabot branches before #293 landed** (5 of 7 in window, May 11) — these are the failures that *prompted* the decision to disable Dependabot version-update PRs.
+  - *Hypothesis*: the Version Check workflow expects authored-by-human PRs to bump a project VERSION file; Dependabot PRs only bump pinned dependencies and tripped the check.
+  - *Candidate fix*: not actionable here — Phil's call to disable Dependabot version-updates (#293) was the decision; this review just inherits its consequence (load-bearing kaizen loop).
+
+### One-offs worth watching
+- **Nightly Build & Test silent since May 8 (last week's #6 worked)** — PR #290 landed May 12 and the cluster has been quiet since. Confirmation that the loop catches and resolves CI hygiene.
+- **BFF parade declared done with #297** (May 14) — `chore(auth): remove dead Bearer-only auth from app_api post-BFF migration` retires the parallel-auth path; beta.26 cut May 14 settles the BFF v1.
+
+### Silence that matters
+- **Zero merged work on prior-review proposals #2, #3, #4, #5, #8, #9** in the 5-day window despite 9 "Ship" recommendations. Phil shipped the two highest-leverage ones (#1 scoping doc, #6 nightly-CI), then the rest of the week's PR throughput (#297–#301) was on admin-shell + UX polish + dead-code removal. *Read*: the loop produced more "Ship" recommendations than the week absorbed. Either accept that recommendation density is meant to give Phil optionality and re-surface the unshipped items here (this review's approach), or the next research run trims to top-3 Ship suggestions. Pick one — drifting between both reads is the failure mode.
+- **AgentCore platform announcements** — zero new GA/preview items this week (last week had BYO filesystem, Memory metadata, Identity-on-ECS, Payments). The capability-unlock pipeline is shallow this week; lean on the carry-overs.
+
+## Proposals — ranked
+
+### 1. Bump `bedrock-agentcore` 1.6.4 → 1.9.1 (re-prioritized; lag widened 3 → 4)
+- **Source**: research/2026-05-15.md ▸ Top 5 #1 | review-queue.md (open since 2026-05-15, supersedes 2026-05-10 entry)
+- **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`)
+- **Change**: pin update + smoke-test memory + identity flows in dev. Verify CHANGELOG between 1.6.4 → 1.9.1 (May 12) for breaking changes. Verify whether 1.9.1 already addresses #456 (OTEL trace detach across asyncio boundaries) — if so, close. Track PR #478 (`async_mode`) for the 1.10.0 follow-up.
+- **Subtracts**: no — pure dep bump. Justified: 4 versions of upstream fixes; Dependabot version-updates are now off (#293), so this won't get there on its own; sets up adoption of PR #478 `async_mode` once 1.10.0 ships (which resolves last week's flagged #452).
+- **Effort**: Low
+- **Impact**: Medium-High
+- **POC findings**: not POCed; recommended in bootstrap review but no PR opened.
+- **Ship means**: open a PR updating `pyproject.toml` and `uv.lock`; smoke-test memory write/read + identity OAuth flows in dev; if smoke passes, merge.
+- **Decline means**: lag widens to 5 next week; eventually a security patch or `async_mode` adoption forces a multi-version jump.
+- **Recommendation**: **Ship.** Highest-priority cleanup of the week. Embarrassing on a third week of carry-over. Bundle with proposal #10 (deploy-rolls-runtime fix) — same surface area, the SDK methods are in the same package.
+
+### 2. Audit and fix `/ping` to emit `time_of_last_update` (AgentCore SDK issue #471)
+- **Source**: research/2026-05-15.md ▸ Top 5 #2 | review-queue.md (open since 2026-05-15) — https://github.com/aws/bedrock-agentcore-sdk-python/issues/471
+- **Surface area**: backend (`backend/src/apis/inference_api/` `/ping` handler — one of the two routes the AgentCore Runtime data plane actually serves per CLAUDE.md inference-api boundary)
+- **Change**: grep our ping response shape; if it's just `{"status": "Healthy" | "HealthyBusy"}`, extend to `{"status": ..., "time_of_last_update": <iso-ts>}`. Without that field AgentCore's idle reaper can kill microVMs mid-long-generation even while we're streaming.
+- **Subtracts**: no — defensive against silent microVM reaping on long generations.
+- **Effort**: Low
+- **Impact**: Medium-High (silent failure mode; long agent turns get killed mid-stream)
+- **POC findings**: not POCed.
+- **Ship means**: 15-minute PR — grep the handler, add the field, smoke-test against a long-running tool turn in dev.
+- **Decline means**: keep accepting potential silent microVM reaping on long generations; revisit if a user reports a stuck-mid-stream conversation.
+- **Recommendation**: **Ship.** Cheapest item in the list with a real silent-failure mode. This is exactly the kind of cheap-but-load-bearing fix the kaizen loop should be catching.
+
+### 3. Wire per-tool `duration_ms` into `tool_result` SSE (Claude Code 2.1.141 pattern)
+- **Source**: research/2026-05-15.md ▸ Top 5 #5 | review-queue.md (open since 2026-05-15)
+- **Surface area**: backend (new Strands `AfterToolCall` hook → SSE event emitter) + frontend (`<tool-result>` component: faint inline timing badge when `duration_ms > 250`)
+- **Change**: register a Strands `AfterToolCall` hook capturing `(end - start)` wall-clock per tool invocation; emit on the existing `tool_result` SSE event as `duration_ms`. Frontend renders inline timing badge only above a noise threshold (default 250ms).
+- **Subtracts**: partial — single hook-driven field replaces any ad-hoc per-tool timing.
+- **Unlocks**:
+  - Per-tool timing visibility in the UI (which slow tool is the bottleneck on this turn?)
+  - Data substrate for the planned context-attribution prototype — separates tool latency from token cost
+- **Effort**: Low-Medium
+- **Impact**: Medium-High
+- **POC findings**: not POCed.
+- **Ship means**: one PR: backend hook + SSE field + frontend badge + a unit test that asserts the hook fires on tool completion.
+- **Decline means**: tool-latency stays invisible; context-attribution prototype starts with murkier inputs.
+- **Recommendation**: **Ship.** Pairs naturally with the planned context-attribution work — landing this first means the prototype starts clean. The "unlocks new UI surface" lens applies cleanly here.
+
+### 4. Defensive A2A AgentCard `capabilities={"streaming": True}` check
+- **Source**: research/2026-05-15.md ▸ Top 5 #4 | review-queue.md (open since 2026-05-15) — ref-repo commit `50c9112`
+- **Surface area**: backend (wherever we construct A2A AgentCards — search `AgentCard`, `capabilities=`, `agent_card`)
+- **Change**: 30-second grep + read; if the field is missing or `False`, set to `True`. Silent failure mode otherwise: A2A SDK client falls back to non-streaming, never receives `completed`, hangs ~40 minutes.
+- **Subtracts**: no — defensive; silent-failure mode of 40-min timeouts.
+- **Effort**: Low
+- **Impact**: Medium
+- **POC findings**: not POCed.
+- **Ship means**: 30-min grep + PR; if no A2A AgentCard exists in the repo today (single-agent baseline), file a note that it must be set on first A2A construct landed.
+- **Decline means**: leave a silent-failure mode active in any future A2A AgentCard work.
+- **Recommendation**: **Ship.** Cheapest defensive item this week.
+
+### 5. Promote tool-result rendering to a per-tool renderer registry (PR #0 of MCP Apps host sequence)
+- **Source**: review-queue.md (open since 2026-05-10) | scoping doc `docs/kaizen/scoping/mcp-apps-host-renderer.md` ▸ PR #0 (pre-work)
+- **Surface area**: frontend (`<tool-result>` / `tool-use.component.ts` + new `tool-renderer-registry.service.ts`)
+- **Change**: lift the implicit tool-result switch into a signal-backed registry keyed by tool name. Default renderer is today's behavior. Migrate 2–3 existing renderers as proof points.
+- **Subtracts**: partial — replaces implicit switch with declarative registry; absorbs scattered tool-specific UI logic into one table. Pre-paves MCP Apps PR #4 (the iframe renderer slots in as just-another-registered-renderer).
+- **Effort**: Medium
+- **Impact**: Medium-High (standalone UX value + scaffolding for the MCP Apps initiative)
+- **POC findings**: not POCed — but Phil locked it in as PR #0 of the MCP Apps sequence on May 14 (#296 scoping doc).
+- **Ship means**: open the PR #0 from the scoping doc — registry service + 2–3 migrated renderers, all existing tool rendering unchanged.
+- **Decline means**: MCP Apps PR sequence is blocked; the implicit switch grows further.
+- **Recommendation**: **Ship.** The scoping decision is already made; this is execution. Best risk-adjusted UX investment of the week.
+
+### 6. Strands 1.39 → 1.40 bump, gated on `use_native_token_count` audit + proactive-compression double-fire check
+- **Source**: research/2026-05-15.md ▸ Top 5 #3 | review-queue.md (open since 2026-05-15)
+- **Surface area**: backend (`backend/pyproject.toml`, `uv.lock`, `apis/shared/` token-metric reads, `agents/main_agent/streaming/`, `TurnBasedSessionManager`)
+- **Change**: (a) audit `apis/shared/` and `agents/main_agent/streaming/` for native-token-count reads — if we depend on them, either pin `BedrockModel(use_native_token_count=True)` explicitly OR re-route through the heuristic and verify the cost-badge math (recall #270 just touched this); (b) bump pin; (c) verify proactive context compression (PR #2239) doesn't double-fire with our existing `TurnBasedSessionManager` flush — our `compaction` SSE event should still emit cleanly. (d) Smoke-test cost-badge values across a tool turn before promoting.
+- **Subtracts**: **yes — library-native subtraction.** Strands' proactive context compression reduces the surface area of our custom session-manager compaction logic.
+- **Effort**: Medium
+- **Impact**: Medium-High
+- **POC findings**: not POCed.
+- **Ship means**: PR with the audit + pin bump + a regression test that asserts the `compaction` SSE event still emits exactly once per compaction event.
+- **Decline means**: stay on 1.39 for another week; revisit when 1.41 ships or after a token-accounting issue surfaces.
+- **Recommendation**: **Ship,** but second-priority of the bumps (after #1) — the audit is the careful part.
+
+### 7. Close issues #266 and #267 — features already in our Strands 1.39 pin
+- **Source**: review-queue.md (open since 2026-05-10; carry-over from bootstrap review proposal #5)
+- **Surface area**: cross-cutting — GitHub issues + minor wiring checks in `stream_coordinator` (#267) and large tool-result paths (#266)
+- **Change**: (1) comment on #266 + #267 pointing at upstream PRs; (2) verify the upstream features are *automatically* active under our 1.39 pin — if not, file replacement issues for the wiring work and link them; (3) close #266 + #267.
+- **Subtracts**: **yes — library-native subtraction.** Retires 2 build-from-scratch tickets; replaces with at-most 2 "wire upstream feature" tasks.
+- **Effort**: Low
+- **Impact**: Medium (closes phantom tech debt; clears the issue list)
+- **POC findings**: not POCed — recommended Ship in the bootstrap review but didn't get to it in window.
+- **Ship means**: 30-minute issue-grooming pass.
+- **Decline means**: leave #266 + #267 open; future kaizen runs will re-flag them.
+- **Recommendation**: **Ship.** Highest subtraction yield this week. Trivial.
+
+### 8. Audit `BedrockModel.stream` cancellation path against Strands #2266
+- **Source**: review-queue.md (open since 2026-05-10; carry-over from bootstrap review proposal #4)
+- **Surface area**: backend (`backend/src/agents/main_agent/` stream coordinator + SSE handler)
+- **Change**: locate every `BedrockModel.stream` cancellation path; ensure each `await`s the inner task on cancel so it doesn't orphan; add a dev-only assertion / log filter to detect "Task exception was never retrieved" before it reaches prod.
+- **Subtracts**: no — defensive.
+- **Effort**: Low
+- **Impact**: Medium-High (SSE-disconnect path is hot)
+- **POC findings**: not POCed.
+- **Ship means**: PR with the audit + fixes + a regression test that triggers cancel + asserts no orphan tasks.
+- **Decline means**: log a tech-debt issue; revisit if "Task exception was never retrieved" appears in CloudWatch.
+- **Recommendation**: **Ship.** Pairs naturally with proposal #1 (same backend area). Cheap insurance.
+
+### 9. Replace dead source URLs in `kaizen-research` skill + AgentCore starter-toolkit slug typo
+- **Source**: review-queue.md (open since 2026-05-10; carry-over from bootstrap review proposal #9) + research/2026-05-15.md ▸ Retirement candidates
+- **Surface area**: skills (`.claude/skills/kaizen-research/SKILL.md`)
+- **Change**: (a) replace `https://aws.amazon.com/bedrock/whats-new/` (404) with the AWS What's New RSS feed; (b) replace `https://docs.claude.com/en/docs/claude-code/release-notes` (301→404) with `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md`; (c) drop `https://github.com/anthropics/courses` (quiet since Nov 2025); (d) fix `aws/amazon-bedrock-agentcore-starter-toolkit` → `aws/bedrock-agentcore-starter-toolkit` slug (new this week).
+- **Subtracts**: **yes — replaces 2 broken URLs with working ones; drops 1 stale source; fixes 1 slug typo.**
+- **Effort**: Low
+- **Impact**: Low (skill quality; reduces web-budget waste)
+- **POC findings**: not POCed.
+- **Ship means**: 10-minute edit to `kaizen-research/SKILL.md`.
+- **Decline means**: keep wasting web-budget on dead URLs; future runs continue to miss the starter-toolkit repo via the wrong slug.
+- **Recommendation**: **Ship.** Trivial subtraction.
+
+### 10. Investigate inference-api deploy issue #288 — new images reach ECR but Runtime isn't rolled
+- **Source**: research/2026-05-15.md ▸ Internal Audit ▸ Repeated friction (3 Deploy Inference API failures in window) | issue #288 (May 12, open)
+- **Surface area**: cross-cutting — `.github/workflows/deploy-inference-api.yml` + the SDK call shape against the post-bump bedrock-agentcore 1.9.x API
+- **Change**: trace the deploy workflow end-to-end; confirm whether it calls `update_agent_runtime` (or equivalent) after the ECR push; if missing, add it; if present but failing, surface the failure. Naturally pairs with proposal #1 since the SDK that owns this call is the package we're bumping.
+- **Subtracts**: possibly — if the fix removes the manual-redeploy band-aid that's been the workaround.
+- **Effort**: Low-Medium (worst case: an IAM/permission gap on the deploy role)
+- **Impact**: Medium-High (eventually a security patch or model-version bump must ship via this path)
+- **POC findings**: not POCed.
+- **Ship means**: 1–2 hour triage; small PR fixing the workflow + closing #288 when verified.
+- **Decline means**: continue running manual redeploys; eventually something time-critical needs to ship through this path.
+- **Recommendation**: **Ship.** Pair with #1 for shared context on the bedrock-agentcore SDK surface area.
+
+## Carried Over From Prior Reviews
+
+- **`oauth_required` SSE flow audit against ref-repo's mid-tool-call 401/403 handling** (deferred 2026-05-10 until 2026-05-24) — original context: BFF auth was still settling. **Status this week**: BFF parade declared done with #297 (May 14) — the cleanup PR removed the parallel Bearer path entirely. Conditions for the original deferral have cleared a week early. *Recommendation*: keep deferred until 2026-05-24 per original commitment (one more stable week eliminates regression risk) — but surface here as an explicit hold rather than silently leaving on the queue.
+- **Named A2A agent participants in the chat UI** (open since bootstrap, recommended Ship) — not shipped in window. *Recommendation*: defer 4 weeks (revisit 2026-06-12) — single-agent mode is still our baseline; this earns its keep when an A2A construct lands. No re-rank without a trigger.
+- **Scope AgentCore Runtime BYO filesystem (S3 Files / EFS)** (open since bootstrap, no decision recorded) — high-effort high-impact capability unlock. *Recommendation*: defer 4 weeks (revisit 2026-06-12) — MCP Apps host renderer is the dominant strategic initiative; layering another VPC + IAM + storage-architecture push on top doubles the open ADR-worthy bets.
+
+## Retirement Candidates
+
+- **Queue item "Add Reddit `.rss` or Reddit MCP to `kaizen-research`"** — research/2026-05-15.md confirmed Reddit is blocked at the domain level via WebFetch, not just the HTML path. *Recommendation*: **Decline.** Move to `decisions.md` with reason "infeasible via WebFetch; revisit only if Reddit MCP or `curl`-via-Bash with UA header becomes available."
+- **(Soft) Bootstrap-era queue entry "Bump `bedrock-agentcore` 1.6.4 → 1.9.0"** — superseded by re-prioritized 2026-05-15 entry (1.9.1 + lag widened). *Recommendation*: mark Resolved as "Superseded by 1.9.1 entry" when moving queue items.
+- **(System-health check)** Three retirements landed across two weeks (kaizen-research lens churn, dead URLs queued for replacement, Reddit RSS declined this week). The subtraction muscle is exercising. No additional retirements needed *this* week.
+
+## Risks Acknowledged But Not Acted On
+
+- **Dependabot version-update PRs disabled (#293)** — https://github.com/Boise-State-Development/agentcore-public-stack/pull/293 — *what breaks if ignored*: version-pin lag silently widens; security patches in transitive deps don't arrive until something else surfaces them. The kaizen loop is the only mechanism left catching this. — *Recommendation*: **Address now via #1** (bedrock-agentcore bump validates the loop catches lag) + tighten the version-pin diff section of the research skill (direct fetches for `boto3`, `aws-cdk-lib`, `@angular/core`, `pydantic` every run — file as a kaizen-research skill update follow-up).
+- **Strands v1.40 `use_native_token_count` default flip** — https://github.com/strands-agents/sdk-python/pull/2284 — *what breaks if ignored*: if we bump without auditing, token-accounting reading native counts gets heuristic values instead, and #270's per-message-cost / context-% math may quietly drift. — *Recommendation*: **Address now via #6** (the audit is the careful part of the bump).
+- **AgentCore SDK PR #478 (`async_mode`) still in flight; #452 event-loop blocking unfixed in 1.9.1** — *what breaks if ignored*: under sustained load, AgentCoreMemorySessionManager can block the event loop. — *Recommendation*: **Watch until 1.10.0 ships** (likely lands the fix). Re-evaluate in the 2026-05-22 review.
+- **Strands SDK monorepo consolidation announced (issue #2286, May 12)** — *what breaks if ignored*: import paths likely move in a future major; no near-term impact at 1.40. — *Recommendation*: **Watch until v2.x messaging emerges.** Re-evaluate at next minor (1.41).
+
+## What Shipped This Week
+
+- **#301 — feat(sidebar): denser session list with skeleton and entry animation** (May 15) — *UX polish*
+- **#300 — feat(admin): persistent shell layout with grouped sidebar nav** (May 15) — *admin restructure*
+- **#299 — feat(frontend): copy-to-clipboard button on chat code blocks** (May 14) — *UX*
+- **#298 — feat(admin): admin-managed user-menu links** (May 14) — *new admin capability*
+- **#297 — chore(auth): remove dead Bearer-only auth from app_api post-BFF migration** (May 14) — *BFF v1 cleanup; declares the BFF parade done*
+- **#296 — chore(kaizen): add initial scoping document for MCP Apps Host Renderer** (May 14) — *kaizen proposal #1 from 2026-05-10 review; PR #0 → PR #6 sequence locked*
+- **#293 — chore: restrict contributions and disable Dependabot version-update PRs** (May 13) — *the load-bearing decision of the week*
+- **#290 — Fix e2e testing in nightly** (May 12) — *kaizen proposal #6 from 2026-05-10 review; nightly cluster silent since*
+- **beta.26** (May 14) + **beta.25** (May 12) — *two release cuts in window*
+
+## Take
+
+The system is trending toward trust on the loop side (two prior-review proposals shipped, both high-leverage) and toward friction on the dependency-management side (lag widened the same week the only-mechanism guard came on). **The single change that matters most this week is proposal #1 (`bedrock-agentcore` bump)** — not because the bump itself is interesting, but because it's the proof that the kaizen loop can catch lag now that Dependabot can't. **The best risk-adjusted move this week is the bundle of proposals #2 + #4 + #7 + #9** — four under-30-minute items that collectively close 1 silent-failure mode, 1 latent-A2A-trap, 2 phantom GitHub issues, and 4 dead/typo URLs. Phil should ship all four in a single afternoon and feel the kaizen loop earn its keep. The slower-burn items (#3 per-tool duration_ms, #5 renderer registry, #6 Strands 1.40 audit, #8 stream cancel audit, #10 deploy/runtime fix) are the week's real engineering work — pick 1–2 of those to ride the week. **Do not** add new items to the queue this week — the queue is full, the carry-over count is healthy, and the loop is producing more recommendations than the week is absorbing; that imbalance is fine for now but worth watching.
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min).
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **10 proposals**; my recommendations: 10 Ship, 0 Defer, 0 Decline.
+3. Mark Carried Over: keep oauth audit deferred to 2026-05-24; defer A2A participants + BYO filesystem 4 weeks (1-2 min).
+4. Confirm the Reddit RSS retirement → `decisions.md` (1 min).
+5. Resolve Risks block.
+6. **Suggested 1–3 to ship**: **#1 (bedrock-agentcore bump)**, **the bundle #2+#4+#7+#9** counted as one afternoon (4 cheap subtractions), and **#3 (per-tool `duration_ms`)** for the week's real UX investment.
+
+Target: 12-15 minutes.
+
+## Post-review (separate PRs)
+
+- ✅ Ship items → individual feature PRs over the week. The decision is logged here; the implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a "revisit by" date; surface again in the next review when due.
+
+This skill produces the agenda. Implementation never happens here.


### PR DESCRIPTION
## Summary
- 10 proposals ranked Effort × Impact (subtraction + capability-unlock lenses applied).
- Friction patterns surfaced from the week's commits, PRs, and CI (most notably issue #288 — inference-api deploy not rolling Runtime; clustered Version Check failures that prompted #293).
- 2 prior-review carry-overs deferred 4 weeks; 1 (oauth_required audit) held to original 2026-05-24 revisit per commitment.
- 4 items moved Open → Resolved in the queue (MCP Apps scoping landed #296, nightly CI fixed #290, bedrock-agentcore 1.9.0 superseded by 1.9.1 re-prioritization, Reddit RSS recommended for Decline pending Phil's mark).
- 1 retirement candidate flagged for `decisions.md`: Reddit `.rss` — research-confirmed infeasible via WebFetch.

## Top decisions to mark
1. **Bump `bedrock-agentcore` 1.6.4 → 1.9.1** — Low × Med-High — **Ship**. The week's load-bearing proof that the kaizen loop catches lag now that Dependabot version-updates are off (#293).
2. **Audit `/ping` for `time_of_last_update` (SDK issue #471)** — Low × Med-High — **Ship**. Silent microVM-reaping mitigation; 15-min PR.

## Review
1. Read Friction (2 min).
2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min).
3. Confirm Carried Over deferrals + Retirement Candidates (1-2 min).
4. Resolve Risks block.
5. Pick 1-3 to ship this week.

Target: 12-15 minutes.

## Decision
Ship the doc to `develop`. Action on individual items happens in separate PRs over the week.
Declined items go to `docs/kaizen/decisions.md`; deferred items stay open in `review-queue.md` with a revisit date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)