### PR TITLE
feat(chat): recoverable max_tokens truncation with Continue affordance

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -184,6 +184,7 @@ class BaseAgent(ABC):
         citations: Optional[List] = None,
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List[Dict[str, Any]]] = None,
+        continue_truncated: bool = False,
     ) -> AsyncGenerator[str, None]:
         """Stream agent responses. Subclasses must implement.
 
@@ -191,6 +192,12 @@ class BaseAgent(ABC):
         agent turn (Strands interrupt protocol) instead of starting a new
         one. In that case `message`/`files` are ignored — the original turn
         already has the user's prompt in its context.
+
+        When `continue_truncated` is True, the call resumes after a
+        max_tokens truncation: `message`/`files` are ignored and the loop is
+        re-entered with an empty prompt so the model continues the truncated
+        assistant message already in restored history (assistant-prefill),
+        rather than answering a fresh instruction.
         """
         ...
 

--- a/backend/src/agents/main_agent/chat_agent.py
+++ b/backend/src/agents/main_agent/chat_agent.py
@@ -50,6 +50,7 @@ class ChatAgent(BaseAgent):
         citations: Optional[List] = None,
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List[Dict[str, Any]]] = None,
+        continue_truncated: bool = False,
     ) -> AsyncGenerator[str, None]:
         """
         Stream agent responses.
@@ -65,6 +66,12 @@ class ChatAgent(BaseAgent):
             interrupt_responses: When set, resume a paused agent turn by
                 passing this list as the prompt to Strands. Each entry is
                 `{"interruptResponse": {"interruptId": str, "response": Any}}`.
+            continue_truncated: When True, resume after a max_tokens
+                truncation by passing an empty-list prompt to Strands.
+                `_convert_prompt_to_messages([])` appends no message, so the
+                event loop re-runs against restored history whose tail is the
+                truncated assistant message — the model continues it
+                (assistant-prefill) instead of answering a new instruction.
 
         Yields:
             str: SSE formatted events
@@ -78,6 +85,11 @@ class ChatAgent(BaseAgent):
             # interrupts' `.response`, and continues from the paused tool
             # call. multimodal_builder + files do not apply here.
             prompt: Any = interrupt_responses
+        elif continue_truncated:
+            # Empty list → Strands appends nothing → the loop re-runs against
+            # restored history (tail = truncated assistant message). No new
+            # user turn, no multimodal/files.
+            prompt = []
         else:
             prompt = self.multimodal_builder.build_prompt(message, files)
 

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -157,6 +157,29 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         self._total_message_count_at_init = len(agent.messages)
         self.message_count = self._total_message_count_at_init
 
+        # Slice 0 diagnostic: confirm what restored history a turn actually
+        # sees at init. Decisive for the max_tokens "Continue" flow — on the
+        # continuation turn the restored tail must be the truncated assistant
+        # message for the model to resume rather than restart. One concise
+        # line per init (init is not hot-path frequent).
+        try:
+            _msgs = agent.messages or []
+            if _msgs:
+                _last = _msgs[-1]
+                _last_role = _last.get("role")
+                _last_text = ""
+                for _blk in _last.get("content", []) or []:
+                    if isinstance(_blk, dict) and isinstance(_blk.get("text"), str):
+                        _last_text += _blk["text"]
+                logger.info(
+                    "Restore @init: %d message(s); last role=%s, last text len=%d",
+                    len(_msgs), _last_role, len(_last_text),
+                )
+            else:
+                logger.info("Restore @init: 0 messages (new or empty-at-init session)")
+        except Exception:
+            logger.debug("Restore @init: diagnostic log failed", exc_info=True)
+
         # Initialize compaction defaults
         self.compaction_state = CompactionState()
         self._valid_cutoff_indices = []

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -446,42 +446,86 @@ class StreamCoordinator:
                         code=error_code, error=synthetic_error, session_id=session_id, recoverable=error_data.get("recoverable", False)
                     )
 
-                    # Emit message events so error appears in chat
-                    yield f'event: message_start\ndata: {{"role": "assistant"}}\n\n'
-                    yield f'event: content_block_start\ndata: {{"contentBlockIndex": 0, "type": "text"}}\n\n'
-                    yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': conv_error_event.message})}\n\n"
-                    yield f'event: content_block_stop\ndata: {{"contentBlockIndex": 0}}\n\n'
-                    yield f'event: message_stop\ndata: {{"stopReason": "error"}}\n\n'
-                    yield conv_error_event.to_sse_format()
-                    yield "event: done\ndata: {}\n\n"
+                    if error_code == ErrorCode.MAX_TOKENS:
+                        # No verbose assistant bubble for truncation. The model
+                        # stream already emitted its own message_stop
+                        # (stopReason max_tokens) for the partial, so do NOT
+                        # emit a second synthetic message_stop here — a
+                        # duplicate with no active builder flips the client
+                        # parser into an error state and drops the
+                        # stream_error below. Just emit the stream_error
+                        # signal (frontend shows the inline "response length
+                        # limit reached" notice + Continue on the partial) and
+                        # done; `done` finalizes any still-open builder.
+                        yield conv_error_event.to_sse_format()
+                        # Durable marker so the Continue affordance survives a
+                        # page refresh (the partial itself is already in
+                        # AgentCore Memory). Best-effort; never blocks the
+                        # stream. Cleared at the start of the next non-resume
+                        # turn (see invocations route).
+                        try:
+                            from apis.shared.sessions.metadata import set_truncated_turn
+                            await set_truncated_turn(session_id, user_id)
+                        except Exception as marker_err:
+                            logger.error(
+                                "max_tokens: failed to persist truncated_turn marker for session %s: %s",
+                                session_id, marker_err, exc_info=True,
+                            )
+                        yield "event: done\ndata: {}\n\n"
+                    else:
+                        # Other errors still surface as a conversational
+                        # assistant message in the chat.
+                        yield f'event: message_start\ndata: {{"role": "assistant"}}\n\n'
+                        yield f'event: content_block_start\ndata: {{"contentBlockIndex": 0, "type": "text"}}\n\n'
+                        yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': conv_error_event.message})}\n\n"
+                        yield f'event: content_block_stop\ndata: {{"contentBlockIndex": 0}}\n\n'
+                        yield f'event: message_stop\ndata: {{"stopReason": "error"}}\n\n'
+                        yield conv_error_event.to_sse_format()
+                        yield "event: done\ndata: {}\n\n"
 
-                    # Persist error messages to session
-                    try:
-                        from strands.types.content import Message
-                        from strands.types.session import SessionMessage
+                    # Persist error messages to session.
+                    #
+                    # SKIP for max_tokens: Strands already appended the recovered
+                    # partial assistant turn to agent.messages and the
+                    # MessageAddedEvent hook persisted it to AgentCore Memory
+                    # before the exception propagated; the user turn was
+                    # persisted at turn start by the normal hook. Re-persisting
+                    # here would duplicate the user turn and add a SECOND
+                    # consecutive assistant message, breaking Bedrock role
+                    # alternation for the follow-up "Continue" turn. The error
+                    # explanation stays a live-only UI affordance for this turn.
+                    if error_code == ErrorCode.MAX_TOKENS:
+                        logger.info(
+                            f"max_tokens: skipping error re-persist for session {session_id} "
+                            f"(Strands already committed the recovered partial turn)"
+                        )
+                    else:
+                        try:
+                            from strands.types.content import Message
+                            from strands.types.session import SessionMessage
 
-                        from agents.main_agent.session.session_factory import SessionFactory
+                            from agents.main_agent.session.session_factory import SessionFactory
 
-                        persist_session_manager = SessionFactory.create_session_manager(session_id=session_id, user_id=user_id, caching_enabled=False)
+                            persist_session_manager = SessionFactory.create_session_manager(session_id=session_id, user_id=user_id, caching_enabled=False)
 
-                        # Extract user text from prompt (can be string or ContentBlock list)
-                        if isinstance(prompt, str):
-                            user_text = prompt
-                        else:
-                            # Extract text from ContentBlock list
-                            user_text = " ".join(block.get("text", "") for block in prompt if isinstance(block, dict) and "text" in block)
+                            # Extract user text from prompt (can be string or ContentBlock list)
+                            if isinstance(prompt, str):
+                                user_text = prompt
+                            else:
+                                # Extract text from ContentBlock list
+                                user_text = " ".join(block.get("text", "") for block in prompt if isinstance(block, dict) and "text" in block)
 
-                        user_msg: Message = {"role": "user", "content": [{"text": user_text}]}
-                        assistant_msg: Message = {"role": "assistant", "content": [{"text": conv_error_event.message}]}
+                            user_msg: Message = {"role": "user", "content": [{"text": user_text}]}
+                            assistant_msg: Message = {"role": "assistant", "content": [{"text": conv_error_event.message}]}
 
-                        if hasattr(persist_session_manager, "base_manager") and hasattr(persist_session_manager.base_manager, "create_message"):
-                            user_session_msg = SessionMessage.from_message(user_msg, 0)
-                            assistant_session_msg = SessionMessage.from_message(assistant_msg, 1)
-                            persist_session_manager.base_manager.create_message(session_id, "default", user_session_msg)
-                            persist_session_manager.base_manager.create_message(session_id, "default", assistant_session_msg)
-                            logger.info(f"💾 Saved intercepted error messages to session {session_id}")
-                    except Exception as persist_error:
-                        logger.error(f"Failed to persist intercepted error to session: {persist_error}")
+                            if hasattr(persist_session_manager, "base_manager") and hasattr(persist_session_manager.base_manager, "create_message"):
+                                user_session_msg = SessionMessage.from_message(user_msg, 0)
+                                assistant_session_msg = SessionMessage.from_message(assistant_msg, 1)
+                                persist_session_manager.base_manager.create_message(session_id, "default", user_session_msg)
+                                persist_session_manager.base_manager.create_message(session_id, "default", assistant_session_msg)
+                                logger.info(f"💾 Saved intercepted error messages to session {session_id}")
+                        except Exception as persist_error:
+                            logger.error(f"Failed to persist intercepted error to session: {persist_error}")
 
                     # Skip the original error event and exit the loop - we've handled the error
                     return

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -45,6 +45,8 @@ from decimal import Decimal
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, TypedDict
 from uuid import UUID
 
+from strands.types.exceptions import MaxTokensReachedException
+
 from apis.shared.errors import StreamErrorEvent, ErrorCode
 
 logger = logging.getLogger(__name__)
@@ -1478,6 +1480,24 @@ async def process_agent_stream(
                 recoverable=False
             )
             yield _create_event("error", error_event.model_dump(exclude_none=True))
+
+    except MaxTokensReachedException:
+        # The model hit its output-token ceiling mid-turn. Strands has already
+        # appended the recovered partial assistant message (truncated tool uses
+        # swapped for stubs) to agent.messages, and the MessageAddedEvent hook
+        # has persisted it to AgentCore Memory before this exception propagated
+        # — so the turn is recoverable via a follow-up "continue". Emit a
+        # max_tokens-coded error so the coordinator can render an honest,
+        # actionable message and skip the duplicate-persist path. Do NOT leak
+        # the raw SDK message/URL into `detail`.
+        logger.info("Agent stream stopped: max_tokens limit reached (recoverable via continue)")
+        error_event = StreamErrorEvent(
+            error="Response truncated: maximum output length reached",
+            code=ErrorCode.MAX_TOKENS,
+            detail=None,
+            recoverable=True
+        )
+        yield _create_event("error", error_event.model_dump(exclude_none=True))
 
     except Exception as e:
         # ERROR HANDLING: If anything else goes wrong, log it and send an error event

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -57,6 +57,12 @@ class InvocationRequest(BaseModel):
     # new one. `message` is ignored in that case — the original prompt is
     # already in the agent's interrupt context.
     interrupt_responses: Optional[List[InterruptResponseEntry]] = None
+    # When true, this is a "Continue" after a max_tokens truncation. Like a
+    # resume, `message` is ignored: instead of synthesizing a new user turn,
+    # the agent re-enters the loop with an empty prompt so the model
+    # continues the truncated assistant message already in restored history
+    # (assistant-prefill). Bypasses quota / RAG / file resolution like resume.
+    continue_truncated: Optional[bool] = None
     # Selects which agent factory variant builds the turn. Defaults to "chat"
     # (MainAgent / ChatAgent) when omitted, so existing clients are unaffected.
     # Pass "skill" to route through SkillAgent's progressive skill disclosure.

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -629,8 +629,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # they bypass quota, file resolution, and RAG augmentation because those
     # already ran on the original turn that got paused.
     is_resume = bool(input_data.interrupt_responses)
+    # A "Continue" after a max_tokens truncation. Like resume, it bypasses
+    # quota / RAG / file resolution and does NOT clear the turn state; unlike
+    # resume there is no interrupt to validate — the agent is rebuilt from the
+    # resent params and re-entered with an empty prompt (assistant-prefill).
+    is_continuation = bool(input_data.continue_truncated)
     logger.info(
-        "Invocation request received (resume=%s)" % is_resume
+        "Invocation request received (resume=%s, continue_truncated=%s)" % (is_resume, is_continuation)
     )
     logger.info("Message received")
 
@@ -697,13 +702,24 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # later (mistaken) resume request pick up against a turn the user
     # already moved past.
     is_new_session = False
-    if not is_resume:
+    if not is_resume and not is_continuation:
         is_new_session = await ensure_session_metadata_exists(input_data.session_id, user_id)
         try:
             from apis.shared.sessions.metadata import clear_paused_turn
             await clear_paused_turn(input_data.session_id, user_id)
         except Exception as e:
             logger.error("Failed to clear stale paused_turn on new turn: %s", e, exc_info=True)
+
+    # Invalidate any prior max_tokens "Continue" marker on every new model
+    # turn that isn't an interrupt-resume — both a fresh turn and a
+    # continuation supersede it. If a continuation itself re-truncates, the
+    # stream_coordinator intercept re-sets the marker.
+    if not is_resume:
+        try:
+            from apis.shared.sessions.metadata import clear_truncated_turn
+            await clear_truncated_turn(input_data.session_id, user_id)
+        except Exception as e:
+            logger.error("Failed to clear stale truncated_turn on new turn: %s", e, exc_info=True)
 
     # First turn → kick off title generation concurrently with the stream.
     # Runs as a background task so it doesn't add latency to TTFT. The
@@ -721,7 +737,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # Check quota if enforcement is enabled
     quota_warning_event = None
     quota_exceeded_event = None
-    if is_quota_enforcement_enabled() and not is_resume:
+    if is_quota_enforcement_enabled() and not is_resume and not is_continuation:
         try:
             quota_checker = get_quota_checker()
             quota_result = await quota_checker.check_quota(user=current_user, session_id=input_data.session_id)
@@ -780,7 +796,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         "Invocation request - processing with assistant context"
     )
 
-    if input_data.rag_assistant_id and not is_resume:
+    if input_data.rag_assistant_id and not is_resume and not is_continuation:
         # Local imports to avoid circular dependency
         from apis.shared.assistants.rag_service import (
             augment_prompt_with_context,
@@ -1237,6 +1253,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 citations=citations_for_storage if citations_for_storage else None,
                 original_message=input_data.message if message_will_be_modified else None,
                 interrupt_responses=interrupt_responses_payload,
+                continue_truncated=is_continuation,
             ):
                 yield event
 

--- a/backend/src/apis/shared/errors.py
+++ b/backend/src/apis/shared/errors.py
@@ -28,6 +28,7 @@ class ErrorCode(str, Enum):
     TOOL_ERROR = "tool_error"
     MODEL_ERROR = "model_error"
     STREAM_ERROR = "stream_error"
+    MAX_TOKENS = "max_tokens"
 
 
 class ErrorDetail(BaseModel):
@@ -204,6 +205,12 @@ Try breaking it into smaller parts or simplifying your query."""
 
 Please wait a moment and try again."""
 
+    elif code == ErrorCode.MAX_TOKENS:
+        # Not rendered as a chat bubble — the frontend shows a compact
+        # inline "response length limit reached" notice + Continue button
+        # off the stream_error signal. Kept concise for logs / payload.
+        message = "Response length limit reached."
+
     elif code == ErrorCode.STREAM_ERROR:
         if "accessdenied" in error_lower or "access denied" in error_lower:
             message = f"""⚠️ I don't have access to complete this request.
