### PR TITLE
fix(admin): stop duplicate user-menu-links request on every app load

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/manage-user-menu-links.page.ts
@@ -116,6 +116,10 @@ import { UserMenuLink } from './models/user-menu-link.model';
 export class ManageUserMenuLinksPage {
   private readonly service = inject(UserMenuLinksService);
 
+  constructor() {
+    this.service.ensureAdminLinksLoaded();
+  }
+
   protected readonly links = computed<UserMenuLink[]>(
     () => this.service.adminLinksResource.value()?.links ?? [],
   );

--- a/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
+++ b/frontend/ai.client/src/app/admin/manage-user-menu-links/services/user-menu-links.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, computed, resource } from '@angular/core';
+import { Injectable, inject, computed, resource, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
@@ -32,9 +32,22 @@ export class UserMenuLinksService {
     () => `${this.config.appApiUrl()}/user-menu-links`,
   );
 
+  // The admin resource is gated: this service is `providedIn: 'root'` and is
+  // injected by the always-rendered user-dropdown, so an eager admin loader
+  // would fire `GET /admin/user-menu-links/` on every app load for every user
+  // (401/403 for non-admins). It only loads once the admin manage page calls
+  // `ensureAdminLinksLoaded()`.
+  private readonly adminLinksRequested = signal(false);
+
   readonly adminLinksResource = resource({
+    params: () => (this.adminLinksRequested() ? {} : undefined),
     loader: async () => this.fetchAdminLinks(),
   });
+
+  /** Activates the admin links resource. Called by the admin manage page. */
+  ensureAdminLinksLoaded(): void {
+    this.adminLinksRequested.set(true);
+  }
 
   readonly enabledLinksResource = resource({
     loader: async () => this.fetchEnabledLinks(),


### PR DESCRIPTION
## Summary

`UserMenuLinksService` is `providedIn: 'root'` and is injected by `UserDropdownComponent`, which is always rendered in the sidenav on every app load. Both `resource()`s on that service are eager (loaders fire on creation), so **every** app load fired two user-menu-links requests:

- `GET /user-menu-links/` — legitimate, populates the dropdown
- `GET /admin/user-menu-links/` — only the admin manage page needs it. For non-admin users this returns 401/403, and a 401 is escalated by the error interceptor into a login redirect.

## What changed

- `user-menu-links.service.ts`: `adminLinksResource` is now gated behind an `adminLinksRequested` signal via `params: () => requested ? {} : undefined`. While idle the loader never runs. Added `ensureAdminLinksLoaded()`.
- `manage-user-menu-links.page.ts`: constructor calls `ensureAdminLinksLoaded()`, so the admin endpoint loads only when that page is opened.

The public `enabledLinksResource` is unchanged — the dropdown still loads its data eagerly. Post-mutation `adminLinksResource.reload()` (create/update/delete) still works because the resource is active by the time those run.

## Reviewer notes

- Deep-link edge case: navigating straight to the create/edit form (bypassing the list page) → save → the `reload()` is a no-op while the list resource is idle, but navigating to the list page afterward triggers a fresh load via its constructor, so no stale data.
- Typecheck (`tsc -p tsconfig.app.json --noEmit`) passes.

## Test plan

- [ ] Non-admin load: only one `GET /user-menu-links/`, no `GET /admin/user-menu-links/`
- [ ] Admin manage page: `GET /admin/user-menu-links/` fires once, list renders
- [ ] Admin create/edit/delete: list refreshes and dropdown updates
- [ ] Deep-link to form → save → list page shows fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)