### PR TITLE
fix(artifacts): give create_artifact a CSP-safe React recipe

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/tools.py
+++ b/backend/src/agents/builtin_tools/artifacts/tools.py
@@ -37,9 +37,31 @@ def make_create_artifact_tool(session_id: str, user_id: str):
         - HTML (default): `content` MUST be a complete standalone HTML
           document (include `<!doctype html>` and a full `<html>` …
           `</html>`). It renders in a sandboxed iframe with a strict CSP:
-          inline `<style>`/`<script>` are allowed, as are scripts from
-          `https://cdn.tailwindcss.com` and `https://esm.sh`. It cannot
-          make network calls.
+          inline `<style>`/`<script>` are allowed, and scripts/modules
+          may ONLY be loaded from `https://cdn.tailwindcss.com` and
+          `https://esm.sh`. It cannot make network calls (`fetch`/XHR
+          are blocked), and scripts from any other CDN (unpkg,
+          jsdelivr, cdnjs, …) are BLOCKED by the CSP — the page will
+          render blank (background only, no content).
+
+          For React: do NOT use unpkg, Babel standalone, or
+          `<script type="text/babel">` — all CSP-blocked. Import React
+          from `esm.sh` as ES modules inside an inline
+          `<script type="module">`, and build views with `htm`
+          instead of JSX (no transpiler needed):
+
+              <div id="root"></div>
+              <script type="module">
+                import React, { useState } from "https://esm.sh/react@18.3.1";
+                import { createRoot } from "https://esm.sh/react-dom@18.3.1/client?deps=react@18.3.1";
+                import htm from "https://esm.sh/htm@3.1.1";
+                const html = htm.bind(React.createElement);
+                function App() {
+                  const [n, setN] = useState(0);
+                  return html`<button onClick=${() => setN(n + 1)}>Count: ${n}</button>`;
+                }
+                createRoot(document.getElementById("root")).render(html`<${App} />`);
+              </script>
 
         - Markdown: pass `content_type="text/markdown"` and provide raw
           GitHub-flavored Markdown as `content`. Do NOT add an HTML


### PR DESCRIPTION
## Summary
- React example artifacts rendered blank (HTML shell painted, no content). Root cause: the model's default React pattern loads React/ReactDOM/Babel from `unpkg` and uses `<script type="text/babel">`, all blocked by the artifact iframe CSP, which only permits scripts from `https://esm.sh` and `https://cdn.tailwindcss.com`.
- Updated the `create_artifact` tool docstring with an explicit, CSP-compatible React recipe: React/ReactDOM/`htm` imported as ES modules from `esm.sh`, no Babel, no JSX transpiler. `update_artifact` already defers to these rules.
- Docstring-only change — no infra change, the iframe sandbox/CSP is not widened.

## Notes
- This steers the model strongly but isn't a hard guarantee; the fallback (widening `script-src` to allow `unpkg`/`jsdelivr`) was deliberately not taken to keep the sandbox attack surface small.
- Takes effect once the agents/inference backend is redeployed.

## Test plan
- [ ] Ask the assistant to "create a React demo artifact" and confirm it renders interactive content (not a blank background)
- [ ] Confirm DevTools console shows no CSP `Refused to load the script` violations for the rendered artifact
- [ ] Spot-check that HTML and Markdown artifacts still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)