### PR TITLE
chore(deps): bump strands-agents 1.39.0 -> 1.40.0 (gated on token-count audit + compaction double-fire check)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 # AgentCore-specific dependencies (for inference_api)
 agentcore = [
-    "strands-agents==1.39.0",
+    "strands-agents==1.40.0",
     "strands-agents-tools==0.5.2",
 
     "aws-opentelemetry-distro==0.17.0",
@@ -60,7 +60,7 @@ agentcore = [
 
 # Voice/BidiAgent dependencies (Nova Sonic speech-to-speech)
 bidi = [
-    "strands-agents[bidi]==1.39.0",
+    "strands-agents[bidi]==1.40.0",
 ]
 
 # Document ingestion pipeline dependencies (for Lambda deployment)

--- a/backend/tests/agents/main_agent/streaming/test_compaction_sse_emit_once.py
+++ b/backend/tests/agents/main_agent/streaming/test_compaction_sse_emit_once.py
@@ -1,0 +1,215 @@
+"""Regression: the `compaction` SSE event emits exactly once per compaction event.
+
+The `compaction` SSE event (frontend inline "earlier messages summarized"
+divider, landed in PR #243) is emitted by ``StreamCoordinator.stream_response``
+from inside the single terminal ``done`` handler, gated solely on
+``TurnBasedSessionManager.update_after_turn`` returning a ``CompactionResult``.
+
+``process_agent_stream`` yields exactly one ``done`` event per turn (STEP 9,
+after the raw agent stream is exhausted), so ``update_after_turn`` is awaited
+exactly once and the SSE frame is yielded at most once.
+
+This module locks that once-per-turn invariant against the *real* pipeline
+(``stream_response`` → ``process_agent_stream`` → coordinator emit code),
+stubbing only two narrow seams: ``agent.stream_async`` (raw Strands events)
+and ``session_manager.update_after_turn`` (the compaction decision).
+
+It is also the explicit non-regression guard for the Strands 1.40 bump.
+Strands 1.40 ships proactive context compression (strands PR #2239) and feeds
+``EventLoopMetrics.accumulated_usage`` on the ``AgentResult`` event — which
+``_handle_metadata_events`` surfaces on the ``metadata_summary`` track. Neither
+is a second emit path: proactive compression is opt-in via a
+``ConversationManager``'s ``proactive_compression`` (default ``None`` → the
+``BeforeModelCallEvent`` handler early-returns), and our compaction lives in a
+``SessionManager`` (``TurnBasedSessionManager.update_after_turn``), a different
+abstraction. The third test drives the ``metadata_summary``/accumulated-usage
+surface explicitly and asserts the emit count stays at one.
+"""
+
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import pytest
+
+from agents.main_agent.session.compaction_models import CompactionResult
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+
+# Per-call metadata raw event: Bedrock's `metadata` chunk wrapped inside
+# Strands' ModelStreamChunkEvent. Same shape as the cost-attribution suite.
+def _raw_metadata_event(usage: Dict[str, int]) -> Dict[str, Any]:
+    return {"event": {"metadata": {"usage": usage, "metrics": {"latencyMs": 100}}}}
+
+
+# Strands AgentResult event. EventLoopMetrics.accumulated_usage is summed
+# across all LLM calls in the turn; _handle_metadata_events extracts it onto
+# the `metadata_summary` track. This is the surface Strands 1.40's proactive
+# compression also reads from — included here to prove it is not a second
+# compaction-emit path.
+class _FakeEventLoopMetrics:
+    def __init__(self, accumulated_usage: Dict[str, int]) -> None:
+        self.accumulated_usage = accumulated_usage
+        self.accumulated_metrics = {"latencyMs": 250}
+
+
+class _FakeAgentResult:
+    def __init__(self, accumulated_usage: Dict[str, int]) -> None:
+        self.metrics = _FakeEventLoopMetrics(accumulated_usage)
+
+
+def _raw_agent_result_event(accumulated_usage: Dict[str, int]) -> Dict[str, Any]:
+    return {"result": _FakeAgentResult(accumulated_usage)}
+
+
+class _FakeAgent:
+    """Minimal agent: a message list and a controllable raw event stream.
+
+    No ``_interrupt_state`` so the coordinator's paused-turn snapshot and
+    OAuth / tool-approval extractors all early-return on the ``done`` event.
+    """
+
+    def __init__(self, raw_events: List[Dict[str, Any]]) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        self._raw_events = raw_events
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for ev in self._raw_events:
+                yield ev
+
+        return _gen()
+
+
+class _RecordingSessionManager:
+    """Stub session manager that records ``update_after_turn`` invocations.
+
+    Only the seam the coordinator depends on is implemented; the real
+    threshold/checkpoint math is covered by the TurnBasedSessionManager
+    suite. This isolates the coordinator-level once-per-turn invariant.
+    """
+
+    def __init__(self, result: Optional[CompactionResult]) -> None:
+        self._result = result
+        self.calls: List[int] = []
+
+    async def update_after_turn(
+        self,
+        input_tokens: int,
+        current_messages: Optional[List[Dict]] = None,
+    ) -> Optional[CompactionResult]:
+        self.calls.append(input_tokens)
+        return self._result
+
+
+async def _collect_sse(
+    agent: _FakeAgent, session_manager: _RecordingSessionManager
+) -> List[str]:
+    coordinator = StreamCoordinator()
+    frames: List[str] = []
+    async for sse in coordinator.stream_response(
+        agent=agent,
+        prompt="hi",
+        session_manager=session_manager,
+        session_id="sess-1",
+        user_id="user-1",
+        main_agent_wrapper=None,
+    ):
+        frames.append(sse)
+    return frames
+
+
+def _compaction_frames(frames: List[str]) -> List[str]:
+    return [f for f in frames if f.startswith("event: compaction\n")]
+
+
+# A turn whose summed input buckets exceed any threshold — guarantees the
+# coordinator's `total_input_tokens > 0` guard passes so update_after_turn
+# is consulted.
+_TURN_USAGE = {"inputTokens": 150_000, "outputTokens": 80, "totalTokens": 150_080}
+
+
+@pytest.mark.asyncio
+async def test_compaction_sse_emitted_exactly_once_when_checkpoint_advances():
+    """Checkpoint advances → exactly one `event: compaction` frame."""
+    result = CompactionResult(
+        previous_checkpoint=0,
+        new_checkpoint=4,
+        summarized_turns=2,
+        input_tokens=150_000,
+    )
+    agent = _FakeAgent([_raw_metadata_event(_TURN_USAGE)])
+    sm = _RecordingSessionManager(result)
+
+    frames = await _collect_sse(agent, sm)
+    compaction = _compaction_frames(frames)
+
+    # update_after_turn consulted exactly once (one terminal `done`).
+    assert sm.calls == [150_000]
+    assert len(compaction) == 1, (
+        f"expected exactly one compaction SSE frame, got {len(compaction)}: "
+        f"{compaction}"
+    )
+
+    import json
+
+    payload = json.loads(compaction[0][len("event: compaction\ndata: ") :].strip())
+    assert payload == {
+        "type": "compaction",
+        "previousCheckpoint": 0,
+        "newCheckpoint": 4,
+        "summarizedTurns": 2,
+        "inputTokens": 150_000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_compaction_sse_when_checkpoint_does_not_advance():
+    """update_after_turn returns None → zero compaction frames, still one call."""
+    agent = _FakeAgent([_raw_metadata_event(_TURN_USAGE)])
+    sm = _RecordingSessionManager(None)
+
+    frames = await _collect_sse(agent, sm)
+
+    assert sm.calls == [150_000]
+    assert _compaction_frames(frames) == []
+
+
+@pytest.mark.asyncio
+async def test_strands_result_metadata_track_does_not_double_fire():
+    """Strands 1.40 non-regression guard.
+
+    Interleave per-call `metadata` events with a Strands ``AgentResult``
+    (the ``EventLoopMetrics.accumulated_usage`` / ``metadata_summary``
+    surface that 1.40's proactive compression also reads). There is still
+    exactly one terminal ``done`` → update_after_turn is consulted exactly
+    once → exactly one compaction frame. The accumulated-usage track is not
+    a second emit path.
+    """
+    call_0 = {"inputTokens": 80_000, "outputTokens": 40, "totalTokens": 80_040}
+    call_1 = {"inputTokens": 150_000, "outputTokens": 60, "totalTokens": 150_060}
+    turn_cumulative = {
+        "inputTokens": 230_000,  # Strands sums across calls — must not re-trigger
+        "outputTokens": 100,
+        "totalTokens": 230_100,
+    }
+    agent = _FakeAgent(
+        [
+            _raw_metadata_event(call_0),
+            _raw_metadata_event(call_1),
+            _raw_agent_result_event(turn_cumulative),
+        ]
+    )
+    result = CompactionResult(
+        previous_checkpoint=4,
+        new_checkpoint=8,
+        summarized_turns=2,
+        input_tokens=150_000,
+    )
+    sm = _RecordingSessionManager(result)
+
+    frames = await _collect_sse(agent, sm)
+
+    # Consulted exactly once. The compaction trigger reads "current context"
+    # (last per-call usage via last-write-wins), NOT Strands' summed
+    # accumulated_usage — so the input is call_1's 150_000, not 230_000.
+    assert sm.calls == [150_000]
+    assert len(_compaction_frames(frames)) == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -107,8 +107,8 @@ requires-dist = [
     { name = "python-multipart", specifier = "==0.0.27" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "starlette", specifier = "==1.0.0" },
-    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.39.0" },
-    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.39.0" },
+    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.40.0" },
+    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.40.0" },
     { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.5.2" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260409" },
@@ -4384,7 +4384,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.39.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -4400,9 +4400,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/5b/e267a7dab0b4a6d39133c9c0c516f93f33483e29f39e05c03b755f993ef6/strands_agents-1.39.0.tar.gz", hash = "sha256:efff5914323b8b4b472ca3f13c7115a5746935b00bc86dacc40a5d1ab1242817", size = 873258, upload-time = "2026-05-08T13:27:19.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/fa/b5fdfa099b122fea98fc64b9923237077ed6b7c2a90f2c3a65cba00d7202/strands_agents-1.40.0.tar.gz", hash = "sha256:5d867c1255f8449f0030a9a9c085106c15b1704e871d0fea56d3c20b2309a4d3", size = 878176, upload-time = "2026-05-14T13:48:28.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/41/d054b5a5f54175eb4e775d1e408e169439eba6be63e9e8f2e77ff44e38fc/strands_agents-1.39.0-py3-none-any.whl", hash = "sha256:7369dbfc6be29f59483a6183f5aacf0bdd0e7e5973b4b70f8d0e663880d42f79", size = 430272, upload-time = "2026-05-08T13:27:18.088Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ca/ce4c061d0fa007738f0ce4ebdb234969d9343322a089c24d5986620faa66/strands_agents-1.40.0-py3-none-any.whl", hash = "sha256:40c04f411e4082a6eb78b22d5b421757b27aac1f9a42e8198ff3db7fd4fcc13f", size = 432744, upload-time = "2026-05-14T13:48:26.639Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Implements kaizen `2026-05-15` proposal #6. The version bump itself is trivial; the gates are the point.

## Summary
- `backend/pyproject.toml` + `backend/uv.lock`: `strands-agents` `1.39.0` → `1.40.0` (both the base and `[bidi]` pins; exact pin, no `^`/`~`/`>=`). `uv lock` updated only `strands-agents` — no transitive churn. `strands-agents-tools==0.5.2` left as-is (`requires strands-agents>=1.0.0`, compatible).
- New `backend/tests/agents/main_agent/streaming/test_compaction_sse_emit_once.py` — locks the compaction-once SSE invariant against the real pipeline.

## Audit outcome — `use_native_token_count` default flip (strands PR #2284, `True` → `False`)

**Decision: accept the new default (`False`). Do NOT pin `use_native_token_count=True`.**

The flag gates **only** `BedrockModel.count_tokens()`. In 1.40 (verified in the installed source) `count_tokens()` early-returns to the local heuristic estimator unless `use_native_token_count is True`. Strands calls `count_tokens()` from exactly one place — `event_loop._estimate_input_tokens()` — to populate `projected_input_tokens` on `BeforeModelCallEvent`.

Our token accounting is **independent of that flag**:
- The cost badge, context-% badge, and compaction trigger all read `accumulated_metadata["usage"]`, which is populated from the **native Bedrock Converse streaming response** `usage` (`strands/models/bedrock.py` `format_chunk` metadata handling) — always API-reported, never `count_tokens()`.
- No hook of ours consumes `BeforeModelCallEvent` / `projected_input_tokens` (our only hooks use `BeforeToolCallEvent`: stop, oauth_consent, tool_approval).
- We construct no Strands `ConversationManager` and pass no `proactive_compression`, so the only other `count_tokens()` consumer is dormant (see below).

Pinning `True` would add a redundant Bedrock `CountTokens` API call per model invocation (latency + spend) for a value nothing in our paths reads. The new default is the correct, lower-cost choice — and it's provably inert for the #270 per-message-cost / context-% math.

**Smoke test (cost badge across a tool turn):** the 7 tool-turn tests in `test_per_message_cost_attribution.py` — `TestPerMessageAttributionTwoCallTurn` (2-call tool-use turn per-message cost attribution), `TestStreamCoordinatorContextOccupancy` (context-% occupancy + all-three-bucket compaction input) — pass byte-identically on 1.40, alongside `tests/costs/test_calculator.py` (26 USD-math cases). The frontend badge reads only backend SSE `metadata` (`chatStateService.costDollars` / `contextWindowSize`); there is no independent frontend token estimate. Together these confirm the values are **not** silently heuristic-shifted. A live Bedrock-backed tool turn is not drivable in the implementation environment (backend dep bump, no AWS creds / running stack); manual dev smoke-test script below for a belt-and-suspenders live check.

<details><summary>Manual dev smoke-test script (live tool turn)</summary>

1. `cd backend && uv sync --extra agentcore --extra dev`
2. Run app-api + inference-api in dev against a Bedrock-enabled account.
3. In the chat UI, send a prompt that forces a multi-call tool turn (e.g. a tool the agent must call then summarize).
4. Confirm on the assistant message badge: per-message cost is non-zero and equals `Σ` per-call priced usage (not 2× the first call); the context-% badge reflects the **most recent** call's full input (incl. cacheRead/cacheWrite), not the cross-call sum.
5. Continue the conversation past the compaction threshold; confirm exactly one inline "earlier messages summarized" divider per compaction event and that the context-% badge shrinks after it.
</details>

## Compaction double-fire check — proactive context compression (strands PR #2239)

**Confirmed: the `compaction` SSE event still emits exactly once per compaction event (PR #243 invariant preserved). No double-fire.**

- Proactive compression is **opt-in**: `ConversationManager.__init__(proactive_compression=...)` defaults to `None` → threshold `None` → the always-registered `BeforeModelCallEvent` handler `_on_before_model_call_threshold` early-returns (verified in installed 1.40 source). `DEFAULT_COMPRESSION_THRESHOLD=0.7` only applies when `proactive_compression=True`/dict is explicitly passed.
- It operates on `ConversationManager`; our compaction is in `TurnBasedSessionManager` (an `AgentCoreMemorySessionManager`/`SessionManager`) — a different abstraction. We construct no `ConversationManager` and pass no `proactive_compression`/`compression_threshold` anywhere (`grep` clean across `backend/src`).
- The `compaction` SSE frame is emitted exclusively by `stream_coordinator.py` inside the single terminal `done` handler, gated solely on `TurnBasedSessionManager.update_after_turn()` returning a `CompactionResult`. `process_agent_stream` yields exactly one `done` per turn, so `update_after_turn` is awaited once.

### Regression test
`test_compaction_sse_emit_once.py` drives the **real** `stream_response` → `process_agent_stream` → coordinator emit code (stubbing only `agent.stream_async` and `session_manager.update_after_turn`):
- checkpoint advances → exactly one `event: compaction` frame, correct payload;
- `update_after_turn` returns `None` → zero frames;
- **1.40 non-regression guard**: interleaving per-call `metadata` with a Strands `AgentResult` (the `EventLoopMetrics.accumulated_usage` / `metadata_summary` surface 1.40's proactive compression reads) still yields exactly one `done`-driven `update_after_turn` call and one compaction frame; the trigger uses last-call "current context" (150k), not Strands' summed accumulated usage (230k).

## Subtraction opportunity (noted, NOT acted on)
Strands' built-in proactive context compression (`SummarizingConversationManager(proactive_compression=...)`) overlaps our custom `TurnBasedSessionManager` checkpoint+summary logic. Adopting it could shrink our custom compaction surface. **Out of scope for this PR** (scope = bump + audit + regression test). Removing custom logic is a follow-up only if proven safe — our compaction also does tool-content truncation, AgentCore-Memory LTM summary retrieval, and DynamoDB-persisted checkpoint state that the built-in managers do not, so this is not a drop-in replacement.

## Test plan
- [x] `cd backend && uv sync --extra agentcore --extra dev && uv run python -m pytest tests/ -v` — **2887 passed, 3 skipped** on strands 1.40 (backend pytest is NOT in CI; full local suite is the correctness gate)
- [x] `tests/architecture/test_import_boundaries.py` green (app_api/inference_api/agents → apis.shared boundary)
- [x] `test_per_message_cost_attribution.py` (7) + `tests/costs/test_calculator.py` green — cost-badge math unchanged on 1.40
- [x] new `test_compaction_sse_emit_once.py` (3) green
- [ ] (optional, manual) live dev tool-turn cost-badge smoke per script above

🤖 Generated with [Claude Code](https://claude.com/claude-code)