### PR TITLE
Harden max_tokens inference params: int coercion + model-ceiling cap

### DIFF
--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -52,6 +52,13 @@ _GEMINI_PARAM_MAP: Dict[str, str] = {
 # them. Suppression happens in `_apply_canonical_params` before dispatch.
 _THINKING_INCOMPATIBLE = {"temperature", "top_p", "top_k"}
 
+# Canonical params whose provider-native value must be a plain int. JSON- and
+# DynamoDB-sourced inference params arrive untyped (Dict[str, Any]) and can be
+# a float (e.g. 100000.0); the Bedrock Converse SDK rejects a float maxTokens
+# with a hard boto3 validation error. Coerce at this single translation
+# chokepoint. `thinking` is excluded — `_shape_thinking_value` already int()s it.
+_INTEGER_CANONICAL_PARAMS: frozenset[str] = frozenset({"max_tokens", "top_k"})
+
 # Union of every canonical key we know how to translate. Used by the request
 # merge step to gate user-supplied keys against an allow-list — admins can
 # constrain known params with `supportedParams`, but users shouldn't be able
@@ -129,6 +136,12 @@ def _apply_canonical_params(
             if shaped is None:
                 continue
             value = shaped
+        elif (
+            name in _INTEGER_CANONICAL_PARAMS
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ):
+            value = int(value)
         _set_nested(target, native_path, value)
 
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -83,6 +83,23 @@ def _sanitize_log(value: object) -> str:
     return text.translate(control_map)
 
 
+def _as_int_or_none(value: object) -> int | None:
+    """Coerce a numeric inference-param value to int for safety comparisons.
+
+    Inference params arrive untyped (``Dict[str, Any]`` from JSON), so an
+    integer bound can show up as a float (e.g. ``8192.0``). Returns ``None``
+    for bool / non-numeric values (including a ``thinking`` value an admin
+    pasted as a raw SDK dict) so callers skip the check rather than crash.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
 async def _find_managed_model(model_id: str | None):
     """Best-effort lookup of a managed-model record by external model ID."""
     if not model_id:
@@ -208,15 +225,12 @@ def _merge_inference_params(
     # both are set and inconsistent, drop `thinking` so the response still
     # streams instead of erroring out — the user just doesn't get a
     # reasoning trace this turn. Logged so the gap is visible in metrics.
-    thinking = merged.get("thinking")
-    max_tokens = merged.get("max_tokens")
-    if (
-        isinstance(thinking, int)
-        and not isinstance(thinking, bool)
-        and isinstance(max_tokens, int)
-        and not isinstance(max_tokens, bool)
-        and thinking >= max_tokens
-    ):
+    # Coerce before comparing: both values can arrive as floats (untyped
+    # Dict[str, Any] from JSON), and an `isinstance(..., int)` gate would
+    # silently skip the check on float input and let the bad request through.
+    thinking = _as_int_or_none(merged.get("thinking"))
+    max_tokens = _as_int_or_none(merged.get("max_tokens"))
+    if thinking is not None and max_tokens is not None and thinking >= max_tokens:
         logger.warning(
             "Dropping thinking budget %d for model %s — not less than max_tokens %d",
             thinking,

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -88,6 +88,33 @@ class SupportedParams(BaseModel):
         return self
 
 
+def _max_tokens_within_ceiling(
+    max_output_tokens: Optional[int],
+    supported_params: Optional[SupportedParams],
+) -> None:
+    """Reject a max_tokens spec that lets the runtime request more output
+    than the model can physically produce.
+
+    Mirrors the Angular ``maxTokensCeilingValidator``. Only checks when both
+    the model ceiling and a *supported* max_tokens spec are present in the
+    same payload — a partial update touching only one side is left to the
+    per-field bounds rules.
+    """
+    if max_output_tokens is None or supported_params is None:
+        return
+    spec = supported_params.params.get("max_tokens")
+    if spec is None or not spec.supported:
+        return
+    if spec.max is not None and spec.max > max_output_tokens:
+        raise ValueError("max_tokens max must be <= maxOutputTokens")
+    if (
+        isinstance(spec.default, (int, float))
+        and not isinstance(spec.default, bool)
+        and spec.default > max_output_tokens
+    ):
+        raise ValueError("max_tokens default must be <= maxOutputTokens")
+
+
 class ManagedModelCreate(BaseModel):
     """Request model for creating a managed model."""
     model_config = ConfigDict(populate_by_name=True)
@@ -145,6 +172,11 @@ class ManagedModelCreate(BaseModel):
                     "When None, the runtime sends no inference params."
     )
 
+    @model_validator(mode="after")
+    def _check_max_tokens_within_ceiling(self) -> "ManagedModelCreate":
+        _max_tokens_within_ceiling(self.max_output_tokens, self.supported_params)
+        return self
+
 
 class ManagedModelUpdate(BaseModel):
     """Request model for updating a managed model."""
@@ -200,6 +232,11 @@ class ManagedModelUpdate(BaseModel):
         alias="supportedParams",
         description="Per-model inference parameter capabilities."
     )
+
+    @model_validator(mode="after")
+    def _check_max_tokens_within_ceiling(self) -> "ManagedModelUpdate":
+        _max_tokens_within_ceiling(self.max_output_tokens, self.supported_params)
+        return self
 
 
 class ManagedModel(BaseModel):

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -180,6 +180,27 @@ class TestToBedrockConfig:
         assert result["temperature"] == 0.5
         assert result["top_p"] == 0.8
 
+    def test_bedrock_config_coerces_float_max_tokens_to_int(self):
+        """JSON-sourced inference params can carry a float (100000.0); the
+        Bedrock SDK rejects a float maxTokens, so it must be coerced to int."""
+        cfg = ModelConfig(inference_params={"max_tokens": 100000.0, "top_k": 40.0})
+        result = cfg.to_bedrock_config()
+
+        assert result["max_tokens"] == 100000
+        assert isinstance(result["max_tokens"], int)
+        assert result["additional_request_fields"]["top_k"] == 40
+        assert isinstance(result["additional_request_fields"]["top_k"], int)
+
+    def test_gemini_config_coerces_float_max_tokens_to_int(self):
+        """Coercion applies across providers — Gemini max_output_tokens too."""
+        cfg = ModelConfig(
+            model_id="gemini-pro", inference_params={"max_tokens": 2048.0}
+        )
+        result = cfg.to_gemini_config()
+
+        assert result["params"]["max_output_tokens"] == 2048
+        assert isinstance(result["params"]["max_output_tokens"], int)
+
     def test_bedrock_config_drops_unknown_canonical_param(self):
         """Provider translation table silently drops keys it doesn't know."""
         cfg = ModelConfig(inference_params={"reasoning_effort": "high"})

--- a/backend/tests/apis/inference_api/test_inference_param_merge.py
+++ b/backend/tests/apis/inference_api/test_inference_param_merge.py
@@ -1,0 +1,81 @@
+"""Tests for the inference-param merge guard in ``apis.inference_api.chat.routes``.
+
+Focus: the cross-param safety check that drops ``thinking`` when
+``thinking >= max_tokens`` (Anthropic rejects that request outright). Inference
+params arrive untyped (``Dict[str, Any]`` from JSON), so an int bound can show
+up as a float — an ``isinstance(..., int)`` gate used to silently skip the
+check on float input and let the bad request through.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from apis.inference_api.chat.routes import _as_int_or_none, _merge_inference_params
+from apis.shared.models.models import ModelParamSpec, SupportedParams
+
+
+def _model(**specs: ModelParamSpec) -> SimpleNamespace:
+    """Minimal managed-model stand-in: only ``supported_params`` + ``model_id``."""
+    return SimpleNamespace(
+        model_id="test-model",
+        supported_params=SupportedParams(params=dict(specs)),
+    )
+
+
+# Wide bounds so request values pass through unclamped (and keep their
+# original float type), reproducing the JSON-sourced-float scenario.
+_WIDE_MAX_TOKENS = ModelParamSpec(supported=True, min=1, max=200000)
+_WIDE_THINKING = ModelParamSpec(supported=True, min=1024, max=None)
+
+
+class TestAsIntOrNone:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (8192, 8192),
+            (8192.0, 8192),
+            (100000.0, 100000),
+            (True, None),
+            (False, None),
+            (None, None),
+            ("8192", None),
+            ({"type": "enabled"}, None),
+        ],
+    )
+    def test_coercion(self, value, expected):
+        assert _as_int_or_none(value) == expected
+
+
+class TestThinkingGuardFloatInput:
+    def test_float_thinking_ge_float_max_tokens_drops_thinking(self):
+        """The original bug: both arrive as floats, thinking >= max_tokens.
+        The guard must still fire and drop thinking."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 2048.0, "thinking": 4096.0}
+        )
+
+        assert "thinking" not in merged
+        assert merged["max_tokens"] == 2048.0
+
+    def test_float_thinking_below_float_max_tokens_is_retained(self):
+        """Guard must not over-drop when the float values are consistent."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 8192.0, "thinking": 2048.0}
+        )
+
+        assert merged["thinking"] == 2048.0
+        assert merged["max_tokens"] == 8192.0
+
+    def test_int_inputs_still_guarded(self):
+        """Pre-existing int path must keep working."""
+        model = _model(max_tokens=_WIDE_MAX_TOKENS, thinking=_WIDE_THINKING)
+        merged = _merge_inference_params(
+            model, {"max_tokens": 2048, "thinking": 4096}
+        )
+
+        assert "thinking" not in merged

--- a/backend/tests/shared/test_managed_models.py
+++ b/backend/tests/shared/test_managed_models.py
@@ -92,3 +92,45 @@ class TestManagedModels:
         from apis.shared.models.managed_models import create_managed_model
         model = await create_managed_model(_make_model_data("gpt4", provider="openai"))
         assert model.supports_caching is False
+
+
+class TestMaxTokensCeiling:
+    """max_tokens spec must not exceed the model's declared output ceiling."""
+
+    def test_default_above_ceiling_rejected(self):
+        # Default 8192 is within the (absent) row bounds but exceeds the
+        # model's 4096 ceiling — only the cross-field rule should fire.
+        with pytest.raises(Exception):
+            _make_model_data(
+                maxOutputTokens=4096,
+                supportedParams={"params": {"max_tokens": {"supported": True, "default": 8192}}},
+            )
+
+    def test_max_above_ceiling_rejected(self):
+        with pytest.raises(Exception):
+            _make_model_data(
+                maxOutputTokens=4096,
+                supportedParams={"params": {"max_tokens": {"supported": True, "max": 8192}}},
+            )
+
+    def test_within_ceiling_ok(self):
+        m = _make_model_data(
+            maxOutputTokens=8192,
+            supportedParams={"params": {"max_tokens": {"supported": True, "max": 8192, "default": 8192}}},
+        )
+        assert m.max_output_tokens == 8192
+
+    def test_unsupported_row_not_ceiling_checked(self):
+        m = _make_model_data(
+            maxOutputTokens=4096,
+            supportedParams={"params": {"max_tokens": {"supported": False, "max": 999999, "default": 999999}}},
+        )
+        assert m.max_output_tokens == 4096
+
+    def test_update_payload_enforced(self):
+        from apis.shared.models.models import ManagedModelUpdate
+        with pytest.raises(Exception):
+            ManagedModelUpdate(
+                maxOutputTokens=4096,
+                supportedParams={"params": {"max_tokens": {"supported": True, "default": 8192}}},
+            )

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -131,6 +131,58 @@ function thinkingInvariantsValidator(array: AbstractControl): ValidationErrors |
 }
 
 /**
+ * FormArray-level validator pinning the `max_tokens` row to the model's
+ * declared output ceiling. The model-level `maxOutputTokens` control is a
+ * sibling of this FormArray (reached via `array.parent`) — neither the
+ * `max` bound nor the `default` the runtime sends may exceed what the
+ * model can physically produce.
+ *
+ * Errors land on the `max_tokens` row so the inline markup surfaces them
+ * next to the per-row bounds errors. Mirrored on the backend by
+ * `_max_tokens_within_ceiling` on `ManagedModelCreate`/`ManagedModelUpdate`.
+ */
+function maxTokensCeilingValidator(array: AbstractControl): ValidationErrors | null {
+  if (!(array instanceof FormArray)) return null;
+  let maxTokensRow: FormGroup | undefined;
+  for (const row of array.controls as FormGroup[]) {
+    if (row.get('key')?.value === 'max_tokens') {
+      maxTokensRow = row;
+      break;
+    }
+  }
+  if (!maxTokensRow) return null;
+
+  // Recompute only the two ceiling keys each pass, preserving the per-row
+  // bounds errors paramRowBoundsValidator sets independently.
+  const rewrite = (extra: Record<string, true>): void => {
+    const existing = { ...(maxTokensRow!.errors ?? {}) };
+    delete existing['maxTokensMaxAboveCeiling'];
+    delete existing['maxTokensDefaultAboveCeiling'];
+    const merged = { ...existing, ...extra };
+    maxTokensRow!.setErrors(Object.keys(merged).length > 0 ? merged : null);
+  };
+
+  if (!maxTokensRow.get('supported')?.value) {
+    rewrite({});
+    return null;
+  }
+
+  const ceiling = array.parent?.get('maxOutputTokens')?.value;
+  if (typeof ceiling !== 'number' || !Number.isFinite(ceiling) || ceiling < 1) {
+    rewrite({});
+    return null;
+  }
+
+  const errors: Record<string, true> = {};
+  const max = maxTokensRow.get('max')?.value;
+  const def = maxTokensRow.get('defaultValue')?.value;
+  if (typeof max === 'number' && max > ceiling) errors['maxTokensMaxAboveCeiling'] = true;
+  if (typeof def === 'number' && def > ceiling) errors['maxTokensDefaultAboveCeiling'] = true;
+  rewrite(errors);
+  return null;
+}
+
+/**
  * Helper used as a key on each known-param row so the FormArray validator
  * can find the `thinking` and `max_tokens` rows. Custom rows already store
  * their key in a `key` control; known rows don't, so we tag them with a
@@ -217,7 +269,7 @@ export class ModelFormPage implements OnInit {
     knowledgeCutoffDate: this.fb.control<string | null>(null),
     supportsCaching: this.fb.control(false, { nonNullable: true }),
     inferenceParams: this.fb.array<FormGroup<ParamRowGroup>>([], {
-      validators: [thinkingInvariantsValidator],
+      validators: [thinkingInvariantsValidator, maxTokensCeilingValidator],
     }),
     customInferenceParams: this.fb.array<FormGroup<CustomParamRowGroup>>([]),
   });
@@ -306,6 +358,12 @@ export class ModelFormPage implements OnInit {
     // visible knobs match what the selected SDK actually understands.
     this.modelForm.controls.provider.valueChanges.subscribe(provider => {
       this.rebuildInferenceParamRows(provider);
+    });
+
+    // Keep the max_tokens row pinned to the model's output ceiling: pre-fill
+    // it on a fresh model and re-check the cap whenever the ceiling changes.
+    this.modelForm.controls.maxOutputTokens.valueChanges.subscribe(() => {
+      this.syncMaxTokensCeiling();
     });
   }
 
@@ -422,6 +480,37 @@ export class ModelFormPage implements OnInit {
         }
       });
     }
+
+    this.syncMaxTokensCeiling();
+  }
+
+  /**
+   * Pin the `max_tokens` inference-param row to the model's declared output
+   * ceiling. Pre-fills the row's Max and Default from `maxOutputTokens` so a
+   * fresh model defaults to "request the full ceiling" — but only while
+   * those fields are untouched and weren't loaded from a persisted record,
+   * so deliberate admin edits and saved specs win. Always re-validates the
+   * array so the ceiling cap re-checks when only the model-level field
+   * changed (a sibling value change doesn't re-run the array validator on
+   * its own).
+   */
+  private syncMaxTokensCeiling(): void {
+    const idx = this.inferenceParamRows().findIndex(m => m.key === 'max_tokens');
+    if (idx < 0) return;
+    const row = this.paramRowGroup(idx);
+    const ceiling = this.modelForm.controls.maxOutputTokens.value;
+    const loaded = this.loadedKnownKeys.has('max_tokens');
+
+    if (!loaded && typeof ceiling === 'number' && Number.isFinite(ceiling) && ceiling >= 1) {
+      if (row.controls.max.pristine) {
+        row.controls.max.setValue(ceiling, { emitEvent: false });
+      }
+      if (row.controls.defaultValue.pristine) {
+        row.controls.defaultValue.setValue(ceiling, { emitEvent: false });
+      }
+    }
+
+    this.modelForm.controls.inferenceParams.updateValueAndValidity();
   }
 
   private buildCustomParamRow(key: string, seed: ModelParamSpec | null): FormGroup<CustomParamRowGroup> {
@@ -579,6 +668,15 @@ export class ModelFormPage implements OnInit {
     }
     if (row.errors['thinkingBudgetNotNumeric']) {
       out.push('Thinking budget must be a number — clear the value to disable, or enter an integer ≥ 1024.');
+    }
+    if (row.errors['maxTokensMaxAboveCeiling'] || row.errors['maxTokensDefaultAboveCeiling']) {
+      const ceiling = this.modelForm.controls.maxOutputTokens.value;
+      if (row.errors['maxTokensMaxAboveCeiling']) {
+        out.push(`Max must be ≤ the model's Max Output Tokens (${ceiling}).`);
+      }
+      if (row.errors['maxTokensDefaultAboveCeiling']) {
+        out.push(`Default must be ≤ the model's Max Output Tokens (${ceiling}).`);
+      }
     }
     return out;
   }


