### PR TITLE
feat(artifacts): stream live tool output into the tool rail

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -277,5 +277,33 @@ describe('AssistantMessageComponent', () => {
       const call = blocks[0].group!.calls[0];
       expect(call.status).toBe('pending');
     });
+
+    it('should carry streamingContent through to the ToolCallDisplay', () => {
+      fixture.componentRef.setInput('message', makeMessage([
+        makeToolBlock('create_artifact', {
+          status: 'pending',
+          streamingContent: '<!DOCTYPE html><html><body>partial',
+          // no result yet — still generating
+          result: undefined,
+        }),
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      const call = blocks[0].group!.calls[0];
+      expect(call.streamingContent).toBe('<!DOCTYPE html><html><body>partial');
+      expect(call.status).toBe('pending');
+    });
+
+    it('should leave streamingContent undefined for ordinary tool calls', () => {
+      fixture.componentRef.setInput('message', makeMessage([
+        makeToolBlock('my_tool'),
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      const call = blocks[0].group!.calls[0];
+      expect(call.streamingContent).toBeUndefined();
+    });
   });
 });

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -355,6 +355,7 @@ export class AssistantMessageComponent {
             input: toolUse.input || {},
             result: toolUse.result,
             status,
+            streamingContent: toolUse.streamingContent,
           });
         }
         continue;

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/index.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/index.ts
@@ -1,2 +1,3 @@
 export * from './tool-rail.component';
 export * from './tool-rail.model';
