### PR TITLE
feat(agents): MCP Apps PR #3 — ui_resource SSE event + resources/read fetch path

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -47,6 +47,7 @@ npx cdk deploy --all
 | `content_block_start/delta/stop` | Streaming content |
 | `message_stop` | End of message |
 | `tool_use` / `tool_result` | Tool invocation and result |
+| `ui_resource` | MCP App UI for a tool result (SEP-1865) — payload `{type, toolUseId, resourceUri, html, mimeType, csp, permissions}`, emitted right after the correlated `tool_result` when the tool declared a `ui://` resource. HTML fetched server-side via `resources/read` and inlined. Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false) |
 | `stream_error` | Conversational error |
 | `oauth_required` | External MCP tool needs user consent — payload `{providerId, authorizationUrl}`, one event per provider emitted after `message_stop` |
 | `compaction` | Backend rolled older turns into a summary on this turn — payload `{previousCheckpoint, newCheckpoint, summarizedTurns, inputTokens}`, emitted after the final `metadata` event so the badge updates first, before `done` |

--- a/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
@@ -90,7 +90,9 @@ class FilteredMCPClient(MCPClient):
 
         # Record `_meta.ui` into the catalog and drop app-only tools so the
         # model never sees them (no-op unless the host flag is enabled).
-        filtered_tools = record_and_filter_ui_tools(filtered_tools)
+        # `self` is the client hosting these tools — recorded so PR #3 can
+        # issue `resources/read` against it.
+        filtered_tools = record_and_filter_ui_tools(filtered_tools, client=self)
 
         return PaginatedList(filtered_tools, token=paginated_result.pagination_token)
 

--- a/backend/src/agents/main_agent/integrations/mcp_apps.py
+++ b/backend/src/agents/main_agent/integrations/mcp_apps.py
@@ -33,7 +33,7 @@ ever changes how the session is constructed.
 
 import logging
 import os
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import mcp.types as mcp_types
 from mcp.client.session import ClientSession
@@ -75,22 +75,47 @@ class UIToolCatalog:
     here to fetch the UI resource via `resources/read`. Kept in memory because
     `_meta.ui` is discovered live from the server on every `tools/list`, not
     admin-configured, and is re-derived each agent build.
+
+    PR #3 also records the MCP client that surfaced each UI tool, alongside
+    its metadata. `record_and_filter_ui_tools` is invoked from within a
+    client's own `list_tools_sync`, so "the server hosting the tool" is just
+    that client — `read_resource_sync` against it is the spec-mandated
+    `resources/read`. The client's session stays alive for the agent's
+    lifetime (Strands holds MCP clients as tool providers), so it is still
+    active when a tool result arrives mid-stream.
     """
 
     def __init__(self) -> None:
         self._by_tool_name: dict[str, ToolUIMetadata] = {}
+        self._client_by_tool_name: dict[str, Any] = {}
 
-    def record(self, tool_name: str, ui_metadata: ToolUIMetadata) -> None:
+    def record(
+        self,
+        tool_name: str,
+        ui_metadata: ToolUIMetadata,
+        client: Optional[Any] = None,
+    ) -> None:
         self._by_tool_name[tool_name] = ui_metadata
+        if client is not None:
+            self._client_by_tool_name[tool_name] = client
 
     def get(self, tool_name: str) -> Optional[ToolUIMetadata]:
         return self._by_tool_name.get(tool_name)
+
+    def get_client(self, tool_name: str) -> Optional[Any]:
+        """The MCP client that surfaced `tool_name`, or None.
+
+        Used by `fetch_ui_resource` to issue `resources/read` against the
+        same server the tool came from (spec MUST: never inline).
+        """
+        return self._client_by_tool_name.get(tool_name)
 
     def snapshot(self) -> dict[str, ToolUIMetadata]:
         return dict(self._by_tool_name)
 
     def clear(self) -> None:
         self._by_tool_name.clear()
+        self._client_by_tool_name.clear()
 
 
 _ui_tool_catalog: Optional[UIToolCatalog] = None
@@ -104,7 +129,9 @@ def get_ui_tool_catalog() -> UIToolCatalog:
     return _ui_tool_catalog
 
 
-def record_and_filter_ui_tools(tools: List[Any]) -> List[Any]:
+def record_and_filter_ui_tools(
+    tools: List[Any], client: Optional[Any] = None
+) -> List[Any]:
     """Record `_meta.ui` into the catalog and drop model-invisible tools.
 
     Given the `MCPAgentTool` list a Strands `MCPClient` produced from a