### PR DESCRIPTION
## Summary

Two related changes that make `max_tokens` (and integer inference params generally) safe end-to-end — from the admin model form, through config validation, into the provider SDK call.

### 1. `fix(inference)`: coerce integer inference params to int + harden thinking/max_tokens guard (`016844f0`)
- Untyped inference params (`Dict[str, Any]` from JSON) let a **float** reach the Bedrock Converse SDK, which rejects a float `maxTokens` with a hard boto3 validation error. Now coerced (`max_tokens`/`top_k` → int) at the single provider-translation chokepoint, covering fresh + resumed turns across all providers.
- The thinking-vs-`max_tokens` consistency guard used an `isinstance(..., int)` gate that silently no-opped on float input, letting an inconsistent request (`thinking >= max_tokens`) through to Anthropic. It now coerces both sides before comparing.

### 2. `feat(models)`: pin `max_tokens` inference param to the model output ceiling (`5fa598bf`)
- **Auto-fill (untouched only):** on the admin Add/Edit Model form, the `max_tokens` row's **Max** and **Default** pre-fill from the model-level **Max Output Tokens** so a fresh model defaults to "request the full ceiling". Only applies while those fields are pristine and weren't loaded from a persisted spec — deliberate admin edits and saved specs win.
- **Cap (form + backend):** a supported `max_tokens` whose **Max** or numeric **Default** exceeds the model's `max_output_tokens` is rejected. Enforced in the Angular form (inline error, blocks save, mirrors the existing `thinkingInvariantsValidator` pattern) and on `ManagedModelCreate`/`ManagedModelUpdate` (Pydantic `model_validator`, defense in depth).

## Why

A float or over-ceiling `max_tokens` only surfaced as a mid-conversation SDK 400. These changes move the failure to config time (admin sees an inline error) and to the translation chokepoint (type-safe regardless of client), instead of letting it reach the provider.

## Reviewer notes

- Backend validators only cross-check when both `maxOutputTokens` and `supportedParams.max_tokens` are present in the same payload — the form always sends both. A hand-rolled partial `PUT` sending only `supportedParams` is not cross-checked (deeper enforcement would require the route to load-and-merge the stored ceiling); flagged intentionally as out of scope.
- Targets `develop` per repo workflow.

## Test plan

- [x] Backend: `pytest tests/shared/test_managed_models.py tests/apis/inference_api/test_inference_param_merge.py` — 25/25 pass (incl. 6 new `TestMaxTokensCeiling` cases + int-coercion/merge cases).
- [x] Frontend: `tsc -p tsconfig.app.json --noEmit` clean.
- [ ] Manual UI (admin): auto-fill on ceiling change, edits respected, over-ceiling inline error blocks save, edit-mode persisted spec not clobbered. (Preview blocked on local cross-origin dev-login cookie.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)