### PR TITLE
feat(inference): admin-configurable effort + model-aware adaptive thinking

### DIFF
--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -207,6 +207,26 @@ CLAUDE_CHAT_SUPPORTED_PARAMS: dict[str, Any] = {
 }
 
 
+# Sonnet 4.6 adds the `effort` knob (adaptive-thinking depth + overall token
+# spend). The per-model `allowed` set is the whole point of the design —
+# it's data, not code, so Opus 4.7 (which also gets `xhigh`/`max`) is just a
+# different array on a different record. Ordered low->high so future clamping
+# degrades gracefully. NOTE: Anthropic's published docs additionally list
+# `max` for Sonnet 4.6; this seeds the narrower low/medium/high set — widen
+# the array here if you want `max` exposed on this model.
+CLAUDE_SONNET_46_SUPPORTED_PARAMS: dict[str, Any] = {
+    "params": {
+        **CLAUDE_CHAT_SUPPORTED_PARAMS["params"],
+        "effort": {
+            "supported": True,
+            "allowed": ["low", "medium", "high"],
+            "default": "high",
+            "locked": False,
+        },
+    }
+}
+
+
 # Default Bedrock models to seed
 DEFAULT_MODELS: list[dict[str, Any]] = [
     {
@@ -241,7 +261,7 @@ DEFAULT_MODELS: list[dict[str, Any]] = [
         "cacheReadPricePerMillionTokens": Decimal("0.30"),
         "supportsCaching": True,
         "isDefault": False,
-        "supportedParams": CLAUDE_CHAT_SUPPORTED_PARAMS,
+        "supportedParams": CLAUDE_SONNET_46_SUPPORTED_PARAMS,
     },
     {
         "modelId": "amazon.nova-2-sonic-v1:0",

--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -30,6 +30,11 @@ _BEDROCK_PARAM_MAP: Dict[str, str] = {
     "top_k": "additional_request_fields.top_k",
     "max_tokens": "max_tokens",
     "thinking": "additional_request_fields.thinking",
+    # `effort` is Anthropic's top-level `output_config.effort`. It isn't on
+    # the Bedrock Converse standard shape either, so it rides through
+    # `additionalModelRequestFields` like `thinking`/`top_k`. Soft guidance
+    # for thinking depth on adaptive models; also tunes overall token spend.
+    "effort": "additional_request_fields.output_config.effort",
 }
 
 _OPENAI_PARAM_MAP: Dict[str, str] = {
@@ -78,19 +83,49 @@ def _set_nested(target: Dict[str, Any], dotted_path: str, value: Any) -> None:
     cursor[keys[-1]] = value
 
 
-def _shape_thinking_value(provider_label: str, value: Any) -> Any:
+# Bedrock model-id substrings whose Anthropic models require (Opus 4.7) or
+# recommend (Opus 4.6, Sonnet 4.6, Mythos) adaptive thinking. On these,
+# `{type: "enabled", budget_tokens: N}` is rejected (4.7) or deprecated; the
+# shape is `{type: "adaptive"}` and depth is governed by the `effort` param.
+# Substring match — real ids are inference-profile-prefixed and date-stamped
+# (e.g. `us.anthropic.claude-opus-4-7-20XXXXXX-v1:0`). Unknown ids fall back
+# to the legacy enabled shape, which is the safe default for older models.
+_BEDROCK_ADAPTIVE_THINKING_MARKERS = (
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-mythos",
+)
+
+
+def _bedrock_uses_adaptive_thinking(model_id: Optional[str]) -> bool:
+    """True when the Bedrock model id requires/recommends adaptive thinking."""
+    mid = (model_id or "").lower()
+    return any(marker in mid for marker in _BEDROCK_ADAPTIVE_THINKING_MARKERS)
+
+
+def _shape_thinking_value(
+    provider_label: str, value: Any, model_id: Optional[str] = None
+) -> Any:
     """Wrap a canonical ``thinking`` value into the provider-native object.
 
     The canonical value is an ``int`` budget (>= 1024), or falsy / 0 to disable.
-    Anthropic on Bedrock requires ``{type, budget_tokens}``; Gemini wants
-    ``{thinking_budget}``. Anything that's already a dict (admin pasting raw
-    SDK shape) is passed through verbatim.
+    On Bedrock, older Anthropic models take ``{type: "enabled", budget_tokens}``;
+    Opus 4.6/4.7 and Sonnet 4.6 require ``{type: "adaptive"}`` instead (Opus 4.7
+    rejects ``enabled`` with a 400). For adaptive models the int budget only
+    signals "thinking on" — depth is controlled by the separate ``effort``
+    param — and we set ``display: "summarized"`` so the reasoning trace the
+    UI renders isn't blank (Opus 4.7 defaults ``display`` to ``"omitted"``).
+    Gemini wants ``{thinking_budget}``. Anything that's already a dict (admin
+    pasting raw SDK shape) is passed through verbatim.
     """
     if isinstance(value, dict):
         return value
     if not value:
         return None
     if provider_label == "bedrock":
+        if _bedrock_uses_adaptive_thinking(model_id):
+            return {"type": "adaptive", "display": "summarized"}
         return {"type": "enabled", "budget_tokens": int(value)}
     if provider_label == "gemini":
         return {"thinking_budget": int(value)}
@@ -102,6 +137,7 @@ def _apply_canonical_params(
     canonical_params: Dict[str, Any],
     provider_map: Dict[str, str],
     provider_label: str,
+    model_id: Optional[str] = None,
 ) -> None:
     """Translate canonical inference params into provider-native shape.
 
@@ -132,7 +168,7 @@ def _apply_canonical_params(
             )
             continue
         if name == "thinking":
-            shaped = _shape_thinking_value(provider_label, value)
+            shaped = _shape_thinking_value(provider_label, value, model_id)
             if shaped is None:
                 continue
             value = shaped
@@ -240,7 +276,9 @@ class ModelConfig:
     def to_bedrock_config(self) -> Dict[str, Any]:
         """Convert to BedrockModel kwargs, translating canonical inference params."""
         config: Dict[str, Any] = {"model_id": self.model_id}
-        _apply_canonical_params(config, self.inference_params, _BEDROCK_PARAM_MAP, "bedrock")
+        _apply_canonical_params(
+            config, self.inference_params, _BEDROCK_PARAM_MAP, "bedrock", self.model_id
+        )
 
         # Bedrock prompt caching is intentionally deferred. The previous SDK
         # blocker — strands PR #1438, which fixed `cachePoint` blocks landing
@@ -269,7 +307,9 @@ class ModelConfig:
     def to_openai_config(self) -> Dict[str, Any]:
         """Convert to OpenAIModel kwargs, translating canonical inference params."""
         params: Dict[str, Any] = {}
-        _apply_canonical_params(params, self.inference_params, _OPENAI_PARAM_MAP, "openai")
+        _apply_canonical_params(
+            params, self.inference_params, _OPENAI_PARAM_MAP, "openai", self.model_id
+        )
         config: Dict[str, Any] = {"model_id": self.model_id}
         if params:
             config["params"] = params
@@ -278,7 +318,9 @@ class ModelConfig:
     def to_gemini_config(self) -> Dict[str, Any]:
         """Convert to GeminiModel kwargs, translating canonical inference params."""
         params: Dict[str, Any] = {}
-        _apply_canonical_params(params, self.inference_params, _GEMINI_PARAM_MAP, "gemini")
+        _apply_canonical_params(
+            params, self.inference_params, _GEMINI_PARAM_MAP, "gemini", self.model_id
+        )
         config: Dict[str, Any] = {"model_id": self.model_id}
         if params:
             config["params"] = params

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -190,6 +190,19 @@ def _merge_inference_params(
                 merged[name] = spec.default
             continue
 
+        # Enum params (e.g. `effort`): the override must be a member of the
+        # admin-declared `allowed` set; an out-of-domain value falls back to
+        # the default rather than erroring mid-stream. Mirrors the numeric
+        # clamp below, and the per-model `allowed` differences (Sonnet 4.6
+        # vs Opus 4.7) stay data, not code.
+        if spec.allowed is not None:
+            req = request_params.get(name)
+            if req is not None and req in spec.allowed:
+                merged[name] = req
+            elif spec.default is not None:
+                merged[name] = spec.default
+            continue
+
         if name in request_params and request_params[name] is not None:
             value = request_params[name]
             if isinstance(value, (int, float)):

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -21,10 +21,19 @@ class ModelParamSpec(BaseModel):
     supported: bool = True
     min: Optional[float] = None
     max: Optional[float] = None
+    allowed: Optional[list[Any]] = Field(
+        None,
+        description="Permissible values for enum-style params (e.g. `effort`: "
+                    "low/medium/high/xhigh/max). When set, `default` and any "
+                    "user override must be a member; `min`/`max` don't apply. "
+                    "Keep ordered low->high so future clamping (request `max`, "
+                    "model caps at `high`) can degrade gracefully."
+    )
     default: Optional[Any] = Field(
         None,
         description="Value sent when the user doesn't override. Type depends on the param "
-                    "(number for temperature/top_p, bool for thinking, etc.)."
+                    "(number for temperature/top_p, int budget for thinking, "
+                    "string for effort, etc.)."
     )
     locked: bool = Field(
         False,
@@ -41,6 +50,11 @@ class ModelParamSpec(BaseModel):
                 raise ValueError("default must be >= min")
             if self.max is not None and self.default > self.max:
                 raise ValueError("default must be <= max")
+        if self.allowed is not None:
+            if not self.allowed:
+                raise ValueError("allowed must be non-empty when set")
+            if self.default is not None and self.default not in self.allowed:
+                raise ValueError("default must be one of allowed")
         return self
 
 
@@ -54,8 +68,11 @@ class SupportedParams(BaseModel):
 
     For ``thinking``, ``ModelParamSpec.default`` carries the budget in
     tokens (int >= 1024, or 0/None to disable). The provider translator
-    wraps it into the Anthropic ``{type: "enabled", budget_tokens: N}``
-    shape on the way out.
+    wraps a truthy value into the Anthropic ``{type: "enabled",
+    budget_tokens: N}`` shape on older models, or ``{type: "adaptive"}``
+    on models that require adaptive thinking (Opus 4.6/4.7, Sonnet 4.6) —
+    where the int just means "thinking on" and depth is governed by the
+    separate ``effort`` param.
     """
     model_config = ConfigDict(populate_by_name=True)
 

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -180,6 +180,88 @@ class TestToBedrockConfig:
         assert result["temperature"] == 0.5
         assert result["top_p"] == 0.8
 
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "us.anthropic.claude-opus-4-7-20260115-v1:0",
+            "us.anthropic.claude-opus-4-6",
+            "us.anthropic.claude-sonnet-4-6",
+            "claude-mythos-preview",
+        ],
+    )
+    def test_bedrock_thinking_uses_adaptive_shape_on_newer_models(self, model_id):
+        """Opus 4.6/4.7, Sonnet 4.6 and Mythos require/recommend adaptive
+        thinking. Opus 4.7 rejects `{type:"enabled"}` with a 400, so the
+        int budget only signals "on" and the shape is `{type:"adaptive"}`.
+        `display:"summarized"` keeps the reasoning trace from going blank
+        (Opus 4.7 defaults display to "omitted")."""
+        cfg = ModelConfig(model_id=model_id, inference_params={"thinking": 4096})
+        result = cfg.to_bedrock_config()
+
+        assert result["additional_request_fields"]["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+        }
+        assert "budget_tokens" not in result["additional_request_fields"]["thinking"]
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "us.anthropic.claude-sonnet-4-5-20250101-v1:0",
+            "claude-3-opus",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        ],
+    )
+    def test_bedrock_thinking_keeps_legacy_enabled_shape_on_older_models(self, model_id):
+        """Older models (Sonnet 4.5, Claude 3, Haiku 4.5) still take the
+        legacy `{type:"enabled", budget_tokens:N}` shape — unchanged."""
+        cfg = ModelConfig(model_id=model_id, inference_params={"thinking": 4096})
+        result = cfg.to_bedrock_config()
+
+        assert result["additional_request_fields"]["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 4096,
+        }
+
+    def test_bedrock_adaptive_thinking_still_suppresses_sampling_params(self):
+        """Anthropic rejects temperature/top_p/top_k while extended thinking
+        is on regardless of mode — suppression still fires for adaptive."""
+        cfg = ModelConfig(
+            model_id="us.anthropic.claude-opus-4-7-20260115-v1:0",
+            inference_params={"thinking": 2048, "temperature": 0.7, "top_p": 0.9},
+        )
+        result = cfg.to_bedrock_config()
+
+        assert "temperature" not in result
+        assert "top_p" not in result
+        assert result["additional_request_fields"]["thinking"]["type"] == "adaptive"
+
+    def test_bedrock_effort_maps_to_output_config(self):
+        """`effort` rides through additional_request_fields as Anthropic's
+        top-level `output_config.effort` — not a Converse standard field."""
+        cfg = ModelConfig(
+            model_id="us.anthropic.claude-opus-4-7-20260115-v1:0",
+            inference_params={"effort": "xhigh"},
+        )
+        result = cfg.to_bedrock_config()
+
+        assert result["additional_request_fields"]["output_config"]["effort"] == "xhigh"
+        assert "effort" not in result
+        assert "output_config" not in result
+
+    def test_bedrock_effort_and_adaptive_thinking_coexist(self):
+        """effort and adaptive thinking are independent knobs — both land
+        under additional_request_fields together."""
+        cfg = ModelConfig(
+            model_id="us.anthropic.claude-opus-4-7-20260115-v1:0",
+            inference_params={"thinking": 2048, "effort": "high"},
+        )
+        result = cfg.to_bedrock_config()
+
+        arf = result["additional_request_fields"]
+        assert arf["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert arf["output_config"]["effort"] == "high"
+
     def test_bedrock_config_coerces_float_max_tokens_to_int(self):
         """JSON-sourced inference params can carry a float (100000.0); the
         Bedrock SDK rejects a float maxTokens, so it must be coerced to int."""

--- a/backend/tests/apis/inference_api/test_inference_param_merge.py
+++ b/backend/tests/apis/inference_api/test_inference_param_merge.py
@@ -79,3 +79,45 @@ class TestThinkingGuardFloatInput:
         )
 
         assert "thinking" not in merged
+
+
+class TestEffortAllowedGating:
+    """`effort` is enum-gated: a request override must be a member of the
+    admin-declared `allowed` set, else it falls back to the default. The
+    per-model effort-tier difference (Sonnet 4.6 vs Opus 4.7) is data on
+    `ModelParamSpec.allowed`, not model-family code."""
+
+    _SONNET_EFFORT = ModelParamSpec(
+        supported=True, allowed=["low", "medium", "high"], default="high"
+    )
+    _OPUS_EFFORT = ModelParamSpec(
+        supported=True, allowed=["low", "medium", "high", "xhigh", "max"], default="high"
+    )
+
+    def test_in_domain_override_is_kept(self):
+        model = _model(effort=self._SONNET_EFFORT)
+        merged = _merge_inference_params(model, {"effort": "low"})
+        assert merged["effort"] == "low"
+
+    def test_out_of_domain_override_falls_back_to_default(self):
+        # `xhigh` is Opus-4.7-only; on a Sonnet-4.6-shaped spec it's rejected
+        # and the admin default wins instead of erroring mid-stream.
+        model = _model(effort=self._SONNET_EFFORT)
+        merged = _merge_inference_params(model, {"effort": "xhigh"})
+        assert merged["effort"] == "high"
+
+    def test_xhigh_allowed_on_opus_spec(self):
+        model = _model(effort=self._OPUS_EFFORT)
+        merged = _merge_inference_params(model, {"effort": "xhigh"})
+        assert merged["effort"] == "xhigh"
+
+    def test_no_override_uses_default(self):
+        model = _model(effort=self._SONNET_EFFORT)
+        merged = _merge_inference_params(model, {})
+        assert merged["effort"] == "high"
+
+    def test_out_of_domain_with_no_default_is_dropped(self):
+        spec = ModelParamSpec(supported=True, allowed=["low", "medium", "high"])
+        model = _model(effort=spec)
+        merged = _merge_inference_params(model, {"effort": "max"})
+        assert "effort" not in merged

--- a/backend/tests/shared/test_managed_models.py
+++ b/backend/tests/shared/test_managed_models.py
@@ -134,3 +134,47 @@ class TestMaxTokensCeiling:
                 maxOutputTokens=4096,
                 supportedParams={"params": {"max_tokens": {"supported": True, "default": 8192}}},
             )
