### PR TITLE
fix(artifacts): scope artifact card z-index with isolation:isolate

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -122,9 +122,13 @@ interface ArtifactKind {
     }
 
     /* Card shell: a positioning context for the stretched open button
-       and the download button. No chrome of its own. */
+       and the download button. No chrome of its own. isolation:isolate
+       keeps the internal z-index (hit=1, surface=2) scoped to the card
+       so it can't paint over page overlays (e.g. the context popover) —
+       the card as a whole stacks at its normal flow level. */
     .artifact-card {
       position: relative;
+      isolation: isolate;
       display: block;
       width: 100%;
       /* matches the chat input's rounded-2xl so the focus ring and the


### PR DESCRIPTION
## Summary
- Adds `isolation: isolate` to `.artifact-card` so the card's internal stacking context (`hit=1`, `surface=2`) stays scoped to the card.
- Without it, the card's positioned children could paint over page overlays (e.g. the context popover); the card now stacks at its normal flow level as a whole.

## Test plan
- [ ] Open a session with an inline artifact card and trigger the context popover near/over the card — popover renders above the card.
- [ ] Confirm the card's open/download buttons still layer correctly within the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)