### PR TITLE
feat(mcp-apps): PR #7 — dogfood + flip AGENTCORE_MCP_APPS_HOST_ENABLED on

### DIFF
--- a/.github/docs/deploy/step-04-deploy.md
+++ b/.github/docs/deploy/step-04-deploy.md
@@ -169,7 +169,7 @@ To enable, set these GitHub environment variables before running:
 - `CDK_MCP_SANDBOX_CERTIFICATE_ARN` — ACM cert ARN that covers `mcp-sandbox.{domain}`. **Must be in `us-east-1`** (CloudFront requirement). The same wildcard-depth caveat as Artifacts applies: a `*.example.com` cert covers `mcp-sandbox.example.com` but **not** `mcp-sandbox.alpha.example.com`. If `CDK_DOMAIN_NAME` is a subdomain, issue a dedicated `us-east-1` cert for `*.{CDK_DOMAIN_NAME}`. See [Step 2c](./step-02-aws-setup.md#2c-create-acm-certificates).
 - `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS` *(optional, default none)* — comma-separated extra origins allowed to embed the proxy iframe via CSP `frame-ancestors`, on top of `https://{domain}`. Set to `http://localhost:4200` to point a local SPA at this environment. **Leave unset in production** — every listed origin can frame the proxy. Prefer a one-off targeted `cdk deploy '*McpSandboxStack*'` with this var exported over committing it as a CI variable, so localhost never lands in automated shared-env deploys.
 
-The sandbox origin is intentionally a sibling subdomain (not the SPA origin), matching the Artifacts pattern: it is the **outer** half of the spec's Sandbox Proxy pattern, giving a stable cross-origin boundary so the inner MCP App content frame's `allow-same-origin` never reaches the SPA's cookies/`localStorage`/app API. **This stack is inert on its own** — nothing consumes its `/mcp-sandbox/origin` SSM export until the frontend `<mcp-app-frame>` lands in a later PR, and the whole feature stays behind `MCP_APPS_HOST_ENABLED` until the initiative's final PR. Standing it up early is safe and changes nothing user-facing.
+The sandbox origin is intentionally a sibling subdomain (not the SPA origin), matching the Artifacts pattern: it is the **outer** half of the spec's Sandbox Proxy pattern, giving a stable cross-origin boundary so the inner MCP App content frame's `allow-same-origin` never reaches the SPA's cookies/`localStorage`/app API. When this stack is enabled, the Inference API conditionally consumes its `/mcp-sandbox/origin` SSM export into `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` and surfaces it on the `ui_resource` SSE event so the SPA knows where to frame an App. The MCP Apps host surface is now on by default (`AGENTCORE_MCP_APPS_HOST_ENABLED=true` since PR #7), but **stays dormant until an MCP-Apps-capable server is registered** in the tool catalog — see [Register an MCP-Apps-capable MCP server](#register-an-mcp-apps-capable-mcp-server) below. If you skip this stack the surface stays dormant regardless, because the SPA has no proxy origin to frame an App in.
 
 </details>
 
@@ -222,6 +222,77 @@ You can re-run this workflow later to update seed data.
 > Authentication is handled by Cognito's first-boot flow — no auth provider seeding is needed. The first person to access the application will create the admin account directly.
 
 </details>
+
+---
+
+## Register an MCP-Apps-capable MCP server
+
+The MCP Apps host renderer (`docs/kaizen/scoping/mcp-apps-host-renderer.md`) is **on by default** (`AGENTCORE_MCP_APPS_HOST_ENABLED=true` since PR #7). But it stays completely dormant until you register an MCP-Apps-capable MCP server in the tool catalog — there is no built-in MCP App. Registration is a normal **tool-catalog** operation (DynamoDB, via the admin API); it is *not* a code constant or part of bootstrap seeding, so each environment opts in explicitly.
+
+### What "MCP-Apps-capable" means
+
+A server is MCP-Apps-capable when, on top of being a normal external MCP server, it:
+
+- advertises `_meta.ui` on its `tools/list` entries (a `resourceUri` of the form `ui://…` plus a `visibility` that includes `app`), and
+- serves that `ui://` resource via `resources/read` as `text/html;profile=mcp-app`.
+
+Our host advertises the `io.modelcontextprotocol/ui` extension on every outbound MCP `initialize` automatically (Gateway + external clients) — the server side needs no per-server opt-in here. Servers that don't speak the extension simply ignore it and behave as plain MCP tools.
+
+### Prerequisites
+
+1. **MCP Sandbox stack deployed** (`CDK_MCP_SANDBOX_ENABLED=true`, see *Deploy MCP Sandbox (Optional)* under [What Each Workflow Does](#what-each-workflow-does)). Without it the Inference API has no `/{prefix}/mcp-sandbox/origin` SSM value to consume, `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` stays empty, and the SPA has no cross-origin shell to frame the App in — every other piece can be wired and the App still won't render.
+2. **An MCP-Apps server reachable over Streamable HTTP.** External MCP tools connect via the Streamable-HTTP client (not stdio). Run the example server in HTTP mode (below).
+3. **Admin access** to the running App API (admin session cookie; the tool admin endpoints chain through `require_admin`).
+
+### Step 1 — Run the example server (dogfood)
+
+We dogfood with [`modelcontextprotocol/ext-apps` → `budget-allocator-server`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/budget-allocator-server) — a form-style App (sliders, presets, benchmarks) that exercises `ui/update-model-context` and app-initiated `tools/call` without any 3D/charting backend infra. `scenario-modeler-server` works the same way if you prefer it.
+
+```bash
+git clone https://github.com/modelcontextprotocol/ext-apps
+cd ext-apps/examples/budget-allocator-server
+npm install
+npm run start:http          # stateless Streamable HTTP on http://localhost:3001/mcp
+```
+
+(Override the port with `PORT=…`. The README's default config is stdio — use `start:http`, since external MCP tools here are Streamable-HTTP only.)
+
+### Step 2 — Register it in the tool catalog
+
+Either use the **Admin UI** (Settings → Tools → Add tool → protocol *MCP (external)*) or the admin API directly. A ready-to-POST body is committed at [`docs/kaizen/scoping/mcp-apps-budget-allocator.tool.json`](../../../docs/kaizen/scoping/mcp-apps-budget-allocator.tool.json).
+
+Optionally pre-flight discovery (lists the server's tool names so you can confirm reachability/auth before creating the catalog entry):
+
+```bash
+curl -X POST "$APP_API/admin/tools/discover" \
+  -H 'Content-Type: application/json' --cookie "$ADMIN_COOKIE" \
+  -d '{"serverUrl":"http://localhost:3001/mcp","transport":"streamable-http","authType":"none"}'
+```
+
+Then create the catalog entry:
+
+```bash
+curl -X POST "$APP_API/admin/tools/" \
+  -H 'Content-Type: application/json' --cookie "$ADMIN_COOKIE" \
+  -d @docs/kaizen/scoping/mcp-apps-budget-allocator.tool.json
+```
+
+`authType: none` is only appropriate for an unauthenticated local/dev server. A real deployed MCP-Apps server uses `aws-iam` (Lambda Function URL / API Gateway behind SigV4), `api-key` (+ `secretArn`), or `oauth2` — exactly like any other external MCP tool. After creating the tool, grant it to the relevant App roles (Settings → Tools → Roles, or the `/admin/tools/{id}/roles` endpoints); a freshly created tool is in the catalog but not yet visible to any role.
+
+### Step 3 — Local-dev environment
+
+When running the backend locally (App API + Inference API), set in `backend/src/.env` (template: `backend/src/.env.example`):
+
+| Var | Value | Why |
+|-----|-------|-----|
+| `AGENTCORE_MCP_APPS_HOST_ENABLED` | `true` | Default; set `false` to opt this env out entirely. |
+| `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` | the deployed `mcp-sandbox.{domain}` origin (SSM `/{prefix}/mcp-sandbox/origin`) | The agent puts this on the `ui_resource` SSE event as `sandboxOrigin`; the SPA frames the App in it. Empty ⇒ no render. There is no local sandbox shell — point at a deployed one. |
+
+For the local SPA (`http://localhost:4200`) to be allowed to embed that deployed sandbox origin, the sandbox stack must list it in CSP `frame-ancestors` — deploy McpSandbox once with `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS=http://localhost:4200` (one-off targeted deploy; never commit localhost as a shared CI variable — see *Deploy MCP Sandbox (Optional)* under [What Each Workflow Does](#what-each-workflow-does)).
+
+### Step 4 — Verify end-to-end
+
+In a chat, prompt the agent so it invokes the registered tool. You should see, in order: a `tool_use`/`tool_result` card, then the App's iframe rendering inside it (`ui_resource` SSE event carrying a non-empty `sandboxOrigin`). Driving the form should push `ui/notifications/tool-input`, app-initiated buttons should round-trip through `tools/call`, and an `ui/update-model-context` write should be visible to the model on the **next** turn. If the iframe stays blank, the `sandboxOrigin` is almost always empty (prerequisite 1) or the SPA origin isn't in the sandbox `frame-ancestors` (Step 3).
 
 ---
 

--- a/.github/docs/deploy/step-05-verify.md
+++ b/.github/docs/deploy/step-05-verify.md
@@ -72,6 +72,34 @@ The user who completed the first-boot setup is automatically the system admin.
 > [!TIP]
 > To add federated identity providers (Entra ID, Okta, Google, etc.), use the admin dashboard's authentication settings. No redeployment is needed.
 
+### 5. (Optional) MCP Apps dogfood — end-to-end
+
+Run this only if you've enabled the MCP Apps host renderer (MCP Sandbox stack deployed and an MCP-Apps server registered — see [Register an MCP-Apps-capable MCP server](./step-04-deploy.md#register-an-mcp-apps-capable-mcp-server)). It is the manual e2e scenario for the host-renderer initiative and walks every host↔App interaction. Using the `budget-allocator-server` example from the runbook:
+
+**Setup**
+- [ ] `budget-allocator-server` running over Streamable HTTP and registered as an `mcp_external` tool, granted to your role
+- [ ] `AGENTCORE_MCP_APPS_HOST_ENABLED=true` (default) and `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` resolves to the deployed `mcp-sandbox.{domain}` origin
+- [ ] Your SPA origin is in the sandbox's CSP `frame-ancestors`
+
+**Scenario** — in a fresh chat, ask the agent to "help me allocate a budget" (or anything that invokes the tool):
+
+- [ ] **Resource fetch** — a `tool_use` then `tool_result` card appears; backend logs show a server-side `resources/read` for the tool's `ui://…` resource (no client fetch)
+- [ ] **Iframe render** — the App renders *inside* the tool card: a `ui_resource` SSE event arrives with a **non-empty** `sandboxOrigin`, and the iframe is sourced from that origin (not `srcdoc` against the SPA origin)
+- [ ] **Tool-input push** — the App shows the arguments the model called it with (host pushed `ui/notifications/tool-input` from the active stream)
+- [ ] **App-initiated `tools/call`** — drive the form (move a slider / pick a preset) so the App calls a server tool; the call shows up as its own tool card in the thread *and* the App updates from the `ui/notifications/tool-result` it gets back
+- [ ] **`ui/update-model-context` mutates the next turn** — after changing the allocation, send a new chat message that asks about it (e.g. "is my current split reasonable?"); the model's reply reflects the App's latest state — i.e. context written via `ui/update-model-context` was merged into the **next** turn (not the one that opened the App)
+- [ ] **`ui/open-link` consent prompt** — trigger a link-open from the App (e.g. an "industry benchmarks" link); an inline consent prompt appears in the message list (modeled on the OAuth-consent prompt) and the link only opens after you approve. (Consent is **frontend-only** — there is no `ui_consent_required` SSE event; don't look for one.)
+
+<details>
+<summary>The App card appears but the iframe is blank</summary>
+
+In order of likelihood:
+1. `sandboxOrigin` is empty on the `ui_resource` event → the MCP Sandbox stack isn't deployed, or `CDK_MCP_SANDBOX_ENABLED` wasn't `true` when the Inference API deployed (it consumes `/{prefix}/mcp-sandbox/origin` conditionally).
+2. The SPA origin isn't in the sandbox CSP `frame-ancestors` → the browser blocks the frame (console shows a `frame-ancestors` violation). Redeploy McpSandbox with the right origin (`CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS` for localhost).
+3. The server didn't return `_meta.ui` on `tools/list`, or its `ui://` resource isn't `text/html;profile=mcp-app` → it isn't actually MCP-Apps-capable; re-check with the discover endpoint and the server's own logs.
+
+</details>
+
 ---
 
 ## You're Done!

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -32,7 +32,7 @@ npx cdk deploy --all
 
 ## Key Conventions
 
-- **Deploy order:** Infrastructure → (Gateway, RAG Ingestion, SageMaker Fine-Tuning, Artifacts — parallel-safe) → Inference API → App API → Frontend (App API reads `runtime-workload-identity-name` from SSM, published by Inference API; Inference API + App API + Frontend conditionally consume `/{prefix}/artifacts/*` SSM params when `CDK_ARTIFACTS_ENABLED=true`)
+- **Deploy order:** Infrastructure → (Gateway, RAG Ingestion, SageMaker Fine-Tuning, Artifacts, MCP Sandbox — parallel-safe) → Inference API → App API → Frontend (App API reads `runtime-workload-identity-name` from SSM, published by Inference API; Inference API + App API + Frontend conditionally consume `/{prefix}/artifacts/*` SSM params when `CDK_ARTIFACTS_ENABLED=true`; Inference API conditionally consumes `/{prefix}/mcp-sandbox/origin` into `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` when `CDK_MCP_SANDBOX_ENABLED=true`)
 - **Admin endpoints** go under `/admin/<domain>/`, user-facing under `/<domain>/`
 - **Errors stream as assistant messages** via SSE (not HTTP error codes)
 - **Signal-based state** throughout frontend (`signal()`, `computed()`)
@@ -47,7 +47,7 @@ npx cdk deploy --all
 | `content_block_start/delta/stop` | Streaming content |
 | `message_stop` | End of message |
 | `tool_use` / `tool_result` | Tool invocation and result |
-| `ui_resource` | MCP App UI for a tool result (SEP-1865) — payload `{type, toolUseId, resourceUri, html, mimeType, csp, permissions, sandboxOrigin}`, emitted right after the correlated `tool_result` when the tool declared a `ui://` resource. HTML fetched server-side via `resources/read` and inlined; `sandboxOrigin` is the proxy.html origin the SPA frames it in (empty until the mcp-sandbox stack is deployed). Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default false) |
+| `ui_resource` | MCP App UI for a tool result (SEP-1865) — payload `{type, toolUseId, resourceUri, html, mimeType, csp, permissions, sandboxOrigin}`, emitted right after the correlated `tool_result` when the tool declared a `ui://` resource. HTML fetched server-side via `resources/read` and inlined; `sandboxOrigin` is the proxy.html origin the SPA frames it in (empty unless the mcp-sandbox stack is deployed — inference-api consumes its SSM origin only when `CDK_MCP_SANDBOX_ENABLED=true`; an empty origin means the SPA cannot frame the App). Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default true since PR #7; set `=false` to opt an environment out) |
 | `stream_error` | Conversational error |
 | `oauth_required` | External MCP tool needs user consent — payload `{providerId, authorizationUrl}`, one event per provider emitted after `message_stop` |
 | `compaction` | Backend rolled older turns into a summary on this turn — payload `{previousCheckpoint, newCheckpoint, summarizedTurns, inputTokens}`, emitted after the final `metadata` event so the badge updates first, before `done` |

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -56,14 +56,17 @@ AGENTCORE_MEMORY_TOP_K=10
 # Requires: Gateway deployed via GatewayStack and SSM parameter /{projectPrefix}/mcp/gateway-url
 AGENTCORE_GATEWAY_MCP_ENABLED=true
 
-# MCP Apps host renderer (OPTIONAL — docs/kaizen/scoping/mcp-apps-host-renderer.md)
-# Gates the entire MCP Apps host surface. Stays false until PR #7 flips it on.
-AGENTCORE_MCP_APPS_HOST_ENABLED=false
+# MCP Apps host renderer (docs/kaizen/scoping/mcp-apps-host-renderer.md)
+# Gates the entire MCP Apps host surface. Default true since PR #7; set
+# false to opt this environment out. With no MCP-Apps-capable server
+# registered in the tool catalog the surface stays dormant regardless.
+AGENTCORE_MCP_APPS_HOST_ENABLED=true
 # Origin of the sandbox-proxy (proxy.html) the SPA frames an MCP App in.
 # Surfaced to the SPA on the `ui_resource` SSE event so the frontend needs no
-# separate config fetch. Leave empty until the mcp-sandbox stack is deployed.
-# Where to find: SSM /{projectPrefix}/mcp-sandbox/origin (published by the
-# mcp-sandbox CDK stack).
+# separate config fetch. The iframe cannot render until this is set: point it
+# at a deployed mcp-sandbox origin (SSM /{projectPrefix}/mcp-sandbox/origin,
+# published by the mcp-sandbox CDK stack). See the MCP Apps registration
+# runbook in .github/docs/deploy/step-04-deploy.md.
 AGENTCORE_MCP_APPS_SANDBOX_ORIGIN=
 
 # AgentCore Code Interpreter ID (OPTIONAL)

--- a/backend/src/agents/main_agent/config/constants.py
+++ b/backend/src/agents/main_agent/config/constants.py
@@ -113,12 +113,16 @@ class Defaults:
     GATEWAY_MCP_ENABLED = True
 
     # --- MCP Apps (host renderer initiative) ---
-    # Gates the entire MCP Apps host surface. Stays False until PR #7 of
-    # docs/kaizen/scoping/mcp-apps-host-renderer.md flips it on.
-    MCP_APPS_HOST_ENABLED = False
-    # Empty until the mcp-sandbox stack (PR #1) is deployed and the deploy
-    # pipeline wires its SSM origin into the env. Empty string is benign:
-    # the whole surface is inert behind MCP_APPS_HOST_ENABLED anyway.
+    # Gates the entire MCP Apps host surface. Flipped on in PR #7 of
+    # docs/kaizen/scoping/mcp-apps-host-renderer.md (the full #1–#6 chain
+    # landed first). Set AGENTCORE_MCP_APPS_HOST_ENABLED=false to opt a
+    # given environment back out.
+    MCP_APPS_HOST_ENABLED = True
+    # Empty unless the mcp-sandbox stack is deployed: the inference-api CDK
+    # stack wires `/{prefix}/mcp-sandbox/origin` into this env only when
+    # `config.mcpSandbox.enabled` (conditional-SSM, mirrors artifacts).
+    # An empty origin keeps the surface dormant — the SPA has no proxy
+    # origin to frame an App in even with the host flag on.
     MCP_APPS_SANDBOX_ORIGIN = ""
 
     # --- Voice Agent ---

--- a/backend/src/agents/main_agent/integrations/mcp_apps.py
+++ b/backend/src/agents/main_agent/integrations/mcp_apps.py
@@ -15,10 +15,10 @@ surface for the MCP Apps extension (SEP-1865):
    Strands agent's tool list — the model must never see app-only tools — while
    the full metadata stays in the catalog.
 
-The entire surface is inert unless `AGENTCORE_MCP_APPS_HOST_ENABLED=true`
-(default false until PR #7 flips it on). When the flag is off, no extension is
-advertised and no tool is filtered or recorded — behavior is byte-for-byte
-unchanged.
+The entire surface is gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default
+true since PR #7; set it to `false` to opt an environment back out). When
+the flag is off, no extension is advertised and no tool is filtered or
+recorded — behavior is byte-for-byte unchanged.
 
 Why a `ClientSession` symbol patch: Strands' `MCPClient` constructs the MCP
 SDK `ClientSession` itself inside its background thread and exposes no hook to

--- a/backend/src/apis/app_api/mcp_apps/routes.py
+++ b/backend/src/apis/app_api/mcp_apps/routes.py
@@ -16,9 +16,9 @@ authoritative spec-MUST "reject tools whose visibility excludes 'app'"
 gate lives in the inference-api dispatch (`dispatch_app_tool_call`). This
 boundary's contribution is auth + request validation + the bearer hand-off.
 
-Inert until PR #7 flips `AGENTCORE_MCP_APPS_HOST_ENABLED`: with the host
-flag off the inference-api catalog is empty and every call is rejected
-there as not app-visible.
+Gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default true since PR #7):
+with the host flag off the inference-api catalog is empty and every call
+is rejected there as not app-visible.
 """
 
 from __future__ import annotations

--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -16,8 +16,9 @@ single tool call WITHOUT a model turn:
    per-session broker so the live conversation stream shows the card, and
    return the `CallToolResult` so app-api can hand it back to the iframe.
 
-Inert unless `AGENTCORE_MCP_APPS_HOST_ENABLED=true` (default false) — the
-catalog is empty otherwise, so every call is rejected as not app-visible.
+Inert unless `AGENTCORE_MCP_APPS_HOST_ENABLED=true` (default true since
+PR #7) — the catalog is empty when the flag is off, so every call is
+rejected as not app-visible.
 """
 
 from __future__ import annotations

--- a/backend/src/apis/shared/mcp_apps/card_store.py
+++ b/backend/src/apis/shared/mcp_apps/card_store.py
@@ -29,7 +29,7 @@ The write stays on the **app-api boundary** (called from
 `/mcp-apps/proxy-call` after a successful dispatch) so inference-api keeps
 its inference-only scope. Dev/local has no table — every method degrades
 to a no-op / empty list, consistent with the whole MCP Apps surface being
-inert behind `AGENTCORE_MCP_APPS_HOST_ENABLED` until PR #7.
+gated by `AGENTCORE_MCP_APPS_HOST_ENABLED` (default true since PR #7).
 """
 
 from __future__ import annotations

--- a/docs/kaizen/scoping/mcp-apps-budget-allocator.tool.json
+++ b/docs/kaizen/scoping/mcp-apps-budget-allocator.tool.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Example ToolCreateRequest body for registering the modelcontextprotocol/ext-apps `budget-allocator-server` as an MCP-Apps-capable external MCP tool. POST this to `/admin/tools/` on the App API (requires an admin session). The form-style App exercises ui/update-model-context + app-initiated tools/call without 3D/charting backend infra. Run the example server in HTTP mode first (see the runbook in .github/docs/deploy/step-04-deploy.md): `cd examples/budget-allocator-server && npm run start:http` → http://localhost:3001/mcp. Adjust serverUrl for a deployed server. authType `none` is only appropriate for an unauthenticated local/dev server — use aws-iam / api-key / oauth2 for anything real.",
+  "toolId": "budget_allocator",
+  "displayName": "Budget Allocator",
+  "description": "Interactive budget-allocation MCP App (modelcontextprotocol/ext-apps example) — sliders, presets, and benchmarks. Dogfood server for the MCP Apps host renderer.",
+  "category": "data",
+  "protocol": "mcp_external",
+  "status": "active",
+  "isPublic": false,
+  "enabledByDefault": false,
+  "mcpConfig": {
+    "serverUrl": "http://localhost:3001/mcp",
+    "transport": "streamable-http",
+    "authType": "none"
+  }
+}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -44,10 +44,12 @@ export interface AppConfig {
  * docs/kaizen/scoping/mcp-apps-host-renderer.md sequence).
  *
  * Provisions a dedicated cross-origin shell (mcp-sandbox.{domainName}) that
- * later PRs (#4+) point the SPA's <mcp-app-frame> at. Standing this stack up
- * is inert: nothing consumes its SSM origin export until the frontend wiring
- * lands, and the whole host renderer stays behind MCP_APPS_HOST_ENABLED
- * (flipped in PR #7).
+ * the SPA's <mcp-app-frame> is pointed at. When `mcpSandbox.enabled`, the
+ * inference-api stack consumes this stack's SSM origin export into
+ * `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` (conditional-SSM pattern, mirrors
+ * artifacts). The host renderer is gated by MCP_APPS_HOST_ENABLED, flipped
+ * on in PR #7; with this stack disabled the surface stays dormant because
+ * the SPA has no proxy origin to frame an App in.
  */
 export interface McpSandboxConfig {
   // When false the stack is not instantiated at all (bin/infrastructure.ts

--- a/infrastructure/lib/inference-api-stack.ts
+++ b/infrastructure/lib/inference-api-stack.ts
@@ -1100,6 +1100,26 @@ export class InferenceApiStack extends cdk.Stack {
           this,
           `/${config.projectPrefix}/oauth/platform-workload-identity-name`
         ),
+
+        // MCP Apps sandbox-proxy origin (PR #7 of
+        // docs/kaizen/scoping/mcp-apps-host-renderer.md). The agent emits
+        // it on the `ui_resource` SSE event as `sandboxOrigin` — the
+        // cross-origin shell the SPA frames a hosted App in. Gated on
+        // `config.mcpSandbox.enabled` so we don't issue an SSM read against
+        // a parameter that doesn't exist when the mcp-sandbox stack isn't
+        // deployed (same conditional-SSM pattern as artifacts above; that
+        // failure would surface as cdk synth token resolution at deploy).
+        // Without it `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` falls back to its
+        // empty Python default and the SPA has no origin to frame an App
+        // in — the host surface stays dormant even with the flag on.
+        ...(config.mcpSandbox.enabled
+          ? {
+              AGENTCORE_MCP_APPS_SANDBOX_ORIGIN: ssm.StringParameter.valueForStringParameter(
+                this,
+                `/${config.projectPrefix}/mcp-sandbox/origin`
+              ),
+            }
+          : {}),
       },
     });
     this.runtime.node.addDependency(runtimeExecutionRole);

--- a/infrastructure/test/inference-api-stack.test.ts
+++ b/infrastructure/test/inference-api-stack.test.ts
@@ -160,6 +160,39 @@ describe('InferenceApiStack', () => {
         }),
       });
     });
+
+    // MCP Apps sandbox-proxy origin (PR #7 of
+    // docs/kaizen/scoping/mcp-apps-host-renderer.md). Conditional-SSM
+    // pattern: only wired when the mcp-sandbox stack is deployed, so a
+    // disabled environment never issues an SSM read against a parameter
+    // that doesn't exist.
+    test('omits AGENTCORE_MCP_APPS_SANDBOX_ORIGIN when mcp-sandbox disabled', () => {
+      // Default mock config has mcpSandbox.enabled = false.
+      template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+        EnvironmentVariables: Match.objectLike({
+          AGENTCORE_MCP_APPS_SANDBOX_ORIGIN: Match.absent(),
+        }),
+      });
+    });
+
+    test('wires AGENTCORE_MCP_APPS_SANDBOX_ORIGIN when mcp-sandbox enabled', () => {
+      const enabledConfig = createMockConfig({
+        mcpSandbox: { enabled: true, extraFrameAncestors: [] },
+      });
+      const app = createMockApp(enabledConfig, ['InferenceApiStack']);
+      const stack = new InferenceApiStack(app, 'SandboxEnabledStack', {
+        config: enabledConfig,
+        env: mockEnv(enabledConfig),
+      });
+      Template.fromStack(stack).hasResourceProperties(
+        'AWS::BedrockAgentCore::Runtime',
+        {
+          EnvironmentVariables: Match.objectLike({
+            AGENTCORE_MCP_APPS_SANDBOX_ORIGIN: Match.anyValue(),
+          }),
+        }
+      );
+    });
   });
 
   describe('AgentCore Memory', () => {


### PR DESCRIPTION
## Summary

Final PR of the MCP Apps host-renderer initiative (`docs/kaizen/scoping/mcp-apps-host-renderer.md`). PRs #1–#6 are on `develop` ([#348](https://github.com/Boise-State-Development/agentcore-public-stack/pull/348) merged as `4b1f3347`); this PR turns the surface live and dogfoods it.

- **Flag flip** — `Defaults.MCP_APPS_HOST_ENABLED` `False→True`; refreshed the now-stale "default false until PR #7" docstrings across the MCP Apps backend surface + `backend/src/.env.example`. The surface still stays dormant in any environment until an MCP-Apps-capable server is registered, so the flip is low-risk for environments that don't opt in.
- **Closed a real deploy gap (conditional CDK wiring)** — the mcp-sandbox stack publishes `/{prefix}/mcp-sandbox/origin` to SSM but nothing consumed it. The inference-api stack now wires it into `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN`, gated on `config.mcpSandbox.enabled` (conditional-SSM, mirrors the artifacts pattern). Without this a deployed env would emit `ui_resource` with an empty `sandboxOrigin` and the SPA could never frame an App. Two synth tests assert present-when-enabled / absent-when-disabled.
- **Docs** — `CLAUDE.md` SSE table + deploy-order line updated for the live flag and the conditional mcp-sandbox consumption; a "Register an MCP-Apps-capable MCP server" runbook section in `step-04-deploy.md` (discover→create admin API, local-dev env, the `budget-allocator-server` example) + a committed example `ToolCreateRequest` payload; a manual e2e dogfood scenario in `step-05-verify.md`.
- **No `ui_consent_required` SSE row** — consent is frontend-only (PR #6 design departure). That Definition-of-Done line is intentionally void; not a missing deliverable.
- **No auto-seed** — registration stays an explicit per-environment opt-in (a hardcoded server URL in `DEFAULT_TOOLS` would point every deployment at a nonexistent server).

The e2e dogfood scenario (`step-05-verify.md` → section 5) exercises all six Definition-of-Done interactions: resource fetch → iframe render → tool-input push → app-initiated `tools/call` → `ui/update-model-context` mutating the next turn → `ui/open-link` consent prompt. Delivered as a manual test script (not an automated clickthrough): `SKIP_AUTH` is unset here and the full path needs a deployed mcp-sandbox CloudFront origin + a running external MCP server.

## Test plan

- [x] Backend: `cd backend && uv run python -m pytest tests/ -q` → **2952 passed, 3 skipped** (the only correctness gate; not run in CI). Flag flip broke nothing — flag-aware tests set the flag explicitly.
- [x] Frontend: `npm run build` clean (pre-existing warnings only) + `npm run test:ci` → **1067 passed**. Zero frontend source delta in this PR.
- [x] Infra: `npm run build` clean; `stack-dependencies` + `inference-api-stack` (incl. 2 new sandbox-origin tests) + `mcp-sandbox-stack` suites pass.
- [ ] **Manual e2e dogfood** (requires deployed mcp-sandbox origin + registered example server): follow `step-05-verify.md` section 5.

> ⚠️ Pre-existing, unrelated failure on `develop`: `infrastructure-stack.test.ts` "creates all 18 DynamoDB tables" (asserts on `InfrastructureStack`, which PR #7 does not touch — `git diff origin/develop -- infrastructure/lib/infrastructure-stack.ts` is empty). Flagged separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)