+
+
+class TestEffortAllowed:
+    """Enum params carry an `allowed` set; `default` must be a member.
+
+    This is the per-model representation of the effort-tier difference
+    (Sonnet 4.6 vs Opus 4.7) — data, not model-family branching in code.
+    """
+
+    def test_default_in_allowed_ok(self):
+        m = _make_model_data(
+            supportedParams={"params": {"effort": {
+                "supported": True, "allowed": ["low", "medium", "high"], "default": "high",
+            }}},
+        )
+        spec = m.supported_params.params["effort"]
+        assert spec.allowed == ["low", "medium", "high"]
+        assert spec.default == "high"
+
+    def test_default_not_in_allowed_rejected(self):
+        with pytest.raises(Exception):
+            _make_model_data(
+                supportedParams={"params": {"effort": {
+                    "supported": True, "allowed": ["low", "medium", "high"], "default": "xhigh",
+                }}},
+            )
+
+    def test_empty_allowed_rejected(self):
+        with pytest.raises(Exception):
+            _make_model_data(
+                supportedParams={"params": {"effort": {
+                    "supported": True, "allowed": [], "default": None,
+                }}},
+            )
+
+    def test_allowed_without_default_ok(self):
+        # No default is valid — runtime sends nothing, model uses its own
+        # API default (effort "high").
+        m = _make_model_data(
+            supportedParams={"params": {"effort": {
+                "supported": True, "allowed": ["low", "medium", "high", "xhigh", "max"],
+            }}},
+        )
+        assert m.supported_params.params["effort"].default is None

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -552,6 +552,37 @@
                         Default to enabled
                       </label>
                     </div>