@@ -112,6 +139,11 @@ def record_and_filter_ui_tools(tools: List[Any]) -> List[Any]:
     by the agent-facing tool name), and return only the tools the model is
     allowed to see. Tools with no `_meta.ui` are ordinary tools and pass
     through untouched.
+
+    `client` is the MCP client whose `list_tools_sync` produced `tools`. It
+    is recorded alongside each UI tool's metadata so PR #3 can issue
+    `resources/read` against the same server the tool came from. It is
+    optional purely so PR #2's catalog tests can call this without a client.
 
     When the host flag is disabled this is a pure pass-through: nothing is
     recorded and nothing is filtered.
@@ -133,7 +165,7 @@ def record_and_filter_ui_tools(tools: List[Any]) -> List[Any]:
         tool_name = getattr(tool, "tool_name", None) or getattr(
             mcp_tool, "name", "<unknown>"
         )
-        catalog.record(tool_name, ui_metadata)
+        catalog.record(tool_name, ui_metadata, client=client)
 
         if ui_metadata.visible_to_model():
             visible.append(tool)
@@ -146,6 +178,171 @@ def record_and_filter_ui_tools(tools: List[Any]) -> List[Any]:
             )
 
     return visible
+
+
+# =============================================================================
+# resources/read fetch path (PR #3)
+# =============================================================================
+
+# Keys an MCP App resource may carry its `_meta.ui` block under. SEP-1865
+# namespaces it as `io.modelcontextprotocol/ui`; PR #2 also accepts the short
+# `ui` alias on tool `_meta`, so honor both on the resource side too.
+_UI_META_KEYS = (MCP_APPS_UI_EXTENSION_KEY, "ui")
+
+
+def _coerce_meta(meta: Any) -> Dict[str, Any]:
+    """Best-effort `_meta` -> dict. Accepts a dict or a pydantic model."""
+    if isinstance(meta, dict):
+        return meta
+    if meta is not None and hasattr(meta, "model_dump"):
+        try:
+            return meta.model_dump(by_alias=True, exclude_none=True)
+        except Exception:
+            return {}
+    return {}
+
+
+def _ui_block(meta: Any) -> Dict[str, Any]:
+    """Extract the MCP Apps `ui` block from a `_meta` dict, or {}."""
+    data = _coerce_meta(meta)
+    for key in _UI_META_KEYS:
+        block = data.get(key)
+        if isinstance(block, dict):
+            return block
+    return {}
+
+
+def _extract_html_content(result: Any) -> Tuple[Optional[str], str]:
+    """Pick the HTML body + MIME type out of a `resources/read` result.
+
+    Prefers the spec MIME type (`text/html;profile=mcp-app`), then any
+    `text/html*` text content, then untyped text (the tool already declared
+    a `ui://` resource, so an inline body with no MIME is treated as the
+    app). An explicit non-HTML MIME (`text/plain`, `application/json`, …) is
+    rejected — we never pass a non-app body off as the app. Returns
+    `(None, "")` when nothing usable is present (e.g. a blob-only resource);
+    the caller then emits nothing.
+    """
+    contents = getattr(result, "contents", None) or []
+    html_fallback: Optional[Tuple[str, str]] = None
+    untyped_fallback: Optional[Tuple[str, str]] = None
+
+    for item in contents:
+        text = getattr(item, "text", None)
+        if not isinstance(text, str):
+            continue
+        mime = getattr(item, "mimeType", None) or ""
+        if mime == MCP_APPS_UI_MIME_TYPE:
+            return text, mime
+        if html_fallback is None and mime.startswith("text/html"):
+            html_fallback = (text, mime)
+        elif untyped_fallback is None and not mime:
+            untyped_fallback = (text, MCP_APPS_UI_MIME_TYPE)
+
+    chosen = html_fallback or untyped_fallback
+    if chosen is None:
+        return None, ""
+    return chosen[0], chosen[1]
+
+
+def _extract_csp_permissions(
+    result: Any, ui_metadata: ToolUIMetadata
+) -> Tuple[Dict[str, Any], List[Any]]:
+    """Resolve `csp` / `permissions` for the `ui_resource` event.
+
+    The spec declares these on the resource's `_meta.ui` (per-content first,
+    then the result-level `_meta`). We fall back to the tool-level `_meta.ui`
+    PR #2 retained verbatim in `ToolUIMetadata.raw` so a server that declares
+    them only on `tools/list` still works. PR #3 passes them through opaquely;
+    building the actual CSP (deny-by-default) is the frontend's job (PR #4).
+    """
+    sources: List[Dict[str, Any]] = []
+    for item in getattr(result, "contents", None) or []:
+        block = _ui_block(getattr(item, "meta", None))
+        if block:
+            sources.append(block)
+    result_block = _ui_block(getattr(result, "meta", None))
+    if result_block:
+        sources.append(result_block)
+    sources.append(ui_metadata.raw or {})
+
+    csp: Dict[str, Any] = {}
+    permissions: List[Any] = []
+    for block in sources:
+        if not csp and isinstance(block.get("csp"), dict):
+            csp = block["csp"]
+        if not permissions and isinstance(block.get("permissions"), list):
+            permissions = block["permissions"]
+    return csp, permissions
+
+
+def fetch_ui_resource(
+    tool_name: str, tool_use_id: str
+) -> Optional[Dict[str, Any]]:
+    """Fetch a tool's MCP App UI resource and build the `ui_resource` payload.
+
+    Looks up `tool_name` in the catalog PR #2 populates; if it carries a
+    `ui://` `resourceUri`, issues `resources/read` against the same MCP
+    client that surfaced the tool (spec MUST: fetch via `resources/read`,
+    never inline from the server's perspective) and returns the SSE payload
+    `{type, toolUseId, resourceUri, html, mimeType, csp, permissions}` with
+    the HTML inlined so the frontend needs no MCP client of its own.
+
+    Best-effort and fully inert when `AGENTCORE_MCP_APPS_HOST_ENABLED` is
+    false: returns None on flag-off, non-UI tool, unknown hosting client,
+    inactive session, fetch error, or a body with no inline HTML. Never
+    raises into the stream.
+    """
+    if not is_mcp_apps_host_enabled():
+        return None
+
+    catalog = get_ui_tool_catalog()
+    ui_metadata = catalog.get(tool_name)
+    if ui_metadata is None or not ui_metadata.resource_uri:
+        return None
+
+    client = catalog.get_client(tool_name)
+    if client is None:
+        logger.warning(
+            "MCP Apps: tool %s has resourceUri %s but no hosting client "
+            "was recorded; cannot issue resources/read",
+            tool_name,
+            ui_metadata.resource_uri,
+        )
+        return None
+
+    try:
+        result = client.read_resource_sync(ui_metadata.resource_uri)
+    except Exception:
+        logger.warning(
+            "MCP Apps: resources/read failed for %s (%s); emitting no "
+            "ui_resource event",
+            tool_name,
+            ui_metadata.resource_uri,
+            exc_info=True,
+        )
+        return None
+
+    html, mime_type = _extract_html_content(result)
+    if html is None:
+        logger.warning(
+            "MCP Apps: resources/read for %s (%s) returned no inline HTML; "
+            "emitting no ui_resource event",
+            tool_name,
+            ui_metadata.resource_uri,
+        )
+        return None
+
+    csp, permissions = _extract_csp_permissions(result, ui_metadata)
+    return {
+        "type": "ui_resource",
+        "toolUseId": tool_use_id,
+        "resourceUri": ui_metadata.resource_uri,
+        "html": html,
+        "mimeType": mime_type or MCP_APPS_UI_MIME_TYPE,
+        "csp": csp,
+        "permissions": permissions,
+    }
 
 
 # =============================================================================
