### PR TITLE
feat(artifacts): dock artifact panel beside chat, resizable, redesigned card

### DIFF
--- a/frontend/ai.client/src/app/app.css
+++ b/frontend/ai.client/src/app/app.css
@@ -54,3 +54,14 @@
 .sidenav-backdrop-exit {
   animation: fadeOut 0.3s ease-in forwards;
 }
+
+/* Docked artifact pane: reserve right-side space equal to the panel's
+   max width (max-w-2xl = 42rem) so the fixed pane sits beside the chat
+   instead of over it. Desktop only — below lg the pane is a full-width
+   takeover and the chat is not shown alongside it. The wrapper already
+   carries `transition-[padding]`, so this eases in/out with the nav. */
+@media (min-width: 1024px) {
+  .artifact-pane-open {
+    padding-right: var(--artifact-pane-width, 42rem);
+  }
+}

--- a/frontend/ai.client/src/app/app.html
+++ b/frontend/ai.client/src/app/app.html
@@ -103,8 +103,10 @@
 
   <div
     class="transition-[padding] duration-300"
+    [style.--artifact-pane-width]="artifactPaneWidthCss()"
     [class.lg:pl-72]="!sidenavService.isCollapsed() && !sidenavService.isHidden()"
-    [class.lg:pl-0]="sidenavService.isCollapsed() || sidenavService.isHidden()">
+    [class.lg:pl-0]="sidenavService.isCollapsed() || sidenavService.isHidden()"
+    [class.artifact-pane-open]="artifactPanelOpen()">
     <main class="flex flex-col">
       <!-- Scrollable Content -->
       <div class="flex-1 overflow-y-auto">

--- a/frontend/ai.client/src/app/app.ts
+++ b/frontend/ai.client/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { Sidenav } from './components/sidenav/sidenav';
 import { ErrorToastComponent } from './components/error-toast/error-toast.component';
@@ -7,6 +7,7 @@ import { SidenavService } from './services/sidenav/sidenav.service';
 import { HeaderService } from './services/header/header.service';
 import { TooltipDirective } from './components/tooltip/tooltip.directive';
 import { SessionService } from './auth/session.service';
