### PR TITLE
feat(artifacts): inline artifact cards anchored to their producing message + card redesign

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -257,6 +257,33 @@ def update_artifact_record(
     return version
 
 
+def set_produced_by_message_index(
+    user_id: str, artifact_id: str, message_index: int
+) -> None:
+    """Stamp the HEAD row with the index of the assistant message that
+    produced (or last updated) the artifact this turn.
+
+    The artifact tool can't know this at write time — the turn isn't
+    finished — so the stream coordinator writes it back post-turn using
+    the same odd-position index it already computes for per-message
+    metadata (`initial_message_count + 2*i + 1`). That index matches the
+    `idx` the messages endpoint enumerates on reload, so the SPA can
+    render the card inline after the right assistant message.
+
+    Best-effort: a SET on a single attribute, keyed by the HEAD row, that
+    deliberately does not touch `version` so it can never collide with
+    the update_artifact optimistic lock. Failures are swallowed by the
+    caller (linkage is a UX nicety, never worth breaking a turn over).
+    """
+    table = _table()
+    table.update_item(
+        Key={"PK": f"USER#{user_id}", "SK": f"ARTIFACT#{artifact_id}#HEAD"},
+        UpdateExpression="SET produced_by_message_index = :idx",
+        ExpressionAttributeValues={":idx": message_index},
+        ConditionExpression="attribute_exists(SK)",
+    )
+
+
 _SESSION_INDEX = "SessionIndex"
 
 
@@ -302,6 +329,9 @@ def list_session_artifacts(user_id: str, session_id: str) -> list[dict]:
                 ),
                 "updated_at": item.get("updated_at", ""),
                 "created_at": item.get("created_at"),
+                "produced_by_message_index": item.get(
+                    "produced_by_message_index"
+                ),
             }
         )
     return out

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -402,10 +402,25 @@ class StreamCoordinator:
                 # before `done`. Best-effort: a lookup failure logs and is
                 # swallowed so it never breaks the live stream.
                 if event.get("type") == "done" and artifact_tool_invoked:
+                    # Anchor every artifact touched this turn to the turn's
+                    # final assistant message. `done` lands after the last
+                    # `message_stop`, so current_assistant_message_index is
+                    # final here; this is the same odd-position index the
+                    # post-loop block uses for per-message metadata
+                    # (assistant_message_ids[-1]), which the messages
+                    # endpoint re-derives as `idx` on reload.
+                    produced_by_message_index = (
+                        initial_message_count
+                        + 2 * current_assistant_message_index
+                        + 1
+                        if current_assistant_message_index >= 0
+                        else None
+                    )
                     for sse in await self._extract_artifact_events(
                         session_id=session_id,
                         user_id=user_id,
                         turn_start=turn_start_dt,
+                        produced_by_message_index=produced_by_message_index,
                     ):
                         yield sse
 
@@ -902,6 +917,7 @@ class StreamCoordinator:
         session_id: Optional[str],
         user_id: Optional[str],
         turn_start: datetime,
