### PR TITLE
feat(chat): autofocus message input on session load and switch

### DIFF
--- a/frontend/ai.client/src/app/assistants/assistant-form/components/assistant-preview.component.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/components/assistant-preview.component.ts
@@ -69,6 +69,7 @@ import { AssistantCardComponent } from '../../components/assistant-card.componen
                 [sessionId]="previewChatService.sessionId()"
                 [isChatLoading]="previewChatService.isLoading()"
                 [showFileControls]="false"
+                [autoFocus]="false"
                 (messageSubmitted)="onMessageSubmitted($event)"
                 (messageCancelled)="onMessageCancelled()"
               />

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -50,6 +50,7 @@
     <div class="relative">
       <label for="user-message" class="sr-only">How can I help you today?</label>
       <textarea
+        #messageInput
         id="user-message"
         name="user-message"
         rows="1"

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -1,4 +1,15 @@
-import { Component, signal, output, inject, input, computed } from '@angular/core';
+import {
+  Component,
+  signal,
+  output,
+  inject,
+  input,
+  computed,
+  viewChild,
+  effect,
+  afterNextRender,
+  ElementRef,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -62,6 +73,12 @@ export class ChatInputComponent {
 
   // Input: show file attachment controls (defaults to true)
   readonly showFileControls = input<boolean>(true);
+
+  // Input: auto-focus the textarea on load and session change (defaults to true).
+  // Disabled where the input sits beside an editable form (e.g. assistant preview).
+  readonly autoFocus = input<boolean>(true);
+
+  private readonly messageInput = viewChild<ElementRef<HTMLTextAreaElement>>('messageInput');
 
   // Use the input directly - parent controls loading state
   protected readonly isLoading = computed(() => this.isChatLoading());
@@ -139,6 +156,24 @@ export class ChatInputComponent {
       default: return 'Voice mode';
     }
   });
+
+  constructor() {
+    // Focus the textarea on first mount...
+    afterNextRender(() => this.focusInput());
+    // ...and whenever the session changes (new or existing). When switching
+    // between sessions in the messages view the component instance is reused,
+    // so afterNextRender alone would not refocus.
+    effect(() => {
+      this.sessionId();
+      this.focusInput();
+    });
+  }
+
+  private focusInput(): void {
+    if (this.autoFocus()) {
+      this.messageInput()?.nativeElement.focus();
+    }
+  }
 
   onSubmit() {
     if (this.isLoading()) {


### PR DESCRIPTION
## Summary

- Focus the chat message textarea on first mount **and** whenever the session changes (new or existing), so the user can start typing immediately without clicking into the input.
- Add an `autoFocus` input to `ChatInputComponent` (defaults to `true`).
- Opt the assistant-preview empty state out (`[autoFocus]="false"`) so opening the assistant editor doesn't pull focus away from the edit form.

## Why

Previously the chat input had no autofocus, so every new chat or session switch required an extra click before typing. This adds the expected chat-app behavior (matches ChatGPT/Claude).

## Implementation notes

- `afterNextRender` handles the initial mount focus; an `effect` tracking `sessionId()` handles session switches — necessary because in the messages view the `ChatInputComponent` instance is reused across sessions, so a mount-only hook wouldn't refocus.
- The effect only reads signals and calls `.focus()` (no signal writes), so there's no reactivity loop. Focus is not stolen mid-stream since it only reacts to `sessionId` changes, not loading state.
- Assistant-preview: only the empty-state direct input is opted out. Once the preview has messages it routes through `chat-container`, where refocusing for a follow-up after the user has already typed is desirable, so that path keeps the default.

## Test plan

- [ ] New session: navigate to a new chat — textarea is focused, can type without clicking.
- [ ] Existing session: click a conversation in the sidebar — focus lands in the textarea after load.
- [ ] Session→session switch: clicking between conversations refocuses the textarea each time.
- [ ] After submitting a message, focus remains/returns to the textarea.
- [ ] Regression: opening the Assistant editor keeps focus on the form, not the preview input.
- [ ] Enter submits / Shift+Enter inserts newline still work; no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)