+                  } @else if (meta.kind === 'select') {
+                    <div class="md:col-span-2">
+                      <span class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                        Levels this model supports
+                      </span>
+                      <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                        @for (lvl of meta.options ?? []; track lvl) {
+                          <label class="flex items-center gap-2 text-xs/5 text-gray-700 dark:text-gray-300">
+                            <input
+                              type="checkbox"
+                              [checked]="isParamAllowed(i, lvl)"
+                              (change)="toggleParamAllowed(i, lvl)"
+                              class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
+                            />
+                            {{ lvl }}
+                          </label>
+                        }
+                      </div>
+                    </div>
+                    <div>
+                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Default</label>
+                      <select
+                        formControlName="defaultValue"
+                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                      >
+                        <option [ngValue]="null">— none (API default) —</option>
+                        @for (lvl of paramRowGroup(i).controls.allowed.value ?? []; track lvl) {
+                          <option [ngValue]="lvl">{{ lvl }}</option>
+                        }
+                      </select>
+                    </div>
                   }
                   <div>
                     <label class="flex items-center gap-2 pt-5 text-xs/5 font-medium text-gray-600 dark:text-gray-400">

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -37,6 +37,12 @@ interface ParamRowGroup {
   supported: FormControl<boolean>;
   min: FormControl<number | null>;
   max: FormControl<number | null>;
+  /**
+   * Selectable subset for `kind: 'select'` params (e.g. `effort`). `null`
+   * on numeric/toggle rows. The per-model effort tier difference lives
+   * here as data, mirroring `ModelParamSpec.allowed` on the backend.
+   */
+  allowed: FormControl<(string | number)[] | null>;
   defaultValue: FormControl<number | boolean | string | null>;
   locked: FormControl<boolean>;
 }