+export * from './pin-scroll-to-bottom.directive';

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/pin-scroll-to-bottom.directive.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/pin-scroll-to-bottom.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, ElementRef, effect, inject, input } from '@angular/core';
+
+/**
+ * Keeps the host element scrolled to the bottom whenever the bound value
+ * changes. Used for live-streaming output (e.g. artifact generation) so the
+ * latest content stays visible inside a fixed-height scroll box.
+ */
+@Directive({
+  selector: '[appPinScrollToBottom]',
+})
+export class PinScrollToBottomDirective {
+  /** Bind the streamed value; the host re-pins to the bottom on each change. */
+  readonly appPinScrollToBottom = input<string>('');
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  constructor() {
+    effect(() => {
+      // Read the streamed value so the effect re-runs for every chunk.
+      this.appPinScrollToBottom();
+      const el = this.host.nativeElement;
+      el.scrollTop = el.scrollHeight;
+    });
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
@@ -101,6 +101,24 @@
                 </div>
               }
 
+              <!-- Live streaming output (e.g. artifact being generated) -->
+              @if (isGenerating(call)) {
+                <div class="flex items-start gap-1.5">
+                  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0 mt-1">output:</span>
+                  <div class="w-full">
+                    <div class="flex items-center gap-1.5 mb-1 text-xs text-gray-400 dark:text-gray-500">
+                      <span class="status-dot bg-amber-400 shimmer"></span>
+                      <span>Generating output…</span>
+                    </div>
+                    <pre
+                      class="max-h-56 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700/30 rounded-xs px-2 py-1.5"
+                      aria-label="Tool output being generated"
+                      [appPinScrollToBottom]="call.streamingContent ?? ''"
+                    >{{ call.streamingContent }}</pre>
+                  </div>
+                </div>
+              }
+
               <!-- Result -->
               @if (call.result) {
                 <div class="flex items-start gap-1.5">

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.ts
@@ -8,6 +8,7 @@ import {
 import { KeyValuePipe } from '@angular/common';
 import { JsonSyntaxHighlightPipe } from '../tool-use/json-syntax-highlight.pipe';
 import { ToolCallGroup, ToolCallDisplay } from './tool-rail.model';
+import { PinScrollToBottomDirective } from './pin-scroll-to-bottom.directive';
 import { ToolResultContent } from '../../../../services/models/message.model';
 
 @Component({
@@ -15,7 +16,7 @@ import { ToolResultContent } from '../../../../services/models/message.model';
   templateUrl: './tool-rail.component.html',
   styleUrl: './tool-rail.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [JsonSyntaxHighlightPipe, KeyValuePipe],
+  imports: [JsonSyntaxHighlightPipe, KeyValuePipe, PinScrollToBottomDirective],
 })
 export class ToolRailComponent {
   /** The grouped tool calls to display */
@@ -87,6 +88,14 @@ export class ToolRailComponent {
       case 'awaiting_auth':  return 'status-dot bg-primary-500 ring-2 ring-primary-300/40 dark:ring-primary-400/30';
       default:               return 'status-dot bg-gray-400';
     }
+  }
+
+  /**
+   * True while a tool is still streaming its long output (e.g. an artifact)
+   * and has not yet returned a result — drives the live "generating" preview.
+   */
+  isGenerating(call: ToolCallDisplay): boolean {
+    return !!call.streamingContent && !call.result;
   }
 
   /** Format duration for display */

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.model.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.model.ts
@@ -26,6 +26,14 @@ export interface ToolCallDisplay {
    *  for the user to authorize. */
   status: 'pending' | 'complete' | 'error' | 'awaiting_auth';
 
+  /**
+   * Partially-generated long output (e.g. an artifact's HTML) decoded from the
+   * still-incomplete tool-call JSON while the model is streaming it. Present
+   * only while the call is in flight; cleared once a result arrives. Used to
+   * show live "generating output" feedback in the rail.
+   */
+  streamingContent?: string;
+
   /** Optional LLM-generated one-line summary of this tool call's result */
   summary?: string;
 

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -28,6 +28,7 @@ import {
   processStreamEvent,
   createStreamLineParser,
   inferContentBlockType,
+  extractStreamingStringField,
   parseToolResultContent,
   type StreamParserCallbacks,
   type ContentBlockBuilder,
@@ -50,6 +51,12 @@ enum StreamState {
 
 // Re-export ToolProgress for backwards compatibility
 export type { ToolProgress };
+
+/**
+ * Tools whose `content` input is a long document worth surfacing live (as a
+ * "generating…" preview) while the model is still streaming the tool call.
+ */
+const STREAMING_CONTENT_TOOLS = new Set(['create_artifact', 'update_artifact']);
 
 @Injectable({
   providedIn: 'root',
@@ -967,6 +974,21 @@ export class StreamParserService {
 
       if (builder.status) {
         toolUseData['status'] = builder.status;
+      }
+
+      // While an artifact tool is still streaming (no result yet), surface the
+      // partially-generated `content` so the UI can show live progress. The
+      // full tool-input JSON is incomplete during this window, so JSON.parse
+      // above yields {} — we extract the in-flight value directly instead.
+      if (
+        !builder.result &&
+        builder.toolName &&
+        STREAMING_CONTENT_TOOLS.has(builder.toolName)
+      ) {
+        const streaming = extractStreamingStringField(inputStr, 'content');
+        if (streaming) {
+          toolUseData['streamingContent'] = streaming;
+        }
       }
 
       return {

--- a/frontend/ai.client/src/app/session/services/models/message.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/message.model.ts
@@ -71,6 +71,13 @@ export interface ToolUseData {
   };
   /** Tool execution status */
   status?: 'pending' | 'complete' | 'error';
+  /**
+   * Best-effort decoded value of a long string input field (e.g. an artifact's
+   * `content`) extracted from the still-incomplete tool-call JSON while the
+   * model is streaming it. Used to give the user live "generating" feedback
+   * before the full tool input has arrived. Unset once the tool completes.
+   */
+  streamingContent?: string;
 }
 
 /**

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -38,6 +38,7 @@ export {
   processStreamEvent,
   createStreamLineParser,
   inferContentBlockType,
+  extractStreamingStringField,
   parseToolResultContent,
   type StreamParserCallbacks,
 } from './stream-parser-core';

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
@@ -15,6 +15,7 @@ import {
   processStreamEvent,
   createStreamLineParser,
   inferContentBlockType,
+  extractStreamingStringField,
   parseToolResultContent,
   StreamParserCallbacks
 } from './stream-parser-core';
@@ -576,6 +577,65 @@ describe('stream-parser-core', () => {
     it('should return text by default', () => {
       expect(inferContentBlockType({ contentBlockIndex: 0, text: 'hello' })).toBe('text');
       expect(inferContentBlockType({ contentBlockIndex: 0 })).toBe('text');
+    });
+  });
+
+  describe('extractStreamingStringField', () => {
+    it('returns null when input is empty', () => {
+      expect(extractStreamingStringField('', 'content')).toBeNull();
+    });
+
+    it('returns null when the field has not started streaming', () => {
+      expect(extractStreamingStringField('{"title":"Hi"', 'content')).toBeNull();
+      expect(extractStreamingStringField('{"title":"Hi","content"', 'content')).toBeNull();
+      expect(extractStreamingStringField('{"title":"Hi","content":', 'content')).toBeNull();
+    });
+
+    it('returns the partial value while the string is still open', () => {
+      expect(
+        extractStreamingStringField('{"title":"Hi","content":"<!DOCTYPE htm', 'content'),
+      ).toBe('<!DOCTYPE htm');
+    });
+
+    it('returns the full value once the closing quote arrives', () => {
+      expect(
+        extractStreamingStringField('{"content":"<h1>Hello</h1>","x":1}', 'content'),
+      ).toBe('<h1>Hello</h1>');
+    });
+
+    it('decodes JSON string escapes', () => {
+      expect(
+        extractStreamingStringField('{"content":"line1\\nline2\\t\\"q\\"\\\\","', 'content'),
+      ).toBe('line1\nline2\t"q"\\');
+    });
+
+    it('decodes unicode escapes', () => {
+      expect(extractStreamingStringField('{"content":"\\u00e9\\u4e2d', 'content')).toBe(
+        'é中',
+      );
+    });
+
+    it('drops a dangling backslash that has not finished streaming', () => {
+      expect(extractStreamingStringField('{"content":"abc\\', 'content')).toBe('abc');
+    });
+
+    it('drops an incomplete unicode escape', () => {
+      expect(extractStreamingStringField('{"content":"abc\\u00e', 'content')).toBe('abc');
+    });
+
+    it('does not match a different field with a shared prefix', () => {
+      // `content_type` must not be mistaken for `content`
+      expect(
+        extractStreamingStringField('{"content_type":"text/html","content":"body', 'content'),
+      ).toBe('body');
+    });
+
+    it('tolerates whitespace between key, colon, and value', () => {
+      expect(extractStreamingStringField('{"content"  :  "hi', 'content')).toBe('hi');
+    });
+
+    it('returns empty string for an empty completed value', () => {
+      expect(extractStreamingStringField('{"content":""}', 'content')).toBe('');
     });
   });
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -734,6 +734,120 @@ export function inferContentBlockType(
 }
 
 /**
+ * Best-effort extraction of a single string field's value from an incomplete
+ * JSON object that is still streaming in (e.g. a tool call's `input` arriving
+ * as `input_json_delta` chunks).
+ *
+ * Returns the decoded string value so far — even when the closing quote has
+ * not yet arrived — so callers can render live "generating" feedback. Returns
+ * `null` if the field's string value has not started streaming yet.
+ *
+ * Never throws: malformed / truncated input yields the portion decoded so far.
+ * Only string-valued fields are handled (non-string values return `null`).
+ *
+ * @param partialJson Accumulated (possibly incomplete) JSON text
+ * @param field       Top-level field name to extract (e.g. "content")
+ */
+export function extractStreamingStringField(
+  partialJson: string,
+  field: string,
+): string | null {
+  if (!partialJson) {
+    return null;
+  }
+
+  // Locate `"field" : "` allowing JSON-permitted whitespace. Escaping the
+  // field name keeps this safe even though callers pass simple identifiers.
+  const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const opener = new RegExp(`"${escapedField}"\\s*:\\s*"`);
+  const match = opener.exec(partialJson);
+  if (!match) {
+    return null;
+  }
+
+  let i = match.index + match[0].length;
+  let result = '';
+
+  while (i < partialJson.length) {
+    const ch = partialJson[i];
+
+    if (ch === '"') {
+      // Unescaped closing quote -> value is complete.
+      return result;
+    }
+
+    if (ch === '\\') {
+      // Need at least one more char to know the escape; if it hasn't
+      // streamed yet, drop the dangling backslash and return what we have.
+      if (i + 1 >= partialJson.length) {
+        return result;
+      }
+      const esc = partialJson[i + 1];
+      switch (esc) {
+        case '"':
+          result += '"';
+          i += 2;
+          break;
+        case '\\':
+          result += '\\';
+          i += 2;
+          break;
+        case '/':
+          result += '/';
+          i += 2;
+          break;
+        case 'b':
+          result += '\b';
+          i += 2;
+          break;
+        case 'f':
+          result += '\f';
+          i += 2;
+          break;
+        case 'n':
+          result += '\n';
+          i += 2;
+          break;
+        case 'r':
+          result += '\r';
+          i += 2;
+          break;
+        case 't':
+          result += '\t';
+          i += 2;
+          break;
+        case 'u': {
+          // Need 4 hex digits; if the buffer cuts off mid-sequence, drop
+          // the incomplete escape and return the decoded prefix.
+          if (i + 6 > partialJson.length) {
+            return result;
+          }
+          const hex = partialJson.slice(i + 2, i + 6);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+            return result;
+          }
+          result += String.fromCharCode(parseInt(hex, 16));
+          i += 6;
+          break;
+        }
+        default:
+          // Invalid escape — emit the char literally and move on.
+          result += esc;
+          i += 2;
+          break;
+      }
+      continue;
+    }
+
+    result += ch;
+    i += 1;
+  }
+
+  // Buffer exhausted before the closing quote — value still streaming.
+  return result;
+}
+
+/**
  * Parse tool result content array into normalized format
  */
 export function parseToolResultContent(


### PR DESCRIPTION
## Summary
- While `create_artifact` / `update_artifact` run, the model streams the artifact's content as the tool-call input. This surfaces it **live** in the tool rail as a "Generating output…" preview, replacing the opaque spinner with real feedback that the tool is producing output.
- `extractStreamingStringField` — tolerant decoder that pulls a string field's value out of still-incomplete tool-call JSON (handles escapes, partial/incomplete escapes, prefix collisions like `content` vs `content_type`; never throws).
- Stream parser sets `ToolUseData.streamingContent` for artifact tools while in flight (cleared once a result arrives). `assistant-message` carries it into `ToolCallDisplay`; `tool-rail` renders a capped, auto-scrolling `<pre>` via a reusable `appPinScrollToBottom` directive.
- No backend changes — the partial tool-input deltas already reach the SPA; only the rendering path was missing. Side panel is intentionally out of scope (follow-up).

## Test plan
- [x] Unit: `extractStreamingStringField` (partial values, escape decoding, incomplete `\u`, prefix collision) + `streamingContent` mapping in `assistant-message`
- [x] `ng test` green across stream-parser-core / stream-parser.service / tool-rail / assistant-message specs (169 tests); app bundle compiles clean
- [x] Browser E2E (SKIP_AUTH): real `create_artifact` run — rail shows "Generating output…" with HTML/CSS streaming into the `<pre>` live, then preview clears and the normal completed rail entry + artifact card render. No console errors.
- [ ] Reviewer sanity check on a slow/large artifact and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)