### PR TITLE
kaizen bundle: /ping reap fix + A2A guard + research URL cleanup

### DIFF
--- a/.claude/skills/kaizen-research/SKILL.md
+++ b/.claude/skills/kaizen-research/SKILL.md
@@ -25,8 +25,7 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 ### External (web — last 7 days unless noted)
 
 1. **AWS Bedrock + AgentCore "What's New"**
-   - https://aws.amazon.com/about-aws/whats-new/recent/feed/
-   - https://aws.amazon.com/bedrock/whats-new/
+   - https://aws.amazon.com/about-aws/whats-new/recent/feed/ (canonical AWS What's New RSS — filter entries for Bedrock/AgentCore)
    - https://aws.amazon.com/blogs/machine-learning/ (filter: bedrock, agentcore)
    - Filter to: Bedrock, AgentCore, Bedrock Agents, Knowledge Bases, Guardrails, model availability/region/quota changes.
 
@@ -71,7 +70,7 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
 
 6. **Agent harness patterns**
    - https://www.anthropic.com/engineering (Claude Code, agent design posts)
-   - https://docs.claude.com/en/docs/claude-code/release-notes
+   - https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
    - LangChain / LlamaIndex / Pydantic-AI release notes — for ideas, not adoption.
 
 7. **AWS Bedrock pricing + quota**