@@ -75,6 +81,17 @@ function paramRowBoundsValidator(group: AbstractControl): ValidationErrors | nul
   if (typeof def === 'number') {
     if (typeof min === 'number' && def < min) errors['defaultBelowMin'] = true;
     if (typeof max === 'number' && def > max) errors['defaultAboveMax'] = true;
+  }
+  // Enum rows (`kind: 'select'`, e.g. effort) carry an `allowed` array
+  // instead of min/max. The model must support at least one level, and the
+  // default has to be one of them. Mirrors `ModelParamSpec._check_bounds`.
+  const allowed = group.get('allowed')?.value;
+  if (Array.isArray(allowed)) {
+    if (allowed.length === 0) {
+      errors['allowedEmpty'] = true;
+    } else if (def !== null && def !== undefined && def !== '' && !allowed.includes(def)) {
+      errors['defaultNotAllowed'] = true;
+    }
   }
   return Object.keys(errors).length > 0 ? errors : null;
 }
@@ -412,6 +429,7 @@ export class ModelFormPage implements OnInit {
           supported: fromExisting.supported,
           min: fromExisting.min ?? row.controls.min.value,
           max: fromExisting.max ?? row.controls.max.value,
+          allowed: fromExisting.allowed ?? row.controls.allowed.value,
           defaultValue: fromExisting.default ?? null,
           locked: fromExisting.locked,
         });
