### PR TITLE
feat(artifacts): support Markdown content type in artifact tool

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -13,10 +13,19 @@ Frozen cross-PR contract (must stay in sync with the render Lambda
 
 Versions are immutable (no DeleteObject grant in inference-api) — an
 update writes a new version and re-points HEAD.
+
+Markdown artifacts: when `content_type` is a Markdown type, the model
+authors raw Markdown but S3 stores a self-contained HTML render wrapper
+(the writer owns rendering — the render Lambda is a pass-through). The
+version/HEAD rows keep the authored `content_type` (`text/markdown`) so
+the card badge and list stay truthful; the render Lambda maps that type
+to a `text/html` HTTP response so the browser renders the wrapper.
 """
 
 from __future__ import annotations
 
+import base64
+import html
 import logging
 import os
 import uuid
@@ -30,6 +39,112 @@ from botocore.exceptions import ClientError
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8"
+# What S3 physically holds (and the HTTP type the render Lambda emits)
+# for a Markdown artifact: a self-contained HTML render wrapper.
+_RENDERED_CONTENT_TYPE = "text/html; charset=utf-8"
+_MARKDOWN_MIME_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+
+# Markdown is base64-embedded so no character ever needs HTML/JS escaping
+# and there is no second network fetch (the artifact-origin CSP sets
+# connect-src 'none'). The rendered HTML is intentionally NOT sanitized:
+# this document runs in the same null-origin sandboxed iframe as HTML
+# artifacts, so its containment story is identical to theirs. `marked` is
+# pinned (dependency-free single module) and loaded from esm.sh, which the
+# artifact-origin CSP allows under script-src.
+_MARKDOWN_RENDER_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__ARTIFACT_TITLE__</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin-inline: auto;
+    max-width: 56rem;
+    padding: 2.5rem clamp(1rem, 5vw, 4rem);
+    font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif;
+    color: #1f2328;
+    background: #ffffff;
+  }
+  h1, h2, h3, h4 { line-height: 1.25; margin: 2rem 0 1rem; font-weight: 600; }
+  h1 { font-size: 2rem; border-bottom: 1px solid #d0d7de; padding-bottom: .3rem; }
+  h2 { font-size: 1.5rem; border-bottom: 1px solid #d0d7de; padding-bottom: .3rem; }
+  h3 { font-size: 1.25rem; }
+  a { color: #0969da; }
+  p, ul, ol, blockquote, table, pre { margin: 0 0 1rem; }
+  ul, ol { padding-left: 2rem; }
+  code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+      monospace;
+    font-size: .9em;
+    background: rgba(175, 184, 193, .2);
+    padding: .2em .4em;
+    border-radius: 6px;
+  }
+  pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow: auto; }
+  pre code { background: none; padding: 0; font-size: .875em; }
+  blockquote {
+    margin-left: 0;
+    padding: 0 1rem;
+    color: #59636e;
+    border-left: .25rem solid #d0d7de;
+  }
+  table { border-collapse: collapse; display: block; overflow: auto; }
+  th, td { border: 1px solid #d0d7de; padding: .4rem .8rem; }
+  th { background: #f6f8fa; }
+  img { max-width: 100%; }
+  hr { border: none; border-top: 1px solid #d0d7de; margin: 2rem 0; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6edf3; background: #0d1117; }
+    h1, h2 { border-bottom-color: #30363d; }
+    a { color: #4493f8; }
+    code { background: rgba(110, 118, 129, .4); }
+    pre { background: #161b22; }
+    blockquote { color: #9198a1; border-left-color: #30363d; }
+    th, td { border-color: #30363d; }
+    th { background: #161b22; }
+    hr { border-top-color: #30363d; }
+  }
+</style>
+</head>
+<body>
+<main id="content" aria-live="polite">Rendering…</main>
+<script type="application/x-markdown-base64" id="md-src">__ARTIFACT_MD_B64__</script>
+<script type="module">
+  import { marked } from "https://esm.sh/marked@14.1.4";
+  const b64 = document.getElementById("md-src").textContent.trim();
+  const md = new TextDecoder().decode(
+    Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)),
+  );
+  const el = document.getElementById("content");
+  try {
+    el.innerHTML = marked.parse(md, { gfm: true, breaks: false });
+    const h1 = document.querySelector("h1");
+    if (h1 && h1.textContent.trim()) document.title = h1.textContent.trim();
+  } catch (err) {
+    el.textContent = "Could not render this Markdown document.";
+  }
+</script>
+</body>
+</html>
+"""
+
+
+def _is_markdown(content_type: Optional[str]) -> bool:
+    """True for a Markdown MIME type, ignoring any `; charset=` suffix."""
+    bare = (content_type or "").split(";")[0].strip().lower()
+    return bare in _MARKDOWN_MIME_TYPES
+
+
+def _wrap_markdown(title: str, markdown: str) -> str:
+    """Render Markdown source into a self-contained HTML document."""
+    md_b64 = base64.b64encode(markdown.encode("utf-8")).decode("ascii")
+    return _MARKDOWN_RENDER_TEMPLATE.replace(
+        "__ARTIFACT_TITLE__", html.escape(title or "Markdown document")
+    ).replace("__ARTIFACT_MD_B64__", md_b64)
+
 
 _cached_bucket: Optional[str] = None
 _cached_table: Optional[str] = None
@@ -123,13 +238,19 @@ def _now_iso() -> str:
 
 
 def _put_object(user_id: str, artifact_id: str, version: int,
-                content: str, content_type: str) -> str:
+                content: str, content_type: str, title: str) -> str:
     key = f"{user_id}/{artifact_id}/v{version}/index.html"
