### PR TITLE
feat(seed): register artifact tools as default public tools

### DIFF
--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -410,6 +410,26 @@ DEFAULT_TOOLS: list[dict[str, Any]] = [
         "isPublic": False,
         "forwardAuthToken": False,
     },
+    {
+        "toolId": "create_artifact",
+        "displayName": "Create Artifact",
+        "description": "Save standalone HTML or Markdown documents as versioned artifacts the user can open and iterate on.",
+        "category": "document",
+        "protocol": "local",
+        "enabledByDefault": True,
+        "isPublic": True,
+        "forwardAuthToken": False,
+    },
+    {
+        "toolId": "update_artifact",
+        "displayName": "Update Artifact",
+        "description": "Replace an existing artifact's content, creating a new immutable version.",
+        "category": "document",
+        "protocol": "local",
+        "enabledByDefault": True,
+        "isPublic": True,
+        "forwardAuthToken": False,
+    },
 ]
 
 

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -117,7 +117,7 @@ class TestSeedDefaultTools:
         """Creates the default tool entries."""
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 4
+        assert result.created == 6
         assert result.failed == 0
 
         # Verify fetch_url_content
@@ -167,13 +167,39 @@ class TestSeedDefaultTools:
         assert item["category"] == "code"
         assert item["protocol"] == "local"
 
+        # Verify create_artifact
+        resp = dynamodb_table.get_item(
+            Key={"PK": "TOOL#create_artifact", "SK": "METADATA"}
+        )
+        item = resp["Item"]
+        assert item["toolId"] == "create_artifact"
+        assert item["displayName"] == "Create Artifact"
+        assert item["category"] == "document"
+        assert item["protocol"] == "local"
+        assert item["enabledByDefault"] is True
+        assert item["isPublic"] is True
+        assert item["GSI1PK"] == "CATEGORY#document"
+        assert item["GSI1SK"] == "TOOL#create_artifact"
+
+        # Verify update_artifact
+        resp = dynamodb_table.get_item(
+            Key={"PK": "TOOL#update_artifact", "SK": "METADATA"}
+        )
+        item = resp["Item"]
+        assert item["toolId"] == "update_artifact"
+        assert item["displayName"] == "Update Artifact"
+        assert item["category"] == "document"
+        assert item["protocol"] == "local"
+        assert item["enabledByDefault"] is True
+        assert item["isPublic"] is True
+
     def test_skips_existing_tools(self, dynamodb_table):
         """Skips tools that already exist."""
         seed_default_tools(TABLE_NAME, REGION)
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.skipped == 4
+        assert result.skipped == 6
         assert result.created == 0
 
     def test_partial_skip(self, dynamodb_table):
@@ -187,5 +213,5 @@ class TestSeedDefaultTools:
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 3
+        assert result.created == 5
         assert result.skipped == 1


### PR DESCRIPTION
## Summary
- Add `create_artifact` and `update_artifact` to `DEFAULT_TOOLS` in `backend/scripts/seed_bootstrap_data.py` (category `document`, `local` protocol) so they're registered in the tool catalog.
- Both ship `enabledByDefault: True` and `isPublic: True`, so the artifacts feature is available out of the box without an admin enabling it per role. `toolId`s match `ARTIFACT_TOOL_IDS` in the inference-api chat router, which injects the context-bound tools at request time.
- Update `test_seed_system_admin_jwt.py`: bump pinned tool counts (4→6 created/skipped, 3→5 partial) and add field assertions for the two new entries.

Note: both `system_admin` and `default` roles grant tools via wildcard (`TOOL_GRANT#*`, `grantedTools: ["*"]`), so no per-role grant change is needed.

## Test plan
- [x] `uv run python -m pytest tests/test_seed_system_admin_jwt.py -v` — 5/5 passing
- [ ] Run the bootstrap seed against a dev table and confirm both tools appear in the admin tools list and as user-toggleable, enabled by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)