@@ -455,6 +473,7 @@ export class ModelFormPage implements OnInit {
           supported: spec.supported,
           min: spec.min ?? row.controls.min.value,
           max: spec.max ?? row.controls.max.value,
+          allowed: spec.allowed ?? row.controls.allowed.value,
           defaultValue: spec.default ?? null,
           locked: spec.locked,
         });
@@ -520,6 +539,9 @@ export class ModelFormPage implements OnInit {
         supported: this.fb.control(seed?.supported ?? true, { nonNullable: true }),
         min: this.fb.control<number | null>(seed?.min ?? null),
         max: this.fb.control<number | null>(seed?.max ?? null),
+        // Custom rows have no catalog kind, so they're never enum-select;
+        // round-trip a persisted `allowed` if one was stored, else null.
+        allowed: this.fb.control<(string | number)[] | null>(seed?.allowed ?? null),
         defaultValue: this.fb.control<number | boolean | string | null>(seed?.default ?? null),
         locked: this.fb.control(seed?.locked ?? false, { nonNullable: true }),
       },
@@ -575,6 +597,11 @@ export class ModelFormPage implements OnInit {
     const providerBounds = meta.defaults?.[provider];
     const seedMin = seed?.min ?? providerBounds?.min ?? meta.defaultMin ?? null;
     const seedMax = seed?.max ?? providerBounds?.max ?? meta.defaultMax ?? null;
+    // Enum-select rows (e.g. effort) carry an `allowed` subset instead of
+    // min/max. Empty array on a fresh row marks it as "select kind" for the
+    // validator/template and forces the admin to opt into levels explicitly.
+    const seedAllowed: (string | number)[] | null =
+      meta.kind === 'select' ? (seed?.allowed ?? []) : null;
     return this.fb.group<ParamRowGroup>(
       {
         // Catalog key is fixed for known rows — no validators, just a read-only
@@ -583,6 +610,7 @@ export class ModelFormPage implements OnInit {
         supported: this.fb.control(seed?.supported ?? false, { nonNullable: true }),
         min: this.fb.control<number | null>(seedMin),
         max: this.fb.control<number | null>(seedMax),
+        allowed: this.fb.control<(string | number)[] | null>(seedAllowed),
         defaultValue: this.fb.control<number | boolean | string | null>(seed?.default ?? null),
         locked: this.fb.control(seed?.locked ?? false, { nonNullable: true }),
       },
@@ -596,6 +624,7 @@ export class ModelFormPage implements OnInit {
       supported: v.supported,
       min: v.min,
       max: v.max,
+      allowed: v.allowed,
       default: v.defaultValue,
       locked: v.locked,
     };
@@ -678,7 +707,40 @@ export class ModelFormPage implements OnInit {
         out.push(`Default must be ≤ the model's Max Output Tokens (${ceiling}).`);
       }
     }
+    if (row.errors['allowedEmpty']) {
+      out.push('Select at least one level this model supports.');
+    }
+    if (row.errors['defaultNotAllowed']) {
+      out.push('Default must be one of the selected levels.');
+    }
     return out;
+  }
+
+  /**
+   * Whether `value` is in the enum-select row's `allowed` subset. Backs the
+   * per-level checkboxes for `kind: 'select'` params (e.g. effort).
+   */
+  isParamAllowed(index: number, value: string): boolean {
+    return (this.paramRowGroup(index).controls.allowed.value ?? []).includes(value);
+  }
+
+  /**
+   * Toggle a level in the enum-select row's `allowed` subset. Clears the
+   * row default if the level backing it was just removed so the
+   * default-in-allowed invariant can't be left stale.
+   */
+  toggleParamAllowed(index: number, value: string): void {
+    const row = this.paramRowGroup(index);
+    const current = row.controls.allowed.value ?? [];
+    const next = current.includes(value)
+      ? current.filter(v => v !== value)
+      : [...current, value];
+    row.controls.allowed.setValue(next);
+    row.controls.allowed.markAsDirty();
+    if (row.controls.defaultValue.value != null && !next.includes(row.controls.defaultValue.value as string)) {
+      row.controls.defaultValue.setValue(null);
+    }
+    row.controls.allowed.updateValueAndValidity();
   }
 
   /**

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -20,6 +20,13 @@ export interface ModelParamSpec {
   supported: boolean;
   min?: number | null;
   max?: number | null;
+  /**
+   * Permissible values for enum-style params (e.g. `effort`). When set,
+   * `default` and any user override must be a member; `min`/`max` don't
+   * apply. The per-model difference (Sonnet 4.6 vs Opus 4.7 effort tiers)
+   * lives here as data — no model-family branching in code.
+   */
+  allowed?: (string | number)[] | null;
   default?: number | boolean | string | null;
   locked?: boolean;
 }
