### PR TITLE
feat(chat): MCP Apps PR #4 — <mcp-app-frame> + postMessage bridge

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -1,0 +1,193 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import type {
+  ToolResultData,
+  ToolResultRenderer,
+} from '../tool-renderer-registry.service';
+import { McpAppStateService } from '../../../../../services/mcp-apps/mcp-app-state.service';
+import { StreamParserService } from '../../../../../services/chat/stream-parser.service';
+import { ThemeService } from '../../../../../../components/topnav/components/theme-toggle/theme.service';
+import { McpAppBridge } from '../../../../../services/mcp-apps/mcp-app-bridge';
+
+/**
+ * MCP App renderer (SEP-1865), PR #4 of
+ * `docs/kaizen/scoping/mcp-apps-host-renderer.md`.
+ *
+ * Resolves to this component (instead of the default text/JSON renderer)
+ * when the tool invocation produced a `ui_resource` event — see the
+ * `resultRenderer` computed in `ToolUseComponent`. Renders the outer
+ * sandbox-proxy iframe at the deployed `sandboxOrigin` and drives the host
+ * half of the postMessage bridge; the proxy loads the actual App HTML in
+ * its inner null-origin iframe with a per-resource CSP.
+ *
+ * The whole surface is dark until the backend host flag is flipped (PR #7),
+ * so in practice no `ui_resource` arrives and the registry never resolves
+ * here. When it has no resource for its `toolUseId` (e.g. after a reload —
+ * the inline event doesn't re-hydrate) it renders nothing and the tool-use
+ * card falls back to the default renderer path.
+ */
+@Component({
+  selector: 'app-mcp-app-frame',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: ':host { display: block; }',
+  template: `
+    @if (safeProxyUrl(); as url) {
+      <div
+        class="overflow-hidden rounded-sm border border-gray-300 dark:border-gray-600 bg-white"
+      >
+        <iframe
+          #frame
+          [src]="url"
+          [style.height.px]="frameHeight()"
+          [attr.allow]="allowAttr()"
+          class="block w-full border-0 bg-white"
+          title="MCP App"
+          sandbox="allow-scripts allow-same-origin"
+          referrerpolicy="no-referrer"
+          loading="lazy"
+          (load)="onProxyLoad()"
+        ></iframe>
+      </div>
+    }
+  `,
+})
+export class McpAppFrameComponent implements ToolResultRenderer {
+  /** Tool result payload (the renderer contract). Mapped to CallToolResult. */
+  readonly result = input.required<ToolResultData>();
+  readonly minimized = input<boolean>(false);
+  /** Originating tool-use id — keys the resource + correlates tool data. */
+  readonly toolUseId = input<string>();
+
+  private readonly mcpAppState = inject(McpAppStateService);
+  private readonly streamParser = inject(StreamParserService);
+  private readonly theme = inject(ThemeService);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly win = inject(DOCUMENT).defaultView;
+
+  private readonly frameRef =
+    viewChild<ElementRef<HTMLIFrameElement>>('frame');
+
+  /** Initial height; the App drives it via `ui/notifications/size-changed`. */
+  protected readonly frameHeight = signal(360);
+
+  private bridge: McpAppBridge | null = null;
+  private readonly nonce =
+    this.win?.crypto?.randomUUID?.() ?? `n-${Math.random().toString(36).slice(2)}`;
+
+  /** The UI resource for this tool invocation (undefined ⇒ render nothing). */
+  protected readonly resource = computed(() => {
+    const id = this.toolUseId();
+    return id ? this.mcpAppState.get(id) : undefined;
+  });
+
+  protected readonly safeProxyUrl = computed<SafeResourceUrl | null>(() => {
+    const res = this.resource();
+    if (!res || !res.sandboxOrigin) return null;
+    // Trusted single value from our authenticated backend (SSM-sourced);
+    // the sandbox attribute + the proxy's per-resource CSP are the real
+    // containment, same justification as the artifact panel.
+    return this.sanitizer.bypassSecurityTrustResourceUrl(
+      `${res.sandboxOrigin.replace(/\/$/, '')}/proxy.html`,
+    );
+  });
+
+  /** Permissions-Policy `allow` for the outer frame (delegates to inner). */
+  protected readonly allowAttr = computed(() => {
+    const p = this.resource()?.permissions ?? {};
+    const feats: string[] = [];
+    if (p.camera) feats.push('camera');
+    if (p.microphone) feats.push('microphone');
+    if (p.geolocation) feats.push('geolocation');
+    if (p.clipboardWrite) feats.push('clipboard-write');
+    return feats.length ? feats.join('; ') : null;
+  });
+
+  constructor() {
+    // Push theme changes to the App as a host-context-changed partial.
+    effect(() => {
+      const theme = this.theme.theme();
+      this.bridge?.notifyHostContextChanged({ theme });
+    });
+    // Re-push the tool result if it lands/changes after the App initialized.
+    effect(() => {
+      this.result();
+      this.bridge?.refreshToolResult();
+    });
+    this.destroyRef.onDestroy(() => this.bridge?.dispose('component-destroyed'));
+  }
+
+  protected onProxyLoad(): void {
+    const res = this.resource();
+    if (!res || this.bridge || !this.win) return;
+    this.bridge = new McpAppBridge({
+      hostWindow: this.win,
+      getProxyWindow: () => this.frameRef()?.nativeElement.contentWindow ?? null,
+      sandboxOrigin: res.sandboxOrigin.replace(/\/$/, ''),
+      resource: res,
+      nonce: this.nonce,
+      getToolInput: () => this.lookupToolInput(),
+      getToolResult: () => this.toCallToolResult(),
+      getHostContext: () => ({
+        theme: this.theme.theme(),
+        locale: this.win?.navigator?.language,
+        userAgent: 'agentcore-public-stack',
+      }),
+      openLink: (url) => {
+        this.win?.open(url, '_blank', 'noopener,noreferrer');
+      },
+    });
+    this.bridge.onSizeChanged((_w, h) => {
+      if (h > 0) this.frameHeight.set(Math.ceil(h));
+    });
+    this.bridge.start();
+  }
+
+  /** Complete tool-call arguments, found by toolUseId in the live stream. */
+  private lookupToolInput(): Record<string, unknown> {
+    const id = this.toolUseId();
+    if (!id) return {};
+    for (const msg of this.streamParser.allMessages()) {
+      for (const block of msg.content ?? []) {
+        const tu = (block as { toolUse?: { toolUseId?: string; input?: unknown } })
+          .toolUse;
+        if (tu && tu.toolUseId === id && tu.input && typeof tu.input === 'object') {
+          return tu.input as Record<string, unknown>;
+        }
+      }
+    }
+    return {};
+  }
+
+  /** Map the renderer's `ToolResultData` to an MCP `CallToolResult`. */
+  private toCallToolResult(): unknown | null {
+    const r = this.result();
+    if (!r) return null;
+    const content = (r.content ?? []).map((item) => {
+      if (item.image) {
+        return {
+          type: 'image',
+          data: item.image.data,
+          mimeType: `image/${item.image.format}`,
+        };
+      }
+      if (item.json !== undefined) {
+        return { type: 'text', text: JSON.stringify(item.json) };
+      }
+      return { type: 'text', text: item.text ?? '' };
+    });
+    return { content, isError: r.status === 'error' };
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-renderer-registry.service.ts
@@ -21,6 +21,14 @@ export interface ToolResultData {
 export interface ToolResultRenderer {
   readonly result: InputSignal<ToolResultData>;
   readonly minimized: InputSignal<boolean>;
+  /**
+   * Originating tool-use id. Optional: existing renderers don't declare it
+   * and the host only binds it when the resolved renderer is one that
+   * declares it (the MCP App frame) — NgComponentOutlet throws if asked to
+   * set an input a component doesn't expose, so it must not be passed
+   * uniformly.
+   */
+  readonly toolUseId?: InputSignal<string | undefined>;
 }
 
 /**

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
@@ -10,6 +10,8 @@ import { NgComponentOutlet } from '@angular/common';
 import { JsonSyntaxHighlightPipe } from './json-syntax-highlight.pipe';
 import { ContentBlock, ToolUseData } from '../../../../services/models/message.model';
 import { ToolRendererRegistryService } from './tool-renderer-registry.service';
+import { McpAppStateService } from '../../../../services/mcp-apps/mcp-app-state.service';
+import { McpAppFrameComponent } from './renderers/mcp-app-frame.component';
 
 @Component({
   selector: 'app-tool-use',
@@ -29,6 +31,7 @@ export class ToolUseComponent {
   isDetailsExpanded = signal(false);
 
   private readonly rendererRegistry = inject(ToolRendererRegistryService);
+  private readonly mcpAppState = inject(McpAppStateService);
 
   /** Extract tool use data from the content block */
   toolUseData = computed(() => {
@@ -44,6 +47,9 @@ export class ToolUseComponent {
   toolName = computed(() => {
     return this.toolUseData().name || 'Unknown Tool';
   });
+
+  /** Originating tool-use id (correlates the MCP App resource + tool data). */
+  toolUseId = computed(() => this.toolUseData().toolUseId);
 
   /** Tool input */
   toolInput = computed(() => {
@@ -66,17 +72,39 @@ export class ToolUseComponent {
   });
 
   /**
-   * Result-renderer component for this tool, resolved from the registry.
-   * Unregistered tools fall back to the default text/JSON/image renderer.
-   * Reads the registry signal, so it stays reactive to late registrations.
+   * Result-renderer component for this tool.
+   *
+   * An MCP App (SEP-1865) takes precedence: when this tool invocation
+   * produced a `ui_resource` event, render the sandbox-proxy frame. App
+   * tool names are server-defined and per-invocation, so this can't be a
+   * static name→component registry entry (PR #0) — it keys off the
+   * toolUseId-scoped resource instead, but stays a single
+   * `[ngComponentOutlet]` with no template branch. Otherwise fall back to
+   * the name-keyed registry (default = text/JSON/image). Both reads are
+   * signals, so this stays reactive to a `ui_resource` arriving after the
+   * tool-use block first renders.
    */
-  resultRenderer = computed(() => this.rendererRegistry.resolve(this.toolName()));
+  resultRenderer = computed(() =>
+    this.mcpAppState.has(this.toolUseId())
+      ? McpAppFrameComponent
+      : this.rendererRegistry.resolve(this.toolName()),
+  );
 
-  /** Inputs bound onto the resolved renderer via NgComponentOutlet. */
-  rendererInputs = computed(() => ({
-    result: this.toolResult(),
-    minimized: this.minimized(),
-  }));
+  /**
+   * Inputs bound onto the resolved renderer via NgComponentOutlet.
+   * `toolUseId` is passed ONLY to the MCP App frame: NgComponentOutlet
+   * throws (NG0303) if asked to set an input a component doesn't declare,
+   * and the default/other renderers intentionally don't expose it.
+   */
+  rendererInputs = computed(() => {
+    const base = {
+      result: this.toolResult(),
+      minimized: this.minimized(),
+    };
+    return this.resultRenderer() === McpAppFrameComponent
+      ? { ...base, toolUseId: this.toolUseId() }
+      : base;
+  });
 
   /** Preview of input keys for collapsed state */
   inputKeysPreview = computed(() => {

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -19,11 +19,13 @@ import { OAuthConsentService } from '../../../services/oauth-consent/oauth-conse
 import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
 import { CompactionSummaryService } from './compaction-summary.service';
 import { ArtifactStateService } from '../artifacts/artifact-state.service';
+import { McpAppStateService } from '../mcp-apps/mcp-app-state.service';
 import type {
   OAuthRequiredEvent,
   ToolApprovalRequiredEvent,
   CompactionEvent,
   ArtifactEvent,
+  UiResourceEvent,
 } from '../../../shared/utils/stream-parser';
 import {
   processStreamEvent,
@@ -70,6 +72,7 @@ export class StreamParserService {
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
+  private mcpAppState = inject(McpAppStateService);
 
   // =========================================================================
   // State Signals
@@ -359,6 +362,14 @@ export class StreamParserService {
           }
         }
         this.artifactState.recordLive(data, lastAssistantId);
+      },
+
+      onUiResource: (data: UiResourceEvent) => {
+        // Inline event (arrives right after its tool_result, mid-stream),
+        // unlike the post-message_stop side channels above — just record
+        // it keyed by toolUseId. The tool-use renderer picks it up
+        // reactively and swaps in the MCP App frame.
+        this.mcpAppState.recordLive(data);
       },
 
       onToolApprovalRequired: (data: ToolApprovalRequiredEvent) => {

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { McpAppBridge } from './mcp-app-bridge';
+import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
+
+const SANDBOX_ORIGIN = 'https://mcp-sandbox.example.com';
+const NONCE = 'nonce-abc';
+
+function resource(): UiResourceEvent {
+  return {
+    type: 'ui_resource',
+    toolUseId: 'tu-1',
+    resourceUri: 'ui://srv/widget',
+    html: '<h1>app</h1>',
+    mimeType: 'text/html;profile=mcp-app',
+    csp: { connectDomains: ['https://api.test'] },
+    permissions: { clipboardWrite: {} },
+    sandboxOrigin: SANDBOX_ORIGIN,
+  };
+}
+
+/** A postMessage sink standing in for the proxy iframe's contentWindow. */
+class FakeProxyWindow {
+  readonly sent: Array<{ msg: any; targetOrigin: string }> = [];
+  postMessage(msg: unknown, targetOrigin: string): void {
+    this.sent.push({ msg, targetOrigin });
+  }
+  last(): any {
+    return this.sent[this.sent.length - 1]?.msg;
+  }
+  byMethod(method: string): any[] {
+    return this.sent.map((s) => s.msg).filter((m) => m?.method === method);
+  }
+  /** The message responding to/with the given JSON-RPC id, or throws. */
+  byId(id: string | number): any {
+    const found = this.sent.find((s) => s.msg?.id === id);
+    if (!found) throw new Error(`no message with id ${id}`);
+    return found.msg;
+  }
+}
+
+/** Host window: lets the test deliver `message` events to the bridge. */
+class FakeHostWindow {
+  private listener: ((ev: MessageEvent) => void) | null = null;
+  addEventListener(_t: 'message', cb: (ev: MessageEvent) => void): void {
+    this.listener = cb;
+  }
+  removeEventListener(): void {
+    this.listener = null;
+  }
+  get attached(): boolean {
+    return this.listener !== null;
+  }
+  deliver(data: unknown, source: unknown, origin = SANDBOX_ORIGIN): void {
+    this.listener?.({ data, source, origin } as MessageEvent);
+  }
+}
+
+interface Harness {
+  bridge: McpAppBridge;
+  host: FakeHostWindow;
+  proxy: FakeProxyWindow;
+  openLink: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  toolResult: { value: unknown | null };
+}
+
+function makeBridge(): Harness {
+  const host = new FakeHostWindow();
+  const proxy = new FakeProxyWindow();
+  const openLink = vi.fn();
+  const warn = vi.fn();
+  const toolResult: { value: unknown | null } = {
+    value: { content: [{ type: 'text', text: 'ok' }], isError: false },
+  };
+  const bridge = new McpAppBridge({
+    hostWindow: host,
+    getProxyWindow: () => proxy as unknown as Window,
+    sandboxOrigin: SANDBOX_ORIGIN,
+    resource: resource(),
+    nonce: NONCE,
+    getToolInput: () => ({ q: 'paris' }),
+    getToolResult: () => toolResult.value,
+    getHostContext: () => ({ theme: 'dark' }),
+    openLink,
+    onWarn: warn,
+  });
+  bridge.start();
+  return { bridge, host, proxy, openLink, warn, toolResult };
+}
+
+/** Drive the handshake up to (but not including) `initialized`. */
+function handshake(h: Harness): void {
+  h.host.deliver(
+    { jsonrpc: '2.0', method: 'ui/notifications/sandbox-proxy-ready', params: {} },
+    h.proxy,
+  );
+}
+
+describe('McpAppBridge', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeBridge();
+  });
+
+  it('sends sandbox-resource-ready (with nonce + html + csp) on proxy-ready', () => {
+    handshake(h);
+    const msg = h.proxy.byMethod('ui/notifications/sandbox-resource-ready')[0];
+    expect(msg).toBeTruthy();
+    expect(msg.params.html).toBe('<h1>app</h1>');
+    expect(msg.params.nonce).toBe(NONCE);
+    expect(msg.params.csp).toEqual({ connectDomains: ['https://api.test'] });
+    expect(msg.params.permissions).toEqual({ clipboardWrite: {} });
+    expect(msg.params.sandbox).toBe('allow-scripts');
+    // Strict targetOrigin — never '*'.
+    expect(h.proxy.sent[0].targetOrigin).toBe(SANDBOX_ORIGIN);
+  });
+
+  it('rejects messages from the wrong source or origin', () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', id: 1, method: 'ping', nonce: NONCE },
+      {} /* not the proxy window */,
+    );
+    h.host.deliver(
+      { jsonrpc: '2.0', id: 2, method: 'ping', nonce: NONCE },
+      h.proxy,
+      'https://evil.example.com',
+    );
+    // No ping response went out for either rejected message.
+    expect(h.proxy.sent.some((s) => s.msg.id === 1 || s.msg.id === 2)).toBe(false);
+  });
+
+  it('drops post-handshake messages without the nonce', () => {
+    handshake(h);
+    h.host.deliver({ jsonrpc: '2.0', id: 9, method: 'ping' }, h.proxy);
+    expect(h.warn).toHaveBeenCalled();
+    expect(h.proxy.sent.some((s) => s.msg.id === 9)).toBe(false);
+  });
+
+  it('answers ui/initialize with protocol version + host capabilities', () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', id: 'i1', method: 'ui/initialize', nonce: NONCE, params: {} },
+      h.proxy,
+    );
+    const resp = h.proxy.sent.map((s) => s.msg).find((m) => m.id === 'i1');
+    expect(resp.result.protocolVersion).toBe('2026-01-26');
+    expect(resp.result.hostCapabilities.openLinks).toBeDefined();
+    expect(resp.result.hostCapabilities.sandbox.csp).toEqual({
+      connectDomains: ['https://api.test'],
+    });
+    expect(resp.result.hostContext.displayMode).toBe('inline');
+    expect(resp.result.hostContext.theme).toBe('dark');
+  });
+
+  it('does NOT push tool-input before initialized, then flushes on initialized', () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', id: 'i1', method: 'ui/initialize', nonce: NONCE, params: {} },
+      h.proxy,
+    );
+    expect(h.proxy.byMethod('ui/notifications/tool-input')).toHaveLength(0);
+
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    const input = h.proxy.byMethod('ui/notifications/tool-input');
+    const result = h.proxy.byMethod('ui/notifications/tool-result');
+    expect(input).toHaveLength(1);
+    expect(input[0].params).toEqual({ arguments: { q: 'paris' } });
+    expect(result).toHaveLength(1);
+    expect(result[0].params).toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    });
+    // tool-input MUST precede tool-result.
+    const order = h.proxy.sent
+      .map((s) => s.msg.method)
+      .filter((m) => m && m.startsWith('ui/notifications/tool-'));
+    expect(order.indexOf('ui/notifications/tool-input')).toBeLessThan(
+      order.indexOf('ui/notifications/tool-result'),
+    );
+  });
+
+  it('forwards size-changed to the registered sink', () => {
+    const sizes: Array<[number, number]> = [];
+    h.bridge.onSizeChanged((w, ht) => sizes.push([w, ht]));
+    handshake(h);
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/size-changed',
+        nonce: NONCE,
+        params: { width: 320, height: 540 },
+      },
+      h.proxy,
+    );
+    expect(sizes).toEqual([[320, 540]]);
+  });
+
+  it('handles ui/open-link: opens valid https, rejects bad URLs', () => {
+    handshake(h);
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        id: 'l1',
+        method: 'ui/open-link',
+        nonce: NONCE,
+        params: { url: 'https://example.com/x' },
+      },
+      h.proxy,
+    );
+    expect(h.openLink).toHaveBeenCalledWith('https://example.com/x');
+    expect(h.proxy.byId('l1').result).toEqual({});
+
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        id: 'l2',
+        method: 'ui/open-link',
+        nonce: NONCE,
+        params: { url: 'javascript:alert(1)' },
+      },
+      h.proxy,
+    );
+    expect(h.openLink).toHaveBeenCalledTimes(1);
+    expect(h.proxy.byId('l2').error.code).toBe(-32000);
+  });
+
+  it('answers ui/request-display-mode with the resulting mode', () => {
+    handshake(h);
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        id: 'd1',
+        method: 'ui/request-display-mode',
+        nonce: NONCE,
+        params: { mode: 'fullscreen' },
+      },
+      h.proxy,
+    );
+    expect(h.proxy.byId('d1').result).toEqual({
+      mode: 'inline',
+    });
+  });
+
+  it('answers PR #6 methods (ui/message, ui/update-model-context) with method-not-found', () => {
+    handshake(h);
+    for (const [id, method] of [
+      ['m1', 'ui/message'],
+      ['m2', 'ui/update-model-context'],
+    ] as const) {
+      h.host.deliver(
+        { jsonrpc: '2.0', id, method, nonce: NONCE, params: {} },
+        h.proxy,
+      );
+      expect(h.proxy.byId(id).error.code).toBe(-32601);
+    }
+  });
+
+  it('answers ping with an empty result', () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', id: 'p1', method: 'ping', nonce: NONCE },
+      h.proxy,
+    );
+    expect(h.proxy.byId('p1').result).toEqual({});
+  });
+
+  it('dispose() sends resource-teardown after init and detaches the listener', () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    h.bridge.dispose('bye');
+    const td = h.proxy.byMethod('ui/resource-teardown');
+    expect(td).toHaveLength(1);
+    expect(td[0].params).toEqual({ reason: 'bye' });
+    expect(h.host.attached).toBe(false);
+  });
+
+  it('queues host-context-changed before init and flushes after', () => {
+    handshake(h);
+    h.bridge.notifyHostContextChanged({ theme: 'light' });
+    expect(h.proxy.byMethod('ui/notifications/host-context-changed')).toHaveLength(0);
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    const hc = h.proxy.byMethod('ui/notifications/host-context-changed');
+    expect(hc).toHaveLength(1);
+    expect(hc[0].params).toEqual({ theme: 'light' });
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -1,0 +1,391 @@
+/**
+ * MCP Apps host bridge (SEP-1865), PR #4 of
+ * `docs/kaizen/scoping/mcp-apps-host-renderer.md`.
+ *
+ * The host half of the JSON-RPC-2.0-over-postMessage protocol. It talks to
+ * the deployed sandbox-proxy (`proxy.html`, a different origin); the proxy
+ * forwards to/from the App View running in its inner null-origin iframe.
+ *
+ * Security model (spec + scoping doc decision #1/#5):
+ *  - Outer proxy iframe lives at a dedicated origin; messages to/from it are
+ *    validated by `event.source === proxyWindow` AND
+ *    `event.origin === sandboxOrigin`.
+ *  - A per-frame nonce, minted here and handed to the proxy in
+ *    `sandbox-resource-ready`, authenticates every subsequent exchange (the
+ *    inner View is null-origin, so the nonce — not origin — is the real
+ *    check the spec mandates).
+ *  - The host MUST NOT send any request/notification toward the View before
+ *    it observes the View's `ui/notifications/initialized`; pre-init sends
+ *    are queued and flushed on initialized.
+ *
+ * Framework-free and DOM-light on purpose: `hostWindow` and the proxy window
+ * accessor are injected so specs drive it with plain fakes (no vi.mock of
+ * globals — house rule).
+ *
+ * Out of scope for PR #4 (owned by PR #5/#6, answered with JSON-RPC errors
+ * so Apps degrade gracefully): app-initiated `tools/call` proxying,
+ * `ui/message`, `ui/update-model-context`, and `ui/open-link` consent
+ * gating (PR #4 opens links directly via the injected opener).
+ */
+
+import type {
+  UiResourceEvent,
+} from '../../../shared/utils/stream-parser';
+import {
+  HostContext,
+  JsonRpcId,
+  JsonRpcMessage,
+  JsonRpcRequest,
+  JSONRPC_IMPL_ERROR,
+  JSONRPC_METHOD_NOT_FOUND,
+  M_HOST_CONTEXT_CHANGED,
+  M_MESSAGE,
+  M_OPEN_LINK,
+  M_PING,
+  M_REQUEST_DISPLAY_MODE,
+  M_RESOURCE_TEARDOWN,
+  M_SANDBOX_PROXY_READY,
+  M_SANDBOX_RESOURCE_READY,
+  M_SIZE_CHANGED,
+  M_TOOL_CANCELLED,
+  M_TOOL_INPUT,
+  M_TOOL_RESULT,
+  M_UI_INITIALIZE,
+  M_UI_INITIALIZED,
+  M_UPDATE_MODEL_CONTEXT,
+  MCP_UI_PROTOCOL_VERSION,
+  SizeChangedParams,
+  isJsonRpc,
+  isRequest,
+} from './mcp-app-protocol';
+
+/** Minimal window surface the bridge needs (eases testing). */
+export interface BridgeHostWindow {
+  addEventListener(
+    type: 'message',
+    listener: (ev: MessageEvent) => void,
+  ): void;
+  removeEventListener(
+    type: 'message',
+    listener: (ev: MessageEvent) => void,
+  ): void;
+}
+
+export interface McpAppBridgeDeps {
+  /** The window that hosts the outer proxy iframe (for `message` events). */
+  hostWindow: BridgeHostWindow;
+  /** Lazily resolves the proxy iframe's `contentWindow` (null until load). */
+  getProxyWindow: () => Window | null;
+  /** Origin the proxy is served from; targetOrigin + inbound origin check. */
+  sandboxOrigin: string;
+  /** The resource (html/csp/permissions) to render. */
+  resource: UiResourceEvent;
+  /** Per-frame nonce (mint once per frame; never reused). */
+  nonce: string;
+  /** Complete tool-call arguments for `ui/notifications/tool-input`. */
+  getToolInput: () => Record<string, unknown>;
+  /** Tool result as an MCP `CallToolResult`, or null if not yet available. */
+  getToolResult: () => unknown | null;
+  /** Current host UI context (theme, displayMode, …). */
+  getHostContext: () => HostContext;
+  /** Open an external URL (PR #4: direct; PR #6 adds consent). */
+  openLink: (url: string) => void;
+  /** Non-fatal diagnostics (validation drops, protocol slips). */
+  onWarn?: (message: string) => void;
+}
+
+export class McpAppBridge {
+  private readonly d: McpAppBridgeDeps;
+  private listener: ((ev: MessageEvent) => void) | null = null;
+
+  /** Set once `sandbox-resource-ready` is sent — nonce now required. */
+  private nonceArmed = false;
+  /** Set on the View's `ui/notifications/initialized`. */
+  private viewInitialized = false;
+  private disposed = false;
+
+  /** Notifications deferred until the View reports `initialized`. */
+  private readonly preInitQueue: Array<{ method: string; params: unknown }> = [];
+
+  /** Whether tool-input was already pushed (spec: at most once). */
+  private toolInputSent = false;
+
+  /** Pending host→View requests awaiting a JSON-RPC response, by id. */
+  private readonly pending = new Map<
+    JsonRpcId,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void }
+  >();
+  private nextRequestId = 1;
+
+  constructor(deps: McpAppBridgeDeps) {
+    this.d = deps;
+  }
+
+  /** Begin listening. Call once the outer iframe element exists. */
+  start(): void {
+    if (this.listener) return;
+    this.listener = (ev: MessageEvent) => this.onMessage(ev);
+    this.d.hostWindow.addEventListener('message', this.listener);
+  }
+
+  /**
+   * Tear down: best-effort `ui/resource-teardown` toward the View, then
+   * detach. Safe to call multiple times.
+   */
+  dispose(reason = 'host-teardown'): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.viewInitialized) {
+      // Fire-and-forget: we're going away regardless of the ack.
+      this.sendRequest(M_RESOURCE_TEARDOWN, { reason }).catch(() => undefined);
+    }
+    if (this.listener) {
+      this.d.hostWindow.removeEventListener('message', this.listener);
+      this.listener = null;
+    }
+    for (const { reject } of this.pending.values()) {
+      reject(new Error('bridge disposed'));
+    }
+    this.pending.clear();
+  }
+
+  /** Push a `host-context-changed` partial (e.g., theme toggle). */
+  notifyHostContextChanged(partial: Partial<HostContext>): void {
+    this.sendNotification(M_HOST_CONTEXT_CHANGED, partial);
+  }
+
+  // --- inbound ------------------------------------------------------------
+
+  private onMessage(ev: MessageEvent): void {
+    if (this.disposed) return;
+    const proxyWindow = this.d.getProxyWindow();
+    // Source + origin gate. The proxy page is served from sandboxOrigin, so
+    // its window's origin is a real URL (the null-origin inner frame only
+    // ever talks to the proxy, never to us).
+    if (!proxyWindow || ev.source !== proxyWindow) return;
+    if (ev.origin !== this.d.sandboxOrigin) return;
+
+    const data = ev.data;
+    if (!isJsonRpc(data)) return;
+
+    // Nonce gate: armed the moment we hand the proxy the nonce. The only
+    // legitimately pre-nonce message is the proxy's first ready ping.
+    const method = 'method' in data ? (data as { method?: string }).method : undefined;
+    if (this.nonceArmed) {
+      if ((data as { nonce?: string }).nonce !== this.d.nonce) {
+        this.d.onWarn?.(`dropped message with bad/absent nonce (${method ?? 'response'})`);
+        return;
+      }
+    } else if (method !== M_SANDBOX_PROXY_READY) {
+      this.d.onWarn?.(`dropped pre-handshake message (${method ?? 'response'})`);
+      return;
+    }
+
+    this.route(data);
+  }
+
+  private route(msg: JsonRpcMessage): void {
+    // Response to a host-initiated request (e.g. resource-teardown).
+    if (!('method' in msg) && 'id' in msg) {
+      const p = this.pending.get(msg.id);
+      if (!p) return;
+      this.pending.delete(msg.id);
+      if ('error' in msg) p.reject(msg.error);
+      else p.resolve((msg as { result: unknown }).result);
+      return;
+    }
+
+    const method = (msg as { method: string }).method;
+    switch (method) {
+      case M_SANDBOX_PROXY_READY:
+        this.sendSandboxResourceReady();
+        return;
+
+      case M_UI_INITIALIZE:
+        this.handleInitialize(msg as JsonRpcRequest);
+        return;
+
+      case M_UI_INITIALIZED:
+        this.viewInitialized = true;
+        this.flushPreInit();
+        this.pushToolData();
+        return;
+
+      case M_SIZE_CHANGED: {
+        const p = (msg as { params?: SizeChangedParams }).params;
+        if (p && typeof p.height === 'number') {
+          this.sizeChangedCb?.(p.width, p.height);
+        }
+        return;
+      }
+
+      case M_PING:
+        if (isRequest(msg)) this.respond(msg.id, {});
+        return;
+
+      case M_OPEN_LINK: {
+        if (!isRequest(msg)) return;
+        const url = (msg.params as { url?: string } | undefined)?.url;
+        if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+          this.respondError(msg.id, JSONRPC_IMPL_ERROR, 'Invalid URL');
+          return;
+        }
+        // PR #4 opens directly; per-link consent is PR #6.
+        this.d.openLink(url);
+        this.respond(msg.id, {});
+        return;
+      }
+
+      case M_REQUEST_DISPLAY_MODE: {
+        if (!isRequest(msg)) return;
+        // PR #4 host only renders inline; spec: MUST return the resulting
+        // mode (the current one when the request can't be honored).
+        this.respond(msg.id, { mode: 'inline' });
+        return;
+      }
+
+      case M_MESSAGE:
+      case M_UPDATE_MODEL_CONTEXT:
+        // Owned by PR #6. Answer per JSON-RPC so Apps degrade gracefully.
+        if (isRequest(msg)) {
+          this.respondError(
+            msg.id,
+            JSONRPC_METHOD_NOT_FOUND,
+            `${method} not supported yet (PR #6)`,
+          );
+        }
+        return;
+
+      default:
+        // Unknown request → method-not-found; unknown notification → ignore.
+        if (isRequest(msg)) {
+          this.respondError(
+            msg.id,
+            JSONRPC_METHOD_NOT_FOUND,
+            `Unknown method: ${method}`,
+          );
+        }
+        return;
+    }
+  }
+
+  private handleInitialize(req: JsonRpcRequest): void {
+    // A response (not a request/notification toward the View) — allowed
+    // before `initialized`.
+    this.respond(req.id, {
+      protocolVersion: MCP_UI_PROTOCOL_VERSION,
+      hostInfo: { name: 'agentcore-public-stack', version: '1.0.0' },
+      hostCapabilities: {
+        openLinks: {},
+        sandbox: {
+          permissions: this.d.resource.permissions,
+          csp: this.d.resource.csp,
+        },
+      },
+      hostContext: {
+        ...this.d.getHostContext(),
+        displayMode: 'inline',
+        availableDisplayModes: ['inline'],
+      },
+    });
+  }
+
+  // --- outbound -----------------------------------------------------------
+
+  private sizeChangedCb: ((w: number, h: number) => void) | null = null;
+  /** Register the size-changed sink (the component resizes the iframe). */
+  onSizeChanged(cb: (w: number, h: number) => void): void {
+    this.sizeChangedCb = cb;
+  }
+
+  private sendSandboxResourceReady(): void {
+    // Reserved host→proxy notification; consumed by the proxy, not forwarded.
+    this.postToProxy({
+      jsonrpc: '2.0',
+      method: M_SANDBOX_RESOURCE_READY,
+      params: {
+        html: this.d.resource.html,
+        sandbox: 'allow-scripts',
+        csp: this.d.resource.csp,
+        permissions: this.d.resource.permissions,
+        nonce: this.d.nonce,
+      },
+    });
+    // From here on every inbound message MUST carry the nonce.
+    this.nonceArmed = true;
+  }
+
+  /** Push `tool-input` (once) then `tool-result` if it's available. */
+  private pushToolData(): void {
+    if (!this.toolInputSent) {
+      this.toolInputSent = true;
+      this.sendNotification(M_TOOL_INPUT, { arguments: this.d.getToolInput() });
+    }
+    const result = this.d.getToolResult();
+    if (result != null) {
+      this.sendNotification(M_TOOL_RESULT, result);
+    }
+  }
+
+  /** Re-push the tool result if it arrives/changes after init. */
+  refreshToolResult(): void {
+    if (!this.viewInitialized) return;
+    const result = this.d.getToolResult();
+    if (result != null) this.sendNotification(M_TOOL_RESULT, result);
+  }
+
+  notifyToolCancelled(reason: string): void {
+    this.sendNotification(M_TOOL_CANCELLED, { reason });
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    // Spec: the host MUST NOT send any request/notification toward the View
+    // before `initialized`. (The `sandbox-resource-ready` notification and
+    // the `ui/initialize` response are bootstrap — they go straight through
+    // `postToProxy`/`respond`, never here.)
+    if (!this.viewInitialized) {
+      this.preInitQueue.push({ method, params });
+      return;
+    }
+    this.postToProxy({ jsonrpc: '2.0', method, params, nonce: this.d.nonce });
+  }
+
+  private sendRequest(method: string, params: unknown): Promise<unknown> {
+    const id = `host-${this.nextRequestId++}`;
+    const promise = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.postToProxy({ jsonrpc: '2.0', id, method, params, nonce: this.d.nonce });
+    return promise;
+  }
+
+  private respond(id: JsonRpcId, result: unknown): void {
+    this.postToProxy({ jsonrpc: '2.0', id, result, nonce: this.d.nonce });
+  }
+
+  private respondError(id: JsonRpcId, code: number, message: string): void {
+    this.postToProxy({
+      jsonrpc: '2.0',
+      id,
+      error: { code, message },
+      nonce: this.d.nonce,
+    });
+  }
+
+  private flushPreInit(): void {
+    const queued = this.preInitQueue.splice(0, this.preInitQueue.length);
+    for (const { method, params } of queued) {
+      this.postToProxy({ jsonrpc: '2.0', method, params, nonce: this.d.nonce });
+    }
+  }
+
+  private postToProxy(msg: JsonRpcMessage): void {
+    const w = this.d.getProxyWindow();
+    if (!w) {
+      this.d.onWarn?.('proxy window unavailable; message dropped');
+      return;
+    }
+    // Strict targetOrigin: we know exactly where the proxy lives.
+    w.postMessage(msg, this.d.sandboxOrigin);
+  }
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
@@ -1,0 +1,156 @@
+/**
+ * MCP Apps (SEP-1865) host-half protocol types.
+ *
+ * JSON-RPC 2.0 envelopes exchanged over `postMessage` between this host and
+ * the sandbox-proxy (and, through it, the App View). Normative reference:
+ * `specification/2026-01-26/apps.mdx` in `modelcontextprotocol/ext-apps`.
+ *
+ * PR #4 of `docs/kaizen/scoping/mcp-apps-host-renderer.md`. Pure types +
+ * constants; no Angular, no DOM — kept framework-free so the bridge is
+ * unit-testable with plain fakes.
+ */
+
+import type { McpUiCsp, McpUiPermissions } from '../../../shared/utils/stream-parser';
+
+/** Protocol version this host implements (the normative dated spec). */
+export const MCP_UI_PROTOCOL_VERSION = '2026-01-26';
+
+/** JSON-RPC id (spec allows string or number). */
+export type JsonRpcId = string | number;
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+  /** Per-frame transport nonce (host↔proxy auth; not part of JSON-RPC). */
+  nonce?: string;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+  nonce?: string;
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  result: unknown;
+  nonce?: string;
+}
+
+export interface JsonRpcError {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  error: { code: number; message: string; data?: unknown };
+  nonce?: string;
+}
+
+export type JsonRpcMessage =
+  | JsonRpcRequest
+  | JsonRpcNotification
+  | JsonRpcSuccess
+  | JsonRpcError;
+
+/** JSON-RPC reserved code for "method not found". */
+export const JSONRPC_METHOD_NOT_FOUND = -32601;
+/** Implementation-defined error (spec uses -32000 for ui/* denials). */
+export const JSONRPC_IMPL_ERROR = -32000;
+
+// --- Reserved sandbox-proxy methods (host ↔ proxy only) --------------------
+
+/** Sandbox proxy → host: proxy bootstrapped, ready for the resource. */
+export const M_SANDBOX_PROXY_READY = 'ui/notifications/sandbox-proxy-ready';
+/** Host → sandbox proxy: raw HTML + sandbox/CSP/permissions to load. */
+export const M_SANDBOX_RESOURCE_READY = 'ui/notifications/sandbox-resource-ready';
+
+// --- Lifecycle / app methods (host ↔ View, forwarded by the proxy) --------
+
+export const M_UI_INITIALIZE = 'ui/initialize';
+export const M_UI_INITIALIZED = 'ui/notifications/initialized';
+export const M_PING = 'ping';
+
+export const M_TOOL_INPUT = 'ui/notifications/tool-input';
+export const M_TOOL_INPUT_PARTIAL = 'ui/notifications/tool-input-partial';
+export const M_TOOL_RESULT = 'ui/notifications/tool-result';
+export const M_TOOL_CANCELLED = 'ui/notifications/tool-cancelled';
+export const M_RESOURCE_TEARDOWN = 'ui/resource-teardown';
+export const M_HOST_CONTEXT_CHANGED = 'ui/notifications/host-context-changed';
+export const M_SIZE_CHANGED = 'ui/notifications/size-changed';
+
+export const M_OPEN_LINK = 'ui/open-link';
+export const M_REQUEST_DISPLAY_MODE = 'ui/request-display-mode';
+export const M_MESSAGE = 'ui/message';
+export const M_UPDATE_MODEL_CONTEXT = 'ui/update-model-context';
+
+export type DisplayMode = 'inline' | 'fullscreen' | 'pip';
+
+/** Capabilities this host advertises to the View in `ui/initialize`. */
+export interface HostCapabilities {
+  /** Host can open external links (consent gating lands in PR #6). */
+  openLinks?: Record<string, never>;
+  /** Sandbox config the host applied (mirrors what we asked the proxy for). */
+  sandbox?: {
+    permissions?: McpUiPermissions;
+    csp?: McpUiCsp;
+  };
+}
+
+export interface HostContext {
+  theme?: 'light' | 'dark';
+  displayMode?: DisplayMode;
+  availableDisplayModes?: DisplayMode[];
+  locale?: string;
+  timeZone?: string;
+  userAgent?: string;
+}
+
+export interface McpUiInitializeResult {
+  protocolVersion: string;
+  hostCapabilities: HostCapabilities;
+  hostInfo: { name: string; version: string };
+  hostContext: HostContext;
+}
+
+/** Params for `ui/notifications/sandbox-resource-ready` (host → proxy). */
+export interface SandboxResourceReadyParams {
+  html: string;
+  /** Inner-iframe `sandbox` attribute. Defaults to `allow-scripts`. */
+  sandbox?: string;
+  csp?: McpUiCsp;
+  permissions?: McpUiPermissions;
+  /** Per-frame nonce the proxy must echo on every later message. */
+  nonce: string;
+}
+
+export interface SizeChangedParams {
+  width: number;
+  height: number;
+}
+
+export interface OpenLinkParams {
+  url: string;
+}
+
+export interface RequestDisplayModeParams {
+  mode: DisplayMode;
+}
+
+/** Narrowing helpers. */
+export function isJsonRpc(data: unknown): data is JsonRpcMessage {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    (data as { jsonrpc?: unknown }).jsonrpc === '2.0'
+  );
+}
+
+export function isRequest(m: JsonRpcMessage): m is JsonRpcRequest {
+  return 'method' in m && 'id' in m;
+}
+
+export function isNotification(m: JsonRpcMessage): m is JsonRpcNotification {
+  return 'method' in m && !('id' in m);
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { McpAppStateService } from './mcp-app-state.service';
+import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
+
+function ev(toolUseId: string, html = '<h1>hi</h1>'): UiResourceEvent {
+  return {
+    type: 'ui_resource',
+    toolUseId,
+    resourceUri: `ui://srv/${toolUseId}`,
+    html,
+    mimeType: 'text/html;profile=mcp-app',
+    csp: {},
+    permissions: {},
+    sandboxOrigin: 'https://mcp-sandbox.example.com',
+  };
+}
+
+describe('McpAppStateService', () => {
+  let svc: McpAppStateService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(McpAppStateService);
+  });
+
+  it('starts empty', () => {
+    expect(svc.hasApps()).toBe(false);
+    expect(svc.has('tu-1')).toBe(false);
+    expect(svc.get('tu-1')).toBeUndefined();
+  });
+
+  it('records and retrieves a resource by toolUseId', () => {
+    const e = ev('tu-1');
+    svc.recordLive(e);
+    expect(svc.has('tu-1')).toBe(true);
+    expect(svc.get('tu-1')).toEqual(e);
+    expect(svc.hasApps()).toBe(true);
+  });
+
+  it('last write wins for the same toolUseId', () => {
+    svc.recordLive(ev('tu-1', '<old>'));
+    svc.recordLive(ev('tu-1', '<new>'));
+    expect(svc.get('tu-1')?.html).toBe('<new>');
+  });
+
+  it('keeps distinct invocations separate', () => {
+    svc.recordLive(ev('tu-1'));
+    svc.recordLive(ev('tu-2'));
+    expect(svc.get('tu-1')?.resourceUri).toBe('ui://srv/tu-1');
+    expect(svc.get('tu-2')?.resourceUri).toBe('ui://srv/tu-2');
+  });
+
+  it('reset() drops everything (conversation teardown)', () => {
+    svc.recordLive(ev('tu-1'));
+    svc.reset();
+    expect(svc.hasApps()).toBe(false);
+    expect(svc.has('tu-1')).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, computed, signal } from '@angular/core';
+import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
+
+/**
+ * Per-conversation registry of MCP App UI resources (SEP-1865), keyed by the
+ * originating `toolUseId`. Structural sibling of `ArtifactStateService` /
+ * `CompactionSummaryService`: a live SSE path (`recordLive`) and a `reset()`
+ * the session page calls on conversation change.
+ *
+ * The `ui_resource` event is INLINE (it arrives right after its
+ * `tool_result`), so unlike artifacts there is no session-load hydration
+ * path — a refreshed conversation re-streams nothing, and a persisted MCP
+ * App is out of scope until a later PR. Iframes persist for the lifetime of
+ * the conversation per the scoping doc; teardown is on `reset()`.
+ *
+ * The whole surface is dark until the backend `AGENTCORE_MCP_APPS_HOST_ENABLED`
+ * flag is flipped (PR #7), so in practice nothing is recorded here yet.
+ */
+@Injectable({ providedIn: 'root' })
+export class McpAppStateService {
+  private readonly byToolUseId = signal<ReadonlyMap<string, UiResourceEvent>>(
+    new Map(),
+  );
+
+  /** True once any MCP App resource has been recorded this conversation. */
+  readonly hasApps = computed(() => this.byToolUseId().size > 0);
+
+  /**
+   * Record the UI resource for a tool invocation. Last write wins — a tool
+   * that re-emits for the same `toolUseId` replaces the prior resource
+   * (the iframe rebinds to the new HTML). New invocations get new ids.
+   */
+  recordLive(event: UiResourceEvent): void {
+    const next = new Map(this.byToolUseId());
+    next.set(event.toolUseId, event);
+    this.byToolUseId.set(next);
+  }
+
+  /** The UI resource for a tool invocation, or undefined. */
+  get(toolUseId: string): UiResourceEvent | undefined {
+    return this.byToolUseId().get(toolUseId);
+  }
+
+  /**
+   * Whether this tool invocation has an MCP App. Reads the backing signal,
+   * so a `computed()` that calls it stays reactive to the `ui_resource`
+   * event arriving after the tool-use block first renders.
+   */
+  has(toolUseId: string): boolean {
+    return this.byToolUseId().has(toolUseId);
+  }
+
+  /** Drop all resources — called on conversation change (teardown). */
+  reset(): void {
+    this.byToolUseId.set(new Map());
+  }
+}

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -17,6 +17,7 @@ import { StreamParserService } from './services/chat/stream-parser.service';
 import { CompactionSummaryService } from './services/chat/compaction-summary.service';
 import { ArtifactStateService } from './services/artifacts/artifact-state.service';
 import { ArtifactHttpService } from './services/artifacts/artifact-http.service';
+import { McpAppStateService } from './services/mcp-apps/mcp-app-state.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
 import { Assistant } from '../assistants/models/assistant.model';
@@ -47,6 +48,7 @@ export class ConversationPage implements OnDestroy {
   private streamParserService = inject(StreamParserService);
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
+  private mcpAppState = inject(McpAppStateService);
   private artifactHttp = inject(ArtifactHttpService);
   private assistantService = inject(AssistantService);
   private router = inject(Router);
@@ -305,6 +307,11 @@ export class ConversationPage implements OnDestroy {
       // loads so a prior session's cards don't bleed in, then re-hydrate
       // from the app-api list endpoint below.
       this.artifactState.reset();
+
+      // MCP App frames persist for the conversation's lifetime per the
+      // scoping doc; teardown is on conversation change. No re-hydration:
+      // the inline `ui_resource` event only arrives live during a stream.
+      this.mcpAppState.reset();
 
       if (id) {
         // Update the messages signal reference (this triggers reactivity)

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -60,6 +60,7 @@ export {
   validateToolApprovalRequiredEvent,
   validateCompactionEvent,
   validateArtifactEvent,
+  validateUiResourceEvent,
 } from './stream-parser-core';
 
 // Types
@@ -83,6 +84,9 @@ export type {
   ToolApprovalRequiredEvent,
   CompactionEvent,
   ArtifactEvent,
+  UiResourceEvent,
+  McpUiCsp,
+  McpUiPermissions,
   StreamEventType,
   StreamEventData,
   ParsedStreamEvent,

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
@@ -12,6 +12,7 @@ import {
   validateConversationalStreamError,
   validateCitation,
   validateArtifactEvent,
+  validateUiResourceEvent,
   processStreamEvent,
   createStreamLineParser,
   inferContentBlockType,
@@ -419,6 +420,52 @@ describe('stream-parser-core', () => {
     });
   });
 
+  describe('validateUiResourceEvent', () => {
+    const valid = {
+      type: 'ui_resource',
+      toolUseId: 'tu-1',
+      resourceUri: 'ui://srv/widget',
+      html: '<h1>hi</h1>',
+      mimeType: 'text/html;profile=mcp-app',
+      csp: { connectDomains: ['https://api.test'] },
+      permissions: { clipboardWrite: {} },
+      sandboxOrigin: 'https://mcp-sandbox.example.com'
+    };
+
+    it('should return true for a valid ui_resource event', () => {
+      expect(validateUiResourceEvent(valid)).toBe(true);
+    });
+
+    it('should accept empty html and empty sandboxOrigin', () => {
+      expect(validateUiResourceEvent({ ...valid, html: '', sandboxOrigin: '' })).toBe(true);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(validateUiResourceEvent(null)).toBe(false);
+      expect(validateUiResourceEvent(undefined)).toBe(false);
+    });
+
+    it('should return false when type is wrong', () => {
+      expect(validateUiResourceEvent({ ...valid, type: 'artifact' })).toBe(false);
+    });
+
+    it('should return false for empty toolUseId or resourceUri', () => {
+      expect(validateUiResourceEvent({ ...valid, toolUseId: '' })).toBe(false);
+      expect(validateUiResourceEvent({ ...valid, resourceUri: '' })).toBe(false);
+    });
+
+    it('should return false when csp/permissions are not objects', () => {
+      expect(validateUiResourceEvent({ ...valid, csp: null })).toBe(false);
+      expect(validateUiResourceEvent({ ...valid, permissions: 'x' })).toBe(false);
+    });
+
+    it('should return false for missing fields', () => {
+      expect(
+        validateUiResourceEvent({ type: 'ui_resource', toolUseId: 'tu-1' }),
+      ).toBe(false);
+    });
+  });
+
   describe('processStreamEvent', () => {
     let callbacks: StreamParserCallbacks;
 
@@ -436,6 +483,7 @@ describe('stream-parser-core', () => {
         onStreamError: vi.fn(),
         onCitation: vi.fn(),
         onArtifact: vi.fn(),
+        onUiResource: vi.fn(),
         onParseError: vi.fn(),
         onDone: vi.fn(),
         onError: vi.fn(),
@@ -507,6 +555,26 @@ describe('stream-parser-core', () => {
     it('should call onParseError for an invalid artifact event', () => {
       processStreamEvent('artifact', { type: 'artifact', artifactId: '' }, callbacks);
       expect(callbacks.onParseError).toHaveBeenCalledWith('artifact: invalid data structure');
+    });
+
+    it('should call onUiResource for a valid ui_resource event', () => {
+      const data = {
+        type: 'ui_resource',
+        toolUseId: 'tu-1',
+        resourceUri: 'ui://srv/widget',
+        html: '<main>app</main>',
+        mimeType: 'text/html;profile=mcp-app',
+        csp: {},
+        permissions: {},
+        sandboxOrigin: ''
+      };
+      processStreamEvent('ui_resource', data, callbacks);
+      expect(callbacks.onUiResource).toHaveBeenCalledWith(data);
+    });
+
+    it('should call onParseError for an invalid ui_resource event', () => {
+      processStreamEvent('ui_resource', { type: 'ui_resource', toolUseId: '' }, callbacks);
+      expect(callbacks.onParseError).toHaveBeenCalledWith('ui_resource: invalid data structure');
     });
   });
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -40,6 +40,7 @@ import type {
   ToolApprovalRequiredEvent,
   CompactionEvent,
   ArtifactEvent,
+  UiResourceEvent,
   ToolProgress,
 } from './stream-parser-types';
 import type { MetadataEvent } from '../../../session/services/models/content-types';
@@ -91,6 +92,11 @@ export interface StreamParserCallbacks {
   // Artifact created/updated this turn (existence signal; content is
   // fetched out-of-band via a render token + sandboxed iframe)
   onArtifact?: (data: ArtifactEvent) => void;
+
+  // MCP App UI resource for a tool result (SEP-1865). Inline event,
+  // correlated to its tool-use block by toolUseId; carries the HTML to
+  // render in the sandbox-proxy iframe.
+  onUiResource?: (data: UiResourceEvent) => void;
 
   // Error handling
   onError?: (data: StreamErrorEvent | ConversationalStreamErrorEvent | string) => void;
@@ -424,6 +430,37 @@ export function validateArtifactEvent(data: unknown): data is ArtifactEvent {
 }
 
 /**
+ * Validate UiResourceEvent structure (SEP-1865 MCP App, PR #3 wire shape).
+ *
+ * `html` may legitimately be empty only in degenerate cases; we require it
+ * to be a string but not non-empty so a future server that streams an
+ * empty shell still round-trips. `csp`/`permissions` are objects;
+ * `sandboxOrigin` may be '' until the sandbox stack is deployed.
+ */
+export function validateUiResourceEvent(data: unknown): data is UiResourceEvent {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const event = data as Partial<UiResourceEvent>;
+
+  return (
+    event.type === 'ui_resource' &&
+    typeof event.toolUseId === 'string' &&
+    event.toolUseId.length > 0 &&
+    typeof event.resourceUri === 'string' &&
+    event.resourceUri.length > 0 &&
+    typeof event.html === 'string' &&
+    typeof event.mimeType === 'string' &&
+    typeof event.sandboxOrigin === 'string' &&
+    typeof event.csp === 'object' &&
+    event.csp !== null &&
+    typeof event.permissions === 'object' &&
+    event.permissions !== null
+  );
+}
+
+/**
  * Validate Citation structure
  */
 export function validateCitation(data: unknown): data is Citation {
@@ -617,6 +654,14 @@ export function processStreamEvent(
           callbacks.onArtifact?.(data);
         } else {
           callbacks.onParseError?.('artifact: invalid data structure');
+        }
+        break;
+
+      case 'ui_resource':
+        if (validateUiResourceEvent(data)) {
+          callbacks.onUiResource?.(data);
+        } else {
+          callbacks.onParseError?.('ui_resource: invalid data structure');
         }
         break;
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -176,6 +176,57 @@ export interface ArtifactEvent {
 }
 
 /**
+ * CSP domain allowlists declared by an MCP App resource (SEP-1865
+ * `McpUiResourceCsp`). The sandbox proxy composes the inner iframe's CSP
+ * from these plus the spec's deny-by-default fallbacks.
+ */
+export interface McpUiCsp {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+}
+
+/**
+ * Sandbox permissions an MCP App resource requested (SEP-1865). Each key,
+ * when present (as an empty object), maps to a Permissions-Policy feature on
+ * the inner iframe's `allow` attribute. Absence = not requested.
+ */
+export interface McpUiPermissions {
+  camera?: Record<string, never>;
+  microphone?: Record<string, never>;
+  geolocation?: Record<string, never>;
+  clipboardWrite?: Record<string, never>;
+}
+
+/**
+ * UI resource event — emitted by the backend (PR #3) right after the
+ * correlated `tool_result` when the tool declared a `ui://` MCP App
+ * resource (SEP-1865). Unlike `artifact`/`oauth_required` this is an
+ * INLINE event during streaming, correlated to its tool-use block by
+ * `toolUseId`. The HTML is fetched server-side via `resources/read` and
+ * inlined here so the frontend needs no MCP client of its own.
+ *
+ * `sandboxOrigin` is the origin of the deployed sandbox-proxy (proxy.html)
+ * the SPA frames the App in; empty until that stack is deployed + wired
+ * (the whole surface is inert behind the backend host flag until then).
+ *
+ * The entire MCP Apps surface stays dark until PR #7 flips the backend
+ * `AGENTCORE_MCP_APPS_HOST_ENABLED` flag, so in practice this event does
+ * not arrive in production yet.
+ */
+export interface UiResourceEvent {
+  type: 'ui_resource';
+  toolUseId: string;
+  resourceUri: string;
+  html: string;
+  mimeType: string;
+  csp: McpUiCsp;
+  permissions: McpUiPermissions;
+  sandboxOrigin: string;
+}
+
+/**
  * Tool result event data structure
  */
 export interface ToolResultEventData {
@@ -215,7 +266,8 @@ export type StreamEventType =
   | 'citation'
   | 'oauth_required'
   | 'compaction'
-  | 'artifact';
+  | 'artifact'
+  | 'ui_resource';
 
 /**
  * Union type of all possible event data types
@@ -238,6 +290,7 @@ export type StreamEventData =
   | OAuthRequiredEvent
   | CompactionEvent
   | ArtifactEvent
+  | UiResourceEvent
   | null
   | undefined;
 

--- a/infrastructure/assets/mcp-sandbox/proxy.html
+++ b/infrastructure/assets/mcp-sandbox/proxy.html
@@ -2,28 +2,27 @@
 <!--
   MCP Apps host renderer — Sandbox Proxy shell (OUTER iframe)
 
-  PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md.
+  PR #1 (origin + shell) + PR #4 (proxy.js protocol) of
+  docs/kaizen/scoping/mcp-apps-host-renderer.md.
 
   This is the static shell served at mcp-sandbox.{domain}/proxy.html. It is
   the OUTER half of the spec's "Sandbox Proxy pattern" for web hosts:
 
     ai.client (SPA)
       └─ <iframe src="https://mcp-sandbox.{domain}/proxy.html">   ← THIS FILE
-           └─ <iframe srcdoc="...">  inner content frame (created here)
+           └─ <iframe srcdoc="...">  inner content frame (created by proxy.js)
 
   Why two iframes: this outer page is a stable cross-origin boundary against
-  the host page, so `allow-same-origin` on the INNER frame never grants the
-  MCP App access to the SPA origin (cookies / localStorage / app API). The
-  inner frame takes the strict per-resource CSP from `_meta.ui.csp` — that
-  composition lands in PR #4.
+  the host page, so the INNER (null-origin, no allow-same-origin) frame
+  never grants the MCP App access to the SPA origin (cookies / localStorage
+  / app API). proxy.js gives the inner frame the strict per-resource CSP
+  composed from `_meta.ui.csp` (carried on the `ui_resource` SSE event).
 
-  SCOPE OF THIS PR: stand up the origin + the static shell only. There is NO
-  MCP server wiring and NO JSON-RPC postMessage protocol here yet — the shell
-  only answers a liveness handshake so the SPA can prove it can reach this
-  origin. The full host bridge (ui/initialize, tool-input, resource-teardown,
-  per-frame nonce auth, etc.) is PR #4. Until PR #7 flips
-  MCP_APPS_HOST_ENABLED nothing in the SPA points at this page, so deploying
-  this stack is inert.
+  proxy.js (PR #4) implements the sandbox-proxy half of the JSON-RPC-2.0
+  postMessage protocol: it announces readiness, receives the resource, loads
+  the View under a composed CSP, and forwards messages host<->View with
+  per-frame nonce auth. Until PR #7 flips MCP_APPS_HOST_ENABLED nothing in
+  the SPA points at this page, so deploying this stack is inert.
 
   CSP NOTE: the security-critical control for this PR is the response
   `Content-Security-Policy: frame-ancestors <SPA origin only>` stamped by the
@@ -42,9 +41,9 @@
   <body>
     <!--
       The inner content frame is created at runtime by proxy.js (via srcdoc),
-      not declared here, because in later PRs its srcdoc / sandbox / CSP are
-      derived per-resource from the `ui_resource` SSE event. For PR #1 it is
-      an empty placeholder so the two-iframe structure is observable.
+      not declared here: its srcdoc / sandbox / CSP / allow are derived
+      per-resource from the `ui_resource` SSE event the host relays in the
+      `ui/notifications/sandbox-resource-ready` message.
     -->
     <script src="proxy.js"></script>
   </body>

--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -1,83 +1,282 @@
 /*
- * MCP Apps host renderer — Sandbox Proxy bootstrap (OUTER iframe).
+ * MCP Apps host renderer — Sandbox Proxy (OUTER iframe).
  *
- * PR #1 of docs/kaizen/scoping/mcp-apps-host-renderer.md. See proxy.html for
- * the architecture overview. This file is intentionally tiny: it exists so
- * the served CSP can be `script-src 'self'` (no inline script, no
- * `'unsafe-inline'`).
+ * PR #4 of docs/kaizen/scoping/mcp-apps-host-renderer.md (supersedes the
+ * PR #1 liveness shell). Normative spec: ext-apps
+ * specification/2026-01-26/apps.mdx, "Sandbox proxy".
  *
- * What it does in PR #1 — and ONLY this:
- *   1. Create the inner content iframe via `srcdoc` (empty placeholder),
- *      establishing the two-iframe Sandbox Proxy structure.
- *   2. Answer a liveness handshake from the embedding SPA so the frontend
- *      (and tests) can prove the cross-origin channel works.
+ * This file is served from the dedicated mcp-sandbox origin and runs inside
+ * the OUTER iframe the SPA created with sandbox="allow-scripts
+ * allow-same-origin". It is the stable cross-origin boundary between the
+ * host (ai.client) and the untrusted App View (an inner null-origin srcdoc
+ * iframe this script creates).
  *
- * What it deliberately does NOT do (PR #4+):
- *   - JSON-RPC 2.0 over postMessage (ui/initialize, ui/notifications/*, etc.)
- *   - Per-frame nonce authentication of the protocol channel
- *   - Loading real MCP App HTML / composing the inner CSP from _meta.ui.csp
- *   - tools/call proxying (PR #5)
+ * Responsibilities (spec §"Sandbox proxy"):
+ *   3. Announce readiness to the host (ui/notifications/sandbox-proxy-ready).
+ *   4. Receive the raw HTML + sandbox/CSP/permissions
+ *      (ui/notifications/sandbox-resource-ready).
+ *   5. Load the View HTML in the inner iframe with a CSP composed from
+ *      _meta.ui.csp plus the spec's deny-by-default fallbacks; map
+ *      _meta.ui.permissions onto the inner iframe `allow` attribute.
+ *   6. Forward every JSON-RPC message host<->View whose method does not
+ *      start with "ui/notifications/sandbox-". The host enforces the
+ *      "no sends before initialized" rule; the proxy is a dumb pipe.
  *
- * Origin handling: this outer page can only ever be framed by the SPA origin
- * because CloudFront serves it with `frame-ancestors <SPA origin only>`. The
- * browser enforces that before any script here runs, so the PR #1 handshake
- * does not need to re-check event.origin (and per spec the inner frame's
- * origin will be "null" anyway — real auth is the per-frame nonce added in
- * PR #4). We simply echo back the caller's nonce so the SPA can correlate.
+ * Auth: a per-frame nonce, minted by the host and delivered in
+ * sandbox-resource-ready, authenticates the host<->proxy leg (the inner
+ * View is null-origin, so origin matching is impossible — the nonce is the
+ * real check the spec mandates). The proxy adds the nonce on View->host
+ * forwards and strips it on host->View forwards (the View speaks plain
+ * spec JSON-RPC and never sees transport auth). No inline script: the
+ * served CSP can stay script-src 'self'.
  */
 (function () {
   'use strict';
 
-  var PROTOCOL = 'mcp-sandbox-proxy';
-  var PHASE = 'pr1-shell';
+  var PROXY_READY = 'ui/notifications/sandbox-proxy-ready';
+  var RESOURCE_READY = 'ui/notifications/sandbox-resource-ready';
+  var SANDBOX_RESERVED_PREFIX = 'ui/notifications/sandbox-';
 
-  // 1. Establish the inner content frame. srcdoc (not src) keeps it at a
-  //    distinct opaque origin ("null"); PR #4 replaces this placeholder with
-  //    the real MCP App resource and widens `sandbox` per _meta.ui.permissions.
-  var inner = document.createElement('iframe');
-  inner.id = 'mcp-app-content';
-  inner.title = 'MCP App content';
-  // Most-restrictive sandbox for the inert placeholder. PR #4 adds
-  // allow-scripts / allow-same-origin (spec minimum) and any opted-in
-  // capability flags from _meta.ui.permissions.
-  inner.setAttribute('sandbox', '');
-  inner.setAttribute(
-    'srcdoc',
-    '<!doctype html><meta charset="utf-8"><title>MCP App placeholder</title>' +
-      'MCP Apps sandbox proxy ready (PR #1 shell — no content bound).'
-  );
-  document.body.appendChild(inner);
+  var hostWindow = window.parent;
+  var hostOrigin = null; // learned from the first sandbox-resource-ready
+  var nonce = null;
+  var inner = null;
+  var innerReady = false;
+  var pendingToInner = []; // host->View messages queued until inner loads
 
-  // 2. Liveness handshake. The SPA posts {type:"<PROTOCOL>:ping", nonce} once
-  //    its <mcp-app-frame> sees this iframe load; we reply to the sender so
-  //    the SPA can confirm the cross-origin proxy is reachable. This is NOT
-  //    the protocol channel — that is PR #4.
-  window.addEventListener('message', function (event) {
-    var data = event && event.data;
-    if (!data || data.type !== PROTOCOL + ':ping') {
+  // --- CSP composition (spec §"Sandbox proxy" point 5 + Host Behavior) ----
+
+  function list(domains) {
+    return Array.isArray(domains)
+      ? domains.filter(function (d) {
+          return typeof d === 'string' && d.length > 0;
+        })
+      : [];
+  }
+
+  // Restrictive default when no _meta.ui.csp is supplied (verbatim from the
+  // normative spec), hardened with object-src/frame-src/base-uri.
+  function defaultCsp() {
+    return [
+      "default-src 'none'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "media-src 'self' data:",
+      "font-src 'self'",
+      "connect-src 'none'",
+      "frame-src 'none'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "form-action 'none'"
+    ].join('; ');
+  }
+
+  // Compose from declared domains. resourceDomains maps to the static
+  // resource directives; connectDomains to connect-src; frameDomains to
+  // frame-src; baseUriDomains to base-uri. Undeclared => deny (spec: MUST
+  // NOT allow undeclared domains; MAY further restrict).
+  function composeCsp(csp) {
+    if (!csp || typeof csp !== 'object') {
+      return defaultCsp();
+    }
+    var res = list(csp.resourceDomains).join(' ');
+    var conn = list(csp.connectDomains).join(' ');
+    var frame = list(csp.frameDomains).join(' ');
+    var base = list(csp.baseUriDomains).join(' ');
+    return [
+      "default-src 'none'",
+      ("script-src 'self' 'unsafe-inline'" + (res ? ' ' + res : '')),
+      ("style-src 'self' 'unsafe-inline'" + (res ? ' ' + res : '')),
+      ("img-src 'self' data:" + (res ? ' ' + res : '')),
+      ("font-src 'self'" + (res ? ' ' + res : '')),
+      ("media-src 'self' data:" + (res ? ' ' + res : '')),
+      ('connect-src ' + (conn || "'none'")),
+      ('frame-src ' + (frame || "'none'")),
+      ('base-uri ' + (base || "'self'")),
+      "object-src 'none'",
+      "form-action 'none'"
+    ].join('; ');
+  }
+
+  // Map _meta.ui.permissions (object form, SEP-1865) to a Permissions-Policy
+  // `allow` attribute value for the inner iframe.
+  function allowAttr(permissions) {
+    if (!permissions || typeof permissions !== 'object') {
+      return '';
+    }
+    var feats = [];
+    if (permissions.camera) feats.push('camera');
+    if (permissions.microphone) feats.push('microphone');
+    if (permissions.geolocation) feats.push('geolocation');
+    if (permissions.clipboardWrite) feats.push('clipboard-write');
+    return feats.join('; ');
+  }
+
+  // Inject the composed CSP as the first <head> child so it governs the
+  // whole document. Relies on the App being a valid HTML5 document (spec
+  // MUST); falls back to wrapping if no <head> is present.
+  function withCsp(html, cspValue) {
+    var meta =
+      '<meta http-equiv="Content-Security-Policy" content="' +
+      cspValue.replace(/"/g, '&quot;') +
+      '">';
+    if (/<head[^>]*>/i.test(html)) {
+      return html.replace(/(<head[^>]*>)/i, '$1' + meta);
+    }
+    if (/<html[^>]*>/i.test(html)) {
+      return html.replace(/(<html[^>]*>)/i, '$1<head>' + meta + '</head>');
+    }
+    return '<!doctype html><html><head>' + meta + '</head><body>' + html +
+      '</body></html>';
+  }
+
+  // --- inner iframe (the View) -------------------------------------------
+
+  function mountView(params) {
+    var sandbox =
+      typeof params.sandbox === 'string' && params.sandbox
+        ? params.sandbox
+        : 'allow-scripts';
+    var allow = allowAttr(params.permissions);
+
+    inner = document.createElement('iframe');
+    inner.id = 'mcp-app-content';
+    inner.title = 'MCP App content';
+    inner.setAttribute('sandbox', sandbox);
+    if (allow) {
+      inner.setAttribute('allow', allow);
+    }
+    inner.setAttribute('referrerpolicy', 'no-referrer');
+    inner.style.cssText =
+      'border:0;width:100%;height:100%;display:block;background:#fff';
+    inner.addEventListener('load', function () {
+      innerReady = true;
+      var queued = pendingToInner.splice(0, pendingToInner.length);
+      for (var i = 0; i < queued.length; i++) {
+        postToInner(queued[i]);
+      }
+    });
+    // srcdoc keeps the document at an opaque ("null") origin — no
+    // allow-same-origin — so it cannot reach the mcp-sandbox origin's
+    // storage; the per-frame nonce is the real channel auth.
+    inner.setAttribute(
+      'srcdoc',
+      withCsp(String(params.html || ''), composeCsp(params.csp))
+    );
+    document.body.appendChild(inner);
+  }
+
+  // --- message plumbing ---------------------------------------------------
+
+  function isJsonRpc(d) {
+    return d && typeof d === 'object' && d.jsonrpc === '2.0';
+  }
+
+  function methodOf(d) {
+    return d && typeof d.method === 'string' ? d.method : null;
+  }
+
+  function isSandboxReserved(method) {
+    return !!method && method.indexOf(SANDBOX_RESERVED_PREFIX) === 0;
+  }
+
+  function postToInner(msg) {
+    if (!inner || !inner.contentWindow) {
       return;
     }
-    var reply = {
-      type: PROTOCOL + ':pong',
-      phase: PHASE,
-      ready: true,
-      // Echo the caller's correlation token verbatim if present.
-      nonce: typeof data.nonce === 'string' ? data.nonce : null
-    };
-    if (event.source && typeof event.source.postMessage === 'function') {
-      // targetOrigin "*" is acceptable here: the reply carries no secrets,
-      // only a liveness ack, and the embedder is already constrained to the
-      // SPA origin by the server-side frame-ancestors CSP.
-      event.source.postMessage(reply, '*');
+    // Inner is null-origin; targetOrigin must be "*". Strip transport nonce
+    // so the View only ever sees spec-clean JSON-RPC.
+    var clean = {};
+    for (var k in msg) {
+      if (Object.prototype.hasOwnProperty.call(msg, k) && k !== 'nonce') {
+        clean[k] = msg[k];
+      }
+    }
+    inner.contentWindow.postMessage(clean, '*');
+  }
+
+  function postToHost(msg) {
+    if (!hostWindow) {
+      return;
+    }
+    var withNonce = {};
+    for (var k in msg) {
+      if (Object.prototype.hasOwnProperty.call(msg, k)) {
+        withNonce[k] = msg[k];
+      }
+    }
+    if (nonce) {
+      withNonce.nonce = nonce;
+    }
+    hostWindow.postMessage(withNonce, hostOrigin || '*');
+  }
+
+  function onHostMessage(event) {
+    var data = event.data;
+    if (!isJsonRpc(data)) {
+      return;
+    }
+    var method = methodOf(data);
+
+    if (method === RESOURCE_READY) {
+      // First authenticated host message: lock onto the host origin and
+      // the per-frame nonce, then mount the View.
+      if (inner) {
+        return; // one resource per proxy instance
+      }
+      hostOrigin = event.origin && event.origin !== 'null' ? event.origin : null;
+      nonce =
+        data.params && typeof data.params.nonce === 'string'
+          ? data.params.nonce
+          : null;
+      mountView(data.params || {});
+      return;
+    }
+
+    // Reserved sandbox-* messages are proxy-private and never forwarded.
+    if (isSandboxReserved(method)) {
+      return;
+    }
+
+    // Everything else is host->View. Authenticate the nonce once armed.
+    if (nonce && data.nonce !== nonce) {
+      return;
+    }
+    if (innerReady) {
+      postToInner(data);
+    } else {
+      pendingToInner.push(data);
+    }
+  }
+
+  function onInnerMessage(event) {
+    if (!inner || event.source !== inner.contentWindow) {
+      return;
+    }
+    var data = event.data;
+    if (!isJsonRpc(data)) {
+      return;
+    }
+    // The View must not speak the reserved sandbox channel.
+    if (isSandboxReserved(methodOf(data))) {
+      return;
+    }
+    postToHost(data);
+  }
+
+  window.addEventListener('message', function (event) {
+    if (event.source === hostWindow) {
+      onHostMessage(event);
+    } else if (inner && event.source === inner.contentWindow) {
+      onInnerMessage(event);
     }
   });
 
-  // Signal to the embedder that the shell finished bootstrapping, for SPAs
-  // that prefer to wait for a push rather than poll with a ping.
-  if (window.parent && window.parent !== window) {
-    window.parent.postMessage(
-      { type: PROTOCOL + ':ready', phase: PHASE },
-      '*'
-    );
+  // Step 3: announce readiness. targetOrigin "*" is acceptable — this
+  // carries no secret and the host validates by source window + origin
+  // before sending the nonce-bearing resource.
+  if (hostWindow && hostWindow !== window) {
+    hostWindow.postMessage({ jsonrpc: '2.0', method: PROXY_READY, params: {} }, '*');
   }
 })();


### PR DESCRIPTION
## Summary

PR #4 of the MCP Apps host-renderer initiative (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). The frontend host renderer for MCP Apps (SEP-1865) and the upgrade of the sandbox-proxy from the PR #1 liveness shell to the full protocol.

Implemented against the **normative `specification/2026-01-26/apps.mdx`** (the dated version the scoping doc locks); see "Spec drift" below for movement vs. `draft`.

### What's here
- **Stream parser**: `UiResourceEvent` type + `McpUiCsp`/`McpUiPermissions`, `validateUiResourceEvent`, and the `ui_resource` case wired through `stream-parser-types.ts`, `-core.ts`, and the barrel. `McpAppStateService` (signal-backed, keyed by `toolUseId`, conversation-scoped) is fed by `StreamParserService.onUiResource`; conversation teardown is wired in `session.page.ts` next to the artifact reset. Unlike `artifact`/`oauth_required` this is an **inline** event (arrives right after its `tool_result`), so there's no session-load hydration path — consistent with the scoping doc (iframes live for the conversation, not persisted).
- **Host bridge** (`mcp-app-bridge.ts`, framework-free + DI-injected windows): the host half of JSON-RPC-2.0 over `postMessage` — `sandbox-proxy-ready` → `sandbox-resource-ready` handshake; per-frame nonce + `event.source`/`event.origin` gating; `ui/initialize` → `McpUiInitializeResult`; the spec's "host MUST NOT send before `ui/notifications/initialized`" rule via a pre-init queue; `tool-input` then `tool-result` (ordering enforced); `size-changed`; `ui/open-link` (opened directly — per-link consent is PR #6); `ui/request-display-mode` (returns the resulting mode); `host-context-changed` (theme); `ui/resource-teardown` on dispose. `ui/message` and `ui/update-model-context` are answered with JSON-RPC method-not-found so Apps degrade gracefully (PR #6 owns them).
- **Component** (`mcp-app-frame.component.ts`): renders the outer iframe at the event's `sandboxOrigin/proxy.html` with `sandbox="allow-scripts allow-same-origin"` and a permission-derived `allow` attribute; `bypassSecurityTrustResourceUrl` for the trusted backend-supplied origin (same justification as the artifact panel — sandbox + the proxy's per-resource CSP are the real containment). `ToolUseComponent` resolves to it when `McpAppStateService.has(toolUseId)` — a single `[ngComponentOutlet]`, **no template branch** (honours PR #0). App tool names are server-defined and per-invocation so this can't be a static name→component registry entry; it keys off the toolUseId-scoped resource instead.
- **`proxy.js`**: upgraded to the real sandbox proxy — announces readiness, receives the resource, builds the inner null-origin srcdoc iframe with a CSP composed from `_meta.ui.csp` plus the spec's verbatim deny-by-default fallbacks, maps `_meta.ui.permissions` onto the inner `allow`, and forwards JSON-RPC host↔View for non-`ui/notifications/sandbox-` methods, stripping the transport nonce toward the View and adding it toward the host. Still no inline script (served CSP stays `script-src 'self'`).

## Dependency / independence
Depends on the coordinated backend follow-up **[#345](https://github.com/Boise-State-Development/agentcore-public-stack/pull/345)** (adds `sandboxOrigin` to the `ui_resource` event and fixes `permissions` to the spec's object shape). Both target `develop`; #345 should merge first/with this. Independent of the merged PR #3 (#344), PR #1, PR #2. App-initiated `tools/call` proxying is PR #5; `ui/message` / `ui/update-model-context` / open-link consent / capability gating are PR #6.

## Inert behind the flag
No `ui_resource` event is emitted until PR #7 flips the backend `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false), so `McpAppStateService` stays empty, `ToolUseComponent` always resolves to the existing renderers, and nothing points at the sandbox origin. This PR changes nothing user-facing on its own.

## Spec drift (normative 2026-01-26 vs. draft)
Diffed `specification/draft/apps.mdx` against the dated normative version:
- **Metadata location** (draft adds): `_meta.ui` may appear on both `resources/list` and each `resources/read` content item, content-item taking precedence; hosts MUST check both. #345's extraction already prefers content-item `_meta`, then result-level, then the tool-list value retained by PR #2 — forward-compatible.
- Draft relaxes the sandbox handshake notifications from MUST to SHOULD. We implement the stricter MUST handshake, which interoperates with a SHOULD-compliant peer.
- Draft adds a bidirectional `tools/call` note (App→Host→Server needs a host `serverTools` capability). We deliberately do **not** advertise `serverTools` yet — that's PR #5.
- Remaining diffs are cosmetic (example `protocolVersion` string).

## Verification
- [x] Full frontend suite green — **1040 passed / 89 files, 0 failed** (`npm run test:ci`). Includes new specs: parser-core `ui_resource` (validator + dispatch), `McpAppStateService`, and a thorough `McpAppBridge` protocol spec (handshake, nonce/origin/source rejection, pre-init gate + flush, tool-input→tool-result ordering, open-link allow/deny, request-display-mode, PR #6 method-not-found, ping, size-changed, dispose/teardown). Bridge specs use DI-injected fake windows — no `vi.mock` of globals (house rule).
- [x] Pre-existing `tool-use.component.spec.ts` still green after the renderer-resolution change (an earlier iteration regressed it with `NG0303` by passing `toolUseId` to all renderers; fixed by binding it only when the resolved renderer is the MCP frame).
- [x] CDK `mcp-sandbox-stack.test.ts` — **18/18 passed** (the `proxy.js`/`proxy.html` asset changes don't affect the stack; it asserts CloudFront/CSP/DefaultRootObject, not asset bytes).
- [ ] **Not browser-observable in this PR.** With the flag off no `ui_resource` event ever arrives, so there is no meaningful preview to run — stating this explicitly rather than faking a screenshot. The end-to-end dev exercise is gated on PR #7.

### Manual end-to-end test (run when PR #7 flips the flag)
1. Deploy the `mcp-sandbox` stack; confirm the deploy pipeline wires its SSM origin into `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` and set `AGENTCORE_MCP_APPS_HOST_ENABLED=true`.
2. Register an `ext-apps/examples` server (e.g. the QR/basic-host example) and invoke its UI tool in a conversation.
3. Expect: a `ui_resource` SSE after the `tool_result`; the tool-use card renders an iframe at `mcp-sandbox.<domain>/proxy.html`; the App paints inside the inner frame; DevTools shows the `sandbox-proxy-ready` → `sandbox-resource-ready` → `ui/initialize`/`initialized` → `tool-input`/`tool-result` exchange, all carrying the per-frame nonce; resizing the App updates the iframe height; toggling theme pushes `host-context-changed`; switching conversations tears the frame down.
4. Confirm the inner frame's CSP matches the resource's `_meta.ui.csp` (Network → the inner doc) and that undeclared origins are blocked.

## Carry-forward risk (unchanged from PR #3/#345)
Whether AWS AgentCore Gateway forwards `_meta.ui` through its MCP proxy is still unverifiable from unit tests and needs a deployed dev environment before PR #7 — tracked on #345. This PR is purely the client side and is safe to land behind the flag regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)