### PR TITLE
fix(mcp-apps): unblock App rendering — blob iframe, first-class block, Angular 21 fixes

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { provideMarkdown, MarkdownService } from 'ngx-markdown';
 import { AssistantMessageComponent } from './assistant-message.component';
 import { Message, ContentBlock } from '../../../services/models/message.model';
+import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
+import { UiResourceEvent } from '../../../../shared/utils/stream-parser/stream-parser-types';
 
 function makeMessage(content: ContentBlock[]): Message {
   return {
@@ -209,6 +211,104 @@ describe('AssistantMessageComponent', () => {
       expect(blocks[2].type).toBe('promoted_visual');
       expect(blocks[3].type).toBe('tool_group');
       expect(blocks[3].group!.calls.length).toBe(2);
+    });
+  });
+
+  // Regression: a tool whose result content carries no inline ui_type/ui_display
+  // marker (i.e. not a legacy promoted-visual tool) was being folded into the
+  // collapsed tool_group, so no <app-tool-use> ever existed for it — and the
+  // MCP App frame (which lives inside <app-tool-use>) never instantiated even
+  // though the backend correctly emitted ui_resource. Surfaced dogfooding the
+  // excalidraw-mcp server, whose `create_view` returns plain text. The fix
+  // promotes any tool whose toolUseId is recorded in McpAppStateService.
+  describe('MCP Apps promote tool out of tool_group', () => {
+    function makeUiResource(toolUseId: string): UiResourceEvent {
+      return {
+        type: 'ui_resource',
+        toolUseId,
+        resourceUri: 'ui://example/app.html',
+        html: '<!doctype html><html><body>app</body></html>',
+        mimeType: 'text/html;profile=mcp-app',
+        csp: {},
+        permissions: {},
+        sandboxOrigin: 'https://mcp-sandbox.example.com',
+      };
+    }
+
+    it('folds a plain-text-result tool into tool_group when there is no ui_resource', () => {
+      const tool = makeToolBlock('create_view', {
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('tool_group');
+      expect(blocks[0].group!.calls.length).toBe(1);
+    });
+
+    it('promotes the same tool to tool_use_minimized when its toolUseId is in McpAppStateService', () => {
+      const mcpAppState = TestBed.inject(McpAppStateService);
+      const tool = makeToolBlock('create_view', {
+        toolUseId: 'tooluse_mcp_app_1',
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_1'));
+
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      // Two blocks: the minimized tool card (provenance) plus a sibling
+      // mcp_app_frame block that hosts the iframe at the same level as
+      // text/visuals. No `promoted_visual` — MCP Apps have their own type.
+      expect(blocks.length).toBe(2);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+      expect(blocks[1].type).toBe('mcp_app_frame');
+      expect(blocks[1].toolUseId).toBe('tooluse_mcp_app_1');
+      expect(blocks.some((b) => b.type === 'promoted_visual')).toBe(false);
+
+      mcpAppState.reset();
+    });
+
+    it('retroactively promotes when ui_resource arrives AFTER tool_result (late-arrival reactivity)', () => {
+      const mcpAppState = TestBed.inject(McpAppStateService);
+      const tool = makeToolBlock('create_view', {
+        toolUseId: 'tooluse_mcp_app_2',
+        result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
+      });
+
+      // Initial render: ui_resource hasn't arrived yet → tool folded into group.
+      fixture.componentRef.setInput('message', makeMessage([tool]));
+      fixture.detectChanges();
+      expect(component.displayBlocks()[0].type).toBe('tool_group');
+
+      // ui_resource arrives ~40ms after tool_result on the wire. The
+      // displayBlocks computed must re-run on the McpAppStateService signal
+      // update, or the tool stays folded forever.
+      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_2'));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(2);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+      expect(blocks[1].type).toBe('mcp_app_frame');
+
+      mcpAppState.reset();
+    });
+
+    it('promoted-visual tool still emits both tool_use_minimized AND promoted_visual blocks', () => {
+      // Sanity: the new gate must not regress the legacy promoted-visual path.
+      fixture.componentRef.setInput('message', makeMessage([
+        makePromotedVisualToolBlock('chart_tool'),
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(2);
+      expect(blocks[0].type).toBe('tool_use_minimized');
+      expect(blocks[1].type).toBe('promoted_visual');
     });
   });
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -7,10 +7,13 @@ import { ReasoningContentComponent } from './reasoning-content';
 import { StreamingTextComponent } from './streaming-text.component';
 import { InlineVisualComponent } from './inline-visual';
 import { OAuthConsentPromptComponent } from './oauth-consent-prompt/oauth-consent-prompt.component';
+import { McpAppFrameComponent } from './tool-use/renderers/mcp-app-frame.component';
 import {
   OAuthConsentRequest,
   OAuthConsentService,
 } from '../../../../services/oauth-consent/oauth-consent.service';
+import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
+import type { ToolResultData } from './tool-use/tool-renderer-registry.service';
 
 // ──────────────────────────────────────────────────────────────
 // 🔧 MOCK FLAG — set to true to render 10 fake tool calls
@@ -108,6 +111,7 @@ interface DisplayBlock {
     | 'tool_group'
     | 'tool_use_minimized'
     | 'promoted_visual'
+    | 'mcp_app_frame'
     | 'reasoningContent'
     | 'oauth_required';
   data?: ContentBlock;
@@ -117,6 +121,8 @@ interface DisplayBlock {
   uiType?: string;
   payload?: unknown;
   toolUseId?: string;
+  // For MCP App frames (SEP-1865): the tool result re-shaped for the renderer.
+  mcpResult?: ToolResultData;
   // For inline OAuth consent prompts
   oauthRequest?: OAuthConsentRequest;
 }
@@ -131,6 +137,7 @@ interface DisplayBlock {
     StreamingTextComponent,
     InlineVisualComponent,
     OAuthConsentPromptComponent,
+    McpAppFrameComponent,
   ],
   template: `
     <div class="block-container">
@@ -192,6 +199,18 @@ interface DisplayBlock {
               <app-inline-visual
                 [uiType]="block.uiType!"
                 [payload]="block.payload"
+                [toolUseId]="block.toolUseId!"
+              />
+            </div>
+          }
+          @case ('mcp_app_frame') {
+            <div
+              class="message-block visual-block"
+              [style.animation-delay]="$index * 0.1 + 's'"
+            >
+              <app-mcp-app-frame
+                class="block w-full"
+                [result]="block.mcpResult!"
                 [toolUseId]="block.toolUseId!"
               />
             </div>
@@ -259,6 +278,7 @@ export class AssistantMessageComponent {
   isStreaming = input<boolean>(false);
 
   private consentService = inject(OAuthConsentService);
+  private mcpAppState = inject(McpAppStateService);
 
   /**
    * Transforms content blocks into display blocks.
@@ -321,9 +341,23 @@ export class AssistantMessageComponent {
       if ((block.type === 'toolUse' || block.type === 'tool_use') && block.toolUse) {
         const toolUse = block.toolUse as ToolUseData;
         const promotedVisual = this.extractPromotedVisual(toolUse);
+        // An MCP App tool (SEP-1865) renders its sandbox-proxy iframe inside
+        // <app-tool-use> via the resultRenderer computed there, so it must
+        // escape the collapsed tool_group exactly like a promoted visual.
+        // `extractPromotedVisual` only fires on the legacy in-result
+        // `ui_type`/`ui_display` marker; MCP Apps deliver UI via a separate
+        // `ui_resource` SSE event that arrives *after* `tool_result` and
+        // their tool result content carries no inline marker. Reading the
+        // signal here keeps `displayBlocks` reactive to a late-arriving
+        // `ui_resource` — the computed re-runs when McpAppStateService
+        // updates and the tool gets promoted retroactively (vs. staying
+        // folded into the group forever).
+        const hasMcpAppResource = this.mcpAppState.has(toolUse.toolUseId);
 
-        if (promotedVisual) {
-          // Promoted visuals break the tool group and render separately
+        if (promotedVisual || hasMcpAppResource) {
+          // Promoted visuals and MCP Apps both need their own first-class
+          // sibling block (the iframe is not "tool output", it's a primary
+          // UI surface); break the tool group here.
           flushToolGroup();
 
           result.push({
@@ -332,12 +366,22 @@ export class AssistantMessageComponent {
             toolUseId: toolUse.toolUseId
           });
 
-          result.push({
-            type: 'promoted_visual',
-            uiType: promotedVisual.uiType,
-            payload: promotedVisual.payload,
-            toolUseId: toolUse.toolUseId
-          });
+          if (promotedVisual) {
+            result.push({
+              type: 'promoted_visual',
+              uiType: promotedVisual.uiType,
+              payload: promotedVisual.payload,
+              toolUseId: toolUse.toolUseId
+            });
+          }
+
+          if (hasMcpAppResource) {
+            result.push({
+              type: 'mcp_app_frame',
+              toolUseId: toolUse.toolUseId,
+              mcpResult: this.toResultData(toolUse),
+            });
+          }
         } else {
           // Accumulate into the current tool group. A tool_use with no result
           // on a message that has a pending OAuth interrupt is the row that
@@ -374,6 +418,16 @@ export class AssistantMessageComponent {
 
     return result;
   });
+
+  /**
+   * Reshape a tool-use's `result` into the renderer's `ToolResultData`
+   * contract. Until the `tool_result` event arrives we pass an empty
+   * success stub — the renderer holds the iframe until the result comes
+   * in (and re-pushes it via the `refreshToolResult` effect).
+   */
+  private toResultData(toolUse: ToolUseData): ToolResultData {
+    return toolUse.result ?? { content: [], status: 'success' };
+  }
 
   /**
    * Extract promoted visual data from a tool use result.

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -11,7 +11,6 @@ import {
   viewChild,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import type {
   ToolResultData,
   ToolResultRenderer,
@@ -23,6 +22,7 @@ import { McpAppBridge } from '../../../../../services/mcp-apps/mcp-app-bridge';
 import { McpAppProxyService } from '../../../../../services/mcp-apps/mcp-app-proxy.service';
 import { McpAppMessageService } from '../../../../../services/mcp-apps/mcp-app-message.service';
 import { McpAppConsentService } from '../../../../../services/mcp-apps/mcp-app-consent.service';
+import { McpAppConsentPromptComponent } from '../../mcp-app-consent-prompt/mcp-app-consent-prompt.component';
 import type { CapabilityKey } from '../../../../../services/mcp-apps/mcp-app-protocol';
 import { ChatRequestService } from '../../../../../services/chat/chat-request.service';
 import { SessionService } from '../../../../../services/session/session.service';
@@ -47,25 +47,19 @@ import { SessionService } from '../../../../../services/session/session.service'
 @Component({
   selector: 'app-mcp-app-frame',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [McpAppConsentPromptComponent],
   styles: ':host { display: block; }',
   template: `
-    @if (safeProxyUrl(); as url) {
-      <div
-        class="overflow-hidden rounded-sm border border-gray-300 dark:border-gray-600 bg-white"
-      >
-        <iframe
-          #frame
-          [src]="url"
-          [style.height.px]="frameHeight()"
-          [attr.allow]="allowAttr()"
-          class="block w-full border-0 bg-white"
-          title="MCP App"
-          sandbox="allow-scripts allow-same-origin"
-          referrerpolicy="no-referrer"
-          loading="lazy"
-          (load)="onProxyLoad()"
-        ></iframe>
+    @if (currentPrompt(); as prompt) {
+      <div class="mb-2 flex justify-start">
+        <app-mcp-app-consent-prompt [prompt]="prompt" />
       </div>
+    }
+    @if (proxyUrl(); as url) {
+      <div
+        #host
+        class="overflow-hidden rounded-sm border border-gray-300 dark:border-gray-600 bg-white"
+      ></div>
     }
   `,
 })
@@ -84,12 +78,13 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   private readonly conversation = inject(SessionService);
   private readonly streamParser = inject(StreamParserService);
   private readonly theme = inject(ThemeService);
-  private readonly sanitizer = inject(DomSanitizer);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly win = inject(DOCUMENT).defaultView;
+  private readonly doc = inject(DOCUMENT);
+  private readonly win = this.doc.defaultView;
 
-  private readonly frameRef =
-    viewChild<ElementRef<HTMLIFrameElement>>('frame');
+  private readonly hostRef =
+    viewChild<ElementRef<HTMLDivElement>>('host');
+  private iframeEl: HTMLIFrameElement | null = null;
 
   /** Initial height; the App drives it via `ui/notifications/size-changed`. */
   protected readonly frameHeight = signal(360);
@@ -125,6 +120,16 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   private readonly capabilityGrant = signal<boolean | null>(null);
   private capabilityAsked = false;
 
+  /** Id of this frame's currently-open consent prompt (capability ask or
+   *  open-link), used to render it inline above the iframe instead of in
+   *  an unanchored message-list strip. */
+  private readonly openPromptId = signal<string | null>(null);
+  protected readonly currentPrompt = computed(() => {
+    const id = this.openPromptId();
+    if (!id) return null;
+    return this.mcpAppConsent.pending().find((p) => p.id === id) ?? null;
+  });
+
   /** True once requested capabilities are decided (or none were asked). */
   private readonly capabilitiesResolved = computed(
     () => this.requestedCaps().length === 0 || this.capabilityGrant() !== null,
@@ -137,18 +142,18 @@ export class McpAppFrameComponent implements ToolResultRenderer {
     return this.capabilityGrant() ? declared : {};
   });
 
-  protected readonly safeProxyUrl = computed<SafeResourceUrl | null>(() => {
+  /**
+   * Plain string URL the iframe `src` is set to. Stays null until consent
+   * resolves so the @if-gated host div doesn't appear. Trusted single
+   * value from our authenticated backend (SSM-sourced); the imperative
+   * sandbox attribute + the proxy's per-resource CSP are the real
+   * containment, same justification as the artifact panel.
+   */
+  protected readonly proxyUrl = computed<string | null>(() => {
     const res = this.resource();
     if (!res || !res.sandboxOrigin) return null;
-    // Hold the frame until the user has answered the capability prompt —
-    // building it later would race the proxy's sandbox-resource-ready.
     if (!this.capabilitiesResolved()) return null;
-    // Trusted single value from our authenticated backend (SSM-sourced);
-    // the sandbox attribute + the proxy's per-resource CSP are the real
-    // containment, same justification as the artifact panel.
-    return this.sanitizer.bypassSecurityTrustResourceUrl(
-      `${res.sandboxOrigin.replace(/\/$/, '')}/proxy.html`,
-    );
+    return `${res.sandboxOrigin.replace(/\/$/, '')}/proxy.html`;
   });
 
   /** Permissions-Policy `allow` for the outer frame (delegates to inner). */
@@ -179,15 +184,60 @@ export class McpAppFrameComponent implements ToolResultRenderer {
       const caps = this.requestedCaps();
       if (caps.length === 0 || this.capabilityAsked) return;
       this.capabilityAsked = true;
-      this.mcpAppConsent
-        .request({ kind: 'capabilities', capabilities: caps })
-        .then((granted) => this.capabilityGrant.set(granted))
-        .catch(() => this.capabilityGrant.set(false));
+      const { id, granted } = this.mcpAppConsent.request({
+        kind: 'capabilities',
+        capabilities: caps,
+      });
+      this.openPromptId.set(id);
+      granted
+        .then((g) => this.capabilityGrant.set(g))
+        .catch(() => this.capabilityGrant.set(false))
+        .finally(() => this.openPromptId.set(null));
+    });
+    // Imperatively create the iframe once the host div mounts and consent
+    // is resolved. Angular 21 forbids dynamic `[attr.allow]` on <iframe>
+    // (NG0910), so we build the element by hand with all attributes set
+    // before src — the browser only consults `allow` at load-start.
+    effect(() => {
+      const host = this.hostRef();
+      const url = this.proxyUrl();
+      if (!host || !url) {
+        if (this.iframeEl) {
+          this.iframeEl.remove();
+          this.iframeEl = null;
+        }
+        return;
+      }
+      if (this.iframeEl) return;
+      const iframe = this.doc.createElement('iframe');
+      iframe.setAttribute('title', 'MCP App');
+      iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+      iframe.setAttribute('referrerpolicy', 'no-referrer');
+      iframe.setAttribute('loading', 'lazy');
+      const allow = this.allowAttr();
+      if (allow) iframe.setAttribute('allow', allow);
+      iframe.className = 'block w-full border-0 bg-white';
+      iframe.style.height = `${this.frameHeight()}px`;
+      // Append BEFORE setting src so contentWindow exists, then start the
+      // bridge so the host listener is registered before the proxy script
+      // posts its `sandbox-proxy-ready` notification. Doing this in the
+      // (load) callback races: the proxy fires ready as soon as its IIFE
+      // runs, which is before the host's load event handler dispatches —
+      // miss that and the inner App iframe is never mounted (blank frame).
+      host.nativeElement.appendChild(iframe);
+      this.iframeEl = iframe;
+      this.startBridge();
+      iframe.src = url;
+    });
+    // Keep the iframe height in sync as the App reports size changes.
+    effect(() => {
+      const h = this.frameHeight();
+      if (this.iframeEl) this.iframeEl.style.height = `${h}px`;
     });
     this.destroyRef.onDestroy(() => this.bridge?.dispose('component-destroyed'));
   }
 
-  protected onProxyLoad(): void {
+  private startBridge(): void {
     const res = this.resource();
     if (!res || this.bridge || !this.win) return;
     // Hand the bridge a resource whose permissions are already narrowed to
@@ -197,7 +247,7 @@ export class McpAppFrameComponent implements ToolResultRenderer {
     const effectiveRes = { ...res, permissions: this.effectivePermissions() };
     this.bridge = new McpAppBridge({
       hostWindow: this.win,
-      getProxyWindow: () => this.frameRef()?.nativeElement.contentWindow ?? null,
+      getProxyWindow: () => this.iframeEl?.contentWindow ?? null,
       sandboxOrigin: res.sandboxOrigin.replace(/\/$/, ''),
       resource: effectiveRes,
       nonce: this.nonce,
@@ -224,7 +274,11 @@ export class McpAppFrameComponent implements ToolResultRenderer {
         ),
       updateModelContext: (payload) =>
         this.mcpAppMessage.updateModelContext(res.resourceUri, payload),
-      requestConsent: (req) => this.mcpAppConsent.request(req),
+      requestConsent: (req) => {
+        const { id, granted } = this.mcpAppConsent.request(req);
+        this.openPromptId.set(id);
+        return granted.finally(() => this.openPromptId.set(null));
+      },
     });
     this.bridge.onSizeChanged((_w, h) => {
       if (h > 0) this.frameHeight.set(Math.ceil(h));

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/tool-use.component.ts
@@ -10,8 +10,6 @@ import { NgComponentOutlet } from '@angular/common';
 import { JsonSyntaxHighlightPipe } from './json-syntax-highlight.pipe';
 import { ContentBlock, ToolUseData } from '../../../../services/models/message.model';
 import { ToolRendererRegistryService } from './tool-renderer-registry.service';
-import { McpAppStateService } from '../../../../services/mcp-apps/mcp-app-state.service';
-import { McpAppFrameComponent } from './renderers/mcp-app-frame.component';
 
 @Component({
   selector: 'app-tool-use',
@@ -31,7 +29,6 @@ export class ToolUseComponent {
   isDetailsExpanded = signal(false);
 
   private readonly rendererRegistry = inject(ToolRendererRegistryService);
-  private readonly mcpAppState = inject(McpAppStateService);
 
   /** Extract tool use data from the content block */
   toolUseData = computed(() => {
@@ -72,39 +69,21 @@ export class ToolUseComponent {
   });
 
   /**
-   * Result-renderer component for this tool.
-   *
-   * An MCP App (SEP-1865) takes precedence: when this tool invocation
-   * produced a `ui_resource` event, render the sandbox-proxy frame. App
-   * tool names are server-defined and per-invocation, so this can't be a
-   * static name→component registry entry (PR #0) — it keys off the
-   * toolUseId-scoped resource instead, but stays a single
-   * `[ngComponentOutlet]` with no template branch. Otherwise fall back to
-   * the name-keyed registry (default = text/JSON/image). Both reads are
-   * signals, so this stays reactive to a `ui_resource` arriving after the
-   * tool-use block first renders.
+   * Result-renderer component for this tool. Resolved from the name-keyed
+   * registry (default = text/JSON/image). MCP Apps (SEP-1865) deliberately
+   * do NOT route through here — they render as their own first-class
+   * `mcp_app_frame` block in <app-assistant-message>, with the tool card
+   * still showing the call's input/output as provenance.
    */
   resultRenderer = computed(() =>
-    this.mcpAppState.has(this.toolUseId())
-      ? McpAppFrameComponent
-      : this.rendererRegistry.resolve(this.toolName()),
+    this.rendererRegistry.resolve(this.toolName()),
   );
 
-  /**
-   * Inputs bound onto the resolved renderer via NgComponentOutlet.
-   * `toolUseId` is passed ONLY to the MCP App frame: NgComponentOutlet
-   * throws (NG0303) if asked to set an input a component doesn't declare,
-   * and the default/other renderers intentionally don't expose it.
-   */
-  rendererInputs = computed(() => {
-    const base = {
-      result: this.toolResult(),
-      minimized: this.minimized(),
-    };
-    return this.resultRenderer() === McpAppFrameComponent
-      ? { ...base, toolUseId: this.toolUseId() }
-      : base;
-  });
+  /** Inputs bound onto the resolved renderer via NgComponentOutlet. */
+  rendererInputs = computed(() => ({
+    result: this.toolResult(),
+    minimized: this.minimized(),
+  }));
 
   /** Preview of input keys for collapsed state */
   inputKeysPreview = computed(() => {

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -94,16 +94,6 @@
     </div>
   }
 
-  <!-- Frontend-only consent for App-initiated open-link / capability
-       requests (PR #6). These originate from a postMessage on the embedded
-       App, not a backend turn, so they live entirely client-side and are
-       not persisted (transient interaction gates). -->
-  @for (prompt of mcpConsentPrompts(); track prompt.id) {
-    <div class="flex justify-start">
-      <app-mcp-app-consent-prompt [prompt]="prompt" />
-    </div>
-  }
-
   <!-- Static historical cards for app-initiated tool calls (PR #6,
        Option A). The PR #5 broker is in-memory, so on reload the live
        tool_use/tool_result are gone; these replay them as a read-only

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -14,9 +14,7 @@ import { CompactionSummaryComponent } from './components/compaction-summary/comp
 import { ArtifactCardComponent } from './components/artifact/artifact-card.component';
 import { ArtifactPanelComponent } from './components/artifact/artifact-panel.component';
 import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
-import { McpAppConsentPromptComponent } from './components/mcp-app-consent-prompt/mcp-app-consent-prompt.component';
 import { McpAppCardComponent } from './components/mcp-app-card/mcp-app-card.component';
-import { McpAppConsentService } from '../../services/mcp-apps/mcp-app-consent.service';
 import { McpAppCardStateService } from '../../services/mcp-apps/mcp-app-card-state.service';
 import {
   OAuthConsentRequest,
@@ -43,7 +41,6 @@ import { ChatStateService } from '../../services/chat/chat-state.service';
     CompactionSummaryComponent,
     ArtifactCardComponent,
     ArtifactPanelComponent,
-    McpAppConsentPromptComponent,
     McpAppCardComponent,
   ],
   templateUrl: './message-list.component.html',
@@ -72,12 +69,9 @@ export class MessageListComponent implements OnDestroy {
   private toolApprovalService = inject(ToolApprovalService);
   private compactionSummary = inject(CompactionSummaryService);
   private artifactState = inject(ArtifactStateService);
-  private mcpAppConsent = inject(McpAppConsentService);
   private mcpAppCardState = inject(McpAppCardStateService);
   private chatStateService = inject(ChatStateService);
 
-  /** Pending frontend-only MCP App consent prompts (PR #6). */
-  protected mcpConsentPrompts = this.mcpAppConsent.pending;
   /** Persisted app-initiated tool cards, hydrated on reload (PR #6). */
   protected mcpAppCards = this.mcpAppCardState.cards;
   protected hasMcpAppCards = this.mcpAppCardState.hasCards;

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.spec.ts
@@ -9,23 +9,27 @@ describe('McpAppConsentService', () => {
   });
 
   it('surfaces a pending prompt and resolves it on answer(true)', async () => {
-    const p = svc.request({ kind: 'open-link', url: 'https://x.test' });
+    const { id, granted } = svc.request({
+      kind: 'open-link',
+      url: 'https://x.test',
+    });
     expect(svc.pending()).toHaveLength(1);
     const entry = svc.pending()[0];
+    expect(entry.id).toBe(id);
     expect(entry.request).toEqual({ kind: 'open-link', url: 'https://x.test' });
 
     svc.answer(entry.id, true);
-    await expect(p).resolves.toBe(true);
+    await expect(granted).resolves.toBe(true);
     expect(svc.pending()).toHaveLength(0);
   });
 
   it('resolves false on deny', async () => {
-    const p = svc.request({
+    const { granted } = svc.request({
       kind: 'capabilities',
       capabilities: ['microphone'],
     });
     svc.answer(svc.pending()[0].id, false);
-    await expect(p).resolves.toBe(false);
+    await expect(granted).resolves.toBe(false);
   });
 
   it('answer() on an unknown id is a no-op', () => {
@@ -41,8 +45,8 @@ describe('McpAppConsentService', () => {
 
     svc.reset();
     expect(svc.pending()).toHaveLength(0);
-    await expect(a).resolves.toBe(false);
-    await expect(b).resolves.toBe(false);
+    await expect(a.granted).resolves.toBe(false);
+    await expect(b.granted).resolves.toBe(false);
   });
 
   it('keeps multiple prompts independently addressable', async () => {
@@ -51,11 +55,11 @@ describe('McpAppConsentService', () => {
     const [ea, eb] = svc.pending();
 
     svc.answer(eb.id, true);
-    await expect(b).resolves.toBe(true);
+    await expect(b.granted).resolves.toBe(true);
     expect(svc.pending()).toHaveLength(1);
     expect(svc.pending()[0].id).toBe(ea.id);
 
     svc.answer(ea.id, false);
-    await expect(a).resolves.toBe(false);
+    await expect(a.granted).resolves.toBe(false);
   });
 });

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-consent.service.ts
@@ -38,12 +38,14 @@ export class McpAppConsentService {
 
   /**
    * Surface a consent prompt and resolve once the user answers. The bridge
-   * awaits this before opening a link. If the conversation changes while a
-   * prompt is open, `reset()` resolves it as denied (fail-closed).
+   * awaits `granted` before opening a link; the frame uses `id` to render
+   * the prompt inline next to its own iframe (PR #6 follow-up — replaces
+   * the unanchored message-list strip). If the conversation changes while
+   * a prompt is open, `reset()` resolves it as denied (fail-closed).
    */
-  request(request: ConsentRequest): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
-      const id = `mcp-consent-${++this.seq}`;
+  request(request: ConsentRequest): { id: string; granted: Promise<boolean> } {
+    const id = `mcp-consent-${++this.seq}`;
+    const granted = new Promise<boolean>((resolve) => {
       const entry: PendingConsent = {
         id,
         request,
@@ -52,6 +54,7 @@ export class McpAppConsentService {
       };
       this.pendingSignal.set([...this.pendingSignal(), entry]);
     });
+    return { id, granted };
   }
 
   /** User answered a prompt (Allow/Deny). Idempotent. */

--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -150,20 +150,30 @@
     inner.setAttribute('referrerpolicy', 'no-referrer');
     inner.style.cssText =
       'border:0;width:100%;height:100%;display:block;background:#fff';
+    // Build the App document and hand it to the inner iframe as a blob URL.
+    // srcdoc / data: / about:blank are "local schemes" that inherit the
+    // embedder's HTTP CSP (CSP3 §"Initialize a Document's CSP list"); blob:
+    // is NOT, so the inner doc's effective CSP is exactly what composeCsp
+    // emits via the injected <meta> tag — no intersection with proxy.html's
+    // strict `script-src 'self'`. Null-origin is unaffected: it comes from
+    // `sandbox` without `allow-same-origin`, regardless of URL scheme. The
+    // per-frame nonce is still the real channel auth.
+    var blob = new Blob(
+      [withCsp(String(params.html || ''), composeCsp(params.csp))],
+      { type: 'text/html' }
+    );
+    var blobUrl = URL.createObjectURL(blob);
     inner.addEventListener('load', function () {
+      // Release the blob backing store as soon as the doc is loaded —
+      // keeping it would pin memory for the iframe's lifetime.
+      URL.revokeObjectURL(blobUrl);
       innerReady = true;
       var queued = pendingToInner.splice(0, pendingToInner.length);
       for (var i = 0; i < queued.length; i++) {
         postToInner(queued[i]);
       }
     });
-    // srcdoc keeps the document at an opaque ("null") origin — no
-    // allow-same-origin — so it cannot reach the mcp-sandbox origin's
-    // storage; the per-frame nonce is the real channel auth.
-    inner.setAttribute(
-      'srcdoc',
-      withCsp(String(params.html || ''), composeCsp(params.csp))
-    );
+    inner.src = blobUrl;
     document.body.appendChild(inner);
   }
 

--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -75,14 +75,14 @@ export function buildMcpSandboxFrameAncestors(
  *   - `script-src 'self'`  — proxy.js only; no inline script, no
  *     `'unsafe-inline'` (proxy.html ships zero inline script/style on
  *     purpose so this stays clean).
- *   - `frame-src 'self'`   — permits the inner `srcdoc` content frame the
- *     shell creates. The strict PER-RESOURCE inner CSP composed from
- *     `_meta.ui.csp` is PR #4's job (and is browser-verifiable there, once
- *     real content actually loads); this outer policy is intentionally
- *     provisional until then. Nested-CSP / `frame-ancestors` interplay has
- *     no prior art in this stack — flagged as expected debugging in the
- *     scoping doc; deferring the inner-frame tuning to the PR where it can
- *     be exercised in a browser is the safe sequencing.
+ *   - `frame-src 'self' blob:` — permits the inner content frame the shell
+ *     creates. The shell mounts that frame from a `blob:` URL (NOT srcdoc):
+ *     blob URLs are not "local schemes" under CSP3, so the inner App
+ *     document's effective CSP is exactly what proxy.js composes from
+ *     `_meta.ui.csp`, with no inheritance/intersection from this outer
+ *     policy. Modern browsers match blob: against `'self'` when the blob
+ *     was created same-origin, but `blob:` is listed explicitly for
+ *     durability across engines.
  *   - everything else denied via `default-src 'none'`.
  *
  * Exported for direct unit testing.
@@ -91,7 +91,7 @@ export function buildMcpSandboxProxyCsp(frameAncestors: string): string {
   return [
     `default-src 'none'`,
     `script-src 'self'`,
-    `frame-src 'self'`,
+    `frame-src 'self' blob:`,
     `frame-ancestors ${frameAncestors}`,
     `base-uri 'none'`,
     `form-action 'none'`,

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -165,7 +165,10 @@ describe('buildMcpSandboxProxyCsp', () => {
     const csp = buildMcpSandboxProxyCsp('https://alpha.example.com');
     expect(csp).toContain("default-src 'none'");
     expect(csp).toContain("script-src 'self'");
-    expect(csp).toContain("frame-src 'self'");
+    // Inner App iframe mounts from a blob: URL (not srcdoc) to escape the
+    // local-scheme CSP inheritance that would intersect the App's own CSP
+    // with proxy.html's strict outer policy. frame-src must permit blob:.
+    expect(csp).toContain("frame-src 'self' blob:");
     expect(csp).toContain('frame-ancestors https://alpha.example.com');
     expect(csp).toContain("base-uri 'none'");
     expect(csp).toContain("form-action 'none'");


### PR DESCRIPTION
## Summary

PR #7 flipped the host flag, but the dogfood revealed real Apps (e.g. Excalidraw) still render blank. Three independent issues, all downstream of the merged PR #1–#7 contracts:

- **Angular 21 NG0910** — dynamic `[attr.allow]` on `<iframe>` is rejected. Outer iframe now built imperatively (`document.createElement` + `setAttribute('allow', …)` before `src`). [mcp-app-frame.component.ts](frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts)
- **Handshake race** — `proxy.js` fires `sandbox-proxy-ready` inside its IIFE; the prior bridge wiring registered the host listener in `(load)`, so the ready notification was lost and the inner App iframe never mounted (blank, 200-OK proxy.html). Bridge now starts **before** `iframe.src` is assigned.
- **CSP inheritance** — srcdoc is a CSP3 "local scheme" and inherits the embedder's HTTP CSP. `proxy.html`'s strict `script-src 'self'` (correctly hardening the shell) intersected with `composeCsp()`'s output, blocking every inline `<script>`/`<style>` in App HTML. [proxy.js](infrastructure/assets/mcp-sandbox/proxy.js) now mounts the inner iframe from a **blob: URL** instead of srcdoc — blob isn't a local scheme, so no inheritance; null-origin is still enforced by `sandbox` (no `allow-same-origin`). [mcp-sandbox-stack.ts](infrastructure/lib/mcp-sandbox-stack.ts) adds `blob:` to `frame-src` for cross-browser durability.

Plus a UX cut from the dogfood: the MCP App frame and its capability-consent prompt no longer live inside the tool-use card's collapsible "Output" section. They render as their own first-class sibling block in `app-assistant-message` (alongside `promoted_visual`), with the consent prompt inline above the iframe area instead of in an unanchored message-list strip.

## Test plan

- [x] `npm run test:ci` (frontend) — 1071 passed
- [x] `npm test` (infrastructure) — 334 passed; new assertion locks in `frame-src 'self' blob:`
- [ ] Deploy `McpSandboxStack` to alpha
- [ ] Invalidate CloudFront for `/proxy.js` + `/proxy.html` (verify the `mcp-sandbox.yml` workflow does this; run manually if not)
- [ ] Hard-refresh the SPA, run an Excalidraw `create_view` prompt
- [ ] Confirm: consent prompt appears inline above the frame slot, Allow → iframe mounts → App renders
- [ ] Confirm: console has no `Executing inline script violates...` errors
- [ ] (Benign warning to expect: "iframe which has both allow-scripts and allow-same-origin…" — outer iframe legitimately needs both since proxy is cross-origin)

## Notes

- Requires redeploying the mcp-sandbox stack. The frontend changes alone are inert without the new `proxy.js`.
- No SSE-event-shape changes, no backend API changes, no auth changes.
- Gotchas captured in [memory/project_mcp_apps_pr_progress.md](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/.claude/projects/-Users-philmerrell-Repos-agentcore-public-stack/memory/project_mcp_apps_pr_progress.md) gotcha #4 (local file, not committed) so a future session doesn't relearn them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)