### PR TITLE
feat(artifacts): full-width inline card + download button (card & panel)

### DIFF
--- a/backend/src/lambdas/artifact_render/handler.py
+++ b/backend/src/lambdas/artifact_render/handler.py
@@ -45,9 +45,10 @@ import hmac
 import json
 import logging
 import os
+import re
 import time
 from typing import Any
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote
 
 import boto3
 from botocore.exceptions import ClientError
@@ -145,6 +146,72 @@ def _security_headers(content_type: str) -> dict[str, str]:
     return {
         "content-type": content_type,
         "content-security-policy": _csp_header(),
+        "x-content-type-options": "nosniff",
+        "referrer-policy": "no-referrer",
+        "cache-control": "no-store",
+    }
+
+
+# File extension to suggest when saving an artifact. Keyed by the bare
+# (parameter-stripped, lowercased) authored content type. Markdown rows
+# hold the writer's HTML render wrapper in S3 (see module docstring), so
+# the saved bytes are HTML — extension follows the bytes, not the label.
+_DOWNLOAD_EXTENSIONS = {
+    "text/html": "html",
+    "text/markdown": "html",
+    "text/x-markdown": "html",
+    "image/svg+xml": "svg",
+    "application/json": "json",
+    "text/css": "css",
+    "text/javascript": "js",
+    "application/javascript": "js",
+    "text/plain": "txt",
+}
+
+# Anything outside this set is collapsed to '_' for the ASCII fallback
+# filename. The UTF-8 `filename*` form carries the original title.
+_SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._ -]+")
+_MAX_FILENAME_BASE = 120
+
+
+def _download_extension(stored_content_type: str) -> str:
+    bare = (stored_content_type or "").split(";")[0].strip().lower()
+    return _DOWNLOAD_EXTENSIONS.get(bare, "bin")
+
+
+def _content_disposition(title: str, ext: str) -> str:
+    """Build an `attachment` Content-Disposition with an ASCII-safe
+    `filename` plus an RFC 5987 `filename*` that preserves a non-ASCII
+    title. Never reflects raw bytes into a header value."""
+    base = (title or "").strip() or "artifact"
+    ascii_base = _SAFE_FILENAME_RE.sub("_", base).strip(" ._")[
+        :_MAX_FILENAME_BASE
+    ] or "artifact"
+    fallback = f"{ascii_base}.{ext}"
+    utf8 = quote(f"{base}.{ext}", safe="")
+    return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{utf8}"
+
+
+def _wants_download(event: dict[str, Any]) -> bool:
+    """True when the request asked to save rather than render (`?download=1`).
+    Read the same two ways as the render token (parsed params, then the
+    raw query string) so it survives whichever the Function URL provides."""
+    params = event.get("queryStringParameters") or {}
+    value = params.get("download")
+    if value is None:
+        raw = event.get("rawQueryString") or ""
+        value = (parse_qs(raw).get("download") or [None])[0]
+    return value == "1"
+
+
+def _download_headers(content_type: str, disposition: str) -> dict[str, str]:
+    """Headers for an attachment response. No CSP/frame-ancestors here —
+    the bytes are saved to disk, not framed — but keep nosniff so the
+    browser doesn't re-sniff the type, and no-store so a one-time
+    credentialed URL isn't cached."""
+    return {
+        "content-type": content_type,
+        "content-disposition": disposition,
         "x-content-type-options": "nosniff",
         "referrer-policy": "no-referrer",
         "cache-control": "no-store",
@@ -393,6 +460,8 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
             raise _ArtifactNotFound("version record has no content pointer")
         stored_content_type = record.get("content_type") or _HTML_CONTENT_TYPE
         content_type = _serve_content_type(stored_content_type)
+        raw_title = record.get("title")
+        title = raw_title if isinstance(raw_title, str) else ""
         body = _fetch_content(content_key)
     except _ArtifactNotFound as exc:
         logger.warning(
@@ -415,6 +484,17 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     except _RenderConfigError as exc:
         logger.error("render config error during fetch: %s", exc)
         return _error_response(500, "The artifact service is misconfigured.")
+
+    if _wants_download(event):
+        ext = _download_extension(stored_content_type)
+        headers = _download_headers(
+            content_type, _content_disposition(title, ext)
+        )
+        return {
+            "statusCode": 200,
+            "headers": headers,
+            "body": "" if method == "HEAD" else body,
+        }
 
     if method == "HEAD":
         return _response(200, "", content_type)

--- a/backend/tests/lambdas/test_artifact_render.py
+++ b/backend/tests/lambdas/test_artifact_render.py
@@ -266,11 +266,21 @@ def _put_record(ddb, **overrides: Any) -> None:
     ddb.Table(TABLE).put_item(Item=item)
 
 
-def _event(token: str | None, method: str = "GET") -> dict[str, Any]:
+def _event(
+    token: str | None, method: str = "GET", *, download: bool = False
+) -> dict[str, Any]:
+    qsp: dict[str, str] = {}
+    raw_parts: list[str] = []
+    if token:
+        qsp["t"] = token
+        raw_parts.append(f"t={token}")
+    if download:
+        qsp["download"] = "1"
+        raw_parts.append("download=1")
     return {
         "requestContext": {"http": {"method": method}},
-        "queryStringParameters": {"t": token} if token else {},
-        "rawQueryString": f"t={token}" if token else "",
+        "queryStringParameters": qsp,
+        "rawQueryString": "&".join(raw_parts),
     }
 
 
@@ -410,3 +420,131 @@ def test_oversized_content_is_500(aws_env, monkeypatch: pytest.MonkeyPatch) -> N
     _put_record(aws_env["ddb"])
     resp = handler.handler(_event(_mint(_valid_claims())), None)
     assert resp["statusCode"] == 500
+
+
+# --------------------------------------------------------------------------
+# Download mode (`?download=1`): attachment disposition, no CSP, gated by
+# the same token as render.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stored,ext",
+    [
+        ("text/html; charset=utf-8", "html"),
+        ("text/markdown", "html"),  # S3 body is the HTML render wrapper
+        ("text/x-markdown", "html"),
+        ("TEXT/MARKDOWN; charset=utf-8", "html"),
+        ("image/svg+xml", "svg"),
+        ("application/json", "json"),
+        ("text/css", "css"),
+        ("application/javascript", "js"),
+        ("text/plain", "txt"),
+        ("application/x-weird", "bin"),
+    ],
+)
+def test_download_extension_mapping(stored: str, ext: str) -> None:
+    assert handler._download_extension(stored) == ext
+
+
+def test_content_disposition_sanitizes_title() -> None:
+    cd = handler._content_disposition("Q3 / Report: <draft>", "html")
+    assert cd.startswith('attachment; filename="')
+    # The ASCII fallback must not carry path/header-hostile characters.
+    fallback = cd.split('filename="', 1)[1].split('"', 1)[0]
+    assert fallback.endswith(".html")
+    for bad in ("/", ":", "<", ">", "\\", "\r", "\n"):
+        assert bad not in fallback
+    # The original title is preserved in the RFC 5987 form.
+    assert "filename*=UTF-8''" in cd
+
+
+def test_content_disposition_defaults_when_title_blank() -> None:
+    # A whitespace-only title is treated as absent: both forms fall back
+    # to "artifact" (never a file literally named "   .json").
+    assert handler._content_disposition("   ", "json") == (
+        "attachment; filename=\"artifact.json\"; "
+        "filename*=UTF-8''artifact.json"
+    )
+
+
+def test_content_disposition_preserves_unicode_title() -> None:
+    cd = handler._content_disposition("résumé", "txt")
+    # Non-ASCII collapses to '_' in the fallback but survives in filename*.
+    assert 'filename="r' in cd
+    assert "filename*=UTF-8''r%C3%A9sum%C3%A9.txt" in cd
+
+
+def test_download_returns_attachment(aws_env) -> None:
+    _put_record(aws_env["ddb"], title="My Page")
+    resp = handler.handler(
+        _event(_mint(_valid_claims()), download=True), None
+    )
+    assert resp["statusCode"] == 200
+    assert resp["body"] == DOC
+    cd = resp["headers"]["content-disposition"]
+    assert cd.startswith("attachment; ")
+    assert 'filename="My Page.html"' in cd
+    assert resp["headers"]["content-type"] == "text/html; charset=utf-8"
+    assert resp["headers"]["x-content-type-options"] == "nosniff"
+    assert resp["headers"]["cache-control"] == "no-store"
+    # An attachment is saved, never framed — no CSP/frame-ancestors.
+    assert "content-security-policy" not in resp["headers"]
+
+
+def test_download_markdown_uses_html_extension(aws_env) -> None:
+    wrapper = "<!doctype html><html><body>rendered md</body></html>"
+    boto3.client("s3", region_name="us-east-1").put_object(
+        Bucket=BUCKET, Key=CONTENT_KEY, Body=wrapper.encode()
+    )
+    _put_record(
+        aws_env["ddb"],
+        content_type="text/markdown; charset=utf-8",
+        title="Notes",
+    )
+    resp = handler.handler(
+        _event(_mint(_valid_claims()), download=True), None
+    )
+    assert resp["statusCode"] == 200
+    assert resp["body"] == wrapper
+    assert resp["headers"]["content-type"] == "text/html; charset=utf-8"
+    assert 'filename="Notes.html"' in resp["headers"]["content-disposition"]
+
+
+def test_download_default_filename_when_title_missing(aws_env) -> None:
+    _put_record(aws_env["ddb"], content_type="application/json")
+    resp = handler.handler(
+        _event(_mint(_valid_claims()), download=True), None
+    )
+    assert 'filename="artifact.json"' in resp["headers"]["content-disposition"]
+
+
+def test_head_download_omits_body_keeps_disposition(aws_env) -> None:
+    _put_record(aws_env["ddb"], title="Doc")
+    resp = handler.handler(
+        _event(_mint(_valid_claims()), method="HEAD", download=True), None
+    )
+    assert resp["statusCode"] == 200
+    assert resp["body"] == ""
+    assert resp["headers"]["content-disposition"].startswith("attachment; ")
+
+
+def test_download_still_requires_valid_token(aws_env) -> None:
+    _put_record(aws_env["ddb"])
+    bad = _mint(_valid_claims(), tamper_sig=True)
+    resp = handler.handler(_event(bad, download=True), None)
+    assert resp["statusCode"] == 403
+    assert "content-disposition" not in resp["headers"]
+
+
+def test_download_flag_from_raw_query_string(aws_env) -> None:
+    _put_record(aws_env["ddb"], title="Doc")
+    token = _mint(_valid_claims())
+    event = {
+        "requestContext": {"http": {"method": "GET"}},
+        "queryStringParameters": None,
+        "rawQueryString": f"t={token}&download=1",
+    }
+    resp = handler.handler(event, None)
+    assert resp["statusCode"] == 200
+    assert resp["headers"]["content-disposition"].startswith("attachment; ")

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -4,15 +4,18 @@ import {
   computed,
   inject,
   input,
+  signal,
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroCodeBracket,
   heroDocumentText,
-  heroArrowLongRight,
+  heroArrowDownTray,
+  heroArrowPath,
 } from '@ng-icons/heroicons/outline';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 
 /** Visual treatment derived from an artifact's content type. */
 interface ArtifactKind {
@@ -52,16 +55,19 @@ interface ArtifactKind {
     provideIcons({
       heroCodeBracket,
       heroDocumentText,
-      heroArrowLongRight,
+      heroArrowDownTray,
+      heroArrowPath,
     }),
   ],
   template: `
-    <button
-      type="button"
-      class="artifact-card"
-      [attr.aria-label]="ariaLabel()"
-      (click)="open()"
-    >
+    <div class="artifact-card">
+      <button
+        type="button"
+        class="artifact-card__hit"
+        [attr.aria-label]="ariaLabel()"
+        (click)="open()"
+      ></button>
+
       <span class="artifact-card__surface">
         <span
           class="artifact-card__rule"
@@ -77,67 +83,92 @@ interface ArtifactKind {
           <ng-icon [name]="kind().icon" />
         </span>
 
-        <span class="artifact-card__body">
+        <span class="artifact-card__body" aria-hidden="true">
           <span class="artifact-card__title">{{
             artifact().title || 'Untitled artifact'
           }}</span>
           <span class="artifact-card__meta">
             <span class="artifact-card__type">{{ kind().label }}</span>
-            <span class="artifact-card__sep" aria-hidden="true">·</span>
+            <span class="artifact-card__sep">·</span>
             <span>v{{ artifact().version }}</span>
             @if (updatedLabel()) {
-              <span class="artifact-card__sep" aria-hidden="true">·</span>
+              <span class="artifact-card__sep">·</span>
               <span>{{ updatedLabel() }}</span>
             }
           </span>
         </span>
 
-        <span class="artifact-card__open" aria-hidden="true">
-          <ng-icon name="heroArrowLongRight" />
-        </span>
+        <button
+          type="button"
+          class="artifact-card__download"
+          [class.is-busy]="downloading()"
+          [attr.aria-label]="downloadAriaLabel()"
+          [attr.aria-busy]="downloading()"
+          [disabled]="downloading()"
+          (click)="download()"
+        >
+          <ng-icon
+            [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
+            aria-hidden="true"
+          />
+          <span class="artifact-card__download-label">Download</span>
+        </button>
       </span>
-    </button>
+    </div>
   `,
   styles: `
     :host {
       display: block;
     }
 
-    /* The focusable element carries no visual chrome; it owns only the
-       focus ring (an un-clipped rectangle, so the notched corner can't
-       eat it). */
+    /* Card shell: a positioning context for the stretched open button
+       and the download button. No chrome of its own. */
     .artifact-card {
+      position: relative;
+      display: block;
+      width: 100%;
+      /* matches the chat input's rounded-2xl so the focus ring and the
+         surface share the app's corner radius */
+      border-radius: 1rem;
+    }
+
+    /* Primary action: an invisible button stretched over the whole card.
+       It owns the focus ring (an un-clipped rectangle so the rounded
+       corner can't eat it). The surface above is pointer-events:none, so
+       a click anywhere but the download button falls through to here. */
+    .artifact-card__hit {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
       appearance: none;
       -webkit-appearance: none;
       margin: 0;
       padding: 0;
       border: 0;
       background: none;
-      color: inherit;
       font: inherit;
-      text-align: left;
-      display: block;
-      width: 100%;
-      max-width: 28rem;
-      /* matches the chat input's rounded-2xl so the focus ring (and the
-         surface below) share the app's corner radius */
-      border-radius: 1rem;
+      border-radius: inherit;
       cursor: pointer;
     }
 
-    .artifact-card:focus-visible {
+    .artifact-card__hit:focus-visible {
       outline: 2px solid #2563eb;
       outline-offset: 3px;
     }
 
-    :host-context(html.dark) .artifact-card:focus-visible {
+    :host-context(html.dark) .artifact-card__hit:focus-visible {
       outline-color: #60a5fa;
     }
 
     /* The visible body: a borderless, tinted, generously rounded card.
-       overflow:hidden so the left rule conforms to the rounded edge. */
+       overflow:hidden so the left rule conforms to the rounded edge.
+       pointer-events:none delegates clicks to the stretched button
+       beneath; the download button (col 3) re-enables them. The grid's
+       auto last column sizes itself to the button — no manual gutter. */
     .artifact-card__surface {
       position: relative;
+      z-index: 2;
+      pointer-events: none;
       display: grid;
       grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
@@ -178,7 +209,9 @@ interface ArtifactKind {
     }
 
     .artifact-card:hover .artifact-card__rule,
-    .artifact-card:focus-visible .artifact-card__rule {
+    .artifact-card__hit:focus-visible
+      ~ .artifact-card__surface
+      .artifact-card__rule {
       height: 100%;
       opacity: 1;
     }
@@ -246,49 +279,92 @@ interface ArtifactKind {
       opacity: 0.4;
     }
 
-    /* Quiet open affordance: a long thin arrow that settles in on
-       hover. No label, no shouting. */
-    .artifact-card__open {
-      display: flex;
+    /* Secondary action: a bordered, labelled download button in the
+       grid's last column. It lives inside the pointer-events:none
+       surface but re-enables them for itself, so it captures its own
+       clicks while the rest of the card falls through to the open
+       button. Resting colour clears the 3:1 non-text contrast bar. */
+    .artifact-card__download {
+      pointer-events: auto;
+      display: inline-flex;
       align-items: center;
-      color: #9ca3af;
-      opacity: 0.5;
-      transform: translateX(-3px);
+      gap: 0.4rem;
+      margin: 0;
+      padding: 0.34rem 0.7rem;
+      border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+      border-radius: 7px;
+      background: none;
+      color: #6b7280;
+      font: inherit;
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1;
+      white-space: nowrap;
+      cursor: pointer;
       transition:
-        opacity 0.18s ease,
-        transform 0.18s ease,
-        color 0.18s ease;
+        color 0.18s ease,
+        border-color 0.18s ease,
+        background-color 0.18s ease;
     }
 
-    .artifact-card__open ng-icon {
-      font-size: 1.05rem;
+    .artifact-card__download ng-icon {
+      font-size: 0.95rem;
       line-height: 1;
     }
 
-    .artifact-card:hover .artifact-card__open,
-    .artifact-card:focus-visible .artifact-card__open {
-      opacity: 1;
-      transform: translateX(0);
-      color: #4b5563;
+    .artifact-card:hover .artifact-card__download,
+    .artifact-card__download:hover {
+      color: #374151;
     }
 
-    :host-context(html.dark) .artifact-card__open {
-      color: #6b7280;
+    .artifact-card__download:hover {
+      background: rgba(0, 0, 0, 0.05);
     }
 
-    :host-context(html.dark) .artifact-card:hover .artifact-card__open,
-    :host-context(html.dark) .artifact-card:focus-visible .artifact-card__open {
-      color: #aab2c0;
+    .artifact-card__download:focus-visible {
+      outline: 2px solid #2563eb;
+      outline-offset: 2px;
+    }
+
+    .artifact-card__download:disabled {
+      cursor: default;
+    }
+
+    .artifact-card__download.is-busy ng-icon {
+      animation: artifact-card-spin 0.8s linear infinite;
+    }
+
+    :host-context(html.dark) .artifact-card__download {
+      color: #9aa3b2;
+    }
+
+    :host-context(html.dark) .artifact-card:hover .artifact-card__download,
+    :host-context(html.dark) .artifact-card__download:hover {
+      color: #cbd2dd;
+    }
+
+    :host-context(html.dark) .artifact-card__download:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    :host-context(html.dark) .artifact-card__download:focus-visible {
+      outline-color: #60a5fa;
+    }
+
+    @keyframes artifact-card-spin {
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     @media (prefers-reduced-motion: reduce) {
       .artifact-card__surface,
       .artifact-card__rule,
-      .artifact-card__open {
+      .artifact-card__download {
         transition: none;
       }
-      .artifact-card__open {
-        transform: none;
+      .artifact-card__download.is-busy ng-icon {
+        animation: none;
       }
     }
   `,
@@ -297,6 +373,9 @@ export class ArtifactCardComponent {
   artifact = input.required<Artifact>();
 
   private artifactState = inject(ArtifactStateService);
+  private artifactDownload = inject(ArtifactDownloadService);
+
+  protected readonly downloading = signal(false);
 
   protected readonly kind = computed<ArtifactKind>(() =>
     classifyContentType(this.artifact().contentType),
@@ -313,6 +392,13 @@ export class ArtifactCardComponent {
       `Open ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
   );
 
+  /** Static so the visible "Download" label is always contained in the
+   *  accessible name (WCAG 2.5.3); the working state rides `aria-busy`. */
+  protected readonly downloadAriaLabel = computed(
+    () =>
+      `Download ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
+  );
+
   protected open(): void {
     const a = this.artifact();
     this.artifactState.openArtifactPanel({
@@ -320,6 +406,20 @@ export class ArtifactCardComponent {
       version: a.version,
       title: a.title,
     });
+  }
+
+  protected async download(): Promise<void> {
+    if (this.downloading()) return;
+    const a = this.artifact();
+    this.downloading.set(true);
+    try {
+      await this.artifactDownload.download({
+        artifactId: a.artifactId,
+        version: a.version,
+      });
+    } finally {
+      this.downloading.set(false);
+    }
   }
 }
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -12,9 +12,11 @@ import {
   heroXMark,
   heroArrowPath,
   heroExclamationTriangle,
+  heroArrowDownTray,
 } from '@ng-icons/heroicons/outline';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
+import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { SessionService } from '../../../../services/session/session.service';
 
 /**
@@ -39,7 +41,12 @@ import { SessionService } from '../../../../services/session/session.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
   providers: [
-    provideIcons({ heroXMark, heroArrowPath, heroExclamationTriangle }),
+    provideIcons({
+      heroXMark,
+      heroArrowPath,
+      heroExclamationTriangle,
+      heroArrowDownTray,
+    }),
   ],
   host: {
     '(document:keydown.escape)': 'onEscape()',
@@ -85,6 +92,23 @@ import { SessionService } from '../../../../services/session/session.service';
               Version {{ ref.version }}
             </p>
           </div>
+          <button
+            type="button"
+            class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+            [attr.aria-label]="
+              downloading() ? 'Downloading artifact…' : 'Download artifact'
+            "
+            [attr.aria-busy]="downloading()"
+            [disabled]="downloading() || !safeUrl()"
+            (click)="download()"
+          >
+            <ng-icon
+              [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
+              class="text-lg"
+              [class.animate-spin]="downloading()"
+              aria-hidden="true"
+            />
+          </button>
           <button
             type="button"
             class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -155,12 +179,14 @@ export class ArtifactPanelComponent {
   private artifactHttp = inject(ArtifactHttpService);
   private sessionService = inject(SessionService);
   private sanitizer = inject(DomSanitizer);
+  private artifactDownload = inject(ArtifactDownloadService);
 
   protected readonly open = this.artifactState.openArtifact;
 
   protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
   protected readonly loading = signal(false);
   protected readonly error = signal<string | null>(null);
+  protected readonly downloading = signal(false);
 
   // Resize handle state. Width itself lives in ArtifactStateService so
   // the layout (content padding + fixed footer/topnav) can reserve the
@@ -279,6 +305,20 @@ export class ArtifactPanelComponent {
 
   protected retry(): void {
     void this.load();
+  }
+
+  protected async download(): Promise<void> {
+    const ref = this.open();
+    if (!ref || this.downloading()) return;
+    this.downloading.set(true);
+    try {
+      await this.artifactDownload.download({
+        artifactId: ref.artifactId,
+        version: ref.version,
+      });
+    } finally {
+      this.downloading.set(false);
+    }
   }
 
   private reset(): void {

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-download.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-download.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, inject } from '@angular/core';
+import { ArtifactHttpService } from './artifact-http.service';
+import { SessionService } from '../session/session.service';
+import { ToastService } from '../../../services/toast/toast.service';
+
+/** Minimal identity of the artifact version to save. */
+export interface DownloadableArtifact {
+  artifactId: string;
+  version: number;
+}
+
+/**
+ * Saves an artifact version to disk. Shared by the inline card and the
+ * docked panel so the credential handling stays in exactly one place.
+ *
+ * The content only lives on the artifact origin (no CORS,
+ * `connect-src 'none'`), so the SPA can't fetch the bytes into a blob.
+ * Instead it mints a fresh single-use render token and points a
+ * throwaway hidden iframe at the render URL with `download=1`; the
+ * render Lambda answers that with `Content-Disposition: attachment`, so
+ * the browser saves the file without navigating this document. A
+ * bad/expired token lands as an error page inside the discarded iframe,
+ * never the SPA.
+ */
+@Injectable({ providedIn: 'root' })
+export class ArtifactDownloadService {
+  private artifactHttp = inject(ArtifactHttpService);
+  private sessionService = inject(SessionService);
+  private toast = inject(ToastService);
+
+  /** Mint a token and kick off the save. Surfaces a toast and resolves
+   *  `false` on failure so callers can clear their own busy state. */
+  async download(ref: DownloadableArtifact): Promise<boolean> {
+    try {
+      const sessionId = this.sessionService.currentSession().sessionId;
+      const token = await this.artifactHttp.mintRenderToken(
+        ref.artifactId,
+        ref.version,
+        sessionId,
+      );
+      const sep = token.url.includes('?') ? '&' : '?';
+      this.trigger(`${token.url}${sep}download=1`);
+      return true;
+    } catch {
+      this.toast.error(
+        'Download failed',
+        "This artifact couldn't be downloaded. It may have expired or been removed.",
+      );
+      return false;
+    }
+  }
+
+  private trigger(url: string): void {
+    if (typeof document === 'undefined') return;
+    const frame = document.createElement('iframe');
+    frame.setAttribute('aria-hidden', 'true');
+    frame.style.display = 'none';
+    frame.src = url;
+    document.body.appendChild(frame);
+    // The token is single-use and short-lived; the save kicks off on
+    // load. Keep the frame briefly so the transfer can start, then drop
+    // it so the credential URL doesn't linger in the DOM.
+    setTimeout(() => frame.remove(), 60_000);
+  }
+}


### PR DESCRIPTION
## Summary

- The inline artifact **card** now spans the full message width (removed the `max-width: 28rem` cap) and carries a bordered **Download** button alongside the existing open affordance.
- The docked **panel** header also gets a Download button.
- The `artifact_render` Lambda now honors `?download=1` and responds with `Content-Disposition: attachment`.

## Why

Users want to save an artifact without opening the viewer, and the full-width card has room for an explicit, labelled control.

## What changed

**Frontend**
- The card was a single `<button>`; you can't nest a download `<button>` in it (invalid HTML / fails AXE). It's restructured into a non-interactive container with a **stretched invisible "open" button** (preserves whole-card-click + owns the focus ring) plus a **real bordered "Download" button** in the grid's last column.
- Decorative card content is `aria-hidden` (the open button's label already names it); the download button's accessible name is static so the visible "Download" word is always contained in it (WCAG 2.5.3), with the working state on `aria-busy` + spinner + disabled.
- New `ArtifactDownloadService`: the credentialed token + hidden-iframe handling lives in one place, used by both the card and the panel so they can't drift.

**Backend**
- `artifact_render` Lambda: `?download=1` → `Content-Disposition: attachment`, filename from the artifact title (sanitized ASCII + RFC 5987 UTF-8 form), extension by content type (markdown → `.html` since S3 holds the HTML render wrapper). No CSP/frame-ancestors on the attachment response; `nosniff` + `no-store` kept. No app-api contract, infra, or IAM change.

## How download works

The content only lives on the air-gapped artifact origin (no CORS, `connect-src 'none'`), so the SPA can't `fetch` it into a blob. It mints a fresh single-use render token and points a throwaway hidden iframe at the render URL with `download=1`; the Lambda's attachment response makes the browser save the file without navigating the SPA. A bad/expired token lands as an error page in the discarded iframe, never the SPA.

## Reviewer notes

- ⚠️ **Deploy dependency:** the download produces a file only once the **Artifacts CDK stack (`artifact_render` Lambda)** is deployed with this change. Until then the artifact origin ignores `download=1` and renders into the hidden iframe (nothing visible). This also means it can't be exercised on a purely local frontend (no artifact origin locally).
- The panel revert/full-width history in this session is **not** in this PR — only the final state: card full-width + download buttons + Lambda download mode.

## Test plan

- [x] Backend: `pytest` 87/87, incl. new download tests (attachment headers, filename sanitization/UTF-8, markdown→`.html`, HEAD, still token-gated, raw-query parsing).
- [x] Frontend: `tsc` clean; artifact specs 16/16.
- [ ] Post-deploy: produce an artifact → card spans full width with a bordered Download button; clicking it saves the file and does **not** open the panel; clicking elsewhere still opens it; panel header Download works; keyboard order (open → download), focus rings, dark mode, reduced-motion; expired token → "Download failed" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)