@@ -241,9 +248,13 @@ Please try again."""
 
 Please try again."""
 
-    metadata = {}
+    metadata: Dict[str, Any] = {}
     if session_id:
         metadata["session_id"] = session_id
+    if code == ErrorCode.MAX_TOKENS:
+        # Machine-readable hint so the frontend can offer a "Continue"
+        # affordance without parsing the human-readable message.
+        metadata["error_kind"] = "max_tokens"
 
     return ConversationalErrorEvent(
         code=code,

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -1919,3 +1919,83 @@ async def clear_paused_turn(session_id: str, user_id: str) -> None:
         logger.info("Cleared paused_turn for session %s", session_id)
     except Exception as e:
         logger.error("Failed to clear paused_turn: %s", e, exc_info=True)
+
+
+async def set_truncated_turn(session_id: str, user_id: str) -> None:
+    """Mark that the last turn ended in a recoverable max_tokens truncation.
+
+    Lets the client re-show the "Continue" affordance after a page refresh
+    (the truncated partial assistant message is already in AgentCore Memory;
+    this flag is the only missing piece). Idempotent overwrite. Best-effort:
+    a write failure logs but never breaks the live SSE flow. No-op when the
+    session record is missing or the table env var is unset.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        logger.warning("DYNAMODB_SESSIONS_METADATA_TABLE_NAME not set; skipping truncated_turn persistence")
+        return
+
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            logger.info("Skipping truncated_turn write — session %s not found", session_id)
+            return
+
+        sk = existing.get("SK")
+        if not sk:
+            logger.warning("Session %s has no SK; cannot update truncated_turn", session_id)
+            return
+
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="SET #ltc = :ltc",
+            ExpressionAttributeNames={"#ltc": "lastTurnContinuable"},
+            ExpressionAttributeValues={":ltc": True},
+        )
+        logger.info("Persisted truncated_turn marker for session %s", session_id)
+    except Exception as e:
+        logger.error("Failed to persist truncated_turn: %s", e, exc_info=True)
+
+
+async def clear_truncated_turn(session_id: str, user_id: str) -> None:
+    """Drop the truncated-turn marker.
+
+    Called at the start of any new turn that isn't an interrupt-resume
+    (fresh turn or a max_tokens continuation), so a stale marker can't
+    resurrect "Continue" against a turn the user moved past. If a
+    continuation itself re-truncates, the intercept re-sets the marker.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        return
+
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            return
+
+        sk = existing.get("SK")
+        if not sk:
+            return
+
+        if "lastTurnContinuable" not in existing:
+            return  # Already clear
+
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="REMOVE #ltc",
+            ExpressionAttributeNames={"#ltc": "lastTurnContinuable"},
+        )
+        logger.info("Cleared truncated_turn for session %s", session_id)
+    except Exception as e:
+        logger.error("Failed to clear truncated_turn: %s", e, exc_info=True)

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -185,6 +185,11 @@ class SessionMetadata(BaseModel):
         alias="pausedTurn",
         description="Agent-construction snapshot for a turn paused on OAuth consent; cleared on successful resume or when a new turn supersedes it",
     )
