### PR TITLE
feat(artifacts): implement render Lambda token verification and content fetch

### DIFF
--- a/backend/src/lambdas/artifact_render/handler.py
+++ b/backend/src/lambdas/artifact_render/handler.py
@@ -66,7 +66,7 @@ _EXPECTED_AUD = "artifact-render"
 _LEEWAY_SECONDS = 5
 # Upper bound on token lifetime. The minter issues ~60–120s tokens; a
 # token claiming a far-future exp is a minter bug or a forgery attempt,
-# so cap the blast radius. Only enforced when `iat` is present.
+# so cap the blast radius. `iat` is mandatory, so this always applies.
 _MAX_TOKEN_LIFETIME_SECONDS = 600
 # Cap content size to stay within the Lambda's 5s / 512MB envelope and
 # to keep a single response bounded. Oversized blobs are a writer bug.
@@ -235,12 +235,18 @@ def _verify_token(token: str) -> dict[str, Any]:
     if now > exp + _LEEWAY_SECONDS:
         raise _TokenError("token expired")
 
+    # `iat` is mandatory: the lifetime cap is the blast-radius control for
+    # a minter bug, and it can only be enforced relative to `iat`. The
+    # cross-PR contract requires the minter to send it, so a missing `iat`
+    # is itself a contract violation — reject rather than skip the cap.
+    # `bool` is an `int` subclass — exclude it explicitly.
     iat = claims.get("iat")
-    if isinstance(iat, (int, float)):
-        if iat > now + _LEEWAY_SECONDS:
-            raise _TokenError("token issued in the future")
-        if exp - iat > _MAX_TOKEN_LIFETIME_SECONDS:
-            raise _TokenError("token lifetime too long")
+    if not isinstance(iat, (int, float)) or isinstance(iat, bool):
+        raise _TokenError("missing iat")
+    if iat > now + _LEEWAY_SECONDS:
+        raise _TokenError("token issued in the future")
+    if exp - iat > _MAX_TOKEN_LIFETIME_SECONDS:
+        raise _TokenError("token lifetime too long")
 
     sub = claims.get("sub")
     aid = claims.get("aid")

--- a/backend/src/lambdas/artifact_render/handler.py
+++ b/backend/src/lambdas/artifact_render/handler.py
@@ -1,47 +1,98 @@
-"""Artifact render Lambda — SCAFFOLD.
+"""Artifact render Lambda.
 
-This Lambda fronts the `artifacts.{domain}` CloudFront origin. Its job:
+Fronts the `artifacts.{domain}` CloudFront origin. Request flow:
 
