### PR TITLE
fix(mcp-apps): shorten CFN Comment to fit the 128-char AWS cap

### DIFF
--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -236,9 +236,11 @@ export class McpSandboxStack extends cdk.Stack {
     // the function uses ES2017 features (regex literals, template
     // strings, JSON.parse) that the legacy JS_1_0 runtime doesn't accept.
     const cspFunctionCode = loadMcpSandboxCspFunctionCode(frameAncestors);
+    // AWS caps CloudFront Function `Comment` at 128 chars — design rationale
+    // lives in the docstring above and the scoping doc, not here.
     const cspFunction = new cloudfront.Function(this, 'McpSandboxCspFunction', {
       functionName: getResourceName(config, 'mcp-sandbox-csp'),
-      comment: 'Composes the per-resource Content-Security-Policy header from the ?csp= query parameter (matching modelcontextprotocol/ext-apps basic-host/serve.ts).',
+      comment: 'Composes per-resource CSP header from ?csp= query (mirrors ext-apps basic-host/serve.ts).',
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       code: cloudfront.FunctionCode.fromInline(cspFunctionCode),
     });

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -114,6 +114,17 @@ describe('McpSandboxStack', () => {
     expect(code).not.toContain("'__INJECT_FRAME_ANCESTORS__'");
   });
 
+  test('CFN function comment fits within the AWS-enforced 128-char limit', () => {
+    // CloudFront::Function.FunctionConfig.Comment maxes at 128 chars and
+    // CloudFormation rejects the create with a 400 if exceeded — see
+    // alpha deploy 2026-05-19 which rolled back on this. Catching at
+    // synth time prevents another wasted deploy round-trip.
+    const fns = template.findResources('AWS::CloudFront::Function');
+    const fn = Object.values(fns)[0] as any;
+    const comment = fn.Properties.FunctionConfig.Comment as string;
+    expect(comment.length).toBeLessThanOrEqual(128);
+  });
+
   test('CFN function is wired to viewer-response on the default behavior', () => {
     template.hasResourceProperties('AWS::CloudFront::Distribution', {
       DistributionConfig: Match.objectLike({


### PR DESCRIPTION
## Summary

Follow-up to [#355](https://github.com/Boise-State-Development/agentcore-public-stack/pull/355). The dynamic-CSP CloudFront Function I added there ships with a 149-char `Comment` field; CloudFront's `AWS::CloudFront::Function.FunctionConfig.Comment` is capped at 128 chars and CloudFormation rejects the create with HTTP 400 when exceeded. Caught during the alpha deploy that immediately followed the merge — stack rolled back.

```
CREATE_FAILED  AWS::CloudFront::Function  McpSandboxCspFunction
"Invalid request provided: AWS::CloudFront::Function: The parameter Comment is too big."
```

## Changes

- `mcp-sandbox-stack.ts`: shorten the function `comment` from 149 → 89 chars (`"Composes per-resource CSP header from ?csp= query (mirrors ext-apps basic-host/serve.ts)."`). Full design rationale stays in the surrounding code comments and the scoping doc — the synthesized field is just an AWS-visible label.
- `mcp-sandbox-stack.test.ts`: regression test asserting `FunctionConfig.Comment.length <= 128`, so a future PR can't reintroduce the overrun without a CI failure.

## Test plan

- [x] `cd infrastructure && npx jest mcp-sandbox-stack` — 24 pass (23 prior + 1 new)
- [ ] `cd infrastructure && npx cdk deploy McpSandboxStack -c environment=alpha` — stack creates CloudFront Function cleanly, distribution wires the function-association on viewer-response

🤖 Generated with [Claude Code](https://claude.com/claude-code)