### PR TITLE
feat(agents): add sandboxOrigin to ui_resource + fix permissions shape

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -47,7 +47,7 @@ npx cdk deploy --all
 | `content_block_start/delta/stop` | Streaming content |
 | `message_stop` | End of message |
 | `tool_use` / `tool_result` | Tool invocation and result |
-| `ui_resource` | MCP App UI for a tool result (SEP-1865) — payload `{type, toolUseId, resourceUri, html, mimeType, csp, permissions}`, emitted right after the correlated `tool_result` when the tool declared a `ui://` resource. HTML fetched server-side via `resources/read` and inlined. Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false) |
+| `ui_resource` | MCP App UI for a tool result (SEP-1865) — payload `{type, toolUseId, resourceUri, html, mimeType, csp, permissions, sandboxOrigin}`, emitted right after the correlated `tool_result` when the tool declared a `ui://` resource. HTML fetched server-side via `resources/read` and inlined; `sandboxOrigin` is the proxy.html origin the SPA frames it in (empty until the mcp-sandbox stack is deployed). Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false) |
 | `stream_error` | Conversational error |
 | `oauth_required` | External MCP tool needs user consent — payload `{providerId, authorizationUrl}`, one event per provider emitted after `message_stop` |
 | `compaction` | Backend rolled older turns into a summary on this turn — payload `{previousCheckpoint, newCheckpoint, summarizedTurns, inputTokens}`, emitted after the final `metadata` event so the badge updates first, before `done` |

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -56,6 +56,16 @@ AGENTCORE_MEMORY_TOP_K=10
 # Requires: Gateway deployed via GatewayStack and SSM parameter /{projectPrefix}/mcp/gateway-url
 AGENTCORE_GATEWAY_MCP_ENABLED=true
 
+# MCP Apps host renderer (OPTIONAL — docs/kaizen/scoping/mcp-apps-host-renderer.md)
+# Gates the entire MCP Apps host surface. Stays false until PR #7 flips it on.
+AGENTCORE_MCP_APPS_HOST_ENABLED=false
+# Origin of the sandbox-proxy (proxy.html) the SPA frames an MCP App in.
+# Surfaced to the SPA on the `ui_resource` SSE event so the frontend needs no
+# separate config fetch. Leave empty until the mcp-sandbox stack is deployed.
+# Where to find: SSM /{projectPrefix}/mcp-sandbox/origin (published by the
+# mcp-sandbox CDK stack).
+AGENTCORE_MCP_APPS_SANDBOX_ORIGIN=
+
 # AgentCore Code Interpreter ID (OPTIONAL)
 # Purpose: AWS Bedrock AgentCore Code Interpreter for executing Python code in a sandbox
 # Features: Generate charts/diagrams with matplotlib, data analysis with pandas/numpy

--- a/backend/src/agents/main_agent/config/constants.py
+++ b/backend/src/agents/main_agent/config/constants.py
@@ -51,6 +51,11 @@ class EnvVars:
 
     # --- MCP Apps (host renderer initiative) ---
     MCP_APPS_HOST_ENABLED = "AGENTCORE_MCP_APPS_HOST_ENABLED"
+    # Origin of the sandbox-proxy (proxy.html) the SPA frames an MCP App in.
+    # Deploy pipeline sources it from SSM /{projectPrefix}/mcp-sandbox/origin
+    # (published by the PR #1 CDK stack). Surfaced to the SPA on the
+    # `ui_resource` SSE event so the frontend needs no separate config fetch.
+    MCP_APPS_SANDBOX_ORIGIN = "AGENTCORE_MCP_APPS_SANDBOX_ORIGIN"
 
     # --- Frontend ---
     FRONTEND_URL = "FRONTEND_URL"
@@ -111,6 +116,10 @@ class Defaults:
     # Gates the entire MCP Apps host surface. Stays False until PR #7 of
     # docs/kaizen/scoping/mcp-apps-host-renderer.md flips it on.
     MCP_APPS_HOST_ENABLED = False
+    # Empty until the mcp-sandbox stack (PR #1) is deployed and the deploy
+    # pipeline wires its SSM origin into the env. Empty string is benign:
+    # the whole surface is inert behind MCP_APPS_HOST_ENABLED anyway.
+    MCP_APPS_SANDBOX_ORIGIN = ""
 
     # --- Voice Agent ---
     NOVA_SONIC_MODEL_ID = "amazon.nova-2-sonic-v1:0"

--- a/backend/src/agents/main_agent/integrations/mcp_apps.py
+++ b/backend/src/agents/main_agent/integrations/mcp_apps.py
@@ -63,6 +63,20 @@ def is_mcp_apps_host_enabled() -> bool:
     return raw.strip().lower() == "true"
 
 
