### PR TITLE
feat(artifacts): add app-api render-token minter endpoint

### DIFF
--- a/backend/src/apis/app_api/artifacts/__init__.py
+++ b/backend/src/apis/app_api/artifacts/__init__.py
@@ -1,0 +1,7 @@
+"""Artifact render-token minter (app-api).
+
+Issues short-lived HS256 JWTs that the artifact render Lambda (a
+separate deployable) verifies before serving a sandboxed iframe. The
+claim shape and DDB lookup keys here are a cross-PR contract with that
+Lambda — see `backend/src/lambdas/artifact_render/handler.py`.
+"""

--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -1,0 +1,25 @@
+"""Request/response models for the render-token endpoint."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RenderTokenRequest(BaseModel):
+    version: int = Field(..., ge=1, description="Artifact version to render")
+    session_id: Optional[str] = Field(
+        default=None,
+        validation_alias="sessionId",
+        description="Originating chat session id — audit correlation only",
+    )
+
+
+class RenderTokenResponse(BaseModel):
+    url: str = Field(
+        ...,
+        description="Artifact origin URL with the embedded render token "
+        "(set directly as the iframe src)",
+    )
+    expires_at: str = Field(..., description="ISO-8601 UTC token expiry")

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -1,7 +1,6 @@
 """Artifact render-token API routes."""
 
 import logging
-import os
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -36,7 +35,7 @@ async def mint_render_token(
     than a token that renders the Lambda's error page in the iframe.
     """
     try:
