### PR TITLE
feat(admin): redesign model views as compact expandable rows

### DIFF
--- a/frontend/ai.client/src/app/admin/bedrock-models/bedrock-models.page.html
+++ b/frontend/ai.client/src/app/admin/bedrock-models/bedrock-models.page.html
@@ -1,149 +1,119 @@
 <div class="min-h-dvh">
-  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Back Button -->
     <a
       routerLink="/admin/manage-models"
       class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
     >
-      <ng-icon name="heroArrowLeft" class="size-4" />
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
       Back to Manage Models
     </a>
 
     <!-- Page Header -->
-    <div class="mb-8">
-      <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">Bedrock Foundation Models</h1>
-      <p class="mt-2 text-base/7 text-gray-600 dark:text-gray-400">
-        View and filter available AWS Bedrock foundation models
+    <div class="mb-6">
+      <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Bedrock Foundation Models</h1>
+      <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        Browse available AWS Bedrock foundation models and add them to your managed list.
       </p>
     </div>
 
-    <!-- Filters Section -->
-    <div class="mb-6 rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-      <h2 class="mb-4 text-lg/7 font-semibold text-gray-900 dark:text-white">Filters</h2>
-
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <!-- Search Filter -->
-        <div>
-          <label for="search" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Search Models
-          </label>
-          <input
-            type="text"
-            id="search"
-            [ngModel]="searchQuery()"
-            (ngModelChange)="searchQuery.set($event)"
-            placeholder="Search by ID, name, or provider..."
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
-
-        <!-- Provider Filter -->
-        <div>
-          <label for="provider" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Provider
-          </label>
-          <select
-            id="provider"
-            [ngModel]="providerFilter()"
-            (ngModelChange)="providerFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Providers</option>
-            @for (provider of availableProviders(); track provider) {
-              <option [value]="provider">{{ provider }}</option>
-            }
-          </select>
-        </div>
-
-        <!-- Output Modality Filter -->
-        <div>
-          <label for="outputModality" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Output Modality
-          </label>
-          <select
-            id="outputModality"
-            [ngModel]="outputModalityFilter()"
-            (ngModelChange)="outputModalityFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Modalities</option>
-            @for (modality of availableOutputModalities(); track modality) {
-              <option [value]="modality">{{ modality }}</option>
-            }
-          </select>
-        </div>
-
-        <!-- Inference Type Filter -->
-        <div>
-          <label for="inferenceType" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Inference Type
-          </label>
-          <select
-            id="inferenceType"
-            [ngModel]="inferenceTypeFilter()"
-            (ngModelChange)="inferenceTypeFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Types</option>
-            @for (type of availableInferenceTypes(); track type) {
-              <option [value]="type">{{ type }}</option>
-            }
-          </select>
-        </div>
-
-        <!-- Customization Type Filter -->
-        <div>
-          <label for="customizationType" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Customization Type
-          </label>
-          <select
-            id="customizationType"
-            [ngModel]="customizationTypeFilter()"
-            (ngModelChange)="customizationTypeFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Types</option>
-            @for (type of availableCustomizationTypes(); track type) {
-              <option [value]="type">{{ type }}</option>
-            }
-          </select>
-        </div>
-
-        <!-- Max Results Filter -->
-        <div>
-          <label for="maxResults" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Max Results
-          </label>
-          <input
-            type="number"
-            id="maxResults"
-            [ngModel]="maxResultsFilter()"
-            (ngModelChange)="maxResultsFilter.set($event || undefined)"
-            placeholder="No limit"
-            min="1"
-            max="1000"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
+    <!-- Toolbar: search + filters inline -->
+    <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+      <div class="relative min-w-48 flex-1">
+        <ng-icon
+          name="heroMagnifyingGlass"
+          class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <label for="search" class="sr-only">Search models</label>
+        <input
+          type="text"
+          id="search"
+          [ngModel]="searchQuery()"
+          (ngModelChange)="searchQuery.set($event)"
+          placeholder="Search by ID, name, or provider…"
+          class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+        />
       </div>
 
