### PR TITLE
fix(mcp-apps): shorten RHP Comment to fit the same 128-char AWS cap

### DIFF
--- a/infrastructure/lib/mcp-sandbox-stack.ts
+++ b/infrastructure/lib/mcp-sandbox-stack.ts
@@ -210,7 +210,10 @@ export class McpSandboxStack extends cdk.Stack {
       'McpSandboxResponseHeaders',
       {
         responseHeadersPolicyName: getResourceName(config, 'mcp-sandbox-headers'),
-        comment: 'Security headers (HSTS, Referrer-Policy, X-Content-Type-Options) for the MCP Apps sandbox proxy. CSP is composed per-request by the dynamic-CSP CloudFront Function.',
+        // AWS caps ResponseHeadersPolicy `Comment` at 128 chars (same as
+        // CloudFront::Function). Full rationale lives in the code comments
+        // above; this field is just the AWS-visible label.
+        comment: 'HSTS + Referrer-Policy + X-Content-Type-Options for MCP Apps sandbox proxy. CSP via dynamic CloudFront Function.',
         securityHeadersBehavior: {
           contentTypeOptions: { override: true },
           // Intentionally NOT setting frameOptions — `frame-ancestors`

--- a/infrastructure/test/mcp-sandbox-stack.test.ts
+++ b/infrastructure/test/mcp-sandbox-stack.test.ts
@@ -125,6 +125,18 @@ describe('McpSandboxStack', () => {
     expect(comment.length).toBeLessThanOrEqual(128);
   });
 
+  test('ResponseHeadersPolicy comment fits within the AWS-enforced 128-char limit', () => {
+    // ResponseHeadersPolicy.ResponseHeadersPolicyConfig.Comment shares
+    // the same 128-char cap. The 2026-05-19 alpha redeploy hit this
+    // (generic "Invalid request" — AWS doesn't echo the field name) so
+    // we lock both sibling Comments in the stack down with the same
+    // guard.
+    const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+    const policy = Object.values(policies)[0] as any;
+    const comment = policy.Properties.ResponseHeadersPolicyConfig.Comment as string;
+    expect(comment.length).toBeLessThanOrEqual(128);
+  });
+
   test('CFN function is wired to viewer-response on the default behavior', () => {
     template.hasResourceProperties('AWS::CloudFront::Distribution', {
       DistributionConfig: Match.objectLike({


### PR DESCRIPTION
## Summary

Follow-up to [#356](https://github.com/Boise-State-Development/agentcore-public-stack/pull/356). The CFN-comment fix unblocked the `AWS::CloudFront::Function` create, but the redeploy then failed on the sibling `AWS::CloudFront::ResponseHeadersPolicy` update with the same root cause — `Comment` exceeds AWS's 128-char limit. CloudFormation surfaced this with a generic message that doesn't name the field:

```
UPDATE_FAILED  AWS::CloudFront::ResponseHeadersPolicy
"Invalid request provided: AWS::CloudFront::ResponseHeadersPolicy"
```

The RHP comment was 164 chars (same 128 cap as `CloudFront::Function.Comment`). The original #356 fix missed it because it only audited the CFN side.

## Changes

- `mcp-sandbox-stack.ts`: shorten the RHP `comment` from 164 → 112 chars (`"HSTS + Referrer-Policy + X-Content-Type-Options for MCP Apps sandbox proxy. CSP via dynamic CloudFront Function."`).
- `mcp-sandbox-stack.test.ts`: add a second regression test asserting `ResponseHeadersPolicyConfig.Comment.length <= 128` (sibling to the CFN one #356 added). Both sibling Comments in this stack are now locked down.

## Test plan

- [x] `cd infrastructure && npx jest mcp-sandbox-stack -t Comment` — 2 pass (CFN + RHP)
- [ ] `cd infrastructure && npx cdk deploy McpSandboxStack -c environment=alpha` — RHP update succeeds, CFN creates, function-association attaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)