-        token, exp = service.mint(
+        url, exp = service.mint(
             user_id=user.user_id,
             artifact_id=artifact_id,
             version=request.version,
@@ -53,8 +52,7 @@ async def mint_render_token(
             "Artifact rendering is unavailable",
         )
 
-    origin = os.environ.get("ARTIFACTS_ORIGIN", "").rstrip("/")
     return RenderTokenResponse(
-        url=f"{origin}/?t={token}",
+        url=url,
         expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
     )

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -1,0 +1,60 @@
+"""Artifact render-token API routes."""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.shared.auth import User, get_current_user_from_session
+
+from .models import RenderTokenRequest, RenderTokenResponse
+from .service import (
+    ArtifactNotFoundError,
+    RenderTokenConfigError,
+    RenderTokenService,
+    get_render_token_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+
+
+@router.post("/{artifact_id}/render-token", response_model=RenderTokenResponse)
+async def mint_render_token(
+    artifact_id: str,
+    request: RenderTokenRequest,
+    user: User = Depends(get_current_user_from_session),
+    service: RenderTokenService = Depends(get_render_token_service),
+) -> RenderTokenResponse:
+    """Mint a short-lived render token for one artifact version.
+
+    `sub` is taken from the authenticated session, so a caller can only
+    ever obtain a token for their own artifact. The version is validated
+    against DynamoDB before minting so the SPA gets a clean 404 rather
+    than a token that renders the Lambda's error page in the iframe.
+    """
+    try:
+        token, exp = service.mint(
+            user_id=user.user_id,
+            artifact_id=artifact_id,
+            version=request.version,
+            session_id=request.session_id,
+        )
+    except ArtifactNotFoundError:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Artifact version not found"
+        )
+    except RenderTokenConfigError:
+        logger.exception("render token service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact rendering is unavailable",
+        )
+
+    origin = os.environ.get("ARTIFACTS_ORIGIN", "").rstrip("/")
+    return RenderTokenResponse(
+        url=f"{origin}/?t={token}",
+        expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
+    )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -1,0 +1,173 @@
+"""Render-token minting service.
+
+Mints the HS256 JWT that the artifact render Lambda verifies. The claim
+shape, signing key, and DynamoDB lookup keys are a frozen cross-PR
+contract with `backend/src/lambdas/artifact_render/handler.py` — any
+change here must be mirrored in that verifier (and vice versa).
+
+SECURITY: the minted token is a bearer credential carried in a URL.
+Never log the token or the assembled URL — log identifiers only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+import boto3
+import jwt
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# Frozen contract — must match the render Lambda's _verify_token.
+_ISS = "app-api"
+_AUD = "artifact-render"
+# The verifier hard-caps exp - iat at 600s. 120s comfortably covers an
+# iframe load while keeping a leaked-in-a-log token useless almost
+# immediately.
+_TTL_SECONDS = 120
+
+_secret_lock = threading.Lock()
+_cached_signing_key: Optional[str] = None
+_secrets_client = None
+_ddb_table = None
+
+
+class RenderTokenError(Exception):
+    """Base class for render-token failures."""
+
+
+class ArtifactNotFoundError(RenderTokenError):
+    """No version record for the requested (user, artifact, version)."""
+
+
+class RenderTokenConfigError(RenderTokenError):
+    """Required environment / AWS configuration is missing or unusable."""
+
+
+def _reset_caches_for_tests() -> None:
+    """Drop process-wide singletons so test order can't leak a stale
+    signing key, secrets client, or DDB table handle."""
+    global _cached_signing_key, _secrets_client, _ddb_table
+    _cached_signing_key = None
+    _secrets_client = None
+    _ddb_table = None
+
+
+def _region() -> str:
+    return (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-west-2"
+    )
+
+
+def _signing_key() -> str:
+    """Fetch and cache the HMAC signing key. The secret is a plain
+    string (Secrets Manager generateSecretString, no JSON wrapper) —
+    same shape as the BFF cookie data key."""
+    global _cached_signing_key, _secrets_client
+    if _cached_signing_key is not None:
+        return _cached_signing_key
+    with _secret_lock:
+        if _cached_signing_key is not None:
+            return _cached_signing_key
+        arn = os.environ.get("ARTIFACTS_RENDER_TOKEN_SECRET_ARN", "")
+        if not arn:
+            raise RenderTokenConfigError(
+                "ARTIFACTS_RENDER_TOKEN_SECRET_ARN is not set"
+            )
+        if _secrets_client is None:
+            _secrets_client = boto3.client(
+                "secretsmanager", region_name=_region()
+            )
+        try:
+            response = _secrets_client.get_secret_value(SecretId=arn)
+        except ClientError as exc:
+            raise RenderTokenConfigError(
+                "could not read render token secret"
+            ) from exc
+        key = response.get("SecretString") or ""
+        if not key:
+            raise RenderTokenConfigError("render token secret is empty")
+        _cached_signing_key = key
+        return key
+
+
+def _table():
+    global _ddb_table
+    if _ddb_table is None:
+        name = os.environ.get("DYNAMODB_ARTIFACTS_TABLE_NAME", "")
+        if not name:
+            raise RenderTokenConfigError(
+                "DYNAMODB_ARTIFACTS_TABLE_NAME is not set"
+            )
+        _ddb_table = boto3.resource(
+            "dynamodb", region_name=_region()
+        ).Table(name)
+    return _ddb_table
+
+
+def _assert_version_exists(
+    user_id: str, artifact_id: str, version: int
+) -> None:
+    """Confirm the exact version row exists and belongs to this user.
+
+    Building the PK from the authenticated user's id is what scopes the
+    token: a caller can never mint for another user's artifact. The
+    SK zero-pad must match the verifier's `V#{version:05d}`."""
+    sk = f"ARTIFACT#{artifact_id}#V#{version:05d}"
+    try:
+        result = _table().get_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk}
+        )
+    except ClientError as exc:
+        raise RenderTokenConfigError(
+            "artifact metadata lookup failed"
+        ) from exc
+    if "Item" not in result:
+        raise ArtifactNotFoundError("artifact version not found")
+
+
+class RenderTokenService:
+    def mint(
+        self,
+        *,
+        user_id: str,
+        artifact_id: str,
+        version: int,
+        session_id: Optional[str],
+    ) -> tuple[str, int]:
+        """Validate ownership/existence, then mint a short-lived token.
+
+        Returns (token, exp_unix). Raises ArtifactNotFoundError or
+        RenderTokenConfigError."""
+        _assert_version_exists(user_id, artifact_id, version)
+        now = int(time.time())
+        exp = now + _TTL_SECONDS
+        claims = {
+            "iss": _ISS,
+            "aud": _AUD,
+            "sub": user_id,
+            "aid": artifact_id,
+            "ver": version,
+            "sid": session_id or "",
+            "iat": now,
+            "exp": exp,
+        }
+        token = jwt.encode(claims, _signing_key(), algorithm="HS256")
+        logger.info(
+            "minted render token user=%s artifact=%s v=%s",
+            user_id,
+            artifact_id,
+            version,
+        )
+        return token, exp
+
+
+def get_render_token_service() -> RenderTokenService:
+    return RenderTokenService()

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -32,6 +32,7 @@ _AUD = "artifact-render"
 _TTL_SECONDS = 120
 
 _secret_lock = threading.Lock()