+import { ArtifactStateService } from './session/services/artifacts/artifact-state.service';
 
 @Component({
   selector: 'app-root',
@@ -26,6 +27,20 @@ export class App {
   protected headerService = inject(HeaderService);
   private router = inject(Router);
   private session = inject(SessionService);
+  private artifactState = inject(ArtifactStateService);
+
+  /** True while an artifact pane is docked — content reserves right-side
+   *  space for it (desktop only) so the fixed panel doesn't occlude chat. */
+  protected readonly artifactPanelOpen = computed(
+    () => this.artifactState.openArtifact() !== null,
+  );
+
+  /** Exposed as a CSS var on the content wrapper so the desktop-only
+   *  media-query rules (here and in chat-container) reserve exactly the
+   *  user-chosen pane width. */
+  protected readonly artifactPaneWidthCss = computed(
+    () => `${this.artifactState.paneWidth()}px`,
+  );
 
   constructor() {
     // Re-probe the BFF session whenever the tab regains focus. A session

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.css
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.css
@@ -14,7 +14,7 @@
   left: 0;
   right: 0;
   z-index: 40;
-  transition: left 300ms;
+  transition: left 300ms, right 300ms;
 }
 
 /* Chat input footer for full-page mode */
@@ -25,7 +25,7 @@
   left: 0;
   right: 0;
   animation: fade-in 0.3s ease-out forwards;
-  transition: left 300ms;
+  transition: left 300ms, right 300ms;
   background-color: var(--color-gray-50);
 }
 
@@ -55,7 +55,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: left 300ms;
+  transition: left 300ms, right 300ms;
   background-color: var(--color-gray-50);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23d1d5db' fill-opacity='0.4'%3E%3Cpath opacity='.5' d='M96 95h4v1h-4v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9zm-1 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9z'/%3E%3Cpath d='M6 5V0H5v5H0v1h5v94h1V6h94V5H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
@@ -97,6 +97,14 @@
   .chat-container-empty.full-page.sidenav-expanded,
   .chat-topnav-wrapper.sidenav-expanded {
     left: 18rem; /* 72 in Tailwind = 18rem */
+  }
+
+  /* Reserve room for the right-docked artifact pane (max-w-2xl = 42rem)
+     so the fixed footer/topnav sit beside it instead of under it. */
+  .chat-input-footer.full-page.artifact-pane-open,
+  .chat-container-empty.full-page.artifact-pane-open,
+  .chat-topnav-wrapper.artifact-pane-open {
+    right: var(--artifact-pane-width, 42rem);
   }
 }
 

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -4,7 +4,8 @@
     <!-- Full-page mode: fixed topnav with sidenav awareness -->
     <div
       class="chat-topnav-wrapper"
-      [class.sidenav-expanded]="!isSidenavCollapsed()">
+      [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
       <app-topnav />
     </div>
   }
@@ -82,7 +83,8 @@
       <!-- Assistant is loading: show skeleton card -->
       <div
         class="chat-container-empty full-page"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <div class="w-full max-w-sm px-4 -mt-20">
           <div class="animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 overflow-hidden">
             <!-- Skeleton gradient header -->
@@ -107,7 +109,8 @@
       <!-- Input at bottom while loading -->
       <div
         class="chat-input-footer full-page"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <div class="mx-auto px-4 max-w-[720px]">
           <!-- Skeleton indicator chip -->
           <div class="flex justify-center mb-2">
@@ -136,7 +139,8 @@
       <!-- Assistant selected: show only assistant card with fixed input at bottom -->
       <div
         class="chat-container-empty full-page"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <div class="w-full max-w-[720px] animate-fade-in px-4 -mt-20 relative">
           <!-- Assistant Card -->
           <div class="mb-6 relative">
@@ -171,7 +175,8 @@
       <!-- Fixed input at bottom when assistant is selected -->
       <div
         class="chat-input-footer full-page"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <div class="mx-auto px-4 max-w-[720px]">
           <app-chat-input
             [sessionId]="sessionId()"
@@ -189,7 +194,8 @@
       <!-- No assistant: show greeting with inline input -->
       <div
         class="chat-container-empty full-page"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <div class="w-full max-w-[720px] animate-fade-in px-4 -mt-20 relative">
           <div class="mb-8 flex items-center justify-center gap-4 relative" data-testid="greeting-message">
             <img
@@ -294,7 +300,8 @@
       <!-- Header (fixed, content scrolls underneath) -->
       <div
         class="chat-topnav-wrapper"
-        [class.sidenav-expanded]="!isSidenavCollapsed()">
+        [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
         <app-topnav />
       </div>
     }
@@ -318,7 +325,8 @@
     <!-- Chat input footer -->
     <div
       class="chat-input-footer full-page"
-      [class.sidenav-expanded]="!isSidenavCollapsed()">
+      [class.sidenav-expanded]="!isSidenavCollapsed()"
+      [class.artifact-pane-open]="artifactPanelOpen()">
       <div class="mx-auto px-4 max-w-[720px]">
         <!-- Assistant Indicator (floating badge above input) -->
         @if (isLoadingAssistant()) {

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -16,6 +16,7 @@ import { AnimatedTextComponent } from '../../../components/animated-text';
 import { ParagraphSkeletonComponent } from '../../../components/paragraph-skeleton';
 import { Topnav } from '../../../components/topnav/topnav';
 import { SidenavService } from '../../../services/sidenav/sidenav.service';
+import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
 import { Assistant } from '../../../assistants/models/assistant.model';
 import { AssistantCardComponent } from '../../../assistants/components/assistant-card.component';
 import { AssistantIndicatorComponent } from '../assistant-indicator/assistant-indicator.component';
@@ -72,6 +73,7 @@ export interface ChatContainerConfig {
 export class ChatContainerComponent {
   // Inject sidenav service for full-page mode positioning
   protected sidenavService = inject(SidenavService);
+  private artifactState = inject(ArtifactStateService);
   private voiceChatService = inject(VoiceChatService);
   protected readonly isVoiceActive = this.voiceChatService.isVoiceActive;
 
@@ -129,6 +131,11 @@ export class ChatContainerComponent {
   );
   protected readonly isSidenavCollapsed = computed(() =>
     this.sidenavService.isCollapsed()
+  );
+  /** True while the docked artifact pane is open — the fixed footer /
+   *  topnav reserve right-side space so the pane doesn't cover them. */
+  protected readonly artifactPanelOpen = computed(
+    () => this.artifactState.openArtifact() !== null
   );
   protected readonly isAssistantOwner = computed(() => {
     const a = this.assistant();

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -9,35 +9,40 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroCodeBracket,
   heroDocumentText,
-  heroArrowTopRightOnSquare,
+  heroArrowLongRight,
 } from '@ng-icons/heroicons/outline';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 
 /** Visual treatment derived from an artifact's content type. */
 interface ArtifactKind {
+  /** Short type label (HTML, JS, MD…). */
   label: string;
+  /** Heroicon name for the type stamp. */
   icon: string;
-  /** Full class list for the icon tile (no static classes — see note). */
-  tile: string;
-  /** Full class list for the type badge. */
-  badge: string;
-  /** Full class list for the left accent rail. */
-  rail: string;
+  /** Single accent color (CSS). Used sparingly — a 2px edge rule, the
+   *  stamp outline, and the type glyph — never as a fill. One mid tone
+   *  that holds up on both the light and dark surface. */
+  accent: string;
 }
 
 /**
- * Compact, clickable card for one artifact. The artifact's content is
- * never inlined here — opening the card asks the panel to mint a
- * short-lived render token and load it in a sandboxed iframe.
+ * One artifact, presented as a calm, rounded card — deliberately
+ * un-"component-kit": a borderless tinted surface (radius matched to the
+ * chat input), a hairline type stamp, and a quiet sans metadata line.
+ * The lone accent color appears only as a thin left rule, the stamp
+ * outline, and the glyph — not as a filled tile or pill.
+ *
+ * The artifact's content is never inlined here — opening asks the panel
+ * to mint a short-lived render token and load it in a sandboxed iframe.
  *
  * Anchored inline after its producing assistant message by the
  * message-list (via `Artifact.producedByMessageIndex`); only legacy /
  * unanchorable artifacts fall back to the end-of-conversation strip.
  *
- * The colored sub-elements bind `[class]` to a full computed class
- * string (no static `class` on those nodes) so the accent swaps cleanly
- * by content type without static/dynamic class-merge ambiguity.
+ * Accent is applied via `[style.color]` (not a bound class string) so
+ * the structural classes stay static and there's no class-merge
+ * ambiguity; `currentColor` then carries it into the rule/stamp/glyph.
  */
 @Component({
   selector: 'app-artifact-card',
@@ -47,57 +52,244 @@ interface ArtifactKind {
     provideIcons({
       heroCodeBracket,
       heroDocumentText,
-      heroArrowTopRightOnSquare,
+      heroArrowLongRight,
     }),
   ],
   template: `
     <button
       type="button"
-      class="group relative flex w-full max-w-md items-center gap-3 overflow-hidden rounded-xl border border-gray-200/80 bg-white py-3 pl-4 pr-3.5 text-left shadow-sm transition-all duration-150 hover:-translate-y-px hover:border-gray-300 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-gray-700/80 dark:bg-gray-800/70 dark:hover:border-gray-600 dark:focus-visible:ring-offset-gray-900"
+      class="artifact-card"
       [attr.aria-label]="ariaLabel()"
       (click)="open()"
     >
-      <span aria-hidden="true" [class]="kind().rail"></span>
-
-      <span [class]="kind().tile">
-        <ng-icon [name]="kind().icon" class="text-lg" aria-hidden="true" />
-      </span>
-
-      <span class="min-w-0 flex-1">
+      <span class="artifact-card__surface">
         <span
-          class="block truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
-        >
-          {{ artifact().title || 'Untitled artifact' }}
-        </span>
-        <span
-          class="mt-1 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
-        >
-          <span [class]="kind().badge">{{ kind().label }}</span>
-          <span>v{{ artifact().version }}</span>
-          @if (updatedLabel()) {
-            <span aria-hidden="true" class="text-gray-300 dark:text-gray-600"
-              >·</span
-            >
-            <span>{{ updatedLabel() }}</span>
-          }
-        </span>
-      </span>
-
-      <span
-        class="flex shrink-0 items-center gap-1 text-xs font-medium text-gray-400 transition-colors group-hover:text-blue-600 dark:text-gray-500 dark:group-hover:text-blue-300"
-      >
-        <span class="hidden sm:inline">Open</span>
-        <ng-icon
-          name="heroArrowTopRightOnSquare"
-          class="text-base"
+          class="artifact-card__rule"
+          [style.color]="kind().accent"
           aria-hidden="true"
-        />
+        ></span>
+
+        <span
+          class="artifact-card__stamp"
+          [style.color]="kind().accent"
+          aria-hidden="true"
+        >
+          <ng-icon [name]="kind().icon" />
+        </span>
+
+        <span class="artifact-card__body">
+          <span class="artifact-card__title">{{
+            artifact().title || 'Untitled artifact'
+          }}</span>
+          <span class="artifact-card__meta">
+            <span class="artifact-card__type">{{ kind().label }}</span>
+            <span class="artifact-card__sep" aria-hidden="true">·</span>
+            <span>v{{ artifact().version }}</span>
+            @if (updatedLabel()) {
+              <span class="artifact-card__sep" aria-hidden="true">·</span>
+              <span>{{ updatedLabel() }}</span>
+            }
+          </span>
+        </span>
+
+        <span class="artifact-card__open" aria-hidden="true">
+          <ng-icon name="heroArrowLongRight" />
+        </span>
       </span>
     </button>
   `,
   styles: `
     :host {
       display: block;
+    }
+
+    /* The focusable element carries no visual chrome; it owns only the
+       focus ring (an un-clipped rectangle, so the notched corner can't
+       eat it). */
+    .artifact-card {
+      appearance: none;
+      -webkit-appearance: none;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      background: none;
+      color: inherit;
+      font: inherit;
+      text-align: left;
+      display: block;
+      width: 100%;
+      max-width: 28rem;
+      /* matches the chat input's rounded-2xl so the focus ring (and the
+         surface below) share the app's corner radius */
+      border-radius: 1rem;
+      cursor: pointer;
+    }
+
+    .artifact-card:focus-visible {
+      outline: 2px solid #2563eb;
+      outline-offset: 3px;
+    }
+
+    :host-context(html.dark) .artifact-card:focus-visible {
+      outline-color: #60a5fa;
+    }
+
+    /* The visible body: a borderless, tinted, generously rounded card.
+       overflow:hidden so the left rule conforms to the rounded edge. */
+    .artifact-card__surface {
+      position: relative;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 0.875rem;
+      padding: 0.8rem 1rem 0.8rem 1.1rem;
+      background: #f1f2f4;
+      border-radius: 1rem;
+      overflow: hidden;
+      transition: background-color 0.18s ease;
+    }
+
+    :host-context(html.dark) .artifact-card__surface {
+      background: rgba(255, 255, 255, 0.045);
+    }
+
+    .artifact-card:hover .artifact-card__surface {
+      background: #e7e8ec;
+    }
+
+    :host-context(html.dark) .artifact-card:hover .artifact-card__surface {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    /* Thin left rule: a short tick at rest, runs the full height on
+       hover/focus. The card's only structural line. */
+    .artifact-card__rule {
+      position: absolute;
+      left: 0;
+      top: 50%;
+      width: 2px;
+      height: 1.15rem;
+      transform: translateY(-50%);
+      background: currentColor;
+      opacity: 0.65;
+      transition:
+        height 0.2s ease,
+        opacity 0.2s ease;
+    }
+
+    .artifact-card:hover .artifact-card__rule,
+    .artifact-card:focus-visible .artifact-card__rule {
+      height: 100%;
+      opacity: 1;
+    }
+
+    /* Hairline type stamp — outline only, no fill. */
+    .artifact-card__stamp {
+      display: grid;
+      place-items: center;
+      width: 2rem;
+      height: 2rem;
+      border: 1px solid color-mix(in srgb, currentColor 32%, transparent);
+      border-radius: 4px;
+    }
+
+    .artifact-card__stamp ng-icon {
+      font-size: 1rem;
+      line-height: 1;
+    }
+
+    .artifact-card__body {
+      min-width: 0;
+    }
+
+    .artifact-card__title {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      letter-spacing: -0.006em;
+      color: #1f2430;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    :host-context(html.dark) .artifact-card__title {
+      color: #eceef2;
+    }
+
+    /* Metadata line — the app's sans, small and quiet. */
+    .artifact-card__meta {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      margin-top: 0.2rem;
+      font-size: 0.75rem;
+      color: #4b5563;
+    }
+
+    :host-context(html.dark) .artifact-card__meta {
+      color: #9aa3b2;
+    }
+
+    .artifact-card__type {
+      text-transform: uppercase;
+      font-weight: 600;
+      letter-spacing: 0.07em;
+      color: #353c4a;
+    }
+
+    :host-context(html.dark) .artifact-card__type {
+      color: #c4cbd8;
+    }
+
+    .artifact-card__sep {
+      opacity: 0.4;
+    }
+
+    /* Quiet open affordance: a long thin arrow that settles in on
+       hover. No label, no shouting. */
+    .artifact-card__open {
+      display: flex;
+      align-items: center;
+      color: #9ca3af;
+      opacity: 0.5;
+      transform: translateX(-3px);
+      transition:
+        opacity 0.18s ease,
+        transform 0.18s ease,
+        color 0.18s ease;
+    }
+
+    .artifact-card__open ng-icon {
+      font-size: 1.05rem;
+      line-height: 1;
+    }
+
+    .artifact-card:hover .artifact-card__open,
+    .artifact-card:focus-visible .artifact-card__open {
+      opacity: 1;
+      transform: translateX(0);
+      color: #4b5563;
+    }
+
+    :host-context(html.dark) .artifact-card__open {
+      color: #6b7280;
+    }
+
+    :host-context(html.dark) .artifact-card:hover .artifact-card__open,
+    :host-context(html.dark) .artifact-card:focus-visible .artifact-card__open {
+      color: #aab2c0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .artifact-card__surface,
+      .artifact-card__rule,
+      .artifact-card__open {
+        transition: none;
+      }
+      .artifact-card__open {
+        transform: none;
+      }
     }
   `,
 })
@@ -131,95 +323,37 @@ export class ArtifactCardComponent {
   }
 }
 
-const TILE_BASE =
-  'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg';
-const BADGE_BASE =
-  'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
-const RAIL_BASE = 'absolute inset-y-0 left-0 w-1';
-
-function kind(
-  label: string,
-  icon: string,
-  tile: string,
-  badge: string,
-  rail: string,
-): ArtifactKind {
-  return {
-    label,
-    icon,
-    tile: `${TILE_BASE} ${tile}`,
-    badge: `${BADGE_BASE} ${badge}`,
-    rail: `${RAIL_BASE} ${rail}`,
-  };
-}
-
 const CODE = 'heroCodeBracket';
 const DOC = 'heroDocumentText';
 
-/** Map a MIME type to a label + accent palette. The match is on the
- *  bare type (parameters like `; charset=utf-8` are ignored). */
+/** Map a MIME type to a label + accent. The match is on the bare type
+ *  (parameters like `; charset=utf-8` are ignored). One mid-tone accent
+ *  per type — legible on both the light and dark surface, used only as
+ *  a thin rule / outline / glyph. */
 function classifyContentType(contentType: string): ArtifactKind {
   const mime = (contentType || '').split(';')[0].trim().toLowerCase();
 
   switch (mime) {
     case 'text/html':
     case 'application/xhtml+xml':
-      return kind(
-        'HTML',
-        CODE,
-        'bg-orange-100 text-orange-600 dark:bg-orange-900/40 dark:text-orange-300',
-        'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
-        'bg-orange-400 dark:bg-orange-500',
-      );
+      return { label: 'HTML', icon: CODE, accent: '#e8762a' };
     case 'text/javascript':
     case 'application/javascript':
-      return kind(
-        'JS',
-        CODE,
-        'bg-amber-100 text-amber-600 dark:bg-amber-900/40 dark:text-amber-300',
-        'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-        'bg-amber-400 dark:bg-amber-500',
-      );
+      return { label: 'JS', icon: CODE, accent: '#cf9a13' };
     case 'text/css':
-      return kind(
-        'CSS',
-        CODE,
-        'bg-sky-100 text-sky-600 dark:bg-sky-900/40 dark:text-sky-300',
-        'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
-        'bg-sky-400 dark:bg-sky-500',
-      );
+      return { label: 'CSS', icon: CODE, accent: '#2f9bd6' };
     case 'application/json':
-      return kind(
-        'JSON',
-        CODE,
-        'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/40 dark:text-emerald-300',
-        'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
-        'bg-emerald-400 dark:bg-emerald-500',
-      );
+      return { label: 'JSON', icon: CODE, accent: '#1f9d6b' };
     case 'image/svg+xml':
-      return kind(
-        'SVG',
-        CODE,
-        'bg-pink-100 text-pink-600 dark:bg-pink-900/40 dark:text-pink-300',
-        'bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300',
-        'bg-pink-400 dark:bg-pink-500',
-      );
+      return { label: 'SVG', icon: CODE, accent: '#d6519a' };
     case 'text/markdown':
-      return kind(
-        'MD',
-        DOC,
-        'bg-violet-100 text-violet-600 dark:bg-violet-900/40 dark:text-violet-300',
-        'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
-        'bg-violet-400 dark:bg-violet-500',
-      );
+      return { label: 'MD', icon: DOC, accent: '#7c6cf0' };
     default:
-      return kind(
-        mime.startsWith('text/') ? 'TEXT' : 'DOC',
-        DOC,
-        'bg-slate-100 text-slate-600 dark:bg-slate-700/60 dark:text-slate-300',
-        'bg-slate-100 text-slate-600 dark:bg-slate-700/60 dark:text-slate-300',
-        'bg-slate-400 dark:bg-slate-500',
-      );
+      return {
+        label: mime.startsWith('text/') ? 'TEXT' : 'DOC',
+        icon: DOC,
+        accent: '#8a93a3',
+      };
   }
 }
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -18,8 +18,10 @@ import { ArtifactHttpService } from '../../../../services/artifacts/artifact-htt
 import { SessionService } from '../../../../services/session/session.service';
 
 /**
- * Right slide-over that renders one artifact version in a sandboxed
- * iframe. Open state lives in `ArtifactStateService`; this component
+ * Right-docked pane that renders one artifact version in a sandboxed
+ * iframe. Non-modal: the side nav collapses to free the space (handled
+ * by `ArtifactStateService`) and the chat stays visible and interactive
+ * alongside it. Open state lives in `ArtifactStateService`; this component
  * mints a fresh short-lived render token each time it opens (the token
  * is a ~120s bearer credential — never cached) and points the iframe at
  * the returned artifact-origin URL.
@@ -44,17 +46,32 @@ import { SessionService } from '../../../../services/session/session.service';
   },
   template: `
     @if (open(); as ref) {
-      <div
-        class="fixed inset-0 z-40 bg-black/30"
-        (click)="close()"
-        aria-hidden="true"
-      ></div>
       <aside
-        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-2xl flex-col border-l border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
-        role="dialog"
-        aria-modal="true"
+        class="fixed inset-y-0 right-0 z-40 flex w-full flex-col border-l border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+        [style.maxWidth]="paneWidthCss()"
+        [class.select-none]="dragging()"
         [attr.aria-label]="'Artifact: ' + ref.title"
       >
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          tabindex="0"
+          aria-label="Resize artifact panel"
+          [attr.aria-valuemin]="paneWidthMin"
+          [attr.aria-valuemax]="paneWidthMax"
+          [attr.aria-valuenow]="paneWidth()"
+          class="group absolute inset-y-0 left-0 z-10 flex w-2 -translate-x-1/2 cursor-col-resize touch-none items-center justify-center focus-visible:outline-none"
+          (pointerdown)="onHandlePointerDown($event)"
+          (pointermove)="onHandlePointerMove($event)"
+          (pointerup)="onHandlePointerUp($event)"
+          (pointercancel)="onHandlePointerUp($event)"
+          (keydown)="onHandleKeydown($event)"
+        >
+          <span
+            aria-hidden="true"
+            class="h-12 w-1 rounded-full bg-gray-300 transition-colors group-hover:bg-blue-500 group-focus-visible:bg-blue-500 dark:bg-gray-600 dark:group-hover:bg-blue-400"
+          ></span>
+        </div>
         <header
           class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700"
         >
@@ -116,6 +133,7 @@ import { SessionService } from '../../../../services/session/session.service';
             <iframe
               [src]="safeUrl()"
               class="h-full w-full border-0 bg-white"
+              [class.pointer-events-none]="dragging()"
               [title]="ref.title || 'Artifact'"
               sandbox="allow-scripts"
               referrerpolicy="no-referrer"
@@ -144,6 +162,19 @@ export class ArtifactPanelComponent {
   protected readonly loading = signal(false);
   protected readonly error = signal<string | null>(null);
 
+  // Resize handle state. Width itself lives in ArtifactStateService so
+  // the layout (content padding + fixed footer/topnav) can reserve the
+  // same amount via a CSS var.
+  protected readonly paneWidth = this.artifactState.paneWidth;
+  protected readonly paneWidthMin = this.artifactState.paneWidthMin;
+  protected readonly paneWidthMax = this.artifactState.paneWidthMax;
+  protected readonly paneWidthCss = computed(
+    () => `${this.artifactState.paneWidth()}px`,
+  );
+  protected readonly dragging = signal(false);
+  private dragStartX = 0;
+  private dragStartWidth = 0;
+
   /** Bumped per open/retry so a slow mint that resolves after the panel
    *  closed (or moved to another artifact) is discarded. */
   private requestSeq = 0;
@@ -165,6 +196,77 @@ export class ArtifactPanelComponent {
       }
       void this.load();
     });
+  }
+
+  protected onHandlePointerDown(e: PointerEvent): void {
+    e.preventDefault();
+    // Capture so the drag keeps tracking even while the cursor is over
+    // the sandboxed iframe (which would otherwise swallow the events).
+    try {
+      (e.target as Element).setPointerCapture(e.pointerId);
+    } catch {
+      /* not all pointer types/environments allow capture — drag still works */
+    }
+    this.dragStartX = e.clientX;
+    this.dragStartWidth = this.artifactState.paneWidth();
+    this.dragging.set(true);
+  }
+
+  protected onHandlePointerMove(e: PointerEvent): void {
+    if (!this.dragging()) return;
+    // Pane is docked to the right edge: dragging the handle left (a
+    // smaller clientX) widens it.
+    const delta = this.dragStartX - e.clientX;
+    this.applyWidth(this.dragStartWidth + delta);
+  }
+
+  protected onHandlePointerUp(e: PointerEvent): void {
+    if (!this.dragging()) return;
+    this.dragging.set(false);
+    try {
+      const el = e.target as Element;
+      if (el.hasPointerCapture(e.pointerId)) {
+        el.releasePointerCapture(e.pointerId);
+      }
+    } catch {
+      /* capture may never have been established — nothing to release */
+    }
+  }
+
+  protected onHandleKeydown(e: KeyboardEvent): void {
+    const step = e.shiftKey ? 64 : 16;
+    const w = this.artifactState.paneWidth();
+    switch (e.key) {
+      case 'ArrowLeft': // widen (boundary moves left)
+        this.applyWidth(w + step);
+        break;
+      case 'ArrowRight': // narrow
+        this.applyWidth(w - step);
+        break;
+      case 'Home':
+        this.applyWidth(this.paneWidthMax);
+        break;
+      case 'End':
+        this.applyWidth(this.paneWidthMin);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+  }
+
+  /** Clamp to the absolute service bounds and to a viewport-relative
+   *  ceiling so the chat column can never be squeezed away entirely. */
+  private applyWidth(px: number): void {
+    let target = px;
+    if (typeof window !== 'undefined') {
+      const maxByViewport = Math.max(
+        this.paneWidthMin,
+        window.innerWidth - 360,
+      );
+      target = Math.min(target, maxByViewport);
+    }
+    this.artifactState.setPaneWidth(target);
   }
 
   protected onEscape(): void {

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
 import { ArtifactStateService } from './artifact-state.service';
 import type { ArtifactEvent } from '../../../shared/utils/stream-parser';
 import type { Artifact } from './artifact.model';
@@ -21,7 +22,11 @@ describe('ArtifactStateService', () => {
   let svc: ArtifactStateService;
 
   beforeEach(() => {
-    svc = new ArtifactStateService();
+    // ArtifactStateService injects SidenavService (both providedIn:
+    // 'root'), so it must be created in an injection context rather
+    // than via `new`.
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(ArtifactStateService);
   });
 
   it('starts empty', () => {

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { SidenavService } from '../../../services/sidenav/sidenav.service';
 import type { ArtifactEvent } from '../../../shared/utils/stream-parser';
 import type { Artifact, OpenArtifactRef } from './artifact.model';
 
@@ -16,8 +17,26 @@ import type { Artifact, OpenArtifactRef } from './artifact.model';
  */
 @Injectable({ providedIn: 'root' })
 export class ArtifactStateService {
+  private readonly sidenav = inject(SidenavService);
+
   private readonly byId = signal<Map<string, Artifact>>(new Map());
   private readonly openRef = signal<OpenArtifactRef | null>(null);
+
+  /** Sidenav collapsed state captured the moment the panel opened, so a
+   *  user who had the nav open isn't left with it collapsed after they
+   *  close the artifact (and one who had it collapsed keeps it that way). */
+  private navWasCollapsed = false;
+
+  /** User-controlled docked pane width in px. Shared with the layout
+   *  (content padding + fixed footer/topnav offset) via a CSS var so the
+   *  chat never ends up under the pane. Survives open/close within a
+   *  session (it's a root singleton); resets on full reload. */
+  private static readonly MIN_PANE_WIDTH = 360;
+  private static readonly MAX_PANE_WIDTH = 1200;
+  private static readonly DEFAULT_PANE_WIDTH = 672; // 42rem, prior fixed size
+  private readonly paneWidthSignal = signal(
+    ArtifactStateService.DEFAULT_PANE_WIDTH,
+  );
 
   /** Artifacts for the current session, newest update first. */
   readonly artifacts = computed<Artifact[]>(() =>
@@ -30,6 +49,28 @@ export class ArtifactStateService {
 
   /** The artifact the side panel is showing, or null when closed. */
   readonly openArtifact = this.openRef.asReadonly();
+
+  /** Current docked pane width in px (clamped). */
+  readonly paneWidth = this.paneWidthSignal.asReadonly();
+
+  get paneWidthMin(): number {
+    return ArtifactStateService.MIN_PANE_WIDTH;
+  }
+
+  get paneWidthMax(): number {
+    return ArtifactStateService.MAX_PANE_WIDTH;
+  }
+
+  /** Set the docked pane width, clamped to the allowed range. The caller
+   *  is responsible for any viewport-relative ceiling (the service only
+   *  knows absolute bounds, not the window size). */
+  setPaneWidth(px: number): void {
+    const clamped = Math.min(
+      ArtifactStateService.MAX_PANE_WIDTH,
+      Math.max(ArtifactStateService.MIN_PANE_WIDTH, Math.round(px)),
+    );
+    this.paneWidthSignal.set(clamped);
+  }
 
   /** Latest known version of an artifact, if any (used by the card). */
   get(artifactId: string): Artifact | undefined {
@@ -66,17 +107,36 @@ export class ArtifactStateService {
   }
 
   openArtifactPanel(ref: OpenArtifactRef): void {
+    // Collapse the side nav to make room for the docked pane. Only capture
+    // the prior state on a genuine closed -> open transition: switching
+    // between artifacts while the panel is already open must not overwrite
+    // it (the nav is collapsed by us at that point).
+    if (this.openRef() === null) {
+      this.navWasCollapsed = this.sidenav.isCollapsed();
+      this.sidenav.collapse();
+    }
     this.openRef.set(ref);
   }
 
   closeArtifactPanel(): void {
+    if (this.openRef() === null) return;
     this.openRef.set(null);
+    this.restoreNav();
   }
 
   /** Clear all state — called on session change. */
   reset(): void {
     this.byId.set(new Map());
-    this.openRef.set(null);
+    if (this.openRef() !== null) {
+      this.openRef.set(null);
+      this.restoreNav();
+    }
+  }
+
+  /** Return the side nav to whatever state it was in before the panel
+   *  opened. If the user had it collapsed already, leave it collapsed. */
+  private restoreNav(): void {
+    if (!this.navWasCollapsed) this.sidenav.expand();
   }
 
   private upsert(a: Artifact): void {


### PR DESCRIPTION
## Summary

Reworks the artifact panel UX and the artifact card.

- **Side-by-side docked pane.** Opening an artifact now collapses the side nav and docks the panel beside the chat instead of a modal overlay with a dark backdrop. The chat stays visible and interactive. The nav is restored to its prior state on close (re-expands only if it was expanded before; stays collapsed if the user had it collapsed).
- **Resizable.** A draggable handle on the panel's left edge (with a `col-resize` cursor) lets the user set the width. It's keyboard-accessible (`role="separator"`, `aria-valuemin/max/now`, Arrow/Shift+Arrow/Home/End). Width is clamped to 360–1200px and a viewport-relative ceiling so the chat column can't be squeezed away. Pointer capture keeps the drag tracking over the sandboxed iframe.
- **No chat occlusion.** The chosen width is shared via a `--artifact-pane-width` CSS var consumed by the content padding (`app.css`) and the fixed chat footer/topnav offsets (`chat-container.component.css`), so the chat input is never covered at any width. Desktop-only; below `lg` the pane remains a full-width takeover.
- **Slim border** instead of the heavy `shadow-2xl` on the panel.
- **Redesigned artifact card** away from the generic Tailwind look: a calm, borderless, rounded tinted surface (radius matched to the chat input), a hairline type stamp, a quiet sans metadata line, and a single restrained accent used only as a thin left rule / stamp outline / glyph. Same information and footprint; keyboard focus ring; `prefers-reduced-motion` respected.

## Test plan

- [ ] Open an artifact from a card → side nav collapses, panel docks beside chat (no backdrop), chat remains interactive.
- [ ] Close the panel → nav returns to its prior state (expanded → re-expands; was-collapsed → stays collapsed).
- [ ] Drag the left-edge handle → panel resizes; chat content + input footer reflow in sync; cursor is `col-resize`; no overlap at min/max.
- [ ] Keyboard: focus the handle, Arrow/Shift+Arrow/Home/End resize.
- [ ] Verify on `< lg` the pane is a full-width takeover (no broken offset).
- [ ] Dark mode: card surface, accent, focus ring, and panel border look correct.
- [ ] Artifact card: title/type/version/relative-time render; click and Enter/Space open the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)