+        produced_by_message_index: Optional[int] = None,
     ) -> List[str]:
         """Yield one SSE-formatted `artifact` event per artifact whose
         HEAD was created or updated during this turn.
@@ -922,6 +938,7 @@ class StreamCoordinator:
             from agents.builtin_tools.artifacts.service import (
                 ArtifactConfigError,
                 list_session_artifacts,
+                set_produced_by_message_index,
             )
 
             rows = await asyncio.to_thread(
@@ -942,10 +959,26 @@ class StreamCoordinator:
                 touched = True
             if not touched:
                 continue
+            artifact_id = row.get("artifact_id", "")
+            if produced_by_message_index is not None and artifact_id:
+                try:
+                    await asyncio.to_thread(
+                        set_produced_by_message_index,
+                        user_id,
+                        artifact_id,
+                        produced_by_message_index,
+                    )
+                except Exception as e:  # noqa: BLE001 - best-effort linkage
+                    logger.warning(
+                        "Failed to stamp produced_by_message_index "
+                        "(artifact=%s): %s",
+                        artifact_id,
+                        e,
+                    )
             version = int(row.get("version", 0))
             payload = {
                 "type": "artifact",
-                "artifactId": row.get("artifact_id", ""),
+                "artifactId": artifact_id,
                 "version": version,
                 "title": row.get("title", ""),
                 "contentType": row.get(
@@ -954,6 +987,7 @@ class StreamCoordinator:
                 "sessionId": session_id,
                 "updatedAt": updated_at,
                 "action": "created" if version == 1 else "updated",
+                "producedByMessageIndex": produced_by_message_index,
             }
             events.append(
                 f"event: artifact\ndata: {json.dumps(payload)}\n\n"

--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -39,6 +39,13 @@ class ArtifactSummary(BaseModel):
     content_type: str
     updated_at: str
     created_at: Optional[str] = None
+    produced_by_message_index: Optional[int] = Field(
+        default=None,
+        description="0-based index of the assistant message that produced "
+        "or last updated this artifact, matching the messages endpoint's "
+        "`msg-{session_id}-{index}` id. Null for artifacts written before "
+        "linkage existed — the SPA falls back to the end-of-chat strip.",
+    )
 
 
 class ArtifactListResponse(BaseModel):

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -256,6 +256,9 @@ class ArtifactListService:
                     ),
                     "updated_at": item.get("updated_at", ""),
                     "created_at": item.get("created_at"),
+                    "produced_by_message_index": item.get(
+                        "produced_by_message_index"
+                    ),
                 }
             )
         return summaries

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -196,3 +196,25 @@ def test_list_session_artifacts_scopes_to_user(aws) -> None:
 
 def test_list_session_artifacts_empty_session(aws) -> None:
     assert service.list_session_artifacts(USER, "no-such-session") == []
+
+
+def test_set_produced_by_message_index_stamps_head_and_lists(aws) -> None:
+    aid, _ = service.create_artifact_record(USER, SESSION, "Doc", DOC, "")
+    assert service.list_session_artifacts(USER, SESSION)[0][
+        "produced_by_message_index"
+    ] is None
+
+    service.set_produced_by_message_index(USER, aid, 7)
+
+    rows = service.list_session_artifacts(USER, SESSION)
+    assert rows[0]["produced_by_message_index"] == 7
+    # The stamp must leave the optimistic-lock `version` untouched so a
+    # later update_artifact still re-points HEAD cleanly.
+    assert service.update_artifact_record(USER, aid, DOC, None, None) == 2
+
+
+def test_set_produced_by_message_index_requires_existing_head(aws) -> None:
+    from botocore.exceptions import ClientError
+
+    with pytest.raises(ClientError):
+        service.set_produced_by_message_index(USER, "nope", 1)

--- a/backend/tests/agents/main_agent/streaming/test_artifact_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_artifact_events.py
@@ -65,7 +65,51 @@ async def test_emits_created_for_v1(coord, turn_start, monkeypatch) -> None:
         "sessionId": SESSION,
         "updatedAt": "2026-05-15T12:00:05+00:00",
         "action": "created",
+        "producedByMessageIndex": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_stamps_and_emits_produced_by_message_index(
+    coord, turn_start, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        artifact_service,
+        "list_session_artifacts",
+        lambda u, s: [_row(artifact_id="a"), _row(artifact_id="b")],
+    )
+    stamped: list[tuple] = []
+    monkeypatch.setattr(
+        artifact_service,
+        "set_produced_by_message_index",
+        lambda u, aid, idx: stamped.append((u, aid, idx)),
+    )
+    out = await coord._extract_artifact_events(
+        SESSION, USER, turn_start, produced_by_message_index=7
+    )
+    assert {_parse_sse(e)["producedByMessageIndex"] for e in out} == {7}
+    assert stamped == [(USER, "a", 7), (USER, "b", 7)]
+
+
+@pytest.mark.asyncio
+async def test_stamp_failure_is_swallowed(
+    coord, turn_start, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        artifact_service, "list_session_artifacts", lambda u, s: [_row()]
+    )
+
+    def _boom(u, aid, idx):
+        raise RuntimeError("ddb down")
+
+    monkeypatch.setattr(
+        artifact_service, "set_produced_by_message_index", _boom
+    )
+    out = await coord._extract_artifact_events(
+        SESSION, USER, turn_start, produced_by_message_index=3
+    )
+    # Stamp failure must not drop the live event.
+    assert _parse_sse(out[0])["producedByMessageIndex"] == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
+++ b/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
@@ -153,6 +153,27 @@ def test_lists_head_rows_newest_first(client) -> None:
     assert arts[0]["content_type"] == "text/html; charset=utf-8"
 
 
+def test_produced_by_message_index_round_trips(client) -> None:
+    """The HEAD row's linkage index (stamped post-turn by the stream
+    coordinator) must surface on the list DTO so the SPA can anchor the
+    card inline; absent on legacy rows → null (SPA falls back to strip)."""
+    tc, ddb = client
+    _put_head(ddb, artifact="linked", updated_at="2026-05-15T12:00:00+00:00")
+    ddb.Table(TABLE).update_item(
+        Key={"PK": f"USER#{USER_ID}", "SK": "ARTIFACT#linked#HEAD"},
+        UpdateExpression="SET produced_by_message_index = :i",
+        ExpressionAttributeValues={":i": 5},
+    )
+    _put_head(ddb, artifact="legacy", updated_at="2026-05-15T11:00:00+00:00")
+
+    arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
+        "artifacts"
+    ]
+    by_id = {a["artifact_id"]: a for a in arts}
+    assert by_id["linked"]["produced_by_message_index"] == 5
+    assert by_id["legacy"]["produced_by_message_index"] is None
+
+
 def test_reflects_current_version(client) -> None:
     tc, ddb = client
     _put_head(ddb, artifact="art-1", version=3, title="V3")

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -8,54 +8,91 @@ import {
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroCodeBracket,
+  heroDocumentText,
   heroArrowTopRightOnSquare,
 } from '@ng-icons/heroicons/outline';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+
+/** Visual treatment derived from an artifact's content type. */
+interface ArtifactKind {
+  label: string;
+  icon: string;
+  /** Full class list for the icon tile (no static classes — see note). */
+  tile: string;
+  /** Full class list for the type badge. */
+  badge: string;
+  /** Full class list for the left accent rail. */
+  rail: string;
+}
 
 /**
  * Compact, clickable card for one artifact. The artifact's content is
  * never inlined here — opening the card asks the panel to mint a
  * short-lived render token and load it in a sandboxed iframe.
  *
- * Rendered as a session-level strip (next to the compaction summary),
- * not anchored to a specific message: the backend doesn't track which
- * message produced which artifact, and the panel is the real surface.
+ * Anchored inline after its producing assistant message by the
+ * message-list (via `Artifact.producedByMessageIndex`); only legacy /
+ * unanchorable artifacts fall back to the end-of-conversation strip.
+ *
+ * The colored sub-elements bind `[class]` to a full computed class
+ * string (no static `class` on those nodes) so the accent swaps cleanly
+ * by content type without static/dynamic class-merge ambiguity.
  */
 @Component({
   selector: 'app-artifact-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
   providers: [
-    provideIcons({ heroCodeBracket, heroArrowTopRightOnSquare }),
+    provideIcons({
+      heroCodeBracket,
+      heroDocumentText,
+      heroArrowTopRightOnSquare,
+    }),
   ],
   template: `
     <button
       type="button"
-      class="group flex w-full max-w-md items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-blue-400 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500 dark:hover:bg-gray-700/60 dark:focus-visible:ring-offset-gray-900"
+      class="group relative flex w-full max-w-md items-center gap-3 overflow-hidden rounded-xl border border-gray-200/80 bg-white py-3 pl-4 pr-3.5 text-left shadow-sm transition-all duration-150 hover:-translate-y-px hover:border-gray-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-gray-700/80 dark:bg-gray-800/70 dark:hover:border-gray-600 dark:focus-visible:ring-offset-gray-900"
       [attr.aria-label]="ariaLabel()"
       (click)="open()"
     >
-      <span
-        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300"
-      >
-        <ng-icon name="heroCodeBracket" class="text-lg" aria-hidden="true" />
+      <span aria-hidden="true" [class]="kind().rail"></span>
+
+      <span [class]="kind().tile">
+        <ng-icon [name]="kind().icon" class="text-lg" aria-hidden="true" />
       </span>
+
       <span class="min-w-0 flex-1">
         <span
-          class="block truncate text-sm font-medium text-gray-900 dark:text-gray-100"
+          class="block truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
         >
           {{ artifact().title || 'Untitled artifact' }}
         </span>
-        <span class="block text-xs text-gray-500 dark:text-gray-400">
-          Artifact · v{{ artifact().version }}
+        <span
+          class="mt-1 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+        >
+          <span [class]="kind().badge">{{ kind().label }}</span>
+          <span>v{{ artifact().version }}</span>
+          @if (updatedLabel()) {
+            <span aria-hidden="true" class="text-gray-300 dark:text-gray-600"
+              >·</span
+            >
+            <span>{{ updatedLabel() }}</span>
+          }
         </span>
       </span>
-      <ng-icon
-        name="heroArrowTopRightOnSquare"
-        class="shrink-0 text-base text-gray-400 transition-colors group-hover:text-blue-600 dark:group-hover:text-blue-300"
-        aria-hidden="true"
-      />
+
+      <span
+        class="flex shrink-0 items-center gap-1 text-xs font-medium text-gray-400 transition-colors group-hover:text-blue-600 dark:text-gray-500 dark:group-hover:text-blue-300"
+      >
+        <span class="hidden sm:inline">Open</span>
+        <ng-icon
+          name="heroArrowTopRightOnSquare"
+          class="text-base"
+          aria-hidden="true"
+        />
+      </span>
     </button>
   `,
   styles: `
@@ -69,9 +106,19 @@ export class ArtifactCardComponent {
 
   private artifactState = inject(ArtifactStateService);
 
+  protected readonly kind = computed<ArtifactKind>(() =>
+    classifyContentType(this.artifact().contentType),
+  );
+
+  /** Short, human relative time for the meta line. Empty when the
+   *  timestamp is missing or unparseable so the row just omits it. */
+  protected readonly updatedLabel = computed<string>(() =>
+    relativeTime(this.artifact().updatedAt),
+  );
+
   protected readonly ariaLabel = computed(
     () =>
-      `Open artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
+      `Open ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
   );
 
   protected open(): void {
@@ -82,4 +129,120 @@ export class ArtifactCardComponent {
       title: a.title,
     });
   }
+}
+
+const TILE_BASE =
+  'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg';
+const BADGE_BASE =
+  'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
+const RAIL_BASE = 'absolute inset-y-0 left-0 w-1';
+
+function kind(
+  label: string,
+  icon: string,
+  tile: string,
+  badge: string,
+  rail: string,
+): ArtifactKind {
+  return {
+    label,
+    icon,
+    tile: `${TILE_BASE} ${tile}`,
+    badge: `${BADGE_BASE} ${badge}`,
+    rail: `${RAIL_BASE} ${rail}`,
+  };
+}
+
+const CODE = 'heroCodeBracket';
+const DOC = 'heroDocumentText';
+
+/** Map a MIME type to a label + accent palette. The match is on the
+ *  bare type (parameters like `; charset=utf-8` are ignored). */
+function classifyContentType(contentType: string): ArtifactKind {
+  const mime = (contentType || '').split(';')[0].trim().toLowerCase();
+
+  switch (mime) {
+    case 'text/html':
+    case 'application/xhtml+xml':
+      return kind(
+        'HTML',
+        CODE,
+        'bg-orange-100 text-orange-600 dark:bg-orange-900/40 dark:text-orange-300',
+        'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
+        'bg-orange-400 dark:bg-orange-500',
+      );
+    case 'text/javascript':
+    case 'application/javascript':
+      return kind(
+        'JS',
+        CODE,
+        'bg-amber-100 text-amber-600 dark:bg-amber-900/40 dark:text-amber-300',
+        'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+        'bg-amber-400 dark:bg-amber-500',
+      );
+    case 'text/css':
+      return kind(
+        'CSS',
+        CODE,
+        'bg-sky-100 text-sky-600 dark:bg-sky-900/40 dark:text-sky-300',
+        'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
+        'bg-sky-400 dark:bg-sky-500',
+      );
+    case 'application/json':
+      return kind(
+        'JSON',
+        CODE,
+        'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/40 dark:text-emerald-300',
+        'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+        'bg-emerald-400 dark:bg-emerald-500',
+      );
+    case 'image/svg+xml':
+      return kind(
+        'SVG',
+        CODE,
+        'bg-pink-100 text-pink-600 dark:bg-pink-900/40 dark:text-pink-300',
+        'bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300',
+        'bg-pink-400 dark:bg-pink-500',
+      );
+    case 'text/markdown':
+      return kind(
+        'MD',
+        DOC,
+        'bg-violet-100 text-violet-600 dark:bg-violet-900/40 dark:text-violet-300',
+        'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+        'bg-violet-400 dark:bg-violet-500',
+      );
+    default:
+      return kind(
+        mime.startsWith('text/') ? 'TEXT' : 'DOC',
+        DOC,
+        'bg-slate-100 text-slate-600 dark:bg-slate-700/60 dark:text-slate-300',
+        'bg-slate-100 text-slate-600 dark:bg-slate-700/60 dark:text-slate-300',
+        'bg-slate-400 dark:bg-slate-500',
+      );
+  }
+}
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago", else a short date.
+ *  Returns '' for a missing or unparseable timestamp. */
+function relativeTime(iso: string): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+
+  const diffMs = Date.now() - then;
+  const min = Math.floor(diffMs / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+
+  return new Date(then).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
 }

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -32,6 +32,22 @@
         </div>
     }
 
+    <!-- Artifacts produced by this turn, anchored to their final
+         assistant message via producedByMessageIndex. Renders both live
+         (the `artifact` SSE event carries the index) and after a session
+         reload (the list endpoint persists it on the HEAD row). -->
+    @let messageArtifacts = artifactsForMessageId(message.id);
+    @if (messageArtifacts.length > 0) {
+      <section
+        class="flex flex-col gap-2"
+        aria-label="Artifacts from this response"
+      >
+        @for (artifact of messageArtifacts; track artifact.artifactId) {
+          <app-artifact-card [artifact]="artifact" />
+        }
+      </section>
+    }
+
   }
 
   <!-- Single subtle compaction summary at the end of the conversation,
@@ -45,17 +61,16 @@
     />
   }
 
-  <!-- Session-level artifact strip. Not anchored to a message: the
-       backend doesn't track which message produced which artifact, and
-       the panel (opened from a card) is the real surface. Hydrated from
-       the app-api list endpoint on load, appended live via the
-       `artifact` SSE event. -->
-  @if (hasArtifacts()) {
+  <!-- Fallback strip for artifacts that can't be anchored to a loaded
+       message: legacy rows written before linkage existed, or an index
+       pointing outside the currently paginated page. Anchored artifacts
+       render inline after their producing message (see the @for above). -->
+  @if (hasOrphanArtifacts()) {
     <section
       class="mt-3 flex flex-col gap-2"
       aria-label="Artifacts created in this conversation"
     >
-      @for (artifact of artifacts(); track artifact.artifactId) {
+      @for (artifact of orphanArtifacts(); track artifact.artifactId) {
         <app-artifact-card [artifact]="artifact" />
       }
     </section>

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, input, signal, effect, OnDestroy, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { Message } from '../../services/models/message.model';
+import type { Artifact } from '../../services/artifacts/artifact.model';
 import { UserMessageComponent } from './components/user-message.component';
 import { AssistantMessageComponent } from './components/assistant-message.component';
 import { MessageMetadataBadgesComponent } from './components/message-metadata-badges.component';
@@ -60,9 +61,81 @@ export class MessageListComponent implements OnDestroy {
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
 
-  /** Session artifacts, newest first, for the end-of-conversation strip. */
+  /** Session artifacts, newest first. Anchored ones render inline after
+   *  their producing assistant message (`producedByMessageIndex` matches
+   *  the `msg-{sessionId}-{index}` id); the rest fall back to the
+   *  end-of-conversation strip. */
   protected artifacts = this.artifactState.artifacts;
-  protected hasArtifacts = this.artifactState.hasArtifacts;
+
+  /** Trailing 0-based index from a `msg-{sessionId}-{index}` id. Splits
+   *  on the last `-` so a session id containing dashes is irrelevant.
+   *  Null for any id that doesn't end in an integer. */
+  private parseMessageIndex(id: string): number | null {
+    const dash = id.lastIndexOf('-');
+    if (dash < 0) return null;
+    const n = Number(id.slice(dash + 1));
+    return Number.isInteger(n) ? n : null;
+  }
+
+  /** The message index an artifact anchors to. Live events carry a
+   *  concrete producing message id (stable as later turns append);
+   *  reload hydration only has the AgentCore-Memory numeric index, which
+   *  is exact there. Prefer the live id, fall back to the index. */
+  private resolveArtifactIndex(a: Artifact): number | null {
+    if (a.producedByMessageId) {
+      const live = this.parseMessageIndex(a.producedByMessageId);
+      if (live !== null) return live;
+    }
+    return a.producedByMessageIndex ?? null;
+  }
+
+  private readonly loadedMessageIndices = computed<ReadonlySet<number>>(() => {
+    const s = new Set<number>();
+    for (const m of this.messages()) {
+      const n = this.parseMessageIndex(m.id);
+      if (n !== null) s.add(n);
+    }
+    return s;
+  });
+
+  /** artifacts grouped by the message index that produced them, limited
+   *  to indices that are actually in the loaded (possibly paginated)
+   *  message list. */
+  private readonly artifactsByMessageIndex = computed<
+    ReadonlyMap<number, Artifact[]>
+  >(() => {
+    const loaded = this.loadedMessageIndices();
+    const map = new Map<number, Artifact[]>();
+    for (const a of this.artifacts()) {
+      const idx = this.resolveArtifactIndex(a);
+      if (idx == null || !loaded.has(idx)) continue;
+      const list = map.get(idx);
+      if (list) list.push(a);
+      else map.set(idx, [a]);
+    }
+    return map;
+  });
+
+  /** Artifacts with no usable anchor (legacy rows written before linkage,
+   *  or an index pointing outside the loaded page) — keep them visible in
+   *  the end-of-conversation strip so nothing silently disappears. */
+  protected readonly orphanArtifacts = computed<Artifact[]>(() => {
+    const loaded = this.loadedMessageIndices();
+    return this.artifacts().filter((a) => {
+      const idx = this.resolveArtifactIndex(a);
+      return idx == null || !loaded.has(idx);
+    });
+  });
+
+  protected readonly hasOrphanArtifacts = computed(
+    () => this.orphanArtifacts().length > 0,
+  );
+
+  protected artifactsForMessageId(id: string): Artifact[] {
+    const n = this.parseMessageIndex(id);
+    if (n === null) return [];
+    return this.artifactsByMessageIndex().get(n) ?? [];
+  }
 
   /** Single end-of-conversation compaction summary inputs. Sourced from
    *  live SSE events plus session-metadata hydration on load. The fade-in

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
@@ -67,6 +67,15 @@ describe('ArtifactHttpService', () => {
           content_type: 'text/html; charset=utf-8',
           updated_at: '2026-05-15T12:00:00+00:00',
           created_at: '2026-05-15T10:00:00+00:00',
+          produced_by_message_index: 4,
+        },
+        {
+          artifact_id: 'legacy',
+          version: 1,
+          title: 'Old',
+          content_type: 'text/html; charset=utf-8',
+          updated_at: '2026-05-15T11:00:00+00:00',
+          created_at: '2026-05-15T11:00:00+00:00',
         },
       ],
     });
@@ -78,6 +87,16 @@ describe('ArtifactHttpService', () => {
         contentType: 'text/html; charset=utf-8',
         updatedAt: '2026-05-15T12:00:00+00:00',
         createdAt: '2026-05-15T10:00:00+00:00',
+        producedByMessageIndex: 4,
+      },
+      {
+        artifactId: 'legacy',
+        version: 1,
+        title: 'Old',
+        contentType: 'text/html; charset=utf-8',
+        updatedAt: '2026-05-15T11:00:00+00:00',
+        createdAt: '2026-05-15T11:00:00+00:00',
+        producedByMessageIndex: null,
       },
     ]);
   });

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
@@ -16,6 +16,7 @@ interface ArtifactSummaryDto {
   content_type: string;
   updated_at: string;
   created_at?: string | null;
+  produced_by_message_index?: number | null;
 }
 
 interface ArtifactListResponseDto {
@@ -70,6 +71,7 @@ export class ArtifactHttpService {
       contentType: a.content_type,
       updatedAt: a.updated_at,
       createdAt: a.created_at ?? undefined,
+      producedByMessageIndex: a.produced_by_message_index ?? null,
     }));
   }
 }

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
@@ -36,6 +36,26 @@ describe('ArtifactStateService', () => {
     expect(svc.get('art-1')?.version).toBe(1);
   });
 
+  it('threads producedByMessageIndex from the live event', () => {
+    svc.recordLive(ev({ producedByMessageIndex: 7 }));
+    expect(svc.get('art-1')?.producedByMessageIndex).toBe(7);
+  });
+
+  it('defaults producedByMessageIndex to null when the event omits it', () => {
+    svc.recordLive(ev());
+    expect(svc.get('art-1')?.producedByMessageIndex).toBeNull();
+  });
+
+  it('stores the live producing message id when provided', () => {
+    svc.recordLive(ev(), 'msg-sess-9-3');
+    expect(svc.get('art-1')?.producedByMessageId).toBe('msg-sess-9-3');
+  });
+
+  it('defaults producedByMessageId to null on the hydration-style call', () => {
+    svc.recordLive(ev());
+    expect(svc.get('art-1')?.producedByMessageId).toBeNull();
+  });
+
   it('keeps the highest version for the same id (update_artifact)', () => {
     svc.recordLive(ev({ version: 1 }));
     svc.recordLive(ev({ version: 3, updatedAt: '2026-05-15T12:05:00+00:00' }));

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
@@ -36,14 +36,23 @@ export class ArtifactStateService {
     return this.byId().get(artifactId);
   }
 
-  /** Record a live `artifact` SSE event. Keeps the highest version. */
-  recordLive(event: ArtifactEvent): void {
+  /**
+   * Record a live `artifact` SSE event. Keeps the highest version.
+   *
+   * `producedByMessageId` is the concrete id of the assistant message
+   * that just streamed (resolved by the caller the same way oauth /
+   * tool-approval prompts are). Live placement keys off this rather than
+   * the numeric index, which only lines up after a reload.
+   */
+  recordLive(event: ArtifactEvent, producedByMessageId?: string | null): void {
     this.upsert({
       artifactId: event.artifactId,
       version: event.version,
       title: event.title,
       contentType: event.contentType,
       updatedAt: event.updatedAt,
+      producedByMessageIndex: event.producedByMessageIndex ?? null,
+      producedByMessageId: producedByMessageId ?? null,
     });
   }
 

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact.model.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact.model.ts
@@ -14,6 +14,28 @@ export interface Artifact {
   contentType: string;
   updatedAt: string;
   createdAt?: string;
+  /**
+   * 0-based index of the assistant message that produced (or last
+   * updated) this artifact, in AgentCore Memory ordering — matches the
+   * messages endpoint's `msg-{sessionId}-{index}` id on **reload**, when
+   * the SPA enumerates the same memory messages the backend indexed.
+   *
+   * Not reliable for live placement: a tool-using turn is one folded
+   * assistant message client-side, but this index counts the interleaved
+   * tool_use/tool_result memory messages, so it drifts. Live placement
+   * uses `producedByMessageId` instead. Null/undefined for artifacts
+   * written before linkage existed — those fall back to the strip.
+   */
+  producedByMessageIndex?: number | null;
+
+  /**
+   * Concrete client message id of the assistant turn that produced this
+   * artifact, resolved at live-event time (same way oauth/tool-approval
+   * prompts anchor). Set only on the live path; absent on reload
+   * hydration (the numeric index governs there). Stable as later turns
+   * append, so the card stays put without a refresh.
+   */
+  producedByMessageId?: string | null;
 }
 
 /** Which artifact the side panel is currently showing. */

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -337,7 +337,22 @@ export class StreamParserService {
 
       onCompaction: (data: CompactionEvent) => this.compactionSummary.recordLive(data),
 
-      onArtifact: (data: ArtifactEvent) => this.artifactState.recordLive(data),
+      onArtifact: (data: ArtifactEvent) => {
+        // Same post-message_stop timing as oauth_required: the producing
+        // assistant message is the last assistant message in the list.
+        // Anchor live placement to its concrete id — the numeric index
+        // only lines up after a reload (it counts the memory tool
+        // messages the folded client message doesn't have).
+        const messages = this.allMessages();
+        let lastAssistantId: string | undefined;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === 'assistant') {
+            lastAssistantId = messages[i].id;
+            break;
+          }
+        }
+        this.artifactState.recordLive(data, lastAssistantId);
+      },
 
       onToolApprovalRequired: (data: ToolApprovalRequiredEvent) => {
         const messages = this.allMessages();

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -156,6 +156,12 @@ export interface CompactionEvent {
  * `action` is `created` for v1, `updated` for any later version. Cards
  * also hydrate on session load via the app-api list endpoint; the SPA
  * dedupes by `artifactId` keeping the highest `version`.
+ *
+ * `producedByMessageIndex` is the 0-based index of the turn's final
+ * assistant message (`msg-{sessionId}-{index}`), stamped by the stream
+ * coordinator so the SPA can anchor the card inline after that message.
+ * Null when the index couldn't be resolved — the SPA falls back to the
+ * end-of-conversation strip.
  */
 export interface ArtifactEvent {
   type: 'artifact';
@@ -166,6 +172,7 @@ export interface ArtifactEvent {
   sessionId: string;
   updatedAt: string;
   action: 'created' | 'updated';
+  producedByMessageIndex?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Artifact cards now render **inline, right after the assistant response that produced them**, instead of bundled in one strip at the end of the conversation — both live and after a session reload.
- Adds exact artifact↔message linkage end-to-end (no timestamp heuristics): the stream coordinator stamps the artifact's DynamoDB HEAD row post-turn with the turn's final assistant-message index — the same odd-position index it already computes for per-message metadata, which the messages endpoint re-derives on reload — emits it on the `artifact` SSE event, and the app-api list DTO carries it. The stamp is a single-attribute SET that doesn't touch `version`, so it can't collide with the `update_artifact` optimistic lock. Additive/nullable: legacy artifacts (written before linkage) fall back to the existing end-of-conversation strip.
- Live placement anchors to the producing assistant message's **concrete id** (resolved at event time the same way `oauth_required`/`tool_approval_required` prompts are). The AgentCore-Memory numeric index only aligns after a reload — a tool-using turn is one folded client message, but the index counts the interleaved `tool_use`/`tool_result` memory messages — so the index is used solely for the reload path, where it's exact.
- **Card redesign (refined-minimal):** content-type accent rail + icon tile + uppercase type badge (HTML/JS/CSS/JSON/SVG/MD/TEXT), version, relative timestamp, explicit "Open" affordance, hover/focus polish, dark mode. Behavior unchanged (opens the token-gated panel).

Cross-package contract change kept in one PR per `CLAUDE.md`: SSE `artifact` event + app-api list DTO + frontend types updated together. Backward compatible (nullable field).

## Test plan

- [x] Backend: `pytest` artifact tools / SSE events / app-api list + import-boundary suites green; added coverage for the HEAD-row stamp, write-back failure tolerance, and DTO round-trip.
- [x] Frontend: `tsc` clean; full `ng build` clean (new `@let` / `[class]` / dynamic `ng-icon` templates compile); artifact-state + stream-parser specs green, incl. new linkage + live-id cases.
- [x] Updated `artifact-http.service.spec.ts` expectations to the new contract (note: that spec has a **pre-existing** `provideHttpClientTesting` TestBed failure on clean `develop`, unrelated to this change).
- [ ] Manual UI (SKIP_AUTH off, needs an authed agent turn): create an artifact → card appears under that response; send another message → card stays put (the live drift this fixes); reload → still correctly anchored; update an artifact → card moves to the later turn; legacy/older sessions → cards still show in the bottom strip; dark mode accent/contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)