+    last_turn_continuable: Optional[bool] = Field(
+        default=None,
+        alias="lastTurnContinuable",
+        description="True when the last turn ended in a recoverable max_tokens truncation; lets the 'Continue' affordance survive a page refresh. Cleared at the start of any new (non-interrupt-resume) turn",
+    )
 
     # Denormalized cost + context aggregates for the session-cost badge.
     # Maintained by _bump_session_aggregates after each turn (write-time
@@ -266,6 +271,11 @@ class SessionMetadataResponse(BaseModel):
         default=None,
         alias="totalSummarizedTurns",
         description="Cumulative count of turns rolled into a compaction summary in this session",
+    )
+    last_turn_continuable: Optional[bool] = Field(
+        default=None,
+        alias="lastTurnContinuable",
+        description="True when the last turn ended in a recoverable max_tokens truncation, so the client can re-show the 'Continue' affordance after a refresh",
     )
 
 

--- a/backend/tests/agents/main_agent/streaming/test_stream_processor.py
+++ b/backend/tests/agents/main_agent/streaming/test_stream_processor.py
@@ -19,6 +19,7 @@ from agents.main_agent.streaming.stream_processor import (
     _handle_reasoning_events,
     _handle_tool_events,
     _serialize_object,
+    process_agent_stream,
 )
 
 
@@ -787,3 +788,52 @@ class TestProcessedEventStructure:
             "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
         })
         self._assert_structure(events)
+
+
+class TestProcessAgentStreamMaxTokens:
+    """MaxTokensReachedException is classified as a recoverable max_tokens
+    error event (not the generic stream_error) and never leaks the raw SDK
+    message/URL."""
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_emits_recoverable_error_event(self):
+        from strands.types.exceptions import MaxTokensReachedException
+
+        async def mock_stream():
+            yield {"start_event_loop": True}
+            raise MaxTokensReachedException(
+                "Agent has reached an unrecoverable state due to max_tokens "
+                "limit. For more information see: https://strandsagents.com/x"
+            )
+
+        events = []
+        async for ev in process_agent_stream(mock_stream()):
+            events.append(ev)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+        data = error_events[0]["data"]
+        assert data["code"] == "max_tokens"
+        assert data["recoverable"] is True
+        # detail is None and excluded — no leaked SDK URL/raw exception text.
+        assert "strandsagents.com" not in str(data)
+        assert "unrecoverable" not in str(data).lower()
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_still_stream_error(self):
+        """Regression: a non-max_tokens exception still maps to the
+        non-recoverable generic stream_error."""
+
+        async def mock_stream():
+            yield {"start_event_loop": True}
+            raise RuntimeError("totally unrelated boom")
+
+        events = []
+        async for ev in process_agent_stream(mock_stream()):
+            events.append(ev)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+        data = error_events[0]["data"]
+        assert data["code"] == "stream_error"
+        assert data["recoverable"] is False

