### PR TITLE
feat(mcp-apps): PR #6 — ui/message, ui/update-model-context, frontend consent + reload persistence

### DIFF
--- a/backend/src/apis/app_api/mcp_apps/routes.py
+++ b/backend/src/apis/app_api/mcp_apps/routes.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel, Field
 from apis.app_api.chat import proxy_routes
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
+from apis.shared.mcp_apps.card_store import get_app_card_store
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,125 @@ async def proxy_call(
     except Exception:  # noqa: BLE001 - upstream returned non-JSON
         raise HTTPException(status_code=502, detail="Bad upstream response")
 
+    # Option A (PR #6): on success, persist a static provenance card so the
+    # call survives a page reload (the broker is in-memory; the live thread
+    # event is otherwise lost on refresh). Best-effort + provenance-only —
+    # model-visible state flows through ui/update-model-context, never a
+    # persisted synthetic tool turn. A failed write must not fail the call.
+    if response.status_code == 200 and isinstance(payload, dict):
+        result = payload.get("result") or {}
+        try:
+            get_app_card_store().store(
+                user_id=current_user.user_id,
+                session_id=body.session_id,
+                tool_use_id=body.tool_use_id,
+                tool_name=body.tool_name,
+                arguments=body.arguments,
+                content=result.get("content") or [],
+                is_error=bool(result.get("isError")),
+            )
+        except Exception:  # noqa: BLE001 - provenance is best-effort
+            logger.warning(
+                "mcp-apps: failed to persist provenance card", exc_info=True
+            )
+
     # Relay inference-api's status verbatim (403 not-app-visible, 409 no
     # live client, 502 tool failure, 200 success) so the bridge can answer
     # the iframe's JSON-RPC with the right error.
     return JSONResponse(payload, status_code=response.status_code)
+
+
+class ProxyContextUpdateRequest(BaseModel):
+    """App-pushed model context proxied from an embedded MCP App (PR #6).
+
+    The iframe's `ui/update-model-context` params are `{content?,
+    structuredContent?}`; `resourceUri` is the bound App resource the SPA
+    already holds (the `ui_resource` event's `resourceUri`) and is the
+    host's per-App dedupe key. `enabledTools` / `modelId` carry the
+    conversation config so inference-api rebuilds the same cached agent.
+    """
+
+    session_id: str = Field(..., alias="sessionId")
+    resource_uri: str = Field(..., alias="resourceUri")
+    content: Optional[List[Dict[str, Any]]] = None
+    structured_content: Optional[Dict[str, Any]] = Field(
+        default=None, alias="structuredContent"
+    )
+    enabled_tools: List[str] = Field(default_factory=list, alias="enabledTools")
+    model_id: Optional[str] = Field(default=None, alias="modelId")
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post("/update-context")
+async def update_context(
+    body: ProxyContextUpdateRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user_from_session),
+) -> JSONResponse:
+    """Relay an app-pushed model-context update to inference-api.
+
+    Non-streaming, runs no model turn: inference-api stashes the payload on
+    the conversation agent's Strands state; the next real user turn merges
+    it. Mirrors `/proxy-call`'s auth + bearer hand-off — this boundary's
+    only job is the session-cookie → bearer exchange.
+    """
+    invocation_body = {
+        "session_id": body.session_id,
+        "enabled_tools": body.enabled_tools,
+        "model_id": body.model_id,
+        "app_context_update": {
+            "resource_uri": body.resource_uri,
+            "content": body.content,
+            "structured_content": body.structured_content,
+        },
+    }
+
+    target_url = proxy_routes._build_invocations_url(
+        proxy_routes._inference_api_url()
+    )
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {current_user.raw_token}",
+    }
+
+    client = proxy_routes._build_upstream_client()
+    try:
+        response = await client.post(
+            target_url, headers=headers, json=invocation_body
+        )
+    except httpx.ConnectError:
+        logger.error("Cannot reach Inference API at %s", target_url)
+        raise HTTPException(status_code=502, detail="Inference API is unreachable")
+    except httpx.TimeoutException:
+        logger.error("Inference API request timed out: %s", target_url)
+        raise HTTPException(status_code=504, detail="Inference API request timed out")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("MCP Apps update-context error: %s", exc, exc_info=True)
+        raise HTTPException(status_code=502, detail="Proxy error")
+    finally:
+        await client.aclose()
+
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001 - upstream returned non-JSON
+        raise HTTPException(status_code=502, detail="Bad upstream response")
+
+    return JSONResponse(payload, status_code=response.status_code)
+
+
+@router.get("/cards")
+async def list_cards(
+    session_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> JSONResponse:
+    """Return this user's app-initiated tool-call cards for a session.
+
+    Reload hydration for Option A: the SPA replays these as *static
+    historical cards* (the App iframe itself is not re-instantiated).
+    Ownership is re-checked in the store against a guessed session id.
+    """
+    cards = get_app_card_store().list_for_session(
+        session_id=session_id, user_id=current_user.user_id
+    )
+    return JSONResponse({"cards": cards})

--- a/backend/src/apis/inference_api/chat/app_context_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_context_dispatch.py
@@ -1,0 +1,191 @@
+"""App-pushed model context (`ui/update-model-context`, MCP Apps PR #6).
+
+`docs/kaizen/scoping/mcp-apps-host-renderer.md`, decision #3. An embedded
+MCP App pushes structured/text context to the host over the postMessage
+bridge; app-api relays it to `/invocations` with an `app_context_update`
+directive. Like PR #5's `app_tool_call` this runs WITHOUT a model turn —
+it stashes the payload on the conversation agent's Strands `agent.state`,
+keyed by the App's bound resource URI.
+
+Storage (decision #3): `agent.state` is the live Strands `AgentState` of
+the cached conversation agent. Multi-turn continuity in cloud rides the
+in-process LRU agent cache (AgentCore Memory is write-only for continuity —
+see docs/specs/MAX_TOKENS_CONTINUE_SESSION_RESTORE_ANALYSIS.md), so the
+same `agent.state` survives turn boundaries for free; a cold start /
+eviction drops the *entire* conversation anyway, so a dropped pending
+context there is consistent with existing behavior, not a new regression.
+No `TurnBasedSessionManager` / Memory change is needed.
+
+`AgentState` in strands 1.40 is a `.get()/.set()/.delete()` store whose
+`.get()` returns a **deep copy** — nested in-place mutation does NOT
+persist, so the bag under `STATE_KEY` is read-modify-written wholesale,
+and every value must be JSON-serializable.
+
+Read path: `merge_and_clear_pending_context` is called once before each
+real user turn (not resume / continuation / a directive call). It dedupes
+by resource URI (last-write-wins is inherent in the dict), renders a
+single delimited block, clears the bag, and the caller prepends the block
+to that turn's prompt only (kept out of persisted history + the cached
+system prefix, so prompt-cache stability is preserved).
+
+Inert unless `AGENTCORE_MCP_APPS_HOST_ENABLED=true` — app-api still relays,
+but with no live App nothing ever calls this.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Top-level Strands `agent.state` key that holds all MCP Apps host state.
+STATE_KEY = "mcp_apps"
+# Sub-key under STATE_KEY mapping resource_uri -> pending context entry.
+_CONTEXT_SUBKEY = "context"
+
+
+class AppContextUpdateError(Exception):
+    """Dispatch failed in a way the caller should surface as an error.
+
+    `code` is an app-api HTTP status hint; `message` is safe to return to
+    the client (no internals).
+    """
+
+    def __init__(self, message: str, code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def _strands_agent(agent: Any) -> Any:
+    """The inner Strands `Agent` (its `.state` is the `AgentState`).
+
+    `get_agent` returns a `BaseAgent` wrapper; the Strands agent is
+    `BaseAgent.agent` (set in `chat_agent._create_agent`).
+    """
+    strands_agent = getattr(agent, "agent", None)
+    if strands_agent is None or not hasattr(strands_agent, "state"):
+        raise AppContextUpdateError(
+            "Conversation agent has no state to update", code=409
+        )
+    return strands_agent
+
+
+def dispatch_app_context_update(
+    agent: Any,
+    *,
+    resource_uri: str,
+    content: Optional[List[Dict[str, Any]]],
+    structured_content: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Stash one app-pushed context update on the cached agent's state.
+
+    Last-write-wins per `resource_uri` (the dedupe key). Returns a small
+    JSON-able ack for app-api to relay to the iframe. Raises
+    `AppContextUpdateError` on a missing/un-serializable payload.
+    """
+    if content is None and structured_content is None:
+        raise AppContextUpdateError(
+            "ui/update-model-context requires content or structuredContent",
+            code=400,
+        )
+
+    strands_agent = _strands_agent(agent)
+
+    entry: Dict[str, Any] = {
+        "resourceUri": resource_uri,
+        "updatedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    if content is not None:
+        entry["content"] = content
+    if structured_content is not None:
+        entry["structuredContent"] = structured_content
+
+    # AgentState.get() deep-copies, so read-modify-write the whole bag.
+    bag: Dict[str, Any] = strands_agent.state.get(STATE_KEY) or {}
+    ctx: Dict[str, Any] = dict(bag.get(_CONTEXT_SUBKEY) or {})
+    ctx[resource_uri] = entry  # last-write-wins
+    bag[_CONTEXT_SUBKEY] = ctx
+
+    try:
+        strands_agent.state.set(STATE_KEY, bag)
+    except ValueError as exc:  # not JSON serializable
+        raise AppContextUpdateError(
+            "ui/update-model-context payload is not JSON serializable",
+            code=400,
+        ) from exc
+
+    logger.info(
+        "mcp-apps: stored model context (resource=%s, pending=%d)",
+        resource_uri,
+        len(ctx),
+    )
+    return {"resourceUri": resource_uri, "status": "stored", "pending": len(ctx)}
+
+
+def _render_entry(resource_uri: str, entry: Dict[str, Any]) -> str:
+    parts: List[str] = [f'<context resource="{resource_uri}">']
+    structured = entry.get("structuredContent")
+    if structured is not None:
+        try:
+            parts.append(json.dumps(structured, ensure_ascii=False, indent=2))
+        except (TypeError, ValueError):
+            parts.append(str(structured))
+    for block in entry.get("content") or []:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+                continue
+            try:
+                parts.append(json.dumps(block, ensure_ascii=False))
+            except (TypeError, ValueError):
+                parts.append(str(block))
+        else:
+            parts.append(str(block))
+    parts.append("</context>")
+    return "\n".join(parts)
+
+
+def merge_and_clear_pending_context(agent: Any) -> Optional[str]:
+    """Drain pending app-pushed context into a single prompt block.
+
+    Returns a delimited block to prepend to the current turn's prompt, or
+    `None` when nothing is pending. Clears the bag so each update reaches
+    the model exactly once. Never raises into the turn — context is
+    best-effort and must not break a conversation.
+    """
+    try:
+        strands_agent = _strands_agent(agent)
+    except AppContextUpdateError:
+        return None
+
+    try:
+        bag: Dict[str, Any] = strands_agent.state.get(STATE_KEY) or {}
+        ctx: Dict[str, Any] = bag.get(_CONTEXT_SUBKEY) or {}
+        if not ctx:
+            return None
+
+        rendered = "\n".join(
+            _render_entry(uri, entry) for uri, entry in ctx.items()
+        )
+
+        bag[_CONTEXT_SUBKEY] = {}
+        strands_agent.state.set(STATE_KEY, bag)
+    except Exception:  # noqa: BLE001 - context is best-effort, never fatal
+        logger.warning(
+            "mcp-apps: failed to merge pending model context", exc_info=True
+        )
+        return None
+
+    return (
+        "<mcp_app_context>\n"
+        "The user's embedded app(s) provided this context for the request "
+        "that follows. Treat it as authoritative app state, not as the "
+        "user's words.\n"
+        f"{rendered}\n"
+        "</mcp_app_context>"
+    )

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -49,6 +49,29 @@ class AppToolCallEntry(BaseModel):
     arguments: Dict[str, Any] = {}
 
 
+class AppContextUpdateEntry(BaseModel):
+    """App-supplied model context pushed via `ui/update-model-context`.
+
+    MCP Apps PR #6. The embedded App's JSON-RPC `ui/update-model-context`
+    is relayed by app-api to `/invocations` with this directive. Like
+    `app_tool_call` it runs NO model turn — it stashes the payload on the
+    conversation agent's Strands `agent.state` under
+    `mcp_apps.context[resource_uri]`. The next real user turn merges any
+    pending entries into that turn's prompt and clears them.
+
+    `resource_uri` is the bound MCP App resource (`ui://...`) and is the
+    dedupe key: the host keeps only the last update per resource between
+    turns (spec: "if multiple updates are received before the next user
+    message, Host SHOULD only send the last"). `content` /
+    `structured_content` mirror the spec's `ui/update-model-context`
+    params; at least one is set.
+    """
+
+    resource_uri: str
+    content: Optional[List[Dict[str, Any]]] = None
+    structured_content: Optional[Dict[str, Any]] = None
+
+
 class InvocationRequest(BaseModel):
     """Input for /invocations endpoint with multi-provider support"""
 
@@ -90,6 +113,11 @@ class InvocationRequest(BaseModel):
     # When set, this invocation is an app-initiated tools/call proxied from
     # an embedded MCP App (PR #5). `message` is ignored; no model turn runs.
     app_tool_call: Optional[AppToolCallEntry] = None
+    # When set, this invocation pushes app-supplied model context onto the
+    # conversation agent's state (PR #6, `ui/update-model-context`).
+    # `message` is ignored; no model turn runs. The context is merged into
+    # (and cleared before) the next real user turn's prompt.
+    app_context_update: Optional[AppContextUpdateEntry] = None
 
 
 class InvocationResponse(BaseModel):

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -41,6 +41,11 @@ from apis.shared.rbac.service import get_app_role_service
 from apis.shared.sessions.metadata import ensure_session_metadata_exists
 from apis.shared.user_settings.repository import UserSettingsRepository
 
+from .app_context_dispatch import (
+    AppContextUpdateError,
+    dispatch_app_context_update,
+    merge_and_clear_pending_context,
+)
 from .app_tool_dispatch import AppToolCallError, dispatch_app_tool_call
 from .models import FileContent, InvocationRequest
 from .service import generate_conversation_title, get_agent
@@ -732,6 +737,49 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             logger.error("app tools/call invocation failed", exc_info=True)
             return JSONResponse({"error": "Internal error"}, status_code=500)
 
+    # App-pushed model context (MCP Apps PR #6, `ui/update-model-context`).
+    # Like app_tool_call it bypasses quota / RAG / file resolution / title
+    # and runs NO model turn — we rebuild the conversation agent (so the
+    # same cached `agent.state` is reused) and stash the payload under
+    # `mcp_apps.context[resource_uri]`. The next real user turn merges and
+    # clears it. Inert behind the host flag (no live App ever calls this).
+    if input_data.app_context_update is not None:
+        acu = input_data.app_context_update
+        try:
+            request_inference_params = dict(input_data.inference_params or {})
+            caching_enabled, inference_params = await _resolve_model_settings(
+                model_id=input_data.model_id,
+                explicit_caching_enabled=input_data.caching_enabled,
+                request_inference_params=request_inference_params,
+            )
+            agent = await get_agent(
+                session_id=input_data.session_id,
+                user_id=user_id,
+                auth_token=auth_token,
+                enabled_tools=input_data.enabled_tools,
+                model_id=input_data.model_id,
+                system_prompt=input_data.system_prompt,
+                caching_enabled=caching_enabled,
+                provider=input_data.provider,
+                inference_params=inference_params,
+                agent_type=input_data.agent_type,
+                is_resume=False,
+            )
+            payload = dispatch_app_context_update(
+                agent,
+                resource_uri=acu.resource_uri,
+                content=acu.content,
+                structured_content=acu.structured_content,
+            )
+            return JSONResponse(payload)
+        except AppContextUpdateError as e:
+            return JSONResponse({"error": e.message}, status_code=e.code)
+        except HTTPException:
+            raise
+        except Exception:
+            logger.error("app context update invocation failed", exc_info=True)
+            return JSONResponse({"error": "Internal error"}, status_code=500)
+
     if input_data.enabled_tools:
         logger.info(f"Enabled tools ({len(input_data.enabled_tools)})")
 
@@ -1324,6 +1372,18 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 final_message = f"{final_message}\n\n{attachment_guidance}"
             if tabular_inventory:
                 final_message = f"{final_message}\n\n{tabular_inventory}"
+
+            # MCP Apps PR #6: drain any context an embedded App pushed via
+            # `ui/update-model-context` since the last turn and prepend it
+            # to this turn only. Skipped on resume/continuation (Strands
+            # ignores `final_message` there) so a pending update survives
+            # until the next real user turn instead of being silently
+            # cleared. Kept out of persisted history via the
+            # `original_message` path below (cache-prefix-safe).
+            if not is_resume and not is_continuation:
+                pending_ctx_block = merge_and_clear_pending_context(agent)
+                if pending_ctx_block:
+                    final_message = f"{pending_ctx_block}\n\n{final_message}"
 
             message_will_be_modified = (
                 final_message != input_data.message  # RAG augmentation / attachment guidance / inventory

--- a/backend/src/apis/shared/mcp_apps/card_store.py
+++ b/backend/src/apis/shared/mcp_apps/card_store.py
@@ -1,0 +1,230 @@
+"""Reload persistence for app-initiated tool-call cards (MCP Apps PR #6).
+
+PR #5's broker (`broker.py`) is in-memory only: when an embedded MCP App
+runs a server tool via `tools/call`, the synthesized `tool_use`/
+`tool_result` surface in the *live* conversation stream, but on a full
+page reload they're gone (the App iframe itself isn't re-instantiated on
+reload either). "Option A" of the scoping doc closes that gap with a
+side-channel store, mirroring the Artifacts feature: a small per-session
+provenance record the SPA replays as a *static historical card* on load.
+
+**This is provenance / UI only.** Model-visible state flows solely through
+`ui/update-model-context` (`app_context_dispatch.py`). We deliberately do
+NOT persist a synthetic tool turn into AgentCore Memory — that breaks
+Bedrock's user/assistant role alternation, a hazard this codebase has been
+bitten by (see `stream_coordinator` / max_tokens re-persist comments).
+
+Storage (decision #4): reuse the existing `sessions-metadata` DynamoDB
+table — its `SessionLookupIndex` GSI (`GSI_PK=SESSION#<id>`, Projection
+ALL) and the app-api task role's Query/Read grant already exist, so this
+needs **zero new infra**. New `APPCARD#` SK prefix, alongside the `C#`
+(cost) and `META` rows:
+
+    PK:     USER#<user_id>
+    SK:     APPCARD#<created_at>#<card_id>
+    GSI_PK: SESSION#<session_id>      (SessionLookupIndex)
+    GSI_SK: APPCARD#<created_at>
+
+The write stays on the **app-api boundary** (called from
+`/mcp-apps/proxy-call` after a successful dispatch) so inference-api keeps
+its inference-only scope. Dev/local has no table — every method degrades
+to a no-op / empty list, consistent with the whole MCP Apps surface being
+inert behind `AGENTCORE_MCP_APPS_HOST_ENABLED` until PR #7.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid as uuid_lib
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    Key = None  # type: ignore[assignment]
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# Cards expire with the conversation; 90d matches "conversation history"
+# retention expectations without keeping provenance forever.
+_CARD_TTL_DAYS = 90
+# DynamoDB item hard limit is 400KB; cap the embedded result well under
+# that so a chatty tool can't fail the write (or bloat hydration).
+_MAX_CONTENT_BYTES = 200_000
+_KEY_ATTRS = ("PK", "SK", "GSI_PK", "GSI_SK", "ttl")
+
+
+def _floats_to_decimal(obj: Any) -> Any:
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: _floats_to_decimal(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_floats_to_decimal(v) for v in obj]
+    return obj
+
+
+def _decimal_to_native(obj: Any) -> Any:
+    if isinstance(obj, Decimal):
+        # int when whole, else float — keeps message-index style fields tidy.
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    if isinstance(obj, dict):
+        return {k: _decimal_to_native(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_decimal_to_native(v) for v in obj]
+    return obj
+
+
+class AppCardStore:
+    """Per-session store of app-initiated tool-call provenance cards."""
+
+    def __init__(self) -> None:
+        self._table = None
+        if boto3 is None:
+            return
+        table_name = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+        if not table_name:
+            return
+        try:
+            self._table = boto3.resource("dynamodb").Table(table_name)
+        except Exception:  # noqa: BLE001 - dev without AWS creds
+            logger.warning(
+                "mcp-apps card store: DynamoDB unavailable; persistence "
+                "disabled (cards will be live-only).",
+                exc_info=True,
+            )
+            self._table = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._table is not None
+
+    def store(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        tool_use_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        content: List[Dict[str, Any]],
+        is_error: bool,
+        produced_by_message_index: Optional[int] = None,
+    ) -> None:
+        """Persist one app-initiated tool-call card. Best-effort.
+
+        Never raises into the proxy path — a failed provenance write must
+        not fail the tool call the App is waiting on (it still surfaced
+        live via the broker; only the reload card is lost).
+        """
+        if self._table is None:
+            return
+        created_at = datetime.now(timezone.utc).isoformat()
+        card_id = uuid_lib.uuid4().hex[:12]
+
+        safe_content = content
+        try:
+            import json
+
+            if len(json.dumps(content, ensure_ascii=False).encode()) > _MAX_CONTENT_BYTES:
+                safe_content = [
+                    {
+                        "type": "text",
+                        "text": "[result omitted from history — too large to persist]",
+                    }
+                ]
+        except (TypeError, ValueError):
+            safe_content = [
+                {"type": "text", "text": "[result not serializable for history]"}
+            ]
+
+        ttl = int(
+            (datetime.now(timezone.utc) + timedelta(days=_CARD_TTL_DAYS)).timestamp()
+        )
+        item = {
+            "PK": f"USER#{user_id}",
+            "SK": f"APPCARD#{created_at}#{card_id}",
+            "GSI_PK": f"SESSION#{session_id}",
+            "GSI_SK": f"APPCARD#{created_at}",
+            "userId": user_id,
+            "sessionId": session_id,
+            "cardId": card_id,
+            "toolUseId": tool_use_id,
+            "toolName": tool_name,
+            "arguments": arguments,
+            "content": safe_content,
+            "isError": is_error,
+            "createdAt": created_at,
+            "producedByMessageIndex": produced_by_message_index,
+            "ttl": ttl,
+        }
+        try:
+            self._table.put_item(Item=_floats_to_decimal(item))
+        except Exception:  # noqa: BLE001 - provenance is best-effort
+            logger.warning(
+                "mcp-apps card store: failed to persist card (session=%s)",
+                session_id,
+                exc_info=True,
+            )
+
+    def list_for_session(
+        self, *, session_id: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Return this user's app-initiated tool cards for a session.
+
+        Queried off the session GSI then re-filtered by `userId` so a
+        guessed session id can't surface another user's cards (mirrors the
+        Artifacts ownership re-check). Oldest-first for stable rendering.
+        """
+        if self._table is None:
+            return []
+        try:
+            items: List[Dict[str, Any]] = []
+            kwargs: Dict[str, Any] = {
+                "IndexName": "SessionLookupIndex",
+                "KeyConditionExpression": Key("GSI_PK").eq(f"SESSION#{session_id}")
+                & Key("GSI_SK").begins_with("APPCARD#"),
+                "ScanIndexForward": True,
+            }
+            while True:
+                resp = self._table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                lek = resp.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                kwargs["ExclusiveStartKey"] = lek
+        except ClientError:
+            logger.warning(
+                "mcp-apps card store: query failed (session=%s)",
+                session_id,
+                exc_info=True,
+            )
+            return []
+
+        cards: List[Dict[str, Any]] = []
+        for raw in items:
+            if raw.get("userId") != user_id:
+                continue  # ownership re-check (guessed session id)
+            card = _decimal_to_native(
+                {k: v for k, v in raw.items() if k not in _KEY_ATTRS}
+            )
+            cards.append(card)
+        return cards
+
+
+_store: Optional[AppCardStore] = None
+
+
+def get_app_card_store() -> AppCardStore:
+    """Get or create the process-global card store."""
+    global _store
+    if _store is None:
+        _store = AppCardStore()
+    return _store

--- a/backend/tests/apis/app_api/test_mcp_apps_update_context.py
+++ b/backend/tests/apis/app_api/test_mcp_apps_update_context.py
@@ -1,0 +1,125 @@
+"""Tests for the cookie-authenticated ui/update-model-context relay (PR #6).
+
+Mirrors `test_mcp_apps_proxy_call.py`: the upstream client seam is swapped
+for a MockTransport so the relay to inference-api `/invocations` is
+asserted without a network.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Optional
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.chat import proxy_routes
+from apis.app_api.mcp_apps.routes import router as mcp_apps_router
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+
+
+def _user(raw_token: str = "access.token.value") -> User:
+    user = User(
+        email="alice@example.com",
+        user_id="user-sub",
+        name="Alice",
+        roles=["user"],
+    )
+    user.raw_token = raw_token
+    return user
+
+
+def _build_app(*, user_override: Optional[User] = None) -> FastAPI:
+    app = FastAPI()
+    app.include_router(mcp_apps_router)
+    if user_override is not None:
+        app.dependency_overrides[get_current_user_from_session] = (
+            lambda: user_override
+        )
+    return app
+
+
+def _patch_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        proxy_routes,
+        "_build_upstream_client",
+        lambda: httpx.AsyncClient(transport=transport),
+    )
+
+
+_BODY = {
+    "sessionId": "sess-1",
+    "resourceUri": "ui://srv/widget",
+    "content": [{"type": "text", "text": "user picked X"}],
+    "structuredContent": {"selection": "X"},
+    "enabledTools": ["gateway_widget"],
+    "modelId": "m1",
+}
+
+
+def test_requires_session() -> None:
+    resp = TestClient(_build_app()).post("/mcp-apps/update-context", json=_BODY)
+    assert resp.status_code == 401
+
+
+def test_relays_directive_and_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization")
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"resourceUri": "ui://srv/widget", "status": "stored"}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user("tok-xyz"))
+
+    resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "stored"
+    assert seen["url"].endswith("/invocations")
+    assert seen["auth"] == "Bearer tok-xyz"
+    assert seen["body"]["session_id"] == "sess-1"
+    assert seen["body"]["enabled_tools"] == ["gateway_widget"]
+    assert seen["body"]["app_context_update"] == {
+        "resource_uri": "ui://srv/widget",
+        "content": [{"type": "text", "text": "user picked X"}],
+        "structured_content": {"selection": "X"},
+    }
+
+
+def test_relays_inference_error_status_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "needs content"})
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "needs content"
+
+
+def test_maps_unreachable_inference_to_502(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
+    assert resp.status_code == 502

--- a/backend/tests/apis/inference_api/test_app_context_dispatch.py
+++ b/backend/tests/apis/inference_api/test_app_context_dispatch.py
@@ -1,0 +1,137 @@
+"""Tests for app-pushed model context dispatch (MCP Apps PR #6).
+
+Uses a fake that faithfully mimics strands 1.40 `AgentState`: `.get()`
+returns a deep copy (so the read-modify-write path is genuinely
+exercised) and `.set()` enforces JSON-serializability. No live agent.
+"""
+
+import copy
+import json
+
+import pytest
+
+from apis.inference_api.chat.app_context_dispatch import (
+    STATE_KEY,
+    AppContextUpdateError,
+    dispatch_app_context_update,
+    merge_and_clear_pending_context,
+)
+
+
+class _FakeState:
+    """Mimics strands.agent.state.AgentState get/set semantics."""
+
+    def __init__(self) -> None:
+        self._data: dict = {}
+
+    def get(self, key=None):
+        if key is None:
+            return copy.deepcopy(self._data)
+        return copy.deepcopy(self._data.get(key))
+
+    def set(self, key: str, value) -> None:
+        json.dumps(value)  # raises TypeError/ValueError if not serializable
+        self._data[key] = copy.deepcopy(value)
+
+
+class _FakeStrands:
+    def __init__(self) -> None:
+        self.state = _FakeState()
+
+
+class _FakeAgent:
+    """BaseAgent wrapper — inner Strands agent is `.agent`."""
+
+    def __init__(self) -> None:
+        self.agent = _FakeStrands()
+
+
+def test_dispatch_writes_under_resource_uri_and_acks():
+    agent = _FakeAgent()
+    ack = dispatch_app_context_update(
+        agent,
+        resource_uri="ui://srv/widget",
+        content=[{"type": "text", "text": "hello"}],
+        structured_content={"count": 2},
+    )
+    assert ack == {
+        "resourceUri": "ui://srv/widget",
+        "status": "stored",
+        "pending": 1,
+    }
+    bag = agent.agent.state.get(STATE_KEY)
+    entry = bag["context"]["ui://srv/widget"]
+    assert entry["content"] == [{"type": "text", "text": "hello"}]
+    assert entry["structuredContent"] == {"count": 2}
+    assert "updatedAt" in entry
+
+
+def test_last_write_wins_per_resource_uri():
+    agent = _FakeAgent()
+    dispatch_app_context_update(
+        agent, resource_uri="ui://a", content=None, structured_content={"v": 1}
+    )
+    ack = dispatch_app_context_update(
+        agent, resource_uri="ui://a", content=None, structured_content={"v": 2}
+    )
+    assert ack["pending"] == 1  # same uri overwrote, not appended
+    bag = agent.agent.state.get(STATE_KEY)
+    assert bag["context"]["ui://a"]["structuredContent"] == {"v": 2}
+
+
+def test_requires_content_or_structured():
+    with pytest.raises(AppContextUpdateError) as ei:
+        dispatch_app_context_update(
+            _FakeAgent(), resource_uri="ui://a", content=None, structured_content=None
+        )
+    assert ei.value.code == 400
+
+
+def test_missing_agent_state_is_409():
+    class _NoState:
+        agent = None
+
+    with pytest.raises(AppContextUpdateError) as ei:
+        dispatch_app_context_update(
+            _NoState(), resource_uri="ui://a", content=None,
+            structured_content={"x": 1},
+        )
+    assert ei.value.code == 409
+
+
+def test_merge_drains_clears_and_dedupes_by_uri():
+    agent = _FakeAgent()
+    dispatch_app_context_update(
+        agent, resource_uri="ui://a", content=None,
+        structured_content={"a": 1},
+    )
+    dispatch_app_context_update(
+        agent,
+        resource_uri="ui://b",
+        content=[{"type": "text", "text": "note-b"}],
+        structured_content=None,
+    )
+
+    block = merge_and_clear_pending_context(agent)
+    assert block is not None
+    assert "<mcp_app_context>" in block and "</mcp_app_context>" in block
+    assert 'resource="ui://a"' in block
+    assert 'resource="ui://b"' in block
+    assert "note-b" in block
+    assert '"a": 1' in block
+
+    # Cleared: a second merge with no new updates yields nothing.
+    assert merge_and_clear_pending_context(agent) is None
+
+
+def test_merge_empty_returns_none():
+    assert merge_and_clear_pending_context(_FakeAgent()) is None
+
+
+def test_merge_never_raises_on_bad_agent():
+    class _Broken:
+        agent = None
+
+    # _strands_agent would raise AppContextUpdateError(409); merge swallows
+    # it (context is best-effort and must never break a turn).
+    assert merge_and_clear_pending_context(_Broken()) is None

--- a/backend/tests/shared/test_mcp_apps_card_store.py
+++ b/backend/tests/shared/test_mcp_apps_card_store.py
@@ -1,0 +1,128 @@
+"""Tests for the app-initiated tool-card store (MCP Apps PR #6, Option A).
+
+The store reuses the existing `sessions-metadata` table. No DynamoDB in
+tests — the no-table path is a silent no-op (matches dev), and a fake
+table asserts the record shape, the ownership re-check, and the size cap.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from apis.shared.mcp_apps.card_store import AppCardStore
+
+
+class _FakeTable:
+    def __init__(self, items=None) -> None:
+        self.items = items or []
+        self.puts: list = []
+
+    def put_item(self, Item):  # noqa: N803 - boto3 kwarg name
+        self.puts.append(Item)
+
+    def query(self, **kwargs):
+        return {"Items": self.items}
+
+
+def _store_with(table) -> AppCardStore:
+    s = AppCardStore()  # __init__ sets _table=None without the env var
+    s._table = table
+    return s
+
+
+def test_no_table_is_silent_noop():
+    s = AppCardStore()
+    assert s.enabled is False
+    # Must not raise.
+    s.store(
+        user_id="u1",
+        session_id="s1",
+        tool_use_id="tu1",
+        tool_name="t",
+        arguments={},
+        content=[],
+        is_error=False,
+    )
+    assert s.list_for_session(session_id="s1", user_id="u1") == []
+
+
+def test_store_writes_appcard_record_shape():
+    table = _FakeTable()
+    s = _store_with(table)
+    s.store(
+        user_id="u1",
+        session_id="s1",
+        tool_use_id="tu1",
+        tool_name="widget_tool",
+        arguments={"q": "x", "n": 1.5},
+        content=[{"type": "text", "text": "ok"}],
+        is_error=False,
+    )
+    assert len(table.puts) == 1
+    item = table.puts[0]
+    assert item["PK"] == "USER#u1"
+    assert item["SK"].startswith("APPCARD#")
+    assert item["GSI_PK"] == "SESSION#s1"
+    assert item["GSI_SK"].startswith("APPCARD#")
+    assert item["toolName"] == "widget_tool"
+    assert item["isError"] is False
+    # floats are stored as Decimal for DynamoDB.
+    assert item["arguments"]["n"] == Decimal("1.5")
+    assert "ttl" in item
+
+
+def test_store_caps_oversized_content():
+    table = _FakeTable()
+    s = _store_with(table)
+    huge = [{"type": "text", "text": "z" * 300_000}]
+    s.store(
+        user_id="u1",
+        session_id="s1",
+        tool_use_id="tu1",
+        tool_name="t",
+        arguments={},
+        content=huge,
+        is_error=False,
+    )
+    stored = table.puts[0]["content"]
+    assert stored == [
+        {"type": "text", "text": "[result omitted from history — too large to persist]"}
+    ]
+
+
+def test_list_filters_by_owner_and_cleans_record():
+    items = [
+        {
+            "PK": "USER#u1",
+            "SK": "APPCARD#2026-01-01T00:00:00#aaa",
+            "GSI_PK": "SESSION#s1",
+            "GSI_SK": "APPCARD#2026-01-01T00:00:00",
+            "ttl": 123,
+            "userId": "u1",
+            "sessionId": "s1",
+            "toolName": "mine",
+            "isError": False,
+            "producedByMessageIndex": Decimal("4"),
+        },
+        {
+            "PK": "USER#someone-else",
+            "SK": "APPCARD#2026-01-01T00:00:01#bbb",
+            "GSI_PK": "SESSION#s1",
+            "GSI_SK": "APPCARD#2026-01-01T00:00:01",
+            "userId": "other",
+            "toolName": "not-mine",
+            "isError": False,
+        },
+    ]
+    s = _store_with(_FakeTable(items))
+    cards = s.list_for_session(session_id="s1", user_id="u1")
+
+    assert len(cards) == 1
+    card = cards[0]
+    assert card["toolName"] == "mine"
+    # Key attributes are stripped from the returned card.
+    for k in ("PK", "SK", "GSI_PK", "GSI_SK", "ttl"):
+        assert k not in card
+    # Decimals are converted back to native ints/floats.
+    assert card["producedByMessageIndex"] == 4
+    assert isinstance(card["producedByMessageIndex"], int)

--- a/frontend/ai.client/src/app/session/components/message-list/components/mcp-app-card/mcp-app-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/mcp-app-card/mcp-app-card.component.ts
@@ -1,0 +1,103 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroExclamationTriangle,
+  heroPuzzlePiece,
+} from '@ng-icons/heroicons/outline';
+import type { McpAppCard } from '../../../../services/mcp-apps/mcp-app-card-state.service';
+
+/**
+ * Static historical card for an app-initiated tool call (MCP Apps PR #6,
+ * Option A). Rendered on reload from persisted provenance — read-only by
+ * design: the App iframe itself is not re-instantiated, so this records
+ * *what the embedded app ran on the user's behalf*, not an interactive
+ * surface. Live app-initiated calls render through the normal tool path
+ * (PR #5); this only appears after a refresh.
+ */
+@Component({
+  selector: 'app-mcp-app-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({ heroExclamationTriangle, heroPuzzlePiece }),
+  ],
+  host: { class: 'block' },
+  template: `
+    <div
+      class="flex max-w-xl flex-col gap-1.5 rounded-lg border border-gray-200/80 bg-white px-3 py-2 text-sm dark:border-white/10 dark:bg-slate-800/70"
+      role="group"
+      [attr.aria-label]="'App ran ' + card().toolName"
+    >
+      <div class="flex items-center gap-2">
+        <ng-icon
+          name="heroPuzzlePiece"
+          class="size-4 shrink-0 text-primary-600 dark:text-primary-300"
+          aria-hidden="true"
+        />
+        <span
+          class="text-[10px] font-semibold uppercase tracking-[0.08em] text-primary-600 dark:text-primary-300"
+        >
+          Ran by app
+        </span>
+        <span
+          class="truncate font-mono text-xs text-gray-900 dark:text-gray-100"
+        >
+          {{ card().toolName }}
+        </span>
+        @if (card().isError) {
+          <ng-icon
+            name="heroExclamationTriangle"
+            class="size-4 shrink-0 text-red-600 dark:text-red-400"
+            [attr.aria-label]="'errored'"
+          />
+        }
+      </div>
+
+      @if (argsPreview(); as args) {
+        <pre
+          class="overflow-x-auto rounded bg-gray-50 px-2 py-1 text-[11px] leading-relaxed text-gray-700 dark:bg-slate-900 dark:text-gray-300"
+        >{{ args }}</pre>
+      }
+
+      @if (resultText(); as text) {
+        <p
+          class="whitespace-pre-wrap text-xs/5 text-gray-700 dark:text-gray-300"
+        >
+          {{ text }}
+        </p>
+      }
+    </div>
+  `,
+})
+export class McpAppCardComponent {
+  readonly card = input.required<McpAppCard>();
+
+  protected readonly argsPreview = computed<string | null>(() => {
+    const args = this.card().arguments;
+    if (!args || Object.keys(args).length === 0) return null;
+    let text: string;
+    try {
+      text = JSON.stringify(args);
+    } catch {
+      return null;
+    }
+    return text.length > 300 ? `${text.slice(0, 300)}…` : text;
+  });
+
+  protected readonly resultText = computed<string | null>(() => {
+    const blocks = this.card().content ?? [];
+    const parts: string[] = [];
+    for (const block of blocks) {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === 'string' && text) parts.push(text);
+    }
+    const joined = parts.join('\n').trim();
+    if (!joined) return null;
+    return joined.length > 500 ? `${joined.slice(0, 500)}…` : joined;
+  });
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/mcp-app-consent-prompt/mcp-app-consent-prompt.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/mcp-app-consent-prompt/mcp-app-consent-prompt.component.ts
@@ -1,0 +1,227 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowTopRightOnSquare,
+  heroCheck,
+  heroShieldCheck,
+  heroVideoCamera,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import {
+  McpAppConsentService,
+  PendingConsent,
+} from '../../../../services/mcp-apps/mcp-app-consent.service';
+
+/**
+ * Inline consent prompt for an App-initiated action (MCP Apps PR #6).
+ *
+ * Frontend-only: the request came from a postMessage on the embedded App,
+ * not a backend turn, so this is purely a client gate (see
+ * {@link McpAppConsentService}). Visually mirrors the OAuth consent prompt
+ * so the two read as one family; renders in the message-list strip with
+ * the unanchored OAuth prompts.
+ */
+@Component({
+  selector: 'app-mcp-app-consent-prompt',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({
+      heroArrowTopRightOnSquare,
+      heroCheck,
+      heroShieldCheck,
+      heroVideoCamera,
+      heroXMark,
+    }),
+  ],
+  host: { class: 'block' },
+  template: `
+    <div
+      class="mcp-consent group relative flex max-w-xl items-center gap-2.5 overflow-hidden rounded-lg border border-gray-200/80 bg-white py-1.5 pr-1.5 pl-3 shadow-[0_1px_2px_rgba(15,23,42,0.04)] dark:border-white/10 dark:bg-slate-800/70"
+      role="region"
+      aria-live="polite"
+      [attr.aria-label]="ariaLabel()"
+    >
+      <span
+        class="absolute inset-y-0 left-0 w-[2px] bg-primary-500 dark:bg-primary-400"
+        aria-hidden="true"
+      ></span>
+
+      <div
+        class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-50 ring-1 ring-gray-200/70 dark:bg-slate-900 dark:ring-white/10"
+      >
+        <ng-icon
+          [name]="isLink() ? 'heroArrowTopRightOnSquare' : 'heroVideoCamera'"
+          class="size-5 text-gray-700 dark:text-gray-300"
+          aria-hidden="true"
+        />
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <p
+          class="inline-flex items-center gap-1 text-[10px] leading-none font-semibold uppercase tracking-[0.08em] text-primary-600 dark:text-primary-300"
+        >
+          <ng-icon name="heroShieldCheck" class="size-3" aria-hidden="true" />
+          Permission requested
+        </p>
+        <p class="truncate text-xs/5 text-gray-900 dark:text-gray-100">
+          @if (isLink()) {
+            This app wants to open
+            <span class="font-semibold">{{ linkHost() }}</span>
+          } @else {
+            This app requests
+            <span class="font-semibold">{{ capabilityList() }}</span>
+          }
+        </p>
+      </div>
+
+      <div class="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          (click)="allow()"
+          class="action-btn"
+          [attr.aria-label]="'Allow: ' + summary()"
+        >
+          <ng-icon name="heroCheck" class="size-3" aria-hidden="true" />
+          <span>Allow</span>
+        </button>
+        <button
+          type="button"
+          (click)="deny()"
+          class="dismiss-btn flex size-6 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/10 dark:hover:text-gray-200"
+          [attr.aria-label]="'Deny: ' + summary()"
+        >
+          <ng-icon name="heroXMark" class="size-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import 'tailwindcss';
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    :host {
+      display: block;
+    }
+
+    .mcp-consent {
+      animation: mcp-consent-rise 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .mcp-consent p {
+      margin-bottom: 0;
+    }
+
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.625rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: white;
+      background: var(--color-secondary-500);
+      transition:
+        background-color 120ms ease,
+        transform 120ms ease;
+    }
+
+    .action-btn:hover {
+      background: var(--color-secondary-600);
+    }
+
+    .action-btn:active {
+      transform: translateY(1px);
+    }
+
+    .action-btn:focus-visible {
+      outline: 2px solid var(--color-secondary-500);
+      outline-offset: 2px;
+    }
+
+    .dismiss-btn {
+      opacity: 0;
+    }
+
+    .group:hover .dismiss-btn,
+    .group:focus-within .dismiss-btn {
+      opacity: 1;
+    }
+
+    @keyframes mcp-consent-rise {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .mcp-consent {
+        animation: none;
+      }
+      .action-btn {
+        transition: none;
+      }
+    }
+  `,
+})
+export class McpAppConsentPromptComponent {
+  readonly prompt = input.required<PendingConsent>();
+
+  private readonly consentService = inject(McpAppConsentService);
+
+  protected readonly isLink = computed(
+    () => this.prompt().request.kind === 'open-link',
+  );
+
+  protected readonly linkHost = computed<string>(() => {
+    const req = this.prompt().request;
+    if (req.kind !== 'open-link') return '';
+    try {
+      return new URL(req.url).host;
+    } catch {
+      return req.url;
+    }
+  });
+
+  protected readonly capabilityList = computed<string>(() => {
+    const req = this.prompt().request;
+    if (req.kind !== 'capabilities') return '';
+    const labels: Record<string, string> = {
+      camera: 'camera',
+      microphone: 'microphone',
+      geolocation: 'location',
+      clipboardWrite: 'clipboard',
+    };
+    return req.capabilities.map((c) => labels[c] ?? c).join(', ');
+  });
+
+  protected readonly summary = computed<string>(() =>
+    this.isLink()
+      ? `open ${this.linkHost()}`
+      : `${this.capabilityList()} access`,
+  );
+
+  protected readonly ariaLabel = computed<string>(
+    () => `App permission requested: ${this.summary()}`,
+  );
+
+  allow(): void {
+    this.consentService.answer(this.prompt().id, true);
+  }
+
+  deny(): void {
+    this.consentService.answer(this.prompt().id, false);
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -21,6 +21,11 @@ import { StreamParserService } from '../../../../../services/chat/stream-parser.
 import { ThemeService } from '../../../../../../components/topnav/components/theme-toggle/theme.service';
 import { McpAppBridge } from '../../../../../services/mcp-apps/mcp-app-bridge';
 import { McpAppProxyService } from '../../../../../services/mcp-apps/mcp-app-proxy.service';
+import { McpAppMessageService } from '../../../../../services/mcp-apps/mcp-app-message.service';
+import { McpAppConsentService } from '../../../../../services/mcp-apps/mcp-app-consent.service';
+import type { CapabilityKey } from '../../../../../services/mcp-apps/mcp-app-protocol';
+import { ChatRequestService } from '../../../../../services/chat/chat-request.service';
+import { SessionService } from '../../../../../services/session/session.service';
 
 /**
  * MCP App renderer (SEP-1865), PR #4 of
@@ -73,6 +78,10 @@ export class McpAppFrameComponent implements ToolResultRenderer {
 
   private readonly mcpAppState = inject(McpAppStateService);
   private readonly mcpAppProxy = inject(McpAppProxyService);
+  private readonly mcpAppMessage = inject(McpAppMessageService);
+  private readonly mcpAppConsent = inject(McpAppConsentService);
+  private readonly chatRequest = inject(ChatRequestService);
+  private readonly conversation = inject(SessionService);
   private readonly streamParser = inject(StreamParserService);
   private readonly theme = inject(ThemeService);
   private readonly sanitizer = inject(DomSanitizer);
@@ -95,9 +104,45 @@ export class McpAppFrameComponent implements ToolResultRenderer {
     return id ? this.mcpAppState.get(id) : undefined;
   });
 
+  /** Capabilities the resource declares (`_meta.ui.permissions`). */
+  private readonly requestedCaps = computed<CapabilityKey[]>(() => {
+    const p = this.resource()?.permissions ?? {};
+    const caps: CapabilityKey[] = [];
+    if (p.camera) caps.push('camera');
+    if (p.microphone) caps.push('microphone');
+    if (p.geolocation) caps.push('geolocation');
+    if (p.clipboardWrite) caps.push('clipboardWrite');
+    return caps;
+  });
+
+  /**
+   * Render-time capability consent (PR #6). `null` = undecided. When the
+   * resource requests sensitive sandbox features we hold the frame until
+   * the user answers an inline prompt, then grant only what was approved
+   * (all-or-nothing for v1). Frontend-only — the request never reaches a
+   * backend turn, same justification as `McpAppConsentService`.
+   */
+  private readonly capabilityGrant = signal<boolean | null>(null);
+  private capabilityAsked = false;
+
+  /** True once requested capabilities are decided (or none were asked). */
+  private readonly capabilitiesResolved = computed(
+    () => this.requestedCaps().length === 0 || this.capabilityGrant() !== null,
+  );
+
+  /** Permissions actually applied to the frame: declared ∩ consent. */
+  private readonly effectivePermissions = computed(() => {
+    const declared = this.resource()?.permissions ?? {};
+    if (this.requestedCaps().length === 0) return declared;
+    return this.capabilityGrant() ? declared : {};
+  });
+
   protected readonly safeProxyUrl = computed<SafeResourceUrl | null>(() => {
     const res = this.resource();
     if (!res || !res.sandboxOrigin) return null;
+    // Hold the frame until the user has answered the capability prompt —
+    // building it later would race the proxy's sandbox-resource-ready.
+    if (!this.capabilitiesResolved()) return null;
     // Trusted single value from our authenticated backend (SSM-sourced);
     // the sandbox attribute + the proxy's per-resource CSP are the real
     // containment, same justification as the artifact panel.
@@ -108,7 +153,7 @@ export class McpAppFrameComponent implements ToolResultRenderer {
 
   /** Permissions-Policy `allow` for the outer frame (delegates to inner). */
   protected readonly allowAttr = computed(() => {
-    const p = this.resource()?.permissions ?? {};
+    const p = this.effectivePermissions();
     const feats: string[] = [];
     if (p.camera) feats.push('camera');
     if (p.microphone) feats.push('microphone');
@@ -128,17 +173,33 @@ export class McpAppFrameComponent implements ToolResultRenderer {
       this.result();
       this.bridge?.refreshToolResult();
     });
+    // Render-time capability consent: when the resource requests sensitive
+    // sandbox features, ask once and hold the frame until answered.
+    effect(() => {
+      const caps = this.requestedCaps();
+      if (caps.length === 0 || this.capabilityAsked) return;
+      this.capabilityAsked = true;
+      this.mcpAppConsent
+        .request({ kind: 'capabilities', capabilities: caps })
+        .then((granted) => this.capabilityGrant.set(granted))
+        .catch(() => this.capabilityGrant.set(false));
+    });
     this.destroyRef.onDestroy(() => this.bridge?.dispose('component-destroyed'));
   }
 
   protected onProxyLoad(): void {
     const res = this.resource();
     if (!res || this.bridge || !this.win) return;
+    // Hand the bridge a resource whose permissions are already narrowed to
+    // what the user consented to, so sandbox-resource-ready + the
+    // initialize `hostCapabilities.sandbox.permissions` advertise only the
+    // granted subset (consistent with the outer iframe's `allow`).
+    const effectiveRes = { ...res, permissions: this.effectivePermissions() };
     this.bridge = new McpAppBridge({
       hostWindow: this.win,
       getProxyWindow: () => this.frameRef()?.nativeElement.contentWindow ?? null,
       sandboxOrigin: res.sandboxOrigin.replace(/\/$/, ''),
-      resource: res,
+      resource: effectiveRes,
       nonce: this.nonce,
       getToolInput: () => this.lookupToolInput(),
       getToolResult: () => this.toCallToolResult(),
@@ -156,6 +217,14 @@ export class McpAppFrameComponent implements ToolResultRenderer {
           toolName,
           args,
         ),
+      sendMessage: (text) =>
+        this.chatRequest.submitChatRequest(
+          text,
+          this.conversation.currentSession().sessionId || null,
+        ),
+      updateModelContext: (payload) =>
+        this.mcpAppMessage.updateModelContext(res.resourceUri, payload),
+      requestConsent: (req) => this.mcpAppConsent.request(req),
     });
     this.bridge.onSizeChanged((_w, h) => {
       if (h > 0) this.frameHeight.set(Math.ceil(h));

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -94,6 +94,31 @@
     </div>
   }
 
+  <!-- Frontend-only consent for App-initiated open-link / capability
+       requests (PR #6). These originate from a postMessage on the embedded
+       App, not a backend turn, so they live entirely client-side and are
+       not persisted (transient interaction gates). -->
+  @for (prompt of mcpConsentPrompts(); track prompt.id) {
+    <div class="flex justify-start">
+      <app-mcp-app-consent-prompt [prompt]="prompt" />
+    </div>
+  }
+
+  <!-- Static historical cards for app-initiated tool calls (PR #6,
+       Option A). The PR #5 broker is in-memory, so on reload the live
+       tool_use/tool_result are gone; these replay them as a read-only
+       record at the end of the conversation. -->
+  @if (hasMcpAppCards()) {
+    <section
+      class="mt-3 flex flex-col gap-2"
+      aria-label="Tool calls run by embedded apps in this conversation"
+    >
+      @for (card of mcpAppCards(); track card.cardId) {
+        <app-mcp-app-card [card]="card" />
+      }
+    </section>
+  }
+
   <!-- Per-tool approval prompts (catalog-flagged needs_approval). Tied to
        the live SSE turn; refresh during the prompt orphans it. -->
   @for (request of pendingToolApprovals(); track request.interruptId) {

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -14,6 +14,10 @@ import { CompactionSummaryComponent } from './components/compaction-summary/comp
 import { ArtifactCardComponent } from './components/artifact/artifact-card.component';
 import { ArtifactPanelComponent } from './components/artifact/artifact-panel.component';
 import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
+import { McpAppConsentPromptComponent } from './components/mcp-app-consent-prompt/mcp-app-consent-prompt.component';
+import { McpAppCardComponent } from './components/mcp-app-card/mcp-app-card.component';
+import { McpAppConsentService } from '../../services/mcp-apps/mcp-app-consent.service';
+import { McpAppCardStateService } from '../../services/mcp-apps/mcp-app-card-state.service';
 import {
   OAuthConsentRequest,
   OAuthConsentService,
@@ -39,6 +43,8 @@ import { ChatStateService } from '../../services/chat/chat-state.service';
     CompactionSummaryComponent,
     ArtifactCardComponent,
     ArtifactPanelComponent,
+    McpAppConsentPromptComponent,
+    McpAppCardComponent,
   ],
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
@@ -66,7 +72,15 @@ export class MessageListComponent implements OnDestroy {
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
+  private mcpAppConsent = inject(McpAppConsentService);
+  private mcpAppCardState = inject(McpAppCardStateService);
   private chatStateService = inject(ChatStateService);
+
+  /** Pending frontend-only MCP App consent prompts (PR #6). */
+  protected mcpConsentPrompts = this.mcpAppConsent.pending;
+  /** Persisted app-initiated tool cards, hydrated on reload (PR #6). */
+  protected mcpAppCards = this.mcpAppCardState.cards;
+  protected hasMcpAppCards = this.mcpAppCardState.hasCards;
 
   /** Only the final message of a recoverable max_tokens turn gets the
    *  "Continue" affordance. Live-only state, never shown while a new

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -61,11 +61,16 @@ interface Harness {
   proxy: FakeProxyWindow;
   openLink: ReturnType<typeof vi.fn>;
   proxyToolCall: ReturnType<typeof vi.fn>;
+  sendMessage: ReturnType<typeof vi.fn>;
+  updateModelContext: ReturnType<typeof vi.fn>;
+  requestConsent: ReturnType<typeof vi.fn>;
   warn: ReturnType<typeof vi.fn>;
   toolResult: { value: unknown | null };
 }
 
-function makeBridge(opts: { withProxy?: boolean } = {}): Harness {
+function makeBridge(
+  opts: { withProxy?: boolean; pr6?: boolean } = {},
+): Harness {
   const host = new FakeHostWindow();
   const proxy = new FakeProxyWindow();
   const openLink = vi.fn();
@@ -73,6 +78,12 @@ function makeBridge(opts: { withProxy?: boolean } = {}): Harness {
     content: [{ type: 'text', text: 'tool-ok' }],
     isError: false,
   }));
+  // PR #6 deps. Wired only when opts.pr6 — otherwise the bridge must
+  // degrade per JSON-RPC (method-not-found / direct open) so older hosts
+  // keep working.
+  const sendMessage = vi.fn(async () => undefined);
+  const updateModelContext = vi.fn(async () => undefined);
+  const requestConsent = vi.fn(async () => true);
   const warn = vi.fn();
   const toolResult: { value: unknown | null } = {
     value: { content: [{ type: 'text', text: 'ok' }], isError: false },
@@ -89,10 +100,22 @@ function makeBridge(opts: { withProxy?: boolean } = {}): Harness {
     openLink,
     // Default harness can proxy; opt out to assert the no-capability path.
     ...(opts.withProxy === false ? {} : { proxyToolCall }),
+    ...(opts.pr6 ? { sendMessage, updateModelContext, requestConsent } : {}),
     onWarn: warn,
   });
   bridge.start();
-  return { bridge, host, proxy, openLink, proxyToolCall, warn, toolResult };
+  return {
+    bridge,
+    host,
+    proxy,
+    openLink,
+    proxyToolCall,
+    sendMessage,
+    updateModelContext,
+    requestConsent,
+    warn,
+    toolResult,
+  };
 }
 
 /** Drive the handshake up to (but not including) `initialized`. */
@@ -252,7 +275,10 @@ describe('McpAppBridge', () => {
     });
   });
 
-  it('answers PR #6 methods (ui/message, ui/update-model-context) with method-not-found', () => {
+  it('degrades ui/message + ui/update-model-context to method-not-found when the host lacks the deps', () => {
+    // Default harness wires no PR #6 deps → an older host that doesn't
+    // support these methods. Per JSON-RPC the App should get -32601 and
+    // fall back, regardless of payload.
     handshake(h);
     for (const [id, method] of [
       ['m1', 'ui/message'],
@@ -264,6 +290,139 @@ describe('McpAppBridge', () => {
       );
       expect(h.proxy.byId(id).error.code).toBe(-32601);
     }
+  });
+
+  describe('PR #6 — implemented (deps wired)', () => {
+    let p: Harness;
+    beforeEach(() => {
+      p = makeBridge({ pr6: true });
+      handshake(p);
+    });
+
+    it('ui/message relays a valid user text as a real turn', async () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'm1',
+          method: 'ui/message',
+          nonce: NONCE,
+          params: { role: 'user', content: { type: 'text', text: '  hi  ' } },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(p.sendMessage).toHaveBeenCalledWith('hi');
+      expect(p.proxy.byId('m1').result).toEqual({});
+    });
+
+    it('ui/message with bad params is invalid-params (-32000), not relayed', () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'm2',
+          method: 'ui/message',
+          nonce: NONCE,
+          params: { role: 'assistant' },
+        },
+        p.proxy,
+      );
+      expect(p.sendMessage).not.toHaveBeenCalled();
+      expect(p.proxy.byId('m2').error.code).toBe(-32000);
+    });
+
+    it('ui/update-model-context relays structuredContent', async () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'c1',
+          method: 'ui/update-model-context',
+          nonce: NONCE,
+          params: { structuredContent: { picked: 'X' } },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(p.updateModelContext).toHaveBeenCalledWith({
+        content: undefined,
+        structuredContent: { picked: 'X' },
+      });
+      expect(p.proxy.byId('c1').result).toEqual({});
+    });
+
+    it('ui/update-model-context with neither content nor structured is -32000', () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'c2',
+          method: 'ui/update-model-context',
+          nonce: NONCE,
+          params: {},
+        },
+        p.proxy,
+      );
+      expect(p.updateModelContext).not.toHaveBeenCalled();
+      expect(p.proxy.byId('c2').error.code).toBe(-32000);
+    });
+
+    it('ui/open-link asks for consent and opens only when granted', async () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'l1',
+          method: 'ui/open-link',
+          nonce: NONCE,
+          params: { url: 'https://example.com/x' },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(p.requestConsent).toHaveBeenCalledWith({
+        kind: 'open-link',
+        url: 'https://example.com/x',
+      });
+      expect(p.openLink).toHaveBeenCalledWith('https://example.com/x');
+      expect(p.proxy.byId('l1').result).toEqual({});
+    });
+
+    it('ui/open-link denied → not opened, JSON-RPC error', async () => {
+      p.requestConsent.mockResolvedValueOnce(false);
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'l2',
+          method: 'ui/open-link',
+          nonce: NONCE,
+          params: { url: 'https://example.com/y' },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(p.openLink).not.toHaveBeenCalled();
+      expect(p.proxy.byId('l2').error.code).toBe(-32000);
+    });
+
+    it('a rejected sendMessage surfaces a JSON-RPC error', async () => {
+      p.sendMessage.mockRejectedValueOnce(new Error('quota exceeded'));
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'm3',
+          method: 'ui/message',
+          nonce: NONCE,
+          params: { role: 'user', content: { type: 'text', text: 'go' } },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      const err = p.proxy.byId('m3').error;
+      expect(err.code).toBe(-32000);
+      expect(err.message).toBe('quota exceeded');
+    });
   });
 
   it('answers ping with an empty result', () => {

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -22,16 +22,22 @@
  * accessor are injected so specs drive it with plain fakes (no vi.mock of
  * globals — house rule).
  *
- * Out of scope for PR #4 (owned by PR #5/#6, answered with JSON-RPC errors
- * so Apps degrade gracefully): app-initiated `tools/call` proxying,
- * `ui/message`, `ui/update-model-context`, and `ui/open-link` consent
- * gating (PR #4 opens links directly via the injected opener).
+ * PR #6 implements the remaining View→host methods: `ui/message` (relayed
+ * to the chat send path — a real streaming turn, identical to a typed
+ * message), `ui/update-model-context` (relayed to app-api → stashed on the
+ * agent's Strands state for the next turn), and `ui/open-link` consent
+ * gating (frontend-only — the request originates here, so there is no
+ * backend turn to pause; the host obtains an inline in-thread consent
+ * before opening). Each new dep is optional: when absent the bridge keeps
+ * PR #4/#5 behavior (method-not-found / direct open) so older hosts and
+ * specs degrade gracefully.
  */
 
 import type {
   UiResourceEvent,
 } from '../../../shared/utils/stream-parser';
 import {
+  ConsentRequest,
   HostContext,
   JsonRpcId,
   JsonRpcMessage,
@@ -55,7 +61,9 @@ import {
   M_UI_INITIALIZED,
   M_UPDATE_MODEL_CONTEXT,
   MCP_UI_PROTOCOL_VERSION,
+  MessageParams,
   SizeChangedParams,
+  UpdateModelContextParams,
   isJsonRpc,
   isRequest,
 } from './mcp-app-protocol';
@@ -89,7 +97,7 @@ export interface McpAppBridgeDeps {
   getToolResult: () => unknown | null;
   /** Current host UI context (theme, displayMode, …). */
   getHostContext: () => HostContext;
-  /** Open an external URL (PR #4: direct; PR #6 adds consent). */
+  /** Open an external URL once consent (if wired) is granted. */
   openLink: (url: string) => void;
   /**
    * Proxy an App-initiated `tools/call` to the MCP server (PR #5) via
@@ -101,6 +109,29 @@ export interface McpAppBridgeDeps {
     toolName: string,
     args: Record<string, unknown>,
   ) => Promise<{ content: unknown[]; isError: boolean }>;
+  /**
+   * Relay `ui/message` as a real user turn (PR #6). The host treats it
+   * identically to a typed message — it starts a normal streaming turn.
+   * Absent (older hosts / specs) ⇒ `ui/message` is method-not-found.
+   */
+  sendMessage?: (text: string) => Promise<void>;
+  /**
+   * Relay `ui/update-model-context` (PR #6) to app-api, which stashes it
+   * on the conversation agent's state for the next turn. Resolves on
+   * acceptance; rejects with a safe Error message. Absent ⇒
+   * `ui/update-model-context` is method-not-found.
+   */
+  updateModelContext?: (
+    payload: UpdateModelContextParams,
+  ) => Promise<void>;
+  /**
+   * Obtain user consent for an App-initiated action (PR #6, frontend-only
+   * — no backend turn to pause). Resolves `true` to proceed. Absent ⇒ the
+   * bridge keeps PR #4 behavior and opens links directly (back-compat for
+   * older hosts / specs). Capability consent is handled host-side before
+   * the frame renders, so the bridge only ever asks for `open-link`.
+   */
+  requestConsent?: (req: ConsentRequest) => Promise<boolean>;
   /** Non-fatal diagnostics (validation drops, protocol slips). */
   onWarn?: (message: string) => void;
 }
@@ -276,9 +307,36 @@ export class McpAppBridge {
           this.respondError(msg.id, JSONRPC_IMPL_ERROR, 'Invalid URL');
           return;
         }
-        // PR #4 opens directly; per-link consent is PR #6.
-        this.d.openLink(url);
-        this.respond(msg.id, {});
+        const reqId = msg.id;
+        if (!this.d.requestConsent) {
+          // No consent gate wired (older host / specs): PR #4 behavior.
+          this.d.openLink(url);
+          this.respond(reqId, {});
+          return;
+        }
+        // PR #6: frontend-only consent. Hold the JSON-RPC response open
+        // until the user answers the inline in-thread prompt.
+        this.d
+          .requestConsent({ kind: 'open-link', url })
+          .then((granted) => {
+            if (granted) {
+              this.d.openLink(url);
+              this.respond(reqId, {});
+            } else {
+              this.respondError(
+                reqId,
+                JSONRPC_IMPL_ERROR,
+                'User declined to open the link',
+              );
+            }
+          })
+          .catch(() =>
+            this.respondError(
+              reqId,
+              JSONRPC_IMPL_ERROR,
+              'Consent could not be obtained',
+            ),
+          );
         return;
       }
 
@@ -290,17 +348,93 @@ export class McpAppBridge {
         return;
       }
 
-      case M_MESSAGE:
-      case M_UPDATE_MODEL_CONTEXT:
-        // Owned by PR #6. Answer per JSON-RPC so Apps degrade gracefully.
-        if (isRequest(msg)) {
+      case M_MESSAGE: {
+        if (!isRequest(msg)) return;
+        // Capability check before params: a host without the dep simply
+        // doesn't support the method (older host / tests degrade per
+        // JSON-RPC, regardless of payload).
+        if (!this.d.sendMessage) {
           this.respondError(
             msg.id,
             JSONRPC_METHOD_NOT_FOUND,
-            `${method} not supported yet (PR #6)`,
+            'ui/message not supported by this host',
           );
+          return;
         }
+        const p = msg.params as Partial<MessageParams> | undefined;
+        const text =
+          p?.role === 'user' &&
+          p?.content?.type === 'text' &&
+          typeof p.content.text === 'string'
+            ? p.content.text.trim()
+            : '';
+        if (!text) {
+          this.respondError(
+            msg.id,
+            JSONRPC_IMPL_ERROR,
+            'Invalid ui/message params',
+          );
+          return;
+        }
+        const reqId = msg.id;
+        // Treated identically to a typed message: a real streaming turn.
+        this.d
+          .sendMessage(text)
+          .then(() => this.respond(reqId, {}))
+          .catch((err: unknown) =>
+            this.respondError(
+              reqId,
+              JSONRPC_IMPL_ERROR,
+              err instanceof Error ? err.message : 'Failed to send message',
+            ),
+          );
         return;
+      }
+
+      case M_UPDATE_MODEL_CONTEXT: {
+        if (!isRequest(msg)) return;
+        if (!this.d.updateModelContext) {
+          this.respondError(
+            msg.id,
+            JSONRPC_METHOD_NOT_FOUND,
+            'ui/update-model-context not supported by this host',
+          );
+          return;
+        }
+        const p = msg.params as UpdateModelContextParams | undefined;
+        const hasContent =
+          Array.isArray(p?.content) && p!.content!.length > 0;
+        const hasStructured =
+          !!p?.structuredContent &&
+          typeof p.structuredContent === 'object';
+        if (!hasContent && !hasStructured) {
+          this.respondError(
+            msg.id,
+            JSONRPC_IMPL_ERROR,
+            'Invalid ui/update-model-context params',
+          );
+          return;
+        }
+        const reqId = msg.id;
+        this.d
+          .updateModelContext({
+            content: hasContent ? p!.content : undefined,
+            structuredContent: hasStructured
+              ? p!.structuredContent
+              : undefined,
+          })
+          .then(() => this.respond(reqId, {}))
+          .catch((err: unknown) =>
+            this.respondError(
+              reqId,
+              JSONRPC_IMPL_ERROR,
+              err instanceof Error
+                ? err.message
+                : 'Failed to update model context',
+            ),
+          );
+        return;
+      }
 
       default:
         // Unknown request → method-not-found; unknown notification → ignore.

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-http.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import type { McpAppCard } from './mcp-app-card-state.service';
+
+interface McpAppCardDto {
+  cardId: string;
+  toolUseId: string;
+  toolName: string;
+  arguments?: Record<string, unknown>;
+  content?: Array<Record<string, unknown>>;
+  isError?: boolean;
+  createdAt: string;
+  producedByMessageIndex?: number | null;
+}
+
+interface McpAppCardListDto {
+  cards: McpAppCardDto[];
+}
+
+/**
+ * app-api client for Option A reload hydration (MCP Apps PR #6). Auth
+ * rides the BFF session cookie via the HttpClient pipeline (GET is a safe
+ * method — no CSRF needed), same as `ArtifactHttpService.listSessionArtifacts`.
+ */
+@Injectable({ providedIn: 'root' })
+export class McpAppCardHttpService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  /** List this user's persisted app-initiated tool cards for a session. */
+  async listSessionCards(sessionId: string): Promise<McpAppCard[]> {
+    const res = await firstValueFrom(
+      this.http.get<McpAppCardListDto>(
+        `${this.config.appApiUrl()}/mcp-apps/cards`,
+        { params: { session_id: sessionId } },
+      ),
+    );
+    return (res.cards ?? []).map((c) => ({
+      cardId: c.cardId,
+      toolUseId: c.toolUseId,
+      toolName: c.toolName,
+      arguments: c.arguments ?? {},
+      content: c.content ?? [],
+      isError: !!c.isError,
+      createdAt: c.createdAt,
+      producedByMessageIndex: c.producedByMessageIndex ?? null,
+    }));
+  }
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-state.service.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  McpAppCardStateService,
+  McpAppCard,
+} from './mcp-app-card-state.service';
+
+function card(over: Partial<McpAppCard> = {}): McpAppCard {
+  return {
+    cardId: 'c1',
+    toolUseId: 'tu1',
+    toolName: 'widget_tool',
+    arguments: {},
+    content: [{ type: 'text', text: 'ok' }],
+    isError: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    producedByMessageIndex: null,
+    ...over,
+  };
+}
+
+describe('McpAppCardStateService', () => {
+  let svc: McpAppCardStateService;
+
+  beforeEach(() => {
+    svc = new McpAppCardStateService();
+  });
+
+  it('seeds cards and sorts oldest-first', () => {
+    svc.seedFromHydration([
+      card({ cardId: 'b', createdAt: '2026-01-02T00:00:00Z' }),
+      card({ cardId: 'a', createdAt: '2026-01-01T00:00:00Z' }),
+    ]);
+    expect(svc.hasCards()).toBe(true);
+    expect(svc.cards().map((c) => c.cardId)).toEqual(['a', 'b']);
+  });
+
+  it('seedFromHydration is non-clobbering by cardId', () => {
+    svc.seedFromHydration([card({ cardId: 'a', toolName: 'first' })]);
+    // A later (e.g. slower) response must not overwrite an existing card.
+    svc.seedFromHydration([card({ cardId: 'a', toolName: 'second' })]);
+    expect(svc.cards()).toHaveLength(1);
+    expect(svc.cards()[0].toolName).toBe('first');
+  });
+
+  it('empty seed is a no-op', () => {
+    svc.seedFromHydration([]);
+    expect(svc.hasCards()).toBe(false);
+    expect(svc.cards()).toEqual([]);
+  });
+
+  it('reset() clears all cards', () => {
+    svc.seedFromHydration([card()]);
+    svc.reset();
+    expect(svc.hasCards()).toBe(false);
+    expect(svc.cards()).toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-card-state.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+/**
+ * A persisted app-initiated tool-call card (MCP Apps PR #6, Option A).
+ * Mirrors the backend `card_store` record (key attrs stripped).
+ */
+export interface McpAppCard {
+  cardId: string;
+  toolUseId: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  content: Array<Record<string, unknown>>;
+  isError: boolean;
+  createdAt: string;
+  producedByMessageIndex?: number | null;
+}
+
+/**
+ * Reload hydration for app-initiated tool-call cards (MCP Apps PR #6).
+ *
+ * PR #5's broker is in-memory: an App's `tools/call` surfaces *live* as
+ * `tool_use`/`tool_result` in the thread, but those synthesized events are
+ * never persisted to AgentCore Memory (persisting a synthetic tool turn
+ * would break Bedrock role alternation). So on a page reload they vanish.
+ * Option A closes that gap exactly like the Artifacts feature: app-api
+ * persists a side-channel provenance record and the SPA replays it here as
+ * a **static historical card** (the App iframe itself is not
+ * re-instantiated on reload — the realistic target is a read-only record).
+ *
+ * Structural sibling of `ArtifactStateService` / `McpAppStateService`: a
+ * session-load `seedFromHydration` path and a `reset()` the session page
+ * calls on conversation change. There is deliberately no `recordLive`:
+ * live app-initiated calls already render through the normal tool path
+ * (PR #5), so a live card would double-render.
+ */
+@Injectable({ providedIn: 'root' })
+export class McpAppCardStateService {
+  private readonly byId = signal<ReadonlyMap<string, McpAppCard>>(new Map());
+
+  /** Cards for the current conversation, oldest-first (stable order). */
+  readonly cards = computed<McpAppCard[]>(() =>
+    [...this.byId().values()].sort((a, b) =>
+      a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
+    ),
+  );
+
+  readonly hasCards = computed(() => this.byId().size > 0);
+
+  /**
+   * Seed cards fetched from the app-api list endpoint on conversation
+   * load. Non-clobbering by `cardId` so a slow response can't undo state
+   * (matches `ArtifactStateService.seedFromHydration` semantics).
+   */
+  seedFromHydration(list: readonly McpAppCard[]): void {
+    if (!list.length) return;
+    const next = new Map(this.byId());
+    for (const card of list) {
+      if (!next.has(card.cardId)) next.set(card.cardId, card);
+    }
+    this.byId.set(next);
+  }
+
+  /** Drop all cards — called on conversation change. */
+  reset(): void {
+    if (this.byId().size) this.byId.set(new Map());
+  }
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { McpAppConsentService } from './mcp-app-consent.service';
+
+describe('McpAppConsentService', () => {
+  let svc: McpAppConsentService;
+
+  beforeEach(() => {
+    svc = new McpAppConsentService();
+  });
+
+  it('surfaces a pending prompt and resolves it on answer(true)', async () => {
+    const p = svc.request({ kind: 'open-link', url: 'https://x.test' });
+    expect(svc.pending()).toHaveLength(1);
+    const entry = svc.pending()[0];
+    expect(entry.request).toEqual({ kind: 'open-link', url: 'https://x.test' });
+
+    svc.answer(entry.id, true);
+    await expect(p).resolves.toBe(true);
+    expect(svc.pending()).toHaveLength(0);
+  });
+
+  it('resolves false on deny', async () => {
+    const p = svc.request({
+      kind: 'capabilities',
+      capabilities: ['microphone'],
+    });
+    svc.answer(svc.pending()[0].id, false);
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('answer() on an unknown id is a no-op', () => {
+    svc.request({ kind: 'open-link', url: 'https://x.test' });
+    svc.answer('nope', true);
+    expect(svc.pending()).toHaveLength(1);
+  });
+
+  it('reset() fails open prompts closed (resolve false) and clears', async () => {
+    const a = svc.request({ kind: 'open-link', url: 'https://a.test' });
+    const b = svc.request({ kind: 'open-link', url: 'https://b.test' });
+    expect(svc.pending()).toHaveLength(2);
+
+    svc.reset();
+    expect(svc.pending()).toHaveLength(0);
+    await expect(a).resolves.toBe(false);
+    await expect(b).resolves.toBe(false);
+  });
+
+  it('keeps multiple prompts independently addressable', async () => {
+    const a = svc.request({ kind: 'open-link', url: 'https://a.test' });
+    const b = svc.request({ kind: 'open-link', url: 'https://b.test' });
+    const [ea, eb] = svc.pending();
+
+    svc.answer(eb.id, true);
+    await expect(b).resolves.toBe(true);
+    expect(svc.pending()).toHaveLength(1);
+    expect(svc.pending()[0].id).toBe(ea.id);
+
+    svc.answer(ea.id, false);
+    await expect(a).resolves.toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, computed, signal } from '@angular/core';
+import type { ConsentRequest } from './mcp-app-protocol';
+
+/**
+ * Frontend-only consent for App-initiated actions (MCP Apps PR #6).
+ *
+ * Decision (`docs/kaizen/scoping/mcp-apps-host-renderer.md`, PR #6): unlike
+ * the OAuth-tool `oauth_required` SSE family — which exists because OAuth
+ * consent fires *inside a backend agent turn* and pauses it via a Strands
+ * interrupt — `ui/open-link` and capability requests originate from a
+ * postMessage on a possibly-idle iframe. There is no backend turn to
+ * pause, so routing through the backend would be pure round-trip
+ * ceremony. The host obtains consent entirely on the client: a pending
+ * request is surfaced as an inline in-thread prompt (structural sibling of
+ * `OAuthConsentService` + the unanchored-prompt strip) and the bridge's
+ * JSON-RPC response is held open until the user answers.
+ *
+ * Transient by design: prompts are interaction gates, not provenance, so
+ * they are NOT persisted and do not survive a reload (consistent with the
+ * App iframe itself not being re-instantiated on reload).
+ */
+export interface PendingConsent {
+  /** Stable id for `@for` tracking + resolution. */
+  id: string;
+  request: ConsentRequest;
+  receivedAt: number;
+  resolve: (granted: boolean) => void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class McpAppConsentService {
+  private readonly pendingSignal = signal<readonly PendingConsent[]>([]);
+
+  /** Pending consent prompts to render in the message-list strip. */
+  readonly pending = computed(() => this.pendingSignal());
+
+  private seq = 0;
+
+  /**
+   * Surface a consent prompt and resolve once the user answers. The bridge
+   * awaits this before opening a link. If the conversation changes while a
+   * prompt is open, `reset()` resolves it as denied (fail-closed).
+   */
+  request(request: ConsentRequest): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const id = `mcp-consent-${++this.seq}`;
+      const entry: PendingConsent = {
+        id,
+        request,
+        receivedAt: Date.now(),
+        resolve,
+      };
+      this.pendingSignal.set([...this.pendingSignal(), entry]);
+    });
+  }
+
+  /** User answered a prompt (Allow/Deny). Idempotent. */
+  answer(id: string, granted: boolean): void {
+    const entry = this.pendingSignal().find((p) => p.id === id);
+    if (!entry) return;
+    this.pendingSignal.set(this.pendingSignal().filter((p) => p.id !== id));
+    entry.resolve(granted);
+  }
+
+  /** Drop all prompts on conversation change — fail closed (deny). */
+  reset(): void {
+    const open = this.pendingSignal();
+    if (open.length) {
+      this.pendingSignal.set([]);
+      for (const e of open) e.resolve(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-message.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-message.service.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { McpAppMessageService } from './mcp-app-message.service';
+import { ConfigService } from '../../../services/config.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
+import { SessionService } from '../session/session.service';
+import { ToolService } from '../../../services/tool/tool.service';
+import { ModelService } from '../model/model.service';
+
+describe('McpAppMessageService', () => {
+  let svc: McpAppMessageService;
+  let httpMock: HttpTestingController;
+  let usingDefault = false;
+
+  beforeEach(() => {
+    usingDefault = false;
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        McpAppMessageService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+        { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({ 'X-CSRF-Token': 't' }) } },
+        { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }) } },
+        { provide: ToolService, useValue: { getEnabledToolIds: vi.fn().mockReturnValue(['gw_x']) } },
+        {
+          provide: ModelService,
+          useValue: {
+            isUsingDefaultModel: () => usingDefault,
+            selectedModel: signal({ modelId: 'm1' }),
+          },
+        },
+      ],
+    });
+    svc = TestBed.inject(McpAppMessageService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('posts the conversation binding + resourceUri + payload', async () => {
+    const promise = svc.updateModelContext('ui://srv/w', {
+      structuredContent: { picked: 'X' },
+    });
+
+    const req = httpMock.expectOne(
+      'http://localhost:8000/mcp-apps/update-context',
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBe(true);
+    expect(req.request.headers.get('X-CSRF-Token')).toBe('t');
+    expect(req.request.body).toEqual({
+      sessionId: 's1',
+      resourceUri: 'ui://srv/w',
+      content: null,
+      structuredContent: { picked: 'X' },
+      enabledTools: ['gw_x'],
+      modelId: 'm1',
+    });
+
+    req.flush({ resourceUri: 'ui://srv/w', status: 'stored' });
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('sends modelId null when using the default model', async () => {
+    usingDefault = true;
+    const promise = svc.updateModelContext('ui://srv/w', {
+      content: [{ type: 'text', text: 'note' }],
+    });
+    const req = httpMock.expectOne(
+      'http://localhost:8000/mcp-apps/update-context',
+    );
+    expect(req.request.body.modelId).toBeNull();
+    expect(req.request.body.content).toEqual([{ type: 'text', text: 'note' }]);
+    req.flush({ status: 'stored' });
+    await promise;
+  });
+
+  it('rejects with the inference error message on a non-2xx', async () => {
+    const promise = svc.updateModelContext('ui://srv/w', {
+      structuredContent: {},
+    });
+    const req = httpMock.expectOne(
+      'http://localhost:8000/mcp-apps/update-context',
+    );
+    req.flush(
+      { error: 'needs content' },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    await expect(promise).rejects.toThrow('needs content');
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-message.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-message.service.ts
@@ -1,0 +1,77 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import { SessionService as BffSessionService } from '../../../auth/session.service';
+import { ToolService } from '../../../services/tool/tool.service';
+import { SessionService } from '../session/session.service';
+import { ModelService } from '../model/model.service';
+import type { UpdateModelContextParams } from './mcp-app-protocol';
+
+/**
+ * App-pushed `ui/update-model-context` relay (MCP Apps PR #6).
+ *
+ * Structural sibling of {@link McpAppProxyService}: the authenticated POST
+ * to app-api `/mcp-apps/update-context` (session cookie + CSRF) plus the
+ * conversation-binding assembly so inference-api rebuilds the same cached
+ * agent and stashes the payload on its Strands state for the next turn.
+ * Kept as a service so the bridge stays framework-free — the component
+ * injects this and hands the bridge a plain `updateModelContext` callback.
+ *
+ * `ui/message` is intentionally NOT here: it is "treated identically to a
+ * typed message", so it goes through the normal chat send path
+ * (`ChatRequestService.submitChatRequest`), starting a real streaming turn.
+ */
+@Injectable({ providedIn: 'root' })
+export class McpAppMessageService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+  private readonly bffSession = inject(BffSessionService);
+  private readonly toolService = inject(ToolService);
+  private readonly sessionService = inject(SessionService);
+  private readonly modelService = inject(ModelService);
+
+  /**
+   * Relay one model-context update. Resolves on acceptance; rejects with
+   * an Error whose message is safe to surface to the App.
+   *
+   * @param resourceUri the bound App resource (`ui://…`) — the host's
+   *   per-App dedupe key (last-write-wins between turns).
+   */
+  async updateModelContext(
+    resourceUri: string,
+    payload: UpdateModelContextParams,
+  ): Promise<void> {
+    const appApiUrl = this.config.appApiUrl();
+    const sessionId = this.sessionService.currentSession().sessionId;
+    if (!appApiUrl || !sessionId) {
+      throw new Error('No active conversation for the context update');
+    }
+
+    const usingDefault = this.modelService.isUsingDefaultModel();
+    const selected = this.modelService.selectedModel();
+    const body = {
+      sessionId,
+      resourceUri,
+      content: payload.content ?? null,
+      structuredContent: payload.structuredContent ?? null,
+      enabledTools: this.toolService.getEnabledToolIds(),
+      modelId: usingDefault ? null : selected?.modelId ?? null,
+    };
+
+    try {
+      await firstValueFrom(
+        this.http.post(`${appApiUrl}/mcp-apps/update-context`, body, {
+          headers: this.bffSession.csrfHeaders(),
+          withCredentials: true,
+        }),
+      );
+    } catch (err) {
+      const message =
+        err instanceof HttpErrorResponse
+          ? (err.error?.error ?? `Context update failed (${err.status})`)
+          : 'Context update failed';
+      throw new Error(message);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
@@ -142,6 +142,38 @@ export interface RequestDisplayModeParams {
   mode: DisplayMode;
 }
 
+/** Spec shape of `ui/message` params (View → host). */
+export interface MessageParams {
+  role: 'user';
+  content: { type: 'text'; text: string };
+}
+
+/** Spec shape of `ui/update-model-context` params (View → host). */
+export interface UpdateModelContextParams {
+  content?: unknown[];
+  structuredContent?: Record<string, unknown>;
+}
+
+/** Sandbox capability keys an App may request (`_meta.ui.permissions`). */
+export type CapabilityKey =
+  | 'camera'
+  | 'microphone'
+  | 'geolocation'
+  | 'clipboardWrite';
+
+/**
+ * A user-consent decision the host must obtain before acting on an
+ * App-initiated request. PR #6 of
+ * `docs/kaizen/scoping/mcp-apps-host-renderer.md`, decision: consent is
+ * **frontend-only** — these requests originate from a postMessage on a
+ * possibly-idle iframe, so there is no backend agent turn to pause (unlike
+ * the OAuth-tool `oauth_required` SSE family). The host resolves them with
+ * an inline in-thread prompt and gates the bridge response on the answer.
+ */
+export type ConsentRequest =
+  | { kind: 'open-link'; url: string }
+  | { kind: 'capabilities'; capabilities: CapabilityKey[] };
+
 /** Narrowing helpers. */
 export function isJsonRpc(data: unknown): data is JsonRpcMessage {
   return (

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -18,6 +18,9 @@ import { CompactionSummaryService } from './services/chat/compaction-summary.ser
 import { ArtifactStateService } from './services/artifacts/artifact-state.service';
 import { ArtifactHttpService } from './services/artifacts/artifact-http.service';
 import { McpAppStateService } from './services/mcp-apps/mcp-app-state.service';
+import { McpAppCardStateService } from './services/mcp-apps/mcp-app-card-state.service';
+import { McpAppCardHttpService } from './services/mcp-apps/mcp-app-card-http.service';
+import { McpAppConsentService } from './services/mcp-apps/mcp-app-consent.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
 import { Assistant } from '../assistants/models/assistant.model';
@@ -49,6 +52,9 @@ export class ConversationPage implements OnDestroy {
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
   private mcpAppState = inject(McpAppStateService);
+  private mcpAppCardState = inject(McpAppCardStateService);
+  private mcpAppCardHttp = inject(McpAppCardHttpService);
+  private mcpAppConsent = inject(McpAppConsentService);
   private artifactHttp = inject(ArtifactHttpService);
   private assistantService = inject(AssistantService);
   private router = inject(Router);
@@ -313,6 +319,12 @@ export class ConversationPage implements OnDestroy {
       // the inline `ui_resource` event only arrives live during a stream.
       this.mcpAppState.reset();
 
+      // Option A (PR #6): app-initiated tool cards DO re-hydrate (the
+      // broker is in-memory). Any open consent prompt for the prior
+      // conversation is dropped fail-closed.
+      this.mcpAppCardState.reset();
+      this.mcpAppConsent.reset();
+
       if (id) {
         // Update the messages signal reference (this triggers reactivity)
         this.messagesSignal.set(this.messageMapService.getMessagesForSession(id));
@@ -335,6 +347,7 @@ export class ConversationPage implements OnDestroy {
         // artifacts feature is off for this environment) or any network
         // error just means no cards — never disrupt the session.
         this.hydrateArtifacts(id);
+        this.hydrateMcpAppCards(id);
       } else {
         // No session selected, clear the session metadata
         this.sessionService.setSessionMetadataId(null);
@@ -366,6 +379,25 @@ export class ConversationPage implements OnDestroy {
       .then(artifacts => {
         if (artifacts.length && this.sessionId() === sessionId) {
           this.artifactState.seedFromHydration(artifacts);
+        }
+      })
+      .catch(() => {
+        // Feature disabled (404) or transient error — no cards, no noise.
+      });
+  }
+
+  /**
+   * Best-effort: pull persisted app-initiated tool cards and seed the
+   * registry so they survive a reload (the PR #5 broker is in-memory).
+   * Mirrors {@link hydrateArtifacts}: non-clobbering, session-guarded,
+   * silent on 404 (MCP Apps host flag off) or transient error.
+   */
+  private hydrateMcpAppCards(sessionId: string): void {
+    this.mcpAppCardHttp
+      .listSessionCards(sessionId)
+      .then(cards => {
+        if (cards.length && this.sessionId() === sessionId) {
+          this.mcpAppCardState.seedFromHydration(cards);
         }
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

PR #6 of the MCP Apps host-renderer initiative (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). Implements the remaining View→host methods and the folded-in "Option A" reload persistence.

**Stacking:** hard-depends on PR #5 ([#347](https://github.com/Boise-State-Development/agentcore-public-stack/pull/347)) — broker, `app_tool_dispatch`, the `InvocationRequest` directive pattern, the bridge stubs, `visible_to_app()`. #347 was still open, so this is **based on `feature/mcp-apps-tools-call-proxy`** for a clean diff; GitHub will auto-retarget the base to `develop` when #347 merges. **Do not merge before #347.** Whole surface stays inert until PR #7 flips `AGENTCORE_MCP_APPS_HOST_ENABLED`.

### Backend
- **`ui/update-model-context`**: new `app_context_update` directive on `InvocationRequest` + `app_context_dispatch.py` (no model turn; mirrors PR #5 `app_tool_call`). Writes `agent.state.mcp_apps.context[resourceUri]` on the cached agent (read-modify-write — strands 1.40 `AgentState.get()` deep-copies, nested mutation does not persist). `merge_and_clear_pending_context` runs before each real user turn, prepending a delimited block to **that turn only** (cache-prefix-safe; `original_message` keeps history clean). app-api `POST /mcp-apps/update-context` relay (cookie auth, mirrors `/proxy-call`).
- **Option A persistence**: app-api persists an `APPCARD#`-prefixed provenance record to the existing **`sessions-metadata`** table after a successful `/proxy-call` (SESSION# GSI + Query/Read grant already exist → **zero new infra**). New `GET /mcp-apps/cards`, ownership re-checked on read. Provenance/UI only — **no synthetic tool turn persisted to AgentCore Memory** (Bedrock role-alternation hazard).

### Frontend
- **Bridge**: implements `ui/message` (→ `ChatRequestService.submitChatRequest` — a real streaming turn, "treated identically to a typed message"), `ui/update-model-context` (→ relay service), and `ui/open-link` consent gating. Capability check precedes param validation so older hosts degrade per JSON-RPC (method-not-found); every new dep is optional.
- **Frontend-only consent** (`McpAppConsentService` + inline prompt modeled on `oauth-consent-prompt`): rendered in the message-list strip. Render-time capability consent filters the forwarded + advertised sandbox permissions.
- **Option A hydration**: `McpAppCardStateService.seedFromHydration` mirrors `ArtifactStateService`; static historical cards render in a session-level strip; `session.page.ts` resets + hydrates on conversation change.

## Deviations from the scoping doc (owner-approved 2026-05-19)

1. **Consent is frontend-only** — no `ui_consent_required` SSE event family, no CLAUDE.md SSE-table row (that Definition-of-Done line is intentionally void). `oauth_required` is an SSE event only because OAuth consent pauses a *backend agent turn* via a Strands interrupt; `ui/open-link`/capability requests originate from an iframe postMessage with no turn to pause.
2. **`ui/message` = frontend send path**, not a backend injection directive (avoids the Bedrock role-alternation hazard).
3. **No `TurnBasedSessionManager`/Memory change** — `agent.state` rides the in-process LRU agent cache, the same write-only-Memory mechanism cloud continuity already depends on; cold-start/eviction drops the whole conversation anyway (consistent, not a new regression).
4. **Option A reuses `sessions-metadata`** (new `APPCARD#` SK prefix) — zero new CDK/infra.

## Test plan

- [x] Backend full pytest suite: **2981 passed, 3 skipped, 0 failed** (the only correctness gate — not run in CI)
- [x] New backend tests: `test_app_context_dispatch.py` (7), `test_mcp_apps_update_context.py` (4), `test_mcp_apps_card_store.py` (4); architecture import-boundary tests green
- [x] Frontend: `npm run build` clean; `npm run test:ci` **1067 passed** (incl. 24 bridge specs + new consent/card-state/message specs)
- [x] Manual e2e deferred to PR #7 (surface inert until `AGENTCORE_MCP_APPS_HOST_ENABLED` is flipped — no MCP App renders before then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)