+_table_lock = threading.Lock()
 _cached_signing_key: Optional[str] = None
 _secrets_client = None
 _ddb_table = None
@@ -100,7 +101,11 @@ def _signing_key() -> str:
 
 def _table():
     global _ddb_table
-    if _ddb_table is None:
+    if _ddb_table is not None:
+        return _ddb_table
+    with _table_lock:
+        if _ddb_table is not None:
+            return _ddb_table
         name = os.environ.get("DYNAMODB_ARTIFACTS_TABLE_NAME", "")
         if not name:
             raise RenderTokenConfigError(
@@ -109,7 +114,21 @@ def _table():
         _ddb_table = boto3.resource(
             "dynamodb", region_name=_region()
         ).Table(name)
-    return _ddb_table
+        return _ddb_table
+
+
+def _origin() -> str:
+    """The artifact origin the render token is bound to.
+
+    Validated like the signing key and table so a misconfigured deploy
+    fails closed with a 500 — never returns a usable token embedded in a
+    relative, unloadable URL. Infra sets this env var alongside the
+    secret ARN and table name, so an empty value here means a broken
+    artifacts deploy, not a disabled feature."""
+    origin = os.environ.get("ARTIFACTS_ORIGIN", "").strip().rstrip("/")
+    if not origin:
+        raise RenderTokenConfigError("ARTIFACTS_ORIGIN is not set")
+    return origin
 
 
 def _assert_version_exists(
@@ -142,10 +161,12 @@ class RenderTokenService:
         version: int,
         session_id: Optional[str],
     ) -> tuple[str, int]:
-        """Validate ownership/existence, then mint a short-lived token.
+        """Validate config + ownership/existence, then mint a token.
 
-        Returns (token, exp_unix). Raises ArtifactNotFoundError or
-        RenderTokenConfigError."""
+        Returns (render_url, exp_unix). Raises ArtifactNotFoundError or
+        RenderTokenConfigError. Origin is resolved first so a misconfig
+        fails closed before any DDB call or credential is generated."""
+        origin = _origin()
         _assert_version_exists(user_id, artifact_id, version)
         now = int(time.time())
         exp = now + _TTL_SECONDS
@@ -166,7 +187,7 @@ class RenderTokenService:
             artifact_id,
             version,
         )
-        return token, exp
+        return f"{origin}/?t={token}", exp
 
 
 def get_render_token_service() -> RenderTokenService:

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -216,6 +216,14 @@ if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":
     app.include_router(fine_tuning_router)
     logger.info("Fine-tuning routes enabled")
 
+# Conditionally register artifact render-token routes. Infra only sets
+# the secret ARN when the artifacts feature is enabled for the
+# environment, so its presence is the enablement signal.
+if os.environ.get("ARTIFACTS_RENDER_TOKEN_SECRET_ARN"):
+    from apis.app_api.artifacts.routes import router as artifacts_router
+    app.include_router(artifacts_router)
+    logger.info("Artifact render-token routes enabled")
+
 # Mount static file directories for serving generated content
 # These are created by tools (visualization, code interpreter, etc.)
 # Use parent directory (src/) as base

