### PR TITLE
feat(artifacts): add create_artifact / update_artifact agent tools

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/__init__.py
+++ b/backend/src/agents/builtin_tools/artifacts/__init__.py
@@ -1,0 +1,13 @@
+"""Artifact authoring tools.
+
+Lets the agent persist standalone HTML documents as versioned artifacts.
+The writer here owns S3 upload + the DynamoDB version/HEAD rows; the
+render Lambda (`backend/src/lambdas/artifact_render/handler.py`) and the
+app-api render-token minter read those rows back. The DDB key layout and
+the `storage`/`content_key`/`content_type` attributes are a frozen
+cross-PR contract with both readers.
+"""
+
+from .tools import make_create_artifact_tool, make_update_artifact_tool
+
+__all__ = ["make_create_artifact_tool", "make_update_artifact_tool"]

--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -1,0 +1,256 @@
+"""Artifact writer — S3 upload + DynamoDB version/HEAD rows.
+
+Frozen cross-PR contract (must stay in sync with the render Lambda
+`backend/src/lambdas/artifact_render/handler.py` and the app-api minter
+`backend/src/apis/app_api/artifacts/service.py`):
+
+  Version row : PK=USER#{user_id}  SK=ARTIFACT#{aid}#V#{version:05d}
+                attrs storage="s3", content_key, content_type
+  HEAD row    : PK=USER#{user_id}  SK=ARTIFACT#{aid}#HEAD
+                + GSI1PK=SESSION#{session_id}
+                + GSI1SK=ARTIFACT#{updated_at}#{aid}   (SessionIndex)
+  S3 layout   : {user_id}/{aid}/v{n}/index.html
+
+Versions are immutable (no DeleteObject grant in inference-api) — an
+update writes a new version and re-points HEAD.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8"
+
+_cached_bucket: Optional[str] = None
+_cached_table: Optional[str] = None
+_ssm_client = None
+_s3_client = None
+_ddb_resource = None
+
+
+class ArtifactError(Exception):
+    """Base class for artifact write failures."""
+
+
+class ArtifactNotFoundError(ArtifactError):
+    """Update target does not exist for this user."""
+
+
+class ArtifactConfigError(ArtifactError):
+    """Artifacts feature is not configured for this environment."""
+
+
+def _reset_caches_for_tests() -> None:
+    global _cached_bucket, _cached_table, _ssm_client, _s3_client, _ddb_resource
+    _cached_bucket = None
+    _cached_table = None
+    _ssm_client = None
+    _s3_client = None
+    _ddb_resource = None
+
+
+def _region() -> str:
+    return (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-west-2"
+    )
+
+
+def _resolve(env_var: str, ssm_suffix: str) -> str:
+    """Env var first, then SSM under the runtime's PROJECT_PREFIX.
+
+    inference-api exposes PROJECT_PREFIX and holds ssm:GetParameter on
+    `/{prefix}/*`, so the artifacts params published by the artifacts
+    stack are readable without any extra wiring."""
+    value = os.environ.get(env_var)
+    if value:
+        return value
+    global _ssm_client
+    prefix = os.environ.get("PROJECT_PREFIX")
+    if not prefix:
+        raise ArtifactConfigError(
+            f"{env_var} unset and PROJECT_PREFIX unavailable"
+        )
+    if _ssm_client is None:
+        _ssm_client = boto3.client("ssm", region_name=_region())
+    try:
+        resp = _ssm_client.get_parameter(
+            Name=f"/{prefix}/artifacts/{ssm_suffix}"
+        )
+    except ClientError as exc:
+        raise ArtifactConfigError(
+            f"artifacts {ssm_suffix} parameter not found"
+        ) from exc
+    return resp["Parameter"]["Value"]
+
+
+def _bucket_name() -> str:
+    global _cached_bucket
+    if _cached_bucket is None:
+        _cached_bucket = _resolve("S3_ARTIFACTS_BUCKET_NAME", "bucket-name")
+    return _cached_bucket
+
+
+def _table():
+    global _cached_table, _ddb_resource
+    if _cached_table is None:
+        _cached_table = _resolve("DYNAMODB_ARTIFACTS_TABLE_NAME", "table-name")
+    if _ddb_resource is None:
+        _ddb_resource = boto3.resource("dynamodb", region_name=_region())
+    return _ddb_resource.Table(_cached_table)
+
+
+def _s3():
+    global _s3_client
+    if _s3_client is None:
+        _s3_client = boto3.client("s3", region_name=_region())
+    return _s3_client
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _put_object(user_id: str, artifact_id: str, version: int,
+                content: str, content_type: str) -> str:
+    key = f"{user_id}/{artifact_id}/v{version}/index.html"
+    _s3().put_object(
+        Bucket=_bucket_name(),
+        Key=key,
+        Body=content.encode("utf-8"),
+        ContentType=content_type,
+    )
+    return key
+
+
+def create_artifact_record(
+    user_id: str,
+    session_id: str,
+    title: str,
+    content: str,
+    content_type: str,
+) -> tuple[str, int]:
+    """Create v1 of a new artifact. Returns (artifact_id, version)."""
+    artifact_id = uuid.uuid4().hex
+    version = 1
+    content_type = content_type or _DEFAULT_CONTENT_TYPE
+    now = _now_iso()
+    content_key = _put_object(user_id, artifact_id, version, content, content_type)
+
+    pk = f"USER#{user_id}"
+    common = {
+        "storage": "s3",
+        "content_key": content_key,
+        "content_type": content_type,
+        "version": version,
+        "artifact_id": artifact_id,
+        "user_id": user_id,
+        "session_id": session_id,
+        "title": title,
+        "created_at": now,
+    }
+    table = _table()
+    try:
+        table.put_item(
+            Item={**common, "PK": pk, "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}"},
+            ConditionExpression="attribute_not_exists(SK)",
+        )
+        table.put_item(
+            Item={
+                **common,
+                "PK": pk,
+                "SK": f"ARTIFACT#{artifact_id}#HEAD",
+                "updated_at": now,
+                "GSI1PK": f"SESSION#{session_id}",
+                "GSI1SK": f"ARTIFACT#{now}#{artifact_id}",
+            },
+            ConditionExpression="attribute_not_exists(SK)",
+        )
+    except ClientError as exc:
+        raise ArtifactError("failed to write artifact metadata") from exc
+
+    logger.info(
+        "created artifact user=%s artifact=%s v=%s session=%s",
+        user_id, artifact_id, version, session_id,
+    )
+    return artifact_id, version
+
+
+def update_artifact_record(
+    user_id: str,
+    artifact_id: str,
+    content: str,
+    title: Optional[str],
+    content_type: Optional[str],
+) -> int:
+    """Append a new immutable version and re-point HEAD. Returns version."""
+    pk = f"USER#{user_id}"
+    table = _table()
+    try:
+        head = table.get_item(
+            Key={"PK": pk, "SK": f"ARTIFACT#{artifact_id}#HEAD"}
+        ).get("Item")
+    except ClientError as exc:
+        raise ArtifactError("artifact metadata lookup failed") from exc
+    if not head:
+        raise ArtifactNotFoundError(artifact_id)
+
+    current = int(head["version"])
+    version = current + 1
+    title = title or head.get("title", "")
+    content_type = content_type or head.get("content_type") or _DEFAULT_CONTENT_TYPE
+    now = _now_iso()
+    content_key = _put_object(user_id, artifact_id, version, content, content_type)
+
+    common = {
+        "storage": "s3",
+        "content_key": content_key,
+        "content_type": content_type,
+        "version": version,
+        "artifact_id": artifact_id,
+        "user_id": user_id,
+        "session_id": head.get("session_id", ""),
+        "title": title,
+        "created_at": head.get("created_at", now),
+    }
+    try:
+        table.put_item(
+            Item={**common, "PK": pk, "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}"},
+            ConditionExpression="attribute_not_exists(SK)",
+        )
+        # Optimistic lock: HEAD must still be at the version we read, so
+        # two concurrent updates can't silently clobber each other.
+        table.put_item(
+            Item={
+                **common,
+                "PK": pk,
+                "SK": f"ARTIFACT#{artifact_id}#HEAD",
+                "updated_at": now,
+                "GSI1PK": f"SESSION#{head.get('session_id', '')}",
+                "GSI1SK": f"ARTIFACT#{now}#{artifact_id}",
+            },
+            ConditionExpression="version = :cur",
+            ExpressionAttributeValues={":cur": current},
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "ConditionalCheckFailedException":
+            raise ArtifactError(
+                "artifact changed concurrently; retry the update"
+            ) from exc
+        raise ArtifactError("failed to write artifact metadata") from exc
+
+    logger.info(
+        "updated artifact user=%s artifact=%s v=%s", user_id, artifact_id, version
+    )
+    return version

--- a/backend/src/agents/builtin_tools/artifacts/tools.py
+++ b/backend/src/agents/builtin_tools/artifacts/tools.py
@@ -1,0 +1,114 @@
+"""Context-bound factories for the artifact authoring tools.
+
+Identity is captured by closure (the codebase has no tool-execution
+contextvar) — same pattern as the spreadsheet_analysis tools. Blocking
+boto3 work is offloaded with ``asyncio.to_thread`` so the chat event
+loop stays responsive under concurrent load.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from strands import tool
+
+from . import service
+
+logger = logging.getLogger(__name__)
+
+
+def make_create_artifact_tool(session_id: str, user_id: str):
+    @tool
+    async def create_artifact(
+        title: str,
+        content: str,
+        content_type: str = "text/html; charset=utf-8",
+    ) -> dict[str, Any]:
+        """Save a standalone document as a versioned artifact the user can open.
+
+        Use this when you produce a self-contained deliverable the user
+        will want to view, keep, or iterate on — an HTML page, a chart,
+        an interactive widget, a formatted report.
+
+        `content` MUST be a complete standalone HTML document (include
+        `<!doctype html>` and a full `<html>` … `</html>`). It renders in
+        a sandboxed iframe with a strict CSP: inline `<style>`/`<script>`
+        are allowed, as are scripts from `https://cdn.tailwindcss.com`
+        and `https://esm.sh`. It cannot make network calls. Do NOT wrap
+        the document in markdown fences.
+
+        Args:
+            title: Short human-readable name shown in the artifacts list.
+            content: The full HTML document.
+            content_type: Defaults to text/html; leave as-is for HTML.
+
+        Returns the new artifact id and version — reference the id if the
+        user later asks you to change it (via update_artifact).
+        """
+        try:
+            artifact_id, version = await asyncio.to_thread(
+                service.create_artifact_record,
+                user_id, session_id, title, content, content_type,
+            )
+        except service.ArtifactConfigError as exc:
+            return {"content": [{"text": f"❌ Artifacts are not available: {exc}"}], "status": "error"}
+        except service.ArtifactError as exc:
+            return {"content": [{"text": f"❌ Failed to create artifact: {exc}"}], "status": "error"}
+        return {
+            "content": [{"text": (
+                f'Created artifact "{title}" '
+                f"(id: {artifact_id}, version {version})."
+            )}],
+            "status": "success",
+        }
+
+    return create_artifact
+
+
+def make_update_artifact_tool(session_id: str, user_id: str):
+    @tool
+    async def update_artifact(
+        artifact_id: str,
+        content: str,
+        title: Optional[str] = None,
+        content_type: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Replace an existing artifact's content, creating a new version.
+
+        Prior versions are kept immutably. Pass the `artifact_id`
+        returned by an earlier create_artifact. `content` follows the
+        same rules as create_artifact (a complete standalone HTML
+        document, no markdown fences).
+
+        Args:
+            artifact_id: The artifact to update.
+            content: The full replacement HTML document.
+            title: Optional new title; unchanged if omitted.
+            content_type: Optional; unchanged if omitted.
+
+        Returns the new version number.
+        """
+        try:
+            version = await asyncio.to_thread(
+                service.update_artifact_record,
+                user_id, artifact_id, content, title, content_type,
+            )
+        except service.ArtifactNotFoundError:
+            return {"content": [{"text": (
+                f"❌ Artifact {artifact_id} was not found. Use the id "
+                f"returned by create_artifact."
+            )}], "status": "error"}
+        except service.ArtifactConfigError as exc:
+            return {"content": [{"text": f"❌ Artifacts are not available: {exc}"}], "status": "error"}
+        except service.ArtifactError as exc:
+            return {"content": [{"text": f"❌ Failed to update artifact: {exc}"}], "status": "error"}
+        return {
+            "content": [{"text": (
+                f"Updated artifact {artifact_id} to version {version}."
+            )}],
+            "status": "success",
+        }
+
+    return update_artifact

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -296,6 +296,41 @@ def _build_spreadsheet_tools(
 
 
 # ============================================================
+# Artifact Authoring Tool Injection
+# ============================================================
+
+ARTIFACT_TOOL_IDS = {"create_artifact", "update_artifact"}
+
+
+def _build_artifact_tools(
+    enabled_tools: list | None,
+    session_id: str,
+    user_id: str,
+) -> list:
+    """Create context-bound artifact authoring tools if enabled by the user."""
+    if not enabled_tools:
+        return []
+
+    requested = ARTIFACT_TOOL_IDS.intersection(enabled_tools)
+    if not requested:
+        return []
+
+    from agents.builtin_tools.artifacts import (
+        make_create_artifact_tool,
+        make_update_artifact_tool,
+    )
+
+    tools = []
+    if "create_artifact" in requested:
+        tools.append(make_create_artifact_tool(session_id, user_id))
+    if "update_artifact" in requested:
+        tools.append(make_update_artifact_tool(session_id, user_id))
+
+    logger.info(f"Created {len(tools)} artifact authoring tools")
+    return tools
+
+
+# ============================================================
 # Attachment Partitioning (#206)
 # ============================================================
 
@@ -1077,6 +1112,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             extra_tools = _build_spreadsheet_tools(
                 enabled_tools=input_data.enabled_tools,
                 assistant_id=input_data.rag_assistant_id,
+                session_id=input_data.session_id,
+                user_id=user_id,
+            ) + _build_artifact_tools(
+                enabled_tools=input_data.enabled_tools,
                 session_id=input_data.session_id,
                 user_id=user_id,
             )

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -1,0 +1,171 @@
+"""Tests for the artifact authoring tools.
+
+The headline guarantee is `test_record_satisfies_minter`: a row written
+by this tool must be accepted byte-for-byte by #310's app-api minter
+(the real downstream reader) and resolve to the S3 object #309's render
+Lambda would serve.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from agents.builtin_tools.artifacts import service
+from apis.inference_api.chat.routes import _build_artifact_tools
+
+REGION = "us-east-1"
+TABLE = "test-user-artifacts"
+BUCKET = "test-artifacts-content"
+USER = "user-123"
+SESSION = "sess-9"
+DOC = "<!doctype html><html><body><h1>hi</h1></body></html>"
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    service._reset_caches_for_tests()
+
+
+@pytest.fixture
+def aws(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+
+        boto3.client("s3", region_name=REGION).create_bucket(Bucket=BUCKET)
+        boto3.client("dynamodb", region_name=REGION).create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "SessionIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield boto3.resource("dynamodb", region_name=REGION), boto3.client(
+            "s3", region_name=REGION
+        )
+
+
+def _item(ddb, artifact_id: str, sk_suffix: str) -> dict:
+    return ddb.Table(TABLE).get_item(
+        Key={"PK": f"USER#{USER}", "SK": f"ARTIFACT#{artifact_id}#{sk_suffix}"}
+    ).get("Item")
+
+
+def test_create_writes_s3_and_rows(aws) -> None:
+    ddb, s3 = aws
+    aid, ver = service.create_artifact_record(USER, SESSION, "My Art", DOC, "")
+    assert ver == 1
+
+    key = f"{USER}/{aid}/v1/index.html"
+    assert s3.get_object(Bucket=BUCKET, Key=key)["Body"].read().decode() == DOC
+
+    vrow = _item(ddb, aid, "V#00001")
+    assert vrow["storage"] == "s3"
+    assert vrow["content_key"] == key
+    assert vrow["content_type"] == "text/html; charset=utf-8"
+
+    head = _item(ddb, aid, "HEAD")
+    assert head["version"] == 1
+    assert head["GSI1PK"] == f"SESSION#{SESSION}"
+    assert head["GSI1SK"].startswith("ARTIFACT#") and head["GSI1SK"].endswith(aid)
+
+
+def test_update_increments_and_preserves_old(aws) -> None:
+    ddb, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+    new_doc = "<!doctype html><html><body>v2</body></html>"
+    ver = service.update_artifact_record(USER, aid, new_doc, None, None)
+    assert ver == 2
+
+    # Old version object is immutable / still present.
+    assert s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode() == DOC
+    assert s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v2/index.html"
+    )["Body"].read().decode() == new_doc
+
+    assert _item(ddb, aid, "V#00002")["content_key"] == f"{USER}/{aid}/v2/index.html"
+    head = _item(ddb, aid, "HEAD")
+    assert head["version"] == 2
+    assert head["title"] == "T"  # carried forward
+
+
+def test_update_unknown_artifact_raises(aws) -> None:
+    with pytest.raises(service.ArtifactNotFoundError):
+        service.update_artifact_record(USER, "nope", DOC, None, None)
+
+
+def test_update_foreign_artifact_raises(aws) -> None:
+    aid, _ = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+    with pytest.raises(service.ArtifactNotFoundError):
+        service.update_artifact_record("someone-else", aid, DOC, None, None)
+
+
+def test_content_type_default(aws) -> None:
+    ddb, _ = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+    assert _item(ddb, aid, "V#00001")["content_type"] == "text/html; charset=utf-8"
+
+
+def test_ssm_fallback(aws, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env unset → resolve bucket/table from /{PROJECT_PREFIX}/artifacts/*."""
+    monkeypatch.delenv("S3_ARTIFACTS_BUCKET_NAME", raising=False)
+    monkeypatch.delenv("DYNAMODB_ARTIFACTS_TABLE_NAME", raising=False)
+    monkeypatch.setenv("PROJECT_PREFIX", "myproj")
+    ssm = boto3.client("ssm", region_name=REGION)
+    ssm.put_parameter(Name="/myproj/artifacts/bucket-name", Value=BUCKET, Type="String")
+    ssm.put_parameter(Name="/myproj/artifacts/table-name", Value=TABLE, Type="String")
+    service._reset_caches_for_tests()
+
+    aid, ver = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+    assert ver == 1 and aid
+
+
+def test_record_satisfies_minter(aws) -> None:
+    """Cross-PR contract: the written version row must be accepted by
+    #310's app-api minter and resolve to the S3 object #309 serves."""
+    _, s3 = aws
+    aid, ver = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+
+    from apis.app_api.artifacts import service as minter
+
+    minter._reset_caches_for_tests()
+    # Minter reads its own table handle from the same env we set.
+    minter._assert_version_exists(USER, aid, ver)  # must not raise
+
+    # And the content_key the readers trust actually points at content.
+    vrow = _item(boto3.resource("dynamodb", region_name=REGION), aid, "V#00001")
+    assert s3.get_object(
+        Bucket=BUCKET, Key=vrow["content_key"]
+    )["Body"].read().decode() == DOC
+
+
+@pytest.mark.parametrize(
+    "enabled,expected",
+    [(None, 0), ([], 0), (["other"], 0), (["create_artifact"], 1),
+     (["create_artifact", "update_artifact"], 2)],
+)
+def test_routes_gating(enabled, expected) -> None:
+    tools = _build_artifact_tools(enabled, SESSION, USER)
+    assert len(tools) == expected


### PR DESCRIPTION
## Summary

Fifth piece of the artifacts sequence (infra [#306](https://github.com/Boise-State-Development/agentcore-public-stack/pull/306) → hotfix [#307](https://github.com/Boise-State-Development/agentcore-public-stack/pull/307) → render Lambda [#309](https://github.com/Boise-State-Development/agentcore-public-stack/pull/309) → token minter [#310](https://github.com/Boise-State-Development/agentcore-public-stack/pull/310) → **this** → SPA panel + SSE).

The **writers** that close the loop: `create_artifact` / `update_artifact` Strands tools that upload a standalone HTML document to S3 and write the frozen DynamoDB version + HEAD rows the render Lambda and minter read back. After this PR an agent can persist an artifact, the minter can issue a token for it, and the Lambda can render it — the only thing still missing is the SPA surface (next PR).

## Design

- **Placement / pattern:** `agents/builtin_tools/artifacts/` (AWS-backed, mirrors `spreadsheet_analysis`). Factory pattern — identity is captured by closure because there is no tool-execution contextvar in this codebase; `make_create_artifact_tool(session_id, user_id)` / `make_update_artifact_tool(...)`.
- **Wiring:** `_build_artifact_tools(...)` in `inference_api/chat/routes.py`, concatenated onto the same `extra_tools` as the spreadsheet builder, **gated on the user's `enabled_tools`** (`{"create_artifact","update_artifact"}`) exactly like every other optional tool.
- **Config (backend-only):** bucket/table names resolve env-var-first, then SSM under the runtime's already-exposed `PROJECT_PREFIX` (inference-api already holds `ssm:GetParameter` on `/{prefix}/*`). No infra change, no redeploy of the stack.

## Frozen contract written here

- **Version row** `PK=USER#{user_id}`, `SK=ARTIFACT#{aid}#V#{version:05d}`, attrs `storage="s3"`, `content_key`, `content_type` — exactly what #309's Lambda and #310's minter read.
- **HEAD row** `SK=ARTIFACT#{aid}#HEAD` + `GSI1PK=SESSION#{session_id}`, `GSI1SK=ARTIFACT#{updated_at}#{aid}` so the future SPA can list session artifacts newest-first.
- **S3** `PutObject` at `{user_id}/{aid}/v{n}/index.html`. Versions are **immutable** (no `DeleteObject` grant): `update_artifact` writes a new version and re-points HEAD under an optimistic `version`-match condition; old versions and objects are never mutated.

## Security / scope notes

- Ownership is enforced by construction: the DDB PK is built from the closed-over authenticated `user_id`, so `update_artifact` on another user's id simply 404s.
- Tool docstrings instruct the model to emit a complete standalone HTML document (no markdown fences) consistent with #309's CSP (inline script/style + tailwindcss/esm.sh).
- **Out of scope (stated):** soft-delete (no grant), and SSE `artifact_block_*` events + the SPA side panel — the next and final PR.

## Test plan

- [x] `pytest tests/agents/builtin_tools/artifacts/` — 12/12 (create writes S3+rows, update increments + preserves old immutably, unknown/foreign artifact → not-found, content-type default, SSM fallback, route gating matrix, **cross-PR contract: written row accepted by #310's `_assert_version_exists` and resolves to the S3 object #309 serves**)
- [x] `pytest tests/architecture/` — import-boundary intact (agents code imports only stdlib/boto3/strands; the inference_api→agents factory import mirrors the existing spreadsheet pattern)
- [x] `ruff check` clean on all new files; `routes.py` error count unchanged (5 → 5, pre-existing)
- [ ] Post-merge: end-to-end once the SPA panel (next PR) calls the minter and renders a tool-created artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)