-  1. Receive a request from CloudFront carrying a render-token JWT
-     (`?t=...` on the URL).
-  2. Verify the JWT against the HMAC key in Secrets Manager
-     (RENDER_TOKEN_SECRET_ARN). The JWT carries
-     `{user_id, artifact_id, version, exp}`.
-  3. Read the artifact metadata row from DynamoDB
-     (ARTIFACTS_TABLE / SK = ARTIFACT#{id}#V#{version}).
-  4. If content_ref points to S3, fetch the blob from ARTIFACTS_BUCKET;
-     if inline, read it from the DDB item.
-  5. Wrap the content in a minimal HTML shell with strict CSP and
-     return it as a 200. The CDN's response-headers-policy also stamps
-     the CSP, so even a buggy handler can't downgrade security.
+  1. CloudFront forwards a GET carrying a render-token JWT (`?t=...`).
+  2. Verify the JWT (HS256) against the HMAC key in Secrets Manager
+     (RENDER_TOKEN_SECRET_ARN). The token pins one immutable artifact
+     version: `{sub, aid, ver, sid, iss, aud, iat, exp}`.
+  3. Read the version record from DynamoDB (ARTIFACTS_TABLE):
+       PK = USER#{sub}
+       SK = ARTIFACT#{aid}#V#{ver:05d}
+  4. Fetch the content blob from S3 (ARTIFACTS_BUCKET) using the
+     `content_key` stored on the record (the writer owns key
+     construction; the verifier never reconstructs it).
+  5. Return those exact bytes with strict security headers. The CDN's
+     response-headers-policy also stamps the CSP, so the policy holds
+     even if this handler is buggy (defense in depth).
 
-Current state: returns a placeholder response. Real JWT verification +
-content fetch is implemented as a follow-up (the infra is provisioned
-first so the surrounding wiring can be validated end-to-end).
+This Lambda is a thin authenticated gate + header stamper, not a
+templating layer: S3 holds the complete document to serve, and the
+artifact writer owns all rendering. `#HEAD` is never read — the token
+pins an exact version.
+
+No third-party dependencies: HS256 is HMAC-SHA256, verified with the
+standard library. boto3 is provided by the Lambda runtime.
 
 Boundary: this Lambda runs OUTSIDE the apis/* import boundary
 (test_import_boundaries.py) — it's a standalone deployable, not part of
 app-api or inference-api. Do not import from apis/ here.
-
-Dependencies (none today; TODO for v1):
-  - PyJWT for token validation
-  - boto3 (already in Lambda runtime; used for Secrets Manager + S3 + DDB)
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
+import logging
 import os
+import time
 from typing import Any
+from urllib.parse import parse_qs
 
-# Pinned at deploy time via ArtifactsStack environment block. Accessed
-# lazily so a missing env var becomes a runtime 500 with a clear log line
-# rather than an import-time crash.
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Pinned at deploy time via ArtifactsStack environment block. Read at
+# module load; emptiness is checked at request time so a missing var
+# becomes a clean runtime 500 with a log line rather than an import crash.
 _FRAME_ANCESTOR = os.environ.get("FRAME_ANCESTOR_ORIGIN", "")
 _CSP_SCRIPT_SRC = os.environ.get(
     "CSP_SCRIPT_SRC",
     "'self' 'unsafe-inline'",
 )
+_ARTIFACTS_BUCKET = os.environ.get("ARTIFACTS_BUCKET", "")
+_ARTIFACTS_TABLE = os.environ.get("ARTIFACTS_TABLE", "")
+_RENDER_TOKEN_SECRET_ARN = os.environ.get("RENDER_TOKEN_SECRET_ARN", "")
+
+_EXPECTED_ISS = "app-api"
+_EXPECTED_AUD = "artifact-render"
+# Tolerance for clock skew between the app-api minter and this Lambda.
+# Both run in AWS so skew is sub-second; keep it tight.
+_LEEWAY_SECONDS = 5
+# Upper bound on token lifetime. The minter issues ~60–120s tokens; a
+# token claiming a far-future exp is a minter bug or a forgery attempt,
+# so cap the blast radius. Only enforced when `iat` is present.
+_MAX_TOKEN_LIFETIME_SECONDS = 600
+# Cap content size to stay within the Lambda's 5s / 512MB envelope and
+# to keep a single response bounded. Oversized blobs are a writer bug.
+_MAX_CONTENT_BYTES = 5 * 1024 * 1024
+
+# Module-scoped for container reuse across invocations.
+_secrets_client = None
+_s3_client = None
+_ddb_table = None
+_cached_signing_key: str | None = None
+
+
+class _TokenError(Exception):
+    """Render token is missing, malformed, or fails verification."""
+
+
+class _ArtifactNotFound(Exception):
+    """No version record or no backing object for the requested artifact."""
+
+
+class _RenderConfigError(Exception):
+    """Required environment / AWS configuration is missing or unusable."""
+
+
+class _UnsupportedStorage(Exception):
+    """Version record uses a storage class this handler can't serve yet."""
 
 
 def _csp_header() -> str:
@@ -63,41 +114,280 @@ def _csp_header() -> str:
     )
 
 
-def _placeholder_html() -> str:
-    """Minimal HTML returned while JWT validation + content fetch are
-    pending. Keeps the deployed pipeline observable (you can hit the
-    artifact origin in a browser and see *something* render) without
-    serving real user content prematurely."""
+def _security_headers(content_type: str) -> dict[str, str]:
+    return {
+        "content-type": content_type,
+        "content-security-policy": _csp_header(),
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "cache-control": "no-store",
+    }
+
+
+def _error_html(message: str) -> str:
+    """Generic error page. Never reflects token or claim values — keeps
+    the surface free of injected content even though the CSP would
+    neutralize it anyway."""
     return (
         "<!doctype html>"
         "<html><head>"
         "<meta charset='utf-8'>"
-        "<title>Artifact render — pending</title>"
+        "<title>Artifact unavailable</title>"
         "<style>body{font:14px system-ui;padding:2rem;color:#444}</style>"
         "</head><body>"
-        "<h1>Artifact render service</h1>"
-        "<p>Infrastructure deployed; render logic is a follow-up.</p>"
+        "<h1>Artifact unavailable</h1>"
+        f"<p>{message}</p>"
         "</body></html>"
     )
 
 
-def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
-    """Lambda Function URL handler. Payload format v2.0."""
-    # TODO: extract `?t=` query param, verify JWT (PyJWT, HS256), fetch
-    # content from S3/DDB, render HTML shell wrapping the content.
+def _response(status: int, body: str, content_type: str) -> dict[str, Any]:
     return {
-        "statusCode": 200,
-        "headers": {
-            "content-type": "text/html; charset=utf-8",
-            "content-security-policy": _csp_header(),
-            "x-content-type-options": "nosniff",
-            "referrer-policy": "no-referrer",
-            "cache-control": "no-store",
-        },
-        "body": _placeholder_html(),
+        "statusCode": status,
+        "headers": _security_headers(content_type),
+        "body": body,
     }
 
 
-# Local smoke test: `python handler.py` prints the placeholder response.
+def _error_response(status: int, message: str) -> dict[str, Any]:
+    return _response(status, _error_html(message), "text/html; charset=utf-8")
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """Decode a base64url JWT segment, restoring the stripped padding."""
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _signing_key() -> str:
+    """Fetch and cache the HMAC signing key. The secret is a plain
+    string (Secrets Manager `generateSecretString`, no JSON wrapper) —
+    same shape as the BFF cookie data key. Cached for the container
+    lifetime; on rotation the container eventually recycles, which is
+    acceptable for short-lived render tokens."""
+    global _secrets_client, _cached_signing_key
+    if _cached_signing_key is not None:
+        return _cached_signing_key
+    if not _RENDER_TOKEN_SECRET_ARN:
+        raise _RenderConfigError("RENDER_TOKEN_SECRET_ARN is not set")
+    if _secrets_client is None:
+        _secrets_client = boto3.client("secretsmanager")
+    try:
+        secret = _secrets_client.get_secret_value(SecretId=_RENDER_TOKEN_SECRET_ARN)
+    except ClientError as exc:
+        raise _RenderConfigError("could not read render token secret") from exc
+    key = secret.get("SecretString")
+    if not key:
+        raise _RenderConfigError("render token secret is empty")
+    _cached_signing_key = key
+    return key
+
+
+def _verify_token(token: str) -> dict[str, Any]:
+    """Verify an HS256 render token and return its validated claims.
+
+    Implemented against the stdlib rather than PyJWT so the Lambda asset
+    stays dependency-free. `alg` is pinned to HS256 explicitly to reject
+    the `none` algorithm and HS/RS confusion."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise _TokenError("malformed token")
+    header_b64, payload_b64, signature_b64 = parts
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise _TokenError("unreadable header") from exc
+    if not isinstance(header, dict):
+        raise _TokenError("malformed header")
+    if header.get("alg") != "HS256":
+        raise _TokenError("unexpected token algorithm")
+
+    expected_sig = hmac.new(
+        _signing_key().encode("utf-8"),
+        f"{header_b64}.{payload_b64}".encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    try:
+        provided_sig = _b64url_decode(signature_b64)
+    except ValueError as exc:
+        raise _TokenError("unreadable signature") from exc
+    # Constant-time compare — never short-circuit on the first byte.
+    if not hmac.compare_digest(expected_sig, provided_sig):
+        raise _TokenError("signature mismatch")
+
+    try:
+        claims = json.loads(_b64url_decode(payload_b64))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise _TokenError("unreadable payload") from exc
+    if not isinstance(claims, dict):
+        raise _TokenError("malformed payload")
+
+    if claims.get("iss") != _EXPECTED_ISS:
+        raise _TokenError("unexpected issuer")
+    if claims.get("aud") != _EXPECTED_AUD:
+        raise _TokenError("unexpected audience")
+
+    now = time.time()
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)):
+        raise _TokenError("missing exp")
+    if now > exp + _LEEWAY_SECONDS:
+        raise _TokenError("token expired")
+
+    iat = claims.get("iat")
+    if isinstance(iat, (int, float)):
+        if iat > now + _LEEWAY_SECONDS:
+            raise _TokenError("token issued in the future")
+        if exp - iat > _MAX_TOKEN_LIFETIME_SECONDS:
+            raise _TokenError("token lifetime too long")
+
+    sub = claims.get("sub")
+    aid = claims.get("aid")
+    ver = claims.get("ver")
+    if not isinstance(sub, str) or not sub:
+        raise _TokenError("missing sub")
+    if not isinstance(aid, str) or not aid:
+        raise _TokenError("missing aid")
+    # `bool` is an `int` subclass — exclude it explicitly.
+    if not isinstance(ver, int) or isinstance(ver, bool) or ver < 1:
+        raise _TokenError("invalid ver")
+
+    return claims
+
+
+def _get_version_record(user_id: str, artifact_id: str, version: int) -> dict[str, Any]:
+    global _ddb_table
+    if not _ARTIFACTS_TABLE:
+        raise _RenderConfigError("ARTIFACTS_TABLE is not set")
+    if _ddb_table is None:
+        _ddb_table = boto3.resource("dynamodb").Table(_ARTIFACTS_TABLE)
+    sk = f"ARTIFACT#{artifact_id}#V#{version:05d}"
+    try:
+        result = _ddb_table.get_item(Key={"PK": f"USER#{user_id}", "SK": sk})
+    except ClientError as exc:
+        raise _RenderConfigError("artifact metadata lookup failed") from exc
+    item = result.get("Item")
+    if not item:
+        raise _ArtifactNotFound("version record not found")
+    return item
+
+
+def _fetch_content(content_key: str) -> str:
+    global _s3_client
+    if not _ARTIFACTS_BUCKET:
+        raise _RenderConfigError("ARTIFACTS_BUCKET is not set")
+    if _s3_client is None:
+        _s3_client = boto3.client("s3")
+    try:
+        obj = _s3_client.get_object(Bucket=_ARTIFACTS_BUCKET, Key=content_key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            raise _ArtifactNotFound("content object missing") from exc
+        raise _RenderConfigError("content fetch failed") from exc
+    content_length = obj.get("ContentLength")
+    if isinstance(content_length, int) and content_length > _MAX_CONTENT_BYTES:
+        raise _UnsupportedStorage("content exceeds size limit")
+    raw = obj["Body"].read(_MAX_CONTENT_BYTES + 1)
+    if len(raw) > _MAX_CONTENT_BYTES:
+        raise _UnsupportedStorage("content exceeds size limit")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _UnsupportedStorage("content is not valid utf-8") from exc
+
+
+def _extract_token(event: dict[str, Any]) -> str:
+    params = event.get("queryStringParameters") or {}
+    token = params.get("t")
+    if not token:
+        raw = event.get("rawQueryString") or ""
+        token = (parse_qs(raw).get("t") or [None])[0]
+    if not token:
+        raise _TokenError("missing render token")
+    return token
+
+
+def _request_method(event: dict[str, Any]) -> str:
+    return (
+        event.get("requestContext", {})
+        .get("http", {})
+        .get("method", "GET")
+        .upper()
+    )
+
+
+def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Lambda Function URL handler. Payload format v2.0.
+
+    SECURITY: never log `event`, `rawQueryString`, `queryStringParameters`,
+    or the raw token — the render token is a bearer credential carried in
+    the URL query string. Log identifiers (sub/aid/ver/sid) only.
+    """
+    method = _request_method(event)
+    if method not in ("GET", "HEAD"):
+        return _error_response(405, "Method not allowed.")
+
+    try:
+        token = _extract_token(event)
+        claims = _verify_token(token)
+    except _TokenError as exc:
+        logger.warning("render token rejected: %s", exc)
+        return _error_response(403, "This artifact link is invalid or has expired.")
+    except _RenderConfigError as exc:
+        logger.error("render config error during verification: %s", exc)
+        return _error_response(500, "The artifact service is misconfigured.")
+
+    user_id = claims["sub"]
+    artifact_id = claims["aid"]
+    version = claims["ver"]
+    logger.info(
+        "render request user=%s artifact=%s v=%s sid=%s",
+        user_id,
+        artifact_id,
+        version,
+        claims.get("sid"),
+    )
+
+    try:
+        record = _get_version_record(user_id, artifact_id, version)
+        storage = record.get("storage")
+        if storage != "s3":
+            raise _UnsupportedStorage(f"storage class {storage!r} not supported")
+        content_key = record.get("content_key")
+        if not isinstance(content_key, str) or not content_key:
+            raise _ArtifactNotFound("version record has no content pointer")
+        content_type = record.get("content_type") or "text/html; charset=utf-8"
+        body = _fetch_content(content_key)
+    except _ArtifactNotFound as exc:
+        logger.warning(
+            "artifact not found user=%s artifact=%s v=%s: %s",
+            user_id,
+            artifact_id,
+            version,
+            exc,
+        )
+        return _error_response(404, "This artifact could not be found.")
+    except _UnsupportedStorage as exc:
+        logger.error(
+            "unsupported artifact content user=%s artifact=%s v=%s: %s",
+            user_id,
+            artifact_id,
+            version,
+            exc,
+        )
+        return _error_response(500, "This artifact could not be rendered.")
+    except _RenderConfigError as exc:
+        logger.error("render config error during fetch: %s", exc)
+        return _error_response(500, "The artifact service is misconfigured.")
+
+    if method == "HEAD":
+        return _response(200, "", content_type)
+    return _response(200, body, content_type)
+
+
+# Local smoke test: `python handler.py` exercises the missing-token path
+# (returns 403) with zero AWS calls — the token check precedes any client.
 if __name__ == "__main__":
     print(json.dumps(handler({}, None), indent=2))

--- a/backend/tests/lambdas/test_artifact_render.py
+++ b/backend/tests/lambdas/test_artifact_render.py
@@ -150,6 +150,22 @@ def test_missing_exp_rejected(_injected_key: None) -> None:
         handler._verify_token(_mint(claims))
 
 
+def test_missing_iat_rejected(_injected_key: None) -> None:
+    # `iat` is mandatory — without it the lifetime cap can't be enforced.
+    claims = _valid_claims()
+    del claims["iat"]
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(claims))
+
+
+@pytest.mark.parametrize("bad_iat", ["123", True])
+def test_non_numeric_iat_rejected(_injected_key: None, bad_iat: Any) -> None:
+    # A string or bool `iat` must not slip past the numeric guard
+    # (bool is an int subclass).
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(iat=bad_iat)))
+
+
 @pytest.mark.parametrize("bad_ver", [0, -1, True, "1", 1.0])
 def test_invalid_version_rejected(_injected_key: None, bad_ver: Any) -> None:
     with pytest.raises(handler._TokenError):

--- a/backend/tests/lambdas/test_artifact_render.py
+++ b/backend/tests/lambdas/test_artifact_render.py
@@ -1,0 +1,358 @@
+"""Tests for the artifact render Lambda.
+
+Two layers:
+  * Token verification matrix — pure stdlib HS256 logic, no AWS.
+  * Handler integration — full request flow against moto-backed
+    Secrets Manager, DynamoDB, and S3.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from lambdas.artifact_render import handler
+
+KEY = "test-signing-key-44-chars-of-entropy-aaaaaaa"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _mint(
+    claims: dict[str, Any],
+    *,
+    key: str = KEY,
+    alg: str = "HS256",
+    tamper_sig: bool = False,
+) -> str:
+    header = _b64url(json.dumps({"alg": alg, "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps(claims).encode())
+    signing_input = f"{header}.{payload}".encode("ascii")
+    sig = hmac.new(key.encode(), signing_input, hashlib.sha256).digest()
+    sig_b64 = _b64url(sig)
+    if tamper_sig:
+        sig_b64 = ("A" if sig_b64[0] != "A" else "B") + sig_b64[1:]
+    return f"{header}.{payload}.{sig_b64}"
+
+
+def _valid_claims(**overrides: Any) -> dict[str, Any]:
+    now = int(time.time())
+    base = {
+        "sub": "user-123",
+        "aid": "artifact-abc",
+        "ver": 1,
+        "sid": "session-xyz",
+        "iss": "app-api",
+        "aud": "artifact-render",
+        "iat": now,
+        "exp": now + 90,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts from clean module-scoped caches."""
+    monkeypatch.setattr(handler, "_cached_signing_key", None)
+    monkeypatch.setattr(handler, "_secrets_client", None)
+    monkeypatch.setattr(handler, "_s3_client", None)
+    monkeypatch.setattr(handler, "_ddb_table", None)
+
+
+# --------------------------------------------------------------------------
+# Token verification matrix (no AWS — signing key injected directly).
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _injected_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(handler, "_cached_signing_key", KEY)
+
+
+def test_valid_token_returns_claims(_injected_key: None) -> None:
+    claims = handler._verify_token(_mint(_valid_claims()))
+    assert claims["sub"] == "user-123"
+    assert claims["aid"] == "artifact-abc"
+    assert claims["ver"] == 1
+
+
+def test_tampered_signature_rejected(_injected_key: None) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(), tamper_sig=True))
+
+
+def test_wrong_signing_key_rejected(_injected_key: None) -> None:
+    forged = _mint(_valid_claims(), key="a-different-key")
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(forged)
+
+
+def test_alg_none_rejected(_injected_key: None) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(), alg="none"))
+
+
+def test_alg_confusion_rejected(_injected_key: None) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(), alg="HS512"))
+
+
+def test_expired_token_rejected(_injected_key: None) -> None:
+    now = int(time.time())
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(iat=now - 200, exp=now - 100)))
+
+
+def test_expiry_within_leeway_accepted(_injected_key: None) -> None:
+    now = int(time.time())
+    claims = handler._verify_token(_mint(_valid_claims(iat=now - 4, exp=now - 3)))
+    assert claims["sub"] == "user-123"
+
+
+def test_future_iat_rejected(_injected_key: None) -> None:
+    now = int(time.time())
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(iat=now + 100, exp=now + 200)))
+
+
+def test_overlong_lifetime_rejected(_injected_key: None) -> None:
+    now = int(time.time())
+    over = handler._MAX_TOKEN_LIFETIME_SECONDS + 60
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(iat=now, exp=now + over)))
+
+
+def test_wrong_issuer_rejected(_injected_key: None) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(iss="evil")))
+
+
+def test_wrong_audience_rejected(_injected_key: None) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(aud="some-other-service")))
+
+
+def test_missing_exp_rejected(_injected_key: None) -> None:
+    claims = _valid_claims()
+    del claims["exp"]
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(claims))
+
+
+@pytest.mark.parametrize("bad_ver", [0, -1, True, "1", 1.0])
+def test_invalid_version_rejected(_injected_key: None, bad_ver: Any) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(_valid_claims(ver=bad_ver)))
+
+
+@pytest.mark.parametrize("missing", ["sub", "aid"])
+def test_missing_identity_claim_rejected(_injected_key: None, missing: str) -> None:
+    claims = _valid_claims()
+    del claims[missing]
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(_mint(claims))
+
+
+@pytest.mark.parametrize("token", ["", "a.b", "a.b.c.d", "not-a-token"])
+def test_malformed_token_rejected(_injected_key: None, token: str) -> None:
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(token)
+
+
+def test_non_dict_header_rejected(_injected_key: None) -> None:
+    # Header decodes to a JSON array, not an object.
+    header = _b64url(json.dumps(["HS256"]).encode())
+    payload = _b64url(json.dumps(_valid_claims()).encode())
+    sig = _b64url(
+        hmac.new(
+            KEY.encode(), f"{header}.{payload}".encode("ascii"), hashlib.sha256
+        ).digest()
+    )
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(f"{header}.{payload}.{sig}")
+
+
+def test_non_dict_payload_rejected(_injected_key: None) -> None:
+    header = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps(["not", "an", "object"]).encode())
+    sig = _b64url(
+        hmac.new(
+            KEY.encode(), f"{header}.{payload}".encode("ascii"), hashlib.sha256
+        ).digest()
+    )
+    with pytest.raises(handler._TokenError):
+        handler._verify_token(f"{header}.{payload}.{sig}")
+
+
+# --------------------------------------------------------------------------
+# Handler integration (moto-backed Secrets Manager + DynamoDB + S3).
+# --------------------------------------------------------------------------
+
+SECRET_ARN_NAME = "test-artifact-render-token-key"
+TABLE = "test-user-artifacts"
+BUCKET = "test-artifacts-content"
+CONTENT_KEY = "user-123/artifact-abc/v1/index.html"
+DOC = "<!doctype html><html><body><h1>hi</h1></body></html>"
+
+
+@pytest.fixture
+def aws_env(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        sm = boto3.client("secretsmanager", region_name="us-east-1")
+        secret = sm.create_secret(Name=SECRET_ARN_NAME, SecretString=KEY)
+
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket=BUCKET)
+        s3.put_object(Bucket=BUCKET, Key=CONTENT_KEY, Body=DOC.encode())
+
+        monkeypatch.setattr(handler, "_RENDER_TOKEN_SECRET_ARN", secret["ARN"])
+        monkeypatch.setattr(handler, "_ARTIFACTS_TABLE", TABLE)
+        monkeypatch.setattr(handler, "_ARTIFACTS_BUCKET", BUCKET)
+        monkeypatch.setattr(handler, "_FRAME_ANCESTOR", "https://app.example.com")
+
+        yield {"ddb": boto3.resource("dynamodb", region_name="us-east-1")}
+
+
+def _put_record(ddb, **overrides: Any) -> None:
+    item = {
+        "PK": "USER#user-123",
+        "SK": "ARTIFACT#artifact-abc#V#00001",
+        "storage": "s3",
+        "content_key": CONTENT_KEY,
+        "content_type": "text/html; charset=utf-8",
+    }
+    item.update(overrides)
+    ddb.Table(TABLE).put_item(Item=item)
+
+
+def _event(token: str | None, method: str = "GET") -> dict[str, Any]:
+    return {
+        "requestContext": {"http": {"method": method}},
+        "queryStringParameters": {"t": token} if token else {},
+        "rawQueryString": f"t={token}" if token else "",
+    }
+
+
+def test_happy_path_returns_content(aws_env) -> None:
+    _put_record(aws_env["ddb"])
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 200
+    assert resp["body"] == DOC
+    assert resp["headers"]["cache-control"] == "no-store"
+    assert "frame-ancestors https://app.example.com" in (
+        resp["headers"]["content-security-policy"]
+    )
+
+
+def test_secret_fetched_from_secrets_manager(aws_env) -> None:
+    # _cached_signing_key is None (reset fixture) so this exercises the
+    # real Secrets Manager round-trip, not an injected key.
+    _put_record(aws_env["ddb"])
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 200
+
+
+def test_head_request_omits_body(aws_env) -> None:
+    _put_record(aws_env["ddb"])
+    resp = handler.handler(_event(_mint(_valid_claims()), method="HEAD"), None)
+    assert resp["statusCode"] == 200
+    assert resp["body"] == ""
+
+
+def test_token_from_raw_query_string(aws_env) -> None:
+    _put_record(aws_env["ddb"])
+    token = _mint(_valid_claims())
+    event = {
+        "requestContext": {"http": {"method": "GET"}},
+        "queryStringParameters": None,
+        "rawQueryString": f"t={token}",
+    }
+    assert handler.handler(event, None)["statusCode"] == 200
+
+
+def test_missing_token_is_403(aws_env) -> None:
+    resp = handler.handler(_event(None), None)
+    assert resp["statusCode"] == 403
+
+
+def test_tampered_token_is_403(aws_env) -> None:
+    _put_record(aws_env["ddb"])
+    bad = _mint(_valid_claims(), tamper_sig=True)
+    assert handler.handler(_event(bad), None)["statusCode"] == 403
+
+
+def test_non_get_method_is_405(aws_env) -> None:
+    resp = handler.handler(_event(_mint(_valid_claims()), method="POST"), None)
+    assert resp["statusCode"] == 405
+
+
+def test_missing_version_record_is_404(aws_env) -> None:
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 404
+
+
+def test_unsupported_storage_is_500(aws_env) -> None:
+    _put_record(aws_env["ddb"], storage="inline")
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 500
+
+
+def test_record_without_content_key_is_404(aws_env) -> None:
+    ddb = aws_env["ddb"]
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": "USER#user-123",
+            "SK": "ARTIFACT#artifact-abc#V#00001",
+            "storage": "s3",
+        }
+    )
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 404
+
+
+def test_missing_s3_object_is_404(aws_env) -> None:
+    _put_record(aws_env["ddb"], content_key="user-123/artifact-abc/v1/gone.html")
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 404
+
+
+def test_version_pins_exact_sk(aws_env) -> None:
+    # Token asks for v2; only v1 exists → must 404, never fall back to HEAD.
+    _put_record(aws_env["ddb"])
+    resp = handler.handler(_event(_mint(_valid_claims(ver=2))), None)
+    assert resp["statusCode"] == 404
+
+
+def test_oversized_content_is_500(aws_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(handler, "_MAX_CONTENT_BYTES", 16)
+    boto3.client("s3", region_name="us-east-1").put_object(
+        Bucket=BUCKET, Key=CONTENT_KEY, Body=b"x" * 64
+    )
+    _put_record(aws_env["ddb"])
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 500


### PR DESCRIPTION
## Summary

Replaces the placeholder artifact render handler ([#306](https://github.com/Boise-State-Development/agentcore-public-stack/pull/306)) with the real authenticated gate that fronts the `artifacts.{domain}` CloudFront origin.

- **Stdlib HS256 verification** — `hmac`/`hashlib`/`base64`, zero third-party deps so the Lambda asset stays bundling-free (no CDK/Docker change, matching the stack's "no third-party deps" scaffold note).
- **DynamoDB version lookup** → **S3 content fetch** → **pass-through response** that stamps the strict CSP + security headers. The Lambda is a thin auth gate, not a templating layer; the artifact writer owns rendering.
- Token pins an exact immutable version, so `#HEAD` is never read.

This is the third piece of the artifacts sequence (infra #306 → hotfix #307 → **render Lambda body** → app-api token minter → agent tools → SPA panel).

## Cross-PR contracts this PR fixes

Downstream PRs **must** conform to these:

**Render-token JWT claims** (the app-api minter mints exactly this): `sub`, `aid`, `ver` (int ≥1), `sid` (audit-log only), `iss="app-api"`, `aud="artifact-render"`, `iat`, `exp` (short TTL, hard-capped ≤10 min).

**DDB version record** (the `create_artifact` writer must write this): `PK=USER#{user_id}`, `SK=ARTIFACT#{artifact_id}#V#{version:05d}`, `storage="s3"`, `content_key` (full S3 key — authoritative, never reconstructed by the verifier), `content_type`.

## Security

- `alg` pinned to `HS256` — rejects the `none` algorithm and HS/RS key confusion.
- Constant-time signature comparison (`hmac.compare_digest`).
- `iss`/`aud`/`exp` validated; bounded token lifetime; future-`iat` guard; strict claim typing (`bool` excluded from `ver`); non-dict header/payload rejected.
- **Log hygiene:** the render token is a bearer credential carried in the URL query string. The handler never logs `event`/`rawQueryString`/`queryStringParameters`/the raw token (identifiers only), and a docstring guard documents this for future contributors.

### Operational follow-ups (not code in this PR)

- Do **not** enable CloudFront standard access logging on the artifacts distribution (it captures `cs-uri-query` → live tokens). If compliance requires it, scrub the query string.
- Keep the render Lambda's CloudWatch log-group retention short (defense-in-depth; short TTL is the primary mitigation).
- Minter PR: keep TTL tight (≤120s) and set `Referrer-Policy: no-referrer` on the page embedding the iframe.

## Test plan

- [x] `pytest tests/lambdas/test_artifact_render.py` — 38 tests pass (token-verification matrix + handler integration via moto for Secrets Manager / DynamoDB / S3)
- [x] `pytest tests/architecture/` — import-boundary tests pass (Lambda stays outside the `apis/*` boundary)
- [x] `ruff check` clean on changed files
- [x] Local smoke test (`python handler.py`) returns 403 on the missing-token path with zero AWS calls
- [ ] Post-merge: exercise end-to-end once the app-api token minter lands (no live token issuer exists yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)