@@ -237,5 +434,5 @@ class UICapableMCPClient(MCPClient):
 
     def list_tools_sync(self, *args: Any, **kwargs: Any) -> PaginatedList:
         result = super().list_tools_sync(*args, **kwargs)
-        filtered = record_and_filter_ui_tools(list(result))
+        filtered = record_and_filter_ui_tools(list(result), client=self)
         return PaginatedList(filtered, token=result.pagination_token)

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -77,6 +77,15 @@ class StreamCoordinator:
         # query + `artifact` SSE emit. Normal turns pay nothing.
         artifact_tool_invoked = False
 
+        # MCP Apps (PR #3): toolUseId -> tool name, learned from tool_use /
+        # content_block_start events so a later tool_result can be matched
+        # back to its catalog `_meta.ui`. `ui_resource_emitted` dedupes the
+        # `ui_resource` SSE per toolUseId (a tool result can surface twice —
+        # once via the lifecycle path, once via the tool path). Both stay
+        # empty and unused unless AGENTCORE_MCP_APPS_HOST_ENABLED=true.
+        ui_tool_use_names: Dict[str, str] = {}
+        ui_resource_emitted: set[str] = set()
+
         # Accumulate metadata from stream
         accumulated_metadata: Dict[str, Any] = {"usage": {}, "metrics": {}}
 
@@ -144,6 +153,27 @@ class StreamCoordinator:
                     )
                     if tool_name in ("create_artifact", "update_artifact"):
                         artifact_tool_invoked = True