-      <!-- Filter Actions -->
-      <div class="mt-4 flex gap-3">
-        <button
-          (click)="applyFilters()"
-          class="rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
-        >
-          Apply Filters
-        </button>
-        @if (hasActiveFilters()) {
-          <button
-            (click)="resetFilters()"
-            class="rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-          >
-            Reset Filters
-          </button>
+      <label for="provider" class="sr-only">Filter by provider</label>
+      <select
+        id="provider"
+        [ngModel]="providerFilter()"
+        (ngModelChange)="providerFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All providers</option>
+        @for (provider of availableProviders(); track provider) {
+          <option [value]="provider">{{ provider }}</option>
         }
-      </div>
+      </select>
+
+      <label for="outputModality" class="sr-only">Filter by output modality</label>
+      <select
+        id="outputModality"
+        [ngModel]="outputModalityFilter()"
+        (ngModelChange)="outputModalityFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All modalities</option>
+        @for (modality of availableOutputModalities(); track modality) {
+          <option [value]="modality">{{ modality }}</option>
+        }
+      </select>
+
+      <label for="inferenceType" class="sr-only">Filter by inference type</label>
+      <select
+        id="inferenceType"
+        [ngModel]="inferenceTypeFilter()"
+        (ngModelChange)="inferenceTypeFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All inference types</option>
+        @for (type of availableInferenceTypes(); track type) {
+          <option [value]="type">{{ type }}</option>
+        }
+      </select>
+
+      <label for="customizationType" class="sr-only">Filter by customization type</label>
+      <select
+        id="customizationType"
+        [ngModel]="customizationTypeFilter()"
+        (ngModelChange)="customizationTypeFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All customizations</option>
+        @for (type of availableCustomizationTypes(); track type) {
+          <option [value]="type">{{ type }}</option>
+        }
+      </select>
+
+      <label for="maxResults" class="sr-only">Max results</label>
+      <input
+        type="number"
+        id="maxResults"
+        [ngModel]="maxResultsFilter()"
+        (ngModelChange)="maxResultsFilter.set($event || undefined)"
+        placeholder="Max"
+        min="1"
+        max="1000"
+        class="w-24 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+      />
+
+      <button
+        (click)="applyFilters()"
+        class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+      >
+        Apply
+      </button>
+      @if (hasActiveFilters()) {
+        <button
+          (click)="resetFilters()"
+          class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+        >
+          Reset
+        </button>
+      }
     </div>
 
     <!-- Loading State -->
@@ -155,157 +125,125 @@
 
     <!-- Error State -->
     @if (error()) {
-      <div class="rounded-sm border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
         <h3 class="text-sm/6 font-medium text-red-800 dark:text-red-400">Error loading models</h3>
         <p class="mt-1 text-sm/6 text-red-700 dark:text-red-500">{{ error() }}</p>
       </div>
     }
 
-    <!-- Results Header -->
     @if (!isLoading() && !error()) {
-      <div class="mb-4 flex items-center justify-between">
-        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-          Showing {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
-        </p>
-      </div>
+      <!-- Count -->
+      <p class="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+        {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
+      </p>
 
       <!-- Models List -->
       @if (models().length === 0) {
-        <div class="rounded-sm border border-gray-200 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
-          <p class="text-base/7 text-gray-500 dark:text-gray-400">
+        <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+          <p class="text-sm/6 text-gray-500 dark:text-gray-400">
             No models found matching the current filters.
           </p>
         </div>
       } @else {
-        <div class="space-y-4">
+        <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
           @for (model of models(); track model.modelId) {
-            <div class="rounded-sm border border-gray-200 bg-white p-6 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
-              <!-- Model Header -->
-              <div class="mb-4 flex items-start justify-between">
-                <div class="flex-1">
-                  <h3 class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+            <li>
+              <!-- Row -->
+              <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                <button
+                  type="button"
+                  (click)="toggleExpand(model.modelId)"
+                  [attr.aria-expanded]="isExpanded(model.modelId)"
+                  [attr.aria-controls]="'model-detail-' + model.modelId"
+                  [attr.aria-label]="(isExpanded(model.modelId) ? 'Hide' : 'Show') + ' details for ' + model.modelName"
+                  class="flex size-7 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon
+                    name="heroChevronDown"
+                    class="size-4 transition-transform duration-150"
+                    [class.rotate-180]="isExpanded(model.modelId)"
+                    aria-hidden="true"
+                  />
+                </button>
+
+                <div class="min-w-0 flex-1">
+                  <span class="block truncate text-sm/6 font-medium text-gray-900 dark:text-white">
                     {{ model.modelName }}
-                  </h3>
-                  <p class="mt-1 font-mono text-sm/6 text-gray-600 dark:text-gray-400">
+                  </span>
+                  <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
                     {{ model.modelId }}
                   </p>
                 </div>
-                <span class="inline-flex shrink-0 items-center rounded-sm bg-blue-100 px-3 py-1 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">
+
+                <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
                   {{ model.providerName }}
                 </span>
-              </div>
 
-              <!-- Model Details Grid -->
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <!-- Input Modalities -->
-                <div>
-                  <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Input Modalities</h4>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    @for (modality of model.inputModalities; track modality) {
-                      <span class="inline-flex items-center rounded-sm bg-gray-100 px-2 py-1 text-xs/5 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
-                        {{ modality }}
-                      </span>
-                    }
-                    @if (model.inputModalities.length === 0) {
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">None</span>
-                    }
-                  </div>
-                </div>
-
-                <!-- Output Modalities -->
-                <div>
-                  <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Output Modalities</h4>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    @for (modality of model.outputModalities; track modality) {
-                      <span class="inline-flex items-center rounded-sm bg-gray-100 px-2 py-1 text-xs/5 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
-                        {{ modality }}
-                      </span>
-                    }
-                    @if (model.outputModalities.length === 0) {
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">None</span>
-                    }
-                  </div>
-                </div>
-
-                <!-- Inference Types -->
-                <div>
-                  <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Inference Types</h4>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    @for (type of model.inferenceTypesSupported; track type) {
-                      <span class="inline-flex items-center rounded-sm bg-green-100 px-2 py-1 text-xs/5 text-green-700 dark:bg-green-900/50 dark:text-green-300">
-                        {{ type }}
-                      </span>
-                    }
-                    @if (model.inferenceTypesSupported.length === 0) {
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">None</span>
-                    }
-                  </div>
-                </div>
-
-                <!-- Customizations Supported -->
-                <div>
-                  <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Customizations</h4>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    @for (customization of model.customizationsSupported; track customization) {
-                      <span class="inline-flex items-center rounded-sm bg-purple-100 px-2 py-1 text-xs/5 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
-                        {{ customization }}
-                      </span>
-                    }
-                    @if (model.customizationsSupported.length === 0) {
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">None</span>
-                    }
-                  </div>
-                </div>
-              </div>
-
-              <!-- Model Features and Actions -->
-              <div class="mt-4 flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-gray-700">
-                <div class="flex gap-4">
-                  <div class="flex items-center gap-2">
-                    @if (model.responseStreamingSupported) {
-                      <svg class="size-5 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-                      </svg>
-                      <span class="text-sm/6 text-gray-700 dark:text-gray-300">Streaming supported</span>
-                    } @else {
-                      <svg class="size-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
-                      </svg>
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">No streaming</span>
-                    }
-                  </div>
-
-                  @if (model.modelLifecycle) {
-                    <div class="flex items-center gap-2">
-                      <span class="text-sm/6 text-gray-600 dark:text-gray-400">Status:</span>
-                      <span class="font-medium text-sm/6 text-gray-900 dark:text-white">{{ model.modelLifecycle }}</span>
-                    </div>
-                  }
-                </div>
-
-                <!-- Add Model Button or Added Status -->
                 @if (isModelAdded(model.modelId)) {
-                  <div class="inline-flex items-center gap-2 rounded-sm bg-green-100 px-3 py-1.5 text-sm/6 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
-                    <svg class="size-4" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-                    </svg>
+                  <span class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-green-100 px-3 py-1.5 text-xs/5 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
+                    <ng-icon name="heroCheckCircleSolid" class="size-4" aria-hidden="true" />
                     Added
-                  </div>
+                  </span>
                 } @else {
                   <button
                     (click)="addModelFromBedrock(model)"
-                    class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-xs/5 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
                   >
-                    <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-                    </svg>
-                    Add Model
+                    <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                    Add
                   </button>
                 }
               </div>
-            </div>
+
+              <!-- Expanded detail -->
+              @if (isExpanded(model.modelId)) {
+                <div
+                  [id]="'model-detail-' + model.modelId"
+                  class="border-t border-gray-100 bg-gray-50 px-4 py-3 sm:pl-14 dark:border-gray-700/60 dark:bg-gray-900/40"
+                >
+                  <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-3">
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Input modalities</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        {{ model.inputModalities.length > 0 ? model.inputModalities.join(', ') : 'None' }}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Output modalities</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        {{ model.outputModalities.length > 0 ? model.outputModalities.join(', ') : 'None' }}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Streaming</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        {{ model.responseStreamingSupported ? 'Supported' : 'Not supported' }}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Inference types</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        {{ model.inferenceTypesSupported.length > 0 ? model.inferenceTypesSupported.join(', ') : 'None' }}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Customizations</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        {{ model.customizationsSupported.length > 0 ? model.customizationsSupported.join(', ') : 'None' }}
+                      </dd>
+                    </div>
+                    @if (model.modelLifecycle) {
+                      <div>
+                        <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Lifecycle</dt>
+                        <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">{{ model.modelLifecycle }}</dd>
+                      </div>
+                    }
+                  </dl>
+                </div>
+              }
+            </li>
           }
-        </div>
+        </ul>
       }
     }
   </div>

--- a/frontend/ai.client/src/app/admin/bedrock-models/bedrock-models.page.ts
+++ b/frontend/ai.client/src/app/admin/bedrock-models/bedrock-models.page.ts
@@ -2,7 +2,13 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@a
 import { Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import {
+  heroArrowLeft,
+  heroPlus,
+  heroMagnifyingGlass,
+  heroChevronDown,
+} from '@ng-icons/heroicons/outline';
+import { heroCheckCircleSolid } from '@ng-icons/heroicons/solid';
 import { BedrockModelsService } from './services/bedrock-models.service';
 import { FoundationModelSummary } from './models/bedrock-model.model';
 import { ManagedModelsService } from '../manage-models/services/managed-models.service';
@@ -11,7 +17,15 @@ import { ThinkingDotsComponent } from '../../components/thinking-dots.component'
 @Component({
   selector: 'app-bedrock-models-page',
   imports: [FormsModule, ThinkingDotsComponent, RouterLink, NgIcon],
-  providers: [provideIcons({ heroArrowLeft })],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPlus,
+      heroMagnifyingGlass,
+      heroChevronDown,
+      heroCheckCircleSolid,
+    }),
+  ],
   templateUrl: './bedrock-models.page.html',
   styleUrl: './bedrock-models.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,6 +42,9 @@ export class BedrockModelsPage {
   customizationTypeFilter = signal<string>('');
   maxResultsFilter = signal<number | undefined>(undefined);
   searchQuery = signal<string>('');
+
+  // Row detail expansion state (set of model ids currently expanded)
+  private expandedIds = signal<ReadonlySet<string>>(new Set());
 
   // Access the models resource from the service
   readonly modelsResource = this.bedrockModelsService.modelsResource;
@@ -124,6 +141,22 @@ export class BedrockModelsPage {
       this.searchQuery()
     );
   });
