### PR TITLE
feat(artifacts): preview/code toggle with syntax-highlighted source view

### DIFF
--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -50,3 +50,17 @@ class ArtifactSummary(BaseModel):
 
 class ArtifactListResponse(BaseModel):
     artifacts: list[ArtifactSummary] = Field(default_factory=list)
+
+
+class ArtifactContentResponse(BaseModel):
+    """Raw source of one artifact version, for the panel's code view.
+
+    `content` is inert text the SPA highlights client-side — never
+    executed. For Markdown artifacts the stored S3 object is a rendered
+    HTML wrapper; the service unwraps it back to the authored Markdown
+    and `content_type` is normalized to `text/markdown` accordingly.
+    """
+
+    content: str
+    content_type: str
+    version: int

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -8,17 +8,21 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from apis.shared.auth import User, get_current_user_from_session
 
 from .models import (
+    ArtifactContentResponse,
     ArtifactListResponse,
     ArtifactSummary,
     RenderTokenRequest,
     RenderTokenResponse,
 )
 from .service import (
+    ArtifactContentService,
     ArtifactListService,
     ArtifactNotFoundError,
     ArtifactQueryError,
+    ArtifactTooLargeError,
     RenderTokenConfigError,
     RenderTokenService,
+    get_artifact_content_service,
     get_artifact_list_service,
     get_render_token_service,
 )
@@ -102,4 +106,55 @@ async def list_session_artifacts(
 
     return ArtifactListResponse(
         artifacts=[ArtifactSummary(**row) for row in rows]
+    )
+
+
+@router.get("/{artifact_id}/content", response_model=ArtifactContentResponse)
+async def get_artifact_content(
+    artifact_id: str,
+    version: int = Query(..., ge=1, description="Artifact version to read"),
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactContentService = Depends(get_artifact_content_service),
+) -> ArtifactContentResponse:
+    """Return one artifact version's raw source for the panel code view.
+
+    The bytes are inert text the SPA highlights client-side — never
+    executed. Ownership is enforced by building the lookup key from the
+    authenticated session, so a borrowed artifact/session id can't read
+    another user's content. Markdown is unwrapped back to the authored
+    source (see ArtifactContentService). Oversized artifacts 413 so the
+    SPA can steer the user to the download path instead.
+    """
+    try:
+        content, content_type = service.get(
+            user_id=user.user_id,
+            artifact_id=artifact_id,
+            version=version,
+        )
+    except ArtifactNotFoundError:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Artifact version not found"
+        )
+    except ArtifactTooLargeError:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "Artifact is too large to preview — download it instead",
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact content service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact content is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact content fetch failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact content is temporarily unavailable",
+        )
+
+    return ArtifactContentResponse(
+        content=content,
+        content_type=content_type,
+        version=version,
     )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -11,8 +11,10 @@ Never log the token or the assembled URL — log identifiers only.
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
+import re
 import threading
 import time
 from typing import Optional
@@ -34,9 +36,30 @@ _TTL_SECONDS = 120
 
 _secret_lock = threading.Lock()
 _table_lock = threading.Lock()
+_s3_lock = threading.Lock()
 _cached_signing_key: Optional[str] = None
 _secrets_client = None
 _ddb_table = None
+_s3_client = None
+_cached_bucket: Optional[str] = None
+
+# Inline code-view ceiling. Past this the SPA shows a "too large to
+# preview — download instead" affordance rather than highlighting a
+# multi-MB blob in the DOM.
+_MAX_CONTENT_BYTES = 2 * 1024 * 1024
+
+# Bare Markdown MIME types. Duplicated (not imported) from the agent
+# writer: the import-boundary rule forbids app_api importing from
+# agents/, and this set rarely changes.
+_MARKDOWN_MIME_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+
+# The writer embeds the authored Markdown as base64 in this exact script
+# tag inside the rendered HTML wrapper (agents/builtin_tools/artifacts
+# _MARKDOWN_RENDER_TEMPLATE). We unwrap it back to source for code view.
+_MD_SRC_RE = re.compile(
+    r'<script type="application/x-markdown-base64" id="md-src">'
+    r"(?P<b64>[^<]*)</script>"
+)
 
 
 class RenderTokenError(Exception):
@@ -57,10 +80,19 @@ class ArtifactQueryError(RenderTokenError):
     feature is set up correctly, the request just couldn't be served."""
 
 
