### PR TITLE
fix(inference): coerce integer inference params to int + harden thinking/max_tokens guard

### DIFF
--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -52,6 +52,13 @@ _GEMINI_PARAM_MAP: Dict[str, str] = {
 # them. Suppression happens in `_apply_canonical_params` before dispatch.
 _THINKING_INCOMPATIBLE = {"temperature", "top_p", "top_k"}
 
+# Canonical params whose provider-native value must be a plain int. JSON- and
+# DynamoDB-sourced inference params arrive untyped (Dict[str, Any]) and can be
+# a float (e.g. 100000.0); the Bedrock Converse SDK rejects a float maxTokens
+# with a hard boto3 validation error. Coerce at this single translation
+# chokepoint. `thinking` is excluded — `_shape_thinking_value` already int()s it.
+_INTEGER_CANONICAL_PARAMS: frozenset[str] = frozenset({"max_tokens", "top_k"})
+
 # Union of every canonical key we know how to translate. Used by the request
 # merge step to gate user-supplied keys against an allow-list — admins can
 # constrain known params with `supportedParams`, but users shouldn't be able
@@ -129,6 +136,12 @@ def _apply_canonical_params(
             if shaped is None:
                 continue
             value = shaped
+        elif (
+            name in _INTEGER_CANONICAL_PARAMS
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ):
+            value = int(value)
         _set_nested(target, native_path, value)
 
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -83,6 +83,23 @@ def _sanitize_log(value: object) -> str:
     return text.translate(control_map)
 
 
+def _as_int_or_none(value: object) -> int | None:
+    """Coerce a numeric inference-param value to int for safety comparisons.
+
+    Inference params arrive untyped (``Dict[str, Any]`` from JSON), so an
+    integer bound can show up as a float (e.g. ``8192.0``). Returns ``None``
+    for bool / non-numeric values (including a ``thinking`` value an admin
+    pasted as a raw SDK dict) so callers skip the check rather than crash.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
 async def _find_managed_model(model_id: str | None):
     """Best-effort lookup of a managed-model record by external model ID."""
     if not model_id:
@@ -208,15 +225,12 @@ def _merge_inference_params(
     # both are set and inconsistent, drop `thinking` so the response still
     # streams instead of erroring out — the user just doesn't get a
     # reasoning trace this turn. Logged so the gap is visible in metrics.
-    thinking = merged.get("thinking")
-    max_tokens = merged.get("max_tokens")
-    if (
-        isinstance(thinking, int)
-        and not isinstance(thinking, bool)
-        and isinstance(max_tokens, int)
-        and not isinstance(max_tokens, bool)
-        and thinking >= max_tokens
-    ):
+    # Coerce before comparing: both values can arrive as floats (untyped
+    # Dict[str, Any] from JSON), and an `isinstance(..., int)` gate would
+    # silently skip the check on float input and let the bad request through.
+    thinking = _as_int_or_none(merged.get("thinking"))
+    max_tokens = _as_int_or_none(merged.get("max_tokens"))
+    if thinking is not None and max_tokens is not None and thinking >= max_tokens:
         logger.warning(
             "Dropping thinking budget %d for model %s — not less than max_tokens %d",
             thinking,

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -180,6 +180,27 @@ class TestToBedrockConfig:
         assert result["temperature"] == 0.5
         assert result["top_p"] == 0.8
 
+    def test_bedrock_config_coerces_float_max_tokens_to_int(self):
+        """JSON-sourced inference params can carry a float (100000.0); the
+        Bedrock SDK rejects a float maxTokens, so it must be coerced to int."""
+        cfg = ModelConfig(inference_params={"max_tokens": 100000.0, "top_k": 40.0})
+        result = cfg.to_bedrock_config()
+
+        assert result["max_tokens"] == 100000
+        assert isinstance(result["max_tokens"], int)
+        assert result["additional_request_fields"]["top_k"] == 40
+        assert isinstance(result["additional_request_fields"]["top_k"], int)
+
+    def test_gemini_config_coerces_float_max_tokens_to_int(self):
+        """Coercion applies across providers — Gemini max_output_tokens too."""
+        cfg = ModelConfig(
+            model_id="gemini-pro", inference_params={"max_tokens": 2048.0}
+        )
+        result = cfg.to_gemini_config()
+
+        assert result["params"]["max_output_tokens"] == 2048
+        assert isinstance(result["params"]["max_output_tokens"], int)
+
     def test_bedrock_config_drops_unknown_canonical_param(self):
         """Provider translation table silently drops keys it doesn't know."""
         cfg = ModelConfig(inference_params={"reasoning_effort": "high"})

--- a/backend/tests/apis/inference_api/test_inference_param_merge.py
+++ b/backend/tests/apis/inference_api/test_inference_param_merge.py
@@ -1,0 +1,81 @@
+"""Tests for the inference-param merge guard in ``apis.inference_api.chat.routes``.
+
+Focus: the cross-param safety check that drops ``thinking`` when
+``thinking >= max_tokens`` (Anthropic rejects that request outright). Inference
+params arrive untyped (``Dict[str, Any]`` from JSON), so an int bound can show
+up as a float — an ``isinstance(..., int)`` gate used to silently skip the
+check on float input and let the bad request through.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from apis.inference_api.chat.routes import _as_int_or_none, _merge_inference_params
+from apis.shared.models.models import ModelParamSpec, SupportedParams
+
+
+def _model(**specs: ModelParamSpec) -> SimpleNamespace:
+    """Minimal managed-model stand-in: only ``supported_params`` + ``model_id``."""
+    return SimpleNamespace(
+        model_id="test-model",
+        supported_params=SupportedParams(params=dict(specs)),
+    )
+
+
+# Wide bounds so request values pass through unclamped (and keep their
+# original float type), reproducing the JSON-sourced-float scenario.
+_WIDE_MAX_TOKENS = ModelParamSpec(supported=True, min=1, max=200000)
+_WIDE_THINKING = ModelParamSpec(supported=True, min=1024, max=None)
+
+
+class TestAsIntOrNone:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (8192, 8192),
+            (8192.0, 8192),
+            (100000.0, 100000),
+            (True, None),
+            (False, None),
+            (None, None),
+            ("8192", None),
+            ({"type": "enabled"}, None),
+        ],
+    )
+    def test_coercion(self, value, expected):
+        assert _as_int_or_none(value) == expected
+
+
+class TestThinkingGuardFloatInput:
+    def test_float_thinking_ge_float_max_tokens_drops_thinking(self):
+        """The original bug: both arrive as floats, thinking >= max_tokens.
+        The guard must still fire and drop thinking."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 2048.0, "thinking": 4096.0}
+        )
+
+        assert "thinking" not in merged
+        assert merged["max_tokens"] == 2048.0
+
+    def test_float_thinking_below_float_max_tokens_is_retained(self):
+        """Guard must not over-drop when the float values are consistent."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 8192.0, "thinking": 2048.0}
+        )
+
+        assert merged["thinking"] == 2048.0
+        assert merged["max_tokens"] == 8192.0
+
+    def test_int_inputs_still_guarded(self):
+        """Pre-existing int path must keep working."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 2048, "thinking": 4096}
+        )
+
+        assert "thinking" not in merged


