### PR TITLE
fix(mcp-apps): promote tools with a ui_resource out of the collapsed tool_group

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { provideMarkdown, MarkdownService } from 'ngx-markdown';
 import { AssistantMessageComponent } from './assistant-message.component';
 import { Message, ContentBlock } from '../../../services/models/message.model';
+import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
+import { UiResourceEvent } from '../../../../shared/utils/stream-parser/stream-parser-types';
 
 function makeMessage(content: ContentBlock[]): Message {
   return {
@@ -209,6 +211,101 @@ describe('AssistantMessageComponent', () => {
       expect(blocks[2].type).toBe('promoted_visual');
       expect(blocks[3].type).toBe('tool_group');
       expect(blocks[3].group!.calls.length).toBe(2);
+    });
+  });
+
+  // Regression: a tool whose result content carries no inline ui_type/ui_display
+  // marker (i.e. not a legacy promoted-visual tool) was being folded into the
+  // collapsed tool_group, so no <app-tool-use> ever existed for it — and the
+  // MCP App frame (which lives inside <app-tool-use>) never instantiated even
+  // though the backend correctly emitted ui_resource. Surfaced dogfooding the
+  // excalidraw-mcp server, whose `create_view` returns plain text. The fix
+  // promotes any tool whose toolUseId is recorded in McpAppStateService.
+  describe('MCP Apps promote tool out of tool_group', () => {
+    function makeUiResource(toolUseId: string): UiResourceEvent {
+      return {
+        type: 'ui_resource',
+        toolUseId,
+        resourceUri: 'ui://example/app.html',
+        html: '<!doctype html><html><body>app</body></html>',
+        mimeType: 'text/html;profile=mcp-app',
+        csp: {},
+        permissions: {},
+        sandboxOrigin: 'https://mcp-sandbox.example.com',
+      };
+    }
+
+    it('folds a plain-text-result tool into tool_group when there is no ui_resource', () => {
+      const tool = makeToolBlock('create_view', {
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('tool_group');
+      expect(blocks[0].group!.calls.length).toBe(1);
+    });
+
+    it('promotes the same tool to tool_use_minimized when its toolUseId is in McpAppStateService', () => {
+      const mcpAppState = TestBed.inject(McpAppStateService);
+      const tool = makeToolBlock('create_view', {
+        toolUseId: 'tooluse_mcp_app_1',
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_1'));
+
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      // Exactly one block: the minimized tool. No `promoted_visual` block —
+      // MCP Apps render their iframe inside <app-tool-use> via the
+      // resultRenderer computed; there is no inline-JSON visual to push.
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+      expect(blocks.some((b) => b.type === 'promoted_visual')).toBe(false);
+
+      mcpAppState.reset();
+    });
+
+    it('retroactively promotes when ui_resource arrives AFTER tool_result (late-arrival reactivity)', () => {
+      const mcpAppState = TestBed.inject(McpAppStateService);
+      const tool = makeToolBlock('create_view', {
+        toolUseId: 'tooluse_mcp_app_2',
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+
+      // Initial render: ui_resource hasn't arrived yet → tool folded into group.
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+      expect(component.displayBlocks()[0].type).toBe('tool_group');
+
+      // ui_resource arrives ~40ms after tool_result on the wire. The
+      // displayBlocks computed must re-run on the McpAppStateService signal
+      // update, or the tool stays folded forever.
+      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_2'));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+
+      mcpAppState.reset();
+    });
+
+    it('promoted-visual tool still emits both tool_use_minimized AND promoted_visual blocks', () => {
+      // Sanity: the new gate must not regress the legacy promoted-visual path.
+      fixture.componentRef.setInput('message', makeMessage([
+        makePromotedVisualToolBlock('chart_tool'),
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(2);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+      expect(blocks[1].type).toBe('promoted_visual');
     });
   });
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -11,6 +11,7 @@ import {
   OAuthConsentRequest,
   OAuthConsentService,
 } from '../../../../services/oauth-consent/oauth-consent.service';
+import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
 
 // ──────────────────────────────────────────────────────────────
 // 🔧 MOCK FLAG — set to true to render 10 fake tool calls
@@ -259,6 +260,7 @@ export class AssistantMessageComponent {
   isStreaming = input<boolean>(false);
 
   private consentService = inject(OAuthConsentService);
+  private mcpAppState = inject(McpAppStateService);
 
   /**
    * Transforms content blocks into display blocks.
@@ -321,9 +323,22 @@ export class AssistantMessageComponent {
       if ((block.type === 'toolUse' || block.type === 'tool_use') && block.toolUse) {
         const toolUse = block.toolUse as ToolUseData;
         const promotedVisual = this.extractPromotedVisual(toolUse);
+        // An MCP App tool (SEP-1865) renders its sandbox-proxy iframe inside
+        // <app-tool-use> via the resultRenderer computed there, so it must
+        // escape the collapsed tool_group exactly like a promoted visual.
+        // `extractPromotedVisual` only fires on the legacy in-result
+        // `ui_type`/`ui_display` marker; MCP Apps deliver UI via a separate
+        // `ui_resource` SSE event that arrives *after* `tool_result` and
+        // their tool result content carries no inline marker. Reading the
+        // signal here keeps `displayBlocks` reactive to a late-arriving
+        // `ui_resource` — the computed re-runs when McpAppStateService
+        // updates and the tool gets promoted retroactively (vs. staying
+        // folded into the group forever).
+        const hasMcpAppResource = this.mcpAppState.has(toolUse.toolUseId);
 
-        if (promotedVisual) {
-          // Promoted visuals break the tool group and render separately
+        if (promotedVisual || hasMcpAppResource) {
+          // Promoted visuals and MCP Apps both need their own <app-tool-use>
+          // row to host the visual or iframe; break the tool group here.
           flushToolGroup();
 
           result.push({
@@ -332,12 +347,14 @@ export class AssistantMessageComponent {
             toolUseId: toolUse.toolUseId
           });
 
-          result.push({
-            type: 'promoted_visual',
-            uiType: promotedVisual.uiType,
-            payload: promotedVisual.payload,
-            toolUseId: toolUse.toolUseId
-          });
+          if (promotedVisual) {
+            result.push({
+              type: 'promoted_visual',
+              uiType: promotedVisual.uiType,
+              payload: promotedVisual.payload,
+              toolUseId: toolUse.toolUseId
+            });
+          }
         } else {
           // Accumulate into the current tool group. A tool_use with no result
           // on a message that has a pending OAuth interrupt is the row that


### PR DESCRIPTION
## Summary

Surfaced dogfooding the MCP Apps host renderer with `excalidraw-mcp`: backend emitted a perfect `ui_resource` SSE event, `McpAppStateService.recordLive` stored it, and yet **no `<app-mcp-app-frame>` ever instantiated**.

**Root cause** in `assistant-message.component.ts`'s `displayBlocks` computed: each `toolUse` is only emitted as a `tool_use_minimized` block (the one that renders `<app-tool-use>`, where the MCP App frame lives via the `resultRenderer` computed) when `extractPromotedVisual` returns non-null — i.e., only for the **legacy** in-result `ui_type`/`ui_display` JSON marker. MCP Apps deliver UI via a *separate* `ui_resource` SSE event (~40 ms after `tool_result`, confirmed on the wire) and their tool result content carries no inline marker, so they fell into the `else` branch and got folded into a collapsed `tool_group`. No `<app-tool-use>` row → no frame → no iframe.

PR #346 / #348 wired the frame inside `<app-tool-use>` but never updated this promotion gate to also promote tools that have an MCP App resource. The component-level unit tests in #346 stubbed `<app-tool-use>` with a renderer harness, so they never exercised the `assistant-message` promotion path.

## Fix

- Inject `McpAppStateService` into `assistant-message.component.ts`.
- Treat `mcpAppState.has(toolUse.toolUseId)` as an **additional** promotion reason alongside `extractPromotedVisual`.
- Signal read is inside `displayBlocks()`, so a late-arriving `ui_resource` re-runs the computation and **retroactively** promotes the tool out of the group.
- The `promoted_visual` block is still pushed only on the legacy path (MCP Apps render their iframe inside `<app-tool-use>` via the resultRenderer — no inline-JSON visual to emit).

## Test plan

- [x] `npm run test:ci` → **1071 passed** (was 1067 on develop; +4 = exactly the new regressions).
- [x] `npm run build` → clean (pre-existing bundle-size warning only).
- [ ] Manual: re-run a `create_view` against `excalidraw-mcp` with the host flag on and a deployed sandbox origin wired — the iframe now renders. (Confirmed locally during this session; the fix is hot-reloaded into the dev SPA.)

Four new specs cover:
- folds-into-`tool_group`-without-resource
- promotes-to-`tool_use_minimized`-with-resource (and no extra `promoted_visual` block)
- **retroactive promotion** when `ui_resource` arrives *after* `tool_result` (the reactivity regression)
- legacy promoted-visual path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)