### PR TITLE
fix(artifacts): allow jsdelivr/unpkg CDNs so Chart.js artifacts render

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/tools.py
+++ b/backend/src/agents/builtin_tools/artifacts/tools.py
@@ -38,8 +38,19 @@ def make_create_artifact_tool(session_id: str, user_id: str):
           document (include `<!doctype html>` and a full `<html>` …
           `</html>`). It renders in a sandboxed iframe with a strict CSP:
           inline `<style>`/`<script>` are allowed, as are scripts from
-          `https://cdn.tailwindcss.com` and `https://esm.sh`. It cannot
-          make network calls.
+          `https://cdn.tailwindcss.com`, `https://esm.sh`,
+          `https://cdn.jsdelivr.net`, and `https://unpkg.com` — no
+          other origin loads. The page cannot make `fetch`/XHR calls
+          (CSP `connect-src` is blocked), so inline any data.
+
+          Load JS libraries from one of those CDNs and pin a version.
+          Chart.js note: use an auto-registering build or charts
+          render blank — e.g.
+          `import Chart from "https://esm.sh/chart.js@4/auto"` inside a
+          `<script type="module">`, or the UMD bundle
+          `<script src="https://cdn.jsdelivr.net/npm/chart.js@4">`. A
+          bare `https://esm.sh/chart.js` import (no `/auto`) silently
+          fails to draw.
 
         - Markdown: pass `content_type="text/markdown"` and provide raw
           GitHub-flavored Markdown as `content`. Do NOT add an HTML

--- a/infrastructure/lib/artifacts-stack.ts
+++ b/infrastructure/lib/artifacts-stack.ts
@@ -182,8 +182,12 @@ export class ArtifactsStack extends cdk.Stack {
         RENDER_TOKEN_SECRET_ARN: renderTokenKeyArn,
         FRAME_ANCESTOR_ORIGIN: frameAncestors,
         // Pinned CSP allow-list. Adjust here if/when the artifact runtime
-        // grows new permitted external script origins (e.g. add chart libs).
-        CSP_SCRIPT_SRC: "'self' 'unsafe-inline' https://cdn.tailwindcss.com https://esm.sh",
+        // grows new permitted external script origins. Keep in exact sync
+        // with the `script-src` line in `cspDirectives` below — the render
+        // Lambda reads this env var, CloudFront stamps the literal, and the
+        // two must be identical (defense in depth).
+        CSP_SCRIPT_SRC:
+          "'self' 'unsafe-inline' https://cdn.tailwindcss.com https://esm.sh https://cdn.jsdelivr.net https://unpkg.com",
       },
     });
 
@@ -230,7 +234,7 @@ export class ArtifactsStack extends cdk.Stack {
     // so other sites can't embed your users' artifacts.
     const cspDirectives = [
       `default-src 'none'`,
-      `script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://esm.sh`,
+      `script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://esm.sh https://cdn.jsdelivr.net https://unpkg.com`,
       `style-src 'self' 'unsafe-inline'`,
       `img-src 'self' data: https:`,
       `font-src 'self' data:`,


### PR DESCRIPTION
## Summary

Chart.js artifacts rendered blank. The artifact-origin CSP `script-src` only allowed `cdn.tailwindcss.com` and `esm.sh`, so Chart.js loaded via its canonical `https://cdn.jsdelivr.net/npm/chart.js` snippet (the form the model is overwhelmingly trained to emit) was refused by the browser.

This is the "both" fix: widen the CSP **and** improve the model-facing authoring guidance.

- **CSP:** add `https://cdn.jsdelivr.net` and `https://unpkg.com` to `script-src`, kept byte-identical across the render Lambda `CSP_SCRIPT_SRC` env var and the CloudFront response-headers policy (defense in depth — both must match). `connect-src 'none'` and all other directives are unchanged.
- **Tool docstring** (`create_artifact`): now lists all four allowed script CDNs, restates that `connect-src` blocks `fetch`/XHR (inline data), and gives a concrete Chart.js pattern that calls out the `chart.js@4/auto` auto-register footgun (a bare `esm.sh/chart.js` import silently draws nothing).

Note: `esm.sh` already serves arbitrary npm, so adding jsdelivr/unpkg does not meaningfully broaden the script trust surface — it matches the existing `cdn.tailwindcss.com` precedent and the design's "libraries come from a CDN" intent.

## Deploy / rollout

- **CSP change** takes effect only after a CDK deploy of the Artifacts stack (CloudFront response-headers-policy + Lambda env update — no data migration, no other stack affected).
- **Docstring change** is live on the next inference-api/agent deploy.

## Test plan

- [x] `backend` artifact + render-Lambda tests pass (`tests/agents/builtin_tools/artifacts/`, `tests/lambdas/test_artifact_render.py` — 90 passed)
- [x] `infrastructure` TypeScript build passes (`npm run build`)
- [ ] After deploying the Artifacts stack: request a Chart.js artifact, confirm it renders and the sandboxed iframe devtools console shows no `script-src` CSP violation
- [ ] Confirm a `cdn.tailwindcss.com` / `esm.sh` artifact still renders (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)