--- a/backend/tests/apis/app_api/artifacts/test_render_token.py
+++ b/backend/tests/apis/app_api/artifacts/test_render_token.py
@@ -1,0 +1,170 @@
+"""Tests for the app-api render-token minter.
+
+The headline test (`test_token_verifies_against_render_lambda`) mints a
+token and feeds it straight through #309's Lambda verifier with a shared
+signing key — that is the real cross-PR contract guarantee.
+"""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+import boto3
+
+from apis.app_api.artifacts import service as token_service
+from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.shared.auth import User, get_current_user_from_session
+from lambdas.artifact_render import handler as render_lambda
+
+KEY = "test-render-key-44-chars-of-entropy-aaaaaaaa"
+SECRET_NAME = "test-artifact-render-token-key"
+TABLE = "test-user-artifacts"
+ORIGIN = "https://artifacts.test.example.com"
+REGION = "us-east-1"
+USER_ID = "user-123"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    token_service._reset_caches_for_tests()
+    # The verifier caches its own signing key separately.
+    monkeypatch.setattr(render_lambda, "_cached_signing_key", None)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        sm = boto3.client("secretsmanager", region_name=REGION)
+        arn = sm.create_secret(Name=SECRET_NAME, SecretString=KEY)["ARN"]
+
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        monkeypatch.setenv("ARTIFACTS_RENDER_TOKEN_SECRET_ARN", arn)
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("ARTIFACTS_ORIGIN", ORIGIN)
+
+        app = FastAPI()
+        app.include_router(artifacts_router)
+        app.dependency_overrides[get_current_user_from_session] = (
+            lambda: User(email="u@x.com", user_id=USER_ID, name="U", roles=[])
+        )
+        yield TestClient(app), boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_version(ddb, *, user_id: str = USER_ID, artifact="art-1", version=1) -> None:
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "storage": "s3",
+            "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+        }
+    )
+
+
+def _token_from_url(url: str) -> str:
+    assert url.startswith(f"{ORIGIN}/?t=")
+    return url.split("?t=", 1)[1]
+
+
+def test_happy_path_mints_valid_token(client) -> None:
+    tc, ddb = client
+    _put_version(ddb)
+    resp = tc.post(
+        "/artifacts/art-1/render-token", json={"version": 1, "sessionId": "sess-9"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    claims = jwt.decode(
+        _token_from_url(body["url"]),
+        KEY,
+        algorithms=["HS256"],
+        audience="artifact-render",
+    )
+    assert claims["iss"] == "app-api"
+    assert claims["sub"] == USER_ID
+    assert claims["aid"] == "art-1"
+    assert claims["ver"] == 1
+    assert claims["sid"] == "sess-9"
+    assert claims["exp"] - claims["iat"] == 120
+    assert body["expires_at"].endswith("+00:00")
+
+
+def test_token_verifies_against_render_lambda(client, monkeypatch) -> None:
+    """The cross-PR contract: a freshly minted token must pass the
+    actual #309 verifier byte-for-byte with the same signing key."""
+    tc, ddb = client
+    _put_version(ddb)
+    monkeypatch.setattr(render_lambda, "_cached_signing_key", KEY)
+
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 1})
+    token = _token_from_url(resp.json()["url"])
+
+    verified = render_lambda._verify_token(token)
+    assert verified["sub"] == USER_ID
+    assert verified["aid"] == "art-1"
+    assert verified["ver"] == 1
+
+
+def test_unknown_version_is_404(client) -> None:
+    tc, _ = client
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 1})
+    assert resp.status_code == 404
+
+
+def test_other_users_artifact_is_404(client) -> None:
+    """Ownership scoping: a record owned by someone else is invisible
+    because the PK is built from the authenticated user's id."""
+    tc, ddb = client
+    _put_version(ddb, user_id="someone-else")
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 1})
+    assert resp.status_code == 404
+
+
+def test_version_must_be_positive(client) -> None:
+    tc, ddb = client
+    _put_version(ddb)
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 0})
+    assert resp.status_code == 422
+
+
+def test_session_id_optional(client) -> None:
+    tc, ddb = client
+    _put_version(ddb)
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 1})
+    assert resp.status_code == 200
+    claims = jwt.decode(
+        _token_from_url(resp.json()["url"]),
+        KEY,
+        algorithms=["HS256"],
+        audience="artifact-render",
+    )
+    assert claims["sid"] == ""
+
+
+def test_requires_authentication() -> None:
+    """No dependency override and no session cookie → the route is
+    blocked by the session dependency, never reaching mint logic."""
+    app = FastAPI()
+    app.include_router(artifacts_router)
+    resp = TestClient(app).post(
+        "/artifacts/art-1/render-token", json={"version": 1}
+    )
+    assert resp.status_code == 401

