### PR TITLE
feat(infra): MCP Apps sandbox-proxy origin (CDK) — host-renderer PR #1

### DIFF
--- a/.github/docs/deploy/step-04-deploy.md
+++ b/.github/docs/deploy/step-04-deploy.md
@@ -10,7 +10,7 @@
 
 ---
 
-Now for the fun part. You'll trigger up to 8 GitHub Actions workflows in order. Each one deploys a different layer of the stack. Workflows that share the same step number can be run in parallel — just wait for the previous step to finish first.
+Now for the fun part. You'll trigger up to 9 GitHub Actions workflows in order. Each one deploys a different layer of the stack. Workflows that share the same step number can be run in parallel — just wait for the previous step to finish first.
 
 ## What you'll need for this step
 
@@ -42,6 +42,7 @@ Now for the fun part. You'll trigger up to 8 GitHub Actions workflows in order. 
 | 2 | **Deploy RAG Ingestion** | Document ingestion pipeline for retrieval-augmented generation |
 | 2 | **Deploy SageMaker Fine-Tuning** *(optional)* | SageMaker training/inference resources, S3 bucket, DynamoDB tables. Requires `CDK_FINE_TUNING_ENABLED=true` ([Step 3](./step-03-github-config.md#optional-features)). |
 | 2 | **Deploy Artifacts** *(optional)* | DynamoDB metadata + S3 content + CloudFront at `artifacts.{domain}` + Lambda render service. Requires `CDK_ARTIFACTS_ENABLED=true` and `CDK_ARTIFACTS_CERTIFICATE_ARN` (cert MUST be in `us-east-1`). |
+| 2 | **Deploy MCP Sandbox** *(optional)* | S3 + CloudFront at `mcp-sandbox.{domain}` + Route53 serving the MCP Apps sandbox-proxy shell. Requires `CDK_MCP_SANDBOX_ENABLED=true` and `CDK_MCP_SANDBOX_CERTIFICATE_ARN` (cert MUST be in `us-east-1`). Inert until later MCP Apps host-renderer PRs wire the SPA to it. |
 | 3 | **Deploy Inference API** | Strands Agent runtime container on ECS (Bedrock AgentCore) |
 | 4 | **Deploy App API** | Backend REST API container on ECS |
 | 5 | **Deploy Frontend** | Angular app to S3 + CloudFront distribution |
@@ -61,6 +62,7 @@ You can monitor the current state of each workflow:
 | Deploy RAG Ingestion | [![2.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/rag-ingestion.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/rag-ingestion.yml) |
 | Deploy SageMaker Fine-Tuning *(optional)* | [![2.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/sagemaker-fine-tuning.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/sagemaker-fine-tuning.yml) |
 | Deploy Artifacts *(optional)* | [![2.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/artifacts.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/artifacts.yml) |
+| Deploy MCP Sandbox *(optional)* | [![2.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/mcp-sandbox.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/mcp-sandbox.yml) |
 | Deploy Inference API | [![3.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/inference-api.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/inference-api.yml) |
 | Deploy App API | [![4.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/app-api.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/app-api.yml) |
 | Deploy Frontend | [![5.](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/frontend.yml/badge.svg)](https://github.com/Boise-State-Development/agentcore-public-stack/actions/workflows/frontend.yml) |
@@ -147,6 +149,27 @@ To enable, set these GitHub environment variables before running:
 - `CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS` *(optional, default none)* — comma-separated extra origins allowed to embed artifact iframes via CSP `frame-ancestors`, on top of `https://{domain}`. Set to `http://localhost:4200` to point a local SPA at this environment. **Leave unset in production** — every listed origin can frame users' artifacts. Prefer a one-off targeted `cdk deploy '*ArtifactsStack*'` with this var exported over committing it as a CI variable, so localhost never lands in automated shared-env deploys.
 
 The artifact origin is intentionally a sibling subdomain (not the SPA origin) so artifact JS runs cross-origin and cannot access the `__Host-` session cookies, `localStorage`, or the app API. Defense in depth via strict CSP (`connect-src 'none'`, pinned `frame-ancestors`) is enforced both at the Lambda response and at the CloudFront response-headers policy.
+
+</details>
+
+<details>
+<summary>2. Deploy MCP Sandbox (Optional)</summary>
+
+Provisions the MCP Apps **sandbox-proxy origin** — a dedicated cross-origin shell that the SPA's MCP App iframe is pointed at, so interactive MCP App UIs run isolated from the `ai.client` origin. This is PR #1 of the MCP Apps host-renderer initiative (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). Skip if you don't need MCP Apps; the rest of the stack works without it.
+
+Creates:
+- S3 bucket (private, OAC-only) holding the static `proxy.html` + `proxy.js` shell
+- CloudFront distribution serving `mcp-sandbox.{CDK_DOMAIN_NAME}`
+- Route 53 A record for the sandbox subdomain
+- A CloudFront response-headers policy that stamps `Content-Security-Policy: frame-ancestors <SPA origin only>`
+
+To enable, set these GitHub environment variables before running:
+
+- `CDK_MCP_SANDBOX_ENABLED=true`
+- `CDK_MCP_SANDBOX_CERTIFICATE_ARN` — ACM cert ARN that covers `mcp-sandbox.{domain}`. **Must be in `us-east-1`** (CloudFront requirement). The same wildcard-depth caveat as Artifacts applies: a `*.example.com` cert covers `mcp-sandbox.example.com` but **not** `mcp-sandbox.alpha.example.com`. If `CDK_DOMAIN_NAME` is a subdomain, issue a dedicated `us-east-1` cert for `*.{CDK_DOMAIN_NAME}`. See [Step 2c](./step-02-aws-setup.md#2c-create-acm-certificates).
+- `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS` *(optional, default none)* — comma-separated extra origins allowed to embed the proxy iframe via CSP `frame-ancestors`, on top of `https://{domain}`. Set to `http://localhost:4200` to point a local SPA at this environment. **Leave unset in production** — every listed origin can frame the proxy. Prefer a one-off targeted `cdk deploy '*McpSandboxStack*'` with this var exported over committing it as a CI variable, so localhost never lands in automated shared-env deploys.
+
+The sandbox origin is intentionally a sibling subdomain (not the SPA origin), matching the Artifacts pattern: it is the **outer** half of the spec's Sandbox Proxy pattern, giving a stable cross-origin boundary so the inner MCP App content frame's `allow-same-origin` never reaches the SPA's cookies/`localStorage`/app API. **This stack is inert on its own** — nothing consumes its `/mcp-sandbox/origin` SSM export until the frontend `<mcp-app-frame>` lands in a later PR, and the whole feature stays behind `MCP_APPS_HOST_ENABLED` until the initiative's final PR. Standing it up early is safe and changes nothing user-facing.
 
 </details>
 

--- a/.github/workflows/mcp-sandbox.yml
+++ b/.github/workflows/mcp-sandbox.yml
@@ -1,0 +1,383 @@
+name: "2. Deploy MCP Sandbox (S3, CloudFront, Route53)"
+
+# Provisions the MCP Apps sandbox-proxy origin: an S3 bucket holding the
+# static proxy shell, a CloudFront distribution at mcp-sandbox.{domain} that
+# stamps the CSP (frame-ancestors = SPA origin only), and a Route53 record.
+# Gated on CDK_MCP_SANDBOX_ENABLED — the stack is skipped end-to-end when
+# disabled, identical to the Artifacts / SageMaker Fine-Tuning pattern.
+#
+# PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md. Deploy tier 1:
+# reads no cross-stack SSM. Parallel-safe with Artifacts, RAG Ingestion,
+# Gateway, and Fine-Tuning. Inert until the SPA wiring (PR #4) and
+# MCP_APPS_HOST_ENABLED (PR #7) land — nothing consumes its SSM origin
+# export before then.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/lib/mcp-sandbox-stack.ts'
+      - 'infrastructure/lib/config.ts'
+      - 'infrastructure/bin/infrastructure.ts'
+      - 'infrastructure/cdk.json'
+      - 'infrastructure/cdk.context.json'
+      - 'infrastructure/package.json'
+      - 'infrastructure/assets/mcp-sandbox/**'
+      - 'scripts/stack-mcp-sandbox/**'
+      - '.github/workflows/mcp-sandbox.yml'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'infrastructure/lib/mcp-sandbox-stack.ts'
+      - 'infrastructure/lib/config.ts'
+      - 'infrastructure/bin/infrastructure.ts'
+      - 'infrastructure/cdk.json'
+      - 'infrastructure/cdk.context.json'
+      - 'infrastructure/package.json'
+      - 'infrastructure/assets/mcp-sandbox/**'
+      - 'scripts/stack-mcp-sandbox/**'
+      - '.github/workflows/mcp-sandbox.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+          - development
+      skip_tests:
+        description: 'Skip tests'
+        required: false
+        default: 'false'
+      skip_deploy:
+        description: 'Skip deployment'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+env:
+  CDK_REQUIRE_APPROVAL: never
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  LOAD_ENV_QUIET: true
+
+concurrency:
+  group: mcp-sandbox-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-stack-dependencies:
+    name: Check Stack Dependencies
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run stack dependency tests
+        run: |
+          bash scripts/common/test-stack-dependencies.sh
+
+  install:
+    name: Install Dependencies
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install system dependencies
+        run: |
+          bash scripts/common/install-deps.sh
+
+      - name: Install CDK dependencies
+        run: |
+          bash scripts/stack-mcp-sandbox/install.sh
+
+      - name: Save node_modules cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: infrastructure/node_modules
+          key: infrastructure-node-modules-${{ hashFiles('infrastructure/package-lock.json') }}
+
+  build:
+    name: Build CDK Code
+    runs-on: ubuntu-24.04
+    needs: [install, check-stack-dependencies]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: infrastructure/node_modules
+          key: infrastructure-node-modules-${{ hashFiles('infrastructure/package-lock.json') }}
+
+      - name: Build CDK
+        run: |
+          bash scripts/stack-mcp-sandbox/build-cdk.sh
+
+      - name: Save build artifacts cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            infrastructure/lib/**/*.js
+            infrastructure/lib/**/*.d.ts
+            infrastructure/bin/**/*.js
+            infrastructure/bin/**/*.d.ts
+          key: infrastructure-build-${{ github.sha }}
+
+  synth:
+    name: Synthesize CloudFormation Template
+    runs-on: ubuntu-24.04
+    needs: build
+    if: github.event_name != 'pull_request'
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+
+    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production') || (github.ref == 'refs/heads/develop' && 'development') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      CDK_VPC_CIDR: ${{ vars.CDK_VPC_CIDR }}
+      CDK_DOMAIN_NAME: ${{ vars.CDK_DOMAIN_NAME }}
+      CDK_HOSTED_ZONE_DOMAIN: ${{ vars.CDK_HOSTED_ZONE_DOMAIN }}
+      CDK_CORS_ORIGINS: ${{ vars.CDK_CORS_ORIGINS }}
+      CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
+      CDK_MCP_SANDBOX_ENABLED: ${{ vars.CDK_MCP_SANDBOX_ENABLED }}
+      CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
+      CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Check if MCP sandbox is enabled
+        id: check
+        run: |
+          if [ "${{ vars.CDK_MCP_SANDBOX_ENABLED }}" = "true" ] || [ "${{ vars.CDK_MCP_SANDBOX_ENABLED }}" = "1" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "MCP Sandbox stack is disabled — skipping synth"
+          fi
+
+      - name: Checkout code
+        if: steps.check.outputs.enabled == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore node_modules cache
+        if: steps.check.outputs.enabled == 'true'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: infrastructure/node_modules
+          key: infrastructure-node-modules-${{ hashFiles('infrastructure/package-lock.json') }}
+
+      - name: Restore build artifacts
+        if: steps.check.outputs.enabled == 'true'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            infrastructure/lib/**/*.js
+            infrastructure/lib/**/*.d.ts
+            infrastructure/bin/**/*.js
+            infrastructure/bin/**/*.d.ts
+          key: infrastructure-build-${{ github.sha }}
+
+      - name: Configure AWS credentials
+        if: steps.check.outputs.enabled == 'true'
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.CDK_AWS_REGION }}
+          role-session-name: GitHubActions-McpSandbox-Synth
+          aws-role-arn: ${{ env.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Install system dependencies
+        if: steps.check.outputs.enabled == 'true'
+        run: |
+          bash scripts/common/install-deps.sh
+
+      - name: Synthesize CloudFormation template
+        if: steps.check.outputs.enabled == 'true'
+        run: |
+          bash scripts/stack-mcp-sandbox/synth.sh
+
+      - name: Upload synthesized templates
+        if: steps.check.outputs.enabled == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-sandbox-cdk-synth
+          path: infrastructure/cdk.out/
+          retention-days: 7
+
+  test:
+    name: Validate CloudFormation Template
+    runs-on: ubuntu-24.04
+    needs: synth
+    if: ${{ needs.synth.outputs.enabled == 'true' && github.event.inputs.skip_tests != 'true' }}
+
+    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production') || (github.ref == 'refs/heads/develop' && 'development') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      CDK_VPC_CIDR: ${{ vars.CDK_VPC_CIDR }}
+      CDK_DOMAIN_NAME: ${{ vars.CDK_DOMAIN_NAME }}
+      CDK_HOSTED_ZONE_DOMAIN: ${{ vars.CDK_HOSTED_ZONE_DOMAIN }}
+      CDK_CORS_ORIGINS: ${{ vars.CDK_CORS_ORIGINS }}
+      CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
+      CDK_MCP_SANDBOX_ENABLED: ${{ vars.CDK_MCP_SANDBOX_ENABLED }}
+      CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
+      CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: infrastructure/node_modules
+          key: infrastructure-node-modules-${{ hashFiles('infrastructure/package-lock.json') }}
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            infrastructure/lib/**/*.js
+            infrastructure/lib/**/*.d.ts
+            infrastructure/bin/**/*.js
+            infrastructure/bin/**/*.d.ts
+          key: infrastructure-build-${{ github.sha }}
+
+      - name: Download synthesized templates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-sandbox-cdk-synth
+          path: infrastructure/cdk.out/
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.CDK_AWS_REGION }}
+          role-session-name: GitHubActions-McpSandbox-Test
+          aws-role-arn: ${{ env.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Install system dependencies
+        run: |
+          bash scripts/common/install-deps.sh
+
+      - name: Run CDK diff to validate template
+        run: |
+          bash scripts/stack-mcp-sandbox/test-cdk.sh
+
+  deploy:
+    name: Deploy MCP Sandbox Stack
+    runs-on: ubuntu-24.04
+    needs: [synth, test]
+    if: |
+      always() && !cancelled() &&
+      needs.synth.outputs.enabled == 'true' &&
+      !contains(needs.*.result, 'failure') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_deploy != 'true')
+
+    environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production') || (github.ref == 'refs/heads/develop' && 'development') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      CDK_VPC_CIDR: ${{ vars.CDK_VPC_CIDR }}
+      CDK_DOMAIN_NAME: ${{ vars.CDK_DOMAIN_NAME }}
+      CDK_HOSTED_ZONE_DOMAIN: ${{ vars.CDK_HOSTED_ZONE_DOMAIN }}
+      CDK_CORS_ORIGINS: ${{ vars.CDK_CORS_ORIGINS }}
+      CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
+      CDK_MCP_SANDBOX_ENABLED: ${{ vars.CDK_MCP_SANDBOX_ENABLED }}
+      CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
+      CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: infrastructure/node_modules
+          key: infrastructure-node-modules-${{ hashFiles('infrastructure/package-lock.json') }}
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            infrastructure/lib/**/*.js
+            infrastructure/lib/**/*.d.ts
+            infrastructure/bin/**/*.js
+            infrastructure/bin/**/*.d.ts
+          key: infrastructure-build-${{ github.sha }}
+
+      - name: Download synthesized templates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-sandbox-cdk-synth
+          path: infrastructure/cdk.out/
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.CDK_AWS_REGION }}
+          role-session-name: GitHubActions-McpSandbox-Deploy
+          aws-role-arn: ${{ env.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Install system dependencies
+        run: |
+          bash scripts/common/install-deps.sh
+
+      - name: Deploy MCP Sandbox Stack
+        run: |
+          bash scripts/stack-mcp-sandbox/deploy.sh
+
+      - name: Upload stack outputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: mcp-sandbox-outputs
+          path: infrastructure/mcp-sandbox-outputs.json
+          retention-days: 30

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -3,6 +3,11 @@
 *.d.ts
 node_modules
 
+# Hand-written static assets deployed verbatim to S3 (e.g. the MCP Apps
+# sandbox-proxy shell) are SOURCE, not compiled CDK output — keep them tracked.
+!assets/
+!assets/**
+
 # CDK asset staging directory
 .cdk.staging
 cdk.out

--- a/infrastructure/assets/mcp-sandbox/proxy.html
+++ b/infrastructure/assets/mcp-sandbox/proxy.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+  MCP Apps host renderer — Sandbox Proxy shell (OUTER iframe)
+
+  PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md.
+
+  This is the static shell served at mcp-sandbox.{domain}/proxy.html. It is
+  the OUTER half of the spec's "Sandbox Proxy pattern" for web hosts:
+
+    ai.client (SPA)
+      └─ <iframe src="https://mcp-sandbox.{domain}/proxy.html">   ← THIS FILE
+           └─ <iframe srcdoc="...">  inner content frame (created here)
+
+  Why two iframes: this outer page is a stable cross-origin boundary against
+  the host page, so `allow-same-origin` on the INNER frame never grants the
+  MCP App access to the SPA origin (cookies / localStorage / app API). The
+  inner frame takes the strict per-resource CSP from `_meta.ui.csp` — that
+  composition lands in PR #4.
+
+  SCOPE OF THIS PR: stand up the origin + the static shell only. There is NO
+  MCP server wiring and NO JSON-RPC postMessage protocol here yet — the shell
+  only answers a liveness handshake so the SPA can prove it can reach this
+  origin. The full host bridge (ui/initialize, tool-input, resource-teardown,
+  per-frame nonce auth, etc.) is PR #4. Until PR #7 flips
+  MCP_APPS_HOST_ENABLED nothing in the SPA points at this page, so deploying
+  this stack is inert.
+
+  CSP NOTE: the security-critical control for this PR is the response
+  `Content-Security-Policy: frame-ancestors <SPA origin only>` stamped by the
+  CloudFront ResponseHeadersPolicy in mcp-sandbox-stack.ts — that is what
+  prevents any site other than the SPA from embedding this proxy. This
+  document loads no inline scripts/styles so the served CSP can stay
+  `script-src 'self'` with no `'unsafe-inline'`.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="no-referrer" />
+    <title>MCP Apps Sandbox Proxy</title>
+  </head>
+  <body>
+    <!--
+      The inner content frame is created at runtime by proxy.js (via srcdoc),
+      not declared here, because in later PRs its srcdoc / sandbox / CSP are
+      derived per-resource from the `ui_resource` SSE event. For PR #1 it is
+      an empty placeholder so the two-iframe structure is observable.
+    -->
+    <script src="proxy.js"></script>
+  </body>
+</html>

--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -1,0 +1,83 @@
+/*
+ * MCP Apps host renderer — Sandbox Proxy bootstrap (OUTER iframe).
+ *
+ * PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md. See proxy.html for
+ * the architecture overview. This file is intentionally tiny: it exists so
+ * the served CSP can be `script-src 'self'` (no inline script, no
+ * `'unsafe-inline'`).
+ *
+ * What it does in PR #1 — and ONLY this:
+ *   1. Create the inner content iframe via `srcdoc` (empty placeholder),
+ *      establishing the two-iframe Sandbox Proxy structure.
+ *   2. Answer a liveness handshake from the embedding SPA so the frontend
+ *      (and tests) can prove the cross-origin channel works.
+ *
+ * What it deliberately does NOT do (PR #4+):
+ *   - JSON-RPC 2.0 over postMessage (ui/initialize, ui/notifications/*, etc.)
+ *   - Per-frame nonce authentication of the protocol channel
+ *   - Loading real MCP App HTML / composing the inner CSP from _meta.ui.csp
+ *   - tools/call proxying (PR #5)
+ *
+ * Origin handling: this outer page can only ever be framed by the SPA origin
+ * because CloudFront serves it with `frame-ancestors <SPA origin only>`. The
+ * browser enforces that before any script here runs, so the PR #1 handshake
+ * does not need to re-check event.origin (and per spec the inner frame's
+ * origin will be "null" anyway — real auth is the per-frame nonce added in
+ * PR #4). We simply echo back the caller's nonce so the SPA can correlate.
+ */
+(function () {
+  'use strict';
+
+  var PROTOCOL = 'mcp-sandbox-proxy';
+  var PHASE = 'pr1-shell';
+
+  // 1. Establish the inner content frame. srcdoc (not src) keeps it at a
+  //    distinct opaque origin ("null"); PR #4 replaces this placeholder with
+  //    the real MCP App resource and widens `sandbox` per _meta.ui.permissions.
+  var inner = document.createElement('iframe');
+  inner.id = 'mcp-app-content';
+  inner.title = 'MCP App content';
+  // Most-restrictive sandbox for the inert placeholder. PR #4 adds
+  // allow-scripts / allow-same-origin (spec minimum) and any opted-in
+  // capability flags from _meta.ui.permissions.
+  inner.setAttribute('sandbox', '');
+  inner.setAttribute(
+    'srcdoc',
+    '<!doctype html><meta charset="utf-8"><title>MCP App placeholder</title>' +
+      'MCP Apps sandbox proxy ready (PR #1 shell — no content bound).'
+  );
+  document.body.appendChild(inner);
+
+  // 2. Liveness handshake. The SPA posts {type:"<PROTOCOL>:ping", nonce} once
+  //    its <mcp-app-frame> sees this iframe load; we reply to the sender so
+  //    the SPA can confirm the cross-origin proxy is reachable. This is NOT
+  //    the protocol channel — that is PR #4.
+  window.addEventListener('message', function (event) {
+    var data = event && event.data;
+    if (!data || data.type !== PROTOCOL + ':ping') {
+      return;
+    }
+    var reply = {
+      type: PROTOCOL + ':pong',
+      phase: PHASE,
+      ready: true,
+      // Echo the caller's correlation token verbatim if present.
+      nonce: typeof data.nonce === 'string' ? data.nonce : null
+    };
+    if (event.source && typeof event.source.postMessage === 'function') {
+      // targetOrigin "*" is acceptable here: the reply carries no secrets,
+      // only a liveness ack, and the embedder is already constrained to the
+      // SPA origin by the server-side frame-ancestors CSP.
+      event.source.postMessage(reply, '*');
+    }
+  });
+
+  // Signal to the embedder that the shell finished bootstrapping, for SPAs
+  // that prefer to wait for a push rather than poll with a ping.
+  if (window.parent && window.parent !== window) {
+    window.parent.postMessage(
+      { type: PROTOCOL + ':ready', phase: PHASE },
+      '*'
+    );
+  }
+})();

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -8,6 +8,7 @@ import { GatewayStack } from '../lib/gateway-stack';
 import { RagIngestionStack } from '../lib/rag-ingestion-stack';
 import { SageMakerFineTuningStack } from '../lib/sagemaker-fine-tuning-stack';
 import { ArtifactsStack } from '../lib/artifacts-stack';
+import { McpSandboxStack } from '../lib/mcp-sandbox-stack';
 import { loadConfig, getStackEnv } from '../lib/config';
 
 const app = new cdk.App();
@@ -33,6 +34,20 @@ if (config.artifacts.enabled) {
     env,
     description: `${config.projectPrefix} Artifacts Stack - DDB, S3, CloudFront + Lambda render service`,
     stackName: `${config.projectPrefix}-ArtifactsStack`,
+  });
+}
+
+// MCP Sandbox Stack - S3 + CloudFront + Route53 serving the MCP Apps
+// sandbox-proxy shell at mcp-sandbox.{domain}. PR #1 of the MCP Apps host
+// renderer initiative; deploy tier 1, parallel-safe with Artifacts / RAG /
+// Gateway / Fine-Tuning (reads no cross-stack SSM). Inert until the SPA
+// wiring (PR #4) and MCP_APPS_HOST_ENABLED (PR #7) land.
+if (config.mcpSandbox.enabled) {
+  new McpSandboxStack(app, 'McpSandboxStack', {
+    config,
+    env,
+    description: `${config.projectPrefix} MCP Sandbox Stack - S3, CloudFront, Route53 (MCP Apps proxy origin)`,
+    stackName: `${config.projectPrefix}-McpSandboxStack`,
   });
 }
 

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -34,8 +34,36 @@ export interface AppConfig {
   ragIngestion: RagIngestionConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
+  mcpSandbox: McpSandboxConfig;
   appVersion: string;
   tags: { [key: string]: string };
+}
+
+/**
+ * MCP Apps host renderer — sandbox-proxy origin (PR #1 of the
+ * docs/kaizen/scoping/mcp-apps-host-renderer.md sequence).
+ *
+ * Provisions a dedicated cross-origin shell (mcp-sandbox.{domainName}) that
+ * later PRs (#4+) point the SPA's <mcp-app-frame> at. Standing this stack up
+ * is inert: nothing consumes its SSM origin export until the frontend wiring
+ * lands, and the whole host renderer stays behind MCP_APPS_HOST_ENABLED
+ * (flipped in PR #7).
+ */
+export interface McpSandboxConfig {
+  // When false the stack is not instantiated at all (bin/infrastructure.ts
+  // skips it). Default false — the origin is opt-in per environment and the
+  // initiative is gated end-to-end until PR #7.
+  enabled: boolean;
+  // ACM certificate ARN for the proxy origin (mcp-sandbox.{domainName}).
+  // MUST be in us-east-1 — CloudFront requires its viewer certs there.
+  // Required (and region-validated) only when enabled; without it the stack
+  // still synthesizes on the CloudFront default domain so unit/synth tests
+  // and domain-less local stacks work.
+  certificateArn?: string;
+  // Extra origins (beyond https://{domainName}) allowed to embed the proxy
+  // iframe via CSP frame-ancestors — e.g. http://localhost:4200 for a local
+  // SPA pointed at this deployment. Empty on prod.
+  extraFrameAncestors: string[];
 }
 
 export interface ArtifactsConfig {
@@ -285,6 +313,14 @@ export function loadConfig(scope: cdk.App): AppConfig {
         || scope.node.tryGetContext('artifacts')?.extraFrameAncestors
         || [],
     },
+    mcpSandbox: {
+      enabled: parseBooleanEnv(process.env.CDK_MCP_SANDBOX_ENABLED) ?? scope.node.tryGetContext('mcpSandbox')?.enabled ?? false,
+      certificateArn: process.env.CDK_MCP_SANDBOX_CERTIFICATE_ARN || scope.node.tryGetContext('mcpSandbox')?.certificateArn,
+      extraFrameAncestors: process.env.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS?.split(',')
+        .map((s) => s.trim()).filter(Boolean)
+        || scope.node.tryGetContext('mcpSandbox')?.extraFrameAncestors
+        || [],
+    },
     tags: {
       ...(scope.node.tryGetContext('tags') || {}),
     },
@@ -302,6 +338,7 @@ export function loadConfig(scope: cdk.App): AppConfig {
   console.log(`   Gateway Enabled: ${config.gateway.enabled}`);
   console.log(`   Fine-Tuning Enabled: ${config.fineTuning.enabled}`);
   console.log(`   Artifacts Enabled: ${config.artifacts.enabled}`);
+  console.log(`   MCP Sandbox Enabled: ${config.mcpSandbox.enabled}`);
   console.log(`   App Version: ${config.appVersion}`);
 
   // Validate configuration
@@ -563,6 +600,36 @@ function validateConfig(config: AppConfig): void {
     if (config.artifacts.retentionDays < 1 || config.artifacts.retentionDays > 3650) {
       throw new Error(
         `Artifacts retentionDays must be between 1 and 3650. Got: ${config.artifacts.retentionDays}`
+      );
+    }
+  }
+
+  if (config.mcpSandbox.enabled) {
+    if (!config.domainName) {
+      throw new Error(
+        'MCP Sandbox stack requires CDK_DOMAIN_NAME to be set — the proxy origin ' +
+        'is derived as mcp-sandbox.{CDK_DOMAIN_NAME} and the CSP frame-ancestors ' +
+        'is locked to the SPA origin https://{CDK_DOMAIN_NAME}.'
+      );
+    }
+    if (!config.infrastructureHostedZoneDomain) {
+      throw new Error(
+        'MCP Sandbox stack requires CDK_HOSTED_ZONE_DOMAIN to be set — used to ' +
+        'look up the Route53 zone where the mcp-sandbox subdomain record is created.'
+      );
+    }
+    if (!config.mcpSandbox.certificateArn) {
+      throw new Error(
+        'MCP Sandbox stack requires CDK_MCP_SANDBOX_CERTIFICATE_ARN — an ACM cert ' +
+        'in us-east-1 for the mcp-sandbox.{domain} CloudFront distribution.'
+      );
+    }
+    // CloudFront requires the viewer cert in us-east-1. Catch the most common
+    // misconfiguration up front rather than letting CloudFormation reject it.
+    if (!/^arn:aws:acm:us-east-1:/.test(config.mcpSandbox.certificateArn)) {
+      throw new Error(
+        `MCP Sandbox certificate must be in us-east-1 (CloudFront requirement). ` +
+        `Got: ${config.mcpSandbox.certificateArn}`
       );
     }
   }

--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -1,0 +1,326 @@
+import * as cdk from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import * as path from 'path';
+import {
+  AppConfig,
+  applyStandardTags,
+  getAutoDeleteObjects,
+  getRemovalPolicy,
+  getResourceName,
+} from './config';
+
+export interface McpSandboxStackProps extends cdk.StackProps {
+  config: AppConfig;
+}
+
+/**
+ * The subdomain label for the MCP Apps sandbox-proxy origin.
+ *
+ * Decision (the scoping doc explicitly leaves this "TBD in PR #1"): use
+ * `mcp-sandbox`, matching the working name in
+ * docs/kaizen/scoping/mcp-apps-host-renderer.md and paralleling the existing
+ * sibling iframe origin `artifacts.{domain}`. This single constant is the
+ * source of truth — it must stay in sync with the CDK_MCP_SANDBOX_* workflow
+ * env vars and the cors-deployment skill notes.
+ */
+export const MCP_SANDBOX_SUBDOMAIN_LABEL = 'mcp-sandbox';
+
+/**
+ * Build the CSP `frame-ancestors` source list for the proxy origin.
+ *
+ * The proxy may ONLY be embedded by the SPA (`ai.client`) origin, which is
+ * `https://{domainName}` plus any explicitly-allowed extras (e.g.
+ * http://localhost:4200 for a local SPA pointed at this env). This is the
+ * security-critical control for PR #1.
+ *
+ * Falls back to `'none'` (deny all framing) when there is no SPA origin to
+ * permit — keeps the stack synthesizable for unit/synth tests and
+ * domain-less local stacks without ever silently allowing `*`.
+ *
+ * Exported so the value is unit-testable directly and the stack body has a
+ * single source of truth.
+ */
+export function buildMcpSandboxFrameAncestors(
+  domainName: string | undefined,
+  extraFrameAncestors: string[],
+): string {
+  const sources: string[] = [];
+  if (domainName) {
+    sources.push(`https://${domainName}`);
+  }
+  for (const extra of extraFrameAncestors) {
+    const trimmed = extra.trim();
+    if (trimmed) {
+      sources.push(trimmed);
+    }
+  }
+  return sources.length > 0 ? sources.join(' ') : `'none'`;
+}
+
+/**
+ * Assemble the Content-Security-Policy served with `proxy.html`.
+ *
+ * `frame-ancestors` is the security-critical directive (who may embed the
+ * proxy — the SPA only). The rest is deny-by-default hardening for the inert
+ * PR #1 shell:
+ *
+ *   - `script-src 'self'`  — proxy.js only; no inline script, no
+ *     `'unsafe-inline'` (proxy.html ships zero inline script/style on
+ *     purpose so this stays clean).
+ *   - `frame-src 'self'`   — permits the inner `srcdoc` content frame the
+ *     shell creates. The strict PER-RESOURCE inner CSP composed from
+ *     `_meta.ui.csp` is PR #4's job (and is browser-verifiable there, once
+ *     real content actually loads); this outer policy is intentionally
+ *     provisional until then. Nested-CSP / `frame-ancestors` interplay has
+ *     no prior art in this stack — flagged as expected debugging in the
+ *     scoping doc; deferring the inner-frame tuning to the PR where it can
+ *     be exercised in a browser is the safe sequencing.
+ *   - everything else denied via `default-src 'none'`.
+ *
+ * Exported for direct unit testing.
+ */
+export function buildMcpSandboxProxyCsp(frameAncestors: string): string {
+  return [
+    `default-src 'none'`,
+    `script-src 'self'`,
+    `frame-src 'self'`,
+    `frame-ancestors ${frameAncestors}`,
+    `base-uri 'none'`,
+    `form-action 'none'`,
+  ].join('; ');
+}
+
+/**
+ * MCP Apps host renderer — Sandbox Proxy origin.
+ *
+ * PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md.
+ *
+ * Provisions a dedicated cross-origin static origin that serves a single
+ * shell, `proxy.html`, at `mcp-sandbox.{domainName}`:
+ *
+ *   - S3 bucket (private, OAC-only) holding proxy.html + proxy.js
+ *   - BucketDeployment that bakes those assets in at deploy time (the stack
+ *     is self-contained — no separate asset-sync step)
+ *   - CloudFront distribution terminating TLS and stamping the CSP
+ *     (`frame-ancestors` locked to the SPA origin)
+ *   - Route53 A record for the subdomain (when a custom domain + cert are
+ *     configured)
+ *
+ * The proxy is the OUTER half of the spec's Sandbox Proxy pattern; it itself
+ * creates the inner content iframe via `srcdoc` (see assets/mcp-sandbox/).
+ *
+ * INERT BY DESIGN: this stack writes exactly one SSM export
+ * (`/{prefix}/mcp-sandbox/origin`) that nothing consumes until the frontend
+ * `<mcp-app-frame>` lands (PR #4) and the whole host renderer stays gated
+ * behind `MCP_APPS_HOST_ENABLED` until PR #7. Deploying it changes nothing
+ * user-facing.
+ *
+ * Cross-stack contract: reads NOTHING from other stacks (cert ARN comes from
+ * config, the hosted zone via Route53 lookup). One-way SSM publish only —
+ * deploy tier 1, parallel-safe with Artifacts / RAG / Gateway / Fine-Tuning.
+ */
+export class McpSandboxStack extends cdk.Stack {
+  public readonly bucket: s3.Bucket;
+  public readonly distribution: cloudfront.Distribution;
+  public readonly proxyOrigin: string;
+
+  constructor(scope: Construct, id: string, props: McpSandboxStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+    applyStandardTags(this, config);
+
+    // Custom domain + cert + Route53 are attached only when BOTH a domain and
+    // an ACM cert are configured (config.ts enforces both, plus the hosted
+    // zone, whenever the stack is *enabled*). Keeping it conditional — the
+    // FrontendStack pattern — lets the stack still synthesize on the
+    // CloudFront default domain for unit/synth tests and domain-less local
+    // stacks, while a real deploy always has the full custom-domain path.
+    const domainName = config.domainName;
+    const certificateArn = config.mcpSandbox.certificateArn;
+    const useCustomDomain = Boolean(domainName && certificateArn);
+    const proxySubdomain = domainName
+      ? `${MCP_SANDBOX_SUBDOMAIN_LABEL}.${domainName}`
+      : undefined;
+
+    // The SPA (ai.client) origin is the ONLY origin allowed to embed the
+    // proxy. Derived from the same domainName the CORS model is centred on
+    // (cors-deployment skill) so the framing allowlist and the CORS
+    // allowlist can never drift apart.
+    const frameAncestors = buildMcpSandboxFrameAncestors(
+      domainName,
+      config.mcpSandbox.extraFrameAncestors,
+    );
+    const proxyCsp = buildMcpSandboxProxyCsp(frameAncestors);
+
+    // ============================================================
+    // S3 — holds the static proxy shell (private, OAC-only)
+    // ============================================================
+    // No public access, no website hosting, no CORS: the shell is loaded
+    // only by being framed (an HTML document navigation), never via XHR.
+    // Content is fully reproducible from source, so removal policy follows
+    // the standard retain/destroy helper like every other bucket.
+    this.bucket = new s3.Bucket(this, 'McpSandboxBucket', {
+      bucketName: getResourceName(config, 'mcp-sandbox', config.awsAccount),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: getRemovalPolicy(config),
+      autoDeleteObjects: getAutoDeleteObjects(config),
+    });
+
+    // ============================================================
+    // CloudFront — terminates TLS, stamps the CSP
+    // ============================================================
+    const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      'McpSandboxResponseHeaders',
+      {
+        responseHeadersPolicyName: getResourceName(config, 'mcp-sandbox-headers'),
+        comment: 'CSP (frame-ancestors = SPA origin only) + security headers for the MCP Apps sandbox proxy',
+        securityHeadersBehavior: {
+          contentSecurityPolicy: {
+            contentSecurityPolicy: proxyCsp,
+            override: true,
+          },
+          contentTypeOptions: { override: true },
+          // Intentionally NOT setting frameOptions — `frame-ancestors` in the
+          // CSP above is the modern, cross-browser-enforced equivalent and is
+          // the control this PR is about. Setting X-Frame-Options too would
+          // only add a legacy, less expressive duplicate.
+          referrerPolicy: {
+            referrerPolicy: cloudfront.HeadersReferrerPolicy.NO_REFERRER,
+            override: true,
+          },
+          strictTransportSecurity: {
+            accessControlMaxAge: cdk.Duration.days(365),
+            includeSubdomains: true,
+            override: true,
+          },
+        },
+      },
+    );
+
+    // Static shell: a short cache is fine and BucketDeployment invalidates on
+    // every deploy so shell changes propagate immediately. No cookies / query
+    // / headers participate in the cache key.
+    const cachePolicy = new cloudfront.CachePolicy(this, 'McpSandboxCachePolicy', {
+      cachePolicyName: getResourceName(config, 'mcp-sandbox-cache'),
+      comment: 'Cache policy for the MCP Apps sandbox proxy shell',
+      defaultTtl: cdk.Duration.minutes(5),
+      minTtl: cdk.Duration.seconds(0),
+      maxTtl: cdk.Duration.hours(1),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: true,
+    });
+
+    const distributionProps: cloudfront.DistributionProps = {
+      comment: getResourceName(config, 'mcp-sandbox-cdn'),
+      defaultRootObject: 'proxy.html',
+      minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy,
+        responseHeadersPolicy,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD,
+        compress: true,
+      },
+      // Cheapest price class — the shell is tiny and not latency-critical.
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+      enabled: true,
+      ...(useCustomDomain
+        ? {
+            domainNames: [proxySubdomain!],
+            certificate: acm.Certificate.fromCertificateArn(
+              this,
+              'McpSandboxCertificate',
+              certificateArn!,
+            ),
+          }
+        : {}),
+    };
+
+    this.distribution = new cloudfront.Distribution(
+      this,
+      'McpSandboxDistribution',
+      distributionProps,
+    );
+
+    // ============================================================
+    // Deploy the static shell into the bucket (self-contained)
+    // ============================================================
+    // Source.asset of plain files needs no Docker — CDK zips locally and the
+    // aws-cdk-lib BucketDeployment Lambda uploads it. distribution +
+    // distributionPaths wires an automatic CloudFront invalidation so a
+    // re-deployed shell is served immediately despite the cache policy.
+    new s3deploy.BucketDeployment(this, 'McpSandboxShellDeployment', {
+      sources: [
+        s3deploy.Source.asset(path.resolve(__dirname, '..', 'assets', 'mcp-sandbox')),
+      ],
+      destinationBucket: this.bucket,
+      distribution: this.distribution,
+      distributionPaths: ['/*'],
+      prune: true,
+    });
+
+    // ============================================================
+    // Route53 — alias the subdomain to CloudFront (custom domain only)
+    // ============================================================
+    if (useCustomDomain) {
+      const hostedZone = route53.HostedZone.fromLookup(this, 'HostedZone', {
+        domainName: config.infrastructureHostedZoneDomain!,
+      });
+
+      new route53.ARecord(this, 'McpSandboxAliasRecord', {
+        zone: hostedZone,
+        recordName: proxySubdomain!,
+        target: route53.RecordTarget.fromAlias(
+          new route53Targets.CloudFrontTarget(this.distribution),
+        ),
+        comment: 'MCP Apps sandbox-proxy origin — proxies to CloudFront → S3 shell',
+      });
+    }
+
+    // ============================================================
+    // SSM export — the outward contract (one-way; nothing reads it yet)
+    // ============================================================
+    this.proxyOrigin = useCustomDomain
+      ? `https://${proxySubdomain}`
+      : `https://${this.distribution.distributionDomainName}`;
+
+    new ssm.StringParameter(this, 'McpSandboxOriginParameter', {
+      parameterName: `/${config.projectPrefix}/mcp-sandbox/origin`,
+      stringValue: this.proxyOrigin,
+      description: 'Origin serving the MCP Apps sandbox proxy shell (https://mcp-sandbox.{domain})',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    // Human-readable CloudFormation outputs for deploy-time visibility.
+    new cdk.CfnOutput(this, 'McpSandboxOrigin', {
+      value: this.proxyOrigin,
+      description: 'MCP Apps sandbox-proxy origin URL',
+    });
+    new cdk.CfnOutput(this, 'McpSandboxProxyUrl', {
+      value: `${this.proxyOrigin}/proxy.html`,
+      description: 'Fully-qualified URL of the sandbox proxy shell',
+    });
+    new cdk.CfnOutput(this, 'McpSandboxDistributionId', {
+      value: this.distribution.distributionId,
+      description: 'CloudFront distribution ID for the sandbox-proxy origin',
+    });
+  }
+}

--- a/infrastructure/test/cors.test.ts
+++ b/infrastructure/test/cors.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { loadConfig, buildCorsOrigins, AppConfig } from '../lib/config';
+import { buildMcpSandboxFrameAncestors } from '../lib/mcp-sandbox-stack';
 import { createMockConfig } from './helpers/mock-config';
 
 /**
@@ -254,5 +255,57 @@ describe('loadConfig CORS derivation', () => {
     const config = loadConfig(app);
     const origins = buildCorsOrigins(config);
     expect(origins).toEqual(['http://localhost:4200']);
+  });
+});
+
+// ============================================================
+// MCP Apps sandbox-proxy origin allowlisting (PR #1)
+//
+// The proxy is not a CORS consumer (buildCorsOrigins) — it is an origin
+// whose CSP frame-ancestors must permit ONLY the SPA. Per the
+// cors-deployment skill, every new env var that names this origin /
+// allowlists it flows through this file: these tests pin that the proxy's
+// framing allowlist is derived from the SAME domainName the CORS model is
+// centred on, so the two allowlists can never silently drift apart.
+// ============================================================
+
+describe('MCP sandbox proxy frame-ancestors vs CORS domain', () => {
+  test('frame-ancestors matches the domain-derived SPA CORS origin', () => {
+    const config = createMockConfig({
+      corsOrigins: 'https://alpha.example.com',
+      domainName: 'alpha.example.com',
+    });
+    const corsOrigins = buildCorsOrigins(config);
+    const frameAncestors = buildMcpSandboxFrameAncestors(
+      config.domainName,
+      config.mcpSandbox.extraFrameAncestors,
+    );
+    // The single SPA origin the CORS layer allows is exactly the single
+    // origin permitted to frame the proxy.
+    expect(corsOrigins).toContain('https://alpha.example.com');
+    expect(frameAncestors).toBe('https://alpha.example.com');
+  });
+
+  test('never widens to * and denies framing when there is no SPA origin', () => {
+    const config = createMockConfig({ corsOrigins: '', domainName: undefined });
+    const frameAncestors = buildMcpSandboxFrameAncestors(
+      config.domainName,
+      config.mcpSandbox.extraFrameAncestors,
+    );
+    expect(frameAncestors).toBe("'none'");
+    expect(frameAncestors).not.toContain('*');
+  });
+
+  test('extra frame ancestors (e.g. localhost SPA) are additive, like CDK_CORS_ORIGINS', () => {
+    const config = createMockConfig({
+      corsOrigins: 'https://alpha.example.com,http://localhost:4200',
+      domainName: 'alpha.example.com',
+      mcpSandbox: { enabled: true, extraFrameAncestors: ['http://localhost:4200'] },
+    });
+    const frameAncestors = buildMcpSandboxFrameAncestors(
+      config.domainName,
+      config.mcpSandbox.extraFrameAncestors,
+    );
+    expect(frameAncestors).toBe('https://alpha.example.com http://localhost:4200');
   });
 });

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -82,6 +82,10 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
       retentionDays: 90,
       extraFrameAncestors: [],
     },
+    mcpSandbox: {
+      enabled: false,
+      extraFrameAncestors: [],
+    },
     cognito: {
       domainPrefix: MOCK_PREFIX,
       passwordMinLength: 8,
@@ -121,6 +125,7 @@ const SSM_READS_BY_STACK: Record<string, string[]> = {
   ArtifactsStack: [
     'artifacts/render-token-key-arn',
   ],
+  McpSandboxStack: [],
   InferenceApiStack: [
     'inference-api/image-tag',
     'oauth/client-secrets-arn',

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -1,0 +1,183 @@
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import {
+  McpSandboxStack,
+  buildMcpSandboxFrameAncestors,
+  buildMcpSandboxProxyCsp,
+  MCP_SANDBOX_SUBDOMAIN_LABEL,
+} from '../lib/mcp-sandbox-stack';
+import { createMockConfig, createMockApp, mockEnv } from './helpers/mock-config';
+
+describe('McpSandboxStack', () => {
+  // Default mock config has a domainName but no mcpSandbox.certificateArn, so
+  // the stack synthesizes on the CloudFront default domain (no ACM import, no
+  // Route53 lookup) while still deriving the real frame-ancestors from the
+  // domain — exactly the unit/synth path.
+  let template: Template;
+
+  beforeEach(() => {
+    const config = createMockConfig({
+      domainName: 'test.example.com',
+      mcpSandbox: {
+        enabled: true,
+        extraFrameAncestors: ['http://localhost:4200'],
+      },
+    });
+    const app = createMockApp(config, ['McpSandboxStack']);
+    const stack = new McpSandboxStack(app, 'TestMcpSandboxStack', {
+      config,
+      env: mockEnv(config),
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test('synthesizes without errors', () => {
+    expect(template.toJSON()).toBeDefined();
+  });
+
+  test('creates a private, encrypted S3 bucket that blocks all public access', () => {
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: Match.arrayWith([
+          Match.objectLike({
+            ServerSideEncryptionByDefault: Match.objectLike({
+              SSEAlgorithm: Match.anyValue(),
+            }),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('creates exactly one CloudFront distribution', () => {
+    template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+  });
+
+  test('CloudFront serves proxy.html as the default root object', () => {
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultRootObject: 'proxy.html',
+      }),
+    });
+  });
+
+  test('ResponseHeadersPolicy CSP locks frame-ancestors to the SPA origin only', () => {
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        SecurityHeadersConfig: Match.objectLike({
+          ContentSecurityPolicy: Match.objectLike({
+            Override: true,
+            ContentSecurityPolicy: Match.stringLikeRegexp(
+              'frame-ancestors https://test\\.example\\.com http://localhost:4200',
+            ),
+          }),
+          StrictTransportSecurity: Match.objectLike({ Override: true }),
+        }),
+      }),
+    });
+  });
+
+  test('does NOT set legacy X-Frame-Options (frame-ancestors is the control)', () => {
+    const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+    const policy = Object.values(policies)[0] as any;
+    const security = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig;
+    expect(security.FrameOptions).toBeUndefined();
+  });
+
+  test('bakes the shell in via a BucketDeployment with CloudFront invalidation', () => {
+    template.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    template.hasResourceProperties('Custom::CDKBucketDeployment', {
+      DistributionPaths: ['/*'],
+    });
+  });
+
+  test('writes the one-way /mcp-sandbox/origin SSM export', () => {
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/test-project/mcp-sandbox/origin',
+      Type: 'String',
+    });
+  });
+
+  test('does not create a Route53 record without a custom domain cert', () => {
+    template.resourceCountIs('AWS::Route53::RecordSet', 0);
+  });
+
+  test('domain-less config denies all framing (frame-ancestors none)', () => {
+    const config = createMockConfig({
+      domainName: undefined,
+      mcpSandbox: { enabled: true, extraFrameAncestors: [] },
+    });
+    const app = createMockApp(config, ['McpSandboxStack']);
+    const stack = new McpSandboxStack(app, 'NoDomainMcpSandboxStack', {
+      config,
+      env: mockEnv(config),
+    });
+    const t = Template.fromStack(stack);
+    t.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        SecurityHeadersConfig: Match.objectLike({
+          ContentSecurityPolicy: Match.objectLike({
+            ContentSecurityPolicy: Match.stringLikeRegexp("frame-ancestors 'none'"),
+          }),
+        }),
+      }),
+    });
+  });
+});
+
+describe('buildMcpSandboxFrameAncestors', () => {
+  test('prod: SPA origin derived from the domain', () => {
+    expect(buildMcpSandboxFrameAncestors('alpha.example.com', [])).toBe(
+      'https://alpha.example.com',
+    );
+  });
+
+  test('prod + extra origins (e.g. local SPA pointed at this env)', () => {
+    expect(
+      buildMcpSandboxFrameAncestors('alpha.example.com', ['http://localhost:4200']),
+    ).toBe('https://alpha.example.com http://localhost:4200');
+  });
+
+  test('no domain, no extras → deny all framing', () => {
+    expect(buildMcpSandboxFrameAncestors(undefined, [])).toBe("'none'");
+  });
+
+  test('extras only (domain-less local stack)', () => {
+    expect(buildMcpSandboxFrameAncestors(undefined, ['http://localhost:4200'])).toBe(
+      'http://localhost:4200',
+    );
+  });
+
+  test('blank extras are filtered out, never widening to *', () => {
+    expect(buildMcpSandboxFrameAncestors('alpha.example.com', ['', '  '])).toBe(
+      'https://alpha.example.com',
+    );
+  });
+});
+
+describe('buildMcpSandboxProxyCsp', () => {
+  test('is deny-by-default and carries the given frame-ancestors', () => {
+    const csp = buildMcpSandboxProxyCsp('https://alpha.example.com');
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("frame-src 'self'");
+    expect(csp).toContain('frame-ancestors https://alpha.example.com');
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  test('never emits unsafe-inline (proxy ships no inline script/style)', () => {
+    expect(buildMcpSandboxProxyCsp("'none'")).not.toContain('unsafe-inline');
+  });
+});
+
+describe('subdomain decision', () => {
+  test('is the documented "mcp-sandbox" label (TBD resolved in PR #1)', () => {
+    expect(MCP_SANDBOX_SUBDOMAIN_LABEL).toBe('mcp-sandbox');
+  });
+});

--- a/infrastructure/test/rag-ingestion-stack.test.ts
+++ b/infrastructure/test/rag-ingestion-stack.test.ts
@@ -88,6 +88,10 @@ describe('RagIngestionStack', () => {
         retentionDays: 90,
         extraFrameAncestors: [],
       },
+      mcpSandbox: {
+        enabled: false,
+        extraFrameAncestors: [],
+      },
       cognito: {
         domainPrefix: 'test-project',
         passwordMinLength: 8,

--- a/infrastructure/test/stack-dependencies.test.ts
+++ b/infrastructure/test/stack-dependencies.test.ts
@@ -35,6 +35,7 @@ const STACK_FILES: Record<string, string> = {
   'gateway-stack.ts': 'GatewayStack',
   'sagemaker-fine-tuning-stack.ts': 'SageMakerFineTuningStack',
   'artifacts-stack.ts': 'ArtifactsStack',
+  'mcp-sandbox-stack.ts': 'McpSandboxStack',
   'inference-api-stack.ts': 'InferenceApiStack',
   'app-api-stack.ts': 'AppApiStack',
   'frontend-stack.ts': 'FrontendStack',
@@ -59,6 +60,10 @@ const DEPLOYMENT_TIERS: Record<string, number> = {
   GatewayStack: 1,
   SageMakerFineTuningStack: 1,
   ArtifactsStack: 1,
+  // Reads no cross-stack SSM (cert from config, hosted zone via lookup);
+  // writes only its own /mcp-sandbox/origin. Parallel-safe with the other
+  // tier-1 stacks.
+  McpSandboxStack: 1,
   InferenceApiStack: 2,
   AppApiStack: 3,
   FrontendStack: 4,

--- a/scripts/stack-mcp-sandbox/build-cdk.sh
+++ b/scripts/stack-mcp-sandbox/build-cdk.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script: Build CDK Code for MCP Sandbox Stack
+# Description: Compiles TypeScript CDK code to JavaScript.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log_info() { echo "[INFO] $1"; }
+log_error() { echo "[ERROR] $1" >&2; }
+log_success() { echo "[SUCCESS] $1"; }
+
+main() {
+    log_info "Building MCP Sandbox Stack CDK code..."
+
+    cd "${PROJECT_ROOT}/infrastructure"
+
+    if [ ! -d "node_modules" ]; then
+        log_error "node_modules not found. Run install.sh first."
+        exit 1
+    fi
+
+    log_info "Compiling TypeScript..."
+    npm run build
+
+    log_success "MCP Sandbox Stack CDK build completed"
+}
+
+main "$@"

--- a/scripts/stack-mcp-sandbox/deploy.sh
+++ b/scripts/stack-mcp-sandbox/deploy.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#============================================================
+# MCP Sandbox Stack - Deploy
+#
+# Deploys the MCP Sandbox Stack (S3, CloudFront, Route53) that serves the
+# MCP Apps sandbox-proxy shell at mcp-sandbox.{domain}.
+#
+# Deploy tier 1: reads no cross-stack SSM. Parallel-safe with Artifacts,
+# RAG Ingestion, Gateway, and Fine-Tuning. Inert until the SPA wiring
+# (PR #4) and MCP_APPS_HOST_ENABLED (PR #7) land.
+#============================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${PROJECT_ROOT}/scripts/common/load-env.sh"
+source "${PROJECT_ROOT}/scripts/common/recover-stack.sh"
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+if [ "${CDK_MCP_SANDBOX_ENABLED:-false}" != "true" ]; then
+    log_info "CDK_MCP_SANDBOX_ENABLED is not 'true' — MCP Sandbox Stack is disabled; skipping deploy."
+    exit 0
+fi
+
+log_info "Deploying MCP Sandbox Stack..."
+cd "${PROJECT_ROOT}/infrastructure"
+
+if [ ! -d "node_modules" ]; then
+    log_info "node_modules not found in CDK directory. Installing dependencies..."
+    npm ci
+fi
+
+# Recover from DELETE_FAILED state if a previous teardown left the stack broken.
+recover_delete_failed_stack "${CDK_PROJECT_PREFIX}-McpSandboxStack"
+
+CONTEXT_PARAMS=$(build_cdk_context_params)
+
+# Prefer the pre-synthesized template when available (CI path) so deploy
+# matches exactly what was reviewed in cdk diff.
+if [ -d "cdk.out" ] && [ -f "cdk.out/McpSandboxStack.template.json" ]; then
+    log_info "Using pre-synthesized template from cdk.out/"
+    eval "cdk deploy McpSandboxStack ${CONTEXT_PARAMS} \
+        --app \"cdk.out/\" \
+        --require-approval never \
+        --outputs-file mcp-sandbox-outputs.json"
+else
+    log_info "Synthesizing and deploying in one step..."
+    eval "cdk deploy McpSandboxStack ${CONTEXT_PARAMS} \
+        --require-approval never \
+        --outputs-file mcp-sandbox-outputs.json"
+fi
+
+log_success "MCP Sandbox Stack deployed"
+
+if [ -f "mcp-sandbox-outputs.json" ]; then
+    log_info "Stack outputs:"
+    cat mcp-sandbox-outputs.json
+fi

--- a/scripts/stack-mcp-sandbox/install.sh
+++ b/scripts/stack-mcp-sandbox/install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script: Install Dependencies for MCP Sandbox Stack
+# Description: Installs Node.js dependencies for CDK synthesis and deployment.
+# Note: the static proxy shell (assets/mcp-sandbox/) is plain HTML/JS bundled
+# by CDK BucketDeployment — no Docker or pip step required.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log_info() { echo "[INFO] $1"; }
+log_error() { echo "[ERROR] $1" >&2; }
+log_success() { echo "[SUCCESS] $1"; }
+
+main() {
+    log_info "Installing MCP Sandbox Stack dependencies..."
+
+    cd "${PROJECT_ROOT}/infrastructure"
+
+    if [ ! -f "package.json" ]; then
+        log_error "package.json not found in ${PROJECT_ROOT}/infrastructure"
+        exit 1
+    fi
+
+    if ! command -v node &> /dev/null; then
+        log_error "Node.js is not installed. Please install Node.js 18 or higher."
+        exit 1
+    fi
+
+    NODE_VERSION=$(node --version)
+    log_info "Using Node.js ${NODE_VERSION}"
+
+    if [ -f "package-lock.json" ]; then
+        log_info "Running npm ci (clean install from package-lock.json)..."
+        npm ci
+    else
+        log_error "package-lock.json not found. Cannot run npm ci."
+        exit 1
+    fi
+
+    if npm list aws-cdk-lib &> /dev/null; then
+        log_success "aws-cdk-lib installed successfully"
+    else
+        log_error "aws-cdk-lib installation verification failed"
+        exit 1
+    fi
+
+    log_success "All MCP Sandbox Stack dependencies installed successfully!"
+}
+
+main "$@"

--- a/scripts/stack-mcp-sandbox/synth.sh
+++ b/scripts/stack-mcp-sandbox/synth.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#============================================================
+# MCP Sandbox Stack - Synthesize
+#
+# Synthesizes the MCP Sandbox Stack CloudFormation template.
+# Skips silently if CDK_MCP_SANDBOX_ENABLED is false so the workflow
+# can run unconditionally before the feature is turned on.
+#============================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${PROJECT_ROOT}/scripts/common/load-env.sh"
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+if [ "${CDK_MCP_SANDBOX_ENABLED:-false}" != "true" ]; then
+    log_info "CDK_MCP_SANDBOX_ENABLED is not 'true' — MCP Sandbox Stack is disabled; skipping synth."
+    exit 0
+fi
+
+log_info "Synthesizing MCP Sandbox Stack CloudFormation template..."
+cd "${PROJECT_ROOT}/infrastructure"
+
+if [ ! -d "node_modules" ]; then
+    log_info "node_modules not found in CDK directory. Installing dependencies..."
+    npm ci
+fi
+
+log_info "Running CDK synth for McpSandboxStack..."
+
+CONTEXT_PARAMS=$(build_cdk_context_params)
+
+eval "cdk synth McpSandboxStack ${CONTEXT_PARAMS} --output \"${PROJECT_ROOT}/infrastructure/cdk.out\""
+
+log_success "MCP Sandbox Stack CloudFormation template synthesized successfully"
+
+if [ -d "${PROJECT_ROOT}/infrastructure/cdk.out" ]; then
+    log_info "Synthesized stacks:"
+    ls -lh "${PROJECT_ROOT}/infrastructure/cdk.out"/*.template.json 2>/dev/null || log_info "No template files found"
+fi

--- a/scripts/stack-mcp-sandbox/test-cdk.sh
+++ b/scripts/stack-mcp-sandbox/test-cdk.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#============================================================
+# MCP Sandbox Stack - Test CDK
+#
+# Validates the synthesized CloudFormation template via cdk diff.
+#============================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${PROJECT_ROOT}/scripts/common/load-env.sh"
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+if [ "${CDK_MCP_SANDBOX_ENABLED:-false}" != "true" ]; then
+    log_info "CDK_MCP_SANDBOX_ENABLED is not 'true' — MCP Sandbox Stack is disabled; skipping test."
+    exit 0
+fi
+
+log_info "Validating synthesized CloudFormation template..."
+cd "${PROJECT_ROOT}/infrastructure"
+
+if [ ! -d "cdk.out" ] || [ ! -f "cdk.out/McpSandboxStack.template.json" ]; then
+    log_error "Synthesized template not found. Run synth.sh first."
+    exit 1
+fi
+
+log_info "Running cdk diff to compare synthesized template with deployed stack..."
+cdk diff McpSandboxStack --app "cdk.out/"
+
+log_success "CloudFormation template validation completed"


### PR DESCRIPTION
## Summary

**PR #1 of the MCP Apps Host Renderer initiative** scoped in `docs/kaizen/scoping/mcp-apps-host-renderer.md` (Architectural decision #1 — Sandbox Proxy pattern). Stands up the dedicated cross-origin sandbox-proxy origin and nothing else.

- New CDK stack `infrastructure/lib/mcp-sandbox-stack.ts`: S3 (private, OAC-only) + CloudFront + ACM + Route53 serving a single static `proxy.html` shell at **`mcp-sandbox.{domain}`**. `proxy.html` + `proxy.js` (`infrastructure/assets/mcp-sandbox/`) implement the **outer** half of the spec's Sandbox Proxy pattern — the shell itself creates the inner content iframe via `srcdoc`.
- CloudFront `ResponseHeadersPolicy` stamps `Content-Security-Policy` whose **`frame-ancestors` permits the `ai.client` SPA origin only** (`https://{domain}` + opt-in extras; `'none'` when there is no SPA origin — never `*`).
- Wire-in: `bin/infrastructure.ts` (conditional on `config.mcpSandbox.enabled`), `config.ts` (`McpSandboxConfig` + validation), `stack-dependencies.test.ts` (registered, **tier 1**), `mock-config.ts`, a dedicated `scripts/stack-mcp-sandbox/` (install/build/synth/test/deploy), a new `.github/workflows/mcp-sandbox.yml`, and `step-04-deploy.md` (row + badge + details).
- Flows through the **cors-deployment skill**: the new `CDK_DOMAIN_NAME`/`CDK_CORS_ORIGINS` (+ `CDK_MCP_SANDBOX_*`) live in the workflow **job-level** env; `cors.test.ts` pins that the proxy's framing allowlist is derived from the same `domainName` the CORS model is centred on (they can't drift).

### Predecessor
PR #0 (frontend tool-renderer registry) — https://github.com/Boise-State-Development/agentcore-public-stack/pull/339 — **merged** into `develop`. PR #1 is independent of it (CDK surface vs frontend) and does not touch its code.

### Inert until PR #7
The stack reads **no** cross-stack SSM and writes exactly one one-way export (`/{prefix}/mcp-sandbox/origin`) that **nothing consumes yet** — the SPA `<mcp-app-frame>` that points at this origin lands in PR #4, and the whole host renderer stays behind **`MCP_APPS_HOST_ENABLED`** until PR #7 flips it. It is also gated per-environment by `CDK_MCP_SANDBOX_ENABLED` (default off). Standing it up changes nothing user-facing.

### Subdomain decision (scoping doc left this "TBD in PR #1")
**`mcp-sandbox.{domain}`** — matches the scoping doc's working name and parallels the existing sibling iframe origin `artifacts.{domain}`. Single source of truth: `MCP_SANDBOX_SUBDOMAIN_LABEL` in the stack, kept in sync with the `CDK_MCP_SANDBOX_*` workflow vars and the deploy doc.

### CSP rationale (no prior art for nested CSP in this stack — flagged risk)
Served CSP: `default-src 'none'; script-src 'self'; frame-src 'self'; frame-ancestors <SPA origin only>; base-uri 'none'; form-action 'none'`.

- **`frame-ancestors`** is the security-critical, in-scope control for PR #1 and is locked to the SPA origin only (CSP-native; `X-Frame-Options` deliberately *not* also set to avoid a weaker legacy duplicate).
- `proxy.html`/`proxy.js` ship **zero inline script/style** on purpose, so `script-src` stays `'self'` with **no `'unsafe-inline'`**.
- `frame-src 'self'` permits the inner `srcdoc` content frame the shell creates. The **strict per-resource inner CSP composed from `_meta.ui.csp`** is explicitly PR #4's job and is browser-verifiable there (once real content loads). The scoping doc budgets nested-CSP debugging for this initiative; deferring inner-frame tuning to the PR where it can actually be exercised in a browser is the safe sequencing — this outer policy is intentionally provisional and documented as such in the stack/asset comments. The shell is inert until then so there is no functional exposure.

### Spec-diff finding (required pre-merge step — surfaced, not actioned)
The scoping doc's paths `specification/2026-01-26/apps.mdx` / `specification/draft/apps.mdx` are **notional** — neither vendored here nor present as dated `apps.mdx` files upstream. The MCP Apps spec is published as an **extension** (`docs/extensions/apps/{overview,build}.mdx`) plus normative **SEP-1865**. Reviewing `modelcontextprotocol/modelcontextprotocol` changes since 2026-01-26:

- SEP-1865 `.md`: 2 commits on 2026-01-28 ("Update for ease of review", "Update with SEP structure") — editorial restructuring only.
- `docs/seps/…mdx`: 2026-03-07 "Promote SEPs to a top-level docs tab" — docs-site nav only.
- `docs/extensions/apps/`: #2263 2026-02-21 (rename/restructure into overview+build), 2026-02-24 (docs URL/subdomain), 2026-03-11 (add Cursor to a host-directory table) — all non-normative.

**→ No material protocol movement** in the host contract (`_meta.ui.*`, the `ui/` postMessage methods, CSP/sandbox rules, capability advertisement) vs the 2026-01-26 normative read. No adjustment needed to PRs #2–#4 on spec grounds; **zero spec-driven impact on PR #1** (Sandbox Proxy pattern + `frame-ancestors` + two-iframe structure unchanged).

## Verification

- `npm run build` (tsc): **clean, 0 errors** (whole CDK app incl. bin/config + new stack). One inline `AppConfig` literal in `rag-ingestion-stack.test.ts` needed the new required `mcpSandbox` field — fixed here.
- `npx jest`: **331/332 pass**, 12/13 suites green. The sole failure — `InfrastructureStack › creates all 18 DynamoDB tables` (expects 18, finds 19) — is **pre-existing and unrelated**: this branch's diff touches neither `infrastructure-stack.ts` nor its test; the 19th table (`SharedConversationsTable`) was introduced on `develop` (commit `056671b8`). Not a regression from this PR.
- **Synth-level proof of the new stack**: `infrastructure/test/mcp-sandbox-stack.test.ts` does a real `Template.fromStack(McpSandboxStack)` and asserts: private/encrypted/no-public-access S3, exactly one CloudFront distribution serving `proxy.html`, the `ResponseHeadersPolicy` CSP with `frame-ancestors` locked to the SPA origin (and `'none'` fallback when domain-less), `Custom::CDKBucketDeployment` with `/*` invalidation, the one-way `/mcp-sandbox/origin` SSM export, and no Route53 record without a custom-domain cert. `stack-dependencies.test.ts` + `cors.test.ts` (now covering mcp-sandbox) pass. **62/62** across these three suites.
- `aws-s3-deployment` resolves in the existing pinned `aws-cdk-lib` — **no new dependency added**.

### Could not run in this environment (stated honestly, not claimed as success)

- `npm install` fails with an **npm 11.7.0 `@npmcli/arborist` internal bug** (`#pruneBundledMetadeps … Cannot read properties of null`) while reifying a *bundled* aws-cdk dep. Environmental, **not caused by this change** — `package.json`/`package-lock.json` are untouched and unchanged; the already-installed `node_modules` is functional and was used for build+test.
- A real `npx cdk synth`/deploy needs AWS credentials for the target account (CDK context lookups + the bootstrap lookup role; this env has creds for a different account). CDK fully assembled the app graph (including the new bin/config wiring) before hitting the AWS lookup, confirming the wiring is sound. The offline `Template.fromStack` test above is the synth-level confirmation in lieu of a credentialed synth.

### Manual verification script (run where AWS creds + a `*.{domain}` us-east-1 cert exist)

```bash
# 1. Enable + provide a us-east-1 cert for mcp-sandbox.{domain}
export CDK_MCP_SANDBOX_ENABLED=true
export CDK_MCP_SANDBOX_CERTIFICATE_ARN=arn:aws:acm:us-east-1:<acct>:certificate/<id>
# (CDK_DOMAIN_NAME / CDK_HOSTED_ZONE_DOMAIN / CDK_AWS_* per the env)

# 2. Synth + diff + deploy just this stack (tier 1, parallel-safe)
bash scripts/stack-mcp-sandbox/synth.sh
bash scripts/stack-mcp-sandbox/test-cdk.sh
bash scripts/stack-mcp-sandbox/deploy.sh

# 3. Confirm the shell serves and the CSP is correct
curl -sI https://mcp-sandbox.<domain>/proxy.html | grep -i 'content-security-policy'
#   → must contain: frame-ancestors https://<domain>   (and ONLY the SPA origin)
curl -s  https://mcp-sandbox.<domain>/proxy.html | head    # 200, the shell HTML

# 4. From the SPA origin only, in devtools console, prove the channel:
#    const f=document.createElement('iframe');
#    f.src='https://mcp-sandbox.<domain>/proxy.html'; document.body.append(f);
#    window.addEventListener('message',e=>console.log('proxy:',e.data));
#    f.onload=()=>f.contentWindow.postMessage({type:'mcp-sandbox-proxy:ping',nonce:'x'},'*');
#    → expect {type:'mcp-sandbox-proxy:ready'|'pong', phase:'pr1-shell', ...}
#    Embedding from any non-SPA origin must be blocked by frame-ancestors.
```

## Test plan

- [x] `npm run build` clean
- [x] `npx jest` — only the unrelated pre-existing `InfrastructureStack` table-count failure
- [x] New stack synth assertions (CloudFront serving `proxy.html` + CSP `frame-ancestors` = SPA origin only) via `Template.fromStack`
- [x] `stack-dependencies.test.ts` (tier 1) + `cors.test.ts` green with the stack registered
- [ ] Credentialed `cdk synth`/deploy + `curl`/devtools clickthrough per the manual script above (needs AWS creds — out of this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)