### PR TITLE
feat(artifacts): per-version history cards + panel version picker

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -286,7 +286,12 @@ def create_artifact_record(
     table = _table()
     try:
         table.put_item(
-            Item={**common, "PK": pk, "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}"},
+            Item={
+                **common,
+                "PK": pk,
+                "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}",
+                "updated_at": now,
+            },
             ConditionExpression="attribute_not_exists(SK)",
         )
         table.put_item(
@@ -351,7 +356,12 @@ def update_artifact_record(
     }
     try:
         table.put_item(
-            Item={**common, "PK": pk, "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}"},
+            Item={
+                **common,
+                "PK": pk,
+                "SK": f"ARTIFACT#{artifact_id}#V#{version:05d}",
+                "updated_at": now,
+            },
             ConditionExpression="attribute_not_exists(SK)",
         )
         # Optimistic lock: HEAD must still be at the version we read, so
@@ -383,30 +393,38 @@ def update_artifact_record(
 
 
 def set_produced_by_message_index(
-    user_id: str, artifact_id: str, message_index: int
+    user_id: str, artifact_id: str, version: int, message_index: int
 ) -> None:
-    """Stamp the HEAD row with the index of the assistant message that
-    produced (or last updated) the artifact this turn.
+    """Stamp the artifact's version row (and HEAD) with the index of the
+    assistant message that produced this version this turn.
 
-    The artifact tool can't know this at write time — the turn isn't
-    finished — so the stream coordinator writes it back post-turn using
-    the same odd-position index it already computes for per-message
+    Per-version linkage is what lets the SPA place every version's card
+    under the turn that produced it after a reload — the list endpoint
+    returns all version rows, not just HEAD. HEAD is stamped too so any
+    HEAD-only reader still sees the latest version's linkage.
+
+    The artifact tool can't know this index at write time — the turn
+    isn't finished — so the stream coordinator writes it back post-turn
+    using the same odd-position index it already computes for per-message
     metadata (`initial_message_count + 2*i + 1`). That index matches the
-    `idx` the messages endpoint enumerates on reload, so the SPA can
-    render the card inline after the right assistant message.
+    `idx` the messages endpoint enumerates on reload.
 
-    Best-effort: a SET on a single attribute, keyed by the HEAD row, that
-    deliberately does not touch `version` so it can never collide with
-    the update_artifact optimistic lock. Failures are swallowed by the
-    caller (linkage is a UX nicety, never worth breaking a turn over).
+    Best-effort: a SET on a single attribute that deliberately does not
+    touch `version`, so it can never collide with the update_artifact
+    optimistic lock. Failures are swallowed by the caller (linkage is a
+    UX nicety, never worth breaking a turn over).
     """
     table = _table()
-    table.update_item(
-        Key={"PK": f"USER#{user_id}", "SK": f"ARTIFACT#{artifact_id}#HEAD"},
-        UpdateExpression="SET produced_by_message_index = :idx",
-        ExpressionAttributeValues={":idx": message_index},
-        ConditionExpression="attribute_exists(SK)",
-    )
+    for sk in (
+        f"ARTIFACT#{artifact_id}#V#{version:05d}",
+        f"ARTIFACT#{artifact_id}#HEAD",
+    ):
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="SET produced_by_message_index = :idx",
+            ExpressionAttributeValues={":idx": message_index},
+            ConditionExpression="attribute_exists(SK)",
+        )
 
 
 _SESSION_INDEX = "SessionIndex"

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -960,12 +960,14 @@ class StreamCoordinator:
             if not touched:
                 continue
             artifact_id = row.get("artifact_id", "")
+            version = int(row.get("version", 0))
             if produced_by_message_index is not None and artifact_id:
                 try:
                     await asyncio.to_thread(
                         set_produced_by_message_index,
                         user_id,
                         artifact_id,
+                        version,
                         produced_by_message_index,
                     )
                 except Exception as e:  # noqa: BLE001 - best-effort linkage
@@ -975,7 +977,6 @@ class StreamCoordinator:
                         artifact_id,
                         e,
                     )
-            version = int(row.get("version", 0))
             payload = {
                 "type": "artifact",
                 "artifactId": artifact_id,

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -76,13 +76,14 @@ async def list_session_artifacts(
     user: User = Depends(get_current_user_from_session),
     service: ArtifactListService = Depends(get_artifact_list_service),
 ) -> ArtifactListResponse:
-    """List the current HEAD of every artifact created in a chat session.
+    """List every version of every artifact created in a chat session.
 
-    Used by the SPA to hydrate artifact cards on session load (live
-    creation is delivered separately via the `artifact` SSE event). Each
-    row is re-checked against the authenticated user, so a borrowed
-    session id cannot enumerate another user's artifacts. An unknown or
-    artifact-free session is a normal empty list, not a 404.
+    Used by the SPA to hydrate per-version artifact cards on session load
+    (live creation/updates are delivered separately via the `artifact`
+    SSE event). Each artifact is re-checked against the authenticated
+    user, so a borrowed session id cannot enumerate another user's
+    artifacts. An unknown or artifact-free session is a normal empty
+    list, not a 404.
     """
     try:
         rows = service.list_for_session(

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -239,27 +239,81 @@ _SESSION_INDEX = "SessionIndex"
 
 
 class ArtifactListService:
-    """List a session's artifacts from the SessionIndex GSI.
+    """List every version of every artifact created in a chat session.
 
-    The GSI projects only HEAD rows (the writer attaches GSI1PK/GSI1SK to
-    the HEAD put only), so a query already returns one row per artifact —
-    its current version — newest-first. GSI1PK is `SESSION#{sid}`, which
-    is NOT user-scoped, so every returned row is re-checked against the
-    authenticated user's id: a caller passing a borrowed session id can
-    never enumerate another user's artifacts.
+    Two-step, because the SessionIndex GSI only projects HEAD rows (the
+    writer attaches GSI1PK/GSI1SK to the HEAD put only):
+
+      1. Query SessionIndex by GSI1PK=SESSION#{sid} to discover the
+         artifacts in the session. GSI1PK is NOT user-scoped, so each
+         HEAD row is re-checked against the authenticated user's id.
+      2. Per artifact, query the main table by PK=USER#{uid} and
+         SK begins_with ARTIFACT#{aid}#V# for all immutable version
+         rows. PK is the authenticated user's id, so step 2 is
+         ownership-safe by construction.
+
+    The SPA renders one card per version, anchored to the turn that
+    produced it via the per-version produced_by_message_index the writer
+    stamps. Version rows written before per-version linkage shipped lack
+    that attribute (and updated_at) and degrade to the SPA's
+    end-of-conversation strip rather than a per-turn anchor.
     """
 
     def list_for_session(
         self, *, user_id: str, session_id: str
     ) -> list[dict]:
         table = _table()
-        items: list[dict] = []
+        head_items: list[dict] = []
         kwargs: dict = {
             "IndexName": _SESSION_INDEX,
             "KeyConditionExpression": Key("GSI1PK").eq(
                 f"SESSION#{session_id}"
             ),
             "ScanIndexForward": False,  # GSI1SK embeds updated_at → newest first
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                head_items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError(
+                "artifact list query failed"
+            ) from exc
+
+        # Distinct artifact ids in the session, newest-first, owned by
+        # the caller. dict.fromkeys dedupes while preserving GSI order.
+        artifact_ids = list(
+            dict.fromkeys(
+                item.get("artifact_id", "")
+                for item in head_items
+                if item.get("user_id") == user_id
+                and item.get("artifact_id")
+            )
+        )
+
+        summaries: list[dict] = []
+        for artifact_id in artifact_ids:
+            summaries.extend(
+                self._versions_for_artifact(user_id, artifact_id)
+            )
+        return summaries
+
+    @staticmethod
+    def _versions_for_artifact(
+        user_id: str, artifact_id: str
+    ) -> list[dict]:
+        """All immutable version rows for one artifact, scoped to the
+        user by PK. The #HEAD row shares the SK prefix but not the `#V#`
+        infix, so begins_with cleanly excludes it."""
+        table = _table()
+        items: list[dict] = []
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with(f"ARTIFACT#{artifact_id}#V#"),
         }
         try:
             while True:
@@ -271,29 +325,25 @@ class ArtifactListService:
                 kwargs["ExclusiveStartKey"] = last
         except ClientError as exc:
             raise ArtifactQueryError(
-                "artifact list query failed"
+                "artifact version query failed"
             ) from exc
 
-        summaries: list[dict] = []
-        for item in items:
-            if item.get("user_id") != user_id:
-                continue
-            summaries.append(
-                {
-                    "artifact_id": item.get("artifact_id", ""),
-                    "version": int(item.get("version", 0)),
-                    "title": item.get("title", ""),
-                    "content_type": item.get(
-                        "content_type", "text/html; charset=utf-8"
-                    ),
-                    "updated_at": item.get("updated_at", ""),
-                    "created_at": item.get("created_at"),
-                    "produced_by_message_index": item.get(
-                        "produced_by_message_index"
-                    ),
-                }
-            )
-        return summaries
+        return [
+            {
+                "artifact_id": item.get("artifact_id", ""),
+                "version": int(item.get("version", 0)),
+                "title": item.get("title", ""),
+                "content_type": item.get(
+                    "content_type", "text/html; charset=utf-8"
+                ),
+                "updated_at": item.get("updated_at", ""),
+                "created_at": item.get("created_at"),
+                "produced_by_message_index": item.get(
+                    "produced_by_message_index"
+                ),
+            }
+            for item in items
+        ]
 
 
 def get_artifact_list_service() -> ArtifactListService:

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -266,14 +266,19 @@ def test_list_session_artifacts_empty_session(aws) -> None:
     assert service.list_session_artifacts(USER, "no-such-session") == []
 
 
-def test_set_produced_by_message_index_stamps_head_and_lists(aws) -> None:
+def test_set_produced_by_message_index_stamps_version_and_head(aws) -> None:
+    ddb, _ = aws
     aid, _ = service.create_artifact_record(USER, SESSION, "Doc", DOC, "")
     assert service.list_session_artifacts(USER, SESSION)[0][
         "produced_by_message_index"
     ] is None
 
-    service.set_produced_by_message_index(USER, aid, 7)
+    service.set_produced_by_message_index(USER, aid, 1, 7)
 
+    # Per-version linkage: the v1 row itself carries the index — this is
+    # what survives reload via the all-versions list endpoint.
+    assert _item(ddb, aid, "V#00001")["produced_by_message_index"] == 7
+    # HEAD is stamped too, so the writer's HEAD-based live list still sees it.
     rows = service.list_session_artifacts(USER, SESSION)
     assert rows[0]["produced_by_message_index"] == 7
     # The stamp must leave the optimistic-lock `version` untouched so a
@@ -281,8 +286,9 @@ def test_set_produced_by_message_index_stamps_head_and_lists(aws) -> None:
     assert service.update_artifact_record(USER, aid, DOC, None, None) == 2
 
 
-def test_set_produced_by_message_index_requires_existing_head(aws) -> None:
+def test_set_produced_by_message_index_requires_existing_rows(aws) -> None:
     from botocore.exceptions import ClientError
 
+    # No version/HEAD rows for "nope": the conditional update fails closed.
     with pytest.raises(ClientError):
-        service.set_produced_by_message_index(USER, "nope", 1)
+        service.set_produced_by_message_index(USER, "nope", 1, 1)

--- a/backend/tests/agents/main_agent/streaming/test_artifact_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_artifact_events.py
@@ -82,13 +82,15 @@ async def test_stamps_and_emits_produced_by_message_index(
     monkeypatch.setattr(
         artifact_service,
         "set_produced_by_message_index",
-        lambda u, aid, idx: stamped.append((u, aid, idx)),
+        lambda u, aid, ver, idx: stamped.append((u, aid, ver, idx)),
     )
     out = await coord._extract_artifact_events(
         SESSION, USER, turn_start, produced_by_message_index=7
     )
     assert {_parse_sse(e)["producedByMessageIndex"] for e in out} == {7}
-    assert stamped == [(USER, "a", 7), (USER, "b", 7)]
+    # Each artifact's own version is threaded to the stamp so the right
+    # version row is linked (both rows are v1 here).
+    assert stamped == [(USER, "a", 1, 7), (USER, "b", 1, 7)]
 
 
 @pytest.mark.asyncio
@@ -99,7 +101,7 @@ async def test_stamp_failure_is_swallowed(
         artifact_service, "list_session_artifacts", lambda u, s: [_row()]
     )
 
-    def _boom(u, aid, idx):
+    def _boom(u, aid, ver, idx):
         raise RuntimeError("ddb down")
 
     monkeypatch.setattr(

--- a/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
+++ b/backend/tests/apis/app_api/artifacts/test_list_artifacts.py
@@ -1,9 +1,11 @@
 """Tests for the app-api session artifacts list endpoint.
 
-Mirrors the writer's frozen HEAD-row shape from #311
-(backend/src/agents/builtin_tools/artifacts/service.py): only HEAD rows
-carry GSI1PK/GSI1SK, so a SessionIndex query returns exactly one row per
-artifact (its current version) newest-first.
+The endpoint returns *every version* of every artifact in a session via
+a two-step query: SessionIndex (HEAD rows only) to discover the
+artifacts, then a per-artifact main-table `SK begins_with #V#` query for
+all immutable version rows. The SPA renders one card per version,
+anchored to the turn that produced it via the per-version
+`produced_by_message_index` the writer stamps.
 """
 
 from __future__ import annotations
@@ -76,17 +78,52 @@ def client(monkeypatch: pytest.MonkeyPatch):
         yield TestClient(app), boto3.resource("dynamodb", region_name=REGION)
 
 
+def _put_version(
+    ddb,
+    *,
+    artifact: str,
+    version: int,
+    user_id: str = USER_ID,
+    session_id: str = SESSION,
+    title: str = "Doc",
+    updated_at: str | None = "2026-05-15T10:00:00+00:00",
+    created_at: str = "2026-05-15T10:00:00+00:00",
+    produced_by: int | None = None,
+) -> None:
+    """One immutable version row, mirroring the writer. `updated_at` /
+    `produced_by` left None models a pre-per-version-linkage row."""
+    item = {
+        "PK": f"USER#{user_id}",
+        "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+        "storage": "s3",
+        "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+        "content_type": "text/html; charset=utf-8",
+        "version": version,
+        "artifact_id": artifact,
+        "user_id": user_id,
+        "session_id": session_id,
+        "title": title,
+        "created_at": created_at,
+    }
+    if updated_at is not None:
+        item["updated_at"] = updated_at
+    if produced_by is not None:
+        item["produced_by_message_index"] = produced_by
+    ddb.Table(TABLE).put_item(Item=item)
+
+
 def _put_head(
     ddb,
     *,
+    artifact: str,
+    head_version: int,
     user_id: str = USER_ID,
     session_id: str = SESSION,
-    artifact: str = "art-1",
-    version: int = 1,
-    title: str = "Doc",
     updated_at: str = "2026-05-15T10:00:00+00:00",
-    created_at: str = "2026-05-15T10:00:00+00:00",
+    title: str = "Doc",
 ) -> None:
+    """The HEAD pointer row — carries the SessionIndex GSI keys used for
+    step-1 artifact discovery."""
     ddb.Table(TABLE).put_item(
         Item={
             "PK": f"USER#{user_id}",
@@ -94,36 +131,46 @@ def _put_head(
             "GSI1PK": f"SESSION#{session_id}",
             "GSI1SK": f"ARTIFACT#{updated_at}#{artifact}",
             "storage": "s3",
-            "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+            "content_key": f"{user_id}/{artifact}/v{head_version}/index.html",
             "content_type": "text/html; charset=utf-8",
-            "version": version,
+            "version": head_version,
             "artifact_id": artifact,
             "user_id": user_id,
             "session_id": session_id,
             "title": title,
-            "created_at": created_at,
+            "created_at": "2026-05-15T10:00:00+00:00",
             "updated_at": updated_at,
         }
     )
 
 
-def _put_version_row(ddb, *, artifact: str = "art-1", version: int = 1) -> None:
-    """A non-HEAD version row — must NOT appear in the SessionIndex query
-    (the writer omits GSI1PK/GSI1SK on version rows)."""
-    ddb.Table(TABLE).put_item(
-        Item={
-            "PK": f"USER#{USER_ID}",
-            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
-            "storage": "s3",
-            "content_key": f"{USER_ID}/{artifact}/v{version}/index.html",
-            "content_type": "text/html; charset=utf-8",
-            "version": version,
-            "artifact_id": artifact,
-            "user_id": USER_ID,
-            "session_id": SESSION,
-            "title": "Doc",
-            "created_at": "2026-05-15T10:00:00+00:00",
-        }
+def _put_artifact(
+    ddb,
+    *,
+    artifact: str,
+    versions: list[dict],
+    user_id: str = USER_ID,
+    session_id: str = SESSION,
+) -> None:
+    """N immutable version rows plus a HEAD at the latest — exactly what
+    the writer leaves after a create + updates sequence."""
+    for v in versions:
+        _put_version(
+            ddb,
+            artifact=artifact,
+            user_id=user_id,
+            session_id=session_id,
+            **v,
+        )
+    last = max(versions, key=lambda v: v["version"])
+    _put_head(
+        ddb,
+        artifact=artifact,
+        head_version=last["version"],
+        user_id=user_id,
+        session_id=session_id,
+        updated_at=last.get("updated_at") or "2026-05-15T10:00:00+00:00",
+        title=last.get("title", "Doc"),
     )
 
 
@@ -134,65 +181,122 @@ def test_empty_session_is_empty_list(client) -> None:
     assert resp.json() == {"artifacts": []}
 
 
-def test_lists_head_rows_newest_first(client) -> None:
+def test_returns_every_version_newest_artifact_first(client) -> None:
     tc, ddb = client
-    _put_head(
-        ddb, artifact="old", updated_at="2026-05-15T10:00:00+00:00", title="Old"
+    _put_artifact(
+        ddb,
+        artifact="old",
+        versions=[
+            {"version": 1, "updated_at": "2026-05-15T10:00:00+00:00", "title": "Old"}
+        ],
     )
-    _put_head(
-        ddb, artifact="new", updated_at="2026-05-15T12:00:00+00:00", title="New"
+    _put_artifact(
+        ddb,
+        artifact="new",
+        versions=[
+            {"version": 1, "updated_at": "2026-05-15T11:00:00+00:00", "title": "New"},
+            {"version": 2, "updated_at": "2026-05-15T11:30:00+00:00", "title": "New"},
+            {"version": 3, "updated_at": "2026-05-15T12:00:00+00:00", "title": "New"},
+        ],
     )
-    # A version row for the same artifact must be ignored by the query.
-    _put_version_row(ddb, artifact="new", version=1)
-
-    resp = tc.get("/artifacts", params={"session_id": SESSION})
-    assert resp.status_code == 200
-    arts = resp.json()["artifacts"]
-    assert [a["artifact_id"] for a in arts] == ["new", "old"]
-    assert arts[0]["title"] == "New"
-    assert arts[0]["content_type"] == "text/html; charset=utf-8"
-
-
-def test_produced_by_message_index_round_trips(client) -> None:
-    """The HEAD row's linkage index (stamped post-turn by the stream
-    coordinator) must surface on the list DTO so the SPA can anchor the
-    card inline; absent on legacy rows → null (SPA falls back to strip)."""
-    tc, ddb = client
-    _put_head(ddb, artifact="linked", updated_at="2026-05-15T12:00:00+00:00")
-    ddb.Table(TABLE).update_item(
-        Key={"PK": f"USER#{USER_ID}", "SK": "ARTIFACT#linked#HEAD"},
-        UpdateExpression="SET produced_by_message_index = :i",
-        ExpressionAttributeValues={":i": 5},
-    )
-    _put_head(ddb, artifact="legacy", updated_at="2026-05-15T11:00:00+00:00")
 
     arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
         "artifacts"
     ]
-    by_id = {a["artifact_id"]: a for a in arts}
-    assert by_id["linked"]["produced_by_message_index"] == 5
-    assert by_id["legacy"]["produced_by_message_index"] is None
+    # Every version of every artifact is present.
+    assert {(a["artifact_id"], a["version"]) for a in arts} == {
+        ("new", 1),
+        ("new", 2),
+        ("new", 3),
+        ("old", 1),
+    }
+    # Step-1 discovery is HEAD-newest-first, so all of "new"'s versions
+    # come before "old"'s.
+    ids = [a["artifact_id"] for a in arts]
+    assert set(ids[:3]) == {"new"}
+    assert ids[-1] == "old"
 
 
-def test_reflects_current_version(client) -> None:
+def test_per_version_produced_by_index(client) -> None:
+    """Each version row carries its own linkage index so the SPA can
+    anchor every version's card under the turn that produced it. A row
+    without one (pre-linkage) is null → SPA end-of-conversation strip."""
     tc, ddb = client
-    _put_head(ddb, artifact="art-1", version=3, title="V3")
-    resp = tc.get("/artifacts", params={"session_id": SESSION})
-    body = resp.json()["artifacts"]
-    assert body[0]["version"] == 3
-    assert body[0]["created_at"] == "2026-05-15T10:00:00+00:00"
+    _put_artifact(
+        ddb,
+        artifact="art-1",
+        versions=[
+            {"version": 1, "updated_at": "2026-05-15T11:00:00+00:00", "produced_by": 3},
+            {"version": 2, "updated_at": "2026-05-15T12:00:00+00:00", "produced_by": 7},
+            {"version": 3, "updated_at": "2026-05-15T12:30:00+00:00"},
+        ],
+    )
+    arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
+        "artifacts"
+    ]
+    by_v = {a["version"]: a for a in arts}
+    assert by_v[1]["produced_by_message_index"] == 3
+    assert by_v[2]["produced_by_message_index"] == 7
+    assert by_v[3]["produced_by_message_index"] is None
 
 
-def test_other_users_session_row_is_filtered(client) -> None:
-    """GSI1PK is SESSION#-scoped, not user-scoped: a row owned by another
-    user that happens to share the queried session id must be dropped."""
+def test_legacy_version_rows_degrade_gracefully(client) -> None:
+    """Version rows written before per-version linkage lack updated_at /
+    produced_by_message_index. They must still be returned (empty/null)
+    so the SPA shows them in the strip rather than dropping them."""
     tc, ddb = client
-    _put_head(ddb, artifact="mine", user_id=USER_ID)
-    _put_head(ddb, artifact="theirs", user_id="someone-else")
+    _put_artifact(
+        ddb,
+        artifact="legacy",
+        versions=[
+            {"version": 1, "updated_at": None},
+            {"version": 2, "updated_at": None},
+        ],
+    )
+    arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
+        "artifacts"
+    ]
+    assert {a["version"] for a in arts} == {1, 2}
+    for a in arts:
+        assert a["updated_at"] == ""
+        assert a["produced_by_message_index"] is None
 
-    resp = tc.get("/artifacts", params={"session_id": SESSION})
-    arts = resp.json()["artifacts"]
-    assert [a["artifact_id"] for a in arts] == ["mine"]
+
+def test_created_at_present_on_each_version(client) -> None:
+    tc, ddb = client
+    _put_artifact(
+        ddb,
+        artifact="art-1",
+        versions=[
+            {"version": 1},
+            {"version": 2, "updated_at": "2026-05-15T12:00:00+00:00"},
+        ],
+    )
+    arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
+        "artifacts"
+    ]
+    assert all(
+        a["created_at"] == "2026-05-15T10:00:00+00:00" for a in arts
+    )
+
+
+def test_other_users_artifact_is_filtered(client) -> None:
+    """Step 1 drops a HEAD owned by another user that happens to share
+    the queried session id; step 2 is PK=USER#{caller}, so their version
+    rows are never read even if a HEAD leaked."""
+    tc, ddb = client
+    _put_artifact(ddb, artifact="mine", versions=[{"version": 1}])
+    _put_artifact(
+        ddb,
+        artifact="theirs",
+        versions=[{"version": 1}],
+        user_id="someone-else",
+    )
+
+    arts = tc.get("/artifacts", params={"session_id": SESSION}).json()[
+        "artifacts"
+    ]
+    assert {a["artifact_id"] for a in arts} == {"mine"}
 
 
 def test_session_id_required(client) -> None:

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -1,10 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   computed,
   effect,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -18,7 +20,9 @@ import {
   heroCodeBracket,
   heroClipboard,
   heroCheck,
+  heroChevronUpDown,
 } from '@ng-icons/heroicons/outline';
+import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 import {
   ArtifactHttpService,
@@ -59,10 +63,12 @@ import { ArtifactSourceComponent } from './artifact-source.component';
       heroCodeBracket,
       heroClipboard,
       heroCheck,
+      heroChevronUpDown,
     }),
   ],
   host: {
     '(document:keydown.escape)': 'onEscape()',
+    '(document:pointerdown)': 'onDocumentPointerDown($event)',
   },
   template: `
     @if (open(); as ref) {
@@ -101,9 +107,83 @@ import { ArtifactSourceComponent } from './artifact-source.component';
             >
               {{ ref.title || 'Untitled artifact' }}
             </h2>
-            <p class="text-xs text-gray-500 dark:text-gray-400">
-              Version {{ ref.version }}
-            </p>
+            @if (versions().length > 1) {
+              <div #versionControl class="relative">
+                <button
+                  type="button"
+                  class="-ml-1 flex items-center gap-0.5 rounded px-1 py-0.5 text-xs text-gray-500 transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:text-gray-100"
+                  aria-haspopup="menu"
+                  [attr.aria-expanded]="menuOpen()"
+                  aria-controls="artifact-version-menu"
+                  [attr.aria-label]="
+                    'Version ' +
+                    ref.version +
+                    ' of ' +
+                    versions().length +
+                    ', change version'
+                  "
+                  (click)="toggleMenu()"
+                >
+                  <span>Version {{ ref.version }}</span>
+                  <ng-icon
+                    name="heroChevronUpDown"
+                    class="text-sm"
+                    aria-hidden="true"
+                  />
+                </button>
+                @if (menuOpen()) {
+                  <div
+                    id="artifact-version-menu"
+                    role="menu"
+                    aria-label="Artifact versions"
+                    class="absolute left-0 z-20 mt-1 max-h-72 w-60 overflow-auto rounded-lg border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+                    (keydown)="onMenuKeydown($event)"
+                  >
+                    @for (v of versions(); track v.version) {
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        [attr.aria-checked]="v.version === ref.version"
+                        class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
+                        [class]="
+                          v.version === ref.version
+                            ? 'bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
+                            : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+                        "
+                        (click)="selectVersion(v)"
+                      >
+                        <span
+                          class="flex h-4 w-4 shrink-0 items-center justify-center"
+                          aria-hidden="true"
+                        >
+                          @if (v.version === ref.version) {
+                            <ng-icon name="heroCheck" class="text-sm" />
+                          }
+                        </span>
+                        <span class="min-w-0 flex-1">
+                          <span class="font-medium">Version {{ v.version }}</span>
+                          @if (relativeLabel(v.updatedAt); as t) {
+                            <span class="ml-1 text-gray-400 dark:text-gray-500"
+                              >· {{ t }}</span
+                            >
+                          }
+                        </span>
+                        @if (v.version === latestVersion()) {
+                          <span
+                            class="shrink-0 rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-500/15 dark:text-blue-300"
+                            >Latest</span
+                          >
+                        }
+                      </button>
+                    }
+                  </div>
+                }
+              </div>
+            } @else {
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                Version {{ ref.version }}
+              </p>
+            }
           </div>
           <div
             role="group"
@@ -337,12 +417,29 @@ export class ArtifactPanelComponent {
     return r ? `${r.artifactId}#${r.version}` : null;
   });
 
+  // Version picker. All versions live in ArtifactStateService (one
+  // registry entry per `artifactId#version`); selecting one just
+  // re-points openRef and the currentKey effect reloads it.
+  protected readonly versions = computed<Artifact[]>(() => {
+    const r = this.open();
+    return r ? this.artifactState.versionsFor(r.artifactId) : [];
+  });
+  /** Highest version number (the list is desc) — drives the badge. */
+  protected readonly latestVersion = computed(
+    () => this.versions()[0]?.version,
+  );
+  protected readonly menuOpen = signal(false);
+  private readonly versionControl =
+    viewChild<ElementRef<HTMLElement>>('versionControl');
+
   constructor() {
     // Mint a fresh token whenever the panel opens or switches artifact.
     // Closing (open() === null) clears the iframe so the credential URL
     // doesn't linger in the DOM.
     effect(() => {
       const key = this.currentKey();
+      // Any open / version-switch / close also dismisses the menu.
+      this.menuOpen.set(false);
       if (!key) {
         this.reset();
         return;
@@ -427,7 +524,108 @@ export class ArtifactPanelComponent {
   }
 
   protected onEscape(): void {
+    if (this.menuOpen()) {
+      this.closeMenuAndRefocus();
+      return;
+    }
     if (this.open()) this.close();
+  }
+
+  protected toggleMenu(): void {
+    const next = !this.menuOpen();
+    this.menuOpen.set(next);
+    // Let the menu render, then move focus into it for keyboard users.
+    if (next) setTimeout(() => this.focusSelectedItem());
+  }
+
+  protected selectVersion(v: Artifact): void {
+    this.menuOpen.set(false);
+    // Re-points openRef; the currentKey effect re-mints the token and
+    // reloads (preview) / refetches (code) for the chosen version, and
+    // the header title tracks that version.
+    this.artifactState.openArtifactPanel({
+      artifactId: v.artifactId,
+      version: v.version,
+      title: v.title,
+    });
+  }
+
+  protected onMenuKeydown(e: KeyboardEvent): void {
+    const items = this.menuItems();
+    if (!items.length) return;
+    const idx = items.indexOf(
+      document.activeElement as HTMLButtonElement,
+    );
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        items[(Math.max(idx, -1) + 1) % items.length]?.focus();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        items[(idx <= 0 ? items.length : idx) - 1]?.focus();
+        break;
+      case 'Home':
+        e.preventDefault();
+        items[0]?.focus();
+        break;
+      case 'End':
+        e.preventDefault();
+        items[items.length - 1]?.focus();
+        break;
+      case 'Tab':
+        // Don't leave an orphaned menu when focus tabs away.
+        this.menuOpen.set(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  protected onDocumentPointerDown(e: PointerEvent): void {
+    if (!this.menuOpen()) return;
+    const root = this.versionControl()?.nativeElement;
+    if (root && !root.contains(e.target as Node)) {
+      this.menuOpen.set(false);
+    }
+  }
+
+  /** Short relative time for a version row; '' (hidden) if unparseable. */
+  protected relativeLabel(iso: string): string {
+    if (!iso) return '';
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return '';
+    const min = Math.floor((Date.now() - then) / 60000);
+    if (min < 1) return 'just now';
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    return `${Math.floor(hr / 24)}d ago`;
+  }
+
+  private menuItems(): HTMLButtonElement[] {
+    const root = this.versionControl()?.nativeElement;
+    if (!root) return [];
+    return Array.from(
+      root.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+    );
+  }
+
+  private focusSelectedItem(): void {
+    const items = this.menuItems();
+    const current =
+      items.find((b) => b.getAttribute('aria-checked') === 'true') ??
+      items[0];
+    current?.focus();
+  }
+
+  private closeMenuAndRefocus(): void {
+    this.menuOpen.set(false);
+    this.versionControl()
+      ?.nativeElement.querySelector<HTMLButtonElement>(
+        '[aria-haspopup="menu"]',
+      )
+      ?.focus();
   }
 
   protected close(): void {

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -42,7 +42,10 @@
         class="flex flex-col gap-2"
         aria-label="Artifacts from this response"
       >
-        @for (artifact of messageArtifacts; track artifact.artifactId) {
+        @for (
+          artifact of messageArtifacts;
+          track artifact.artifactId + '#' + artifact.version
+        ) {
           <app-artifact-card [artifact]="artifact" />
         }
       </section>
@@ -70,7 +73,10 @@
       class="mt-3 flex flex-col gap-2"
       aria-label="Artifacts created in this conversation"
     >
-      @for (artifact of orphanArtifacts(); track artifact.artifactId) {
+      @for (
+        artifact of orphanArtifacts();
+        track artifact.artifactId + '#' + artifact.version
+      ) {
         <app-artifact-card [artifact]="artifact" />
       }
     </section>

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
@@ -61,12 +61,37 @@ describe('ArtifactStateService', () => {
     expect(svc.get('art-1')?.producedByMessageId).toBeNull();
   });
 
-  it('keeps the highest version for the same id (update_artifact)', () => {
+  it('keeps every version of an artifact as its own entry', () => {
     svc.recordLive(ev({ version: 1 }));
     svc.recordLive(ev({ version: 3, updatedAt: '2026-05-15T12:05:00+00:00' }));
-    svc.recordLive(ev({ version: 2 })); // stale/out-of-order — ignored
+    svc.recordLive(ev({ version: 2, updatedAt: '2026-05-15T12:02:00+00:00' }));
+    // All three versions coexist (one card per version); get() resolves
+    // the highest.
+    expect(svc.artifacts().length).toBe(3);
+    expect(
+      svc
+        .artifacts()
+        .map((a) => a.version)
+        .sort(),
+    ).toEqual([1, 2, 3]);
     expect(svc.get('art-1')?.version).toBe(3);
-    expect(svc.artifacts().length).toBe(1);
+  });
+
+  it('orders versions of one artifact by version when timestamps tie', () => {
+    const at = '2026-05-15T12:00:00+00:00';
+    svc.recordLive(ev({ version: 1, updatedAt: at }));
+    svc.recordLive(ev({ version: 2, updatedAt: at }));
+    expect(svc.artifacts().map((a) => a.version)).toEqual([2, 1]);
+  });
+
+  it('versionsFor returns one artifact’s versions, newest first', () => {
+    svc.recordLive(ev({ artifactId: 'a', version: 1 }));
+    svc.recordLive(ev({ artifactId: 'a', version: 2 }));
+    svc.recordLive(ev({ artifactId: 'a', version: 3 }));
+    svc.recordLive(ev({ artifactId: 'b', version: 1 }));
+    expect(svc.versionsFor('a').map((v) => v.version)).toEqual([3, 2, 1]);
+    expect(svc.versionsFor('b').map((v) => v.version)).toEqual([1]);
+    expect(svc.versionsFor('missing')).toEqual([]);
   });
 
   it('orders artifacts newest update first', () => {
@@ -75,17 +100,50 @@ describe('ArtifactStateService', () => {
     expect(svc.artifacts().map((a) => a.artifactId)).toEqual(['new', 'old']);
   });
 
-  it('hydration does not clobber a higher live version', () => {
+  it('hydration adds older versions alongside a newer live one', () => {
     svc.recordLive(ev({ version: 5, updatedAt: '2026-05-15T12:10:00+00:00' }));
-    const stale: Artifact = {
+    const v2: Artifact = {
       artifactId: 'art-1',
       version: 2,
       title: 'Old',
       contentType: 'text/html; charset=utf-8',
       updatedAt: '2026-05-15T11:00:00+00:00',
     };
-    svc.seedFromHydration([stale]);
+    svc.seedFromHydration([v2]);
+    // Distinct versions coexist (history), get() still resolves latest.
+    expect(svc.artifacts().map((a) => a.version).sort()).toEqual([2, 5]);
     expect(svc.get('art-1')?.version).toBe(5);
+  });
+
+  it('live anchor wins when hydration repeats the same (id, version)', () => {
+    svc.recordLive(ev({ version: 1 }), 'msg-sess-9-3');
+    svc.seedFromHydration([
+      {
+        artifactId: 'art-1',
+        version: 1,
+        title: 'Doc',
+        contentType: 'text/html; charset=utf-8',
+        updatedAt: '2026-05-15T12:00:00+00:00',
+        producedByMessageIndex: 4,
+      },
+    ]);
+    // The live entry's precise per-turn anchor must survive a later
+    // index-only hydration of the same version.
+    expect(svc.get('art-1')?.producedByMessageId).toBe('msg-sess-9-3');
+  });
+
+  it('a live event fills in the anchor a prior hydration row lacked', () => {
+    svc.seedFromHydration([
+      {
+        artifactId: 'art-1',
+        version: 1,
+        title: 'Doc',
+        contentType: 'text/html; charset=utf-8',
+        updatedAt: '2026-05-15T12:00:00+00:00',
+      },
+    ]);
+    svc.recordLive(ev({ version: 1 }), 'msg-sess-9-3');
+    expect(svc.get('art-1')?.producedByMessageId).toBe('msg-sess-9-3');
   });
 
   it('hydration adds artifacts not seen live', () => {

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
@@ -9,17 +9,18 @@ import type { Artifact, OpenArtifactRef } from './artifact.model';
  * session-load hydration path (`seedFromHydration`), and a `reset()`
  * called on session change.
  *
- * Artifacts are keyed by `artifactId` holding only the highest version
- * seen — `update_artifact` emits a new event for the same id and the
- * card should track the latest. Hydration never clobbers a higher
- * version already recorded from a live event (a stale list response can
- * arrive after the user has already driven a newer update this session).
+ * Keyed by `artifactId#version` — every version is its own entry so the
+ * conversation can show one card per version. `update_artifact` emits a
+ * new event for a new version (a new key), not a replacement. When the
+ * same (id, version) arrives from both a live event and reload
+ * hydration, the live entry wins: it carries `producedByMessageId`, the
+ * precise per-turn anchor the index-only hydration row lacks.
  */
 @Injectable({ providedIn: 'root' })
 export class ArtifactStateService {
   private readonly sidenav = inject(SidenavService);
 
-  private readonly byId = signal<Map<string, Artifact>>(new Map());
+  private readonly byKey = signal<Map<string, Artifact>>(new Map());
   private readonly openRef = signal<OpenArtifactRef | null>(null);
 
   /** Sidenav collapsed state captured the moment the panel opened, so a
@@ -38,14 +39,17 @@ export class ArtifactStateService {
     ArtifactStateService.DEFAULT_PANE_WIDTH,
   );
 
-  /** Artifacts for the current session, newest update first. */
+  /** Every artifact version for the current session, newest first.
+   *  Tie-broken by version so versions of one artifact stay ordered
+   *  even when their timestamps are equal or missing. */
   readonly artifacts = computed<Artifact[]>(() =>
-    Array.from(this.byId().values()).sort((a, b) =>
-      b.updatedAt.localeCompare(a.updatedAt),
+    Array.from(this.byKey().values()).sort(
+      (a, b) =>
+        b.updatedAt.localeCompare(a.updatedAt) || b.version - a.version,
     ),
   );
 
-  readonly hasArtifacts = computed(() => this.byId().size > 0);
+  readonly hasArtifacts = computed(() => this.byKey().size > 0);
 
   /** The artifact the side panel is showing, or null when closed. */
   readonly openArtifact = this.openRef.asReadonly();
@@ -72,9 +76,23 @@ export class ArtifactStateService {
     this.paneWidthSignal.set(clamped);
   }
 
-  /** Latest known version of an artifact, if any (used by the card). */
+  /** Highest known version of an artifact, if any. */
   get(artifactId: string): Artifact | undefined {
-    return this.byId().get(artifactId);
+    let latest: Artifact | undefined;
+    for (const a of this.byKey().values()) {
+      if (a.artifactId !== artifactId) continue;
+      if (!latest || a.version > latest.version) latest = a;
+    }
+    return latest;
+  }
+
+  /** Every known version of an artifact, newest first. */
+  versionsFor(artifactId: string): Artifact[] {
+    const out: Artifact[] = [];
+    for (const a of this.byKey().values()) {
+      if (a.artifactId === artifactId) out.push(a);
+    }
+    return out.sort((x, y) => y.version - x.version);
   }
 
   /**
@@ -126,7 +144,7 @@ export class ArtifactStateService {
 
   /** Clear all state — called on session change. */
   reset(): void {
-    this.byId.set(new Map());
+    this.byKey.set(new Map());
     if (this.openRef() !== null) {
       this.openRef.set(null);
       this.restoreNav();
@@ -140,11 +158,14 @@ export class ArtifactStateService {
   }
 
   private upsert(a: Artifact): void {
-    const existing = this.byId().get(a.artifactId);
-    if (existing && existing.version >= a.version) return;
-    this.byId.update((m) => {
+    const key = `${a.artifactId}#${a.version}`;
+    const existing = this.byKey().get(key);
+    // A later reload-hydration call for the same (id, version) must not
+    // drop the live entry's precise per-turn anchor.
+    if (existing?.producedByMessageId && !a.producedByMessageId) return;
+    this.byKey.update((m) => {
       const next = new Map(m);
-      next.set(a.artifactId, a);
+      next.set(key, a);
       return next;
     });
   }


### PR DESCRIPTION
## Summary

Builds on the artifacts feature so the conversation shows **every version** of an artifact as its own card (anchored to the turn that produced it), and adds an accessible **version picker** to the artifact panel header.

### Backend (additive to the frozen #309–#311 DDB contract — verifier/minter read exact PK/SK rows, unaffected)
- Version rows now carry their own `updated_at`.
- `set_produced_by_message_index` stamps the specific **version row** (and HEAD); the stream coordinator passes the turn's version so every version persists its own per-turn anchor.
- `GET /artifacts` returns **all** versions per session artifact via a two-step query: SessionIndex GSI for artifact discovery (ownership-filtered), then a per-artifact main-table `SK begins_with #V#` query. No new GSI, no infra, no backfill.

### Frontend
- `ArtifactStateService` registry re-keyed by `artifactId#version`; `get()` resolves the highest version; `versionsFor()` added; same-`(id, version)` dedup keeps the live entry's precise per-turn anchor over an index-only hydration row.
- `message-list` tracks cards by `artifactId#version` so each version renders as its own card under its producing turn.
- Artifact panel header gets a custom version dropdown: `role=menu` / `menuitemradio`, keyboard nav (Arrow/Home/End/Enter/Esc), outside-click + Tab dismiss, focus management, a **Latest** badge, and relative timestamps. Selecting a version re-points the panel (existing effect re-mints the render token and reloads). Single-version artifacts keep the plain static label.

### Scope decisions
- **No backfill**: artifacts created before this deploys (and any intermediate version produced within the same turn as a later one) lack per-version linkage and degrade gracefully to the end-of-conversation strip. Appropriate for the dev/alpha environment.

## Test plan
- [x] Backend: `pytest` artifact suites green (129 passed — writer, list service, stream coordinator, content, render-token, render-lambda).
- [x] Frontend: artifact-state spec green (16 passed) + full app build compiles clean.
- [ ] Manual on an artifacts-enabled stack: create an artifact, request two modifications → three cards (v1/v2/v3) appear under their respective turns; reload → all three persist and stay anchored.
- [ ] Manual: open the panel → header shows a "Version N" dropdown (latest badged, current checked); pick an older version → panel reloads it, title/badge update; verify keyboard nav, Escape, click-outside; confirm a single-version artifact shows plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)