+
+                # MCP Apps (PR #3): remember toolUseId -> tool name so a
+                # later tool_result can be matched to its catalog `_meta.ui`.
+                # Captured from both event flavors that carry the pairing:
+                # the `tool_use` event (data.tool_use) and the
+                # `content_block_start` of a tool-use block (data.toolUse).
+                etype = event.get("type")
+                if etype == "tool_use":
+                    td = event.get("data", {}).get("tool_use", {})
+                    tn = td.get("name")
+                    tuid = td.get("tool_use_id") or td.get("toolUseId")
+                    if tn and tuid:
+                        ui_tool_use_names[tuid] = tn
+                elif etype == "content_block_start":
+                    bd = event.get("data", {})
+                    if bd.get("type") == "tool_use":
+                        tu = bd.get("toolUse", {})
+                        tn = tu.get("name")
+                        tuid = tu.get("toolUseId") or tu.get("tool_use_id")
+                        if tn and tuid:
+                            ui_tool_use_names[tuid] = tn
 
                 # Track when assistant messages end
                 if event.get("type") == "message_stop":
@@ -533,6 +563,20 @@ class StreamCoordinator:
                 # Format as SSE event and yield (including done event after metadata)
                 sse_event = self._format_sse_event(event)
                 yield sse_event
+
+                # MCP Apps (PR #3): if this tool_result belongs to a
+                # UI-bearing tool, fetch its `ui://` resource via
+                # `resources/read` and emit a `ui_resource` SSE right after
+                # the tool_result it correlates to (toolUseId ties them).
+                # Inert + zero-cost unless the host flag is on; best-effort
+                # so a fetch failure never breaks the live stream.
+                if event.get("type") == "tool_result":
+                    for sse in await self._extract_ui_resource_events(
+                        event,
+                        ui_tool_use_names,
+                        ui_resource_emitted,
+                    ):
+                        yield sse
 
             # Calculate end-to-end latency (fallback if done event wasn't received)
             stream_end_time = time.time()
@@ -1038,6 +1082,65 @@ class StreamCoordinator:
                 f"event: artifact\ndata: {json.dumps(payload)}\n\n"
             )
         return events