@@ -165,7 +172,13 @@ export interface KnownParamMeta {
    * stored value is `null` (off) or an int budget (on). The runtime
    * translator wraps the int into the provider-native shape.
    */
-  kind: 'number' | 'integer' | 'toggle' | 'thinkingBudget';
+  kind: 'number' | 'integer' | 'toggle' | 'thinkingBudget' | 'select';
+  /**
+   * Universe of selectable values for `kind: 'select'`. The admin checks the
+   * subset this model supports (stored as `ModelParamSpec.allowed`); the
+   * default is chosen from that subset. Ordered low->high.
+   */
+  options?: string[];
   /** Catalog-wide fallback range, used when no provider-specific entry applies. */
   defaultMin?: number;
   defaultMax?: number;
@@ -235,6 +248,17 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     defaultMin: 1024,
     providers: ['bedrock', 'gemini'],
     incompatibleWith: ['temperature', 'top_p', 'top_k'],
+  },
+  {
+    key: 'effort',
+    label: 'Effort',
+    description:
+      'Reasoning/output effort (Anthropic output_config.effort). Higher = ' +
+      'more thorough, more tokens. On adaptive-thinking models it governs ' +
+      'thinking depth. Check the levels this model supports; pick a default.',
+    kind: 'select',
+    options: ['low', 'medium', 'high', 'xhigh', 'max'],
+    providers: ['bedrock'],
   },
   {
     key: 'reasoning_effort',

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -153,10 +153,6 @@
 
           @if (isAdvancedOpen()) {
             <div id="advanced-params-body" class="space-y-4 px-4 pb-4">
-              <p class="text-xs/5 text-gray-500 dark:text-gray-400">
-                Per-model inference parameters. Values are clamped to the model's allowed range on the server.
-              </p>
-
               @for (row of advancedRows(); track row.key) {
                 <div class="space-y-1.5">
                   <div class="flex items-baseline justify-between gap-2">
@@ -179,9 +175,7 @@
                       </button>
                     }
                   </div>
-                  <p
-                    [id]="'param-desc-' + row.key"
-                    class="text-xs/5 text-gray-500 dark:text-gray-400">
+                  <p [id]="'param-desc-' + row.key" class="sr-only">
                     {{ row.meta.description }}
                   </p>
 
@@ -252,6 +246,19 @@
                           (change)="onThinkingBudgetChange(row, $event)"
                           class="w-32 rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/5 text-gray-900 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:disabled:bg-white/0" />
                       </div>
+                    }
+                    @case ('select') {
+                      <select
+                        [id]="'param-input-' + row.key"
+                        [attr.aria-describedby]="'param-desc-' + row.key"
+                        [disabled]="row.locked || row.disabledByConflict"
+                        (change)="onParamSelectChange(row, $event)"
+                        class="w-40 rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/5 text-gray-900 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:disabled:bg-white/0">
+                        <option value="" [selected]="row.value === null || row.value === undefined">Use admin default</option>
+                        @for (lvl of row.spec.allowed ?? []; track lvl) {
+                          <option [value]="lvl" [selected]="row.value === lvl">{{ lvl }}</option>
+                        }
+                      </select>
                     }
                     @default {
                       <input

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -310,6 +310,20 @@ export class ModelSettings {
   }
 
   /**
+   * Enum-select params (e.g. `effort`). The empty option clears the override
+   * (fall back to the admin default), mirroring how emptying a number input
+   * clears it. Any non-empty value is sent verbatim; the server gates it
+   * against the model's `allowed` set, so an out-of-domain value can't slip
+   * through even if the option list is momentarily stale.
+   */
+  onParamSelectChange(row: AdvancedParamRow, event: Event): void {
+    if (row.locked || row.disabledByConflict) return;
+    const target = event.target as HTMLSelectElement | null;
+    const raw = target?.value ?? '';
+    this.modelService.setInferenceParamOverride(row.key, raw === '' ? null : raw);
+  }
+
+  /**
    * Extended thinking enable/disable. The stored value is `null` (off) or an
    * int budget (on). Default budget falls back to the admin default, then to
    * the catalog `defaultMin` (1024 for thinking).


### PR DESCRIPTION
## Summary

- **Fixes the Opus 4.7 `ConverseStream` 400** (`"thinking.type.enabled" is not supported for this model`). `_shape_thinking_value` is now model-aware: Opus 4.6/4.7, Sonnet 4.6 and Mythos emit `{type:"adaptive", display:"summarized"}`; older models keep the legacy `{type:"enabled", budget_tokens:N}` shape. `display:"summarized"` is required so the reasoning trace doesn't render blank on Opus 4.7 (it defaults `display` to `"omitted"`).
- **Adds `effort` as a first-class inference param** → Anthropic `output_config.effort`, routed through Bedrock `additionalModelRequestFields` like `thinking`/`top_k`.
- **Generic `allowed` enum field on `ModelParamSpec`** so the per-model effort-tier difference (Sonnet 4.6 `low/medium/high` vs Opus 4.7 `+xhigh/max`) is **data, not model-family branching**. `default ∈ allowed` validated at config time; out-of-domain runtime overrides fall back to the default in `_merge_inference_params` instead of erroring mid-stream.
- **UI:** new `select` control on both surfaces that render the param catalog — the admin model form (per-level checkboxes + default dropdown) and the user-facing chat **Settings → Advanced** panel (dropdown). Also decluttered the chat panel's Advanced section (removed static explanatory text; per-param descriptions kept `sr-only` to preserve `aria-describedby` / WCAG).
- **Seed:** Sonnet 4.6 seeded with `effort`. Note: seeded with `low/medium/high` per the requested set — Anthropic docs additionally list `max` for Sonnet 4.6; widen the array in `seed_bootstrap_data.py` if desired (one-line, by design).

## Notes / scope

- The "thinking budget ≥ 1024 and < max_tokens" invariant still applies on adaptive models — the int there is just the "thinking on" signal. Deliberately left unchanged; relaxing it for adaptive models is a clean follow-up.
- Branched from `develop` (contains prerequisite #329/#330); no pre-existing uncommitted work bundled.

## Test plan

- [x] Backend: `uv run pytest` — 107 passed incl. new adaptive/effort/`allowed`-gating cases + architecture import-boundary guard
- [x] Frontend: `ng build` clean (only pre-existing unrelated NG8113 warnings)
- [ ] Manual (Cognito-gated, SKIP_AUTH off): Admin → edit Sonnet 4.6 → Inference Parameters → Effort row shows level checkboxes + default dropdown; default-not-in-allowed / empty-allowed inline errors fire; round-trips on reload
- [ ] Manual: Chat → Settings → Advanced → Effort renders as a dropdown (not a number input) listing the model's allowed levels + "Use admin default"; Reset clears the override
- [ ] Manual: Opus 4.7 model with thinking enabled streams a reasoning trace instead of a Bedrock 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)