### PR TITLE
feat(mcp-apps): dynamic per-resource CSP for the sandbox proxy

### DIFF
--- a/docs/kaizen/scoping/mcp-sandbox-dynamic-csp.md
+++ b/docs/kaizen/scoping/mcp-sandbox-dynamic-csp.md
@@ -1,0 +1,167 @@
+# Scoping — MCP Sandbox Dynamic Per-Resource CSP
+
+> Status: Shipping — feature/mcp-sandbox-dynamic-csp
+> Owner: Phil Merrell
+> Source: dogfood gotcha #3 in [[project-mcp-apps-pr-progress]] (Option 3 of the host-renderer CSP fix); follow-up to #353
+> Spec read: draft `specification/draft/apps.mdx` lines 283–296; reference implementation `modelcontextprotocol/ext-apps/examples/basic-host/serve.ts`
+
+## TL;DR — **Ship**
+
+PR #353 shipped Options 1+2 (broad static outer CSP + `document.write()` mount). That works for the 22/25 reference servers that don't declare `_meta.ui.csp`, but **including our PR #7 dogfood App, Excalidraw**, three real Apps declare external domains the static CSP can't honor — they fail at runtime trying to fetch declared CDN scripts / tiles / fonts / soundfonts under our `connect-src 'self'`. Excalidraw's `create_view` is the canonical case: its server declares `resourceDomains: ['https://esm.sh']` + `connectDomains: ['https://esm.sh']` (see `excalidraw/excalidraw-mcp/src/server.ts`), and the dogfood console shows a wall of blocked esm.sh font / script / stylesheet loads. The spec's draft `apps.mdx` line 283 makes this a **host MUST**: "Host MUST construct CSP headers based on declared domains." We're not currently violating "MUST NOT allow undeclared domains" (we have no externals in our CSP at all), but we're failing the contract Apps rely on. Implementation: a CloudFront Function on viewer-response reading `?csp=` matching the upstream `examples/basic-host/serve.ts` `buildCspHeader` — ~50–100 LoC across `infrastructure/assets/mcp-sandbox/csp-function.js`, `mcp-sandbox-stack.ts`, frontend `proxy-url.ts`, plus tests. Cache stays simple (CFN runs on viewer-response including cache hits; one cached `proxy.html` body, dynamic header per request).
+
+## Apps that need it
+
+Empirical scan of `modelcontextprotocol/ext-apps/examples/*-server/server.ts` and the Excalidraw MCP server for `_meta.ui.csp` declarations. Four servers declare external domains:
+
+### Excalidraw `create_view` (our dogfood)
+
+```typescript
+// excalidraw/excalidraw-mcp/src/server.ts
+const cspMeta = {
+  ui: {
+    csp: {
+      resourceDomains: ['https://esm.sh'],
+      connectDomains: ['https://esm.sh'],
+    },
+  },
+};
+```
+
+The view's HTML pulls React 19, ReactDOM, Excalidraw 0.18, and the font/CSS bundle from `esm.sh`. On broad static CSP every one of those loads is blocked (`script-src` / `style-src` / `font-src` allow only `'self' blob: data:` — no `esm.sh`). The dogfood demo is visibly broken until this lands.
+
+### map-server (CesiumJS globe + OSM tiles)
+
+```typescript
+const cspMeta = {
+  ui: {
+    csp: {
+      connectDomains: [
+        "https://*.openstreetmap.org",   // OSM tiles + Nominatim geocoding
+        "https://cesium.com",
+        "https://*.cesium.com",
+      ],
+      resourceDomains: [
+        "https://*.openstreetmap.org",   // OSM map tiles
+        "https://cesium.com",
+        "https://*.cesium.com",
+      ],
+    },
+  },
+};
+```
+
+Hard fail on broad static — Cesium needs the tile servers + CDN both for `connect` (XHR for tile bytes / geocoding) and `resource` (script-src for ion-loaded JS modules). Our `connect-src 'self'` blocks every tile request the moment the globe initialises.
+
+### pdf-server (PDF.js standard fonts)
+
+```typescript
+csp: {
+  // pdf.js loads the Standard-14 fonts TWO ways:
+  //   - fetch()s the .ttf bytes → connect-src
+  //   - creates FontFace('name', 'url(...)') → font-src
+  // resourceDomains maps to font-src; we need both.
+  connectDomains: [STANDARD_FONT_ORIGIN],
+  resourceDomains: [STANDARD_FONT_ORIGIN],
+},
+```
+
+`STANDARD_FONT_ORIGIN` resolves to the pdf.js CDN host. PDF body renders but every glyph that requires a Standard-14 font (Helvetica, Times, Courier, Symbol, ZapfDingbats) falls back to a substitute or renders as a box — a visible quality regression, not a hard fail.
+
+### sheet-music-server (audio soundfonts)
+
+```typescript
+csp: {
+  // Allow loading soundfonts for audio playback
+  connectDomains: ["https://paulrosen.github.io"],
+},
+```
+
+Visual sheet-music rendering works on broad static (abcjs is bundled). Only the "play audio" button silently fails — soundfont fetches hit `connect-src 'self'` block.
+
+## Apps that don't need it
+
+22 of 25 reference servers declare no `_meta.ui.csp` at all. These work today on our broad static CSP because they:
+
+- Bundle everything (no external CDN fetches).
+- Use only same-origin postMessage to the host (no external network).
+- Use only `permissions` (mic/camera/clipboard) without external resource needs — covered by our `_meta.ui.permissions` plumbing, not CSP.
+
+Concrete list: `basic-server-*` (preact/react/solid/svelte/vanillajs/vue), budget-allocator-server, scenario-modeler-server, cohort-heatmap-server, customer-segmentation-server, integration-server, transcript-server, debug-server, qr-server, say-server, shadertoy-server, system-monitor-server, threejs-server, video-resource-server, wiki-explorer-server. **All five of the "rich UI" candidates the scoping doc considered for PR #7 dogfood** (budget-allocator, scenario-modeler, threejs, shadertoy, transcript) are in this set — none of them are blocked.
+
+Note: shadertoy / threejs being in this set is non-obvious — they're WebGL-heavy and you'd expect external asset CDNs, but in the reference repo they ship fully bundled.
+
+## Cost vs. benefit
+
+### Security gain — small, bordering on theatre
+
+The threat model: "untrusted App HTML escapes its CSP and exfiltrates / phishes from the user." Our current static CSP has:
+
+- `connect-src 'self'` — App cannot make any external network request from inside the iframe.
+- `frame-src 'none'` — App cannot frame anything else.
+- `base-uri 'none'`, `form-action 'none'`, `object-src 'none'` — no base / form / plugin injection.
+
+The remaining attack surface is `'unsafe-inline' 'unsafe-eval' blob: data:` on scripts/styles. But:
+
+1. The inner App iframe is **already cross-origin sandboxed** to the SPA (null origin under `sandbox` attribute). Even if an attacker fully owns the App's JS execution, they can't reach SPA cookies, localStorage, or DOM.
+2. The outer `proxy.html` ships **zero inline content** — every byte that runs is `proxy.js` loaded from same-origin (the dedicated mcp-sandbox CloudFront). `'unsafe-inline'`/`'unsafe-eval'` on the outer document can't be exploited unless an attacker can already inject into a static CloudFront asset, which is a much bigger compromise.
+3. Going dynamic would *narrow* `connect-src` and `script-src` to per-App declared domains. But for the 22/25 Apps without declared CSP, we'd use the spec's restrictive default (`connect-src 'none'`, `script-src 'self' 'unsafe-inline'` — *no* `'unsafe-eval' blob:`), which would **break** many of the bundled-but-eval-needing Apps we currently render fine. The reference implementation acknowledges this by baking `'unsafe-eval' blob: data:` into its default too.
+
+So dynamic CSP buys us: a tighter `connect-src` for the 3 Apps that actually declare it. That's a marginal defense-in-depth gain stacked behind the existing cross-origin sandbox boundary.
+
+### Spec-compliance gain — real but not violated today
+
+Draft `apps.mdx` line 283: **"Host MUST construct CSP headers based on declared domains."**
+Line 295: "No Loosening: Host MAY further restrict but MUST NOT allow undeclared domains."
+
+We don't violate "MUST NOT allow undeclared domains" — we have no external domains in our CSP at all. We *do* violate "MUST construct CSP headers based on declared domains" in the sense that we ignore declared `connectDomains`/`resourceDomains`. The user-visible consequence is that map-server / pdf-server / sheet-music-server can't fully function on us — they DECLARED what they need, we DIDN'T honor the declaration, the App fails. That's not "leaky security," it's "host doesn't implement the contract the App relied on."
+
+If someone is grading us on spec compliance (an external review, an audit, an MCP showcase), this gap is visible. If we're shipping internally, no one notices until we onboard a CSP-declaring App.
+
+### Implementation options compared
+
+| Option | Code | Deploy time | Runtime cost | Cache impact | On-call |
+|---|---|---|---|---|---|
+| **A. CloudFront Function (viewer-request → -response)** | ~30 LoC JS, no async, sanitize `?csp=`, emit header | Standard CFN deploy (~5 min) | $0.10/M invocations — pennies | proxy.html cache key adds `?csp`; hit rate drops to ~0 but origin is S3 (fast). proxy.js unaffected | Low — sync function, no cold start, no env vars |
+| **B. Lambda@Edge (viewer-response)** | ~50 LoC Node, full SDK, easier to test | Slower deploy (~10 min replication) | $0.60/M + duration; <$1/month at our traffic | same as A | Medium — Lambda@Edge logs land in *viewer* region CloudWatch, harder to follow; rollback is slower |
+| **C. Replace CloudFront+S3 with API Gateway + Lambda** | ~150 LoC + CDK rewrite | New stack | Higher | Lose CloudFront edge cache for proxy.js too | High — bigger surface |
+| **D. Origin Lambda behind CloudFront** | Lambda + CFN integration | Standard | Higher than A/B | proxy.js still cacheable; proxy.html per-request | Medium |
+
+Plus, for any option, frontend side: `mcp-app-frame.component.ts` already has `csp` from the `ui_resource` SSE event — it would build `${proxyOrigin}/proxy.html?csp=${encodeURIComponent(JSON.stringify(csp))}` before assigning `iframe.src`. ~10 LoC change, no new SSE event.
+
+**Recommended option if/when we ship: A (CloudFront Function).** It fits the constraint set (sync, no I/O, sanitize + concat into a header), is cheaper and lower-latency than Lambda@Edge, and has the simpler operational story. The sanitizer from `serve.ts` (`/[;\r\n'" ]/.test(d)` reject) is straightforwardly portable to the CFN JS runtime.
+
+The `ResponseHeadersPolicy` in `infrastructure/lib/mcp-sandbox-stack.ts` would need to drop its static `Content-Security-Policy` (the dynamic header would conflict with the policy's "override: true" semantics). Other security headers (HSTS, Referrer-Policy, X-Content-Type-Options) stay in the policy. `frame-ancestors` becomes part of the dynamic CSP since it's the security-critical bit — though it could also stay in a separate static `Content-Security-Policy` header alongside the dynamic one (CSPs combine via intersection).
+
+### Cache implications
+
+Today: `CacheQueryStringBehavior.none()` — every request to `proxy.html` returns the same cached body. Switch to `CacheQueryStringBehavior.allowList(['csp'])` and each unique `?csp=` value becomes a separate cache entry. With ~hundreds of distinct Apps in any deployed env, hit rate on `proxy.html` drops from ~100% to ~0%. proxy.html is ~2 KB, S3 origin response is sub-10ms — the cost is invisible at our traffic. `proxy.js` cache is untouched (no query param on its fetch).
+
+One real concern: cache *explosion* if Apps generate per-call unique `?csp=` query strings (e.g. dynamic per-conversation CSP). The 25 reference Apps all use static `_meta.ui.csp` at resource-declaration time, so in practice the cardinality is bounded by the number of distinct UI resources, not the number of conversations.
+
+## Trigger — what would change the recommendation
+
+**Ship if any of these happen:**
+
+1. We onboard map-server, pdf-server, or sheet-music-server (or any App declaring non-`'self'` `connectDomains` / `resourceDomains` / `frameDomains` / `baseUriDomains`). The CSP work goes in *that* PR — same author, fresh context, no need to reload prior state. **Most likely trigger: CesiumJS map-server when we want a "wow" demo.**
+2. The spec MUST tightens further (e.g. "Host MUST reject UI resources that declare CSP the host doesn't honor"). Skim the draft on each kaizen-research pass — currently line 283 is the relevant MUST; nothing has been added that makes it a *rejection* requirement yet.
+3. An external review / showcase / partner asks for SEP-1865 compliance attestation. The "declared domains not honored" gap is visible to anyone who reads the spec.
+4. We onboard an App that needs nested iframes (`frameDomains`) — our static `frame-src 'none'` blocks all nested framing absolutely. Reference Apps that fit this profile: none today, but anything embedding YouTube / a Tableau viz / a third-party widget would need it.
+
+**Don't ship for:**
+
+- "Defense-in-depth feels nice." The cross-origin sandbox is the real boundary. CSP tightening is icing.
+- "The reference does it, so should we." The reference is a demo host; we're a product. Match capability when we have a user-facing reason.
+- "It's in the scoping doc as a risk." The original scoping doc (`docs/kaizen/scoping/mcp-apps-host-renderer.md`) called out the CSP/`frame-ancestors` interplay as a 0.5–1d debug; we paid that debt. The dynamic-per-resource piece was always a follow-up.
+
+## Files that would change if we ship
+
+For reference (not implementation):
+
+- `infrastructure/lib/mcp-sandbox-stack.ts` — new CloudFront Function resource, drop static CSP from `ResponseHeadersPolicy`, update `CachePolicy` to include `?csp` in cache key on the `proxy.html` path behavior.
+- `infrastructure/lib/mcp-sandbox-function.js` (new) — the CFN handler: read `?csp=`, parse JSON, sanitize domains, build CSP string (mirror `buildCspHeader` from `examples/basic-host/serve.ts`), set response header.
+- `infrastructure/test/mcp-sandbox-stack.test.ts` — unit tests for sanitization (the `/[;\r\n'" ]/` reject rule is security-critical — every CSP-injection attack hides in domain entries with embedded `'`/`;`/space).
+- `frontend/ai.client/src/app/.../mcp-app-frame.component.ts` — build `?csp=` query before setting `iframe.src`; the bridge already receives `csp` on the `ui_resource` event.
+- `frontend/ai.client/src/app/.../mcp-app-frame.component.spec.ts` — unit test the query-string encoding.
+- No backend changes (the `ui_resource` SSE event already carries `csp`).
+
+Total: 1 new file (CFN handler), edits to 4 files, ~80–100 LoC + tests. 1–2 days, mostly testing the cache invalidation + redeploy behavior end-to-end.

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -22,6 +22,7 @@ import { McpAppBridge } from '../../../../../services/mcp-apps/mcp-app-bridge';
 import { McpAppProxyService } from '../../../../../services/mcp-apps/mcp-app-proxy.service';
 import { McpAppMessageService } from '../../../../../services/mcp-apps/mcp-app-message.service';
 import { McpAppConsentService } from '../../../../../services/mcp-apps/mcp-app-consent.service';
+import { buildProxyUrl } from '../../../../../services/mcp-apps/proxy-url';
 import { McpAppConsentPromptComponent } from '../../mcp-app-consent-prompt/mcp-app-consent-prompt.component';
 import type { CapabilityKey } from '../../../../../services/mcp-apps/mcp-app-protocol';
 import { ChatRequestService } from '../../../../../services/chat/chat-request.service';
@@ -148,12 +149,17 @@ export class McpAppFrameComponent implements ToolResultRenderer {
    * value from our authenticated backend (SSM-sourced); the imperative
    * sandbox attribute + the proxy's per-resource CSP are the real
    * containment, same justification as the artifact panel.
+   *
+   * The `?csp=` query the proxy CFN reads is built from the resource's
+   * declared `_meta.ui.csp` (`buildProxyUrl`). Apps that declare nothing
+   * get the bare URL and the proxy's default CSP — no cache fragmentation
+   * for the no-declaration majority.
    */
   protected readonly proxyUrl = computed<string | null>(() => {
     const res = this.resource();
     if (!res || !res.sandboxOrigin) return null;
     if (!this.capabilitiesResolved()) return null;
-    return `${res.sandboxOrigin.replace(/\/$/, '')}/proxy.html`;
+    return buildProxyUrl(res.sandboxOrigin, res.csp);
   });
 
   /** Permissions-Policy `allow` for the outer frame (delegates to inner). */

--- a/frontend/ai.client/src/app/session/services/mcp-apps/proxy-url.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/proxy-url.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest';
+import { buildProxyUrl } from './proxy-url';
+
+describe('buildProxyUrl', () => {
+  const ORIGIN = 'https://mcp-sandbox.example.com';
+
+  test('no csp at all → bare proxy.html (matches the default-CSP fast path)', () => {
+    expect(buildProxyUrl(ORIGIN, null)).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+    expect(buildProxyUrl(ORIGIN, undefined)).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+    expect(buildProxyUrl(ORIGIN, {})).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+  });
+
+  test('declared-but-empty arrays → bare proxy.html (no ?csp=)', () => {
+    // The CFN would produce the default CSP for any of these — sending
+    // ?csp= would just bust the CloudFront cache for no gain.
+    expect(
+      buildProxyUrl(ORIGIN, {
+        connectDomains: [],
+        resourceDomains: [],
+        frameDomains: [],
+        baseUriDomains: [],
+      }),
+    ).toBe('https://mcp-sandbox.example.com/proxy.html');
+  });
+
+  test('Excalidraw shape: connect+resource domains → ?csp= present and JSON-encoded', () => {
+    const url = buildProxyUrl(ORIGIN, {
+      connectDomains: ['https://esm.sh'],
+      resourceDomains: ['https://esm.sh'],
+    });
+    expect(url.startsWith('https://mcp-sandbox.example.com/proxy.html?csp=')).toBe(true);
+    const encoded = url.split('?csp=')[1];
+    const decoded = JSON.parse(decodeURIComponent(encoded));
+    expect(decoded).toEqual({
+      connectDomains: ['https://esm.sh'],
+      resourceDomains: ['https://esm.sh'],
+    });
+  });
+
+  test('CesiumJS map-server shape: multi-entry arrays survive round-trip intact', () => {
+    const csp = {
+      connectDomains: [
+        'https://*.openstreetmap.org',
+        'https://cesium.com',
+        'https://*.cesium.com',
+      ],
+      resourceDomains: [
+        'https://*.openstreetmap.org',
+        'https://cesium.com',
+        'https://*.cesium.com',
+      ],
+    };
+    const url = buildProxyUrl(ORIGIN, csp);
+    const encoded = url.split('?csp=')[1];
+    expect(JSON.parse(decodeURIComponent(encoded))).toEqual(csp);
+  });
+
+  test('any single declared array suffices to attach ?csp=', () => {
+    expect(buildProxyUrl(ORIGIN, { frameDomains: ['https://x.test'] })).toContain('?csp=');
+    expect(buildProxyUrl(ORIGIN, { baseUriDomains: ['https://x.test'] })).toContain(
+      '?csp=',
+    );
+    expect(buildProxyUrl(ORIGIN, { connectDomains: ['https://x.test'] })).toContain(
+      '?csp=',
+    );
+    expect(buildProxyUrl(ORIGIN, { resourceDomains: ['https://x.test'] })).toContain(
+      '?csp=',
+    );
+  });
+
+  test('trailing slash on origin is stripped (no double slash)', () => {
+    expect(buildProxyUrl('https://mcp-sandbox.example.com/', null)).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+    expect(
+      buildProxyUrl('https://mcp-sandbox.example.com/', {
+        connectDomains: ['https://esm.sh'],
+      }),
+    ).toBe(
+      'https://mcp-sandbox.example.com/proxy.html?csp=' +
+        encodeURIComponent('{"connectDomains":["https://esm.sh"]}'),
+    );
+  });
+
+  test('non-object csp inputs degrade safely', () => {
+    // Defensive: SSE event payloads come from a typed channel but JS lets
+    // anything through at runtime. Anything not an object → no ?csp.
+    expect(buildProxyUrl(ORIGIN, 'not-an-object' as unknown as null)).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+    expect(buildProxyUrl(ORIGIN, 42 as unknown as null)).toBe(
+      'https://mcp-sandbox.example.com/proxy.html',
+    );
+  });
+
+  test('encodes URL-special characters in domain entries', () => {
+    // The query value is the JSON serialization, then percent-encoded —
+    // so a `&` or `=` inside a domain entry (shouldn't happen, but still)
+    // gets encoded and can't break out of the query param.
+    const url = buildProxyUrl(ORIGIN, {
+      connectDomains: ['https://api.example.com?token=abc&other=xyz'],
+    });
+    const encoded = url.split('?csp=')[1];
+    // The encoded value contains neither a bare `&` nor a bare `=` — both
+    // would be percent-encoded (`%26`, `%3D`).
+    expect(encoded).not.toMatch(/&/);
+    expect(encoded.split('=').length).toBe(1); // no literal `=` in the encoded value
+    expect(JSON.parse(decodeURIComponent(encoded))).toEqual({
+      connectDomains: ['https://api.example.com?token=abc&other=xyz'],
+    });
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/proxy-url.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/proxy-url.ts
@@ -1,0 +1,42 @@
+import type { McpUiCsp } from '../../../shared/utils/stream-parser';
+
+/**
+ * Build the proxy.html URL the `<mcp-app-frame>` iframe `src` is set to.
+ *
+ * The sandbox-proxy origin runs a CloudFront Function on viewer-response
+ * (`infrastructure/assets/mcp-sandbox/csp-function.js`) that composes the
+ * `Content-Security-Policy` header from a `?csp=` query parameter. Apps
+ * that declare `_meta.ui.csp` get a per-resource CSP that honors their
+ * declared `connectDomains` / `resourceDomains` / `frameDomains` /
+ * `baseUriDomains`; Apps that omit it (or declare an empty shape) get the
+ * default CSP from the function with no query string at all — matching
+ * the upstream `examples/basic-host/serve.ts` reference.
+ *
+ * We only attach `?csp=` when the resource actually declares at least one
+ * non-empty domain array. An empty `{}` or `{ connectDomains: [] }` would
+ * produce identical CSP output from the function either way, and omitting
+ * the param keeps CloudFront cache keys uniform across the no-declaration
+ * majority of Apps.
+ */
+export function buildProxyUrl(
+  sandboxOrigin: string,
+  csp: McpUiCsp | null | undefined,
+): string {
+  const base = `${sandboxOrigin.replace(/\/$/, '')}/proxy.html`;
+  if (!hasDeclaredDomains(csp)) return base;
+  return `${base}?csp=${encodeURIComponent(JSON.stringify(csp))}`;
+}
+
+function hasDeclaredDomains(csp: McpUiCsp | null | undefined): csp is McpUiCsp {
+  if (!csp || typeof csp !== 'object') return false;
+  return (
+    isNonEmptyArray(csp.connectDomains) ||
+    isNonEmptyArray(csp.resourceDomains) ||
+    isNonEmptyArray(csp.frameDomains) ||
+    isNonEmptyArray(csp.baseUriDomains)
+  );
+}
+
+function isNonEmptyArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0;
+}

--- a/infrastructure/assets/mcp-sandbox/csp-function.js
+++ b/infrastructure/assets/mcp-sandbox/csp-function.js
@@ -1,0 +1,138 @@
+/**
+ * MCP Apps sandbox — dynamic per-resource Content-Security-Policy.
+ *
+ * CloudFront Function attached to the proxy.html behavior on
+ * **viewer-response**. Reads the `?csp=<urlencoded-json>` query string
+ * (where the JSON matches the spec's `McpUiResourceCsp` shape from
+ * `_meta.ui.csp`), composes a per-resource CSP header that honors the
+ * declared `connectDomains` / `resourceDomains` / `frameDomains` /
+ * `baseUriDomains`, and stamps it on the response — replacing any CSP
+ * coming from the origin / ResponseHeadersPolicy.
+ *
+ * Mirrors `modelcontextprotocol/ext-apps/examples/basic-host/serve.ts`'s
+ * `buildCspHeader` so a UI resource gets the same CSP from us that it
+ * would on the spec's reference host. Failure paths (missing param,
+ * malformed JSON, non-object payload) degrade silently to the default
+ * (un-declared) CSP — same behavior as if the App had omitted `_meta.ui.csp`.
+ *
+ * Runtime: CloudFront Functions JavaScript runtime v2.0 (~ES2017 strict
+ * subset, sync only, no I/O, no Date.now, no Math.random, no Buffer/URL).
+ *
+ * Frame-ancestors is the security-critical bit that doesn't vary per
+ * resource. It's substituted into this file at CDK synth time by
+ * `loadMcpSandboxCspFunctionCode` (lib/mcp-sandbox-stack.ts), which
+ * replaces the __INJECT_FRAME_ANCESTORS__ string literal below with a
+ * properly JSON-escaped JS literal. The loader asserts the quoted form
+ * appears exactly once; this comment uses the bare token so it does not
+ * count as a second occurrence. Tests run the file as-is and pass
+ * `frameAncestors` directly to `buildCspHeader`.
+ *
+ * The trailing `if (typeof module !== 'undefined')` block is a no-op in
+ * the CloudFront Function runtime (`module` is undeclared, `typeof`
+ * returns `'undefined'`) and exposes the pure helpers for Node unit
+ * tests in `infrastructure/test/mcp-sandbox-csp-function.test.ts`. Don't
+ * delete it — it's how we keep the runtime code and the test surface in
+ * the same file with no duplication.
+ */
+'use strict';
+
+var FRAME_ANCESTORS = '__INJECT_FRAME_ANCESTORS__';
+
+/**
+ * Reject domain entries containing CSP-injection characters. Mirrors the
+ * upstream reference's regex exactly: `;` / CR / LF break out to a new
+ * directive; quotes inject CSP keywords (e.g. `'unsafe-eval'`); space
+ * smuggles multiple sources into one entry.
+ */
+function sanitizeCspDomains(domains) {
+  if (!Array.isArray(domains)) return [];
+  var out = [];
+  for (var i = 0; i < domains.length; i++) {
+    var d = domains[i];
+    if (typeof d === 'string' && d.length > 0 && !/[;\r\n'" ]/.test(d)) {
+      out.push(d);
+    }
+  }
+  return out;
+}
+
+/**
+ * Compose the CSP header. Defaults mirror the ext-apps basic-host
+ * reference (script-src ... 'unsafe-eval' blob: data:), broader than the
+ * spec's "Restrictive Default" so bundled Apps that omit `ui.csp` still
+ * run. Declared resource/connect/frame/baseUri domains are appended to
+ * the corresponding directives.
+ *
+ * `frame-ancestors`, `form-action`, and `object-src` are security-critical
+ * and never vary per resource.
+ */
+function buildCspHeader(cspConfig, frameAncestors) {
+  var csp = cspConfig || {};
+  var resourceDomains = sanitizeCspDomains(csp.resourceDomains).join(' ');
+  var connectDomains = sanitizeCspDomains(csp.connectDomains).join(' ');
+  var frameDomains = sanitizeCspDomains(csp.frameDomains).join(' ');
+  var baseUriDomains = sanitizeCspDomains(csp.baseUriDomains).join(' ');
+
+  var directives = [
+    "default-src 'self' 'unsafe-inline'",
+    ("script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: " + resourceDomains).trim(),
+    ("style-src 'self' 'unsafe-inline' blob: data: " + resourceDomains).trim(),
+    ("img-src 'self' data: blob: " + resourceDomains).trim(),
+    ("font-src 'self' data: blob: " + resourceDomains).trim(),
+    ("media-src 'self' data: blob: " + resourceDomains).trim(),
+    ("connect-src 'self' " + connectDomains).trim(),
+    ("worker-src 'self' blob: " + resourceDomains).trim(),
+    frameDomains ? ("frame-src " + frameDomains) : "frame-src 'none'",
+    "object-src 'none'",
+    baseUriDomains ? ("base-uri " + baseUriDomains) : "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors " + frameAncestors,
+  ];
+
+  return directives.join('; ');
+}
+
+/**
+ * Extract and parse the `csp` query parameter. CloudFront delivers
+ * `request.querystring` as an object keyed by param name where each
+ * value is URL-decoded (we don't need a `decodeURIComponent` call).
+ * Returns the parsed CSP object or null on absent / malformed / non-
+ * object input — never throws.
+ */
+function parseCspParam(querystring) {
+  if (!querystring) return null;
+  var entry = querystring.csp;
+  if (!entry || typeof entry.value !== 'string' || entry.value.length === 0) {
+    return null;
+  }
+  try {
+    var parsed = JSON.parse(entry.value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function handler(event) {
+  var request = event.request || {};
+  var response = event.response || {};
+  response.headers = response.headers || {};
+
+  var cspConfig = parseCspParam(request.querystring);
+  var csp = buildCspHeader(cspConfig, FRAME_ANCESTORS);
+
+  response.headers['content-security-policy'] = { value: csp };
+  return response;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    sanitizeCspDomains: sanitizeCspDomains,
+    buildCspHeader: buildCspHeader,
+    parseCspParam: parseCspParam,
+    handler: handler,
+  };
+}

--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -8,6 +8,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import * as fs from 'fs';
 import * as path from 'path';
 import {
   AppConfig,
@@ -16,6 +17,46 @@ import {
   getRemovalPolicy,
   getResourceName,
 } from './config';
+
+/**
+ * The full JS string literal in `assets/mcp-sandbox/csp-function.js` that
+ * we substitute at synth time. Matching the *quoted* literal (not the
+ * inner identifier) lets us replace it with `JSON.stringify(value)`,
+ * which handles quote-escaping correctly for any `frame-ancestors` source
+ * list — including `'none'` (which would otherwise produce `''none''`,
+ * a JS syntax error).
+ *
+ * The CFN unit tests don't depend on the substitution: they pass
+ * `frameAncestors` directly to `buildCspHeader`, so the unsubstituted
+ * source file is valid JS for `require()` to load.
+ */
+const FRAME_ANCESTORS_PLACEHOLDER_LITERAL = "'__INJECT_FRAME_ANCESTORS__'";
+
+/**
+ * Load the dynamic-CSP CloudFront Function source and inject the real
+ * `frame-ancestors` source list as a properly-escaped JS string literal.
+ * Asserts the placeholder is present exactly once so a future refactor
+ * that loses the marker fails loudly at synth, not at edge runtime.
+ *
+ * Exported for unit testing.
+ */
+export function loadMcpSandboxCspFunctionCode(frameAncestors: string): string {
+  const filePath = path.resolve(
+    __dirname,
+    '..',
+    'assets',
+    'mcp-sandbox',
+    'csp-function.js',
+  );
+  const source = fs.readFileSync(filePath, 'utf8');
+  const occurrences = source.split(FRAME_ANCESTORS_PLACEHOLDER_LITERAL).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(
+      `Expected exactly one occurrence of ${FRAME_ANCESTORS_PLACEHOLDER_LITERAL} in csp-function.js, found ${occurrences}. Did the marker get renamed or duplicated?`,
+    );
+  }
+  return source.replace(FRAME_ANCESTORS_PLACEHOLDER_LITERAL, JSON.stringify(frameAncestors));
+}
 
 export interface McpSandboxStackProps extends cdk.StackProps {
   config: AppConfig;
@@ -63,74 +104,6 @@ export function buildMcpSandboxFrameAncestors(
     }
   }
   return sources.length > 0 ? sources.join(' ') : `'none'`;
-}
-
-/**
- * Assemble the Content-Security-Policy served with `proxy.html`.
- *
- * `frame-ancestors` is the security-critical directive (who may embed the
- * proxy — the SPA only). The rest is deny-by-default hardening for the inert
- * PR #1 shell:
- *
- *   - `script-src 'self'`  — proxy.js only; no inline script, no
- *     `'unsafe-inline'` (proxy.html ships zero inline script/style on
- *     purpose so this stays clean).
- *   - This CSP is **inherited by the inner App iframe**. All three plausible
- *     mounts (srcdoc, blob:, document.write()) leave the inner document at
- *     a "local scheme" under CSP3 §"Initialize a Document's CSP list", so it
- *     inherits the embedder's HTTP CSP. That is why this policy isn't just
- *     the proxy shell's own bound — it's the *superset bound* on every App
- *     we render. The ext-apps reference implementation
- *     (`modelcontextprotocol/ext-apps/examples/basic-host/src/sandbox.ts`)
- *     treats this as a feature, not a bug ("CSP is enforced via HTTP
- *     headers ... tamper-proof unlike meta tags") and ships its outer CSP
- *     with `'unsafe-inline' 'unsafe-eval' blob: data:` baked in so typical
- *     bundled Apps can actually run. We mirror that default below.
- *   - proxy.html itself ships **zero inline content** (proxy.js is external),
- *     so `'unsafe-inline'`/`'unsafe-eval'` on the shell can't be exploited
- *     unless an attacker can already inject HTML into the static asset — a
- *     much larger compromise than this directive's scope. The real
- *     containment boundary for untrusted App HTML remains the inner iframe's
- *     `sandbox` attribute (cross-origin to the SPA, App declares the rest).
- *   - The reference implementation supports tighter per-resource CSPs via a
- *     dynamic origin that reads `?csp=` and stamps headers per-request. We
- *     do not (CloudFront static asset, one CSP for all resources). Apps
- *     that need declared `connectDomains`/`resourceDomains`/`frameDomains`
- *     can't get them honored here — that's a follow-up if/when we onboard
- *     an App that needs it.
- *
- * Exported for direct unit testing.
- */
-export function buildMcpSandboxProxyCsp(frameAncestors: string): string {
-  return [
-    // 'self' + 'unsafe-inline' for everything default-routed; matches the
-    // ext-apps reference's default-src and lets the inner App's misc fetches
-    // resolve when not explicitly directive-typed.
-    `default-src 'self' 'unsafe-inline'`,
-    // Scripts: same-origin + inline + eval (many bundled apps need eval) +
-    // blob: (dynamic workers, Web Workers from blob URLs) + data:.
-    `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:`,
-    // Styles: same-origin + inline + blob:/data:.
-    `style-src 'self' 'unsafe-inline' blob: data:`,
-    // Static-resource directives — blob:/data: are common for bundled assets.
-    `img-src 'self' data: blob:`,
-    `font-src 'self' data: blob:`,
-    `media-src 'self' data: blob:`,
-    // Network: same-origin only. Apps that need external API access need the
-    // dynamic-CSP follow-up; we explicitly do not allow `https:` here so a
-    // dogfood App can't silently exfiltrate to arbitrary origins.
-    `connect-src 'self'`,
-    // Workers: same-origin + blob: for dynamically-constructed worker scripts
-    // (CesiumJS / Three.js / etc. rely on this).
-    `worker-src 'self' blob:`,
-    // Nested iframes inside the App: blocked. Most dogfood Apps are leaf UIs;
-    // Apps needing nested frames need the dynamic-CSP follow-up.
-    `frame-src 'none'`,
-    `frame-ancestors ${frameAncestors}`,
-    `base-uri 'none'`,
-    `form-action 'none'`,
-    `object-src 'none'`,
-  ].join('; ');
 }
 
 /**
@@ -194,7 +167,6 @@ export class McpSandboxStack extends cdk.Stack {
       domainName,
       config.mcpSandbox.extraFrameAncestors,
     );
-    const proxyCsp = buildMcpSandboxProxyCsp(frameAncestors);
 
     // ============================================================
     // S3 — holds the static proxy shell (private, OAC-only)
@@ -213,24 +185,38 @@ export class McpSandboxStack extends cdk.Stack {
     });
 
     // ============================================================
-    // CloudFront — terminates TLS, stamps the CSP
+    // CloudFront — terminates TLS, runs the dynamic-CSP function
     // ============================================================
+    // The CSP itself is composed PER-REQUEST by a CloudFront Function on
+    // viewer-response (see `assets/mcp-sandbox/csp-function.js`). The
+    // function reads the `?csp=` query param the SPA appends when framing
+    // proxy.html — the JSON shape matches the spec's `McpUiResourceCsp`
+    // (`_meta.ui.csp`) and the function honors declared
+    // `connectDomains`/`resourceDomains`/`frameDomains`/`baseUriDomains`.
+    // Apps that omit `_meta.ui.csp` fall through to the same reference-
+    // matching default the previous static CSP shipped, so the 22/25
+    // example servers that worked before continue to work.
+    //
+    // The ResponseHeadersPolicy is left intentionally CSP-less. Doing
+    // both (static via RHP + dynamic via function) would mean every
+    // response carries two `Content-Security-Policy` headers; browsers
+    // intersect them, which would silently re-deny anything an App
+    // legitimately declared. The CFN is the single source of truth for
+    // the CSP directive; other security headers (HSTS, Referrer-Policy,
+    // X-Content-Type-Options) remain on the RHP since they don't vary
+    // per resource.
     const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
       this,
       'McpSandboxResponseHeaders',
       {
         responseHeadersPolicyName: getResourceName(config, 'mcp-sandbox-headers'),
-        comment: 'CSP (frame-ancestors = SPA origin only) + security headers for the MCP Apps sandbox proxy',
+        comment: 'Security headers (HSTS, Referrer-Policy, X-Content-Type-Options) for the MCP Apps sandbox proxy. CSP is composed per-request by the dynamic-CSP CloudFront Function.',
         securityHeadersBehavior: {
-          contentSecurityPolicy: {
-            contentSecurityPolicy: proxyCsp,
-            override: true,
-          },
           contentTypeOptions: { override: true },
-          // Intentionally NOT setting frameOptions — `frame-ancestors` in the
-          // CSP above is the modern, cross-browser-enforced equivalent and is
-          // the control this PR is about. Setting X-Frame-Options too would
-          // only add a legacy, less expressive duplicate.
+          // Intentionally NOT setting frameOptions — `frame-ancestors`
+          // in the dynamic CSP is the modern equivalent and the control
+          // we care about. Setting X-Frame-Options too would only add a
+          // legacy, less expressive duplicate.
           referrerPolicy: {
             referrerPolicy: cloudfront.HeadersReferrerPolicy.NO_REFERRER,
             override: true,
@@ -243,6 +229,19 @@ export class McpSandboxStack extends cdk.Stack {
         },
       },
     );
+
+    // Dynamic-CSP CloudFront Function. The source ships the FRAME_ANCESTORS
+    // placeholder string; we substitute it for the real source list here
+    // so unit tests can run the file as-is. JS_2_0 runtime is required —
+    // the function uses ES2017 features (regex literals, template
+    // strings, JSON.parse) that the legacy JS_1_0 runtime doesn't accept.
+    const cspFunctionCode = loadMcpSandboxCspFunctionCode(frameAncestors);
+    const cspFunction = new cloudfront.Function(this, 'McpSandboxCspFunction', {
+      functionName: getResourceName(config, 'mcp-sandbox-csp'),
+      comment: 'Composes the per-resource Content-Security-Policy header from the ?csp= query parameter (matching modelcontextprotocol/ext-apps basic-host/serve.ts).',
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(cspFunctionCode),
+    });
 
     // Static shell: a short cache is fine and BucketDeployment invalidates on
     // every deploy so shell changes propagate immediately. No cookies / query
@@ -272,6 +271,17 @@ export class McpSandboxStack extends cdk.Stack {
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD,
         compress: true,
+        // The CSP function runs on viewer-response — including cache hits —
+        // so the CSP is composed fresh from the request's `?csp=` query
+        // every time. That lets us keep the cache key simple (no `?csp=`
+        // included) while still emitting per-resource CSPs: one cached
+        // body, dynamic header.
+        functionAssociations: [
+          {
+            function: cspFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
+          },
+        ],
       },
       // Cheapest price class — the shell is tiny and not latency-critical.
       priceClass: cloudfront.PriceClass.PRICE_CLASS_100,

--- a/infrastructure/test/mcp-sandbox-csp-function.test.ts
+++ b/infrastructure/test/mcp-sandbox-csp-function.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Unit tests for the MCP Apps sandbox dynamic-CSP CloudFront Function.
+ *
+ * The function source (`assets/mcp-sandbox/csp-function.js`) is written in
+ * the CloudFront Functions JavaScript runtime v2.0 subset, but also
+ * exports its pure helpers under `typeof module !== 'undefined'` so we
+ * can require it directly from Node. The CDK upload path substitutes the
+ * `FRAME_ANCESTORS_PLACEHOLDER` sentinel before the function runs at
+ * edge; here we pass `frameAncestors` directly to the builder.
+ *
+ * Coverage targets:
+ *   - Default CSP (no `_meta.ui.csp`) matches the ext-apps basic-host
+ *     reference's `buildCspHeader` output. This is what 22/25 reference
+ *     example servers run on.
+ *   - Declared `connectDomains` / `resourceDomains` / `frameDomains` /
+ *     `baseUriDomains` are honored on the right CSP directives.
+ *   - Sanitizer rejects every character class the reference rejects
+ *     (CSP-injection prevention — this is the security-critical bit).
+ *   - The `handler(event)` entry point degrades to default on missing /
+ *     malformed input and returns a CloudFront Functions v2.0–shaped
+ *     response object.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  sanitizeCspDomains,
+  buildCspHeader,
+  parseCspParam,
+  handler,
+} = require('../assets/mcp-sandbox/csp-function');
+
+const FRAME_ANCESTORS = 'https://alpha.example.com';
+
+describe('sanitizeCspDomains', () => {
+  test('returns empty array when domains is not an array', () => {
+    expect(sanitizeCspDomains(undefined)).toEqual([]);
+    expect(sanitizeCspDomains(null)).toEqual([]);
+    expect(sanitizeCspDomains('https://example.com')).toEqual([]);
+    expect(sanitizeCspDomains({})).toEqual([]);
+  });
+
+  test('keeps well-formed origin entries unchanged', () => {
+    expect(
+      sanitizeCspDomains([
+        'https://example.com',
+        'https://*.cesium.com',
+        'https://esm.sh',
+      ]),
+    ).toEqual([
+      'https://example.com',
+      'https://*.cesium.com',
+      'https://esm.sh',
+    ]);
+  });
+
+  test('rejects semicolons (CSP directive break-out)', () => {
+    expect(
+      sanitizeCspDomains(['https://example.com', "https://evil.com; script-src *"]),
+    ).toEqual(['https://example.com']);
+  });
+
+  test('rejects newlines (header injection)', () => {
+    expect(sanitizeCspDomains(['https://evil.com\nscript-src *'])).toEqual([]);
+    expect(sanitizeCspDomains(['https://evil.com\rscript-src *'])).toEqual([]);
+  });
+
+  test("rejects quotes (smuggling CSP keywords like 'unsafe-eval')", () => {
+    expect(sanitizeCspDomains(["https://evil.com 'unsafe-eval'"])).toEqual([]);
+    expect(sanitizeCspDomains(['https://evil.com "x"'])).toEqual([]);
+  });
+
+  test('rejects spaces (multi-source smuggling within one entry)', () => {
+    expect(sanitizeCspDomains(['https://example.com https://evil.com'])).toEqual(
+      [],
+    );
+  });
+
+  test('rejects non-string entries', () => {
+    expect(sanitizeCspDomains(['https://example.com', 42, null, undefined, {}])).toEqual([
+      'https://example.com',
+    ]);
+  });
+
+  test('rejects empty strings', () => {
+    expect(sanitizeCspDomains(['', 'https://example.com', ''])).toEqual([
+      'https://example.com',
+    ]);
+  });
+});
+
+describe('buildCspHeader — default (no _meta.ui.csp)', () => {
+  const csp = buildCspHeader(null, FRAME_ANCESTORS);
+
+  test('matches the ext-apps basic-host reference default tokens', () => {
+    // These are the broader-than-spec defaults the upstream reference
+    // ships in serve.ts so bundled Apps that omit ui.csp still run.
+    // Tightening these would silently break 22/25 of the reference
+    // example servers.
+    expect(csp).toContain("default-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' blob: data:");
+    expect(csp).toContain("img-src 'self' data: blob:");
+    expect(csp).toContain("font-src 'self' data: blob:");
+    expect(csp).toContain("media-src 'self' data: blob:");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("worker-src 'self' blob:");
+  });
+
+  test('locks down un-declared frame / base-uri / object / form-action', () => {
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  test('carries frame-ancestors from the synth-time injection', () => {
+    expect(csp).toContain('frame-ancestors https://alpha.example.com');
+  });
+
+  test('emits directives joined by "; " (no trailing semicolon)', () => {
+    expect(csp).toMatch(/^[^;]+(; [^;]+)+$/);
+  });
+});
+
+describe('buildCspHeader — declared domains', () => {
+  test('Excalidraw: connect+resource domains added to all asset directives', () => {
+    // From excalidraw/excalidraw-mcp/src/server.ts:
+    //   csp: { resourceDomains: ['https://esm.sh'], connectDomains: ['https://esm.sh'] }
+    const csp = buildCspHeader(
+      {
+        resourceDomains: ['https://esm.sh'],
+        connectDomains: ['https://esm.sh'],
+      },
+      FRAME_ANCESTORS,
+    );
+    expect(csp).toContain(
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://esm.sh",
+    );
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' blob: data: https://esm.sh");
+    expect(csp).toContain("font-src 'self' data: blob: https://esm.sh");
+    expect(csp).toContain("img-src 'self' data: blob: https://esm.sh");
+    expect(csp).toContain("media-src 'self' data: blob: https://esm.sh");
+    expect(csp).toContain("worker-src 'self' blob: https://esm.sh");
+    expect(csp).toContain('connect-src \'self\' https://esm.sh');
+  });
+
+  test('CesiumJS map-server: multiple domains on connect-src and resource-* directives', () => {
+    // From modelcontextprotocol/ext-apps/examples/map-server/server.ts
+    const csp = buildCspHeader(
+      {
+        connectDomains: [
+          'https://*.openstreetmap.org',
+          'https://cesium.com',
+          'https://*.cesium.com',
+        ],
+        resourceDomains: [
+          'https://*.openstreetmap.org',
+          'https://cesium.com',
+          'https://*.cesium.com',
+        ],
+      },
+      FRAME_ANCESTORS,
+    );
+    expect(csp).toContain(
+      'connect-src \'self\' https://*.openstreetmap.org https://cesium.com https://*.cesium.com',
+    );
+    expect(csp).toContain(
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.openstreetmap.org https://cesium.com https://*.cesium.com",
+    );
+  });
+
+  test('frameDomains: when declared, replaces "frame-src none" — otherwise stays denied', () => {
+    const withFrames = buildCspHeader(
+      { frameDomains: ['https://youtube.com', 'https://*.youtube.com'] },
+      FRAME_ANCESTORS,
+    );
+    expect(withFrames).toContain('frame-src https://youtube.com https://*.youtube.com');
+    expect(withFrames).not.toContain("frame-src 'none'");
+
+    const withoutFrames = buildCspHeader({}, FRAME_ANCESTORS);
+    expect(withoutFrames).toContain("frame-src 'none'");
+  });
+
+  test('baseUriDomains: when declared, replaces "base-uri none"', () => {
+    const withBase = buildCspHeader(
+      { baseUriDomains: ['https://example.com'] },
+      FRAME_ANCESTORS,
+    );
+    expect(withBase).toContain('base-uri https://example.com');
+    expect(withBase).not.toContain("base-uri 'none'");
+  });
+
+  test('connectDomains alone does NOT widen resource-* directives', () => {
+    // Spec separation: connectDomains → connect-src only; resourceDomains
+    // → script/style/img/font/media/worker. An App that only declares
+    // network destinations should not get static-resource permission as
+    // a side effect.
+    const csp = buildCspHeader(
+      { connectDomains: ['https://api.example.com'] },
+      FRAME_ANCESTORS,
+    );
+    expect(csp).toContain('connect-src \'self\' https://api.example.com');
+    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:");
+    expect(csp).not.toMatch(/script-src[^;]*https:\/\/api\.example\.com/);
+  });
+
+  test('injection attempts in domain entries are silently dropped (not echoed)', () => {
+    const csp = buildCspHeader(
+      {
+        connectDomains: [
+          'https://good.com',
+          "https://evil.com; script-src *",
+          "https://evil.com 'unsafe-eval'",
+          'https://evil.com\nX-Injected: yes',
+        ],
+      },
+      FRAME_ANCESTORS,
+    );
+    expect(csp).toContain('connect-src \'self\' https://good.com');
+    expect(csp).not.toContain('evil.com');
+    expect(csp).not.toContain('X-Injected');
+    // And the directive separator structure is intact.
+    expect(csp).toMatch(/^[^;]+(; [^;]+)+$/);
+  });
+});
+
+describe('parseCspParam', () => {
+  test('null / undefined querystring → null', () => {
+    expect(parseCspParam(undefined)).toBeNull();
+    expect(parseCspParam(null)).toBeNull();
+    expect(parseCspParam({})).toBeNull();
+  });
+
+  test('missing csp key → null', () => {
+    expect(parseCspParam({ other: { value: 'x' } })).toBeNull();
+  });
+
+  test('empty value → null', () => {
+    expect(parseCspParam({ csp: { value: '' } })).toBeNull();
+  });
+
+  test('valid JSON object → parsed', () => {
+    expect(
+      parseCspParam({ csp: { value: '{"connectDomains":["https://esm.sh"]}' } }),
+    ).toEqual({ connectDomains: ['https://esm.sh'] });
+  });
+
+  test('malformed JSON → null (no throw)', () => {
+    expect(parseCspParam({ csp: { value: 'not-json' } })).toBeNull();
+    expect(parseCspParam({ csp: { value: '{unclosed' } })).toBeNull();
+  });
+
+  test('non-object JSON (array / scalar) → null', () => {
+    // We accept only the spec-shaped McpUiResourceCsp object — never an
+    // array (would let an attacker control directive composition).
+    expect(parseCspParam({ csp: { value: '["https://evil.com"]' } })).toBeNull();
+    expect(parseCspParam({ csp: { value: '"https://evil.com"' } })).toBeNull();
+    expect(parseCspParam({ csp: { value: '42' } })).toBeNull();
+    expect(parseCspParam({ csp: { value: 'null' } })).toBeNull();
+  });
+});
+
+describe('handler', () => {
+  function makeEvent(querystring?: Record<string, { value: string }>) {
+    return {
+      request: { querystring: querystring ?? {} },
+      response: { statusCode: 200, headers: {} as Record<string, { value: string }> },
+    };
+  }
+
+  test('with no ?csp= param, emits the default (un-declared) CSP', () => {
+    const event = makeEvent();
+    const result = handler(event);
+    expect(result.headers['content-security-policy']).toBeDefined();
+    expect(result.headers['content-security-policy'].value).toContain(
+      "connect-src 'self'",
+    );
+    // Default → no resource domains beyond keywords/blob/data
+    expect(result.headers['content-security-policy'].value).not.toMatch(
+      /connect-src 'self' \S+/,
+    );
+  });
+
+  test('with declared csp, builds and replaces the response CSP header', () => {
+    const event = makeEvent({
+      csp: {
+        value: JSON.stringify({
+          resourceDomains: ['https://esm.sh'],
+          connectDomains: ['https://esm.sh'],
+        }),
+      },
+    });
+    // Pre-existing CSP from ResponseHeadersPolicy is what the CFN
+    // overrides — we simulate it being on the response.
+    event.response.headers['content-security-policy'] = {
+      value: "default-src 'self'",
+    };
+    const result = handler(event);
+    expect(result.headers['content-security-policy'].value).toContain(
+      'connect-src \'self\' https://esm.sh',
+    );
+    expect(result.headers['content-security-policy'].value).not.toBe(
+      "default-src 'self'",
+    );
+  });
+
+  test('with malformed ?csp=, falls back to default without throwing', () => {
+    const event = makeEvent({ csp: { value: 'not-json' } });
+    const result = handler(event);
+    expect(result.headers['content-security-policy'].value).toContain("connect-src 'self'");
+    expect(result.headers['content-security-policy'].value).not.toMatch(
+      /connect-src 'self' \S/,
+    );
+  });
+
+  test('always emits frame-ancestors so framing control is not lost on the dynamic path', () => {
+    const event = makeEvent();
+    const result = handler(event);
+    // The placeholder is what's in source; in production CDK substitutes
+    // it with the real SPA origin before upload.
+    expect(result.headers['content-security-policy'].value).toContain(
+      'frame-ancestors __INJECT_FRAME_ANCESTORS__',
+    );
+  });
+
+  test('returns the response object in the CloudFront Functions v2.0 shape', () => {
+    const event = makeEvent({
+      csp: { value: JSON.stringify({ connectDomains: ['https://api.example.com'] }) },
+    });
+    const result = handler(event);
+    expect(result).toBe(event.response);
+    expect(typeof result.headers['content-security-policy'].value).toBe('string');
+  });
+
+  test('handles missing response.headers (defensive)', () => {
+    const event = { request: { querystring: {} }, response: {} as any };
+    const result = handler(event);
+    expect(result.headers).toBeDefined();
+    expect(result.headers['content-security-policy']).toBeDefined();
+  });
+});

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -2,7 +2,7 @@ import { Template, Match } from 'aws-cdk-lib/assertions';
 import {
   McpSandboxStack,
   buildMcpSandboxFrameAncestors,
-  buildMcpSandboxProxyCsp,
+  loadMcpSandboxCspFunctionCode,
   MCP_SANDBOX_SUBDOMAIN_LABEL,
 } from '../lib/mcp-sandbox-stack';
 import { createMockConfig, createMockApp, mockEnv } from './helpers/mock-config';
@@ -66,27 +66,67 @@ describe('McpSandboxStack', () => {
     });
   });
 
-  test('ResponseHeadersPolicy CSP locks frame-ancestors to the SPA origin only', () => {
+  test('ResponseHeadersPolicy keeps non-CSP security headers but does NOT emit CSP (CSP is now per-request via the CloudFront Function)', () => {
+    // CSP via the response-headers-policy would be a SECOND `Content-
+    // Security-Policy` header alongside the dynamic one from the CFN;
+    // browsers intersect them, which would silently re-deny anything an
+    // App legitimately declared in `_meta.ui.csp`. So the policy carries
+    // only the headers that don't vary per resource.
     template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
       ResponseHeadersPolicyConfig: Match.objectLike({
         SecurityHeadersConfig: Match.objectLike({
-          ContentSecurityPolicy: Match.objectLike({
-            Override: true,
-            ContentSecurityPolicy: Match.stringLikeRegexp(
-              'frame-ancestors https://test\\.example\\.com http://localhost:4200',
-            ),
-          }),
           StrictTransportSecurity: Match.objectLike({ Override: true }),
+          ReferrerPolicy: Match.objectLike({ Override: true }),
+          ContentTypeOptions: Match.objectLike({ Override: true }),
         }),
       }),
     });
+
+    const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+    const policy = Object.values(policies)[0] as any;
+    const security = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig;
+    expect(security.ContentSecurityPolicy).toBeUndefined();
   });
 
-  test('does NOT set legacy X-Frame-Options (frame-ancestors is the control)', () => {
+  test('does NOT set legacy X-Frame-Options (frame-ancestors via the CSP function is the control)', () => {
     const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
     const policy = Object.values(policies)[0] as any;
     const security = policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig;
     expect(security.FrameOptions).toBeUndefined();
+  });
+
+  test('creates exactly one CloudFront Function for dynamic CSP, on the JS_2_0 runtime', () => {
+    template.resourceCountIs('AWS::CloudFront::Function', 1);
+    template.hasResourceProperties('AWS::CloudFront::Function', {
+      FunctionConfig: Match.objectLike({
+        Runtime: 'cloudfront-js-2.0',
+      }),
+    });
+  });
+
+  test('CFN function body has the frame-ancestors placeholder substituted with the real source list', () => {
+    const fns = template.findResources('AWS::CloudFront::Function');
+    const fn = Object.values(fns)[0] as any;
+    const code = fn.Properties.FunctionCode as string;
+    expect(code).toContain('https://test.example.com http://localhost:4200');
+    // The substitutable JS literal must be gone; the bare token still
+    // appears in a top-of-file comment and that's intentional.
+    expect(code).not.toContain("'__INJECT_FRAME_ANCESTORS__'");
+  });
+
+  test('CFN function is wired to viewer-response on the default behavior', () => {
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({
+              EventType: 'viewer-response',
+              FunctionARN: Match.anyValue(),
+            }),
+          ]),
+        }),
+      }),
+    });
   });
 
   test('bakes the shell in via a BucketDeployment with CloudFront invalidation', () => {
@@ -107,7 +147,7 @@ describe('McpSandboxStack', () => {
     template.resourceCountIs('AWS::Route53::RecordSet', 0);
   });
 
-  test('domain-less config denies all framing (frame-ancestors none)', () => {
+  test('domain-less config bakes "frame-ancestors none" into the CSP function code', () => {
     const config = createMockConfig({
       domainName: undefined,
       mcpSandbox: { enabled: true, extraFrameAncestors: [] },
@@ -118,15 +158,13 @@ describe('McpSandboxStack', () => {
       env: mockEnv(config),
     });
     const t = Template.fromStack(stack);
-    t.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
-      ResponseHeadersPolicyConfig: Match.objectLike({
-        SecurityHeadersConfig: Match.objectLike({
-          ContentSecurityPolicy: Match.objectLike({
-            ContentSecurityPolicy: Match.stringLikeRegexp("frame-ancestors 'none'"),
-          }),
-        }),
-      }),
-    });
+    const fns = t.findResources('AWS::CloudFront::Function');
+    const fn = Object.values(fns)[0] as any;
+    const code = fn.Properties.FunctionCode as string;
+    // JSON.stringify wraps single-quoted CSP keywords in double quotes —
+    // the resulting JS literal is `"'none'"` (no escaping needed since
+    // JSON.stringify never emits backslashed single quotes).
+    expect(code).toContain('var FRAME_ANCESTORS = "\'none\'";');
   });
 });
 
@@ -160,33 +198,39 @@ describe('buildMcpSandboxFrameAncestors', () => {
   });
 });
 
-describe('buildMcpSandboxProxyCsp', () => {
-  test('carries the given frame-ancestors + non-overridable hardening', () => {
-    const csp = buildMcpSandboxProxyCsp('https://alpha.example.com');
-    expect(csp).toContain('frame-ancestors https://alpha.example.com');
-    // Hardening directives that proxy.html shouldn't ever want to relax,
-    // even though most of the rest is intentionally broad.
-    expect(csp).toContain("base-uri 'none'");
-    expect(csp).toContain("form-action 'none'");
-    expect(csp).toContain("object-src 'none'");
-    expect(csp).toContain("frame-src 'none'");
-    expect(csp).toContain("connect-src 'self'");
+describe('loadMcpSandboxCspFunctionCode', () => {
+  test('substitutes the FRAME_ANCESTORS placeholder with the real source list (as a JSON-escaped JS literal)', () => {
+    const code = loadMcpSandboxCspFunctionCode('https://alpha.example.com');
+    expect(code).toContain('var FRAME_ANCESTORS = "https://alpha.example.com";');
+    // The replaceable quoted literal must be gone; the bare token may
+    // still appear in a comment, which is fine.
+    expect(code).not.toContain("'__INJECT_FRAME_ANCESTORS__'");
   });
 
-  test('matches the ext-apps reference defaults so typical bundled Apps run', () => {
-    // The inner App iframe inherits this CSP (CSP3 local-scheme rule applies
-    // to srcdoc / blob: / document.write()-populated about:blank alike). The
-    // modelcontextprotocol/ext-apps basic-host reference ships its outer CSP
-    // with these tokens baked in for the same reason — bundled-App inline
-    // scripts/styles/eval need to actually run. See mcp-sandbox-stack.ts
-    // docstring for the security rationale.
-    const csp = buildMcpSandboxProxyCsp("'none'");
-    expect(csp).toContain(
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:",
+  test('preserves the runtime helpers (sanitize / build / parse / handler)', () => {
+    const code = loadMcpSandboxCspFunctionCode("'none'");
+    expect(code).toContain('function sanitizeCspDomains(');
+    expect(code).toContain('function buildCspHeader(');
+    expect(code).toContain('function parseCspParam(');
+    expect(code).toContain('function handler(');
+  });
+
+  test('handles the deny-all frame-ancestors value without producing invalid JS', () => {
+    const code = loadMcpSandboxCspFunctionCode("'none'");
+    // JSON.stringify yields `"'none'"` (double-quoted, inner single
+    // quotes unescaped) — a valid JS string literal that decodes back to
+    // the CSP source `'none'` at runtime. Without this escaping the
+    // naive replace would produce `''none''`, a syntax error.
+    expect(code).toContain('var FRAME_ANCESTORS = "\'none\'";');
+  });
+
+  test('handles multiple space-separated source list entries (the common production shape)', () => {
+    const code = loadMcpSandboxCspFunctionCode(
+      'https://alpha.example.com http://localhost:4200',
     );
-    expect(csp).toContain("style-src 'self' 'unsafe-inline' blob: data:");
-    expect(csp).toContain("worker-src 'self' blob:");
-    expect(csp).toContain("default-src 'self' 'unsafe-inline'");
+    expect(code).toContain(
+      'var FRAME_ANCESTORS = "https://alpha.example.com http://localhost:4200";',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Compose Content-Security-Policy **per UI resource** on the sandbox-proxy origin so Apps that declare `_meta.ui.csp` get their declared `connectDomains`/`resourceDomains`/`frameDomains`/`baseUriDomains` honored. Matches the upstream `modelcontextprotocol/ext-apps/examples/basic-host/serve.ts` reference.
- Unblocks **our own PR #7 dogfood (Excalidraw)** — its server declares `resourceDomains: ['https://esm.sh']` + `connectDomains: ['https://esm.sh']`, and on the static CSP from [#353](https://github.com/Boise-State-Development/agentcore-public-stack/pull/353) every esm.sh load was blocked (React 19, Excalidraw 0.18, fonts, stylesheets).
- Implements [SEP-1865 draft `apps.mdx`](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx) line 283 MUST: *"Host MUST construct CSP headers based on declared domains."*

## Design

| | |
|---|---|
| **CFN runtime** | `cloudfront-js-2.0` |
| **Attachment** | `viewer-response` on the default behavior |
| **Source of truth for CSP** | the CFN (RHP no longer emits a CSP — two CSP headers would intersect and silently re-deny declared domains) |
| **Cache key** | unchanged — CFN runs on cache hits too, so one cached `proxy.html` body services every `?csp=` variation |
| **`frame-ancestors` injection** | JSON-escaped JS literal at CDK synth time (handles `'none'` correctly) |
| **Default CSP** | reference's pragmatic defaults (keeps `'unsafe-eval' blob: data:` for bundled-but-non-declaring Apps) |
| **Frontend** | `proxy-url.ts` helper builds `?csp=<JSON>` from the `ui_resource` event; skips the query when no domains declared (no cache fragmentation for the 22/25 no-declaration case) |

## Scoping

See [`docs/kaizen/scoping/mcp-sandbox-dynamic-csp.md`](docs/kaizen/scoping/mcp-sandbox-dynamic-csp.md) — empirical scan of all 25 reference example servers + Excalidraw for `_meta.ui.csp` declarations, alternative-implementation comparison (CFN vs Lambda@Edge vs API Gateway), and cache-implications analysis.

## Test plan

- [x] `cd infrastructure && npm test` — 369 pass (53 in `mcp-sandbox*`)
- [x] `cd frontend/ai.client && npm run test:ci` — 1079 pass (9 new in `proxy-url.spec.ts`)
- [x] `cd infrastructure && npx cdk synth` — clean
- [x] `cd frontend/ai.client && npm run build` — clean (only pre-existing warnings)
- [ ] **Manual e2e (post-deploy):**
  - [ ] Deploy `McpSandboxStack` to dev
  - [ ] Invalidate CloudFront `/proxy.html`
  - [ ] Open an Excalidraw `create_view` tool call in dev — browser console should have **zero** esm.sh-related CSP block errors
  - [ ] Sanity-check a no-declaration App (e.g. budget-allocator) still renders with the default CSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)