+
+  isExpanded(modelId: string): boolean {
+    return this.expandedIds().has(modelId);
+  }
+
+  toggleExpand(modelId: string): void {
+    this.expandedIds.update(current => {
+      const next = new Set(current);
+      if (next.has(modelId)) {
+        next.delete(modelId);
+      } else {
+        next.add(modelId);
+      }
+      return next;
+    });
+  }
 
   /**
    * Check if a model has already been added to the managed models list

--- a/frontend/ai.client/src/app/admin/gemini-models/gemini-models.page.html
+++ b/frontend/ai.client/src/app/admin/gemini-models/gemini-models.page.html
@@ -1,77 +1,67 @@
 <div class="min-h-dvh">
-  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Back Button -->
     <a
       routerLink="/admin/manage-models"
       class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
     >
-      <ng-icon name="heroArrowLeft" class="size-4" />
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
       Back to Manage Models
     </a>
 
     <!-- Page Header -->
-    <div class="mb-8">
-      <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">Google Gemini Models</h1>
-      <p class="mt-2 text-base/7 text-gray-600 dark:text-gray-400">
-        View and manage available Google Gemini models
+    <div class="mb-6">
+      <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Google Gemini Models</h1>
+      <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        Browse available Google Gemini models and add them to your managed list.
       </p>
     </div>
 
-    <!-- Filters Section -->
-    <div class="mb-6 rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-      <h2 class="mb-4 text-lg/7 font-semibold text-gray-900 dark:text-white">Filters</h2>
-
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <!-- Search Filter -->
-        <div>
-          <label for="search" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Search Models
-          </label>
-          <input
-            type="text"
-            id="search"
-            [ngModel]="searchQuery()"
-            (ngModelChange)="searchQuery.set($event)"
-            placeholder="Search by name or description..."
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
-
-        <!-- Max Results Filter -->
-        <div>
-          <label for="maxResults" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Max Results
-          </label>
-          <input
-            type="number"
-            id="maxResults"
-            [ngModel]="maxResultsFilter()"
-            (ngModelChange)="maxResultsFilter.set($event || undefined)"
-            placeholder="No limit"
-            min="1"
-            max="1000"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
+    <!-- Toolbar: search + filters inline -->
+    <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+      <div class="relative flex-1">
+        <ng-icon
+          name="heroMagnifyingGlass"
+          class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <label for="search" class="sr-only">Search models</label>
+        <input
+          type="text"
+          id="search"
+          [ngModel]="searchQuery()"
+          (ngModelChange)="searchQuery.set($event)"
+          placeholder="Search by name or description…"
+          class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+        />
       </div>
 
-      <!-- Filter Actions -->
-      <div class="mt-4 flex gap-3">
+      <label for="maxResults" class="sr-only">Max results</label>
+      <input
+        type="number"
+        id="maxResults"
+        [ngModel]="maxResultsFilter()"
+        (ngModelChange)="maxResultsFilter.set($event || undefined)"
+        placeholder="Max"
+        min="1"
+        max="1000"
+        class="w-24 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+      />
+
+      <button
+        (click)="applyFilters()"
+        class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+      >
+        Apply
+      </button>
+      @if (hasActiveFilters()) {
         <button
-          (click)="applyFilters()"
-          class="rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          (click)="resetFilters()"
+          class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
         >
-          Apply Filters
+          Reset
         </button>
-        @if (hasActiveFilters()) {
-          <button
-            (click)="resetFilters()"
-            class="rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-          >
-            Reset Filters
-          </button>
-        }
-      </div>
+      }
     </div>
 
     <!-- Loading State -->
@@ -83,148 +73,133 @@
 
     <!-- Error State -->
     @if (error()) {
-      <div class="rounded-sm border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
         <h3 class="text-sm/6 font-medium text-red-800 dark:text-red-400">Error loading models</h3>
         <p class="mt-1 text-sm/6 text-red-700 dark:text-red-500">{{ error() }}</p>
       </div>
     }
 
-    <!-- Results Header -->
     @if (!isLoading() && !error()) {
-      <div class="mb-4 flex items-center justify-between">
-        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-          Showing {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
-        </p>
-      </div>
+      <!-- Count -->
+      <p class="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+        {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
+      </p>
 
       <!-- Models List -->
       @if (models().length === 0) {
-        <div class="rounded-sm border border-gray-200 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
-          <p class="text-base/7 text-gray-500 dark:text-gray-400">
-            No models found.
-          </p>
+        <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+          <p class="text-sm/6 text-gray-500 dark:text-gray-400">No models found.</p>
         </div>
       } @else {
-        <div class="space-y-4">
+        <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
           @for (model of models(); track model.name) {
-            <div class="rounded-sm border border-gray-200 bg-white p-6 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
-              <!-- Model Header -->
-              <div class="mb-4 flex items-start justify-between">
-                <div class="flex-1">
-                  <h3 class="text-lg/7 font-semibold text-gray-900 dark:text-white">
-                    {{ model.displayName }}
-                  </h3>
-                  <p class="mt-1 font-mono text-sm/6 text-gray-600 dark:text-gray-400">
+            <li>
+              <!-- Row -->
+              <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                <button
+                  type="button"
+                  (click)="toggleExpand(model.name)"
+                  [attr.aria-expanded]="isExpanded(model.name)"
+                  [attr.aria-controls]="'model-detail-' + model.name"
+                  [attr.aria-label]="(isExpanded(model.name) ? 'Hide' : 'Show') + ' details for ' + model.displayName"
+                  class="flex size-7 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon
+                    name="heroChevronDown"
+                    class="size-4 transition-transform duration-150"
+                    [class.rotate-180]="isExpanded(model.name)"
+                    aria-hidden="true"
+                  />
+                </button>
+
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-1.5">
+                    <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                      {{ model.displayName }}
+                    </span>
+                    @if (model.thinking) {
+                      <span class="shrink-0 rounded-2xl bg-purple-100 px-2 py-0.5 text-xs/5 font-medium text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
+                        Thinking
+                      </span>
+                    }
+                  </div>
+                  <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
                     {{ model.name }}
                   </p>
-                  @if (model.description) {
-                    <p class="mt-2 text-sm/6 text-gray-700 dark:text-gray-300">
-                      {{ model.description }}
-                    </p>
-                  }
                 </div>
-                <span class="inline-flex shrink-0 items-center rounded-sm bg-blue-100 px-3 py-1 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">
+
+                <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
                   Google
                 </span>
-              </div>
 
-              <!-- Model Details Grid -->
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <!-- Token Limits -->
-                <div>
-                  <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Token Limits</h4>
-                  <div class="mt-2 space-y-1">
-                    @if (model.inputTokenLimit) {
-                      <div class="flex items-center gap-2">
-                        <span class="text-xs/5 text-gray-600 dark:text-gray-400">Input:</span>
-                        <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ model.inputTokenLimit | number }}</span>
-                      </div>
-                    }
-                    @if (model.outputTokenLimit) {
-                      <div class="flex items-center gap-2">
-                        <span class="text-xs/5 text-gray-600 dark:text-gray-400">Output:</span>
-                        <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ model.outputTokenLimit | number }}</span>
-                      </div>
-                    }
-                    @if (!model.inputTokenLimit && !model.outputTokenLimit) {
-                      <span class="text-sm/6 text-gray-500 dark:text-gray-400">Not specified</span>
-                    }
-                  </div>
-                </div>
-
-                <!-- Model Parameters -->
-                @if (model.temperature !== null || model.topP !== null || model.topK !== null) {
-                  <div>
-                    <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Parameters</h4>
-                    <div class="mt-2 space-y-1">
-                      @if (model.temperature !== null) {
-                        <div class="flex items-center gap-2">
-                          <span class="text-xs/5 text-gray-600 dark:text-gray-400">Temperature:</span>
-                          <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ model.temperature }}</span>
-                        </div>
-                      }
-                      @if (model.topP !== null) {
-                        <div class="flex items-center gap-2">
-                          <span class="text-xs/5 text-gray-600 dark:text-gray-400">Top-P:</span>
-                          <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ model.topP }}</span>
-                        </div>
-                      }
-                      @if (model.topK !== null) {
-                        <div class="flex items-center gap-2">
-                          <span class="text-xs/5 text-gray-600 dark:text-gray-400">Top-K:</span>
-                          <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ model.topK }}</span>
-                        </div>
-                      }
-                    </div>
-                  </div>
-                }
-
-                <!-- Version -->
-                @if (model.version) {
-                  <div>
-                    <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Version</h4>
-                    <p class="mt-2 text-sm/6 text-gray-900 dark:text-white">{{ model.version }}</p>
-                  </div>
-                }
-              </div>
-
-              <!-- Model Features and Actions -->
-              <div class="mt-4 flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-gray-700">
-                <div class="flex flex-wrap gap-4">
-                  <!-- Thinking/Reasoning Capability -->
-                  @if (model.thinking) {
-                    <div class="flex items-center gap-2">
-                      <svg class="size-5 text-purple-600 dark:text-purple-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M10 9a3 3 0 100-6 3 3 0 000 6zM6 8a2 2 0 11-4 0 2 2 0 014 0zM1.49 15.326a.78.78 0 01-.358-.442 3 3 0 014.308-3.516 6.484 6.484 0 00-1.905 3.959c-.023.222-.014.442.025.654a4.97 4.97 0 01-2.07-.655zM16.44 15.98a4.97 4.97 0 002.07-.654.78.78 0 00.357-.442 3 3 0 00-4.308-3.517 6.484 6.484 0 011.907 3.96 2.32 2.32 0 01-.026.654zM18 8a2 2 0 11-4 0 2 2 0 014 0zM5.304 16.19a.844.844 0 01-.277-.71 5 5 0 019.947 0 .843.843 0 01-.277.71A6.975 6.975 0 0110 18a6.974 6.974 0 01-4.696-1.81z" />
-                      </svg>
-                      <span class="text-sm/6 text-purple-700 dark:text-purple-300">Thinking model</span>
-                    </div>
-                  }
-                </div>
-
-                <!-- Add Model Button or Added Status -->
                 @if (isModelAdded(model.name)) {
-                  <div class="inline-flex items-center gap-2 rounded-sm bg-green-100 px-3 py-1.5 text-sm/6 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
-                    <svg class="size-4" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-                    </svg>
+                  <span class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-green-100 px-3 py-1.5 text-xs/5 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
+                    <ng-icon name="heroCheckCircleSolid" class="size-4" aria-hidden="true" />
                     Added
-                  </div>
+                  </span>
                 } @else {
                   <button
                     (click)="addModelFromGemini(model)"
-                    class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-xs/5 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
                   >
-                    <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-                    </svg>
-                    Add Model
+                    <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                    Add
                   </button>
                 }
               </div>
-            </div>
+
+              <!-- Expanded detail -->
+              @if (isExpanded(model.name)) {
+                <div
+                  [id]="'model-detail-' + model.name"
+                  class="border-t border-gray-100 bg-gray-50 px-4 py-3 sm:pl-14 dark:border-gray-700/60 dark:bg-gray-900/40"
+                >
+                  @if (model.description) {
+                    <p class="mb-3 text-sm/6 text-gray-700 dark:text-gray-300">{{ model.description }}</p>
+                  }
+                  <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-3">
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Token limits</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                        @if (model.inputTokenLimit || model.outputTokenLimit) {
+                          {{ (model.inputTokenLimit || 0) | number }} in
+                          ·
+                          {{ (model.outputTokenLimit || 0) | number }} out
+                        } @else {
+                          Not specified
+                        }
+                      </dd>
+                    </div>
+
+                    @if (model.temperature !== undefined || model.topP !== undefined || model.topK !== undefined) {
+                      <div>
+                        <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Parameters</dt>
+                        <dd class="mt-0.5 space-y-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                          @if (model.temperature !== undefined) {
+                            <div>Temperature: {{ model.temperature }}</div>
+                          }
+                          @if (model.topP !== undefined) {
+                            <div>Top-P: {{ model.topP }}</div>
+                          }
+                          @if (model.topK !== undefined) {
+                            <div>Top-K: {{ model.topK }}</div>
+                          }
+                        </dd>
+                      </div>
+                    }
+
+                    @if (model.version) {
+                      <div>
+                        <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Version</dt>
+                        <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">{{ model.version }}</dd>
+                      </div>
+                    }
+                  </dl>
+                </div>
+              }
+            </li>
           }
-        </div>
+        </ul>
       }
     }
   </div>

--- a/frontend/ai.client/src/app/admin/gemini-models/gemini-models.page.ts
+++ b/frontend/ai.client/src/app/admin/gemini-models/gemini-models.page.ts
@@ -3,7 +3,13 @@ import { Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { DecimalPipe } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import {
+  heroArrowLeft,
+  heroPlus,
+  heroMagnifyingGlass,
+  heroChevronDown,
+} from '@ng-icons/heroicons/outline';
+import { heroCheckCircleSolid } from '@ng-icons/heroicons/solid';
 import { GeminiModelsService } from './services/gemini-models.service';
 import { GeminiModelSummary } from './models/gemini-model.model';
 import { ManagedModelsService } from '../manage-models/services/managed-models.service';
@@ -12,7 +18,15 @@ import { ThinkingDotsComponent } from '../../components/thinking-dots.component'
 @Component({
   selector: 'app-gemini-models-page',
   imports: [FormsModule, ThinkingDotsComponent, DecimalPipe, RouterLink, NgIcon],
-  providers: [provideIcons({ heroArrowLeft })],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPlus,
+      heroMagnifyingGlass,
+      heroChevronDown,
+      heroCheckCircleSolid,
+    }),
+  ],
   templateUrl: './gemini-models.page.html',
   styleUrl: './gemini-models.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,6 +39,9 @@ export class GeminiModelsPage {
   // Filter signals
   maxResultsFilter = signal<number | undefined>(undefined);
   searchQuery = signal<string>('');
+
+  // Row detail expansion state (set of model names currently expanded)
+  private expandedIds = signal<ReadonlySet<string>>(new Set());
 
   // Access the models resource from the service
   readonly modelsResource = this.geminiModelsService.modelsResource;
@@ -81,6 +98,22 @@ export class GeminiModelsPage {
   readonly hasActiveFilters = computed(() => {
     return !!(this.maxResultsFilter() || this.searchQuery());
   });
+
+  isExpanded(modelName: string): boolean {
+    return this.expandedIds().has(modelName);
+  }
+
+  toggleExpand(modelName: string): void {
+    this.expandedIds.update(current => {
+      const next = new Set(current);
+      if (next.has(modelName)) {
+        next.delete(modelName);
+      } else {
+        next.add(modelName);
+      }
+      return next;
+    });
+  }
 
   /**
    * Check if a model has already been added to the managed models list

--- a/frontend/ai.client/src/app/admin/manage-models/manage-models.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/manage-models.page.html
@@ -1,234 +1,244 @@
 <div class="min-h-dvh">
-  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Page Header -->
-    <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div>
-        <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">Manage Models</h1>
-        <p class="mt-1 text-gray-600 dark:text-gray-400">
-          View and manage AI models available to users.
+        <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Manage Models</h1>
+        <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+          Enable, configure, and remove the models available to users.
         </p>
       </div>
       <a
         routerLink="/admin/manage-models/new"
-        class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+        class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
       >
-        <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-        </svg>
+        <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
         Add Model
       </a>
     </div>
 
-    <!-- Filters Section -->
-    <div class="mb-6 rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-      <h2 class="mb-4 text-lg/7 font-semibold text-gray-900 dark:text-white">Search & Filters</h2>
-
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <!-- Search -->
-        <div>
-          <label for="search" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Search
-          </label>
-          <input
-            type="text"
-            id="search"
-            [ngModel]="searchQuery()"
-            (ngModelChange)="searchQuery.set($event)"
-            placeholder="Search by name, ID, or provider..."
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400"
-          />
-        </div>
-
-        <!-- Provider Filter -->
-        <div>
-          <label for="provider" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Provider
-          </label>
-          <select
-            id="provider"
-            [ngModel]="providerFilter()"
-            (ngModelChange)="providerFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Providers</option>
-            @for (provider of availableProviders(); track provider) {
-              <option [value]="provider">{{ provider }}</option>
-            }
-          </select>
-        </div>
-
-        <!-- Enabled Filter -->
-        <div>
-          <label for="enabled" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Status
-          </label>
-          <select
-            id="enabled"
-            [ngModel]="enabledFilter()"
-            (ngModelChange)="enabledFilter.set($event)"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">All Statuses</option>
-            <option value="enabled">Enabled</option>
-            <option value="disabled">Disabled</option>
-          </select>
-        </div>
+    <!-- Toolbar: search + filters inline -->
+    <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+      <div class="relative flex-1">
+        <ng-icon
+          name="heroMagnifyingGlass"
+          class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <label for="search" class="sr-only">Search models</label>
+        <input
+          type="text"
+          id="search"
+          [ngModel]="searchQuery()"
+          (ngModelChange)="searchQuery.set($event)"
+          placeholder="Search by name, ID, or provider…"
+          class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+        />
       </div>
 
-      <!-- Filter Actions -->
+      <label for="provider" class="sr-only">Filter by provider</label>
+      <select
+        id="provider"
+        [ngModel]="providerFilter()"
+        (ngModelChange)="providerFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All providers</option>
+        @for (provider of availableProviders(); track provider) {
+          <option [value]="provider">{{ provider }}</option>
+        }
+      </select>
+
+      <label for="enabled" class="sr-only">Filter by status</label>
+      <select
+        id="enabled"
+        [ngModel]="enabledFilter()"
+        (ngModelChange)="enabledFilter.set($event)"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        <option value="">All statuses</option>
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+
       @if (hasActiveFilters()) {
-        <div class="mt-4">
-          <button
-            (click)="resetFilters()"
-            class="rounded-sm border border-gray-300 bg-gray-100 px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-          >
-            Reset Filters
-          </button>
-        </div>
+        <button
+          (click)="resetFilters()"
+          class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+        >
+          Reset
+        </button>
       }
     </div>
 
-    <!-- Results Header -->
-    <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-        Showing {{ filteredModels().length }} model{{ filteredModels().length !== 1 ? 's' : '' }}
+    <!-- Count + catalog links -->
+    <div class="mb-3 flex flex-col gap-1 text-xs/5 sm:flex-row sm:items-center sm:justify-between">
+      <p class="text-gray-500 dark:text-gray-400">
+        {{ filteredModels().length }} model{{ filteredModels().length !== 1 ? 's' : '' }}
       </p>
-      <div class="flex flex-wrap gap-3 sm:gap-4">
-        <a
-          routerLink="/admin/bedrock/models"
-          class="text-sm/6 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-        >
-          Browse Bedrock Models →
-        </a>
-        <a
-          routerLink="/admin/gemini/models"
-          class="text-sm/6 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-        >
-          Browse Gemini Models →
-        </a>
-        <a
-          routerLink="/admin/openai/models"
-          class="text-sm/6 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-        >
-          Browse OpenAI Models →
-        </a>
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <span class="text-gray-400 dark:text-gray-500">Add from catalog:</span>
+        <a routerLink="/admin/bedrock/models" class="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">Bedrock</a>
+        <a routerLink="/admin/gemini/models" class="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">Gemini</a>
+        <a routerLink="/admin/openai/models" class="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">OpenAI</a>
       </div>
     </div>
 
     <!-- Models List -->
     @if (filteredModels().length === 0) {
-      <div class="rounded-sm border border-gray-300 bg-white p-12 text-center dark:border-gray-600 dark:bg-gray-800">
-        <p class="text-base/7 text-gray-500 dark:text-gray-400">
+      <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
           No models found matching the current filters.
         </p>
       </div>
     } @else {
-      <div class="space-y-4">
+      <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
         @for (model of filteredModels(); track model.id) {
-          <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-            <!-- Model Header -->
-            <div class="mb-4 flex items-start justify-between">
-              <div class="flex-1">
-                <div class="flex items-center gap-3">
-                  <h3 class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+          <li>
+            <!-- Row -->
+            <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+              <!-- Expand toggle -->
+              <button
+                type="button"
+                (click)="toggleExpand(model.id)"
+                [attr.aria-expanded]="isExpanded(model.id)"
+                [attr.aria-controls]="'model-detail-' + model.id"
+                [attr.aria-label]="(isExpanded(model.id) ? 'Hide' : 'Show') + ' details for ' + model.modelName"
+                class="flex size-7 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              >
+                <ng-icon
+                  name="heroChevronDown"
+                  class="size-4 transition-transform duration-150"
+                  [class.rotate-180]="isExpanded(model.id)"
+                  aria-hidden="true"
+                />
+              </button>
+
+              <!-- Name + model id -->
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1.5">
+                  <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
                     {{ model.modelName }}
-                  </h3>
-                  @if (model.enabled) {
-                    <span class="inline-flex items-center rounded-sm bg-green-100 px-2 py-1 text-xs/5 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
-                      Enabled
-                    </span>
-                  } @else {
-                    <span class="inline-flex items-center rounded-sm bg-red-100 px-2 py-1 text-xs/5 font-medium text-red-800 dark:bg-red-900/50 dark:text-red-300">
-                      Disabled
-                    </span>
+                  </span>
+                  @if (model.isDefault) {
+                    <ng-icon
+                      name="heroStarSolid"
+                      class="size-4 shrink-0 text-amber-500 dark:text-amber-400"
+                      aria-label="Default model"
+                    />
                   }
                 </div>
-                <p class="mt-1 font-mono text-sm/6 text-gray-600 dark:text-gray-400">
+                <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
                   {{ model.modelId }}
                 </p>
               </div>
-              <div class="flex shrink-0 gap-2">
-                <span class="inline-flex items-center rounded-sm bg-blue-100 px-3 py-1 text-xs/5 font-medium text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">
-                  {{ model.provider }}
+
+              <!-- Provider -->
+              <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
+                {{ model.providerName }}
+              </span>
+
+              <!-- Enable toggle -->
+              <div class="flex shrink-0 items-center gap-2">
+                <span
+                  class="hidden w-14 text-right text-xs/5 font-medium sm:inline-block"
+                  [class]="model.enabled ? 'text-green-700 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'"
+                >
+                  {{ model.enabled ? 'Enabled' : 'Disabled' }}
                 </span>
-                <span class="inline-flex items-center rounded-sm bg-gray-100 px-3 py-1 text-xs/5 font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-                  {{ model.providerName }}
-                </span>
+                <button
+                  type="button"
+                  role="switch"
+                  [attr.aria-checked]="model.enabled"
+                  [attr.aria-label]="(model.enabled ? 'Disable' : 'Enable') + ' ' + model.modelName"
+                  [disabled]="isToggling(model.id)"
+                  (click)="toggleEnabled(model)"
+                  class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-2xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  [class]="model.enabled ? 'bg-green-600 dark:bg-green-500' : 'bg-gray-300 dark:bg-gray-600'"
+                >
+                  <span
+                    class="inline-block size-5 transform rounded-full bg-white shadow transition-transform duration-150"
+                    [class]="model.enabled ? 'translate-x-5' : 'translate-x-0.5'"
+                  ></span>
+                </button>
+              </div>
+
+              <!-- Actions -->
+              <div class="flex shrink-0 items-center gap-1">
+                <a
+                  [routerLink]="['/admin/manage-models/edit', model.id]"
+                  [attr.aria-label]="'Edit ' + model.modelName"
+                  [title]="'Edit ' + model.modelName"
+                  class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                </a>
+                <button
+                  type="button"
+                  (click)="deleteModel(model.id)"
+                  [attr.aria-label]="'Delete ' + model.modelName"
+                  [title]="'Delete ' + model.modelName"
+                  class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                >
+                  <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                </button>
               </div>
             </div>
 
-            <!-- Model Details Grid -->
-            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <!-- Allowed AppRoles -->
-              <div>
-                <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Allowed Roles</h4>
-                <div class="mt-2 flex flex-wrap gap-2">
-                  @if (model.allowedAppRoles && model.allowedAppRoles.length > 0) {
-                    @for (roleId of model.allowedAppRoles; track roleId) {
-                      <span
-                        class="inline-flex items-center rounded-sm bg-purple-100 px-2 py-1 text-xs/5 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300"
-                        [title]="roleId"
-                      >
-                        {{ getRoleDisplayName(roleId) }}
-                      </span>
-                    }
-                  } @else {
-                    <span class="text-xs/5 text-gray-500 dark:text-gray-400 italic">No roles assigned</span>
-                  }
-                </div>
-              </div>
-
-              <!-- Pricing -->
-              <div>
-                <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Pricing (per 1M tokens)</h4>
-                <div class="mt-2 space-y-1">
-                  <p class="text-sm/6 text-gray-900 dark:text-white">
-                    Input: <span class="font-semibold">${{ model.inputPricePerMillionTokens.toFixed(2) }}</span>
-                  </p>
-                  <p class="text-sm/6 text-gray-900 dark:text-white">
-                    Output: <span class="font-semibold">${{ model.outputPricePerMillionTokens.toFixed(2) }}</span>
-                  </p>
-                </div>
-              </div>
-
-              <!-- Modalities -->
-              <div>
-                <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Modalities</h4>
-                <div class="mt-2 space-y-1">
-                  <p class="text-sm/6 text-gray-700 dark:text-gray-300">
-                    <span class="font-medium">Input:</span> {{ model.inputModalities.join(', ') }}
-                  </p>
-                  <p class="text-sm/6 text-gray-700 dark:text-gray-300">
-                    <span class="font-medium">Output:</span> {{ model.outputModalities.join(', ') }}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <!-- Actions -->
-            <div class="mt-4 flex gap-3 border-t border-gray-200 pt-4 dark:border-gray-600">
-              <a
-                [routerLink]="['/admin/manage-models/edit', model.id]"
-                class="inline-flex items-center gap-2 rounded-sm border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            <!-- Expanded detail -->
+            @if (isExpanded(model.id)) {
+              <div
+                [id]="'model-detail-' + model.id"
+                class="border-t border-gray-100 bg-gray-50 px-4 py-3 sm:pl-14 dark:border-gray-700/60 dark:bg-gray-900/40"
               >
-                <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-                Edit
-              </a>
-              <button
-                (click)="deleteModel(model.id)"
-                class="inline-flex items-center gap-2 rounded-sm border border-red-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-400 dark:hover:bg-red-900/20"
-              >
-                <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                Delete
-              </button>
-            </div>
-          </div>
+                <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-3">
+                  <div>
+                    <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Pricing / 1M tokens
+                    </dt>
+                    <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                      <span class="font-semibold text-gray-900 dark:text-white">${{ model.inputPricePerMillionTokens.toFixed(2) }}</span> in
+                      ·
+                      <span class="font-semibold text-gray-900 dark:text-white">${{ model.outputPricePerMillionTokens.toFixed(2) }}</span> out
+                    </dd>
+                  </div>
+
+                  <div>
+                    <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Modalities
+                    </dt>
+                    <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                      {{ model.inputModalities.join(', ') }}
+                      <span class="text-gray-400 dark:text-gray-500">→</span>
+                      {{ model.outputModalities.join(', ') }}
+                    </dd>
+                  </div>
+
+                  <div>
+                    <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Allowed roles
+                    </dt>
+                    <dd class="mt-1 flex flex-wrap gap-1.5">
+                      @if (model.allowedAppRoles && model.allowedAppRoles.length > 0) {
+                        @for (roleId of model.allowedAppRoles; track roleId) {
+                          <span
+                            class="inline-flex items-center rounded-2xl bg-purple-100 px-2 py-0.5 text-xs/5 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300"
+                            [title]="roleId"
+                          >
+                            {{ getRoleDisplayName(roleId) }}
+                          </span>
+                        }
+                      } @else {
+                        <span class="text-xs/5 italic text-gray-500 dark:text-gray-400">No roles assigned</span>
+                      }
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            }
+          </li>
         }
-      </div>
+      </ul>
     }
   </div>
 </div>

--- a/frontend/ai.client/src/app/admin/manage-models/manage-models.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/manage-models.page.ts
@@ -2,14 +2,31 @@ import { Component, ChangeDetectionStrategy, signal, computed, inject } from '@a
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import {
+  heroPlus,
+  heroMagnifyingGlass,
+  heroChevronDown,
+  heroPencilSquare,
+  heroTrash,
+} from '@ng-icons/heroicons/outline';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
 import { ManagedModelsService } from './services/managed-models.service';
 import { AppRolesService } from '../roles/services/app-roles.service';
+import type { ManagedModel } from './models/managed-model.model';
 
 @Component({
   selector: 'app-manage-models-page',
   imports: [RouterLink, FormsModule, NgIcon],
-  providers: [provideIcons({ heroArrowLeft })],
+  providers: [
+    provideIcons({
+      heroPlus,
+      heroMagnifyingGlass,
+      heroChevronDown,
+      heroPencilSquare,
+      heroTrash,
+      heroStarSolid,
+    }),
+  ],
   templateUrl: './manage-models.page.html',
   styleUrl: './manage-models.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,12 +40,17 @@ export class ManageModelsPage {
   providerFilter = signal<string>('');
   enabledFilter = signal<string>('');
 
-  // Get models from service
-  private mockModels = computed(() => this.managedModelsService.getManagedModels());
+  // Row detail expansion state (set of model ids currently expanded)
+  private expandedIds = signal<ReadonlySet<string>>(new Set());
+
+  // Models with an in-flight enable/disable request
+  private togglingIds = signal<ReadonlySet<string>>(new Set());
+
+  private allModels = computed(() => this.managedModelsService.getManagedModels());
 
   // Filtered models based on search and filters
   readonly filteredModels = computed(() => {
-    let models = this.mockModels();
+    let models = this.allModels();
     const query = this.searchQuery().toLowerCase();
     const provider = this.providerFilter();
     const enabled = this.enabledFilter();
@@ -56,7 +78,7 @@ export class ManageModelsPage {
 
   // Available providers for filter dropdown
   readonly availableProviders = computed(() => {
-    const providers = new Set(this.mockModels().map(m => m.providerName));
+    const providers = new Set(this.allModels().map(m => m.providerName));
     return Array.from(providers).sort();
   });
 
@@ -72,6 +94,48 @@ export class ManageModelsPage {
     this.searchQuery.set('');
     this.providerFilter.set('');
     this.enabledFilter.set('');
+  }
+
+  isExpanded(modelId: string): boolean {
+    return this.expandedIds().has(modelId);
+  }
+
+  toggleExpand(modelId: string): void {
+    this.expandedIds.update(current => {
+      const next = new Set(current);
+      if (next.has(modelId)) {
+        next.delete(modelId);
+      } else {
+        next.add(modelId);
+      }
+      return next;
+    });
+  }
+
+  isToggling(modelId: string): boolean {
+    return this.togglingIds().has(modelId);
+  }
+
+  /**
+   * Flip a model's enabled state in place via a partial update.
+   */
+  async toggleEnabled(model: ManagedModel): Promise<void> {
+    if (this.isToggling(model.id)) {
+      return;
+    }
+    this.togglingIds.update(current => new Set(current).add(model.id));
+    try {
+      await this.managedModelsService.updateModel(model.id, { enabled: !model.enabled });
+    } catch (error) {
+      console.error('Error updating model status:', error);
+      alert('Failed to update model status. Please try again.');
+    } finally {
+      this.togglingIds.update(current => {
+        const next = new Set(current);
+        next.delete(model.id);
+        return next;
+      });
+    }
   }
 
   /**

--- a/frontend/ai.client/src/app/admin/openai-models/openai-models.page.html
+++ b/frontend/ai.client/src/app/admin/openai-models/openai-models.page.html
@@ -1,80 +1,69 @@
 <div class="min-h-dvh">
-  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Back Button -->
     <a
       routerLink="/admin/manage-models"
       class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
     >
-      <ng-icon name="heroArrowLeft" class="size-4" />
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
       Back to Manage Models
     </a>
 
     <!-- Page Header -->
-    <div class="mb-8">
-      <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">OpenAI Models</h1>
-      <p class="mt-2 text-base/7 text-gray-600 dark:text-gray-400">
-        View and manage available OpenAI models. For detailed specifications, visit
+    <div class="mb-6">
+      <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">OpenAI Models</h1>
+      <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        Browse available OpenAI models and add them to your managed list. For detailed specs, see
         <a href="https://platform.openai.com/docs/models/compare" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
-          OpenAI's model comparison page
-        </a>
+          OpenAI's model comparison page</a>.
       </p>
     </div>
 
-    <!-- Filters Section -->
-    <div class="mb-6 rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-      <h2 class="mb-4 text-lg/7 font-semibold text-gray-900 dark:text-white">Filters</h2>
-
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <!-- Search Filter -->
-        <div>
-          <label for="search" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Search Models
-          </label>
-          <input
-            type="text"
-            id="search"
-            [ngModel]="searchQuery()"
-            (ngModelChange)="searchQuery.set($event)"
-            placeholder="Search by ID or owner..."
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
-
-        <!-- Max Results Filter -->
-        <div>
-          <label for="maxResults" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-            Max Results
-          </label>
-          <input
-            type="number"
-            id="maxResults"
-            [ngModel]="maxResultsFilter()"
-            (ngModelChange)="maxResultsFilter.set($event || undefined)"
-            placeholder="No limit"
-            min="1"
-            max="1000"
-            class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-          />
-        </div>
+    <!-- Toolbar: search + filters inline -->
+    <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+      <div class="relative flex-1">
+        <ng-icon
+          name="heroMagnifyingGlass"
+          class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <label for="search" class="sr-only">Search models</label>
+        <input
+          type="text"
+          id="search"
+          [ngModel]="searchQuery()"
+          (ngModelChange)="searchQuery.set($event)"
+          placeholder="Search by ID or owner…"
+          class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+        />
       </div>
 
-      <!-- Filter Actions -->
-      <div class="mt-4 flex gap-3">
+      <label for="maxResults" class="sr-only">Max results</label>
+      <input
+        type="number"
+        id="maxResults"
+        [ngModel]="maxResultsFilter()"
+        (ngModelChange)="maxResultsFilter.set($event || undefined)"
+        placeholder="Max"
+        min="1"
+        max="1000"
+        class="w-24 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+      />
+
+      <button
+        (click)="applyFilters()"
+        class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+      >
+        Apply
+      </button>
+      @if (hasActiveFilters()) {
         <button
-          (click)="applyFilters()"
-          class="rounded-sm bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          (click)="resetFilters()"
+          class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
         >
-          Apply Filters
+          Reset
         </button>
-        @if (hasActiveFilters()) {
-          <button
-            (click)="resetFilters()"
-            class="rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-          >
-            Reset Filters
-          </button>
-        }
-      </div>
+      }
     </div>
 
     <!-- Loading State -->
@@ -86,103 +75,105 @@
 
     <!-- Error State -->
     @if (error()) {
-      <div class="rounded-sm border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
         <h3 class="text-sm/6 font-medium text-red-800 dark:text-red-400">Error loading models</h3>
         <p class="mt-1 text-sm/6 text-red-700 dark:text-red-500">{{ error() }}</p>
       </div>
     }
 
-    <!-- Results Header -->
     @if (!isLoading() && !error()) {
-      <div class="mb-4 flex items-center justify-between">
-        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-          Showing {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
-        </p>
-      </div>
+      <!-- Count -->
+      <p class="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+        {{ models().length }} model{{ models().length !== 1 ? 's' : '' }}
+      </p>
 
       <!-- Models List -->
       @if (models().length === 0) {
-        <div class="rounded-sm border border-gray-200 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
-          <p class="text-base/7 text-gray-500 dark:text-gray-400">
-            No models found.
-          </p>
+        <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+          <p class="text-sm/6 text-gray-500 dark:text-gray-400">No models found.</p>
         </div>
       } @else {
-        <div class="space-y-4">
+        <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
           @for (model of models(); track model.id) {
-            <div class="rounded-sm border border-gray-200 bg-white p-6 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
-              <!-- Model Header -->
-              <div class="mb-4 flex items-start justify-between">
-                <div class="flex-1">
-                  <h3 class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+            <li>
+              <!-- Row -->
+              <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                <button
+                  type="button"
+                  (click)="toggleExpand(model.id)"
+                  [attr.aria-expanded]="isExpanded(model.id)"
+                  [attr.aria-controls]="'model-detail-' + model.id"
+                  [attr.aria-label]="(isExpanded(model.id) ? 'Hide' : 'Show') + ' details for ' + model.id"
+                  class="flex size-7 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon
+                    name="heroChevronDown"
+                    class="size-4 transition-transform duration-150"
+                    [class.rotate-180]="isExpanded(model.id)"
+                    aria-hidden="true"
+                  />
+                </button>
+
+                <div class="min-w-0 flex-1">
+                  <span class="block truncate text-sm/6 font-medium text-gray-900 dark:text-white">
                     {{ model.id }}
-                  </h3>
-                  <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                  </span>
+                  <p class="truncate text-xs/5 text-gray-500 dark:text-gray-400">
                     Owned by: {{ model.ownedBy }}
                   </p>
                 </div>
-                <span class="inline-flex shrink-0 items-center rounded-sm bg-green-100 px-3 py-1 text-xs/5 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
+
+                <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
                   OpenAI
                 </span>
-              </div>
 
-              <!-- Model Details Grid -->
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <!-- Created Date -->
-                @if (model.created) {
-                  <div>
-                    <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Created</h4>
-                    <p class="mt-2 text-sm/6 text-gray-900 dark:text-white">{{ formatDate(model.created) }}</p>
-                  </div>
-                }
-
-                <!-- Object Type -->
-                @if (model.object) {
-                  <div>
-                    <h4 class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Type</h4>
-                    <p class="mt-2 text-sm/6 text-gray-900 dark:text-white">{{ model.object }}</p>
-                  </div>
-                }
-              </div>
-
-              <!-- Model Features and Actions -->
-              <div class="mt-4 flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-gray-700">
-                <div class="flex gap-4">
-                  <div class="flex items-center gap-2">
-                    <svg class="size-5 text-blue-600 dark:text-blue-400" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
-                    </svg>
-                    <span class="text-sm/6 text-gray-700 dark:text-gray-300">
-                      <a href="https://platform.openai.com/docs/models/compare" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
-                        View specifications
-                      </a>
-                    </span>
-                  </div>
-                </div>
-
-                <!-- Add Model Button or Added Status -->
                 @if (isModelAdded(model.id)) {
-                  <div class="inline-flex items-center gap-2 rounded-sm bg-green-100 px-3 py-1.5 text-sm/6 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
-                    <svg class="size-4" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-                    </svg>
+                  <span class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-green-100 px-3 py-1.5 text-xs/5 font-medium text-green-800 dark:bg-green-900/50 dark:text-green-300">
+                    <ng-icon name="heroCheckCircleSolid" class="size-4" aria-hidden="true" />
                     Added
-                  </div>
+                  </span>
                 } @else {
                   <button
                     (click)="addModelFromOpenAI(model)"
-                    class="inline-flex items-center gap-2 rounded-sm bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-xs/5 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
                   >
-                    <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-                    </svg>
-                    Add Model
+                    <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                    Add
                   </button>
                 }
               </div>
-            </div>
+
+              <!-- Expanded detail -->
+              @if (isExpanded(model.id)) {
+                <div
+                  [id]="'model-detail-' + model.id"
+                  class="border-t border-gray-100 bg-gray-50 px-4 py-3 sm:pl-14 dark:border-gray-700/60 dark:bg-gray-900/40"
+                >
+                  <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-3">
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Created</dt>
+                      <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">{{ formatDate(model.created) }}</dd>
+                    </div>
+                    @if (model.object) {
+                      <div>
+                        <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Type</dt>
+                        <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">{{ model.object }}</dd>
+                      </div>
+                    }
+                    <div>
+                      <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Specifications</dt>
+                      <dd class="mt-0.5 text-sm/6">
+                        <a href="https://platform.openai.com/docs/models/compare" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+                          View on OpenAI →
+                        </a>
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              }
+            </li>
           }
-        </div>
+        </ul>
       }
     }
   </div>

--- a/frontend/ai.client/src/app/admin/openai-models/openai-models.page.ts
+++ b/frontend/ai.client/src/app/admin/openai-models/openai-models.page.ts
@@ -2,7 +2,13 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@a
 import { Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import {
+  heroArrowLeft,
+  heroPlus,
+  heroMagnifyingGlass,
+  heroChevronDown,
+} from '@ng-icons/heroicons/outline';
+import { heroCheckCircleSolid } from '@ng-icons/heroicons/solid';
 import { OpenAIModelsService } from './services/openai-models.service';
 import { OpenAIModelSummary } from './models/openai-model.model';
 import { ManagedModelsService } from '../manage-models/services/managed-models.service';
@@ -11,7 +17,15 @@ import { ThinkingDotsComponent } from '../../components/thinking-dots.component'
 @Component({
   selector: 'app-openai-models-page',
   imports: [FormsModule, ThinkingDotsComponent, RouterLink, NgIcon],
-  providers: [provideIcons({ heroArrowLeft })],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPlus,
+      heroMagnifyingGlass,
+      heroChevronDown,
+      heroCheckCircleSolid,
+    }),
+  ],
   templateUrl: './openai-models.page.html',
   styleUrl: './openai-models.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,6 +38,9 @@ export class OpenAIModelsPage {
   // Filter signals
   maxResultsFilter = signal<number | undefined>(undefined);
   searchQuery = signal<string>('');
+
+  // Row detail expansion state (set of model ids currently expanded)
+  private expandedIds = signal<ReadonlySet<string>>(new Set());
 
   // Access the models resource from the service
   readonly modelsResource = this.openaiModelsService.modelsResource;
@@ -79,6 +96,22 @@ export class OpenAIModelsPage {
   readonly hasActiveFilters = computed(() => {
     return !!(this.maxResultsFilter() || this.searchQuery());
   });
+
+  isExpanded(modelId: string): boolean {
+    return this.expandedIds().has(modelId);
+  }
+
+  toggleExpand(modelId: string): void {
+    this.expandedIds.update(current => {
+      const next = new Set(current);
+      if (next.has(modelId)) {
+        next.delete(modelId);
+      } else {
+        next.add(modelId);
+      }
+      return next;
+    });
+  }
 
   /**
    * Check if a model has already been added to the managed models list


### PR DESCRIPTION
## Summary

Reworks the admin model screens to fix information overload. Replaces the dense card layouts on **manage-models** and the **Bedrock / Gemini / OpenAI** browse pages with a single scannable list:

- **Compact one-line rows** — name + secondary id (mono) + provider chip + primary action. Per-model pricing/modalities/roles/specs are now hidden behind an **expand-on-demand** chevron (`aria-expanded` / `aria-controls`; multiple rows can be open).
- **Inline enable/disable toggle** on manage-models (`role="switch"`, disabled while the partial `PUT` is in flight) so status changes no longer require the edit form. Backend `update_managed_model` already does an `exclude_none` partial merge, so toggling only sends `{ enabled }` and won't wipe pricing/roles.
- **Slim inline filter toolbar** replaces the heavy "Search & Filters" / "Filters" cards; browse "Add from catalog" links condensed.
- **Border radius standardized on `rounded-2xl`** (1rem) to match the chat input, per request. Switch knob stays circular (functional affordance).
- Browse pages keep their existing Add / Added behavior and `addModelFrom*` navigation; loading/error/empty states preserved and restyled.
- Minor type-accuracy fix on Gemini: param presence checks were `!== null` against a `number | undefined` type → now `!== undefined`.

No backend or service changes. Verified with `ng build` (Angular strict template type-check) on the merged tree — clean, no new warnings.

## Test plan

- [ ] Sign in as admin → `/admin/manage-models`: rows are one-line; chevron expands pricing/modalities/roles
- [ ] Inline toggle flips enabled/disabled, persists on reload, leaves pricing/roles intact
- [ ] Toggle failure (devtools offline) shows alert and reverts
- [ ] Filters: search/provider/status work; Reset shows only when a filter is active
- [ ] Default model shows the amber star; edit → form, delete → confirm
- [ ] Each browse page (Bedrock/Gemini/OpenAI): compact rows, expand shows provider-specific detail, **Add** prefills `/manage-models/new`, **Added** badge on already-managed models
- [ ] Browse filters Apply/Reset; loading/error/empty states render
- [ ] Keyboard: chevron/toggle/actions reachable with visible focus rings; screen reader announces switch + expand state
- [ ] Dark mode and narrow/mobile width hold up

🤖 Generated with [Claude Code](https://claude.com/claude-code)