### PR TITLE
refactor(chat): tool-result renderer registry (MCP Apps PR #0)

### DIFF
--- a/frontend/ai.client/src/app/app.config.ts
+++ b/frontend/ai.client/src/app/app.config.ts
@@ -9,6 +9,7 @@ import { withCredentialsInterceptor } from './auth/with-credentials.interceptor'
 import { MARKED_OPTIONS, MarkedOptions, MarkedRenderer, provideMarkdown } from 'ngx-markdown';
 import { SessionService } from './auth/session.service';
 import { ThemeService } from './components/topnav/components/theme-toggle/theme.service';
+import { provideBuiltInToolRenderers } from './session/components/message-list/components/tool-use/built-in-renderers';
 
 function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -56,5 +57,10 @@ export const appConfig: ApplicationConfig = {
     // dormant. Inject it at bootstrap so the lava-lamp backdrop honors the
     // user's preference (and prefers-color-scheme) on every route.
     provideAppInitializer(() => { inject(ThemeService); }),
+
+    // Register the built-in tool-result renderers (text/JSON/image default
+    // plus the migrated proof-point renderers) into the renderer registry
+    // before the first message renders.
+    provideBuiltInToolRenderers(),
   ]
 };

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/built-in-renderers.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/built-in-renderers.ts
@@ -1,0 +1,20 @@
+import { EnvironmentProviders, inject, provideAppInitializer } from '@angular/core';
+import { ToolRendererRegistryService } from './tool-renderer-registry.service';
+import { CalculatorToolResultComponent } from './renderers/calculator-tool-result.component';
+import { FetchUrlContentToolResultComponent } from './renderers/fetch-url-content-tool-result.component';
+import { CreateVisualizationToolResultComponent } from './renderers/create-visualization-tool-result.component';
+
+/**
+ * Registers the built-in proof-point renderers into
+ * {@link ToolRendererRegistryService} at bootstrap. New renderers (including
+ * the future MCP App renderer) register here — or via their own
+ * `provideAppInitializer` — with no host-template changes.
+ */
+export function provideBuiltInToolRenderers(): EnvironmentProviders {
+  return provideAppInitializer(() => {
+    const registry = inject(ToolRendererRegistryService);
+    registry.register('calculator', CalculatorToolResultComponent);
+    registry.register('fetch_url_content', FetchUrlContentToolResultComponent);
+    registry.register('create_visualization', CreateVisualizationToolResultComponent);
+  });
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/index.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/index.ts
@@ -1,2 +1,5 @@
 export * from './tool-use.component';
 export * from './json-syntax-highlight.pipe';
+export * from './tool-renderer-registry.service';
+export * from './renderers/default-tool-result.component';
+export * from './built-in-renderers';

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/calculator-tool-result.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/calculator-tool-result.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { DefaultToolResultComponent } from './default-tool-result.component';
+import type { ToolResultData, ToolResultRenderer } from '../tool-renderer-registry.service';
+
+/**
+ * Registry proof point for the `calculator` tool. Renders identically to the
+ * default today; it exists to validate that a distinct, tool-named component
+ * resolves and slots in with zero visual change — the exact mechanism the
+ * MCP App renderer will use.
+ */
+@Component({
+  selector: 'app-calculator-tool-result',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DefaultToolResultComponent],
+  template: `<app-default-tool-result [result]="result()" [minimized]="minimized()" />`,
+})
+export class CalculatorToolResultComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/create-visualization-tool-result.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/create-visualization-tool-result.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { DefaultToolResultComponent } from './default-tool-result.component';
+import type { ToolResultData, ToolResultRenderer } from '../tool-renderer-registry.service';
+
+/**
+ * Registry proof point for the `create_visualization` tool. Renders
+ * identically to the default today; it exists to validate the registry
+ * shape with a distinct, tool-named component.
+ */
+@Component({
+  selector: 'app-create-visualization-tool-result',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DefaultToolResultComponent],
+  template: `<app-default-tool-result [result]="result()" [minimized]="minimized()" />`,
+})
+export class CreateVisualizationToolResultComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/default-tool-result.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/default-tool-result.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DefaultToolResultComponent } from './default-tool-result.component';
+import { ToolResultData } from '../tool-renderer-registry.service';
+
+function makeResult(content: ToolResultData['content']): ToolResultData {
+  return { status: 'success', content };
+}
+
+describe('DefaultToolResultComponent', () => {
+  let fixture: ComponentFixture<DefaultToolResultComponent>;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [DefaultToolResultComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DefaultToolResultComponent);
+  });
+
+  it('renders plain text content', () => {
+    fixture.componentRef.setInput('result', makeResult([{ text: 'hello world' }]));
+    fixture.detectChanges();
+
+    const textEl = fixture.nativeElement.querySelector('.whitespace-pre-wrap');
+    expect(textEl).toBeTruthy();
+    expect(textEl.textContent).toContain('hello world');
+  });
+
+  it('renders JSON content as a highlighted code block', () => {
+    fixture.componentRef.setInput('result', makeResult([{ json: { answer: 42 } }]));
+    fixture.detectChanges();
+
+    const codeEl = fixture.nativeElement.querySelector('pre code');
+    expect(codeEl).toBeTruthy();
+    expect(codeEl.textContent).toContain('answer');
+    expect(codeEl.textContent).toContain('42');
+    // The plain-text branch must not be used for JSON items.
+    expect(fixture.nativeElement.querySelector('.whitespace-pre-wrap')).toBeNull();
+  });
+
+  it('renders image content in full (non-minimized) mode', () => {
+    fixture.componentRef.setInput(
+      'result',
+      makeResult([{ image: { format: 'png', data: 'iVBORw0KGgo=' } }]),
+    );
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=');
+  });
+
+  it('uses rounded-sm cards in full mode', () => {
+    fixture.componentRef.setInput('result', makeResult([{ text: 'x' }]));
+    fixture.detectChanges();
+
+    const card = fixture.nativeElement.querySelector('.space-y-2 > div');
+    expect(card.classList.contains('rounded-sm')).toBe(true);
+    expect(card.classList.contains('rounded-xs')).toBe(false);
+  });
+
+  it('omits images and uses rounded-xs cards in minimized mode', () => {
+    fixture.componentRef.setInput(
+      'result',
+      makeResult([
+        { text: 'visible text' },
+        { image: { format: 'png', data: 'abc' } },
+      ]),
+    );
+    fixture.componentRef.setInput('minimized', true);
+    fixture.detectChanges();
+
+    // Image is suppressed in the minimized variant (historical behavior).
+    expect(fixture.nativeElement.querySelector('img')).toBeNull();
+
+    const card = fixture.nativeElement.querySelector('.space-y-2 > div');
+    expect(card.classList.contains('rounded-xs')).toBe(true);
+    expect(card.classList.contains('rounded-sm')).toBe(false);
+    expect(card.textContent).toContain('visible text');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/default-tool-result.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/default-tool-result.component.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { JsonSyntaxHighlightPipe } from '../json-syntax-highlight.pipe';
+import { ToolResultContent } from '../../../../../services/models/message.model';
+import type { ToolResultData, ToolResultRenderer } from '../tool-renderer-registry.service';
+
+/**
+ * Fallback tool-result renderer. Reproduces the historical text / JSON /
+ * image rendering verbatim — this is what every unregistered tool resolves
+ * to, so its output must stay byte-for-byte identical to the markup that
+ * previously lived inline in `tool-use.component.html`.
+ *
+ * `minimized` reproduces the two pre-existing variants: the minimized view
+ * used `rounded-xs` cards and never rendered image content; the full view
+ * used `rounded-sm` cards and appended images after the text/JSON items.
+ */
+@Component({
+  selector: 'app-default-tool-result',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [JsonSyntaxHighlightPipe],
+  styles: ':host { display: block; }',
+  template: `
+    <div class="space-y-2">
+      @for (item of textItems(); track $index) {
+        <div
+          class="p-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
+          [class.rounded-xs]="minimized()"
+          [class.rounded-sm]="!minimized()"
+        >
+          @if (item.json) {
+            <pre class="font-mono text-xs overflow-x-auto"><code [innerHTML]="formatContent(item) | jsonSyntaxHighlight"></code></pre>
+          } @else {
+            <div class="text-sm/6 text-gray-900 dark:text-gray-100 whitespace-pre-wrap">{{ formatContent(item) }}</div>
+          }
+        </div>
+      }
+
+      @if (!minimized()) {
+        @for (item of imageItems(); track $index) {
+          <div class="rounded-sm overflow-hidden bg-gray-100 dark:bg-gray-800 p-2 border border-gray-300 dark:border-gray-600">
+            <img
+              [src]="imageDataUrl(item)"
+              alt="Tool result image"
+              class="max-w-full h-auto rounded-xs"
+            />
+          </div>
+        }
+      }
+    </div>
+  `,
+})
+export class DefaultToolResultComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+
+  /** Text and JSON content items (images are rendered separately). */
+  textItems = computed(() =>
+    this.result().content.filter((item) => Boolean(item.text || item.json)),
+  );
+
+  /** Image content items. */
+  imageItems = computed(() =>
+    this.result().content.filter((item) => Boolean(item.image)),
+  );
+
+  formatContent(item: ToolResultContent): string {
+    if (item.text) return item.text;
+    if (item.json) return JSON.stringify(item.json, null, 2);
+    return '';
+  }
+
+  imageDataUrl(item: ToolResultContent): string {
+    if (!item.image) return '';
+    return `data:image/${item.image.format};base64,${item.image.data}`;
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/fetch-url-content-tool-result.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/fetch-url-content-tool-result.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { DefaultToolResultComponent } from './default-tool-result.component';
+import type { ToolResultData, ToolResultRenderer } from '../tool-renderer-registry.service';
+
+/**
+ * Registry proof point for the `fetch_url_content` tool. Renders identically
+ * to the default today; it exists to validate the registry shape with a
+ * distinct, tool-named component.
+ */
+@Component({
+  selector: 'app-fetch-url-content-tool-result',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DefaultToolResultComponent],
+  template: `<app-default-tool-result [result]="result()" [minimized]="minimized()" />`,
+})
+export class FetchUrlContentToolResultComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.spec.ts
@@ -1,0 +1,70 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ToolRendererRegistryService,
+  ToolResultData,
+  ToolResultRenderer,
+} from './tool-renderer-registry.service';
+import { DefaultToolResultComponent } from './renderers/default-tool-result.component';
+
+@Component({
+  selector: 'app-stub-renderer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="stub-renderer">stub</div>`,
+})
+class StubRendererComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}
+
+@Component({
+  selector: 'app-other-renderer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="other-renderer">other</div>`,
+})
+class OtherRendererComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}
+
+describe('ToolRendererRegistryService', () => {
+  let registry: ToolRendererRegistryService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    registry = TestBed.inject(ToolRendererRegistryService);
+  });
+
+  it('resolves unregistered tools to the default renderer', () => {
+    expect(registry.resolve('not_registered')).toBe(DefaultToolResultComponent);
+    expect(registry.has('not_registered')).toBe(false);
+  });
+
+  it('resolves a registered tool to its component', () => {
+    registry.register('calculator', StubRendererComponent);
+
+    expect(registry.has('calculator')).toBe(true);
+    expect(registry.resolve('calculator')).toBe(StubRendererComponent);
+    // Other tools still fall back to the default.
+    expect(registry.resolve('fetch_url_content')).toBe(DefaultToolResultComponent);
+  });
+
+  it('lets a later registration override an earlier one', () => {
+    registry.register('calculator', StubRendererComponent);
+    registry.register('calculator', OtherRendererComponent);
+
+    expect(registry.resolve('calculator')).toBe(OtherRendererComponent);
+  });
+
+  it('stays reactive inside a computed when a renderer registers late', () => {
+    const resolved = computed(() => registry.resolve('calculator'));
+
+    expect(resolved()).toBe(DefaultToolResultComponent);
+
+    registry.register('calculator', StubRendererComponent);
+
+    expect(resolved()).toBe(StubRendererComponent);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, InputSignal, Type, signal } from '@angular/core';
+import { ToolResultContent } from '../../../../services/models/message.model';
+import { DefaultToolResultComponent } from './renderers/default-tool-result.component';
+
+/**
+ * The tool result payload handed to every renderer. Mirrors the inline
+ * `result` shape on {@link ToolUseData} so renderers don't depend on the
+ * surrounding content-block envelope.
+ */
+export interface ToolResultData {
+  content: ToolResultContent[];
+  status: 'success' | 'error';
+}
+
+/**
+ * Structural contract every registered tool-result renderer must satisfy.
+ * A renderer is just a standalone component that exposes these two signal
+ * inputs; the host binds them via `NgComponentOutlet`. The future MCP App
+ * renderer plugs in as one of these with no host-template changes.
+ */
+export interface ToolResultRenderer {
+  readonly result: InputSignal<ToolResultData>;
+  readonly minimized: InputSignal<boolean>;
+}
+
+/**
+ * Signal-backed lookup of tool name → result-renderer component.
+ *
+ * Unregistered tools resolve to {@link DefaultToolResultComponent}, which
+ * reproduces the historical text/JSON/image rendering verbatim. `resolve`
+ * reads the backing signal, so a `computed()` that calls it stays reactive
+ * to registrations that happen after first render.
+ */
+@Injectable({ providedIn: 'root' })
+export class ToolRendererRegistryService {
+  private readonly renderers = signal<ReadonlyMap<string, Type<ToolResultRenderer>>>(
+    new Map(),
+  );
+
+  register(toolName: string, component: Type<ToolResultRenderer>): void {
+    const next = new Map(this.renderers());
+    next.set(toolName, component);
+    this.renderers.set(next);
+  }
+
+  resolve(toolName: string): Type<ToolResultRenderer> {
+    return this.renderers().get(toolName) ?? DefaultToolResultComponent;
+  }
+
+  has(toolName: string): boolean {
+    return this.renderers().has(toolName);
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.html
@@ -95,17 +95,10 @@
               <span class="text-red-600 dark:text-red-400">(Error)</span>
             }
           </div>
-          <div class="space-y-2">
-            @for (item of resultTextContent(); track $index) {
-              <div class="p-2 bg-gray-100 dark:bg-gray-800 rounded-xs border border-gray-300 dark:border-gray-600">
-                @if (item.json) {
-                  <pre class="font-mono text-xs overflow-x-auto"><code [innerHTML]="formatResultContent(item) | jsonSyntaxHighlight"></code></pre>
-                } @else {
-                  <div class="text-sm/6 text-gray-900 dark:text-gray-100 whitespace-pre-wrap">{{ formatResultContent(item) }}</div>
-                }
-              </div>
-            }
-          </div>
+          <ng-container
+            [ngComponentOutlet]="resultRenderer()"
+            [ngComponentOutletInputs]="rendererInputs()"
+          />
         </div>
       }
     </div>
@@ -242,29 +235,10 @@
                   <span class="text-red-600 dark:text-red-400">(Error)</span>
                 }
               </div>
