### PR TITLE
feat(admin): widen shell and fix sidebar label wrapping

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -72,10 +72,10 @@ interface NavGroup {
         </div>
       </div>
 
-      <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div class="lg:grid lg:grid-cols-12 lg:gap-x-8">
+      <div class="mx-auto max-w-[96rem] px-4 py-8 sm:px-6 lg:px-8">
+        <div class="lg:flex lg:gap-x-8">
           <!-- Sidebar Navigation -->
-          <aside class="lg:col-span-2">
+          <aside class="lg:w-60 lg:shrink-0">
             <!-- Mobile dropdown (shown on small screens) -->
             <div class="lg:hidden">
               <label for="admin-nav" class="sr-only">Admin section</label>
@@ -108,7 +108,7 @@ interface NavGroup {
                           <a
                             [routerLink]="item.route"
                             routerLinkActive="bg-gray-100 text-gray-900 dark:bg-white/10 dark:text-white"
-                            class="group flex items-center gap-x-3 rounded-md px-3 py-2 text-sm/6 font-medium text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white"
+                            class="group flex items-center gap-x-3 whitespace-nowrap rounded-md px-3 py-2 text-sm/6 font-medium text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white"
                           >
                             <ng-icon [name]="item.icon" class="size-5 shrink-0 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" />
                             {{ item.label }}
@@ -123,7 +123,7 @@ interface NavGroup {
           </aside>
 
           <!-- Content area -->
-          <main class="mt-8 lg:col-span-10 lg:mt-0">
+          <main class="mt-8 min-w-0 lg:mt-0 lg:flex-1">
             <router-outlet />
           </main>
         </div>

--- a/frontend/ai.client/src/app/admin/auth-providers/pages/provider-form.page.ts
+++ b/frontend/ai.client/src/app/admin/auth-providers/pages/provider-form.page.ts
@@ -69,8 +69,7 @@ interface ProviderFormGroup {
     class: 'block',
   },
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="max-w-4xl">
         <!-- Back Button -->
         <button
           (click)="goBack()"
@@ -667,7 +666,6 @@ interface ProviderFormGroup {
             </div>
           </form>
         }
-      </div>
     </div>
   `,
 })

--- a/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
+++ b/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
@@ -103,8 +103,7 @@ const ICON_ACCEPTED_MIME_TYPES = [
   ],
   host: { class: 'block' },
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="max-w-3xl">
         <button
           type="button"
           (click)="goBack()"
@@ -572,7 +571,6 @@ const ICON_ACCEPTED_MIME_TYPES = [
             </div>
           </form>
         }
-      </div>
     </div>
   `,
 })

--- a/frontend/ai.client/src/app/admin/connectors/pages/connector-list.page.ts
+++ b/frontend/ai.client/src/app/admin/connectors/pages/connector-list.page.ts
@@ -58,8 +58,7 @@ import {
     class: 'block',
   },
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <div>
         <!-- Page Header -->
         <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -355,7 +354,6 @@ import {
             </div>
           </div>
         }
-      </div>
     </div>
   `,
 })

--- a/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
@@ -39,9 +39,7 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
   providers: [provideIcons({ heroArrowLeft, heroArrowDownTray })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="min-h-dvh bg-gray-50 dark:bg-gray-900">
-      <!-- Content -->
-      <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+    <div>
         <!-- Page Header -->
         <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -163,7 +161,6 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
             />
           </div>
         }
-      </div>
     </div>
   `,
 })

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
@@ -27,9 +27,8 @@ import { UserMenuLink } from './models/user-menu-link.model';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
-        <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">User Menu Links</h1>
             <p class="mt-1 text-gray-600 dark:text-gray-400">
@@ -110,8 +109,7 @@ import { UserMenuLink } from './models/user-menu-link.model';
               </div>
             }
           </div>
-        }
-      </div>
+      }
     </div>
   `,
 })

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/user-menu-link-form.page.ts
@@ -23,8 +23,7 @@ const URL_PATTERN = /^https?:\/\/.+/i;
   providers: [provideIcons({ heroArrowLeft })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="max-w-4xl">
         <a
           routerLink="/admin/manage-user-menu-links"
           class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
@@ -179,7 +178,6 @@ const URL_PATTERN = /^https?:\/\/.+/i;
             </button>
           </div>
         </form>
-      </div>
     </div>
   `,
   styles: `

--- a/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
+++ b/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
@@ -47,8 +47,7 @@ interface RoleFormGroup {
     class: 'block',
   },
   template: `
-    <div class="min-h-dvh">
-      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="max-w-4xl">
         <!-- Back Button -->
         <button
           (click)="goBack()"
@@ -396,7 +395,6 @@ interface RoleFormGroup {
             </div>
           </form>
         }
-      </div>
     </div>
   `,
 })


### PR DESCRIPTION
## Summary
- Switch the admin shell from a 12-col grid to a flex layout with a fixed-width (240px) sidebar so nav width no longer scales with the container — fixes the "User Menu Links" / "Auth Providers" labels wrapping to two lines.
- Widen the outer shell cap from `max-w-7xl` (1280px) to `max-w-[96rem]` (1536px) for more breathing room on wide monitors. Tailwind 4 removed `max-w-screen-2xl`, so the arbitrary value is the explicit form.
- Drop redundant per-page `min-h-dvh` + duplicated `mx-auto max-w-* px-4 py-8 sm:px-6 lg:px-8` wrappers that were double-padding inside the shell and capping content below the available area. List pages now fill the column; form pages keep a narrower `max-w-3xl/4xl` for readability.
- Add `whitespace-nowrap` to sidebar nav anchors as a defense against future long labels.

## Test plan
- [ ] Visit `/admin/manage-user-menu-links` and confirm sidebar labels render on a single line.
- [ ] Cycle through `/admin/costs`, `/admin/connectors`, `/admin/users`, `/admin/roles`, `/admin/auth-providers`, `/admin/manage-models`, `/admin/tools` — content area should breathe more on wide screens; pages that already lacked an outer wrapper (Users, Roles list, Tools, Models) should look unchanged.
- [ ] Open form pages (`/admin/connectors/new`, `/admin/roles/new`, `/admin/manage-user-menu-links/new`, `/admin/auth-providers/new`) — confirm forms remain narrow and readable, not stretched edge-to-edge.
- [ ] Resize to ~1024px (sidebar still fixed width) and ~375px (mobile dropdown nav).
- [ ] Toggle dark mode — the costs page lost its explicit `bg-gray-50 dark:bg-gray-900` wrapper; verify the global body background looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)