### PR TITLE
fix(mcp-apps): decode URL-encoded ?csp= in sandbox CFN

### DIFF
--- a/infrastructure/assets/mcp-sandbox/csp-function.js
+++ b/infrastructure/assets/mcp-sandbox/csp-function.js
@@ -93,20 +93,12 @@ function buildCspHeader(cspConfig, frameAncestors) {
 }
 
 /**
- * Extract and parse the `csp` query parameter. CloudFront delivers
- * `request.querystring` as an object keyed by param name where each
- * value is URL-decoded (we don't need a `decodeURIComponent` call).
- * Returns the parsed CSP object or null on absent / malformed / non-
- * object input — never throws.
+ * Try to parse a string as a JSON object (not array, not scalar). Returns
+ * the parsed object or null. Never throws.
  */
-function parseCspParam(querystring) {
-  if (!querystring) return null;
-  var entry = querystring.csp;
-  if (!entry || typeof entry.value !== 'string' || entry.value.length === 0) {
-    return null;
-  }
+function tryParseObject(s) {
   try {
-    var parsed = JSON.parse(entry.value);
+    var parsed = JSON.parse(s);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed;
     }
@@ -114,6 +106,59 @@ function parseCspParam(querystring) {
   } catch (e) {
     return null;
   }
+}
+
+/**
+ * Extract and parse the `csp` query parameter. CloudFront Functions
+ * deliver `request.querystring[name].value` as the parameter value;
+ * whether that value is URL-decoded depends on runtime/event-type and
+ * doesn't always match the docs in practice. We try the value as-is
+ * first, then fall back to an explicit `decodeURIComponent` if that
+ * parse fails. Returns the parsed CSP object or null on absent /
+ * malformed / non-object input — never throws.
+ */
+function parseCspParam(querystring) {
+  if (!querystring) return null;
+  var entry = querystring.csp;
+  if (!entry || typeof entry.value !== 'string' || entry.value.length === 0) {
+    return null;
+  }
+  var asIs = tryParseObject(entry.value);
+  if (asIs !== null) return asIs;
+  var decoded;
+  try {
+    decoded = decodeURIComponent(entry.value);
+  } catch (e) {
+    return null;
+  }
+  if (decoded === entry.value) return null;
+  return tryParseObject(decoded);
+}
+
+/**
+ * TODO(diag): remove after CSP propagation is verified for external Apps.
+ * Returns a short diagnostic string describing what `parseCspParam` saw,
+ * stamped onto an `x-csp-debug` response header so a curl can pinpoint
+ * which branch the function took without redeploying with logs.
+ */
+function summarizeCspParam(querystring) {
+  if (!querystring) return 'no-querystring';
+  var entry = querystring.csp;
+  if (!entry) return 'no-csp-entry';
+  if (typeof entry.value !== 'string') return 'value-not-string';
+  if (entry.value.length === 0) return 'empty-value';
+  var raw = entry.value;
+  var head = raw.slice(0, 60).replace(/[^\x20-\x7e]/g, '?');
+  if (tryParseObject(raw) !== null) return 'parsed-raw len=' + raw.length;
+  var decoded;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch (e) {
+    return 'decode-threw rawhead=' + head;
+  }
+  if (decoded === raw) return 'parse-failed-noencoded rawhead=' + head;
+  if (tryParseObject(decoded) !== null) return 'parsed-decoded rawlen=' + raw.length;
+  return 'parse-failed-both rawhead=' + head;
 }
 
 function handler(event) {
@@ -125,6 +170,8 @@ function handler(event) {
   var csp = buildCspHeader(cspConfig, FRAME_ANCESTORS);
 
   response.headers['content-security-policy'] = { value: csp };
+  // TODO(diag): remove after CSP propagation is verified for external Apps.
+  response.headers['x-csp-debug'] = { value: summarizeCspParam(request.querystring) };
   return response;
 }
 
@@ -133,6 +180,7 @@ if (typeof module !== 'undefined' && module.exports) {
     sanitizeCspDomains: sanitizeCspDomains,
     buildCspHeader: buildCspHeader,
     parseCspParam: parseCspParam,
+    summarizeCspParam: summarizeCspParam,
     handler: handler,
   };
 }

--- a/infrastructure/test/mcp-sandbox-csp-function.test.ts
+++ b/infrastructure/test/mcp-sandbox-csp-function.test.ts
@@ -26,6 +26,7 @@ const {
   sanitizeCspDomains,
   buildCspHeader,
   parseCspParam,
+  summarizeCspParam,
   handler,
 } = require('../assets/mcp-sandbox/csp-function');
 
@@ -258,6 +259,53 @@ describe('parseCspParam', () => {
     expect(parseCspParam({ csp: { value: '42' } })).toBeNull();
     expect(parseCspParam({ csp: { value: 'null' } })).toBeNull();
   });
+
+  test('URL-encoded value falls back to decodeURIComponent', () => {
+    // CloudFront Functions don't reliably URL-decode querystring values in
+    // every runtime/event-type combo; the function must handle both.
+    const encoded =
+      '%7B%22resourceDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%2C' +
+      '%22connectDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D';
+    expect(parseCspParam({ csp: { value: encoded } })).toEqual({
+      resourceDomains: ['https://esm.sh'],
+      connectDomains: ['https://esm.sh'],
+    });
+  });
+
+  test('URL-encoded but not valid JSON after decode → null', () => {
+    expect(parseCspParam({ csp: { value: '%7Bbroken' } })).toBeNull();
+  });
+});
+
+describe('summarizeCspParam', () => {
+  test('reports no-querystring / no-csp-entry / empty-value', () => {
+    expect(summarizeCspParam(undefined)).toBe('no-querystring');
+    expect(summarizeCspParam({})).toBe('no-csp-entry');
+    expect(summarizeCspParam({ csp: { value: '' } })).toBe('empty-value');
+  });
+
+  test('reports parsed-raw on plain JSON', () => {
+    const v = '{"connectDomains":["https://esm.sh"]}';
+    expect(summarizeCspParam({ csp: { value: v } })).toBe(
+      'parsed-raw len=' + v.length,
+    );
+  });
+
+  test('reports parsed-decoded on URL-encoded JSON', () => {
+    const encoded = '%7B%22connectDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D';
+    expect(summarizeCspParam({ csp: { value: encoded } })).toBe(
+      'parsed-decoded rawlen=' + encoded.length,
+    );
+  });
+
+  test('reports parse-failed-* with a sanitized head fragment', () => {
+    expect(summarizeCspParam({ csp: { value: 'not-json' } })).toContain(
+      'parse-failed-noencoded',
+    );
+    expect(summarizeCspParam({ csp: { value: '%7Bbroken' } })).toContain(
+      'parse-failed-both',
+    );
+  });
 });
 
 describe('handler', () => {
@@ -337,5 +385,18 @@ describe('handler', () => {
     const result = handler(event);
     expect(result.headers).toBeDefined();
     expect(result.headers['content-security-policy']).toBeDefined();
+  });
+
+  test('stamps x-csp-debug describing parse outcome', () => {
+    // TODO(diag): remove with the corresponding header in csp-function.js.
+    const encoded = '%7B%22resourceDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D';
+    const event = makeEvent({ csp: { value: encoded } });
+    const result = handler(event);
+    expect(result.headers['x-csp-debug']).toBeDefined();
+    expect(result.headers['x-csp-debug'].value).toContain('parsed-decoded');
+    // And the CSP itself includes the declared domain.
+    expect(result.headers['content-security-policy'].value).toContain(
+      'https://esm.sh',
+    );
   });
 });