-              <div class="space-y-2">
-                <!-- Text/JSON content -->
-                @for (item of resultTextContent(); track $index) {
-                  <div class="p-2 bg-gray-100 dark:bg-gray-800 rounded-sm border border-gray-300 dark:border-gray-600">
-                    @if (item.json) {
-                      <pre class="font-mono text-xs overflow-x-auto"><code [innerHTML]="formatResultContent(item) | jsonSyntaxHighlight"></code></pre>
-                    } @else {
-                      <div class="text-sm/6 text-gray-900 dark:text-gray-100 whitespace-pre-wrap">{{ formatResultContent(item) }}</div>
-                    }
-                  </div>
-                }
-
-                <!-- Image content -->
-                @for (item of resultImageContent(); track $index) {
-                  <div class="rounded-sm overflow-hidden bg-gray-100 dark:bg-gray-800 p-2 border border-gray-300 dark:border-gray-600">
-                    <img
-                      [src]="getImageDataUrl(item)"
-                      alt="Tool result image"
-                      class="max-w-full h-auto rounded-xs"
-                    />
-                  </div>
-                }
-              </div>
+              <ng-container
+                [ngComponentOutlet]="resultRenderer()"
+                [ngComponentOutletInputs]="rendererInputs()"
+              />
             </div>
           }
         </div>

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.spec.ts
@@ -1,0 +1,136 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ToolUseComponent } from './tool-use.component';
+import {
+  ToolRendererRegistryService,
+  ToolResultData,
+  ToolResultRenderer,
+} from './tool-renderer-registry.service';
+import { CalculatorToolResultComponent } from './renderers/calculator-tool-result.component';
+import { ContentBlock } from '../../../../services/models/message.model';
+
+@Component({
+  selector: 'app-spec-stub-renderer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="spec-stub">STUB RENDERER</div>`,
+})
+class SpecStubRendererComponent implements ToolResultRenderer {
+  result = input.required<ToolResultData>();
+  minimized = input<boolean>(false);
+}
+
+function makeBlock(
+  name: string,
+  result: ToolResultData['content'],
+): ContentBlock {
+  return {
+    type: 'toolUse',
+    toolUse: {
+      toolUseId: `tool-${name}`,
+      name,
+      input: { query: 'test' },
+      status: 'complete',
+      result: { status: 'success', content: result },
+    },
+  };
+}
+
+describe('ToolUseComponent', () => {
+  let fixture: ComponentFixture<ToolUseComponent>;
+  let registry: ToolRendererRegistryService;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ToolUseComponent],
+    }).compileComponents();
+
+    registry = TestBed.inject(ToolRendererRegistryService);
+    fixture = TestBed.createComponent(ToolUseComponent);
+  });
+
+  it('renders a non-migrated tool through the default renderer', () => {
+    fixture.componentRef.setInput(
+      'toolUse',
+      makeBlock('some_unregistered_tool', [{ text: 'default path output' }]),
+    );
+    fixture.detectChanges();
+
+    const def = fixture.nativeElement.querySelector('app-default-tool-result');
+    expect(def).toBeTruthy();
+    expect(def.textContent).toContain('default path output');
+  });
+
+  it('renders a migrated tool through its registered renderer (identical output)', () => {
+    registry.register('calculator', CalculatorToolResultComponent);
+
+    fixture.componentRef.setInput(
+      'toolUse',
+      makeBlock('calculator', [{ text: 'the answer is 42' }]),
+    );
+    fixture.detectChanges();
+
+    // The registered proof-point component is used...
+    const calc = fixture.nativeElement.querySelector('app-calculator-tool-result');
+    expect(calc).toBeTruthy();
+    // ...and it delegates to the default renderer, so output is unchanged.
+    const def = calc.querySelector('app-default-tool-result');
+    expect(def).toBeTruthy();
+    expect(calc.textContent).toContain('the answer is 42');
+  });
+
+  it('renders identical result text for a migrated vs default-path tool', () => {
+    registry.register('calculator', CalculatorToolResultComponent);
+
+    fixture.componentRef.setInput(
+      'toolUse',
+      makeBlock('calculator', [{ text: 'shared output' }]),
+    );
+    fixture.detectChanges();
+    const migratedText = fixture.nativeElement
+      .querySelector('.whitespace-pre-wrap')
+      .textContent.trim();
+
+    const otherFixture = TestBed.createComponent(ToolUseComponent);
+    otherFixture.componentRef.setInput(
+      'toolUse',
+      makeBlock('plain_tool', [{ text: 'shared output' }]),
+    );
+    otherFixture.detectChanges();
+    const defaultText = otherFixture.nativeElement
+      .querySelector('.whitespace-pre-wrap')
+      .textContent.trim();
+
+    expect(migratedText).toBe(defaultText);
+    expect(migratedText).toBe('shared output');
+  });
+
+  it('uses a custom registered renderer instead of the default', () => {
+    registry.register('weird_tool', SpecStubRendererComponent);
+
+    fixture.componentRef.setInput(
+      'toolUse',
+      makeBlock('weird_tool', [{ text: 'ignored by stub' }]),
+    );
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.spec-stub')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('app-default-tool-result')).toBeNull();
+  });
+
+  it('does not render a result section when the tool has no result', () => {
+    fixture.componentRef.setInput('toolUse', {
+      type: 'toolUse',
+      toolUse: {
+        toolUseId: 'tool-pending',
+        name: 'pending_tool',
+        input: {},
+        status: 'pending',
+      },
+    } as ContentBlock);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('app-default-tool-result')).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
@@ -3,17 +3,20 @@ import {
   input,
   signal,
   computed,
+  inject,
   ChangeDetectionStrategy,
 } from '@angular/core';
+import { NgComponentOutlet } from '@angular/common';
 import { JsonSyntaxHighlightPipe } from './json-syntax-highlight.pipe';
-import { ContentBlock, ToolUseData, ToolResultContent } from '../../../../services/models/message.model';
+import { ContentBlock, ToolUseData } from '../../../../services/models/message.model';
+import { ToolRendererRegistryService } from './tool-renderer-registry.service';
 
 @Component({
   selector: 'app-tool-use',
   templateUrl: './tool-use.component.html',
   styleUrl: './tool-use.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [JsonSyntaxHighlightPipe],
+  imports: [JsonSyntaxHighlightPipe, NgComponentOutlet],
 })
 export class ToolUseComponent {
   /** The content block containing tool use data */
@@ -24,6 +27,8 @@ export class ToolUseComponent {
 
   /** Whether the details section is expanded (both input and output) */
   isDetailsExpanded = signal(false);
+
+  private readonly rendererRegistry = inject(ToolRendererRegistryService);
 
   /** Extract tool use data from the content block */
   toolUseData = computed(() => {
@@ -59,6 +64,19 @@ export class ToolUseComponent {
   hasResult = computed(() => {
     return !!this.toolResult();
   });
+
+  /**
+   * Result-renderer component for this tool, resolved from the registry.
+   * Unregistered tools fall back to the default text/JSON/image renderer.
+   * Reads the registry signal, so it stays reactive to late registrations.
+   */
+  resultRenderer = computed(() => this.rendererRegistry.resolve(this.toolName()));
+
+  /** Inputs bound onto the resolved renderer via NgComponentOutlet. */
+  rendererInputs = computed(() => ({
+    result: this.toolResult(),
+    minimized: this.minimized(),
+  }));
 
   /** Preview of input keys for collapsed state */
   inputKeysPreview = computed(() => {
@@ -96,35 +114,6 @@ export class ToolUseComponent {
     if (status === 'error') return 'text-red-600 dark:text-red-400';
     return 'text-blue-600 dark:text-blue-400';
   });
-
-  /** Get result text content */
-  resultTextContent = computed(() => {
-    const result = this.toolResult();
-    if (!result) return [];
-
-    return result.content.filter(item => item.text || item.json);
-  });
-
-  /** Get result image content */
-  resultImageContent = computed(() => {
-    const result = this.toolResult();
-    if (!result) return [];
-
-    return result.content.filter(item => item.image);
-  });
-
-  /** Format result content for display */
-  formatResultContent(item: ToolResultContent): string {
-    if (item.text) return item.text;
-    if (item.json) return JSON.stringify(item.json, null, 2);
-    return '';
-  }
-
-  /** Get image data URL */
-  getImageDataUrl(item: ToolResultContent): string {
-    if (!item.image) return '';
-    return `data:image/${item.image.format};base64,${item.image.data}`;
-  }
 
   /** Toggle the details expanded state */
   toggleDetailsExpanded(): void {


### PR DESCRIPTION
## Summary

PR #0 of the MCP Apps Host Renderer sequence scoped in [`docs/kaizen/scoping/mcp-apps-host-renderer.md`](docs/kaizen/scoping/mcp-apps-host-renderer.md), satisfying proposal #5 from [`docs/kaizen/reviews/2026-05-15.md`](docs/kaizen/reviews/2026-05-15.md). **Pure refactor — no MCP App / iframe / postMessage code.**

Lifts the implicit text/JSON/image rendering switch out of `ToolUseComponent` into a signal-backed registry keyed by tool name, so the future MCP App renderer (PR #4) plugs in as just-another-registered-renderer with zero special-case branches in the host template.

- **`ToolRendererRegistryService`** (`providedIn: 'root'`, signal-backed): `register(toolName, component)` + `resolve(toolName)` (+ `has`). Unregistered tools fall back to `DefaultToolResultComponent`. `resolve` reads the backing signal so a `computed()` stays reactive to late registrations.
- **`DefaultToolResultComponent`**: reproduces the prior result markup verbatim, including the two pre-existing variants — minimized (`rounded-xs` cards, images suppressed) vs full (`rounded-sm` cards, images appended) — driven by a `minimized` input. Zero user-visible change.
- **Proof points**: `calculator`, `fetch_url_content`, `create_visualization` migrated as distinct thin renderer components (delegating to the default) to validate the registry shape and model the PR #4 wire-in. Registered via `provideBuiltInToolRenderers()` in `app.config.ts`.
- `ToolUseComponent` keeps all card chrome (status, input section, "Output/(Error)" header) and renders the resolved renderer for the result body via `NgComponentOutlet` in both the minimized and full template branches.

## Test plan

- [x] `npm run test:ci` — **1014/1014 passing** (87 files), incl. 14 new tests:
  - registry: default fallback, register, override, reactive-in-computed
  - default renderer: text / JSON / image; minimized omits images + uses `rounded-xs`; full uses `rounded-sm`
  - `ToolUseComponent`: non-migrated → default renderer; migrated → registered renderer; **identical result text for migrated vs default-path tool**; custom renderer replaces default; no result section when no result
  - Specs use DI-token (registry) overrides, not `vi.mock`
- [x] `npm run build` — production build + Angular template typecheck clean (no new warnings/errors)
- [x] Authenticated UI clickthrough **not feasible in this environment**: the SPA's `SessionService.bootstrap()` requires a running app-api (`:8000`) with `SKIP_AUTH` configured, plus inference-api and a live tool-calling conversation, to ever render a tool-result card. `SKIP_AUTH` is a backend-only flag and is not set here, and no backend stack is running. Per the team convention, a manual script is provided below in lieu of claiming UI success. Behavioral equivalence is asserted at the DOM level by the new specs.

### Manual verification script (run where the backend stack is up with `SKIP_AUTH=true`)

1. `cd frontend/ai.client && npm install && npm run start` (port 4200); ensure app-api/inference-api are running.
2. Start a chat that triggers a **non-migrated** tool (e.g. a knowledge-base/search tool) returning text and JSON. Expand the tool card → confirm the result body (text block, JSON code block with syntax highlighting), border radius, and spacing are identical to `develop`.
3. Trigger a **migrated** tool — `calculator` (text result), `fetch_url_content` (text/JSON), or `create_visualization` — and confirm its result card is pixel-identical to the non-migrated one (it routes through `app-calculator-tool-result` → `app-default-tool-result`).
4. Trigger a tool returning an **image** result; confirm the image renders in the full card and is suppressed in the minimized/promoted-visual view (unchanged behavior).
5. Toggle dark mode and the card expand/collapse; confirm no visual or animation regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)