--- a/backend/tests/agents/main_agent/test_chat_agent_continue.py
+++ b/backend/tests/agents/main_agent/test_chat_agent_continue.py
@@ -1,0 +1,70 @@
+"""ChatAgent.stream_async continuation-after-max_tokens behavior.
+
+A `continue_truncated=True` call must NOT synthesize a new user prompt: it
+forwards an empty-list prompt so Strands appends no message and the model
+resumes the truncated assistant message already in restored history.
+"""
+
+import pytest
+
+from agents.main_agent.chat_agent import ChatAgent
+
+
+class _RecordingCoordinator:
+    """Captures the prompt stream_async forwards to the coordinator."""
+
+    def __init__(self):
+        self.captured = {}
+
+    async def stream_response(self, **kwargs):
+        self.captured = kwargs
+        if False:  # pragma: no cover - make this an async generator
+            yield ""
+
+
+class _ExplodingMultimodalBuilder:
+    """build_prompt must never be called on the continuation path."""
+
+    def build_prompt(self, message, files):  # noqa: D401
+        raise AssertionError("multimodal build_prompt called on continuation path")
+
+
+def _bare_chat_agent(coordinator, multimodal):
+    agent = object.__new__(ChatAgent)
+    agent.agent = object()  # truthy so _create_agent() is skipped
+    agent.stream_coordinator = coordinator
+    agent.multimodal_builder = multimodal
+    agent.session_manager = object()
+    agent.session_id = "sess-1"
+    agent.user_id = "user-1"
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_continue_truncated_forwards_empty_list_prompt():
+    coordinator = _RecordingCoordinator()
+    agent = _bare_chat_agent(coordinator, _ExplodingMultimodalBuilder())
+
+    async for _ in agent.stream_async(
+        "this message text must be ignored",
+        continue_truncated=True,
+    ):
+        pass
+
+    assert coordinator.captured.get("prompt") == []
+
+
+@pytest.mark.asyncio
+async def test_normal_turn_still_uses_multimodal_builder():
+    coordinator = _RecordingCoordinator()
+
+    class _Builder:
+        def build_prompt(self, message, files):
+            return f"built:{message}"
+
+    agent = _bare_chat_agent(coordinator, _Builder())
+
+    async for _ in agent.stream_async("hello", continue_truncated=False):
+        pass
+
+    assert coordinator.captured.get("prompt") == "built:hello"

--- a/backend/tests/shared/test_models_and_utils.py
+++ b/backend/tests/shared/test_models_and_utils.py
@@ -244,6 +244,27 @@ class TestErrors:
         evt = build_conversational_error_event(ErrorCode.SERVICE_UNAVAILABLE, Exception("down"))
         assert "unavailable" in evt.message.lower()
 
+    def test_build_conversational_error_max_tokens(self):
+        from apis.shared.errors import build_conversational_error_event, ErrorCode
+        # The raw SDK message carries a strandsagents.com URL we must NOT leak.
+        raw = Exception(
+            "Agent has reached an unrecoverable state due to max_tokens limit. "
+            "For more information see: https://strandsagents.com/x"
+        )
+        evt = build_conversational_error_event(
+            ErrorCode.MAX_TOKENS, raw, session_id="s1", recoverable=True
+        )
+        # Concise, not rendered as a bubble — the UI owns the wording.
+        assert "limit" in evt.message.lower()
+        # No leaked SDK URL or raw exception text.
+        assert "strandsagents.com" not in evt.message
+        assert "unrecoverable" not in evt.message.lower()
+        # Recoverable + machine-readable hint for the frontend affordance.
+        assert evt.recoverable is True
+        assert evt.code == ErrorCode.MAX_TOKENS
+        assert evt.metadata["error_kind"] == "max_tokens"
+        assert evt.metadata["session_id"] == "s1"
+
 
 # ===================================================================
 # sessions/metadata.py — pure functions

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -74,6 +74,51 @@ class TestGetSessionMetadata:
         assert result is None
 
 
+class TestTruncatedTurnMarker:
+    """Refresh-survival marker for the max_tokens 'Continue' affordance."""
+
+    @pytest.mark.asyncio
+    async def test_set_then_clear(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_truncated_turn,
+            clear_truncated_turn,
+        )
+        await store_session_metadata(session_id="s1", user_id="u1", session_metadata=_make_session_metadata())
+
+        # Default: not continuable.
+        result = await get_session_metadata("s1", "u1")
+        assert not result.last_turn_continuable
+
+        await set_truncated_turn("s1", "u1")
+        result = await get_session_metadata("s1", "u1")
+        assert result.last_turn_continuable is True
+
+        await clear_truncated_turn("s1", "u1")
+        result = await get_session_metadata("s1", "u1")
+        assert not result.last_turn_continuable
+
+    @pytest.mark.asyncio
+    async def test_survives_response_round_trip(self, sessions_metadata_table):
+        # Exact contract the metadata endpoint uses:
+        # SessionMetadataResponse.model_validate(metadata.model_dump(by_alias=True))
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_truncated_turn,
+        )
+        from apis.shared.sessions.models import SessionMetadataResponse
+
+        await store_session_metadata(session_id="s2", user_id="u1", session_metadata=_make_session_metadata(session_id="s2"))
+        await set_truncated_turn("s2", "u1")
+        meta = await get_session_metadata("s2", "u1")
+
+        resp = SessionMetadataResponse.model_validate(meta.model_dump(by_alias=True))
+        assert resp.last_turn_continuable is True
+        assert resp.model_dump(by_alias=True)["lastTurnContinuable"] is True
+
+
 class TestGetAllMessageMetadata:
     @pytest.mark.asyncio
     async def test_get_cost_records(self, sessions_metadata_table):