### PR DESCRIPTION
## Summary

Untyped inference params (`Dict[str, Any]` from JSON) let a **float** reach the Bedrock Converse SDK, which rejects a float `maxTokens` with a hard boto3 validation error:

> `Invalid type for parameter inferenceConfig.maxTokens, value: 100000.0, type: float, valid types: int`

This was force-stopping agent turns. Two related fixes:

1. **Coerce integer-valued canonical params to `int`** (`max_tokens`, `top_k`) at `_apply_canonical_params` — the single provider-translation chokepoint every agent path converges on (fresh turn, resumed paused turn, Bedrock/OpenAI/Gemini). `thinking` was already `int()`-coerced via `_shape_thinking_value`; these two were not. The direct `converse_routes.py` path is unaffected (its `ConverseRequest.max_tokens` is typed `Optional[int]`, so Pydantic coerces there).

2. **Harden the `thinking`-vs-`max_tokens` consistency guard** in `routes.py`. It used an `isinstance(..., int)` gate that silently no-opped when either value arrived as a float, letting an inconsistent request (`thinking >= max_tokens`) through to Anthropic instead of dropping `thinking`. New `_as_int_or_none` helper coerces both sides before comparing (returns `None` for bool / non-numeric / dict so the guard skips rather than crashes).

## Why

The canonical `inference_params` dict is untyped end-to-end; a JSON float survives `_merge_inference_params` (clamping against `Optional[float]` bounds keeps it a float) and reaches boto3. Fixing at the translation chokepoint covers the resume path too, which bypasses `_merge_inference_params`.

## Reviewer notes

- Fix is intentionally at the single chokepoint rather than scattered casts.
- `temperature`/`top_p` stay float (correct); `reasoning_effort` is a string (untouched).
- No behavior change for already-`int` inputs (`int(x)` is a no-op).

## Test plan

- [x] `test_model_config.py` — float `max_tokens`/`top_k` → int (Bedrock + Gemini); full suite (57) green
- [x] New `test_inference_param_merge.py` — `_as_int_or_none` matrix + guard with float/int inputs incl. over-drop negative case (11 tests)
- [x] Broader sweep: inference_api + agent core + import-boundary architecture test — **101 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)