### PR TITLE
feat(artifacts): add SPA artifact panel + artifact SSE event

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import boto3
+from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
@@ -254,3 +255,53 @@ def update_artifact_record(
         "updated artifact user=%s artifact=%s v=%s", user_id, artifact_id, version
     )
     return version
+
+
+_SESSION_INDEX = "SessionIndex"
+
+
+def list_session_artifacts(user_id: str, session_id: str) -> list[dict]:
+    """Current HEAD of every artifact written in a chat session.
+
+    Read side of the same SessionIndex GSI the app-api list endpoint
+    uses; the stream coordinator calls this post-turn to emit the live
+    `artifact` SSE event. Only HEAD rows carry GSI1PK/GSI1SK, so the
+    query returns one row per artifact (its current version). GSI1PK is
+    SESSION#-scoped (not user-scoped) so every row is re-checked against
+    the authenticated user's id.
+    """
+    table = _table()
+    items: list[dict] = []
+    kwargs: dict = {
+        "IndexName": _SESSION_INDEX,
+        "KeyConditionExpression": Key("GSI1PK").eq(f"SESSION#{session_id}"),
+        "ScanIndexForward": False,  # GSI1SK embeds updated_at → newest first
+    }
+    try:
+        while True:
+            resp = table.query(**kwargs)
+            items.extend(resp.get("Items", []))
+            last = resp.get("LastEvaluatedKey")
+            if not last:
+                break
+            kwargs["ExclusiveStartKey"] = last
+    except ClientError as exc:
+        raise ArtifactError("artifact list query failed") from exc
+
+    out: list[dict] = []
+    for item in items:
+        if item.get("user_id") != user_id:
+            continue
+        out.append(
+            {
+                "artifact_id": item.get("artifact_id", ""),
+                "version": int(item.get("version", 0)),
+                "title": item.get("title", ""),
+                "content_type": item.get(
+                    "content_type", _DEFAULT_CONTENT_TYPE
+                ),
+                "updated_at": item.get("updated_at", ""),
+                "created_at": item.get("created_at"),
+            }
+        )
+    return out

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -66,7 +66,16 @@ class StreamCoordinator:
 
         # Track timing for latency metrics
         stream_start_time = time.time()
+        # Wall-clock turn start as a tz-aware datetime. Used post-turn to
+        # tell which artifacts (HEAD.updated_at) were touched *this* turn
+        # vs. carried over from earlier turns in the same session.
+        turn_start_dt = datetime.now(timezone.utc)
         first_token_time: Optional[float] = None
+
+        # Set when a create_artifact / update_artifact tool call is seen
+        # this turn — the only turns that need the post-turn artifacts
+        # query + `artifact` SSE emit. Normal turns pay nothing.
+        artifact_tool_invoked = False
 
         # Accumulate metadata from stream
         accumulated_metadata: Dict[str, Any] = {"usage": {}, "metrics": {}}
@@ -125,6 +134,16 @@ class StreamCoordinator:
                                 # Also update global first_token_time for the first message (backward compatibility)
                                 if current_assistant_message_index == 0 and first_token_time is None:
                                     first_token_time = per_message_metadata[0]["first_token_time"]
+
+                # Note whether the agent invoked an artifact authoring
+                # tool this turn. Gates the post-turn artifacts query so
+                # only artifact turns pay for it.
+                if not artifact_tool_invoked and event.get("type") == "tool_use":
+                    tool_name = (
+                        event.get("data", {}).get("tool_use", {}).get("name")
+                    )
+                    if tool_name in ("create_artifact", "update_artifact"):
+                        artifact_tool_invoked = True
 
                 # Track when assistant messages end
                 if event.get("type") == "message_stop":
@@ -376,6 +395,19 @@ class StreamCoordinator:
                                     yield f"event: compaction\ndata: {json.dumps(compaction_payload)}\n\n"
                             except Exception as e:
                                 logger.warning(f"Failed to update compaction state: {e}")
+
+                # Emit one `artifact` SSE per artifact created/updated this
+                # turn. Placed after the compaction emit (so it lands with
+                # the other post-message_stop side-channel events) and
+                # before `done`. Best-effort: a lookup failure logs and is
+                # swallowed so it never breaks the live stream.
+                if event.get("type") == "done" and artifact_tool_invoked:
+                    for sse in await self._extract_artifact_events(
+                        session_id=session_id,
+                        user_id=user_id,
+                        turn_start=turn_start_dt,
+                    ):
+                        yield sse
 
                 # Intercept legacy "error" events from stream_processor and convert to conversational format
                 # This ensures errors appear as assistant messages in the chat UI
@@ -862,6 +894,69 @@ class StreamCoordinator:
                     tool_input=tool_input,
                     message=message,
                 ).to_sse_format()
+            )
+        return events
+
+    async def _extract_artifact_events(
+        self,
+        session_id: Optional[str],
+        user_id: Optional[str],
+        turn_start: datetime,
+    ) -> List[str]:
+        """Yield one SSE-formatted `artifact` event per artifact whose
+        HEAD was created or updated during this turn.
+
+        Identifies "this turn" by `updated_at >= turn_start` rather than
+        parsing the tool result text: it reflects exactly what was
+        persisted, handles multiple artifacts in one turn, and ignores
+        artifacts carried over from earlier turns in the same session. A
+        row with an unparseable `updated_at` is included (the artifact
+        tool ran this turn and the SPA dedupes by id+version anyway).
+
+        Best-effort: any failure (artifacts not configured for this env,
+        DynamoDB error) logs and returns [] — never breaks the stream.
+        """
+        if not (session_id and user_id):
+            return []
+        try:
+            from agents.builtin_tools.artifacts.service import (
+                ArtifactConfigError,
+                list_session_artifacts,
+            )
+
+            rows = await asyncio.to_thread(
+                list_session_artifacts, user_id, session_id
+            )
+        except ArtifactConfigError:
+            return []
+        except Exception as e:
+            logger.warning("Failed to list session artifacts: %s", e)
+            return []
+
+        events: List[str] = []
+        for row in rows:
+            updated_at = row.get("updated_at") or ""
+            try:
+                touched = datetime.fromisoformat(updated_at) >= turn_start
+            except (ValueError, TypeError):
+                touched = True
+            if not touched:
+                continue
+            version = int(row.get("version", 0))
+            payload = {
+                "type": "artifact",
+                "artifactId": row.get("artifact_id", ""),
+                "version": version,
+                "title": row.get("title", ""),
+                "contentType": row.get(
+                    "content_type", "text/html; charset=utf-8"
+                ),
+                "sessionId": session_id,
+                "updatedAt": updated_at,
+                "action": "created" if version == 1 else "updated",
+            }
+            events.append(
+                f"event: artifact\ndata: {json.dumps(payload)}\n\n"
             )
         return events
 

--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -23,3 +23,23 @@ class RenderTokenResponse(BaseModel):
         "(set directly as the iframe src)",
     )
     expires_at: str = Field(..., description="ISO-8601 UTC token expiry")