+
+    async def _extract_ui_resource_events(
+        self,
+        event: Dict[str, Any],
+        tool_use_names: Dict[str, str],
+        emitted: set,
+    ) -> List[str]:
+        """Yield a `ui_resource` SSE for a tool_result that ships an MCP App.
+
+        PR #3 of the MCP Apps host-renderer initiative
+        (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). When the host flag
+        is on and this tool_result's tool declared a `ui://` resource in its
+        `tools/list` `_meta.ui` (recorded in the catalog by PR #2), fetch that
+        resource via the spec-mandated `resources/read` against the same MCP
+        client that surfaced the tool, and emit a single
+
+            `{type, toolUseId, resourceUri, html, mimeType, csp, permissions}`
+
+        event with the HTML inlined (so the frontend needs no MCP client).
+        The blocking `resources/read` runs in a worker thread so the live
+        stream is not stalled.
+
+        Inert and zero-cost when `AGENTCORE_MCP_APPS_HOST_ENABLED` is false.
+        Best-effort: deduped per toolUseId, and any failure logs and returns
+        [] — it never breaks the stream.
+        """
+        from agents.main_agent.integrations.mcp_apps import (
+            fetch_ui_resource,
+            is_mcp_apps_host_enabled,
+        )
+
+        if not is_mcp_apps_host_enabled():
+            return []
+
+        try:
+            tool_result = event.get("data", {}).get("tool_result", {})
+            if not isinstance(tool_result, dict):
+                return []
+            tool_use_id = tool_result.get("toolUseId") or tool_result.get(
+                "tool_use_id"
+            )
+            if not tool_use_id or tool_use_id in emitted:
+                return []
+
+            tool_name = tool_use_names.get(tool_use_id)
+            if not tool_name:
+                return []
+
+            payload = await asyncio.to_thread(
+                fetch_ui_resource, tool_name, tool_use_id
+            )
+            if payload is None:
+                return []
+
+            emitted.add(tool_use_id)
+            return [f"event: ui_resource\ndata: {json.dumps(payload)}\n\n"]
+        except Exception as e:  # noqa: BLE001 - best-effort side channel
+            logger.warning("Failed to emit ui_resource event: %s", e)
+            return []
 
     def _format_sse_event(self, event: Dict[str, Any]) -> str:
         """

--- a/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
+++ b/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
@@ -33,6 +33,7 @@ from agents.main_agent.integrations.mcp_apps import (
     UICapableMCPClient,
     _UIExtensionClientSession,
     ensure_ui_extension_session_patch,
+    fetch_ui_resource,
     get_ui_tool_catalog,
     record_and_filter_ui_tools,
 )
@@ -300,3 +301,181 @@ class TestFilteredGatewayClientUIFilter:
 
         assert [t.tool_name for t in result] == ["normal"]
         assert get_ui_tool_catalog().get("app_only").resource_uri == "ui://gw/app"
+
+
+# ── PR #3: resources/read fetch path + ui_resource payload ───────────────────
+
+
+class _FakeMCPClient:
+    """Stand-in for a Strands MCPClient at the `resources/read` boundary.
+
+    Mirrors the mock-the-boundary style in `test_external_mcp_client.py`:
+    the unit under test never starts a real session — it only calls
+    `read_resource_sync`, which we record and stub.
+    """
+
+    def __init__(self, result=None, raises: Exception | None = None) -> None:
+        self._result = result
+        self._raises = raises
+        self.read_calls: list = []
+
+    def read_resource_sync(self, uri):
+        self.read_calls.append(uri)
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _html_resource(
+    *, text="<h1>widget</h1>", mime=MCP_APPS_UI_MIME_TYPE, ui_meta=None
+):
+    """A real `mcp.types.ReadResourceResult` — proves our extraction works
+    against the actual MCP SDK shape, not just a duck-typed fake."""
+    kwargs = {"uri": "ui://srv/widget", "mimeType": mime, "text": text}
+    if ui_meta is not None:
+        kwargs["_meta"] = {MCP_APPS_UI_EXTENSION_KEY: ui_meta}
+    return mcp_types.ReadResourceResult(
+        contents=[mcp_types.TextResourceContents(**kwargs)]
+    )
+
+
+def _seed_catalog(monkeypatch, *, ui, client):
+    """Record a UI tool + its hosting client exactly the way a live
+    `list_tools_sync` would (so the client-passing path is exercised too)."""
+    monkeypatch.setenv(_ENV_FLAG, "true")
+    record_and_filter_ui_tools([_fake_tool("widget", ui=ui)], client=client)
+
+
+class TestFetchUIResource:
+    def test_fetches_via_resources_read_and_inlines_html(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        client = _FakeMCPClient(
+            result=_html_resource(
+                ui_meta={
+                    "csp": {"connectDomains": ["https://api.test"]},
+                    "permissions": ["clipboard-write"],
+                }
+            )
+        )
+        _seed_catalog(
+            monkeypatch,
+            ui={"resourceUri": "ui://srv/widget"},
+            client=client,
+        )
+
+        payload = fetch_ui_resource("widget", "tu-1")
+
+        # Spec MUST: the resource is fetched via resources/read against the
+        # hosting client, addressed by the `ui://` URI — never inlined by us.
+        assert client.read_calls == ["ui://srv/widget"]
+        assert payload == {
+            "type": "ui_resource",
+            "toolUseId": "tu-1",
+            "resourceUri": "ui://srv/widget",
+            "html": "<h1>widget</h1>",
+            "mimeType": MCP_APPS_UI_MIME_TYPE,
+            "csp": {"connectDomains": ["https://api.test"]},
+            "permissions": ["clipboard-write"],
+        }
+
+    def test_inert_when_flag_disabled(self, mcp_apps_clean, monkeypatch):
+        client = _FakeMCPClient(result=_html_resource())
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=client
+        )
+        # Flag flipped off *after* catalog seeding: the fetch path itself
+        # must stay inert regardless of catalog contents.
+        monkeypatch.setenv(_ENV_FLAG, "false")
+
+        assert fetch_ui_resource("widget", "tu-1") is None
+        assert client.read_calls == []
+
+    def test_none_for_unknown_or_non_ui_tool(self, mcp_apps_clean, monkeypatch):
+        monkeypatch.setenv(_ENV_FLAG, "true")
+        assert fetch_ui_resource("never-seen", "tu-1") is None
+
+    def test_none_when_no_hosting_client_recorded(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        # Metadata recorded without a client (e.g. PR #2's catalog-only
+        # path) → we cannot issue resources/read, so no event.
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=None
+        )
+        assert fetch_ui_resource("widget", "tu-1") is None
+
+    def test_resources_read_failure_is_swallowed(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        client = _FakeMCPClient(raises=RuntimeError("session not running"))
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=client
+        )
+        assert fetch_ui_resource("widget", "tu-1") is None
+        assert client.read_calls == ["ui://srv/widget"]
+
+    def test_none_when_resource_has_no_inline_html(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        blob = mcp_types.ReadResourceResult(
+            contents=[
+                mcp_types.BlobResourceContents(
+                    uri="ui://srv/widget",
+                    mimeType="application/octet-stream",
+                    blob="AAAA",
+                )
+            ]
+        )
+        client = _FakeMCPClient(result=blob)
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=client
+        )
+        assert fetch_ui_resource("widget", "tu-1") is None
+
+    def test_csp_permissions_fall_back_to_tool_meta(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        # Resource carries no `_meta.ui`; the tool's `tools/list` `_meta.ui`
+        # (retained verbatim by PR #2 in ToolUIMetadata.raw) supplies them.
+        client = _FakeMCPClient(result=_html_resource(ui_meta=None))
+        _seed_catalog(
+            monkeypatch,
+            ui={
+                "resourceUri": "ui://srv/widget",
+                "csp": {"frameDomains": ["https://embed.test"]},
+                "permissions": ["geolocation"],
+            },
+            client=client,
+        )
+
+        payload = fetch_ui_resource("widget", "tu-9")
+        assert payload is not None
+        assert payload["csp"] == {"frameDomains": ["https://embed.test"]}
+        assert payload["permissions"] == ["geolocation"]
+
+    def test_prefers_mcp_app_mime_when_multiple_text_contents(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        result = mcp_types.ReadResourceResult(
+            contents=[
+                mcp_types.TextResourceContents(
+                    uri="ui://srv/widget",
+                    mimeType="text/plain",
+                    text="ignored",
+                ),
+                mcp_types.TextResourceContents(
+                    uri="ui://srv/widget",
+                    mimeType=MCP_APPS_UI_MIME_TYPE,
+                    text="<main>chosen</main>",
+                ),
+            ]
+        )
+        client = _FakeMCPClient(result=result)
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=client
+        )
+
+        payload = fetch_ui_resource("widget", "tu-2")
+        assert payload["html"] == "<main>chosen</main>"
+        assert payload["mimeType"] == MCP_APPS_UI_MIME_TYPE

--- a/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
@@ -1,0 +1,223 @@
+"""Tests for StreamCoordinator._extract_ui_resource_events.
+
+PR #3 of the MCP Apps host-renderer initiative
+(`docs/kaizen/scoping/mcp-apps-host-renderer.md`). Covers the per-tool-result
+`ui_resource` SSE emit: it fires only for UI-bearing tools, fetches the
+resource via the hosting client's `resources/read` and inlines the HTML,
+correlates by toolUseId, dedupes, stays inert behind the host flag, and
+never breaks the stream on failure.
+
+Mirrors the helper-level style of `test_artifact_events.py` (drive the
+coordinator method directly) and the mock-the-boundary catalog seeding from
+`tests/agents/main_agent/integrations/test_mcp_apps.py`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import mcp.types as mcp_types
+import pytest
+
+from agents.main_agent.integrations import mcp_apps
+from agents.main_agent.integrations.mcp_apps import (
+    MCP_APPS_UI_EXTENSION_KEY,
+    MCP_APPS_UI_MIME_TYPE,
+    get_ui_tool_catalog,
+    record_and_filter_ui_tools,
+)
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+_ENV_FLAG = "AGENTCORE_MCP_APPS_HOST_ENABLED"
+
+
+@pytest.fixture
+def coord() -> StreamCoordinator:
+    return StreamCoordinator()
+
+
+@pytest.fixture
+def catalog_clean(monkeypatch):
+    get_ui_tool_catalog().clear()
+    monkeypatch.delenv(_ENV_FLAG, raising=False)
+    try:
+        yield
+    finally:
+        get_ui_tool_catalog().clear()
+
+
+class _FakeMCPClient:
+    def __init__(self, result):
+        self._result = result
+        self.read_calls: list = []
+
+    def read_resource_sync(self, uri):
+        self.read_calls.append(uri)
+        return self._result
+
+
+def _fake_tool(tool_name, ui):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        tool_name=tool_name,
+        mcp_tool=SimpleNamespace(name=tool_name, meta={"ui": ui}),
+    )
+
+
+def _html_result(text="<h1>hi</h1>"):
+    return mcp_types.ReadResourceResult(
+        contents=[
+            mcp_types.TextResourceContents(
+                uri="ui://srv/widget",
+                mimeType=MCP_APPS_UI_MIME_TYPE,
+                text=text,
+                _meta={
+                    MCP_APPS_UI_EXTENSION_KEY: {
+                        "csp": {"connectDomains": ["https://api.test"]},
+                        "permissions": ["clipboard-write"],
+                    }
+                },
+            )
+        ]
+    )
+
+
+def _seed(monkeypatch, client):
+    monkeypatch.setenv(_ENV_FLAG, "true")
+    record_and_filter_ui_tools(
+        [_fake_tool("widget", {"resourceUri": "ui://srv/widget"})],
+        client=client,
+    )
+
+
+def _tool_result_event(tool_use_id="tu-1"):
+    return {
+        "type": "tool_result",
+        "data": {
+            "tool_result": {
+                "toolUseId": tool_use_id,
+                "status": "success",
+                "content": [{"text": "ok"}],
+            }
+        },
+    }
+
+
+def _parse(raw: str) -> dict:
+    assert raw.startswith("event: ui_resource\ndata: ")
+    assert raw.endswith("\n\n")
+    return json.loads(raw[len("event: ui_resource\ndata: ") :].strip())
+
+
+@pytest.mark.asyncio
+async def test_emits_ui_resource_with_inline_html(
+    coord, catalog_clean, monkeypatch
+):
+    client = _FakeMCPClient(_html_result("<main>app</main>"))
+    _seed(monkeypatch, client)
+
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, set()
+    )
+
+    assert client.read_calls == ["ui://srv/widget"]
+    assert len(out) == 1
+    payload = _parse(out[0])
+    assert payload == {
+        "type": "ui_resource",
+        "toolUseId": "tu-1",
+        "resourceUri": "ui://srv/widget",
+        "html": "<main>app</main>",
+        "mimeType": MCP_APPS_UI_MIME_TYPE,
+        "csp": {"connectDomains": ["https://api.test"]},
+        "permissions": ["clipboard-write"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_dedupes_per_tool_use_id(coord, catalog_clean, monkeypatch):
+    client = _FakeMCPClient(_html_result())
+    _seed(monkeypatch, client)
+    emitted: set = set()
+
+    first = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, emitted
+    )
+    second = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, emitted
+    )
+
+    assert len(first) == 1
+    assert second == []
+    assert emitted == {"tu-1"}
+    # The dedupe must short-circuit before a second resources/read.
+    assert client.read_calls == ["ui://srv/widget"]
+
+
+@pytest.mark.asyncio
+async def test_inert_when_flag_disabled(coord, catalog_clean, monkeypatch):
+    client = _FakeMCPClient(_html_result())
+    _seed(monkeypatch, client)
+    monkeypatch.setenv(_ENV_FLAG, "false")
+
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, set()
+    )
+    assert out == []
+    assert client.read_calls == []
+
+
+@pytest.mark.asyncio
+async def test_noop_for_untracked_tool_use_id(
+    coord, catalog_clean, monkeypatch
+):
+    client = _FakeMCPClient(_html_result())
+    _seed(monkeypatch, client)
+
+    # No name learned for this toolUseId → cannot map to the catalog.
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-unknown"), {}, set()
+    )
+    assert out == []
+    assert client.read_calls == []
+
+
+@pytest.mark.asyncio
+async def test_noop_when_tool_result_has_no_tool_use_id(
+    coord, catalog_clean, monkeypatch
+):
+    client = _FakeMCPClient(_html_result())
+    _seed(monkeypatch, client)
+
+    event = {"type": "tool_result", "data": {"tool_result": {"status": "ok"}}}
+    out = await coord._extract_ui_resource_events(
+        event, {"tu-1": "widget"}, set()
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_noop_for_non_ui_tool(coord, catalog_clean, monkeypatch):
+    # Flag on, but the tool has no `_meta.ui` in the catalog at all.
+    monkeypatch.setenv(_ENV_FLAG, "true")
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "plain_tool"}, set()
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_failure_is_swallowed(coord, catalog_clean, monkeypatch):
+    _seed(monkeypatch, _FakeMCPClient(_html_result()))
+
+    def _boom(tool_name, tool_use_id):
+        raise RuntimeError("catalog exploded")
+
+    monkeypatch.setattr(mcp_apps, "fetch_ui_resource", _boom)
+
+    # A failure in the fetch path must not propagate into the live stream.
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, set()
+    )
+    assert out == []