+def mcp_apps_sandbox_origin() -> str:
+    """Origin of the sandbox-proxy the SPA frames an MCP App in.
+
+    Read on every call (not cached), same as the host flag. Empty string
+    until the PR #1 mcp-sandbox stack is deployed and the deploy pipeline
+    wires its SSM origin into the env — benign because the whole surface is
+    inert behind the host flag. Surfaced to the SPA on the `ui_resource`
+    event so the frontend needs no separate config fetch.
+    """
+    return os.environ.get(
+        EnvVars.MCP_APPS_SANDBOX_ORIGIN, Defaults.MCP_APPS_SANDBOX_ORIGIN
+    ).strip()
+
+
 # =============================================================================
 # In-process UI tool catalog
 # =============================================================================
@@ -247,7 +261,7 @@ def _extract_html_content(result: Any) -> Tuple[Optional[str], str]:
 
 def _extract_csp_permissions(
     result: Any, ui_metadata: ToolUIMetadata
-) -> Tuple[Dict[str, Any], List[Any]]:
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Resolve `csp` / `permissions` for the `ui_resource` event.
 
     The spec declares these on the resource's `_meta.ui` (per-content first,
@@ -255,6 +269,12 @@ def _extract_csp_permissions(
     PR #2 retained verbatim in `ToolUIMetadata.raw` so a server that declares
     them only on `tools/list` still works. PR #3 passes them through opaquely;
     building the actual CSP (deny-by-default) is the frontend's job (PR #4).
+
+    Both are objects per SEP-1865: `csp` is `McpUiResourceCsp`
+    (`{connectDomains, resourceDomains, frameDomains, baseUriDomains}`) and
+    `permissions` is `{camera?, microphone?, geolocation?, clipboardWrite?}`
+    (each an empty object when requested) — NOT a list. The sandbox proxy
+    maps the permission keys onto the inner iframe's `allow` attribute.
     """
     sources: List[Dict[str, Any]] = []
     for item in getattr(result, "contents", None) or []:
@@ -267,11 +287,11 @@ def _extract_csp_permissions(
     sources.append(ui_metadata.raw or {})
 
     csp: Dict[str, Any] = {}
-    permissions: List[Any] = []
+    permissions: Dict[str, Any] = {}
     for block in sources:
         if not csp and isinstance(block.get("csp"), dict):
             csp = block["csp"]
-        if not permissions and isinstance(block.get("permissions"), list):
+        if not permissions and isinstance(block.get("permissions"), dict):
             permissions = block["permissions"]
     return csp, permissions
 
@@ -342,6 +362,10 @@ def fetch_ui_resource(
         "mimeType": mime_type or MCP_APPS_UI_MIME_TYPE,
         "csp": csp,
         "permissions": permissions,
+        # Origin the SPA frames the sandbox-proxy at (PR #1's proxy.html).
+        # Carried on the event so the frontend needs no separate config
+        # fetch. Empty until the mcp-sandbox stack is deployed + wired.
+        "sandboxOrigin": mcp_apps_sandbox_origin(),
     }
 
 

--- a/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
+++ b/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
@@ -41,6 +41,7 @@ from agents.main_agent.integrations.gateway_mcp_client import FilteredMCPClient
 from apis.shared.tools.models import DEFAULT_TOOL_VISIBILITY, ToolUIMetadata
 
 _ENV_FLAG = "AGENTCORE_MCP_APPS_HOST_ENABLED"
+_ENV_SANDBOX_ORIGIN = "AGENTCORE_MCP_APPS_SANDBOX_ORIGIN"
 
 
 @pytest.fixture
@@ -49,6 +50,7 @@ def mcp_apps_clean(monkeypatch):
     get_ui_tool_catalog().clear()
     original_session = strands_mcp_client_mod.ClientSession
     monkeypatch.delenv(_ENV_FLAG, raising=False)
+    monkeypatch.delenv(_ENV_SANDBOX_ORIGIN, raising=False)
     try:
         yield
     finally:
@@ -354,7 +356,8 @@ class TestFetchUIResource:
             result=_html_resource(
                 ui_meta={
                     "csp": {"connectDomains": ["https://api.test"]},
-                    "permissions": ["clipboard-write"],
+                    # SEP-1865: permissions is an OBJECT, not a list.
+                    "permissions": {"clipboardWrite": {}},
                 }
             )
         )
@@ -376,8 +379,24 @@ class TestFetchUIResource:
             "html": "<h1>widget</h1>",
             "mimeType": MCP_APPS_UI_MIME_TYPE,
             "csp": {"connectDomains": ["https://api.test"]},
-            "permissions": ["clipboard-write"],
+            "permissions": {"clipboardWrite": {}},
+            # Empty when the mcp-sandbox stack origin isn't wired into env.
+            "sandboxOrigin": "",
         }
+
+    def test_carries_sandbox_origin_from_env(
+        self, mcp_apps_clean, monkeypatch
+    ):
+        client = _FakeMCPClient(result=_html_resource())
+        _seed_catalog(
+            monkeypatch, ui={"resourceUri": "ui://srv/widget"}, client=client
+        )
+        monkeypatch.setenv(
+            _ENV_SANDBOX_ORIGIN, "https://mcp-sandbox.example.com"
+        )
+
+        payload = fetch_ui_resource("widget", "tu-1")
+        assert payload["sandboxOrigin"] == "https://mcp-sandbox.example.com"
 
     def test_inert_when_flag_disabled(self, mcp_apps_clean, monkeypatch):
         client = _FakeMCPClient(result=_html_resource())
@@ -444,7 +463,7 @@ class TestFetchUIResource:
             ui={
                 "resourceUri": "ui://srv/widget",
                 "csp": {"frameDomains": ["https://embed.test"]},
-                "permissions": ["geolocation"],
+                "permissions": {"geolocation": {}},
             },
             client=client,
         )
@@ -452,7 +471,7 @@ class TestFetchUIResource:
         payload = fetch_ui_resource("widget", "tu-9")
         assert payload is not None
         assert payload["csp"] == {"frameDomains": ["https://embed.test"]}
-        assert payload["permissions"] == ["geolocation"]
+        assert payload["permissions"] == {"geolocation": {}}
 
     def test_prefers_mcp_app_mime_when_multiple_text_contents(
         self, mcp_apps_clean, monkeypatch

--- a/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
@@ -29,6 +29,7 @@ from agents.main_agent.integrations.mcp_apps import (
 from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
 
 _ENV_FLAG = "AGENTCORE_MCP_APPS_HOST_ENABLED"
+_ENV_SANDBOX_ORIGIN = "AGENTCORE_MCP_APPS_SANDBOX_ORIGIN"
 
 
 @pytest.fixture
@@ -40,6 +41,7 @@ def coord() -> StreamCoordinator:
 def catalog_clean(monkeypatch):
     get_ui_tool_catalog().clear()
     monkeypatch.delenv(_ENV_FLAG, raising=False)
+    monkeypatch.delenv(_ENV_SANDBOX_ORIGIN, raising=False)
     try:
         yield
     finally:
@@ -75,7 +77,7 @@ def _html_result(text="<h1>hi</h1>"):
                 _meta={
                     MCP_APPS_UI_EXTENSION_KEY: {
                         "csp": {"connectDomains": ["https://api.test"]},
-                        "permissions": ["clipboard-write"],
+                        "permissions": {"clipboardWrite": {}},
                     }
                 },
             )
@@ -131,7 +133,8 @@ async def test_emits_ui_resource_with_inline_html(
         "html": "<main>app</main>",
         "mimeType": MCP_APPS_UI_MIME_TYPE,
         "csp": {"connectDomains": ["https://api.test"]},
-        "permissions": ["clipboard-write"],
+        "permissions": {"clipboardWrite": {}},
+        "sandboxOrigin": "",
     }
 
 


### PR DESCRIPTION
## Summary

Coordinated backend follow-up to **PR #3 (#344, merged)** of the MCP Apps host-renderer initiative (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). This completes the `ui_resource` SSE event shape so the frontend (PR #4) needs no separate config fetch, and corrects the permission metadata to match the normative SEP-1865 spec. Both target `develop`; this should land before/with the frontend PR.

(#344 was already squash-merged when this delta was ready, so it ships as its own focused PR rather than an amendment to #344 — same intent, kept backend-only per the scoping doc's PR separation.)

### Changes
- **`sandboxOrigin` on `ui_resource`**: new `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` env var (the deploy pipeline sources it from the SSM origin the PR #1 `mcp-sandbox` stack publishes — `/{projectPrefix}/mcp-sandbox/origin`), carried on every `ui_resource` event. The SPA frames the sandbox-proxy at this origin; carrying it on the event means the frontend needs no extra config round-trip. Empty until the stack is deployed + wired — benign, the whole surface is inert behind `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false).
- **Spec fix — `_meta.ui.permissions` is an object, not a list**: the normative `specification/2026-01-26/apps.mdx` defines `permissions` as `{camera?, microphone?, geolocation?, clipboardWrite?}` (each an empty object when requested). PR #3's `_extract_csp_permissions` only extracted it when it was a *list*, so permissions would always have been empty — which would have silently broken PR #4's iframe `allow`-attribute mapping. Now extracted as an object (defaults `{}`).
- `CLAUDE.md` SSE row, `.env.example`, and the PR #3 tests updated for both.

## Inert behind the flag
No behavior change in production: the `ui_resource` event is only emitted when `AGENTCORE_MCP_APPS_HOST_ENABLED=true` (default false, flipped in PR #7).

## Test plan
- [x] `uv sync --extra agentcore --extra dev`
- [x] Full backend suite green — **2915 passed, 3 skipped, 0 failed** (~2:49). Backend pytest is not run in CI here, so the local suite is the gate.
- [x] Updated PR #3 fetch/coordinator tests assert `sandboxOrigin` (env-sourced + empty default) and object-shaped `permissions`; added `test_carries_sandbox_origin_from_env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)