### PR DESCRIPTION
## Summary

External MCP Apps that declare `_meta.ui.csp` (e.g. an Excalidraw server declaring `resourceDomains: ['https://esm.sh']`) were getting the bare default CSP at the edge — esm.sh-hosted scripts, styles, and fonts were being blocked despite the App declaring them.

The backend extracted the CSP correctly and the SPA forwarded it on the proxy URL as `?csp=<urlencoded-json>`. The CloudFront Function was running (it correctly substituted `frame-ancestors` per PR #355), but `parseCspParam` returned `null` for every request — `JSON.parse` threw on `%7B...` and the silent `catch` fell back to the deny-default. The docs-based assumption that CFN URL-decodes querystring values doesn't hold for non-trivial encodings in this runtime/event-type combination.

### What changed

- **`parseCspParam`** now tries the value as-is, then falls back to `decodeURIComponent`. The existing test cases still pass; one new test covers the URL-encoded fallback path.
- **`summarizeCspParam`** is a new helper that emits a short diagnostic string describing which branch was taken (`parsed-raw` / `parsed-decoded` / `parse-failed-*` with a sanitized head fragment of the input). The `handler` stamps this on an `x-csp-debug` response header. **TODO-marked** for removal once the fix is verified in alpha — leaving it in for one deploy cycle is the cheapest way to confirm the fix without redeploying with logs.

### Verification

- `npm test -- mcp-sandbox-csp-function` — 37/37 pass, including 5 new tests for the URL-encoded fallback, `summarizeCspParam` outcomes, and the `x-csp-debug` header.

## Test plan

- [ ] Deploy `McpSandboxStack` to alpha.
- [ ] `curl -D - -o /dev/null "https://mcp-sandbox.alpha.boisestate.ai/proxy.html?csp=%7B%22resourceDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D" | grep -i "x-csp-debug\|content-security-policy"`
  - Expect `x-csp-debug: parsed-decoded ...` (or `parsed-raw ...` if CFN's decode behavior changed).
  - Expect `style-src ... https://esm.sh` (and same on script-src, font-src, img-src, media-src, worker-src) in the CSP response header.
- [ ] Open the Excalidraw App in the SPA and confirm no CSP violations in the browser console.
- [ ] After verification: follow-up PR to remove the `x-csp-debug` header + `summarizeCspParam` (one-line revert apiece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)