### PR TITLE
chore(mcp-apps): remove x-csp-debug diagnostic from sandbox CFN

### DIFF
--- a/infrastructure/assets/mcp-sandbox/csp-function.js
+++ b/infrastructure/assets/mcp-sandbox/csp-function.js
@@ -135,32 +135,6 @@ function parseCspParam(querystring) {
   return tryParseObject(decoded);
 }
 
-/**
- * TODO(diag): remove after CSP propagation is verified for external Apps.
- * Returns a short diagnostic string describing what `parseCspParam` saw,
- * stamped onto an `x-csp-debug` response header so a curl can pinpoint
- * which branch the function took without redeploying with logs.
- */
-function summarizeCspParam(querystring) {
-  if (!querystring) return 'no-querystring';
-  var entry = querystring.csp;
-  if (!entry) return 'no-csp-entry';
-  if (typeof entry.value !== 'string') return 'value-not-string';
-  if (entry.value.length === 0) return 'empty-value';
-  var raw = entry.value;
-  var head = raw.slice(0, 60).replace(/[^\x20-\x7e]/g, '?');
-  if (tryParseObject(raw) !== null) return 'parsed-raw len=' + raw.length;
-  var decoded;
-  try {
-    decoded = decodeURIComponent(raw);
-  } catch (e) {
-    return 'decode-threw rawhead=' + head;
-  }
-  if (decoded === raw) return 'parse-failed-noencoded rawhead=' + head;
-  if (tryParseObject(decoded) !== null) return 'parsed-decoded rawlen=' + raw.length;
-  return 'parse-failed-both rawhead=' + head;
-}
-
 function handler(event) {
   var request = event.request || {};
   var response = event.response || {};
@@ -170,8 +144,6 @@ function handler(event) {
   var csp = buildCspHeader(cspConfig, FRAME_ANCESTORS);
 
   response.headers['content-security-policy'] = { value: csp };
-  // TODO(diag): remove after CSP propagation is verified for external Apps.
-  response.headers['x-csp-debug'] = { value: summarizeCspParam(request.querystring) };
   return response;
 }
 
@@ -180,7 +152,6 @@ if (typeof module !== 'undefined' && module.exports) {
     sanitizeCspDomains: sanitizeCspDomains,
     buildCspHeader: buildCspHeader,
     parseCspParam: parseCspParam,
-    summarizeCspParam: summarizeCspParam,
     handler: handler,
   };
 }

--- a/infrastructure/test/mcp-sandbox-csp-function.test.ts
+++ b/infrastructure/test/mcp-sandbox-csp-function.test.ts
@@ -26,7 +26,6 @@ const {
   sanitizeCspDomains,
   buildCspHeader,
   parseCspParam,
-  summarizeCspParam,
   handler,
 } = require('../assets/mcp-sandbox/csp-function');
 
@@ -277,37 +276,6 @@ describe('parseCspParam', () => {
   });
 });
 
-describe('summarizeCspParam', () => {
-  test('reports no-querystring / no-csp-entry / empty-value', () => {
-    expect(summarizeCspParam(undefined)).toBe('no-querystring');
-    expect(summarizeCspParam({})).toBe('no-csp-entry');
-    expect(summarizeCspParam({ csp: { value: '' } })).toBe('empty-value');
-  });
-
-  test('reports parsed-raw on plain JSON', () => {
-    const v = '{"connectDomains":["https://esm.sh"]}';
-    expect(summarizeCspParam({ csp: { value: v } })).toBe(
-      'parsed-raw len=' + v.length,
-    );
-  });
-
-  test('reports parsed-decoded on URL-encoded JSON', () => {
-    const encoded = '%7B%22connectDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D';
-    expect(summarizeCspParam({ csp: { value: encoded } })).toBe(
-      'parsed-decoded rawlen=' + encoded.length,
-    );
-  });
-
-  test('reports parse-failed-* with a sanitized head fragment', () => {
-    expect(summarizeCspParam({ csp: { value: 'not-json' } })).toContain(
-      'parse-failed-noencoded',
-    );
-    expect(summarizeCspParam({ csp: { value: '%7Bbroken' } })).toContain(
-      'parse-failed-both',
-    );
-  });
-});
-
 describe('handler', () => {
   function makeEvent(querystring?: Record<string, { value: string }>) {
     return {
@@ -385,18 +353,5 @@ describe('handler', () => {
     const result = handler(event);
     expect(result.headers).toBeDefined();
     expect(result.headers['content-security-policy']).toBeDefined();
-  });
-
-  test('stamps x-csp-debug describing parse outcome', () => {
-    // TODO(diag): remove with the corresponding header in csp-function.js.
-    const encoded = '%7B%22resourceDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D';
-    const event = makeEvent({ csp: { value: encoded } });
-    const result = handler(event);
-    expect(result.headers['x-csp-debug']).toBeDefined();
-    expect(result.headers['x-csp-debug'].value).toContain('parsed-decoded');
-    // And the CSP itself includes the declared domain.
-    expect(result.headers['content-security-policy'].value).toContain(
-      'https://esm.sh',
-    );
   });
 });


### PR DESCRIPTION
## Summary

PR #358 added a `parseCspParam` raw → `decodeURIComponent` fallback plus a TODO-marked `x-csp-debug` response header so we could verify the fix end-to-end in alpha. The fix is now confirmed working — Excalidraw loads `esm.sh` through the per-resource CSP, the browser shows no violations, and end-to-end DIAG (run locally) confirms the chain populates the catalog and emits the `ui_resource` SSE event.

This PR removes the diagnostic surface only. The actual fix stays.

### What changed

- Removed the `x-csp-debug` response header from the CloudFront Function handler.
- Removed the `summarizeCspParam` helper.
- Removed the five tests that exercised `summarizeCspParam` and the `x-csp-debug` header.

### What stayed

- `parseCspParam` keeps the raw → `decodeURIComponent` fallback (the actual fix).
- The unit test that covers the URL-encoded-input path stays.

## Verification

- `npm test -- mcp-sandbox-csp-function` → 32/32 pass.
- Pure deletions: -74 lines, no new code.

## Test plan

- [ ] Deploy `McpSandboxStack` to alpha.
- [ ] `curl -s -D - -o /dev/null "https://mcp-sandbox.alpha.boisestate.ai/proxy.html?csp=%7B%22resourceDomains%22%3A%5B%22https%3A%2F%2Fesm.sh%22%5D%7D" | grep -i "content-security-policy\|x-csp-debug"`
  - Expect `content-security-policy: ... style-src ... https://esm.sh ...` (unchanged from current alpha).
  - Expect **no** `x-csp-debug` header in the response.
- [ ] Open the Excalidraw App in the SPA, confirm it still renders with no CSP violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)