+class ArtifactTooLargeError(RenderTokenError):
+    """The artifact body exceeds the inline code-view cap. The caller
+    should fall back to the download path rather than streaming a huge
+    blob into the SPA's DOM for syntax highlighting."""
+
+
 def _reset_caches_for_tests() -> None:
     """Drop process-wide singletons so test order can't leak a stale
     signing key, secrets client, or DDB table handle."""
     global _cached_signing_key, _secrets_client, _ddb_table
+    global _s3_client, _cached_bucket
+    _s3_client = None
+    _cached_bucket = None
     _cached_signing_key = None
     _secrets_client = None
     _ddb_table = None
@@ -266,3 +298,130 @@ class ArtifactListService:
 
 def get_artifact_list_service() -> ArtifactListService:
     return ArtifactListService()
+
+
+def _bucket_name() -> str:
+    """The artifacts S3 bucket. Set by app-api-stack alongside the table
+    name; an empty value means a broken artifacts deploy, not a disabled
+    feature, so fail closed with a 500."""
+    global _cached_bucket
+    if _cached_bucket is not None:
+        return _cached_bucket
+    with _s3_lock:
+        if _cached_bucket is not None:
+            return _cached_bucket
+        name = os.environ.get("S3_ARTIFACTS_BUCKET_NAME", "")
+        if not name:
+            raise RenderTokenConfigError(
+                "S3_ARTIFACTS_BUCKET_NAME is not set"
+            )
+        _cached_bucket = name
+        return name
+
+
+def _s3():
+    global _s3_client
+    if _s3_client is not None:
+        return _s3_client
+    with _s3_lock:
+        if _s3_client is None:
+            _s3_client = boto3.client("s3", region_name=_region())
+        return _s3_client
+
+
+def _get_version_item(
+    user_id: str, artifact_id: str, version: int
+) -> dict:
+    """Fetch the exact version row, scoped to the authenticated user.
+
+    Building the PK from the session user's id is what prevents reading
+    another user's artifact. SK zero-pad matches the writer/verifier
+    `V#{version:05d}` contract."""
+    sk = f"ARTIFACT#{artifact_id}#V#{version:05d}"
+    try:
+        result = _table().get_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk}
+        )
+    except ClientError as exc:
+        raise ArtifactQueryError(
+            "artifact metadata lookup failed"
+        ) from exc
+    item = result.get("Item")
+    if not item:
+        raise ArtifactNotFoundError("artifact version not found")
+    return item
+
+
+def _is_markdown(content_type: str) -> bool:
+    bare = (content_type or "").split(";")[0].strip().lower()
+    return bare in _MARKDOWN_MIME_TYPES
+
+
+def _unwrap_markdown(html_body: str) -> Optional[str]:
+    """Recover the authored Markdown from the writer's HTML wrapper.
+
+    Markdown artifacts are stored as a self-contained HTML render
+    scaffold with the original source base64-embedded in a fixed
+    `<script id="md-src">` tag. Returns the decoded Markdown, or None if
+    the tag is absent / undecodable (legacy object or a future template
+    change) so the caller can fall back to the raw bytes."""
+    match = _MD_SRC_RE.search(html_body)
+    if not match:
+        return None
+    try:
+        return base64.b64decode(match.group("b64")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+class ArtifactContentService:
+    """Return one artifact version's raw source for the panel code view.
+
+    Ownership is enforced by the PK lookup. For Markdown the stored S3
+    object is a rendered HTML wrapper; we unwrap it back to the authored
+    Markdown so code view shows what the model actually wrote, and
+    normalize `content_type` to `text/markdown` to match. Anything that
+    can't be unwrapped falls back to the raw stored bytes + real type so
+    the view still shows something truthful instead of erroring."""
+
+    def get(
+        self, *, user_id: str, artifact_id: str, version: int
+    ) -> tuple[str, str]:
+        bucket = _bucket_name()
+        item = _get_version_item(user_id, artifact_id, version)
+        content_key = item.get("content_key")
+        stored_type = item.get(
+            "content_type", "text/html; charset=utf-8"
+        )
+        if not content_key:
+            raise ArtifactNotFoundError("artifact has no stored content")
+
+        try:
+            obj = _s3().get_object(Bucket=bucket, Key=content_key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "NoSuchBucket", "404"):
+                raise ArtifactNotFoundError(
+                    "artifact content not found"
+                ) from exc
+            raise ArtifactQueryError(
+                "artifact content fetch failed"
+            ) from exc
+
+        if obj.get("ContentLength", 0) > _MAX_CONTENT_BYTES:
+            raise ArtifactTooLargeError("artifact too large for code view")
+
+        raw = obj["Body"].read(_MAX_CONTENT_BYTES + 1)
+        if len(raw) > _MAX_CONTENT_BYTES:
+            raise ArtifactTooLargeError("artifact too large for code view")
+        body = raw.decode("utf-8", errors="replace")
+
+        if _is_markdown(stored_type):
+            unwrapped = _unwrap_markdown(body)
+            if unwrapped is not None:
+                return unwrapped, "text/markdown"
+        return body, stored_type
+
+
+def get_artifact_content_service() -> ArtifactContentService:
+    return ArtifactContentService()

--- a/backend/tests/apis/app_api/artifacts/test_artifact_content.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_content.py
@@ -1,0 +1,203 @@
+"""Tests for the app-api artifact content endpoint (panel code view).
+
+Covers ownership scoping, the Markdown unwrap (+ its fallback), the
+inline size cap, and the fail-closed config behavior.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as artifact_service
+from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+BUCKET = "test-artifacts-bucket"
+REGION = "us-east-1"
+USER_ID = "user-123"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    artifact_service._reset_caches_for_tests()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+
+        app = FastAPI()
+        app.include_router(artifacts_router)
+        app.dependency_overrides[get_current_user_from_session] = (
+            lambda: User(
+                email="u@x.com", user_id=USER_ID, name="U", roles=[]
+            )
+        )
+        yield (
+            TestClient(app),
+            boto3.resource("dynamodb", region_name=REGION),
+            s3,
+        )
+
+
+def _put(
+    ddb,
+    s3,
+    *,
+    user_id: str = USER_ID,
+    artifact: str = "art-1",
+    version: int = 1,
+    content_type: str = "text/html; charset=utf-8",
+    body: bytes = b"<h1>hi</h1>",
+    write_object: bool = True,
+    content_key: str | None = None,
+) -> None:
+    key = content_key
+    if key is None:
+        key = f"{user_id}/{artifact}/v{version}/index.html"
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "storage": "s3",
+            "content_key": key,
+            "content_type": content_type,
+        }
+    )
+    if write_object:
+        s3.put_object(Bucket=BUCKET, Key=key, Body=body)
+
+
+def _markdown_wrapper(md: str) -> bytes:
+    b64 = base64.b64encode(md.encode("utf-8")).decode("ascii")
+    return (
+        "<!doctype html><html><body><main>Rendering…</main>"
+        '<script type="application/x-markdown-base64" '
+        f'id="md-src">{b64}</script>'
+        "<script type=\"module\">/* render */</script>"
+        "</body></html>"
+    ).encode("utf-8")
+
+
+def test_happy_path_returns_raw_source(client) -> None:
+    tc, ddb, s3 = client
+    _put(ddb, s3, body=b"<h1>Hello</h1>")
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == "<h1>Hello</h1>"
+    assert body["content_type"] == "text/html; charset=utf-8"
+    assert body["version"] == 1
+
+
+def test_markdown_is_unwrapped_to_authored_source(client) -> None:
+    tc, ddb, s3 = client
+    md = "# Title\n\nSome **bold** text.\n"
+    _put(
+        ddb,
+        s3,
+        content_type="text/markdown",
+        body=_markdown_wrapper(md),
+    )
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == md
+    assert body["content_type"] == "text/markdown"
+
+
+def test_markdown_without_src_tag_falls_back_to_raw(client) -> None:
+    """A Markdown row whose object lacks the embed (legacy / future
+    template) returns the raw stored bytes + real type, not an error."""
+    tc, ddb, s3 = client
+    _put(
+        ddb,
+        s3,
+        content_type="text/markdown",
+        body=b"<html><body>no embed here</body></html>",
+    )
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "no embed here" in body["content"]
+    assert body["content_type"] == "text/markdown"
+
+
+def test_unknown_version_is_404(client) -> None:
+    tc, _, _ = client
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 404
+
+
+def test_other_users_artifact_is_404(client) -> None:
+    tc, ddb, s3 = client
+    _put(ddb, s3, user_id="someone-else")
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 404
+
+
+def test_missing_s3_object_is_404(client) -> None:
+    tc, ddb, s3 = client
+    _put(ddb, s3, write_object=False)
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 404
+
+
+def test_oversized_artifact_is_413(client, monkeypatch) -> None:
+    tc, ddb, s3 = client
+    monkeypatch.setattr(artifact_service, "_MAX_CONTENT_BYTES", 16)
+    _put(ddb, s3, body=b"x" * 64)
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 413
+
+
+def test_missing_bucket_is_500(client, monkeypatch) -> None:
+    tc, ddb, s3 = client
+    _put(ddb, s3)
+    monkeypatch.delenv("S3_ARTIFACTS_BUCKET_NAME", raising=False)
+    artifact_service._reset_caches_for_tests()
+    resp = tc.get("/artifacts/art-1/content", params={"version": 1})
+    assert resp.status_code == 500
+
+
+def test_version_must_be_positive(client) -> None:
+    tc, ddb, s3 = client
+    _put(ddb, s3)
+    resp = tc.get("/artifacts/art-1/content", params={"version": 0})
+    assert resp.status_code == 422
+
+
+def test_requires_authentication() -> None:
+    app = FastAPI()
+    app.include_router(artifacts_router)
+    resp = TestClient(app).get(
+        "/artifacts/art-1/content", params={"version": 1}
+    )
+    assert resp.status_code == 401

--- a/frontend/ai.client/angular.json
+++ b/frontend/ai.client/angular.json
@@ -46,6 +46,8 @@
               "node_modules/prismjs/components/prism-python.min.js",
               "node_modules/prismjs/components/prism-sql.min.js",
               "node_modules/prismjs/components/prism-css.min.js",
+              "node_modules/prismjs/components/prism-json.min.js",
+              "node_modules/prismjs/components/prism-markdown.min.js",
               "node_modules/mermaid/dist/mermaid.min.js",
               "node_modules/katex/dist/katex.min.js",
               "node_modules/katex/dist/contrib/auto-render.min.js",

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -7,17 +7,26 @@ import {
   signal,
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { HttpErrorResponse } from '@angular/common/http';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroXMark,
   heroArrowPath,
   heroExclamationTriangle,
   heroArrowDownTray,
+  heroEye,
+  heroCodeBracket,
+  heroClipboard,
+  heroCheck,
 } from '@ng-icons/heroicons/outline';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
-import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
+import {
+  ArtifactHttpService,
+  type ArtifactContent,
+} from '../../../../services/artifacts/artifact-http.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { SessionService } from '../../../../services/session/session.service';
+import { ArtifactSourceComponent } from './artifact-source.component';
 
 /**
  * Right-docked pane that renders one artifact version in a sandboxed
@@ -39,13 +48,17 @@ import { SessionService } from '../../../../services/session/session.service';
 @Component({
   selector: 'app-artifact-panel',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon],
+  imports: [NgIcon, ArtifactSourceComponent],
   providers: [
     provideIcons({
       heroXMark,
       heroArrowPath,
       heroExclamationTriangle,
       heroArrowDownTray,
+      heroEye,
+      heroCodeBracket,
+      heroClipboard,
+      heroCheck,
     }),
   ],
   host: {
@@ -92,6 +105,62 @@ import { SessionService } from '../../../../services/session/session.service';
               Version {{ ref.version }}
             </p>
           </div>
+          <div
+            role="group"
+            aria-label="Artifact view mode"
+            class="flex items-center gap-0.5 rounded-md border border-gray-200 p-0.5 dark:border-gray-700"
+          >
+            <button
+              type="button"
+              class="flex h-7 w-7 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              [class]="
+                view() === 'preview'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+              "
+              [attr.aria-pressed]="view() === 'preview'"
+              aria-label="Preview"
+              title="Preview"
+              (click)="setView('preview')"
+            >
+              <ng-icon name="heroEye" class="text-base" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="flex h-7 w-7 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              [class]="
+                view() === 'code'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+              "
+              [attr.aria-pressed]="view() === 'code'"
+              aria-label="View code"
+              title="View code"
+              (click)="setView('code')"
+            >
+              <ng-icon
+                name="heroCodeBracket"
+                class="text-base"
+                aria-hidden="true"
+              />
+            </button>
+          </div>
+          @if (view() === 'code') {
+            <button
+              type="button"
+              class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+              [attr.aria-label]="copied() ? 'Copied' : 'Copy code'"
+              [disabled]="!source()"
+              (click)="copy()"
+            >
+              <ng-icon
+                [name]="copied() ? 'heroCheck' : 'heroClipboard'"
+                class="text-lg"
+                [class.text-green-600]="copied()"
+                aria-hidden="true"
+              />
+            </button>
+          }
           <button
             type="button"
             class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -120,49 +189,91 @@ import { SessionService } from '../../../../services/session/session.service';
         </header>
 
         <div class="relative min-h-0 flex-1">
-          @if (loading()) {
-            <div
-              class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-gray-500 dark:text-gray-400"
-              role="status"
-            >
-              <ng-icon
-                name="heroArrowPath"
-                class="animate-spin text-2xl"
-                aria-hidden="true"
-              />
-              <span class="text-sm">Loading artifact…</span>
-            </div>
-          } @else if (error()) {
-            <div
-              class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
-              role="alert"
-            >
-              <ng-icon
-                name="heroExclamationTriangle"
-                class="text-3xl text-amber-500"
-                aria-hidden="true"
-              />
-              <p class="text-sm text-gray-700 dark:text-gray-300">
-                {{ error() }}
-              </p>
-              <button
-                type="button"
-                class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
-                (click)="retry()"
+          @if (view() === 'code') {
+            @if (sourceLoading()) {
+              <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-gray-500 dark:text-gray-400"
+                role="status"
               >
-                Try again
-              </button>
-            </div>
-          } @else if (safeUrl()) {
-            <iframe
-              [src]="safeUrl()"
-              class="h-full w-full border-0 bg-white"
-              [class.pointer-events-none]="dragging()"
-              [title]="ref.title || 'Artifact'"
-              sandbox="allow-scripts"
-              referrerpolicy="no-referrer"
-              loading="lazy"
-            ></iframe>
+                <ng-icon
+                  name="heroArrowPath"
+                  class="animate-spin text-2xl"
+                  aria-hidden="true"
+                />
+                <span class="text-sm">Loading source…</span>
+              </div>
+            } @else if (sourceError()) {
+              <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+                role="alert"
+              >
+                <ng-icon
+                  name="heroExclamationTriangle"
+                  class="text-3xl text-amber-500"
+                  aria-hidden="true"
+                />
+                <p class="text-sm text-gray-700 dark:text-gray-300">
+                  {{ sourceError() }}
+                </p>
+                <button
+                  type="button"
+                  class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
+                  (click)="retrySource()"
+                >
+                  Try again
+                </button>
+              </div>
+            } @else if (source(); as src) {
+              <app-artifact-source
+                [content]="src.content"
+                [contentType]="src.contentType"
+              />
+            }
+          } @else {
+            @if (loading()) {
+              <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-gray-500 dark:text-gray-400"
+                role="status"
+              >
+                <ng-icon
+                  name="heroArrowPath"
+                  class="animate-spin text-2xl"
+                  aria-hidden="true"
+                />
+                <span class="text-sm">Loading artifact…</span>
+              </div>
+            } @else if (error()) {
+              <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+                role="alert"
+              >
+                <ng-icon
+                  name="heroExclamationTriangle"
+                  class="text-3xl text-amber-500"
+                  aria-hidden="true"
+                />
+                <p class="text-sm text-gray-700 dark:text-gray-300">
+                  {{ error() }}
+                </p>
+                <button
+                  type="button"
+                  class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
+                  (click)="retry()"
+                >
+                  Try again
+                </button>
+              </div>
+            } @else if (safeUrl()) {
+              <iframe
+                [src]="safeUrl()"
+                class="h-full w-full border-0 bg-white"
+                [class.pointer-events-none]="dragging()"
+                [title]="ref.title || 'Artifact'"
+                sandbox="allow-scripts"
+                referrerpolicy="no-referrer"
+                loading="lazy"
+              ></iframe>
+            }
           }
         </div>
       </aside>
@@ -187,6 +298,22 @@ export class ArtifactPanelComponent {
   protected readonly loading = signal(false);
   protected readonly error = signal<string | null>(null);
   protected readonly downloading = signal(false);
+
+  // Code-view state. The source is fetched lazily the first time the
+  // user switches to 'code' for a given artifact (the preview iframe
+  // path is untouched and stays the default).
+  protected readonly view = signal<'preview' | 'code'>('preview');
+  protected readonly source = signal<ArtifactContent | null>(null);
+  protected readonly sourceLoading = signal(false);
+  protected readonly sourceError = signal<string | null>(null);
+  protected readonly copied = signal(false);
+  /** Bumped per source fetch so a slow response that resolves after the
+   *  panel closed or switched artifact is discarded. */
+  private sourceSeq = 0;
+  /** Which `currentKey()` the loaded source belongs to, so re-opening
+   *  the same version doesn't refetch but switching does. */
+  private loadedSourceKey: string | null = null;
+  private copiedTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Resize handle state. Width itself lives in ArtifactStateService so
   // the layout (content padding + fixed footer/topnav) can reserve the
@@ -220,6 +347,10 @@ export class ArtifactPanelComponent {
         this.reset();
         return;
       }
+      // New artifact/version: drop any stale source and return to the
+      // preview default so the toggle doesn't carry across artifacts.
+      this.resetSource();
+      this.view.set('preview');
       void this.load();
     });
   }
@@ -307,6 +438,72 @@ export class ArtifactPanelComponent {
     void this.load();
   }
 
+  protected setView(next: 'preview' | 'code'): void {
+    if (this.view() === next) return;
+    this.view.set(next);
+    if (next === 'code') void this.ensureSource();
+  }
+
+  protected retrySource(): void {
+    this.loadedSourceKey = null;
+    void this.ensureSource();
+  }
+
+  /** Fetch the raw source once per artifact version. No-op if it's
+   *  already loaded for the current key or a fetch is in flight. */
+  private async ensureSource(): Promise<void> {
+    const ref = this.open();
+    if (!ref) return;
+    const key = this.currentKey();
+    if (this.sourceLoading()) return;
+    if (this.source() && this.loadedSourceKey === key) return;
+
+    const seq = ++this.sourceSeq;
+    this.sourceLoading.set(true);
+    this.sourceError.set(null);
+    this.source.set(null);
+    try {
+      const content = await this.artifactHttp.getArtifactContent(
+        ref.artifactId,
+        ref.version,
+      );
+      if (seq !== this.sourceSeq) return; // superseded — drop
+      this.source.set(content);
+      this.loadedSourceKey = key;
+    } catch (err) {
+      if (seq !== this.sourceSeq) return;
+      this.sourceError.set(
+        err instanceof HttpErrorResponse && err.status === 413
+          ? 'This artifact is too large to preview here — download it instead.'
+          : "This artifact's source couldn't be loaded. It may have expired or been removed.",
+      );
+    } finally {
+      if (seq === this.sourceSeq) this.sourceLoading.set(false);
+    }
+  }
+
+  protected async copy(): Promise<void> {
+    const src = this.source();
+    if (!src) return;
+    try {
+      await navigator.clipboard.writeText(src.content);
+      this.copied.set(true);
+      if (this.copiedTimer) clearTimeout(this.copiedTimer);
+      this.copiedTimer = setTimeout(() => this.copied.set(false), 2000);
+    } catch {
+      /* clipboard blocked (permissions/insecure context) — no-op;
+         the user can still select the visible source manually */
+    }
+  }
+
+  private resetSource(): void {
+    this.source.set(null);
+    this.sourceError.set(null);
+    this.sourceLoading.set(false);
+    this.copied.set(false);
+    this.loadedSourceKey = null;
+  }
+
   protected async download(): Promise<void> {
     const ref = this.open();
     if (!ref || this.downloading()) return;
@@ -325,6 +522,8 @@ export class ArtifactPanelComponent {
     this.safeUrl.set(null);
     this.error.set(null);
     this.loading.set(false);
+    this.resetSource();
+    this.view.set('preview');
   }
 
   private async load(): Promise<void> {

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-source.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-source.component.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ArtifactSourceComponent } from './artifact-source.component';
+
+/**
+ * Prism is loaded as a global angular.json script, absent under vitest,
+ * so `getPrism()` returns null and the component falls back to escaped
+ * plain text. That makes the XSS-safety assertion deterministic here
+ * regardless of grammar availability.
+ */
+describe('ArtifactSourceComponent', () => {
+  let fixture: ComponentFixture<ArtifactSourceComponent>;
+
+  function render(content: string, contentType: string): HTMLElement {
+    fixture = TestBed.createComponent(ArtifactSourceComponent);
+    fixture.componentRef.setInput('content', content);
+    fixture.componentRef.setInput('contentType', contentType);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ArtifactSourceComponent],
+    });
+  });
+
+  it('renders one gutter number per source line', () => {
+    const el = render('a\nb\nc', 'text/css');
+    const gutter = el.querySelectorAll('[aria-hidden="true"] > div');
+    expect(gutter.length).toBe(3);
+    expect(Array.from(gutter).map((d) => d.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+  });
+
+  it('counts a trailing newline as a final (empty) line', () => {
+    const el = render('only\n', 'text/css');
+    expect(el.querySelectorAll('[aria-hidden="true"] > div').length).toBe(2);
+  });
+
+  it('maps the content type onto a Prism language class', () => {
+    const el = render('<p>x</p>', 'text/html; charset=utf-8');
+    expect(el.querySelector('code')?.className).toContain(
+      'language-markup',
+    );
+  });
+
+  it('falls back to a plain-text language for unknown types', () => {
+    const el = render('plain', 'application/octet-stream');
+    expect(el.querySelector('code')?.className).toContain('language-none');
+  });
+
+  it('escapes HTML so artifact source can never execute', () => {
+    const el = render('<script>alert(1)</script>', 'text/html');
+    const code = el.querySelector('code');
+    // No live <script> element was injected…
+    expect(code?.querySelector('script')).toBeNull();
+    // …the angle brackets were rendered as text instead.
+    expect(code?.innerHTML).toContain('&lt;script&gt;');
+    expect(code?.textContent).toBe('<script>alert(1)</script>');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-source.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-source.component.ts
@@ -1,0 +1,127 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+/**
+ * Read-only source view for the artifact panel's "code" mode. Highlights
+ * inert artifact text with the globally-loaded Prism (same build/theme
+ * the chat code blocks use) and renders a line-number gutter beside it.
+ *
+ * Safety: the content is never executed. Prism.highlight HTML-escapes
+ * the source and only injects its own `<span class="token">` wrappers,
+ * and the `[innerHTML]` binding is additionally run through Angular's
+ * sanitizer (which strips scripts/handlers but keeps the token spans) —
+ * so this is XSS-safe without `bypassSecurityTrustHtml`.
+ */
+interface PrismLike {
+  languages: Record<string, unknown>;
+  highlight(text: string, grammar: unknown, language: string): string;
+}
+
+function getPrism(): PrismLike | null {
+  const p = (globalThis as { Prism?: PrismLike }).Prism;
+  return p && typeof p.highlight === 'function' ? p : null;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Bare MIME type → Prism language id. Unknown types render as escaped
+ *  plain text (no grammar) so the view never breaks on an exotic type. */
+function mimeToPrismLang(contentType: string): string {
+  const bare = (contentType || '').split(';')[0].trim().toLowerCase();
+  switch (bare) {
+    case 'text/html':
+    case 'application/xhtml+xml':
+    case 'image/svg+xml':
+      return 'markup';
+    case 'text/javascript':
+    case 'application/javascript':
+      return 'javascript';
+    case 'text/css':
+      return 'css';
+    case 'application/json':
+      return 'json';
+    case 'text/markdown':
+    case 'text/x-markdown':
+      return 'markdown';
+    default:
+      return 'none';
+  }
+}
+
+@Component({
+  selector: 'app-artifact-source',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      class="h-full w-full overflow-auto bg-[#272822] text-[13px]"
+      tabindex="0"
+      role="region"
+      [attr.aria-label]="'Artifact source (' + language() + ')'"
+    >
+      <div class="flex min-h-full min-w-full w-max">
+        <div
+          aria-hidden="true"
+          class="sticky left-0 z-10 select-none border-r border-white/10 bg-[#272822] px-3 py-4 text-right font-mono leading-[1.6] text-white/35 tabular-nums"
+        >
+          @for (n of lineNumbers(); track n) {
+            <div>{{ n }}</div>
+          }
+        </div>
+        <pre
+          class="m-0 flex-1 px-4 py-4 font-mono leading-[1.6]"
+        ><code [class]="'language-' + language()" [innerHTML]="highlighted()"></code></pre>
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+    }
+    /* The global okaidia theme paints its own background/padding on
+       pre[class*="language-"]; we host the surface on the scroll
+       container instead so the gutter and code share it. */
+    :host pre {
+      background: transparent;
+      white-space: pre;
+      tab-size: 2;
+    }
+  `,
+})
+export class ArtifactSourceComponent {
+  readonly content = input.required<string>();
+  readonly contentType = input.required<string>();
+
+  protected readonly language = computed(() =>
+    mimeToPrismLang(this.contentType()),
+  );
+
+  protected readonly lineNumbers = computed(() => {
+    const lines = this.content().split('\n').length;
+    return Array.from({ length: lines }, (_, i) => i + 1);
+  });
+
+  protected readonly highlighted = computed(() => {
+    const code = this.content();
+    const lang = this.language();
+    const prism = getPrism();
+    const grammar = prism?.languages[lang];
+    if (lang === 'none' || !prism || !grammar) {
+      return escapeHtml(code);
+    }
+    try {
+      return prism.highlight(code, grammar, lang);
+    } catch {
+      return escapeHtml(code);
+    }
+  });
+}

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.spec.ts
@@ -108,4 +108,33 @@ describe('ArtifactHttpService', () => {
       .flush({});
     await expect(p).resolves.toEqual([]);
   });
+
+  it('fetches artifact content and maps snake_case to camelCase', async () => {
+    const p = service.getArtifactContent('art-1', 2);
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url === `${API}/artifacts/art-1/content` &&
+        r.params.get('version') === '2',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      content: '# Title\n\nbody',
+      content_type: 'text/markdown',
+      version: 2,
+    });
+    await expect(p).resolves.toEqual({
+      content: '# Title\n\nbody',
+      contentType: 'text/markdown',
+      version: 2,
+    });
+  });
+
+  it('url-encodes the artifact id in the content path', async () => {
+    const p = service.getArtifactContent('a/b 1', 1);
+    const req = httpMock.expectOne(
+      (r) => r.url === `${API}/artifacts/a%2Fb%201/content`,
+    );
+    req.flush({ content: '', content_type: 'text/html', version: 1 });
+    await p;
+  });
 });

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
@@ -23,9 +23,22 @@ interface ArtifactListResponseDto {
   artifacts: ArtifactSummaryDto[];
 }
 
+interface ArtifactContentResponseDto {
+  content: string;
+  content_type: string;
+  version: number;
+}
+
 export interface RenderToken {
   url: string;
   expiresAt: string;
+}
+
+/** Raw source of one artifact version, for the panel's code view. */
+export interface ArtifactContent {
+  content: string;
+  contentType: string;
+  version: number;
 }
 
 /**
@@ -55,6 +68,29 @@ export class ArtifactHttpService {
       ),
     );
     return { url: res.url, expiresAt: res.expires_at };
+  }
+
+  /**
+   * Fetch one artifact version's raw source for the code view. The
+   * bytes are inert text the panel highlights client-side. The backend
+   * unwraps Markdown back to the authored source and 413s anything too
+   * large to highlight inline (callers steer to download on that).
+   */
+  async getArtifactContent(
+    artifactId: string,
+    version: number,
+  ): Promise<ArtifactContent> {
+    const res = await firstValueFrom(
+      this.http.get<ArtifactContentResponseDto>(
+        `${this.config.appApiUrl()}/artifacts/${encodeURIComponent(artifactId)}/content`,
+        { params: { version } },
+      ),
+    );
+    return {
+      content: res.content,
+      contentType: res.content_type,
+      version: res.version,
+    };
   }
 
   /** List the current HEAD of every artifact in a chat session. */


### PR DESCRIPTION
## Summary

Adds an eye/`</>` segmented toggle to the artifact panel so users can flip between the live preview iframe and the artifact's **raw source**, rendered with Prism syntax highlighting and a line-number gutter (matches the design in the request screenshots).

- **New app-api endpoint** `GET /artifacts/{id}/content?version=N` — session-cookie auth, ownership-scoped DDB lookup → S3 read, 2 MB inline cap (413). **No infra change** (uses the app-api task role's existing `s3:GetObject` grant). Markdown is unwrapped from the stored HTML render scaffold back to the authored source via the `<script id="md-src">` base64 embed, with a raw-bytes fallback if extraction fails.
- **`ArtifactSourceComponent`** — Prism highlight reusing the app's existing global okaidia theme (consistent with chat code blocks) + sticky line-number gutter. XSS-safe: source is Prism-escaped *and* Angular-sanitized — no `bypassSecurityTrustHtml`.
- **Panel wiring** — lazy source fetch on first switch to code view (request-seq guarded), Copy button (code view only), resets to Preview on artifact/version change. **Preview iframe path is untouched.**
- Added Prism `json` + `markdown` grammars to `angular.json`.

Markdown design decision (confirmed with reviewer during planning): code view shows the **original authored Markdown** (recovered from the base64 embed), not the rendered HTML wrapper. Theme intentionally matches the existing dark okaidia chat code theme rather than the light mock — easy to swap if a light theme is preferred.

## Test plan

- [x] Backend: 34 pytest pass incl. new `test_artifact_content.py` (ownership 404, missing version/object 404, Markdown unwrap + fallback, 413 size cap, 500 misconfig, 401 unauth) and the import-boundary test
- [x] Frontend: 23 vitest pass (http mapping + url-encoding, source component language mapping, line count, HTML-escape/no-script-execution)
- [x] `ng build` clean (no new warnings)
- [ ] Manual UI pass (no `SKIP_AUTH` locally): toggle preview↔code on HTML/JS/CSS/SVG/JSON/Markdown artifacts; gutter alignment on horizontal scroll; Copy → green check; oversized → "too large, download instead"; keyboard/a11y (`aria-pressed`, focus ring, focusable source region); switching artifacts returns to Preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)