--- a/frontend/ai.client/src/app/services/error/error.service.ts
+++ b/frontend/ai.client/src/app/services/error/error.service.ts
@@ -23,6 +23,7 @@ export enum ErrorCode {
   TOOL_ERROR = 'tool_error',
   MODEL_ERROR = 'model_error',
   STREAM_ERROR = 'stream_error',
+  MAX_TOKENS = 'max_tokens',
 
   // Client-side errors
   NETWORK_ERROR = 'network_error',
@@ -298,6 +299,7 @@ export class ErrorService {
       [ErrorCode.TOOL_ERROR]: 'Tool Error',
       [ErrorCode.MODEL_ERROR]: 'Model Error',
       [ErrorCode.STREAM_ERROR]: 'Stream Error',
+      [ErrorCode.MAX_TOKENS]: 'Response Truncated',
       [ErrorCode.NETWORK_ERROR]: 'Network Error',
       [ErrorCode.UNKNOWN_ERROR]: 'Error',
     };

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -252,7 +252,8 @@
             [messages]="messages()"
             [isChatLoading]="isChatLoading()"
             [streamingMessageId]="streamingMessageId()"
-            [embeddedMode]="true" />
+            [embeddedMode]="true"
+            (continueRequested)="continueRequested.emit()" />
         </div>
       </div>
 
@@ -318,7 +319,8 @@
         <app-message-list
           [messages]="messages()"
           [isChatLoading]="isChatLoading()"
-          [streamingMessageId]="streamingMessageId()" />
+          [streamingMessageId]="streamingMessageId()"
+          (continueRequested)="continueRequested.emit()" />
       </div>
     </div>
 

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -108,6 +108,7 @@ export class ChatContainerComponent {
 
   // Output events
   messageSubmitted = output<{ content: string; timestamp: Date; fileUploadIds?: string[] }>();
+  continueRequested = output<void>();
   messageCancelled = output<void>();
   fileAttached = output<File>();
   settingsToggled = output<void>();

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { provideMarkdown, MarkdownService } from 'ngx-markdown';
+import { MessageActionsComponent } from './message-actions.component';
+import { Message } from '../../../services/models/message.model';
+
+function makeMessage(text: string): Message {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  };
+}
+
+function continueButton(fixture: ComponentFixture<MessageActionsComponent>): HTMLButtonElement | null {
+  return fixture.nativeElement.querySelector(
+    'button[aria-label="Continue the truncated response"]',
+  );
+}
+
+describe('MessageActionsComponent — Continue affordance', () => {
+  let fixture: ComponentFixture<MessageActionsComponent>;
+  let component: MessageActionsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessageActionsComponent],
+      providers: [provideMarkdown()],
+    }).compileComponents();
+
+    const markdownService = TestBed.inject(MarkdownService);
+    markdownService.parse = () => '';
+
+    fixture = TestBed.createComponent(MessageActionsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('message', makeMessage('partial answer'));
+  });
+
+  it('hides the Continue button by default', () => {
+    fixture.detectChanges();
+    expect(continueButton(fixture)).toBeNull();
+  });
+
+  it('shows the Continue button when canContinue is true', () => {
+    fixture.componentRef.setInput('canContinue', true);
+    fixture.detectChanges();
+    expect(continueButton(fixture)).not.toBeNull();
+  });
+
+  it('emits continueRequested when the Continue button is clicked', () => {
+    fixture.componentRef.setInput('canContinue', true);
+    fixture.detectChanges();
+
+    let emitted = 0;
+    component.continueRequested.subscribe(() => emitted++);
+
+    continueButton(fixture)!.click();
+    expect(emitted).toBe(1);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.ts
@@ -4,12 +4,13 @@ import {
   computed,
   inject,
   input,
+  output,
   PLATFORM_ID,
   signal,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroSquare2Stack, heroCheck } from '@ng-icons/heroicons/outline';
+import { heroSquare2Stack, heroCheck, heroArrowPath } from '@ng-icons/heroicons/outline';
 import { MarkdownService } from 'ngx-markdown';
 import { Message, isTextContentBlock } from '../../../services/models/message.model';
 import { TooltipDirective } from '../../../../components/tooltip';
@@ -18,7 +19,7 @@ import { TooltipDirective } from '../../../../components/tooltip';
   selector: 'app-message-actions',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, TooltipDirective],
-  providers: [provideIcons({ heroSquare2Stack, heroCheck })],
+  providers: [provideIcons({ heroSquare2Stack, heroCheck, heroArrowPath })],
   template: `
     <div class="flex items-center gap-1">
       <button
@@ -36,6 +37,23 @@ import { TooltipDirective } from '../../../../components/tooltip';
           <ng-icon name="heroSquare2Stack" class="size-4" aria-hidden="true" />
         }
       </button>
+
+      @if (canContinue()) {
+        <span class="pl-1 text-xs text-gray-500 dark:text-gray-400">
+          Response length limit reached
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-300 dark:hover:bg-blue-950/40"
+          appTooltip="Resume response"
+          appTooltipPosition="top"
+          aria-label="Continue the truncated response"
+          (click)="continueRequested.emit()"
+        >
+          <ng-icon name="heroArrowPath" class="size-4" aria-hidden="true" />
+          <span>Continue</span>
+        </button>
+      }
     </div>
   `,
   styles: `
@@ -58,6 +76,13 @@ export class MessageActionsComponent {
   private markdown = inject(MarkdownService);
 
   message = input.required<Message>();
+
+  /** Show a "Continue" button when this is the last assistant message of a
+   *  recoverable max_tokens-truncated turn. */
+  canContinue = input<boolean>(false);
+
+  /** Emitted when the user asks to continue the truncated response. */
+  continueRequested = output<void>();
 
   protected copied = signal(false);
   private resetTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -19,7 +19,10 @@
                 <app-assistant-message class="min-w-0 block" [message]="message" [isStreaming]="message.id === streamingMessageId()"></app-assistant-message>
             </div>
             <div class="mt-1 flex justify-start">
-                <app-message-actions [message]="message"></app-message-actions>
+                <app-message-actions
+                  [message]="message"
+                  [canContinue]="canContinueFor(message.id)"
+                  (continueRequested)="continueRequested.emit()"></app-message-actions>
             </div>
             <div class="invisible mt-1 flex flex-wrap items-center gap-2 opacity-0 transition-opacity duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100" aria-live="polite" aria-atomic="true">
                 @if (message.metadata) {

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, signal, effect, OnDestroy, inject, PLATFORM_ID } from '@angular/core';
+import { Component, computed, input, output, signal, effect, OnDestroy, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { Message } from '../../services/models/message.model';
 import type { Artifact } from '../../services/artifacts/artifact.model';
@@ -23,6 +23,7 @@ import {
   ToolApprovalService,
 } from '../../../services/tool-approval/tool-approval.service';
 import { CompactionSummaryService } from '../../services/chat/compaction-summary.service';
+import { ChatStateService } from '../../services/chat/chat-state.service';
 
 @Component({
   selector: 'app-message-list',
@@ -56,10 +57,32 @@ export class MessageListComponent implements OnDestroy {
   streamingMessageId = input<string | null>(null);
   embeddedMode = input<boolean>(false);
 
+  /** Bubbled up when the user clicks "Continue" on a max_tokens-truncated
+   *  assistant message. The page reuses the normal submit path with a
+   *  canned prompt. */
+  continueRequested = output<void>();
+
   private consentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
+  private chatStateService = inject(ChatStateService);
+
+  /** Only the final message of a recoverable max_tokens turn gets the
+   *  "Continue" affordance. Live-only state, never shown while a new
+   *  response is streaming. */
+  private readonly lastMessageId = computed<string | null>(() => {
+    const m = this.messages();
+    return m.length ? m[m.length - 1].id : null;
+  });
+
+  protected canContinueFor(messageId: string): boolean {
+    return (
+      this.chatStateService.lastTurnContinuable() &&
+      !this.isChatLoading() &&
+      messageId === this.lastMessageId()
+    );
+  }
 
   /** Session artifacts, newest first. Anchored ones render inline after
    *  their producing assistant message (`producedByMessageIndex` matches

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -43,8 +43,8 @@ describe('ChatRequestService', () => {
         ChatRequestService,
         { provide: ChatHttpService, useValue: mockChatHttpService },
         { provide: Router, useValue: mockRouter },
-        { provide: ChatStateService, useValue: { setChatLoading: vi.fn() } },
-        { provide: MessageMapService, useValue: { addUserMessage: vi.fn(), startStreaming: vi.fn(), endStreaming: vi.fn() } },
+        { provide: ChatStateService, useValue: { setChatLoading: vi.fn(), setLastTurnContinuable: vi.fn(), createNewAbortController: vi.fn() } },
+        { provide: MessageMapService, useValue: { addUserMessage: vi.fn(), startStreaming: vi.fn(), beginContinuationStreaming: vi.fn(), endStreaming: vi.fn() } },
         { provide: SessionService, useValue: { addSessionToCache: vi.fn() } },
         { provide: UserService, useValue: { getUser: vi.fn().mockReturnValue({ user_id: 'user1' }) } },
         { provide: ModelService, useValue: mockModelService },
@@ -102,5 +102,34 @@ describe('ChatRequestService', () => {
     await expect(service.submitChatRequest('Hello', 'session1')).rejects.toThrow(
       'No model selected. Please select a model before sending a message.'
     );
+  });
+
+  describe('continueTruncatedTurn', () => {
+    it('sends continue_truncated with an empty message', async () => {
+      await service.continueTruncatedTurn('session1', 'assistant1');
+
+      expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '',
+          session_id: 'session1',
+          continue_truncated: true,
+          rag_assistant_id: 'assistant1',
+        }),
+      );
+    });
+
+    it('does NOT add a user message (no visible bubble); uses continuation streaming', async () => {
+      const messageMap = TestBed.inject(MessageMapService) as any;
+      await service.continueTruncatedTurn('session1');
+
+      expect(messageMap.addUserMessage).not.toHaveBeenCalled();
+      expect(messageMap.startStreaming).not.toHaveBeenCalled();
+      expect(messageMap.beginContinuationStreaming).toHaveBeenCalledWith('session1');
+    });
+
+    it('is a no-op without a session id', async () => {
+      await service.continueTruncatedTurn(null);
+      expect(mockChatHttpService.sendChatRequest).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -68,6 +68,10 @@ export class ChatRequestService implements OnDestroy {
   ): Promise<void> {
     // Ensure conversation exists and get its ID
     // Update URL to reflect current conversation
+    // Any new send (including a "Continue") retires the previous turn's
+    // max_tokens "Continue" affordance immediately, before the stream starts.
+    this.chatStateService.setLastTurnContinuable(false);
+
     const isNewSession = !sessionId;
     sessionId = sessionId || uuidv4();
 
@@ -112,6 +116,52 @@ export class ChatRequestService implements OnDestroy {
       this.chatStateService.setChatLoading(false);
       this.messageMapService.endStreaming();
       throw error; // Re-throw to allow caller to handle
+    }
+  }
+
+  /**
+   * "Continue" after a max_tokens truncation. Modeled on the OAuth/tool
+   * resume flow, NOT on submitChatRequest: no user message is added (no
+   * visible bubble, no new user turn) so the model resumes the truncated
+   * assistant message in restored history instead of answering a fresh
+   * instruction. The full request object is sent so the backend rebuilds
+   * the same agent shape; `continue_truncated` makes it re-enter the loop
+   * with an empty prompt.
+   */
+  async continueTruncatedTurn(
+    sessionId: string | null,
+    assistantId?: string,
+  ): Promise<void> {
+    if (!sessionId) {
+      return;
+    }
+
+    // Hide the affordance immediately; retire any stale continuable state.
+    this.chatStateService.setLastTurnContinuable(false);
+
+    // Continuation streaming: pins the existing messages (history +
+    // truncated partial + error bubble) as a stable prefix and appends the
+    // continuation after them, instead of the normal sync which would
+    // truncate back to the last user message and drop the partial. Also
+    // resets the parser (with the correct starting count) so the resumed
+    // stream is treated as a fresh batch.
+    this.messageMapService.beginContinuationStreaming(sessionId);
+    this.chatStateService.createNewAbortController();
+    this.chatStateService.setChatLoading(true);
+
+    // Reuse the normal request shape so the backend rebuilds the same
+    // model/tools/assistant agent, but with an empty message and the
+    // continuation flag. No addUserMessage call → no user bubble.
+    const requestObject = this.buildChatRequestObject('', sessionId, undefined, assistantId);
+    requestObject['message'] = '';
+    requestObject['continue_truncated'] = true;
+
+    try {
+      await this.chatHttpService.sendChatRequest(requestObject);
+    } catch (error) {
+      this.chatStateService.setChatLoading(false);
+      this.messageMapService.endStreaming();
+      throw error;
     }
   }
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
@@ -40,15 +40,31 @@ describe('ChatStateService', () => {
     });
   });
 
+  describe('setLastTurnContinuable', () => {
+    it('defaults to false', () => {
+      expect(service.lastTurnContinuable()).toBe(false);
+    });
+
+    it('toggles the continuable flag', () => {
+      service.setLastTurnContinuable(true);
+      expect(service.lastTurnContinuable()).toBe(true);
+
+      service.setLastTurnContinuable(false);
+      expect(service.lastTurnContinuable()).toBe(false);
+    });
+  });
+
   describe('resetState', () => {
     it('should reset all state to initial values', () => {
       service.setChatLoading(true);
       service.setStopReason('stop');
-      
+      service.setLastTurnContinuable(true);
+
       service.resetState();
-      
+
       expect(service.isChatLoading()).toBe(false);
       expect(service.currentStopReason()).toBeNull();
+      expect(service.lastTurnContinuable()).toBe(false);
     });
   });
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -12,6 +12,13 @@ export class ChatStateService {
     private readonly stopReason = signal<string | null>(null);
     readonly currentStopReason: Signal<string | null> = this.stopReason.asReadonly();
 
+    // True when the most recent turn ended in a recoverable max_tokens
+    // truncation. Drives the "Continue" affordance on the last assistant
+    // message. Live-only (not hydrated on reload); set from the stream_error
+    // event and cleared the moment a new turn starts.
+    private readonly lastTurnContinuableSignal = signal(false);
+    readonly lastTurnContinuable: Signal<boolean> = this.lastTurnContinuableSignal.asReadonly();
+
     // ----- Session-level cost / context aggregates ---------------------------
     // Drive the cost badge above the composer. Seeded from session metadata
     // on route change, then incrementally updated via the SSE metadata event
@@ -47,6 +54,14 @@ export class ChatStateService {
      */
     setStopReason(reason: string | null): void {
         this.stopReason.set(reason);
+    }
+
+    /**
+     * Marks (or clears) whether the last turn ended in a recoverable
+     * max_tokens truncation that the user can continue from.
+     */
+    setLastTurnContinuable(continuable: boolean): void {
+        this.lastTurnContinuableSignal.set(continuable);
     }
 
     /**
@@ -87,6 +102,7 @@ export class ChatStateService {
     resetState(): void {
         this.chatLoading.set(false);
         this.stopReason.set(null);
+        this.lastTurnContinuableSignal.set(false);
         this.costDollarsSignal.set(0);
         this.contextTokensSignal.set(0);
         this.contextWindowSignal.set(0);

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.spec.ts
@@ -349,3 +349,86 @@ describe('StreamParserService - Citation Handling', () => {
     });
   });
 });
+
+describe('StreamParserService - max_tokens Continue affordance', () => {
+  let service: StreamParserService;
+  let chatState: ChatStateService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        StreamParserService,
+        ChatStateService,
+        ErrorService,
+        QuotaWarningService,
+      ],
+    });
+    service = TestBed.inject(StreamParserService);
+    chatState = TestBed.inject(ChatStateService);
+    service.reset();
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('marks the last turn continuable on a max_tokens stream_error', () => {
+    expect(chatState.lastTurnContinuable()).toBe(false);
+
+    service.parseEventSourceMessage('stream_error', {
+      type: 'stream_error',
+      code: 'max_tokens',
+      message: 'I reached my response-length limit.',
+      recoverable: true,
+      metadata: { error_kind: 'max_tokens' },
+    });
+
+    expect(chatState.lastTurnContinuable()).toBe(true);
+  });
+
+  it('does not mark continuable for a non-max_tokens stream_error', () => {
+    service.parseEventSourceMessage('stream_error', {
+      type: 'stream_error',
+      code: 'stream_error',
+      message: 'Something went wrong.',
+      recoverable: false,
+    });
+
+    expect(chatState.lastTurnContinuable()).toBe(false);
+  });
+
+  it('retires the affordance when the next assistant turn starts streaming', () => {
+    service.parseEventSourceMessage('stream_error', {
+      type: 'stream_error',
+      code: 'max_tokens',
+      message: 'truncated',
+      recoverable: true,
+      metadata: { error_kind: 'max_tokens' },
+    });
+    expect(chatState.lastTurnContinuable()).toBe(true);
+
+    service.parseEventSourceMessage('message_start', { role: 'assistant' });
+    expect(chatState.lastTurnContinuable()).toBe(false);
+  });
+
+  it('processes a terminal stream_error even after the stream completed', () => {
+    // Reproduces the dropped-affordance bug: the parser reaches a
+    // terminal state (message_start sets currentStreamId; done →
+    // Completed), then the max_tokens stream_error arrives last. It must
+    // still be processed (always-allowed) so Continue appears.
+    service.parseEventSourceMessage('message_start', { role: 'assistant' });
+    service.parseEventSourceMessage('done', null);
+    expect(chatState.lastTurnContinuable()).toBe(false);
+
+    service.parseEventSourceMessage('stream_error', {
+      type: 'stream_error',
+      code: 'max_tokens',
+      message: 'Response length limit reached.',
+      recoverable: true,
+      metadata: { error_kind: 'max_tokens' },
+    });
+
+    expect(chatState.lastTurnContinuable()).toBe(true);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -6,6 +6,7 @@ import { ChatStateService } from './chat-state.service';
 import { v4 as uuidv4 } from 'uuid';
 import {
   ErrorService,
+  ErrorCode,
   StreamErrorEvent,
   ConversationalStreamError,
 } from '../../../services/error/error.service';
@@ -217,8 +218,14 @@ export class StreamParserService {
     // Check if we should process this event
     // oauth_required arrives after message_stop/done by design (see CLAUDE.md SSE
     // table) — allow it through even when the stream state is Completed.
+    // stream_error is a terminal signal that likewise arrives after
+    // message_stop (e.g. max_tokens truncation) and must never be dropped by
+    // state gating, or recovery affordances (Continue) silently disappear.
     const isAlwaysAllowedEvent =
-      event === 'message_start' || event === 'error' || event === 'oauth_required';
+      event === 'message_start' ||
+      event === 'error' ||
+      event === 'oauth_required' ||
+      event === 'stream_error';
     if (!isAlwaysAllowedEvent && !this.shouldProcessEvent()) {
       return;
     }
@@ -375,8 +382,19 @@ export class StreamParserService {
       },
 
       onError: (data) => this.handleError(data),
-      onStreamError: (data) =>
-        this.errorService.handleConversationalStreamError(data as ConversationalStreamError),
+      onStreamError: (data) => {
+        const streamError = data as ConversationalStreamError;
+        this.errorService.handleConversationalStreamError(streamError);
+        // A max_tokens truncation is recoverable: Strands already persisted
+        // the partial assistant turn, so the user can continue from it.
+        // Surface the "Continue" affordance on the last assistant message.
+        const isMaxTokens =
+          streamError.code === ErrorCode.MAX_TOKENS ||
+          streamError.metadata?.['error_kind'] === 'max_tokens';
+        if (isMaxTokens) {
+          this.chatStateService.setLastTurnContinuable(true);
+        }
+      },
 
       onParseError: (message) => this.setError(message),
     };
@@ -406,6 +424,10 @@ export class StreamParserService {
 
     // Clear stopReason in ChatStateService
     this.chatStateService.setStopReason(null);
+
+    // A new assistant turn is streaming — retire any stale "Continue"
+    // affordance from a previous max_tokens truncation.
+    this.chatStateService.setLastTurnContinuable(false);
 
     // Compute predictable message ID
     const completedCount = this.completedMessages().length;

--- a/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
@@ -44,6 +44,10 @@ export interface SessionMetadata {
    *  summary in this session. Drives the end-of-conversation summary
    *  indicator after a refresh. */
   totalSummarizedTurns?: number;
+  /** True when the last turn ended in a recoverable max_tokens truncation.
+   *  Lets the "Continue" affordance survive a page refresh. Cleared
+   *  server-side at the start of any new (non-interrupt-resume) turn. */
+  lastTurnContinuable?: boolean;
 }
 
 // Request model for updating session metadata

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -22,6 +22,17 @@ export class MessageMapService {
   private activeStreamSessionId = signal<string | null>(null);
 
   /**
+   * Continuation-after-max_tokens state. A "Continue" turn has NO new user
+   * message, so the normal sync (which truncates back to the last user
+   * message and replaces everything after it) would discard the truncated
+   * partial + error bubbles and show only the continuation. In continuation
+   * mode we instead pin a stable prefix (the messages that existed when the
+   * continuation started) and append the continuation stream after it.
+   */
+  private continuationSessionId: string | null = null;
+  private continuationPrefix: Message[] = [];
+
+  /**
    * Tracks which session is currently loading messages from the API.
    * Used to show skeleton loading state when navigating to a session.
    */
@@ -66,6 +77,10 @@ export class MessageMapService {
   startStreaming(sessionId: string): void {
     this.activeStreamSessionId.set(sessionId);
 
+    // A normal turn uses the standard (truncate-to-last-user) sync.
+    this.continuationSessionId = null;
+    this.continuationPrefix = [];
+
     // Get current message count for this session to enable predictable ID generation
     const currentMessages = this.messageMap()[sessionId]?.() ?? [];
     const messageCount = currentMessages.length;
@@ -83,13 +98,39 @@ export class MessageMapService {
   }
 
   /**
+   * Start a "Continue" stream after a max_tokens truncation. Unlike
+   * {@link startStreaming}, the messages that already exist (including the
+   * truncated partial and the error bubble) are pinned as a stable prefix
+   * and the continuation stream is appended after them — nothing is
+   * truncated away. The parser is reset with the current message count so
+   * the continuation's message IDs follow the prefix instead of colliding.
+   */
+  beginContinuationStreaming(sessionId: string): void {
+    this.activeStreamSessionId.set(sessionId);
+
+    const currentMessages = this.messageMap()[sessionId]?.() ?? [];
+    this.continuationSessionId = sessionId;
+    this.continuationPrefix = [...currentMessages];
+
+    this.streamParser.reset(sessionId, currentMessages.length);
+
+    if (!this.messageMap()[sessionId]) {
+      this.messageMap.update(map => ({
+        ...map,
+        [sessionId]: signal<Message[]>([])
+      }));
+    }
+  }
+
+  /**
    * End streaming for the current session.
    * Finalizes messages and clears streaming state.
    */
   endStreaming(): void {
     const sessionId = this.activeStreamSessionId();
     if (sessionId) {
-      // Ensure final messages are synced
+      // Ensure final messages are synced (continuation merge still active
+      // here so the final flush keeps the pinned prefix).
       const finalMessages = this.streamParser.allMessages();
       if (finalMessages.length > 0) {
         this.syncStreamingMessages(sessionId, finalMessages);
@@ -97,6 +138,8 @@ export class MessageMapService {
     }
 
     this.activeStreamSessionId.set(null);
+    this.continuationSessionId = null;
+    this.continuationPrefix = [];
   }
 
   /**
@@ -214,6 +257,15 @@ export class MessageMapService {
     if (!sessionSignal) return;
 
     sessionSignal.update(existingMessages => {
+      // Continuation-after-max_tokens: there is no new user message to
+      // truncate back to. Pin the prefix captured when the continuation
+      // started (history + truncated partial + error bubble) and append the
+      // continuation stream after it. Rebuilt from the stable prefix every
+      // tick so repeated syncs stay idempotent.
+      if (this.continuationSessionId === sessionId) {
+        return [...this.continuationPrefix, ...streamMessages];
+      }
+
       // Find the index of the last user message
       let lastUserMessageIndex = -1;
       for (let i = existingMessages.length - 1; i >= 0; i--) {

--- a/frontend/ai.client/src/app/session/session.page.html
+++ b/frontend/ai.client/src/app/session/session.page.html
@@ -10,6 +10,7 @@
   [greetingMessage]="greetingMessage()"
   [config]="chatConfig"
   (messageSubmitted)="onMessageSubmitted($event)"
+  (continueRequested)="onContinueRequested()"
   (messageCancelled)="onMessageCancelled()"
   (fileAttached)="onFileAttached($event)"
   (settingsToggled)="toggleSettings()"

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -189,6 +189,14 @@ export class ConversationPage implements OnDestroy {
         lastContextTokens: session.lastContextTokens,
         contextWindow: session.contextWindow,
       });
+      // Refresh-survival for the max_tokens "Continue" affordance: the
+      // truncated partial is already in restored history; this flag is the
+      // missing piece. Only set true here — the route-change reset clears
+      // it (cross-session safety) and the live stream_error path owns the
+      // in-turn signal, so we never clobber a live true with stale metadata.
+      if (session.lastTurnContinuable) {
+        this.chatStateService.setLastTurnContinuable(true);
+      }
     });
 
     // Hydrate the compaction summary indicator from persisted session
@@ -281,6 +289,11 @@ export class ConversationPage implements OnDestroy {
       // metadata loads — otherwise the previous session's totals briefly
       // flash on the badge while the new metadata is in flight.
       this.chatStateService.seedSessionAggregates({});
+
+      // Retire any prior session's "Continue" affordance before the new
+      // session's metadata lands; the seed effect re-sets it from
+      // metadata.lastTurnContinuable when applicable.
+      this.chatStateService.setLastTurnContinuable(false);
 
       // Compaction summary is session-scoped — clear before loading the
       // next session's metadata so the previous session's totals don't
@@ -384,6 +397,23 @@ export class ConversationPage implements OnDestroy {
     if (this.stagedSessionId()) {
       this.stagedSessionId.set(null);
     }
+  }
+
+  /**
+   * "Continue" affordance on a max_tokens-truncated assistant message.
+   * NOT a new user turn: it resumes the truncated assistant message via the
+   * continuation path (no visible user bubble, empty prompt) so the model
+   * picks up where it stopped instead of re-answering the original request.
+   */
+  onContinueRequested() {
+    const sessionIdToUse = this.effectiveSessionId();
+    const assistantIdToUse =
+      this.assistantIdFromQuery() || this.assistant()?.assistantId || undefined;
+    this.chatRequestService
+      .continueTruncatedTurn(sessionIdToUse, assistantIdToUse)
+      .catch((error) => {
+        console.error('Error continuing truncated turn:', error);
+      });
   }
 
   /**


### PR DESCRIPTION
## Summary

Makes hitting the model's output-token limit a recoverable, in-place experience instead of a leaky error + infinite "regenerate from scratch" loop.

- **Before:** `MaxTokensReachedException` surfaced as a generic error bubble (`…unrecoverable state… https://strandsagents.com/…`), and clicking "Continue" sent the canned text as a *new user turn*, so the model re-answered the original prompt verbatim and re-truncated — looping forever.
- **After:** an honest, compact inline "Response length limit reached" notice + a **Continue** button that *resumes* the truncated assistant message; the response finishes in place.

## Why

Root cause (validated against the SDK): the partial assistant message *is* persisted to AgentCore Memory and *is* restored on the next turn — the loop was caused by modeling Continue as a new user instruction rather than a continuation of the open assistant message. Fixing it cleanly meant reusing the existing interrupt-resume seam, not refactoring the session manager.

## What changed

**Backend**
- Classify `MaxTokensReachedException` specifically in the stream processor → a `max_tokens`-coded, `recoverable` `stream_error` with no leaked SDK URL and no verbose chat bubble.
- New `continue_truncated` invocation mode: re-enters the agent loop with an empty-list prompt so Strands appends no message and the model continues the restored truncated assistant message (assistant-prefill). Bypasses quota / RAG / file-resolution exactly like the OAuth/tool-approval resume path; rides `/invocations` (no new inference-api route).
- Don't persist the error as a second consecutive assistant message (would break Bedrock role alternation for the follow-up).
- Refresh-survival: a `lastTurnContinuable` marker on session metadata (set on truncation, cleared at the start of any non-interrupt-resume turn — fresh turn *or* continuation) flows through `SessionMetadataResponse` so Continue reappears after a reload. Mirrors the existing paused-turn/pending-interrupt seam.
- `stream_error` is now an always-allowed parser event so a terminal recovery signal can't be silently dropped by stream-state gating.

**Frontend**
- Compact inline muted "Response length limit reached" text + Continue button on the truncated message (no verbose bubble, no warning icon/color); tooltip "Resume response".
- Continuation-aware message-map sync: pins the existing partial and appends the continuation instead of truncating back to the last user message.
- Continue is a resume-style call (no visible user bubble, no new user turn); hydrate `lastTurnContinuable` from session metadata on load with cross-session reset.

## Reviewer notes

- This is the **correctness-first slice** (Slice 0/1 + refresh-survival). Out of scope / follow-ups: seamless single-bubble stitching, prose auto-continue with guards, and the distinct affordance for tool/artifact truncation (a half-written tool call can't be cleanly resumed).
- Correctness depends on the pinned Bedrock model accepting assistant-prefill (trailing-assistant + empty prompt). A turn-init diagnostic log was added to confirm in a deployed env; `done` finalizes any still-open builder as a fallback.
- Known edge (deferred): if truncation happens *before any text* the partial can be empty-dropped on persist — snapshot-carries-partial is a planned follow-up.

## Test plan

- [x] Backend: `tests/agents/main_agent/streaming/`, `tests/shared/test_models_and_utils.py`, `tests/shared/test_sessions_metadata.py` (incl. new `TestTruncatedTurnMarker`), `tests/agents/main_agent/test_chat_agent_continue.py`, import-boundary tests — all green.
- [x] Frontend: full Vitest suite (1000) + production build/typecheck — green.
- [ ] Deployed env: low `max_tokens` + long prompt → inline notice + Continue; clicking extends in place; **refresh before clicking** still shows Continue; starting any other turn clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)