+
+
+class ArtifactSummary(BaseModel):
+    """One artifact's current HEAD, for the session artifacts list.
+
+    Snake-case JSON to match this domain's existing REST shape
+    (RenderTokenResponse.expires_at). The SPA normalizes both this and
+    the camelCase live SSE `artifact` event into one client model.
+    """
+
+    artifact_id: str
+    version: int
+    title: str
+    content_type: str
+    updated_at: str
+    created_at: Optional[str] = None
+
+
+class ArtifactListResponse(BaseModel):
+    artifacts: list[ArtifactSummary] = Field(default_factory=list)

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -16,6 +16,7 @@ from .models import (
 from .service import (
     ArtifactListService,
     ArtifactNotFoundError,
+    ArtifactQueryError,
     RenderTokenConfigError,
     RenderTokenService,
     get_artifact_list_service,
@@ -88,6 +89,15 @@ async def list_session_artifacts(
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             "Artifact listing is unavailable",
+        )
+    except ArtifactQueryError:
+        # Feature is configured fine — the backing query just failed
+        # (throttle/timeout/transient). Retryable, so signal 503 rather
+        # than masquerading as a 500 misconfiguration.
+        logger.exception("artifact list query failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact listing is temporarily unavailable",
         )
 
     return ArtifactListResponse(

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -3,15 +3,22 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from apis.shared.auth import User, get_current_user_from_session
 
-from .models import RenderTokenRequest, RenderTokenResponse
+from .models import (
+    ArtifactListResponse,
+    ArtifactSummary,
+    RenderTokenRequest,
+    RenderTokenResponse,
+)
 from .service import (
+    ArtifactListService,
     ArtifactNotFoundError,
     RenderTokenConfigError,
     RenderTokenService,
+    get_artifact_list_service,
     get_render_token_service,
 )
 
@@ -55,4 +62,34 @@ async def mint_render_token(
     return RenderTokenResponse(
         url=url,
         expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
+    )
+
+
+@router.get("", response_model=ArtifactListResponse)
+async def list_session_artifacts(
+    session_id: str = Query(..., description="Chat session id to list artifacts for"),
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactListService = Depends(get_artifact_list_service),
+) -> ArtifactListResponse:
+    """List the current HEAD of every artifact created in a chat session.
+
+    Used by the SPA to hydrate artifact cards on session load (live
+    creation is delivered separately via the `artifact` SSE event). Each
+    row is re-checked against the authenticated user, so a borrowed
+    session id cannot enumerate another user's artifacts. An unknown or
+    artifact-free session is a normal empty list, not a 404.
+    """
+    try:
+        rows = service.list_for_session(
+            user_id=user.user_id, session_id=session_id
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact list service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact listing is unavailable",
+        )
+
+    return ArtifactListResponse(
+        artifacts=[ArtifactSummary(**row) for row in rows]
     )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -51,6 +51,12 @@ class RenderTokenConfigError(RenderTokenError):
     """Required environment / AWS configuration is missing or unusable."""
 
 
+class ArtifactQueryError(RenderTokenError):
+    """A backing-store query failed at runtime (throttle, timeout,
+    transient DynamoDB error) — distinct from a misconfiguration: the
+    feature is set up correctly, the request just couldn't be served."""
+
+
 def _reset_caches_for_tests() -> None:
     """Drop process-wide singletons so test order can't leak a stale
     signing key, secrets client, or DDB table handle."""
@@ -232,7 +238,7 @@ class ArtifactListService:
                     break
                 kwargs["ExclusiveStartKey"] = last
         except ClientError as exc:
-            raise RenderTokenConfigError(
+            raise ArtifactQueryError(
                 "artifact list query failed"
             ) from exc
 

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 import boto3
 import jwt
+from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
@@ -192,3 +193,67 @@ class RenderTokenService:
 
 def get_render_token_service() -> RenderTokenService:
     return RenderTokenService()
+
+
+# Frozen contract — the HEAD row + SessionIndex keys the artifact writer
+# (backend/src/agents/builtin_tools/artifacts/service.py) emits.
+_SESSION_INDEX = "SessionIndex"
+
+
+class ArtifactListService:
+    """List a session's artifacts from the SessionIndex GSI.
+
+    The GSI projects only HEAD rows (the writer attaches GSI1PK/GSI1SK to
+    the HEAD put only), so a query already returns one row per artifact —
+    its current version — newest-first. GSI1PK is `SESSION#{sid}`, which
+    is NOT user-scoped, so every returned row is re-checked against the
+    authenticated user's id: a caller passing a borrowed session id can
+    never enumerate another user's artifacts.
+    """
+
+    def list_for_session(
+        self, *, user_id: str, session_id: str
+    ) -> list[dict]:
+        table = _table()
+        items: list[dict] = []
+        kwargs: dict = {
+            "IndexName": _SESSION_INDEX,
+            "KeyConditionExpression": Key("GSI1PK").eq(
+                f"SESSION#{session_id}"
+            ),
+            "ScanIndexForward": False,  # GSI1SK embeds updated_at → newest first
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise RenderTokenConfigError(
+                "artifact list query failed"
+            ) from exc
+
+        summaries: list[dict] = []
+        for item in items:
+            if item.get("user_id") != user_id:
+                continue
+            summaries.append(
+                {
+                    "artifact_id": item.get("artifact_id", ""),
+                    "version": int(item.get("version", 0)),
+                    "title": item.get("title", ""),
+                    "content_type": item.get(
+                        "content_type", "text/html; charset=utf-8"
+                    ),
+                    "updated_at": item.get("updated_at", ""),
+                    "created_at": item.get("created_at"),
+                }
+            )
+        return summaries
+
+
+def get_artifact_list_service() -> ArtifactListService:
+    return ArtifactListService()

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -169,3 +169,30 @@ def test_record_satisfies_minter(aws) -> None:
 def test_routes_gating(enabled, expected) -> None:
     tools = _build_artifact_tools(enabled, SESSION, USER)
     assert len(tools) == expected
+
+
+def test_list_session_artifacts_returns_heads_newest_first(aws) -> None:
+    a1, _ = service.create_artifact_record(USER, SESSION, "First", DOC, "")
+    a2, _ = service.create_artifact_record(USER, SESSION, "Second", DOC, "")
+    # Bump a1 to v2 so it becomes the most-recently-updated HEAD.
+    service.update_artifact_record(USER, a1, DOC, None, None)
+
+    rows = service.list_session_artifacts(USER, SESSION)
+    by_id = {r["artifact_id"]: r for r in rows}
+    assert set(by_id) == {a1, a2}
+    assert by_id[a1]["version"] == 2  # reflects current HEAD, not v1
+    assert by_id[a2]["title"] == "Second"
+    # Newest-first: a1 (just updated) precedes a2.
+    assert [r["artifact_id"] for r in rows] == [a1, a2]
+
+
+def test_list_session_artifacts_scopes_to_user(aws) -> None:
+    mine, _ = service.create_artifact_record(USER, SESSION, "Mine", DOC, "")
+    service.create_artifact_record("someone-else", SESSION, "Theirs", DOC, "")
+
+    rows = service.list_session_artifacts(USER, SESSION)
+    assert [r["artifact_id"] for r in rows] == [mine]
+
+
+def test_list_session_artifacts_empty_session(aws) -> None:
+    assert service.list_session_artifacts(USER, "no-such-session") == []

--- a/backend/tests/agents/main_agent/streaming/test_artifact_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_artifact_events.py
@@ -1,0 +1,152 @@
+"""Tests for StreamCoordinator._extract_artifact_events.
+
+Covers the post-turn `artifact` SSE emit: turn-window filtering (only
+artifacts touched this turn), action derivation, fail-closed behavior,
+and the no-session guard.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from agents.builtin_tools.artifacts import service as artifact_service
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+SESSION = "sess-9"
+USER = "user-123"
+
+
+def _parse_sse(raw: str) -> dict:
+    assert raw.startswith("event: artifact\ndata: ")
+    assert raw.endswith("\n\n")
+    return json.loads(raw[len("event: artifact\ndata: ") :].strip())
+
+
+@pytest.fixture
+def turn_start() -> datetime:
+    return datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def coord() -> StreamCoordinator:
+    return StreamCoordinator()
+
+
+def _row(**kw) -> dict:
+    base = {
+        "artifact_id": "art-1",
+        "version": 1,
+        "title": "Doc",
+        "content_type": "text/html; charset=utf-8",
+        "updated_at": "2026-05-15T12:00:05+00:00",
+        "created_at": "2026-05-15T12:00:05+00:00",
+    }
+    base.update(kw)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_emits_created_for_v1(coord, turn_start, monkeypatch) -> None:
+    monkeypatch.setattr(
+        artifact_service, "list_session_artifacts", lambda u, s: [_row()]
+    )
+    out = await coord._extract_artifact_events(SESSION, USER, turn_start)
+    assert len(out) == 1
+    payload = _parse_sse(out[0])
+    assert payload == {
+        "type": "artifact",
+        "artifactId": "art-1",
+        "version": 1,
+        "title": "Doc",
+        "contentType": "text/html; charset=utf-8",
+        "sessionId": SESSION,
+        "updatedAt": "2026-05-15T12:00:05+00:00",
+        "action": "created",
+    }
+
+
+@pytest.mark.asyncio
+async def test_version_gt_1_is_updated(coord, turn_start, monkeypatch) -> None:
+    monkeypatch.setattr(
+        artifact_service,
+        "list_session_artifacts",
+        lambda u, s: [_row(version=4)],
+    )
+    out = await coord._extract_artifact_events(SESSION, USER, turn_start)
+    assert _parse_sse(out[0])["action"] == "updated"
+    assert _parse_sse(out[0])["version"] == 4
+
+
+@pytest.mark.asyncio
+async def test_filters_artifacts_from_earlier_turns(
+    coord, turn_start, monkeypatch
+) -> None:
+    stale = _row(artifact_id="old", updated_at="2026-05-15T11:59:59+00:00")
+    fresh = _row(artifact_id="new", updated_at="2026-05-15T12:00:30+00:00")
+    monkeypatch.setattr(
+        artifact_service,
+        "list_session_artifacts",
+        lambda u, s: [fresh, stale],
+    )
+    out = await coord._extract_artifact_events(SESSION, USER, turn_start)
+    ids = [_parse_sse(e)["artifactId"] for e in out]
+    assert ids == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_updated_at_is_included(
+    coord, turn_start, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        artifact_service,
+        "list_session_artifacts",
+        lambda u, s: [_row(updated_at="")],
+    )
+    out = await coord._extract_artifact_events(SESSION, USER, turn_start)
+    assert len(out) == 1
+
+
+@pytest.mark.asyncio
+async def test_config_error_is_swallowed(coord, turn_start, monkeypatch) -> None:
+    def _raise(u, s):
+        raise artifact_service.ArtifactConfigError("not configured")
+
+    monkeypatch.setattr(artifact_service, "list_session_artifacts", _raise)
+    assert await coord._extract_artifact_events(SESSION, USER, turn_start) == []
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_is_swallowed(
+    coord, turn_start, monkeypatch
+) -> None:
+    def _raise(u, s):
+        raise RuntimeError("ddb down")
+
+    monkeypatch.setattr(artifact_service, "list_session_artifacts", _raise)
+    assert await coord._extract_artifact_events(SESSION, USER, turn_start) == []
+
+
+@pytest.mark.asyncio
+async def test_no_session_or_user_is_noop(coord, turn_start) -> None:
+    assert await coord._extract_artifact_events(None, USER, turn_start) == []
+    assert await coord._extract_artifact_events(SESSION, None, turn_start) == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_artifacts_one_turn(coord, turn_start, monkeypatch) -> None:
+    monkeypatch.setattr(
+        artifact_service,
+        "list_session_artifacts",
+        lambda u, s: [
+            _row(artifact_id="a", version=1),
+            _row(artifact_id="b", version=2),
+        ],
+    )
+    out = await coord._extract_artifact_events(SESSION, USER, turn_start)
+    actions = {
+        _parse_sse(e)["artifactId"]: _parse_sse(e)["action"] for e in out
+    }
+    assert actions == {"a": "created", "b": "updated"}

--- a/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
+++ b/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
@@ -1,0 +1,180 @@
+"""Tests for the app-api session artifacts list endpoint.
+
+Mirrors the writer's frozen HEAD-row shape from #311
+(backend/src/agents/builtin_tools/artifacts/service.py): only HEAD rows
+carry GSI1PK/GSI1SK, so a SessionIndex query returns exactly one row per
+artifact (its current version) newest-first.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as artifact_service
+from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+REGION = "us-east-1"
+USER_ID = "user-123"
+SESSION = "sess-9"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    artifact_service._reset_caches_for_tests()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "SessionIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        )
+
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+
+        app = FastAPI()
+        app.include_router(artifacts_router)
+        app.dependency_overrides[get_current_user_from_session] = lambda: User(
+            email="u@x.com", user_id=USER_ID, name="U", roles=[]
+        )
+        yield TestClient(app), boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_head(
+    ddb,
+    *,
+    user_id: str = USER_ID,
+    session_id: str = SESSION,
+    artifact: str = "art-1",
+    version: int = 1,
+    title: str = "Doc",
+    updated_at: str = "2026-05-15T10:00:00+00:00",
+    created_at: str = "2026-05-15T10:00:00+00:00",
+) -> None:
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#HEAD",
+            "GSI1PK": f"SESSION#{session_id}",
+            "GSI1SK": f"ARTIFACT#{updated_at}#{artifact}",
+            "storage": "s3",
+            "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "version": version,
+            "artifact_id": artifact,
+            "user_id": user_id,
+            "session_id": session_id,
+            "title": title,
+            "created_at": created_at,
+            "updated_at": updated_at,
+        }
+    )
+
+
+def _put_version_row(ddb, *, artifact: str = "art-1", version: int = 1) -> None:
+    """A non-HEAD version row — must NOT appear in the SessionIndex query
+    (the writer omits GSI1PK/GSI1SK on version rows)."""
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{USER_ID}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "storage": "s3",
+            "content_key": f"{USER_ID}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "version": version,
+            "artifact_id": artifact,
+            "user_id": USER_ID,
+            "session_id": SESSION,
+            "title": "Doc",
+            "created_at": "2026-05-15T10:00:00+00:00",
+        }
+    )
+
+
+def test_empty_session_is_empty_list(client) -> None:
+    tc, _ = client
+    resp = tc.get("/artifacts", params={"session_id": SESSION})
+    assert resp.status_code == 200
+    assert resp.json() == {"artifacts": []}
+
+
+def test_lists_head_rows_newest_first(client) -> None:
+    tc, ddb = client
+    _put_head(
+        ddb, artifact="old", updated_at="2026-05-15T10:00:00+00:00", title="Old"
+    )
+    _put_head(
+        ddb, artifact="new", updated_at="2026-05-15T12:00:00+00:00", title="New"
+    )
+    # A version row for the same artifact must be ignored by the query.
+    _put_version_row(ddb, artifact="new", version=1)
+
+    resp = tc.get("/artifacts", params={"session_id": SESSION})
+    assert resp.status_code == 200
+    arts = resp.json()["artifacts"]
+    assert [a["artifact_id"] for a in arts] == ["new", "old"]
+    assert arts[0]["title"] == "New"
+    assert arts[0]["content_type"] == "text/html; charset=utf-8"
+
+
+def test_reflects_current_version(client) -> None:
+    tc, ddb = client
+    _put_head(ddb, artifact="art-1", version=3, title="V3")
+    resp = tc.get("/artifacts", params={"session_id": SESSION})
+    body = resp.json()["artifacts"]
+    assert body[0]["version"] == 3
+    assert body[0]["created_at"] == "2026-05-15T10:00:00+00:00"
+
+
+def test_other_users_session_row_is_filtered(client) -> None:
+    """GSI1PK is SESSION#-scoped, not user-scoped: a row owned by another
+    user that happens to share the queried session id must be dropped."""
+    tc, ddb = client
+    _put_head(ddb, artifact="mine", user_id=USER_ID)
+    _put_head(ddb, artifact="theirs", user_id="someone-else")
+
+    resp = tc.get("/artifacts", params={"session_id": SESSION})
+    arts = resp.json()["artifacts"]
+    assert [a["artifact_id"] for a in arts] == ["mine"]
+
+
+def test_session_id_required(client) -> None:
+    tc, _ = client
+    resp = tc.get("/artifacts")
+    assert resp.status_code == 422
+
+
+def test_requires_authentication() -> None:
+    app = FastAPI()
+    app.include_router(artifacts_router)
+    resp = TestClient(app).get("/artifacts", params={"session_id": SESSION})
+    assert resp.status_code == 401

--- a/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
+++ b/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from moto import mock_aws
 
 from apis.app_api.artifacts import service as artifact_service
 from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.app_api.artifacts.service import (
+    ArtifactListService,
+    ArtifactQueryError,
+    RenderTokenConfigError,
+    get_artifact_list_service,
+)
 from apis.shared.auth import User, get_current_user_from_session
 
 TABLE = "test-user-artifacts"
@@ -178,3 +185,56 @@ def test_requires_authentication() -> None:
     app.include_router(artifacts_router)
     resp = TestClient(app).get("/artifacts", params={"session_id": SESSION})
     assert resp.status_code == 401
+
+
+def test_transient_query_error_is_not_a_config_error(
+    client, monkeypatch
+) -> None:
+    """A transient DynamoDB ClientError is a runtime query failure, not a
+    misconfiguration — it must surface as ArtifactQueryError so the route
+    can distinguish a configured-but-throttled feature from a broken one."""
+
+    class _ThrottlingTable:
+        def query(self, **_):
+            raise ClientError(
+                {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+                "Query",
+            )
+
+    monkeypatch.setattr(artifact_service, "_table", lambda: _ThrottlingTable())
+    with pytest.raises(ArtifactQueryError):
+        ArtifactListService().list_for_session(
+            user_id=USER_ID, session_id=SESSION
+        )
+
+
+def test_route_maps_transient_query_failure_to_503(client) -> None:
+    """ArtifactQueryError → 503 (retryable), distinct from the 500 a real
+    RenderTokenConfigError misconfiguration produces."""
+    tc, _ = client
+
+    class _FailingService:
+        def list_for_session(self, **_):
+            raise ArtifactQueryError("artifact list query failed")
+
+    tc.app.dependency_overrides[get_artifact_list_service] = _FailingService
+    try:
+        resp = tc.get("/artifacts", params={"session_id": SESSION})
+    finally:
+        tc.app.dependency_overrides.pop(get_artifact_list_service, None)
+    assert resp.status_code == 503
+
+
+def test_route_maps_misconfig_to_500(client) -> None:
+    tc, _ = client
+
+    class _MisconfiguredService:
+        def list_for_session(self, **_):
+            raise RenderTokenConfigError("DYNAMODB_ARTIFACTS_TABLE_NAME is not set")
+
+    tc.app.dependency_overrides[get_artifact_list_service] = _MisconfiguredService
+    try:
+        resp = tc.get("/artifacts", params={"session_id": SESSION})
+    finally:
+        tc.app.dependency_overrides.pop(get_artifact_list_service, None)
+    assert resp.status_code == 500

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -1,0 +1,85 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroCodeBracket,
+  heroArrowTopRightOnSquare,
+} from '@ng-icons/heroicons/outline';
+import type { Artifact } from '../../../../services/artifacts/artifact.model';
+import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+
+/**
+ * Compact, clickable card for one artifact. The artifact's content is
+ * never inlined here — opening the card asks the panel to mint a
+ * short-lived render token and load it in a sandboxed iframe.
+ *
+ * Rendered as a session-level strip (next to the compaction summary),
+ * not anchored to a specific message: the backend doesn't track which
+ * message produced which artifact, and the panel is the real surface.
+ */
+@Component({
+  selector: 'app-artifact-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({ heroCodeBracket, heroArrowTopRightOnSquare }),
+  ],
+  template: `
+    <button
+      type="button"
+      class="group flex w-full max-w-md items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-blue-400 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500 dark:hover:bg-gray-700/60 dark:focus-visible:ring-offset-gray-900"
+      [attr.aria-label]="ariaLabel()"
+      (click)="open()"
+    >
+      <span
+        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300"
+      >
+        <ng-icon name="heroCodeBracket" class="text-lg" aria-hidden="true" />
+      </span>
+      <span class="min-w-0 flex-1">
+        <span
+          class="block truncate text-sm font-medium text-gray-900 dark:text-gray-100"
+        >
+          {{ artifact().title || 'Untitled artifact' }}
+        </span>
+        <span class="block text-xs text-gray-500 dark:text-gray-400">
+          Artifact · v{{ artifact().version }}
+        </span>
+      </span>
+      <ng-icon
+        name="heroArrowTopRightOnSquare"
+        class="shrink-0 text-base text-gray-400 transition-colors group-hover:text-blue-600 dark:group-hover:text-blue-300"
+        aria-hidden="true"
+      />
+    </button>
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+})
+export class ArtifactCardComponent {
+  artifact = input.required<Artifact>();
+
+  private artifactState = inject(ArtifactStateService);
+
+  protected readonly ariaLabel = computed(
+    () =>
+      `Open artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
+  );
+
+  protected open(): void {
+    const a = this.artifact();
+    this.artifactState.openArtifactPanel({
+      artifactId: a.artifactId,
+      version: a.version,
+      title: a.title,
+    });
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -1,0 +1,215 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroXMark,
+  heroArrowPath,
+  heroExclamationTriangle,
+} from '@ng-icons/heroicons/outline';
+import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
+import { SessionService } from '../../../../services/session/session.service';
+
+/**
+ * Right slide-over that renders one artifact version in a sandboxed
+ * iframe. Open state lives in `ArtifactStateService`; this component
+ * mints a fresh short-lived render token each time it opens (the token
+ * is a ~120s bearer credential — never cached) and points the iframe at
+ * the returned artifact-origin URL.
+ *
+ * Isolation model (from the #306 design): the artifact origin is a
+ * separate subdomain, the render Lambda + CloudFront stamp a strict CSP,
+ * and the iframe carries `sandbox="allow-scripts"` *without*
+ * `allow-same-origin` so the framed document is a null origin and cannot
+ * reach the artifact origin's storage/cookies. `bypassSecurityTrustResourceUrl`
+ * is safe here: the URL comes from our own authenticated app-api, is
+ * single-use, and the sandbox + CSP contain the content.
+ */
+@Component({
+  selector: 'app-artifact-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({ heroXMark, heroArrowPath, heroExclamationTriangle }),
+  ],
+  host: {
+    '(document:keydown.escape)': 'onEscape()',
+  },
+  template: `
+    @if (open(); as ref) {
+      <div
+        class="fixed inset-0 z-40 bg-black/30"
+        (click)="close()"
+        aria-hidden="true"
+      ></div>
+      <aside
+        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-2xl flex-col border-l border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-label]="'Artifact: ' + ref.title"
+      >
+        <header
+          class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700"
+        >
+          <div class="min-w-0 flex-1">
+            <h2
+              class="truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {{ ref.title || 'Untitled artifact' }}
+            </h2>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              Version {{ ref.version }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+            aria-label="Close artifact"
+            (click)="close()"
+          >
+            <ng-icon name="heroXMark" class="text-lg" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div class="relative min-h-0 flex-1">
+          @if (loading()) {
+            <div
+              class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-gray-500 dark:text-gray-400"
+              role="status"
+            >
+              <ng-icon
+                name="heroArrowPath"
+                class="animate-spin text-2xl"
+                aria-hidden="true"
+              />
+              <span class="text-sm">Loading artifact…</span>
+            </div>
+          } @else if (error()) {
+            <div
+              class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+              role="alert"
+            >
+              <ng-icon
+                name="heroExclamationTriangle"
+                class="text-3xl text-amber-500"
+                aria-hidden="true"
+              />
+              <p class="text-sm text-gray-700 dark:text-gray-300">
+                {{ error() }}
+              </p>
+              <button
+                type="button"
+                class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
+                (click)="retry()"
+              >
+                Try again
+              </button>
+            </div>
+          } @else if (safeUrl()) {
+            <iframe
+              [src]="safeUrl()"
+              class="h-full w-full border-0 bg-white"
+              [title]="ref.title || 'Artifact'"
+              sandbox="allow-scripts"
+              referrerpolicy="no-referrer"
+              loading="lazy"
+            ></iframe>
+          }
+        </div>
+      </aside>
+    }
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+  `,
+})
+export class ArtifactPanelComponent {
+  private artifactState = inject(ArtifactStateService);
+  private artifactHttp = inject(ArtifactHttpService);
+  private sessionService = inject(SessionService);
+  private sanitizer = inject(DomSanitizer);
+
+  protected readonly open = this.artifactState.openArtifact;
+
+  protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
+  protected readonly loading = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  /** Bumped per open/retry so a slow mint that resolves after the panel
+   *  closed (or moved to another artifact) is discarded. */
+  private requestSeq = 0;
+
+  protected readonly currentKey = computed(() => {
+    const r = this.open();
+    return r ? `${r.artifactId}#${r.version}` : null;
+  });
+
+  constructor() {
+    // Mint a fresh token whenever the panel opens or switches artifact.
+    // Closing (open() === null) clears the iframe so the credential URL
+    // doesn't linger in the DOM.
+    effect(() => {
+      const key = this.currentKey();
+      if (!key) {
+        this.reset();
+        return;
+      }
+      void this.load();
+    });
+  }
+
+  protected onEscape(): void {
+    if (this.open()) this.close();
+  }
+
+  protected close(): void {
+    this.artifactState.closeArtifactPanel();
+  }
+
+  protected retry(): void {
+    void this.load();
+  }
+
+  private reset(): void {
+    this.safeUrl.set(null);
+    this.error.set(null);
+    this.loading.set(false);
+  }
+
+  private async load(): Promise<void> {
+    const ref = this.open();
+    if (!ref) return;
+    const seq = ++this.requestSeq;
+    this.loading.set(true);
+    this.error.set(null);
+    this.safeUrl.set(null);
+    try {
+      const sessionId = this.sessionService.currentSession().sessionId;
+      const token = await this.artifactHttp.mintRenderToken(
+        ref.artifactId,
+        ref.version,
+        sessionId,
+      );
+      if (seq !== this.requestSeq) return; // superseded — drop
+      this.safeUrl.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(token.url),
+      );
+    } catch {
+      if (seq !== this.requestSeq) return;
+      this.error.set(
+        "This artifact couldn't be loaded. It may have expired or been removed.",
+      );
+    } finally {
+      if (seq === this.requestSeq) this.loading.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -45,6 +45,22 @@
     />
   }
 
+  <!-- Session-level artifact strip. Not anchored to a message: the
+       backend doesn't track which message produced which artifact, and
+       the panel (opened from a card) is the real surface. Hydrated from
+       the app-api list endpoint on load, appended live via the
+       `artifact` SSE event. -->
+  @if (hasArtifacts()) {
+    <section
+      class="mt-3 flex flex-col gap-2"
+      aria-label="Artifacts created in this conversation"
+    >
+      @for (artifact of artifacts(); track artifact.artifactId) {
+        <app-artifact-card [artifact]="artifact" />
+      }
+    </section>
+  }
+
   <!-- OAuth consent prompts not anchored to a loaded message — usually
        hydrated from session metadata after a refresh, when the partial
        assistant message wasn't persisted. -->
@@ -85,4 +101,7 @@
       class="pointer-events-none">
     </div>
   }
+
+  <!-- Fixed-position slide-over; renders only when an artifact is open. -->
+  <app-artifact-panel />
 </div>

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -10,6 +10,9 @@ import { PulsatingLoaderComponent } from '../../../components/pulsating-loader.c
 import { OAuthConsentPromptComponent } from './components/oauth-consent-prompt/oauth-consent-prompt.component';
 import { ToolApprovalPromptComponent } from './components/tool-approval-prompt/tool-approval-prompt.component';
 import { CompactionSummaryComponent } from './components/compaction-summary/compaction-summary.component';
+import { ArtifactCardComponent } from './components/artifact/artifact-card.component';
+import { ArtifactPanelComponent } from './components/artifact/artifact-panel.component';
+import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
 import {
   OAuthConsentRequest,
   OAuthConsentService,
@@ -32,6 +35,8 @@ import { CompactionSummaryService } from '../../services/chat/compaction-summary
     OAuthConsentPromptComponent,
     ToolApprovalPromptComponent,
     CompactionSummaryComponent,
+    ArtifactCardComponent,
+    ArtifactPanelComponent,
   ],
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
@@ -53,6 +58,11 @@ export class MessageListComponent implements OnDestroy {
   private consentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
+  private artifactState = inject(ArtifactStateService);
+
+  /** Session artifacts, newest first, for the end-of-conversation strip. */
+  protected artifacts = this.artifactState.artifacts;
+  protected hasArtifacts = this.artifactState.hasArtifacts;
 
   /** Single end-of-conversation compaction summary inputs. Sourced from
    *  live SSE events plus session-metadata hydration on load. The fade-in

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ArtifactHttpService } from './artifact-http.service';
+import { ConfigService } from '../../../services/config.service';
+
+const API = 'http://localhost:8000';
+
+describe('ArtifactHttpService', () => {
+  let service: ArtifactHttpService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ArtifactHttpService,
+        { provide: ConfigService, useValue: { appApiUrl: signal(API) } },
+      ],
+    });
+    service = TestBed.inject(ArtifactHttpService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('mints a render token and maps expires_at', async () => {
+    const p = service.mintRenderToken('art-1', 2, 'sess-9');
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/render-token`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ version: 2, sessionId: 'sess-9' });
+    req.flush({ url: 'https://artifacts.x/?t=jwt', expires_at: '2026-05-15T12:02:00+00:00' });
+    await expect(p).resolves.toEqual({
+      url: 'https://artifacts.x/?t=jwt',
+      expiresAt: '2026-05-15T12:02:00+00:00',
+    });
+  });
+
+  it('url-encodes the artifact id in the token path', async () => {
+    const p = service.mintRenderToken('a/b 1', 1, 's');
+    const req = httpMock.expectOne(`${API}/artifacts/a%2Fb%201/render-token`);
+    req.flush({ url: 'u', expires_at: 'e' });
+    await p;
+  });
+
+  it('lists session artifacts and normalizes snake_case to camelCase', async () => {
+    const p = service.listSessionArtifacts('sess-9');
+    const req = httpMock.expectOne(
+      (r) => r.url === `${API}/artifacts` && r.params.get('session_id') === 'sess-9',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      artifacts: [
+        {
+          artifact_id: 'art-1',
+          version: 3,
+          title: 'Report',
+          content_type: 'text/html; charset=utf-8',
+          updated_at: '2026-05-15T12:00:00+00:00',
+          created_at: '2026-05-15T10:00:00+00:00',
+        },
+      ],
+    });
+    await expect(p).resolves.toEqual([
+      {
+        artifactId: 'art-1',
+        version: 3,
+        title: 'Report',
+        contentType: 'text/html; charset=utf-8',
+        updatedAt: '2026-05-15T12:00:00+00:00',
+        createdAt: '2026-05-15T10:00:00+00:00',
+      },
+    ]);
+  });
+
+  it('tolerates a missing artifacts array', async () => {
+    const p = service.listSessionArtifacts('sess-9');
+    httpMock
+      .expectOne((r) => r.url === `${API}/artifacts`)
+      .flush({});
+    await expect(p).resolves.toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import type { Artifact } from './artifact.model';
+
+interface RenderTokenResponseDto {
+  url: string;
+  expires_at: string;
+}
+
+interface ArtifactSummaryDto {
+  artifact_id: string;
+  version: number;
+  title: string;
+  content_type: string;
+  updated_at: string;
+  created_at?: string | null;
+}
+
+interface ArtifactListResponseDto {
+  artifacts: ArtifactSummaryDto[];
+}
+
+export interface RenderToken {
+  url: string;
+  expiresAt: string;
+}
+
+/**
+ * app-api client for the artifacts feature. Auth rides the httpOnly BFF
+ * session cookie + csrfInterceptor automatically (HttpClient pipeline),
+ * same as every other app-api call — no Bearer here.
+ *
+ * The render token is a short-lived (~120s) bearer credential embedded
+ * in the returned URL; the panel sets it as the iframe `src` and
+ * re-mints on each open rather than caching it.
+ */
+@Injectable({ providedIn: 'root' })
+export class ArtifactHttpService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  /** Mint a single-version render URL for the sandboxed iframe. */
+  async mintRenderToken(
+    artifactId: string,
+    version: number,
+    sessionId: string,
+  ): Promise<RenderToken> {
+    const res = await firstValueFrom(
+      this.http.post<RenderTokenResponseDto>(
+        `${this.config.appApiUrl()}/artifacts/${encodeURIComponent(artifactId)}/render-token`,
+        { version, sessionId },
+      ),
+    );
+    return { url: res.url, expiresAt: res.expires_at };
+  }
+
+  /** List the current HEAD of every artifact in a chat session. */
+  async listSessionArtifacts(sessionId: string): Promise<Artifact[]> {
+    const res = await firstValueFrom(
+      this.http.get<ArtifactListResponseDto>(`${this.config.appApiUrl()}/artifacts`, {
+        params: { session_id: sessionId },
+      }),
+    );
+    return (res.artifacts ?? []).map((a) => ({
+      artifactId: a.artifact_id,
+      version: a.version,
+      title: a.title,
+      contentType: a.content_type,
+      updatedAt: a.updated_at,
+      createdAt: a.created_at ?? undefined,
+    }));
+  }
+}

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ArtifactStateService } from './artifact-state.service';
+import type { ArtifactEvent } from '../../../shared/utils/stream-parser';
+import type { Artifact } from './artifact.model';
+
+function ev(over: Partial<ArtifactEvent> = {}): ArtifactEvent {
+  return {
+    type: 'artifact',
+    artifactId: 'art-1',
+    version: 1,
+    title: 'Doc',
+    contentType: 'text/html; charset=utf-8',
+    sessionId: 'sess-9',
+    updatedAt: '2026-05-15T12:00:00+00:00',
+    action: 'created',
+    ...over,
+  };
+}
+
+describe('ArtifactStateService', () => {
+  let svc: ArtifactStateService;
+
+  beforeEach(() => {
+    svc = new ArtifactStateService();
+  });
+
+  it('starts empty', () => {
+    expect(svc.hasArtifacts()).toBe(false);
+    expect(svc.artifacts()).toEqual([]);
+    expect(svc.openArtifact()).toBeNull();
+  });
+
+  it('records a live artifact event', () => {
+    svc.recordLive(ev());
+    expect(svc.hasArtifacts()).toBe(true);
+    expect(svc.get('art-1')?.version).toBe(1);
+  });
+
+  it('keeps the highest version for the same id (update_artifact)', () => {
+    svc.recordLive(ev({ version: 1 }));
+    svc.recordLive(ev({ version: 3, updatedAt: '2026-05-15T12:05:00+00:00' }));
+    svc.recordLive(ev({ version: 2 })); // stale/out-of-order — ignored
+    expect(svc.get('art-1')?.version).toBe(3);
+    expect(svc.artifacts().length).toBe(1);
+  });
+
+  it('orders artifacts newest update first', () => {
+    svc.recordLive(ev({ artifactId: 'old', updatedAt: '2026-05-15T10:00:00+00:00' }));
+    svc.recordLive(ev({ artifactId: 'new', updatedAt: '2026-05-15T12:00:00+00:00' }));
+    expect(svc.artifacts().map((a) => a.artifactId)).toEqual(['new', 'old']);
+  });
+
+  it('hydration does not clobber a higher live version', () => {
+    svc.recordLive(ev({ version: 5, updatedAt: '2026-05-15T12:10:00+00:00' }));
+    const stale: Artifact = {
+      artifactId: 'art-1',
+      version: 2,
+      title: 'Old',
+      contentType: 'text/html; charset=utf-8',
+      updatedAt: '2026-05-15T11:00:00+00:00',
+    };
+    svc.seedFromHydration([stale]);
+    expect(svc.get('art-1')?.version).toBe(5);
+  });
+
+  it('hydration adds artifacts not seen live', () => {
+    svc.seedFromHydration([
+      {
+        artifactId: 'h1',
+        version: 2,
+        title: 'Hydrated',
+        contentType: 'text/html; charset=utf-8',
+        updatedAt: '2026-05-15T09:00:00+00:00',
+      },
+    ]);
+    expect(svc.get('h1')?.title).toBe('Hydrated');
+  });
+
+  it('opens and closes the panel', () => {
+    svc.openArtifactPanel({ artifactId: 'art-1', version: 1, title: 'Doc' });
+    expect(svc.openArtifact()).toEqual({ artifactId: 'art-1', version: 1, title: 'Doc' });
+    svc.closeArtifactPanel();
+    expect(svc.openArtifact()).toBeNull();
+  });
+
+  it('reset clears artifacts and open panel', () => {
+    svc.recordLive(ev());
+    svc.openArtifactPanel({ artifactId: 'art-1', version: 1, title: 'Doc' });
+    svc.reset();
+    expect(svc.hasArtifacts()).toBe(false);
+    expect(svc.openArtifact()).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, computed, signal } from '@angular/core';
+import type { ArtifactEvent } from '../../../shared/utils/stream-parser';
+import type { Artifact, OpenArtifactRef } from './artifact.model';
+
+/**
+ * Per-session artifact registry + open-panel state. Structural sibling of
+ * `CompactionSummaryService`: a live SSE path (`recordLive`), a
+ * session-load hydration path (`seedFromHydration`), and a `reset()`
+ * called on session change.
+ *
+ * Artifacts are keyed by `artifactId` holding only the highest version
+ * seen — `update_artifact` emits a new event for the same id and the
+ * card should track the latest. Hydration never clobbers a higher
+ * version already recorded from a live event (a stale list response can
+ * arrive after the user has already driven a newer update this session).
+ */
+@Injectable({ providedIn: 'root' })
+export class ArtifactStateService {
+  private readonly byId = signal<Map<string, Artifact>>(new Map());
+  private readonly openRef = signal<OpenArtifactRef | null>(null);
+
+  /** Artifacts for the current session, newest update first. */
+  readonly artifacts = computed<Artifact[]>(() =>
+    Array.from(this.byId().values()).sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    ),
+  );
+
+  readonly hasArtifacts = computed(() => this.byId().size > 0);
+
+  /** The artifact the side panel is showing, or null when closed. */
+  readonly openArtifact = this.openRef.asReadonly();
+
+  /** Latest known version of an artifact, if any (used by the card). */
+  get(artifactId: string): Artifact | undefined {
+    return this.byId().get(artifactId);
+  }
+
+  /** Record a live `artifact` SSE event. Keeps the highest version. */
+  recordLive(event: ArtifactEvent): void {
+    this.upsert({
+      artifactId: event.artifactId,
+      version: event.version,
+      title: event.title,
+      contentType: event.contentType,
+      updatedAt: event.updatedAt,
+    });
+  }
+
+  /**
+   * Replay the persisted session artifact list on load. Idempotent and
+   * non-clobbering: an entry already at an equal-or-higher version (from
+   * a live event that raced ahead) is left untouched.
+   */
+  seedFromHydration(list: readonly Artifact[]): void {
+    for (const a of list) this.upsert(a);
+  }
+
+  openArtifactPanel(ref: OpenArtifactRef): void {
+    this.openRef.set(ref);
+  }
+
+  closeArtifactPanel(): void {
+    this.openRef.set(null);
+  }
+
+  /** Clear all state — called on session change. */
+  reset(): void {
+    this.byId.set(new Map());
+    this.openRef.set(null);
+  }
+
+  private upsert(a: Artifact): void {
+    const existing = this.byId().get(a.artifactId);
+    if (existing && existing.version >= a.version) return;
+    this.byId.update((m) => {
+      const next = new Map(m);
+      next.set(a.artifactId, a);
+      return next;
+    });
+  }
+}

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact.model.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact.model.ts
@@ -1,0 +1,24 @@
+/**
+ * Normalized client model for an agent-authored artifact.
+ *
+ * Both delivery paths converge here: the live `artifact` SSE event
+ * (camelCase wire shape) and the app-api session-list endpoint
+ * (snake_case REST shape, normalized by ArtifactHttpService). The panel
+ * never holds artifact HTML — it mints a short-lived render token and
+ * loads the content in a sandboxed iframe on the artifact origin.
+ */
+export interface Artifact {
+  artifactId: string;
+  version: number;
+  title: string;
+  contentType: string;
+  updatedAt: string;
+  createdAt?: string;
+}
+
+/** Which artifact the side panel is currently showing. */
+export interface OpenArtifactRef {
+  artifactId: string;
+  version: number;
+  title: string;
+}

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -17,10 +17,12 @@ import {
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
 import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
 import { CompactionSummaryService } from './compaction-summary.service';
+import { ArtifactStateService } from '../artifacts/artifact-state.service';
 import type {
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
   CompactionEvent,
+  ArtifactEvent,
 } from '../../../shared/utils/stream-parser';
 import {
   processStreamEvent,
@@ -59,6 +61,7 @@ export class StreamParserService {
   private oauthConsentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
+  private artifactState = inject(ArtifactStateService);
 
   // =========================================================================
   // State Signals
@@ -326,6 +329,8 @@ export class StreamParserService {
       },
 
       onCompaction: (data: CompactionEvent) => this.compactionSummary.recordLive(data),
+
+      onArtifact: (data: ArtifactEvent) => this.artifactState.recordLive(data),
 
       onToolApprovalRequired: (data: ToolApprovalRequiredEvent) => {
         const messages = this.allMessages();

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -15,6 +15,8 @@ import { UserService } from '../auth/user.service';
 import { ChatHttpService } from './services/chat/chat-http.service';
 import { StreamParserService } from './services/chat/stream-parser.service';
 import { CompactionSummaryService } from './services/chat/compaction-summary.service';
+import { ArtifactStateService } from './services/artifacts/artifact-state.service';
+import { ArtifactHttpService } from './services/artifacts/artifact-http.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
 import { Assistant } from '../assistants/models/assistant.model';
@@ -44,6 +46,8 @@ export class ConversationPage implements OnDestroy {
   private chatHttpService = inject(ChatHttpService);
   private streamParserService = inject(StreamParserService);
   private compactionSummary = inject(CompactionSummaryService);
+  private artifactState = inject(ArtifactStateService);
+  private artifactHttp = inject(ArtifactHttpService);
   private assistantService = inject(AssistantService);
   private router = inject(Router);
   private dialog = inject(Dialog);
@@ -284,6 +288,11 @@ export class ConversationPage implements OnDestroy {
       // currentSession.totalSummarizedTurns once the metadata fetch lands.
       this.compactionSummary.reset();
 
+      // Artifacts are session-scoped — clear before the next session
+      // loads so a prior session's cards don't bleed in, then re-hydrate
+      // from the app-api list endpoint below.
+      this.artifactState.reset();
+
       if (id) {
         // Update the messages signal reference (this triggers reactivity)
         this.messagesSignal.set(this.messageMapService.getMessagesForSession(id));
@@ -300,6 +309,12 @@ export class ConversationPage implements OnDestroy {
         } catch (error) {
           console.error('Failed to load messages for session:', id, error);
         }
+
+        // Re-hydrate artifact cards for this session so they survive a
+        // refresh / deep link. Best-effort and non-blocking: a 404 (the
+        // artifacts feature is off for this environment) or any network
+        // error just means no cards — never disrupt the session.
+        this.hydrateArtifacts(id);
       } else {
         // No session selected, clear the session metadata
         this.sessionService.setSessionMetadataId(null);
@@ -316,6 +331,26 @@ export class ConversationPage implements OnDestroy {
   ngOnDestroy() {
     this.routeSubscription?.unsubscribe();
     this.queryParamSubscription?.unsubscribe();
+  }
+
+  /**
+   * Best-effort: pull the session's artifacts and seed the registry so
+   * cards render on load. `seedFromHydration` is non-clobbering, so a
+   * slow response that lands after a live `artifact` event won't undo a
+   * newer version. A guard re-checks the active session because the
+   * fetch is async and the user may have navigated away.
+   */
+  private hydrateArtifacts(sessionId: string): void {
+    this.artifactHttp
+      .listSessionArtifacts(sessionId)
+      .then(artifacts => {
+        if (artifacts.length && this.sessionId() === sessionId) {
+          this.artifactState.seedFromHydration(artifacts);
+        }
+      })
+      .catch(() => {
+        // Feature disabled (404) or transient error — no cards, no noise.
+      });
   }
 
   onMessageSubmitted(message: { content: string, timestamp: Date, fileUploadIds?: string[] }) {

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -58,6 +58,7 @@ export {
   validateOAuthRequiredEvent,
   validateToolApprovalRequiredEvent,
   validateCompactionEvent,
+  validateArtifactEvent,
 } from './stream-parser-core';
 
 // Types
@@ -80,6 +81,7 @@ export type {
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
   CompactionEvent,
+  ArtifactEvent,
   StreamEventType,
   StreamEventData,
   ParsedStreamEvent,

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
@@ -11,6 +11,7 @@ import {
   validateQuotaExceededEvent,
   validateConversationalStreamError,
   validateCitation,
+  validateArtifactEvent,
   processStreamEvent,
   createStreamLineParser,
   inferContentBlockType,
@@ -370,6 +371,53 @@ describe('stream-parser-core', () => {
     });
   });
 
+  describe('validateArtifactEvent', () => {
+    const valid = {
+      type: 'artifact',
+      artifactId: 'art-1',
+      version: 1,
+      title: 'Sales Dashboard',
+      contentType: 'text/html; charset=utf-8',
+      sessionId: 'sess-9',
+      updatedAt: '2026-05-15T12:00:05+00:00',
+      action: 'created'
+    };
+
+    it('should return true for a valid created artifact', () => {
+      expect(validateArtifactEvent(valid)).toBe(true);
+    });
+
+    it('should return true for an updated artifact (version > 1)', () => {
+      expect(validateArtifactEvent({ ...valid, version: 4, action: 'updated' })).toBe(true);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(validateArtifactEvent(null)).toBe(false);
+      expect(validateArtifactEvent(undefined)).toBe(false);
+    });
+
+    it('should return false when type is not "artifact"', () => {
+      expect(validateArtifactEvent({ ...valid, type: 'compaction' })).toBe(false);
+    });
+
+    it('should return false for empty artifactId', () => {
+      expect(validateArtifactEvent({ ...valid, artifactId: '' })).toBe(false);
+    });
+
+    it('should return false for version < 1 or non-integer', () => {
+      expect(validateArtifactEvent({ ...valid, version: 0 })).toBe(false);
+      expect(validateArtifactEvent({ ...valid, version: 1.5 })).toBe(false);
+    });
+
+    it('should return false for an unknown action', () => {
+      expect(validateArtifactEvent({ ...valid, action: 'deleted' })).toBe(false);
+    });
+
+    it('should return false for missing fields', () => {
+      expect(validateArtifactEvent({ type: 'artifact', artifactId: 'art-1' })).toBe(false);
+    });
+  });
+
   describe('processStreamEvent', () => {
     let callbacks: StreamParserCallbacks;
 
@@ -386,6 +434,7 @@ describe('stream-parser-core', () => {
         onQuotaExceeded: vi.fn(),
         onStreamError: vi.fn(),
         onCitation: vi.fn(),
+        onArtifact: vi.fn(),
         onParseError: vi.fn(),
         onDone: vi.fn(),
         onError: vi.fn(),
@@ -437,6 +486,26 @@ describe('stream-parser-core', () => {
     it('should ignore unknown event types', () => {
       processStreamEvent('unknown_event', {}, callbacks);
       expect(callbacks.onParseError).not.toHaveBeenCalled();
+    });
+
+    it('should call onArtifact for a valid artifact event', () => {
+      const data = {
+        type: 'artifact',
+        artifactId: 'art-1',
+        version: 2,
+        title: 'Report',
+        contentType: 'text/html; charset=utf-8',
+        sessionId: 'sess-9',
+        updatedAt: '2026-05-15T12:00:05+00:00',
+        action: 'updated'
+      };
+      processStreamEvent('artifact', data, callbacks);
+      expect(callbacks.onArtifact).toHaveBeenCalledWith(data);
+    });
+
+    it('should call onParseError for an invalid artifact event', () => {
+      processStreamEvent('artifact', { type: 'artifact', artifactId: '' }, callbacks);
+      expect(callbacks.onParseError).toHaveBeenCalledWith('artifact: invalid data structure');
     });
   });
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -39,6 +39,7 @@ import type {
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
   CompactionEvent,
+  ArtifactEvent,
   ToolProgress,
 } from './stream-parser-types';
 import type { MetadataEvent } from '../../../session/services/models/content-types';
@@ -86,6 +87,10 @@ export interface StreamParserCallbacks {
 
   // Compaction (backend rolled older turns into a summary on this turn)
   onCompaction?: (data: CompactionEvent) => void;
+
+  // Artifact created/updated this turn (existence signal; content is
+  // fetched out-of-band via a render token + sandboxed iframe)
+  onArtifact?: (data: ArtifactEvent) => void;
 
   // Error handling
   onError?: (data: StreamErrorEvent | ConversationalStreamErrorEvent | string) => void;
@@ -394,6 +399,31 @@ export function validateCompactionEvent(data: unknown): data is CompactionEvent 
 }
 
 /**
+ * Validate ArtifactEvent structure
+ */
+export function validateArtifactEvent(data: unknown): data is ArtifactEvent {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const event = data as Partial<ArtifactEvent>;
+
+  return (
+    event.type === 'artifact' &&
+    typeof event.artifactId === 'string' &&
+    event.artifactId.length > 0 &&
+    typeof event.version === 'number' &&
+    Number.isInteger(event.version) &&
+    event.version >= 1 &&
+    typeof event.title === 'string' &&
+    typeof event.contentType === 'string' &&
+    typeof event.sessionId === 'string' &&
+    typeof event.updatedAt === 'string' &&
+    (event.action === 'created' || event.action === 'updated')
+  );
+}
+
+/**
  * Validate Citation structure
  */
 export function validateCitation(data: unknown): data is Citation {
@@ -579,6 +609,14 @@ export function processStreamEvent(
           callbacks.onCompaction?.(data);
         } else {
           callbacks.onParseError?.('compaction: invalid data structure');
+        }
+        break;
+
+      case 'artifact':
+        if (validateArtifactEvent(data)) {
+          callbacks.onArtifact?.(data);
+        } else {
+          callbacks.onParseError?.('artifact: invalid data structure');
         }
         break;
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -144,6 +144,31 @@ export interface CompactionEvent {
 }
 
 /**
+ * Artifact event — emitted once per artifact created or updated during a
+ * turn, after the final `metadata`/`compaction` events and before `done`
+ * (same post-`message_stop` side-channel placement as `oauth_required`).
+ *
+ * The artifact's HTML content is never carried on the wire: it lives in
+ * S3 and renders in a sandboxed iframe via the artifact render origin.
+ * This event only signals existence so the SPA can show an inline card
+ * and open the panel (which mints a short-lived render token on demand).
+ *
+ * `action` is `created` for v1, `updated` for any later version. Cards
+ * also hydrate on session load via the app-api list endpoint; the SPA
+ * dedupes by `artifactId` keeping the highest `version`.
+ */
+export interface ArtifactEvent {
+  type: 'artifact';
+  artifactId: string;
+  version: number;
+  title: string;
+  contentType: string;
+  sessionId: string;
+  updatedAt: string;
+  action: 'created' | 'updated';
+}
+
+/**
  * Tool result event data structure
  */
 export interface ToolResultEventData {
@@ -182,7 +207,8 @@ export type StreamEventType =
   | 'stream_error'
   | 'citation'
   | 'oauth_required'
-  | 'compaction';
+  | 'compaction'
+  | 'artifact';
 
 /**
  * Union type of all possible event data types
@@ -204,6 +230,7 @@ export type StreamEventData =
   | Citation
   | OAuthRequiredEvent
   | CompactionEvent
+  | ArtifactEvent
   | null
   | undefined;
 


### PR DESCRIPTION
## Summary

Sixth and final piece of the artifacts sequence ([#306](https://github.com/Boise-State-Development/agentcore-public-stack/pull/306) → [#307](https://github.com/Boise-State-Development/agentcore-public-stack/pull/307) → [#309](https://github.com/Boise-State-Development/agentcore-public-stack/pull/309) → [#310](https://github.com/Boise-State-Development/agentcore-public-stack/pull/310) → [#311](https://github.com/Boise-State-Development/agentcore-public-stack/pull/311) → **this**). After this PR an agent-created artifact is visible and openable in the SPA, closing the loop end to end.

### SSE event (single `artifact` event)

Emitted post-`message_stop` next to `compaction` (same late side-channel placement as `oauth_required`). Artifact HTML never streams to the SPA — it loads via the #309 render iframe — so a `content_block`-style start/delta/stop trio would be pure ceremony. Payload:

```
event: artifact
data: {"type":"artifact","artifactId","version","title","contentType","sessionId","updatedAt","action":"created"|"updated"}
```

`StreamCoordinator._extract_artifact_events` is gated on observing a `create_artifact`/`update_artifact` `tool_use` that turn, then queries the `SessionIndex` GSI and filters `updated_at >= turn_start` — reflects what's actually persisted rather than parsing the human-readable tool-result text. Best-effort: any failure (feature off, DDB error) logs and is swallowed, never breaking the stream.

### app-api list endpoint (refresh survival)

`GET /artifacts?session_id=` in the existing `apis/app_api/artifacts/` domain, `Depends(get_current_user_from_session)`, ownership-filtered (GSI1PK is `SESSION#`-scoped, not user-scoped, so a borrowed session id can't enumerate another user's artifacts). The SPA hydrates cards from this on session load so they survive a refresh / deep link.

**No infra change** — the app-api task role already had `dynamodb:Query` on `${artifactsTableArn}/index/*` and the env vars were already set by #310's infra block.

### SPA

- `ArtifactStateService` (signal store, structural sibling of `CompactionSummaryService`: `recordLive` / `seedFromHydration` / `reset`) + `ArtifactHttpService` (mint token + list; cookie + csrf auto via HttpClient).
- Parser support: `ArtifactEvent` type, `validateArtifactEvent`, dispatch case, `onArtifact` wired through `stream-parser.service`.
- Session lifecycle: `reset()` on session change, best-effort `hydrateArtifacts()` on load (swallows the 404 when the feature is off for an environment).
- Session-level artifact card strip in `message-list` (next to the compaction summary — **not** anchored per-message, since the backend deliberately never tracked which message produced which artifact) → opens a slide-over `artifact-panel` that re-mints a short-lived render token per open and iframes it `sandbox="allow-scripts"` (no `allow-same-origin`), `referrerpolicy="no-referrer"` — the origin-isolation model from #306.

## Design notes

- The SSE wire shape is **new and not a frozen cross-PR contract** — only #309's JWT claims + DDB rows are frozen. Reviewers can still reshape it.
- Single `artifact` event vs. `artifact_block_*` trio and the session-level strip vs. per-message anchoring were both deliberate calls (content is out-of-band; no message↔artifact linkage exists). Happy to revisit.

## Test plan

- [x] `pytest tests/apis/app_api/artifacts/ tests/agents/builtin_tools/artifacts/ tests/agents/main_agent/streaming/ tests/architecture/` — **163 pass** (new list-endpoint, list-helper, coordinator-emit suites + existing #310/#311 + import-boundary intact)
- [x] `ruff check` clean on all new/changed backend code (stream_coordinator.py pre-existing debt in untouched error blocks only, per #310's note)
- [x] `ng test` — **955 pass** (new parser, ArtifactStateService, ArtifactHttpService specs)
- [x] `ng build` clean (only pre-existing unrelated NG8113 warnings)
- [ ] Post-merge: end-to-end once deployed to an env with `CDK_ARTIFACTS_ENABLED=true` — enable the artifact tools, have the agent build a page, confirm the card appears, the panel renders the iframe, and cards survive a refresh (same deferred-verification posture as #309–#311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)