### PR TITLE
fix(frontend): bake real version into deploy builds

### DIFF
--- a/scripts/stack-frontend/build.sh
+++ b/scripts/stack-frontend/build.sh
@@ -144,6 +144,12 @@ if [ -d "dist" ]; then
     rm -rf dist
 fi
 
+# Bake the real version into src/version.ts from the root VERSION file.
+# Invoked explicitly because we call `ng build` directly below, which bypasses
+# the npm `prebuild` lifecycle hook that normally runs gen-version.js.
+log_info "Generating version from root VERSION file..."
+node scripts/gen-version.js
+
 # Build the Angular application
 log_info "Running: ng build --configuration ${BUILD_CONFIG}"
 ./node_modules/.bin/ng build --configuration "${BUILD_CONFIG}"


### PR DESCRIPTION
## Summary

The user menu version label rendered **"local"** on every deployed environment, including develop and main.

**Root cause:** the version is baked into `frontend/ai.client/src/version.ts` from the root `VERSION` file by `scripts/gen-version.js`, wired only as the npm `prebuild` lifecycle hook. The deploy build script `scripts/stack-frontend/build.sh` calls `./node_modules/.bin/ng build` **directly**, which bypasses npm lifecycle scripts — so `prebuild` never ran, the committed `'dev'` placeholder shipped, and the UI mapped `'dev'` → `"local"` ([user-dropdown.component.ts:284](../blob/develop/frontend/ai.client/src/app/components/topnav/components/user-dropdown.component.ts#L284)).

**Fix:** run `node scripts/gen-version.js` explicitly in `build.sh` immediately before the `ng build` call (Option A — no reliance on npm lifecycle semantics). The committed `src/version.ts` placeholder stays `'dev'` so `ng test` / fresh-clone imports keep working.

## Test plan

- [x] `node scripts/gen-version.js` from `frontend/ai.client` produces `VERSION = '1.0.0-beta.25'` (current root `VERSION`)
- [x] Only `scripts/stack-frontend/build.sh` changed; `src/version.ts` placeholder untouched (still `'dev'`)
- [ ] After deploy to develop, confirm user menu shows `v1.0.0-beta.25` instead of "local"

🤖 Generated with [Claude Code](https://claude.com/claude-code)