### PR TITLE
chore(deps): bump bedrock-agentcore 1.6.4 → 1.9.1 (+ coupled boto3 1.43.9)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "uvicorn[standard]==0.46.0",
 
     # AWS and cloud services
-    "boto3==1.42.96",
+    "boto3==1.43.9",
 
     # Utilities
     "python-dotenv==1.2.2",
@@ -52,7 +52,7 @@ agentcore = [
     "strands-agents-tools==0.5.2",
 
     "aws-opentelemetry-distro==0.17.0",
-    "bedrock-agentcore==1.6.4",
+    "bedrock-agentcore==1.9.1",
     # Multi-provider LLM support
     "openai==2.32.0",  # For OpenAI models
     "google-genai==1.73.1",  # For Google Gemini models

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,20 @@ import pytest
 # during import (e.g. agents.main_agent.quota -> boto3.resource('dynamodb'))
 os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 
+# botocore >= 1.43 accesses Credentials.account_id during endpoint
+# construction. On a RefreshableCredentials object (e.g. resolved from a
+# real SSO profile) that property forces a credential _refresh() →
+# GetRoleCredentials, which moto does not implement, so mocked AWS calls
+# fail. Pin static dummy credentials so the chain builds a non-refreshable
+# Credentials object instead. The matching AWS_PROFILE scrub is done
+# per-test below (a process-wide pop here is not enough: tests that reload
+# `apis.app_api.main` run load_dotenv(override=True), which re-injects
+# AWS_PROFILE from backend/src/.env mid-suite). Mirrors moto's practice.
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
+
 # Add backend/src to Python path for imports
 # This file is in backend/tests/, so we need to go up one level to backend/
 BACKEND_DIR = Path(__file__).parent.parent
@@ -50,4 +64,57 @@ def _clear_skip_auth_env():
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+
+
+# Same load_dotenv(override=True) bleed as above, but for AWS_PROFILE.
+# backend/src/.env sets a real SSO profile for local dev; once a test
+# reloads `apis.app_api.main` it lands in process env and every later
+# test that builds a boto3 client resolves SSO credentials. Under
+# botocore >= 1.43 that fails all mocked AWS calls (see import-time note).
+# Scrub per-test so the static dummy credentials win the provider chain.
+_AWS_PROFILE_ENV_KEYS = (
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_aws_profile_env():
+    saved = {k: os.environ.pop(k, None) for k in _AWS_PROFILE_ENV_KEYS}
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# Same load_dotenv(override=True) bleed again, for the infra-resource
+# config families. backend/src/.env sets real DYNAMODB_*_TABLE_NAME and
+# COGNITO_* identifiers for local dev; once a test reloads
+# `apis.app_api.main` they land in process env. Repositories/services gate
+# their "configured" flag on `param or os.getenv("DYNAMODB_..."/"COGNITO_...")`,
+# so a leaked value makes "disabled when unconfigured" tests construct a
+# live client and attempt real AWS calls. Tests always inject their own
+# resource names via moto fixtures, so scrub the whole family per-test.
+_ENV_CONFIG_BLEED_PREFIXES = (
+    "DYNAMODB_",
+    "COGNITO_",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_config_bleed():
+    saved = {
+        k: os.environ.pop(k)
+        for k in list(os.environ)
+        if k.startswith(_ENV_CONFIG_BLEED_PREFIXES)
+    }
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            os.environ[k] = v
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -84,9 +84,9 @@ requires-dist = [
     { name = "aiohttp", specifier = "==3.13.5" },
     { name = "authlib", specifier = "==1.7.0" },
     { name = "aws-opentelemetry-distro", marker = "extra == 'agentcore'", specifier = "==0.17.0" },
-    { name = "bedrock-agentcore", marker = "extra == 'agentcore'", specifier = "==1.6.4" },
+    { name = "bedrock-agentcore", marker = "extra == 'agentcore'", specifier = "==1.9.1" },
     { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
-    { name = "boto3", specifier = "==1.42.96" },
+    { name = "boto3", specifier = "==1.43.9" },
     { name = "cachetools", specifier = "==6.2.4" },
     { name = "cryptography", specifier = "==47.0.0" },
     { name = "fastapi", specifier = "==0.136.1" },
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.6.4"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -527,9 +527,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/6d/6dfd3e9f05fb3fff256312cf7a9cee11d849281dfd4d32fa7aaf3cea87e9/bedrock_agentcore-1.6.4.tar.gz", hash = "sha256:7b3e12361ca432ab1cada5e191e6f3cfa9536cd5cedafc37058f670b263bdabf", size = 521801, upload-time = "2026-04-23T20:08:25.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/91b6ec49558755cccc5bfa5a64916995baed5490768bee33581b370a1e4e/bedrock_agentcore-1.9.1.tar.gz", hash = "sha256:f0e69b41c32c12e395d698299c96981d34035dafa90e0e79fcbd743574315c6a", size = 692593, upload-time = "2026-05-12T21:50:47.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/cc/298426f7601172fab91a7c4fe6c0f7a07ecbdaeb2413f1e8dc5d79aacbd7/bedrock_agentcore-1.6.4-py3-none-any.whl", hash = "sha256:a20f76f23cf08f4c081704eeb85c1899340163066b1612458c93963055a5e3dd", size = 168734, upload-time = "2026-04-23T20:08:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/34/05/a5fbaa2320c34f8df196c105ca1938848845216cacc36850c73d116f28a9/bedrock_agentcore-1.9.1-py3-none-any.whl", hash = "sha256:f323c3d943dfe1defd52febd1409f8c4d04c0fc37848dd100ede692c2a6addd2", size = 262193, upload-time = "2026-05-12T21:50:45.506Z" },
 ]
 
 [[package]]
@@ -578,30 +578,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.96"
+version = "1.43.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/cc/42d798fc5305e4636170b50cdfb305ff0a81f470e35131f4a0d2641976ae/boto3-1.43.9.tar.gz", hash = "sha256:37dac72f2921095378c0200caf07918d5e10a82b7c1f611abb70e44f69d0b962", size = 113135, upload-time = "2026-05-15T19:28:31.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dc/51286e9551f7852a79ce5d2a57468d9d905c30d32bcace55204551db202d/boto3-1.43.9-py3-none-any.whl", hash = "sha256:5e967292d361482793471bd80fad1e714515b7401f65a0d5b4aa6ef9d009c030", size = 140523, upload-time = "2026-05-15T19:28:28.948Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.97"
+version = "1.43.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/95/c37edb602948fad2253ffd1bb3dba5b938645bd1845ee4160350136a0f41/botocore-1.42.97.tar.gz", hash = "sha256:5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310", size = 15269348, upload-time = "2026-04-27T20:39:05.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e8/f696c80982685a4cdb3df5f0781919afa50262f40e1aac7066c9c2520deb/botocore-1.43.9.tar.gz", hash = "sha256:93e91c7160678182860f5902ee4cfe6d643cac0d9ee84d3eb65becc9f4c00228", size = 15357963, upload-time = "2026-05-15T19:28:19.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/d2/8e025ba1a4e257879af72d06913272311af79673d82fa2581a351b924317/botocore-1.42.97-py3-none-any.whl", hash = "sha256:77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc", size = 14950367, upload-time = "2026-04-27T20:39:01.261Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c9/a1b51a74d476f5cb2f555ce8274f0f6b9fb21d75cc3f57b87dd0632ee17a/botocore-1.43.9-py3-none-any.whl", hash = "sha256:b9bdcd9c87fc552aad30006f00167d9ebb3480e1b06f1902bac5b2c41014fdab", size = 15039827, upload-time = "2026-05-15T19:28:14.543Z" },
 ]
 
 [[package]]
@@ -4217,14 +4217,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Kaizen review **2026-05-15 Proposal #1** (highest-priority cleanup; carry-over for a third week). Bumps `bedrock-agentcore` 1.6.4 → 1.9.1. Because 1.9.1 requires `boto3>=1.43.0` and `boto3` is a **core** dependency, this is a coupled bump:

| Package | From | To |
|---------|------|-----|
| bedrock-agentcore | 1.6.4 | 1.9.1 |
| boto3 | 1.42.96 | 1.43.9 |
| botocore | 1.42.97 | 1.43.9 |
| s3transfer | 0.16.0 | 0.17.0 |

CHANGELOG 1.6.4→1.9.1 audited — **no breaking changes for our usage**: the 1.9.1 double-base64 `upload_file/download_file` fix doesn't touch us (our `_download_file` is a local S3 helper), the DP/CP namespace redesign (#449/#450) is backward-compatible, and the 1.9.0 `ConversationTurn` fix is an internal OTEL serializer change.

## Test-harness fixes (bundled — necessary consequence of the bump)

botocore 1.43 newly reads `Credentials.account_id` during endpoint construction. On a `RefreshableCredentials` (SSO) object that forces a refresh → `GetRoleCredentials`, which **moto 5.1.22 doesn't implement**. Combined with `backend/src/.env`'s `AWS_PROFILE` leaking into process env via `load_dotenv(override=True)`, this red the suite order-dependently (95 failures).

Fix: two per-test autouse scrub fixtures in `tests/conftest.py` (`_clear_aws_profile_env`, `_clear_env_config_bleed`) + static dummy creds at import — **mirroring the existing `_clear_skip_auth_env` fixture** for the identical `.env`-bleed class. The `DYNAMODB_*`/`COGNITO_*` leak it also closes **pre-existed** the bump (it was masked by the SSO failures aborting those tests in fixture setup; note: pytest is not run in CI, so this latent flake was never gated). No production code touched; no security control weakened.

## Validation

- ✅ All SDK surfaces we import resolve cleanly under 1.9.1 (`MemoryClient`, `AgentCoreMemorySessionManager`, `IdentityClient`, `TokenPoller`, `BedrockAgentCoreContext`)
- ✅ Full backend suite: **2913 passed, 0 failed** (was 95-failing pre-fix)
- ✅ Read-only dev smoke test against real AgentCore Memory + Identity: `get_memory_strategies` → 3, `retrieve_memories` namespace path → clean soft-fail, `list_workload_identities` → OK

## Test plan

- [x] `uv run python -m pytest tests/` green on the bumped deps
- [x] Dev smoke: memory write/read + identity wire path (read-only)
- [ ] Reviewer: confirm the bundled test-conftest scope is acceptable (kaizen proposal scoped it as a pure dep bump; the boto3 coupling + test-harness fix were necessary consequences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)