--- a/backend/tests/apis/app_api/artifacts/test_render_token.py
+++ b/backend/tests/apis/app_api/artifacts/test_render_token.py
@@ -159,6 +159,18 @@ def test_session_id_optional(client) -> None:
     assert claims["sid"] == ""
 
 
+def test_missing_origin_is_500(client, monkeypatch) -> None:
+    """Fail-closed config: with ARTIFACTS_ORIGIN unset the service must
+    500 before minting — never hand back a usable token embedded in a
+    relative, unloadable URL. The artifact row exists, so a 500 (not a
+    404) proves the origin check fires first."""
+    tc, ddb = client
+    _put_version(ddb)
+    monkeypatch.delenv("ARTIFACTS_ORIGIN", raising=False)
+    resp = tc.post("/artifacts/art-1/render-token", json={"version": 1})
+    assert resp.status_code == 500
+
+
 def test_requires_authentication() -> None:
     """No dependency override and no session cookie → the route is
     blocked by the session dependency, never reaching mint logic."""


### PR DESCRIPTION
## Summary

Fourth piece of the artifacts sequence (infra [#306](https://github.com/Boise-State-Development/agentcore-public-stack/pull/306) → hotfix [#307](https://github.com/Boise-State-Development/agentcore-public-stack/pull/307) → render Lambda [#309](https://github.com/Boise-State-Development/agentcore-public-stack/pull/309) → **this** → agent tools → SPA panel).

Adds `POST /artifacts/{artifact_id}/render-token` on app-api, which mints the short-lived HS256 JWT that the render Lambda from #309 verifies before serving a sandboxed iframe.

- **Ownership-scoped:** `sub` is taken from the authenticated session (`get_current_user_from_session`), so a caller can only ever mint for their own artifact.
- **Pre-validated:** the exact version row is read from DynamoDB (`PK=USER#{user_id}`, `SK=ARTIFACT#{aid}#V#{ver:05d}`) before minting, so the SPA gets a clean 404 instead of a token that renders the Lambda's error page inside the iframe.
- **Backend-only:** the router is registered conditionally on the presence of `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` (infra only sets it when the feature is enabled) — no infra change, no redeploy of the stack.

## Contract conformance with #309

The minted claims exactly satisfy #309's frozen verifier: `iss="app-api"`, `aud="artifact-render"`, `iat` mandatory + integer, `exp - iat = 120s` (well under the verifier's 600s hard cap), `sub`/`aid`/`ver` typed, `sid` for audit correlation. Signed with the same Secrets Manager plain-string key. The headline test mints a token through the real endpoint and feeds it straight into #309's `_verify_token` with a shared key — the cross-PR guarantee, not a mock.

## Security

- The render token is a URL-borne bearer credential: the service never logs the token or the assembled URL (identifiers only). Same discipline as the #309 handler.
- Endpoint is `POST` (produces a credential; uncacheable, not a GET URL).
- Auth uses `Depends(get_current_user_from_session)` per the app-api cookie-auth rule — never bearer-only.

## Files

- `backend/src/apis/app_api/artifacts/` — new domain (`__init__`, `models`, `service`, `routes`)
- `backend/src/apis/app_api/main.py` — conditional router include (8 lines, mirrors the `FINE_TUNING_ENABLED` pattern; pre-existing ruff debt in this file is untouched)
- `backend/tests/apis/app_api/artifacts/test_render_token.py` — 7 tests

## Test plan

- [x] `pytest tests/apis/app_api/artifacts/` — 7/7 pass (happy path, **end-to-end contract vs #309 verifier**, unknown version → 404, other user's artifact → 404, version validation → 422, optional sessionId, unauthenticated → 401)
- [x] `pytest tests/architecture/` — import-boundary intact (production code does not import `lambdas/`; only the test does, which is allowed)
- [x] `ruff check` clean on all new files; `main.py` error count unchanged (31 → 31, all pre-existing)
- [ ] Post-merge: end-to-end once the SPA panel lands and calls this endpoint with a real session cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)