+    if _is_markdown(content_type):
+        body = _wrap_markdown(title, content)
+        object_content_type = _RENDERED_CONTENT_TYPE
+    else:
+        body = content
+        object_content_type = content_type
     _s3().put_object(
         Bucket=_bucket_name(),
         Key=key,
-        Body=content.encode("utf-8"),
-        ContentType=content_type,
+        Body=body.encode("utf-8"),
+        ContentType=object_content_type,
     )
     return key
 
@@ -146,7 +267,9 @@ def create_artifact_record(
     version = 1
     content_type = content_type or _DEFAULT_CONTENT_TYPE
     now = _now_iso()
-    content_key = _put_object(user_id, artifact_id, version, content, content_type)
+    content_key = _put_object(
+        user_id, artifact_id, version, content, content_type, title
+    )
 
     pk = f"USER#{user_id}"
     common = {
@@ -211,7 +334,9 @@ def update_artifact_record(
     title = title or head.get("title", "")
     content_type = content_type or head.get("content_type") or _DEFAULT_CONTENT_TYPE
     now = _now_iso()
-    content_key = _put_object(user_id, artifact_id, version, content, content_type)
+    content_key = _put_object(
+        user_id, artifact_id, version, content, content_type, title
+    )
 
     common = {
         "storage": "s3",

--- a/backend/src/agents/builtin_tools/artifacts/tools.py
+++ b/backend/src/agents/builtin_tools/artifacts/tools.py
@@ -30,19 +30,30 @@ def make_create_artifact_tool(session_id: str, user_id: str):
 
         Use this when you produce a self-contained deliverable the user
         will want to view, keep, or iterate on — an HTML page, a chart,
-        an interactive widget, a formatted report.
+        an interactive widget, a formatted report, or a written document.
 
-        `content` MUST be a complete standalone HTML document (include
-        `<!doctype html>` and a full `<html>` … `</html>`). It renders in
-        a sandboxed iframe with a strict CSP: inline `<style>`/`<script>`
-        are allowed, as are scripts from `https://cdn.tailwindcss.com`
-        and `https://esm.sh`. It cannot make network calls. Do NOT wrap
-        the document in markdown fences.
+        Two authoring modes:
+
+        - HTML (default): `content` MUST be a complete standalone HTML
+          document (include `<!doctype html>` and a full `<html>` …
+          `</html>`). It renders in a sandboxed iframe with a strict CSP:
+          inline `<style>`/`<script>` are allowed, as are scripts from
+          `https://cdn.tailwindcss.com` and `https://esm.sh`. It cannot
+          make network calls.
+
+        - Markdown: pass `content_type="text/markdown"` and provide raw
+          GitHub-flavored Markdown as `content`. Do NOT add an HTML
+          shell — the system renders the Markdown for the user. Prefer
+          this for prose, reports, and documentation.
+
+        Either way, do NOT wrap `content` in markdown code fences.
 
         Args:
             title: Short human-readable name shown in the artifacts list.
-            content: The full HTML document.
-            content_type: Defaults to text/html; leave as-is for HTML.
+            content: The full HTML document, or raw Markdown when
+                content_type is text/markdown.
+            content_type: Defaults to text/html. Pass "text/markdown"
+                to author a Markdown document instead.
 
         Returns the new artifact id and version — reference the id if the
         user later asks you to change it (via update_artifact).
@@ -79,14 +90,18 @@ def make_update_artifact_tool(session_id: str, user_id: str):
 
         Prior versions are kept immutably. Pass the `artifact_id`
         returned by an earlier create_artifact. `content` follows the
-        same rules as create_artifact (a complete standalone HTML
-        document, no markdown fences).
+        same rules as create_artifact: a complete standalone HTML
+        document, or raw Markdown when content_type is text/markdown; no
+        markdown code fences either way. If content_type is omitted the
+        artifact's existing type (HTML or Markdown) is kept.
 
         Args:
             artifact_id: The artifact to update.
-            content: The full replacement HTML document.
+            content: The full replacement HTML document, or raw Markdown
+                for a Markdown artifact.
             title: Optional new title; unchanged if omitted.
-            content_type: Optional; unchanged if omitted.
+            content_type: Optional; unchanged if omitted. Pass
+                "text/markdown" to switch an artifact to Markdown.
 
         Returns the new version number.
         """

--- a/backend/src/lambdas/artifact_render/handler.py
+++ b/backend/src/lambdas/artifact_render/handler.py
@@ -21,6 +21,14 @@ templating layer: S3 holds the complete document to serve, and the
 artifact writer owns all rendering. `#HEAD` is never read — the token
 pins an exact version.
 
+Markdown serve-type mapping: a Markdown artifact's version row carries
+the authored `content_type` (`text/markdown`) so the SPA card/list stay
+truthful, but S3 holds the writer's self-contained HTML render wrapper.
+So records typed as Markdown are served with a `text/html` HTTP
+content type — still the exact S3 bytes, only the response header is
+mapped (header stamping, not templating). Must stay in sync with the
+writer (`agents/builtin_tools/artifacts/service.py`).
+
 No third-party dependencies: HS256 is HMAC-SHA256, verified with the
 standard library. boto3 is provided by the Lambda runtime.
 
@@ -112,6 +120,25 @@ def _csp_header() -> str:
             "base-uri 'none'",
         ]
     )
+
+
+# Authored types whose S3 body is a writer-produced HTML render wrapper
+# (see module docstring). Mirrors `_MARKDOWN_MIME_TYPES` in the writer's
+# service.py — this Lambda is standalone (no apis/* imports) so the small
+# duplication is by design; keep the two in sync.
+_HTML_CONTENT_TYPE = "text/html; charset=utf-8"
+_MARKDOWN_MIME_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+
+
+def _serve_content_type(stored: str) -> str:
+    """HTTP content type to emit for a stored authored type.
+
+    Markdown records hold an HTML render wrapper in S3, so they are
+    served as HTML; every other type is served exactly as stored."""
+    bare = (stored or "").split(";")[0].strip().lower()
+    if bare in _MARKDOWN_MIME_TYPES:
+        return _HTML_CONTENT_TYPE
+    return stored
 
 
 def _security_headers(content_type: str) -> dict[str, str]:
@@ -364,7 +391,8 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
         content_key = record.get("content_key")
         if not isinstance(content_key, str) or not content_key:
             raise _ArtifactNotFound("version record has no content pointer")
-        content_type = record.get("content_type") or "text/html; charset=utf-8"
+        stored_content_type = record.get("content_type") or _HTML_CONTENT_TYPE
+        content_type = _serve_content_type(stored_content_type)
         body = _fetch_content(content_key)
     except _ArtifactNotFound as exc:
         logger.warning(

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -8,6 +8,9 @@ Lambda would serve.
 
 from __future__ import annotations
 
+import base64
+import re
+
 import boto3
 import pytest
 from moto import mock_aws
@@ -21,6 +24,15 @@ BUCKET = "test-artifacts-content"
 USER = "user-123"
 SESSION = "sess-9"
 DOC = "<!doctype html><html><body><h1>hi</h1></body></html>"
+MD = "# Title\n\nSome **bold** text and a list:\n\n- one\n- two\n"
+
+
+def _embedded_markdown(body: str) -> str:
+    """Decode the base64 source the render wrapper embeds (no `<` in
+    base64, so the cheap regex is safe)."""
+    m = re.search(r'id="md-src">([^<]+)</script>', body)
+    assert m, "render wrapper is missing the embedded markdown block"
+    return base64.b64decode(m.group(1)).decode()
 
 
 @pytest.fixture(autouse=True)
@@ -126,6 +138,62 @@ def test_content_type_default(aws) -> None:
     ddb, _ = aws
     aid, _ = service.create_artifact_record(USER, SESSION, "T", DOC, "")
     assert _item(ddb, aid, "V#00001")["content_type"] == "text/html; charset=utf-8"
+
+
+def test_markdown_create_wraps_and_preserves_type(aws) -> None:
+    ddb, s3 = aws
+    aid, ver = service.create_artifact_record(
+        USER, SESSION, "Notes", MD, "text/markdown"
+    )
+    assert ver == 1
+
+    # DDB keeps the authored Markdown type — drives the SPA card badge
+    # and list; the render Lambda maps it to text/html when serving.
+    assert _item(ddb, aid, "V#00001")["content_type"] == "text/markdown"
+
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode()
+    assert body.lstrip().startswith("<!doctype html>")
+    assert "https://esm.sh/marked@14.1.4" in body
+    # Source is base64-embedded, never inlined raw (escaping/XSS-safe).
+    assert MD not in body
+    assert _embedded_markdown(body) == MD
+
+
+def test_markdown_charset_suffix_still_markdown(aws) -> None:
+    _, s3 = aws
+    aid, _ = service.create_artifact_record(
+        USER, SESSION, "Doc", MD, "text/markdown; charset=utf-8"
+    )
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode()
+    assert _embedded_markdown(body) == MD
+
+
+def test_markdown_update_rewraps_inherited_type(aws) -> None:
+    _, s3 = aws
+    aid, _ = service.create_artifact_record(
+        USER, SESSION, "Doc", MD, "text/markdown"
+    )
+    new_md = "## v2\n\nrevised body\n"
+    # content_type omitted → inherits Markdown from HEAD, must re-wrap.
+    ver = service.update_artifact_record(USER, aid, new_md, None, None)
+    assert ver == 2
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v2/index.html"
+    )["Body"].read().decode()
+    assert body.lstrip().startswith("<!doctype html>")
+    assert _embedded_markdown(body) == new_md
+
+
+def test_html_artifact_not_wrapped(aws) -> None:
+    _, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "Page", DOC, "text/html")
+    assert s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode() == DOC
 
 
 def test_ssm_fallback(aws, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/lambdas/test_artifact_render.py
+++ b/backend/tests/lambdas/test_artifact_render.py
@@ -364,6 +364,44 @@ def test_version_pins_exact_sk(aws_env) -> None:
     assert resp["statusCode"] == 404
 
 
+@pytest.mark.parametrize(
+    "stored,served",
+    [
+        ("text/markdown", "text/html; charset=utf-8"),
+        ("text/markdown; charset=utf-8", "text/html; charset=utf-8"),
+        ("text/x-markdown", "text/html; charset=utf-8"),
+        ("TEXT/MARKDOWN", "text/html; charset=utf-8"),
+        ("text/html; charset=utf-8", "text/html; charset=utf-8"),
+        ("image/svg+xml", "image/svg+xml"),
+        ("application/json", "application/json"),
+    ],
+)
+def test_serve_content_type_mapping(stored: str, served: str) -> None:
+    assert handler._serve_content_type(stored) == served
+
+
+def test_markdown_record_served_as_html(aws_env) -> None:
+    # S3 holds the writer's HTML render wrapper; the row is typed
+    # text/markdown so the SPA card/list stay truthful. The Lambda must
+    # serve the exact bytes but with a text/html HTTP content type.
+    wrapper = "<!doctype html><html><body>rendered md</body></html>"
+    boto3.client("s3", region_name="us-east-1").put_object(
+        Bucket=BUCKET, Key=CONTENT_KEY, Body=wrapper.encode()
+    )
+    _put_record(aws_env["ddb"], content_type="text/markdown; charset=utf-8")
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 200
+    assert resp["headers"]["content-type"] == "text/html; charset=utf-8"
+    assert resp["body"] == wrapper  # bytes are an exact pass-through
+
+
+def test_non_markdown_content_type_served_verbatim(aws_env) -> None:
+    _put_record(aws_env["ddb"], content_type="image/svg+xml")
+    resp = handler.handler(_event(_mint(_valid_claims())), None)
+    assert resp["statusCode"] == 200
+    assert resp["headers"]["content-type"] == "image/svg+xml"
+
+
 def test_oversized_content_is_500(aws_env, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(handler, "_MAX_CONTENT_BYTES", 16)
     boto3.client("s3", region_name="us-east-1").put_object(


### PR DESCRIPTION
## Summary

Extends the artifact tool beyond HTML-only to support **Markdown** as a first-class authored type — the first step in accommodating additional content types.

- **Authoring:** the agent passes `content_type="text/markdown"` and raw GitHub-flavored Markdown (no HTML shell, no code fences). Tool docstrings updated to document the two modes.
- **Writer** (`agents/builtin_tools/artifacts/service.py`): wraps Markdown source into a self-contained HTML render document — client-side `marked@14.1.4` from `esm.sh` (already CSP-allowed) + inline light/dark prose CSS. Source is base64-embedded, so there are no HTML/JS escaping pitfalls and no second network fetch (`connect-src 'none'`). Applies to both create and update.
- **Type fidelity:** DynamoDB keeps the authored `text/markdown` type, so the SPA card's `MD` badge and the list endpoint stay truthful. No frontend change needed — the card already classifies `text/markdown`.
- **Render Lambda** (`lambdas/artifact_render/handler.py`): adds `_serve_content_type()` — Markdown-typed records are served with a `text/html` HTTP content type. Still the exact S3 bytes; only the response header is mapped (header stamping, not templating), consistent with the Lambda's pass-through role.
- Rendered HTML is intentionally **not** sanitized — Markdown runs in the same null-origin sandboxed iframe as HTML artifacts, so containment is identical to the existing trust model.

### Deployment coupling

The writer and the render Lambda are separate deployables and **must be deployed together** (cross-PR contract noted in both module docstrings). Until the render Lambda ships, Markdown artifacts render as raw source text (CloudFront forces `nosniff`, so a non-HTML content type is shown verbatim). The Artifacts stack bundles the render Lambda.

## Test plan

- [x] `backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py` — Markdown create wraps + preserves `text/markdown`, base64 round-trips, charset suffix handled, update re-wraps inherited type, HTML path unchanged
- [x] `backend/tests/lambdas/test_artifact_render.py` — `_serve_content_type` mapping matrix, Markdown record served as `text/html` (exact byte pass-through), non-Markdown served verbatim
- [x] Full artifact suite green (99 passed) including cross-PR minter contract tests
- [ ] Post-deploy: create a Markdown artifact, open the card, confirm it renders (esm.sh is CSP-allowed in deployed envs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)