### PR TITLE
fix(mcp-apps): align outer CSP + inner mount to ext-apps basic-host reference

### DIFF
--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -8,27 +8,36 @@
  * This file is served from the dedicated mcp-sandbox origin and runs inside
  * the OUTER iframe the SPA created with sandbox="allow-scripts
  * allow-same-origin". It is the stable cross-origin boundary between the
- * host (ai.client) and the untrusted App View (an inner null-origin srcdoc
- * iframe this script creates).
+ * host (ai.client) and the untrusted App View (an inner iframe this script
+ * creates, mounted via document.write per the ext-apps basic-host
+ * reference). The inner iframe defaults to allow-scripts +
+ * allow-same-origin so document.write can populate it; the App may
+ * override its `_meta.ui.sandbox` to opt back into null-origin (we'll
+ * fall back to srcdoc when contentDocument isn't writable).
  *
  * Responsibilities (spec §"Sandbox proxy"):
  *   3. Announce readiness to the host (ui/notifications/sandbox-proxy-ready).
  *   4. Receive the raw HTML + sandbox/CSP/permissions
  *      (ui/notifications/sandbox-resource-ready).
- *   5. Load the View HTML in the inner iframe with a CSP composed from
- *      _meta.ui.csp plus the spec's deny-by-default fallbacks; map
- *      _meta.ui.permissions onto the inner iframe `allow` attribute.
+ *   5. Load the View HTML in the inner iframe via document.write (falls
+ *      back to srcdoc if the App opted into a stricter cross-origin
+ *      sandbox). Inject a per-resource <meta> CSP composed from
+ *      _meta.ui.csp; map _meta.ui.permissions onto the inner iframe's
+ *      `allow` attribute. NOTE: the inner doc also INHERITS this proxy's
+ *      HTTP CSP (CSP3 local-scheme rule applies to srcdoc + document.write-
+ *      populated about:blank alike); that inherited policy — set in
+ *      mcp-sandbox-stack.ts — is the load-bearing security bound. The
+ *      injected <meta> can only further-restrict via intersection.
  *   6. Forward every JSON-RPC message host<->View whose method does not
  *      start with "ui/notifications/sandbox-". The host enforces the
  *      "no sends before initialized" rule; the proxy is a dumb pipe.
  *
  * Auth: a per-frame nonce, minted by the host and delivered in
- * sandbox-resource-ready, authenticates the host<->proxy leg (the inner
- * View is null-origin, so origin matching is impossible — the nonce is the
- * real check the spec mandates). The proxy adds the nonce on View->host
- * forwards and strips it on host->View forwards (the View speaks plain
- * spec JSON-RPC and never sees transport auth). No inline script: the
- * served CSP can stay script-src 'self'.
+ * sandbox-resource-ready, authenticates the host<->proxy leg. The proxy
+ * adds the nonce on View->host forwards and strips it on host->View
+ * forwards (the View speaks plain spec JSON-RPC and never sees transport
+ * auth). proxy.html itself ships zero inline content so 'unsafe-inline'
+ * on the inherited CSP can't be exploited against the shell.
  */
 (function () {
   'use strict';
@@ -134,10 +143,17 @@
   // --- inner iframe (the View) -------------------------------------------
 
   function mountView(params) {
+    // Default to allow-scripts + allow-same-origin so document.write() can
+    // populate the inner iframe (contentDocument is only accessible when
+    // the inner is same-origin to this proxy, which is fine — the proxy
+    // origin is a static CDN with no shared state). The App can override
+    // via `_meta.ui.sandbox` to opt back into null-origin if it wants
+    // stricter isolation; we'll fall back to srcdoc when contentDocument
+    // isn't writable, matching the ext-apps basic-host reference.
     var sandbox =
       typeof params.sandbox === 'string' && params.sandbox
         ? params.sandbox
-        : 'allow-scripts';
+        : 'allow-scripts allow-same-origin';
     var allow = allowAttr(params.permissions);
 
     inner = document.createElement('iframe');
@@ -150,31 +166,42 @@
     inner.setAttribute('referrerpolicy', 'no-referrer');
     inner.style.cssText =
       'border:0;width:100%;height:100%;display:block;background:#fff';
-    // Build the App document and hand it to the inner iframe as a blob URL.
-    // srcdoc / data: / about:blank are "local schemes" that inherit the
-    // embedder's HTTP CSP (CSP3 §"Initialize a Document's CSP list"); blob:
-    // is NOT, so the inner doc's effective CSP is exactly what composeCsp
-    // emits via the injected <meta> tag — no intersection with proxy.html's
-    // strict `script-src 'self'`. Null-origin is unaffected: it comes from
-    // `sandbox` without `allow-same-origin`, regardless of URL scheme. The
-    // per-frame nonce is still the real channel auth.
-    var blob = new Blob(
-      [withCsp(String(params.html || ''), composeCsp(params.csp))],
-      { type: 'text/html' }
-    );
-    var blobUrl = URL.createObjectURL(blob);
     inner.addEventListener('load', function () {
-      // Release the blob backing store as soon as the doc is loaded —
-      // keeping it would pin memory for the iframe's lifetime.
-      URL.revokeObjectURL(blobUrl);
       innerReady = true;
       var queued = pendingToInner.splice(0, pendingToInner.length);
       for (var i = 0; i < queued.length; i++) {
         postToInner(queued[i]);
       }
     });
-    inner.src = blobUrl;
     document.body.appendChild(inner);
+
+    // Build the App document. Per the ext-apps basic-host reference
+    // (examples/basic-host/src/sandbox.ts): "Use document.write instead
+    // of srcdoc (which the CesiumJS Map won't work with)". The inner
+    // document inherits this proxy's HTTP CSP either way — that's the
+    // load-bearing security boundary (see buildMcpSandboxProxyCsp in
+    // mcp-sandbox-stack.ts). The per-App CSP meta tag we still inject
+    // *intersects* the inherited policy, so Apps can further restrict
+    // but not loosen. Per-frame nonce is the channel auth.
+    var html = withCsp(String(params.html || ''), composeCsp(params.csp));
+    var doc = null;
+    try {
+      doc = inner.contentDocument || (inner.contentWindow && inner.contentWindow.document);
+    } catch (_) {
+      // Cross-origin access throws; we'll fall back to srcdoc below.
+      doc = null;
+    }
+    if (doc) {
+      doc.open();
+      doc.write(html);
+      doc.close();
+    } else {
+      // Fallback path: the App opted into a stricter sandbox without
+      // allow-same-origin, so contentDocument is cross-origin. srcdoc
+      // works for the vast majority of Apps; CesiumJS-class outliers
+      // would need to relax their declared sandbox.
+      inner.setAttribute('srcdoc', html);
+    }
   }
 
   // --- message plumbing ---------------------------------------------------

--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -75,26 +75,61 @@ export function buildMcpSandboxFrameAncestors(
  *   - `script-src 'self'`  — proxy.js only; no inline script, no
  *     `'unsafe-inline'` (proxy.html ships zero inline script/style on
  *     purpose so this stays clean).
- *   - `frame-src 'self' blob:` — permits the inner content frame the shell
- *     creates. The shell mounts that frame from a `blob:` URL (NOT srcdoc):
- *     blob URLs are not "local schemes" under CSP3, so the inner App
- *     document's effective CSP is exactly what proxy.js composes from
- *     `_meta.ui.csp`, with no inheritance/intersection from this outer
- *     policy. Modern browsers match blob: against `'self'` when the blob
- *     was created same-origin, but `blob:` is listed explicitly for
- *     durability across engines.
- *   - everything else denied via `default-src 'none'`.
+ *   - This CSP is **inherited by the inner App iframe**. All three plausible
+ *     mounts (srcdoc, blob:, document.write()) leave the inner document at
+ *     a "local scheme" under CSP3 §"Initialize a Document's CSP list", so it
+ *     inherits the embedder's HTTP CSP. That is why this policy isn't just
+ *     the proxy shell's own bound — it's the *superset bound* on every App
+ *     we render. The ext-apps reference implementation
+ *     (`modelcontextprotocol/ext-apps/examples/basic-host/src/sandbox.ts`)
+ *     treats this as a feature, not a bug ("CSP is enforced via HTTP
+ *     headers ... tamper-proof unlike meta tags") and ships its outer CSP
+ *     with `'unsafe-inline' 'unsafe-eval' blob: data:` baked in so typical
+ *     bundled Apps can actually run. We mirror that default below.
+ *   - proxy.html itself ships **zero inline content** (proxy.js is external),
+ *     so `'unsafe-inline'`/`'unsafe-eval'` on the shell can't be exploited
+ *     unless an attacker can already inject HTML into the static asset — a
+ *     much larger compromise than this directive's scope. The real
+ *     containment boundary for untrusted App HTML remains the inner iframe's
+ *     `sandbox` attribute (cross-origin to the SPA, App declares the rest).
+ *   - The reference implementation supports tighter per-resource CSPs via a
+ *     dynamic origin that reads `?csp=` and stamps headers per-request. We
+ *     do not (CloudFront static asset, one CSP for all resources). Apps
+ *     that need declared `connectDomains`/`resourceDomains`/`frameDomains`
+ *     can't get them honored here — that's a follow-up if/when we onboard
+ *     an App that needs it.
  *
  * Exported for direct unit testing.
  */
 export function buildMcpSandboxProxyCsp(frameAncestors: string): string {
   return [
-    `default-src 'none'`,
-    `script-src 'self'`,
-    `frame-src 'self' blob:`,
+    // 'self' + 'unsafe-inline' for everything default-routed; matches the
+    // ext-apps reference's default-src and lets the inner App's misc fetches
+    // resolve when not explicitly directive-typed.
+    `default-src 'self' 'unsafe-inline'`,
+    // Scripts: same-origin + inline + eval (many bundled apps need eval) +
+    // blob: (dynamic workers, Web Workers from blob URLs) + data:.
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:`,
+    // Styles: same-origin + inline + blob:/data:.
+    `style-src 'self' 'unsafe-inline' blob: data:`,
+    // Static-resource directives — blob:/data: are common for bundled assets.
+    `img-src 'self' data: blob:`,
+    `font-src 'self' data: blob:`,
+    `media-src 'self' data: blob:`,
+    // Network: same-origin only. Apps that need external API access need the
+    // dynamic-CSP follow-up; we explicitly do not allow `https:` here so a
+    // dogfood App can't silently exfiltrate to arbitrary origins.
+    `connect-src 'self'`,
+    // Workers: same-origin + blob: for dynamically-constructed worker scripts
+    // (CesiumJS / Three.js / etc. rely on this).
+    `worker-src 'self' blob:`,
+    // Nested iframes inside the App: blocked. Most dogfood Apps are leaf UIs;
+    // Apps needing nested frames need the dynamic-CSP follow-up.
+    `frame-src 'none'`,
     `frame-ancestors ${frameAncestors}`,
     `base-uri 'none'`,
     `form-action 'none'`,
+    `object-src 'none'`,
   ].join('; ');
 }
 

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -161,21 +161,32 @@ describe('buildMcpSandboxFrameAncestors', () => {
 });
 
 describe('buildMcpSandboxProxyCsp', () => {
-  test('is deny-by-default and carries the given frame-ancestors', () => {
+  test('carries the given frame-ancestors + non-overridable hardening', () => {
     const csp = buildMcpSandboxProxyCsp('https://alpha.example.com');
-    expect(csp).toContain("default-src 'none'");
-    expect(csp).toContain("script-src 'self'");
-    // Inner App iframe mounts from a blob: URL (not srcdoc) to escape the
-    // local-scheme CSP inheritance that would intersect the App's own CSP
-    // with proxy.html's strict outer policy. frame-src must permit blob:.
-    expect(csp).toContain("frame-src 'self' blob:");
     expect(csp).toContain('frame-ancestors https://alpha.example.com');
+    // Hardening directives that proxy.html shouldn't ever want to relax,
+    // even though most of the rest is intentionally broad.
     expect(csp).toContain("base-uri 'none'");
     expect(csp).toContain("form-action 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("connect-src 'self'");
   });
 
-  test('never emits unsafe-inline (proxy ships no inline script/style)', () => {
-    expect(buildMcpSandboxProxyCsp("'none'")).not.toContain('unsafe-inline');
+  test('matches the ext-apps reference defaults so typical bundled Apps run', () => {
+    // The inner App iframe inherits this CSP (CSP3 local-scheme rule applies
+    // to srcdoc / blob: / document.write()-populated about:blank alike). The
+    // modelcontextprotocol/ext-apps basic-host reference ships its outer CSP
+    // with these tokens baked in for the same reason — bundled-App inline
+    // scripts/styles/eval need to actually run. See mcp-sandbox-stack.ts
+    // docstring for the security rationale.
+    const csp = buildMcpSandboxProxyCsp("'none'");
+    expect(csp).toContain(
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:",
+    );
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' blob: data:");
+    expect(csp).toContain("worker-src 'self' blob:");
+    expect(csp).toContain("default-src 'self' 'unsafe-inline'");
   });
 });
 


### PR DESCRIPTION
## Summary

- PR #352's blob-URL mount didn't actually escape CSP inheritance — verified on alpha. CSP3 §\"Initialize a Document's CSP list\" treats `about:`, `blob:`, `data:`, `filesystem:` as local schemes that all inherit the embedder's HTTP CSP. The inner iframe still inherited proxy.html's `script-src 'self'`, blocking every bundled-App inline script/style.
- Fix matches `modelcontextprotocol/ext-apps/examples/basic-host` (`src/sandbox.ts` + `serve.ts`): treat CSP inheritance as a feature and ship the outer `proxy.html` with a CSP permissive enough for typical bundled Apps. Per the reference's own comment: \"CSP is enforced via HTTP headers on sandbox.html ... tamper-proof unlike meta tags.\"
- Switch inner-iframe mount from `blob:` URL to `document.write()` (the reference's primary choice — \"Use document.write instead of srcdoc (which the CesiumJS Map won't work with)\"). Falls back to `srcdoc` when the App declared a stricter sandbox without `allow-same-origin`.

## Changes

- **`buildMcpSandboxProxyCsp`**: mirror the reference's default CSP — `'unsafe-inline' 'unsafe-eval' blob: data:` on `script-src`/`style-src`, `worker-src 'self' blob:` for WebGL apps (CesiumJS / Three.js), `connect-src 'self'` (explicitly no `https:` — Apps that need declared `connectDomains` need the dynamic-CSP follow-up tracked separately), `frame-src 'none'`, hardening directives unchanged.
- **`proxy.js`**: switch inner-iframe mount to `document.write()`; default inner sandbox now `allow-scripts allow-same-origin` so `contentDocument` is writable. Safe because the proxy origin is a static CDN with no shared state. Removed `URL.createObjectURL`/`revokeObjectURL` plumbing.
- **`mcp-sandbox-stack.test`**: tighten assertions to lock in the reference-matching default tokens so a future PR can't silently strip them.

## Why this is safe with the broader outer CSP

`proxy.html` itself ships zero inline content (`proxy.js` is external), so `'unsafe-inline'`/`'unsafe-eval'` on the shell can't be exploited unless an attacker can already inject HTML into the static asset — a much larger compromise than this directive's scope. The real containment boundary for untrusted App HTML remains the inner iframe's `sandbox` attribute + cross-origin isolation from the SPA.

## Follow-up

Dynamic per-resource CSP via a CloudFront Function reading `?csp=` (matching the reference's `serve.ts`) is queued as the next PR — required for Apps that declare external `connectDomains`/`resourceDomains` (e.g. Excalidraw's `https://esm.sh`, CesiumJS map-server's OSM tiles). Scoping doc lands with that PR.

## Test plan

- [ ] `cd infrastructure && npm test` passes (asserts new default CSP tokens)
- [ ] Deploy mcp-sandbox stack to dev
- [ ] Invalidate CloudFront `/proxy.html` + `/proxy.js`
- [ ] Open Excalidraw `create_view` in dev — inner App iframe mounts; verify CSP behavior matches expectations (Excalidraw will still log esm.sh blocks until the dynamic-CSP follow-up lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)