@@ -79,17 +78,16 @@ Friday early morning (~6am MT). `kaizen-review-prep` runs ~2 hours later (~8am M
    - Note any model price/quota changes that could shift architecture choices in this repo (e.g., model selection in `inference_api`).
 
 8. **AgentCore SDK / starter-toolkit issues**
-   - https://github.com/aws/amazon-bedrock-agentcore-sdk-python/issues
-   - https://github.com/aws/amazon-bedrock-agentcore-starter-toolkit/issues
+   - https://github.com/aws/bedrock-agentcore-sdk-python/issues
+   - https://github.com/aws/bedrock-agentcore-starter-toolkit/issues
    - Early-signal bugs/limits other users hit before we do.
 
 9. **Community signal (filtered)**
    - HN search: `site:news.ycombinator.com bedrock OR agentcore OR strands OR "claude code"` (last 7 days)
    - r/LocalLLaMA, r/MachineLearning — agent-harness critiques and patterns surface here before vendor blogs.
 
-10. **Anthropic cookbook + courses**
+10. **Anthropic cookbook**
     - https://github.com/anthropics/anthropic-cookbook
-    - https://github.com/anthropics/courses
     - Worked examples often outpace docs — especially for caching, tool use, and agent loops.
 
 11. **Seasonal sources** (only when in window)

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -61,6 +61,8 @@ npx cdk deploy --all
 | MCP + SigV4 | Cloud Lambda (Gateway) | AWS SigV4 |
 | A2A | Cloud Runtime | AgentCore auth |
 
+Today A2A is **client-only** — `A2AAgentConfig` (`apis/shared/tools/models.py`) describes remote agents we call out to; we do not yet expose an A2A server / `AgentCard`. **When the first A2A server construct lands** (Strands `agent.to_a2a()`, an `A2AServer`, or a hand-built `AgentCard`), its advertised `capabilities` MUST include `streaming=True`. Without it the A2A SDK client silently falls back to non-streaming, never receives a `completed` event, and hangs until its ~40-minute timeout (ref-repo `aws-samples/sample-strands-agent-with-agentcore` commit `50c9112`).
+
 ## Cross-Package Contracts
 
 - Backend route handlers define the API shape; frontend TypeScript interfaces must match

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from typing import AsyncGenerator, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -631,8 +632,24 @@ async def stream_conversational_message(
 
 @router.get("/ping")
 async def ping():
-    """Health check endpoint (required by AgentCore Runtime)"""
-    return {"status": "healthy", "version": os.environ.get("APP_VERSION", "unknown")}
+    """Health check endpoint (required by AgentCore Runtime).
+
+    AgentCore's idle reaper requires ``time_of_last_update`` (int epoch
+    seconds) alongside ``status``. When the field is absent the platform
+    reaps the microVM at ``idleRuntimeSessionTimeout`` even mid-stream,
+    regardless of the reported status (bedrock-agentcore-sdk-python#471).
+
+    We do not run the SDK's async-task busy tracking here (that's the
+    deferred ``async_mode`` work), so we cannot report ``HealthyBusy``.
+    Returning a fresh timestamp on every ping keeps the session alive
+    while the runtime data plane is polling us, which is the documented
+    mitigation for the silent mid-generation reap.
+    """
+    return {
+        "status": "Healthy",
+        "time_of_last_update": int(time.time()),
+        "version": os.environ.get("APP_VERSION", "unknown"),
+    }
 
 
 @router.post("/invocations")

--- a/backend/tests/routes/test_inference.py
+++ b/backend/tests/routes/test_inference.py
@@ -65,11 +65,17 @@ class TestPing:
         assert resp.status_code == 200
 
     def test_ping_response_contains_status(self, app):
-        """Req 15.1: /ping response should contain status field."""
+        """Req 15.1: /ping returns the AgentCore health contract.
+
+        Status must be a valid AgentCore PingStatus value, and the response
+        must carry an integer ``time_of_last_update``; without that field the
+        platform idle-reaps the microVM mid-stream
+        (bedrock-agentcore-sdk-python#471).
+        """
         client = TestClient(app)
         body = client.get("/ping").json()
-        assert "status" in body
-        assert body["status"] == "healthy"
+        assert body["status"] in {"Healthy", "HealthyBusy"}
+        assert isinstance(body["time_of_last_update"], int)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Kaizen 2026-05-15 review bundle — proposals #2 + #4 + #7 + #9. Proposal #1 (`bedrock-agentcore` 1.9.1) already shipped in #337.

## Summary
- **#2 `fix(inference)`** — `/ping` now emits integer `time_of_last_update` + corrected `Healthy` status casing. Without the field AgentCore's idle reaper kills the microVM at `idleRuntimeSessionTimeout` mid-stream regardless of status (bedrock-agentcore-sdk-python#471). We have no async-task busy tracking (deferred `async_mode` work) so we can't report `HealthyBusy`; a fresh per-ping timestamp is the documented mitigation — it disables ping-based idle reaping for this runtime (the explicit, accepted trade).
- **#4 `docs`** — A2A is client-only today (no server `AgentCard`). Added a forward-looking guard in `CLAUDE.MD`: the first A2A server construct MUST advertise `capabilities` with `streaming=True`, else A2A clients hang ~40 min (ref-repo `50c9112`).
- **#9 `chore(kaizen)`** — replaced/dropped dead source URLs in the `kaizen-research` skill; fixed `aws/amazon-bedrock-agentcore-*` → correct `aws/bedrock-agentcore-*` slugs (the review flagged the toolkit; the sdk-python line had the same typo).

## Not in this PR
- **#7** — issues #266/#267 were *not* phantom debt as the review assumed; they're live, well-specified Strands adoption/wiring tasks whose 1.39 precondition is already met. Per decision, posted "unblocked, keep open" comments on both rather than closing. GitHub-only, no code.

## Test plan
- [ ] `cd backend && uv run python -m pytest tests/ -v` (no test asserts the old `/ping` shape; `app_api/health` is a separate endpoint)
- [ ] Smoke `GET /ping` in dev → `{"status":"Healthy","time_of_last_update":<int>,"version":...}`
- [ ] Long tool-turn in dev does not get reaped mid-stream
- [ ] Skim rendered `CLAUDE.MD` Multi-Protocol section + `kaizen-research/SKILL.md` source list

🤖 Generated with [Claude Code](https://claude.com/claude-code)