### PR DESCRIPTION
## Summary

PR #3 of the MCP Apps host-renderer initiative scoped in `docs/kaizen/scoping/mcp-apps-host-renderer.md`. Implements the **"Backend: SSE `ui_resource` event + `resources/read` fetch path"** section only.

When a tool result belongs to a tool that declared a `ui://` resource in its `tools/list` `_meta.ui` (recorded in the `UIToolCatalog` by PR #2), the backend fetches that resource via the spec-mandated MCP `resources/read` against the **same MCP client that surfaced the tool**, and emits a new `ui_resource` SSE event:

```
{type, toolUseId, resourceUri, html, mimeType, csp, permissions}
```

The HTML is **inlined** in the SSE event so the frontend needs no MCP client of its own. Spec note (from the scoping doc): we still call `resources/read` (spec MUST — never inline from the server's perspective); inlining into our SSE is purely a host→frontend transport choice.

### Changes
- **`mcp_apps.py`** — `UIToolCatalog` now records the hosting MCP client alongside each tool's `_meta.ui`; `record_and_filter_ui_tools` threads `client` through (optional arg, **backward-compatible** with PR #2's catalog tests). New `fetch_ui_resource()` + `_extract_html_content` / `_extract_csp_permissions` helpers (prefer `text/html;profile=mcp-app`; reject explicit non-HTML MIME; csp/permissions resolved from the resource `_meta.ui`, falling back to the tool-level `_meta.ui` PR #2 retained verbatim).
- **`gateway_mcp_client.py`** — `FilteredMCPClient.list_tools_sync` passes `client=self`.
- **`stream_coordinator.py`** — learns `toolUseId → tool_name` from `tool_use` / `content_block_start` events; after each `tool_result` SSE, emits a correlated `ui_resource` SSE via the new best-effort `_extract_ui_resource_events` (deduped per `toolUseId`; the blocking `resources/read` runs in a worker thread so the live stream is not stalled). Mirrors the existing post-turn `artifact` SSE precedent.
- **`CLAUDE.md`** — SSE Event Types table gains the `ui_resource` row.

### Path note (doc drift)
The scoping doc named `event_formatter.py` / `tool_result_processor.py` / `stream_processor.py`. As anticipated in the doc ("paths may have drifted", same as PR #2), the actual owner of SSE-event orchestration in this codebase is `stream_coordinator.py` (where the `artifact`, `compaction`, and `oauth_required` side-channel events are emitted). Emission was placed there and the `resources/read` helper added to `mcp_apps.py` (the established module for this initiative, already home to the catalog).

## Inert behind the flag
The entire surface is gated by `is_mcp_apps_host_enabled()` (`AGENTCORE_MCP_APPS_HOST_ENABLED`, **default false**). With the flag off: no client is recorded, no `tool_use` mapping is acted on, and `_extract_ui_resource_events` returns immediately — behavior is byte-for-byte unchanged. The flag is flipped on in PR #7. This PR is safe to land regardless.

## Dependency / independence
Builds on **PR #2 (#342, merged)** — consumes its `UIToolCatalog` / `ToolUIMetadata.resource_uri`. Independent of PR #1 (CDK sandbox origin) and the frontend PRs (#0, #4+). The frontend TS interface for `ui_resource` is a later PR's concern; per the cross-package contract this PR only adds a new, flag-inert SSE event type.

## Carry-forward risk — AgentCore Gateway `_meta` pass-through (UNVERIFIED)
PR #2 could verify code-side `_meta` handling but **could not** verify whether AWS AgentCore Gateway forwards unknown `_meta` keys (like `_meta.ui`) through its MCP proxy — that needs a live Gateway. **PR #3 is the first PR that actually depends on `resourceUri` having arrived from the server**, so this is now the relevant integration concern.

**What the tests in this PR prove:** given a tool whose `_meta.ui.resourceUri` is already in the catalog, the backend calls `resources/read` against the hosting client and emits a correct `ui_resource` event with the HTML inlined (asserted against the real `mcp.types` SDK shapes, not just duck-typed fakes).

**What they do NOT prove:** that `_meta.ui` actually survives AgentCore Gateway's MCP proxy end-to-end. Unit tests cannot exercise a live Gateway. **This still needs validation in a deployed dev environment before the flag is flipped in PR #7.** If Gateway strips unknown `_meta` keys, Gateway-side work is required (externally-hosted/Lambda MCP servers are unaffected — they aren't proxied through Gateway).

## Test plan
- [x] `uv sync --extra agentcore --extra dev`
- [x] Full backend suite green — **2914 passed, 3 skipped, 0 failed** (~4.3 min). Note: backend pytest is **not** run in CI in this repo, so the local suite is the only correctness gate. The known timing-flaky `test_ttfb_under_200ms_with_x_accel_buffering` passed in-suite this run (no isolation re-run needed).
- [x] New: 9 fetch-path tests in `test_mcp_apps.py` (resources/read called, HTML inlined, flag-off inert, no-client, error swallowed, blob-only → none, csp/permissions tool-meta fallback, MIME preference) + 7 coordinator tests in new `test_ui_resource_events.py` (emit + correlation, dedupe, flag-off, untracked toolUseId, missing toolUseId, non-UI tool, failure swallowed).
- [x] PR #2's `test_mcp_apps.py` suite still green (backward compatibility of the catalog/`record_and_filter_ui_tools` signature change).
- [ ] **Deployed dev env:** verify AgentCore Gateway forwards `_meta.ui` end-to-end before PR #7 flips `AGENTCORE_MCP_APPS_HOST_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)