### PR TITLE
fix(mcp-apps): give inner App iframe allow-same-origin to match basic-host reference

### DIFF
--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -140,7 +140,7 @@ describe('McpAppBridge', () => {
     expect(msg.params.nonce).toBe(NONCE);
     expect(msg.params.csp).toEqual({ connectDomains: ['https://api.test'] });
     expect(msg.params.permissions).toEqual({ clipboardWrite: {} });
-    expect(msg.params.sandbox).toBe('allow-scripts');
+    expect(msg.params.sandbox).toBe('allow-scripts allow-same-origin allow-forms');
     // Strict targetOrigin — never '*'.
     expect(h.proxy.sent[0].targetOrigin).toBe(SANDBOX_ORIGIN);
   });

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -483,12 +483,21 @@ export class McpAppBridge {
 
   private sendSandboxResourceReady(): void {
     // Reserved host→proxy notification; consumed by the proxy, not forwarded.
+    // Inner-iframe sandbox matches the ext-apps basic-host reference
+    // (`examples/basic-host/src/sandbox.ts`): allow-scripts + allow-same-origin
+    // + allow-forms. allow-same-origin is required for proxy.js to populate
+    // the inner doc via document.write and for typical App bundles
+    // (Excalidraw, Cesium, etc.) to access localStorage at the sandbox origin.
+    // The mcp-sandbox origin is a static CDN with no shared state, so this
+    // does not weaken the cross-origin boundary against the SPA. Apps wanting
+    // stricter isolation can opt into null-origin via `_meta.ui.sandbox` once
+    // that pass-through lands.
     this.postToProxy({
       jsonrpc: '2.0',
       method: M_SANDBOX_RESOURCE_READY,
       params: {
         html: this.d.resource.html,
-        sandbox: 'allow-scripts',
+        sandbox: 'allow-scripts allow-same-origin allow-forms',
         csp: this.d.resource.csp,
         permissions: this.d.resource.permissions,
         nonce: this.d.nonce,

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
@@ -121,7 +121,10 @@ export interface McpUiInitializeResult {
 /** Params for `ui/notifications/sandbox-resource-ready` (host → proxy). */
 export interface SandboxResourceReadyParams {
   html: string;
-  /** Inner-iframe `sandbox` attribute. Defaults to `allow-scripts`. */
+  /**
+   * Inner-iframe `sandbox` attribute. Host default matches the ext-apps
+   * basic-host reference: `allow-scripts allow-same-origin allow-forms`.
+   */
   sandbox?: string;
   csp?: McpUiCsp;
   permissions?: McpUiPermissions;

--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -11,9 +11,11 @@
  * host (ai.client) and the untrusted App View (an inner iframe this script
  * creates, mounted via document.write per the ext-apps basic-host
  * reference). The inner iframe defaults to allow-scripts +
- * allow-same-origin so document.write can populate it; the App may
- * override its `_meta.ui.sandbox` to opt back into null-origin (we'll
- * fall back to srcdoc when contentDocument isn't writable).
+ * allow-same-origin + allow-forms (matches the basic-host reference) so
+ * document.write can populate it and typical App bundles can use
+ * localStorage at the sandbox origin; the App may override its
+ * `_meta.ui.sandbox` to opt back into null-origin (we'll fall back to
+ * srcdoc when contentDocument isn't writable).
  *
  * Responsibilities (spec §"Sandbox proxy"):
  *   3. Announce readiness to the host (ui/notifications/sandbox-proxy-ready).
@@ -143,17 +145,19 @@
   // --- inner iframe (the View) -------------------------------------------
 
   function mountView(params) {
-    // Default to allow-scripts + allow-same-origin so document.write() can
-    // populate the inner iframe (contentDocument is only accessible when
-    // the inner is same-origin to this proxy, which is fine — the proxy
-    // origin is a static CDN with no shared state). The App can override
-    // via `_meta.ui.sandbox` to opt back into null-origin if it wants
-    // stricter isolation; we'll fall back to srcdoc when contentDocument
-    // isn't writable, matching the ext-apps basic-host reference.
+    // Default matches the ext-apps basic-host reference
+    // (`examples/basic-host/src/sandbox.ts`): allow-scripts +
+    // allow-same-origin + allow-forms. allow-same-origin lets document.write
+    // populate the inner doc (contentDocument is only accessible when the
+    // inner is same-origin to this proxy — fine, the proxy origin is a
+    // static CDN with no shared state) and lets typical bundled Apps reach
+    // localStorage at the sandbox origin. The App can override via
+    // `_meta.ui.sandbox` to opt back into null-origin for stricter isolation;
+    // we'll fall back to srcdoc when contentDocument isn't writable.
     var sandbox =
       typeof params.sandbox === 'string' && params.sandbox
         ? params.sandbox
-        : 'allow-scripts allow-same-origin';
+        : 'allow-scripts allow-same-origin allow-forms';
     var allow = allowAttr(params.permissions);
 
     inner = document.createElement('iframe');


### PR DESCRIPTION
## Summary

- Bridge hardcoded the inner-iframe sandbox to `allow-scripts` only, so the inner doc was null-origin. Any App bundle that touches `localStorage` during init (Excalidraw's `utils.mjs` does for theme/state) hit `SecurityError: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag`. Excalidraw then never reached a stable layout, so the `ui/notifications/size-changed` it eventually reported under-measured the canvas and the drawing got cut off in the iframe.
- Align with the ext-apps `examples/basic-host/src/sandbox.ts` reference: `allow-scripts allow-same-origin allow-forms`. The mcp-sandbox origin is a static CDN with no shared state, so `allow-same-origin` does not weaken the cross-origin boundary against the SPA — it just lets `document.write` populate the inner doc and lets typical bundled Apps reach `localStorage` at the sandbox origin.
- Bring `proxy.js`'s fallback default and header doc in line so host and proxy stay in lockstep if either side stops sending `sandbox` explicitly.

## Why

User-reported (alpha, on develop): Excalidraw `create_view` output rendered as a half-drawn bronco/poop emoji with `SecurityError: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag` in the console. Root cause was `mcp-app-bridge.ts:491` overriding the proxy's same-origin default with the stricter `allow-scripts`.

## What changed

| File | Change |
| --- | --- |
| `frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts` | Send `allow-scripts allow-same-origin allow-forms` on `sandbox-resource-ready`; add comment explaining the alignment + why same-origin at the sandbox origin is safe. |
| `frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts` | Update assertion. |
| `frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts` | Update JSDoc default for `SandboxResourceReadyParams.sandbox`. |
| `infrastructure/assets/mcp-sandbox/proxy.js` | Fallback default + header doc match the new value (kept in sync). |

## Out of scope (intentional)

- `An iframe which has both allow-scripts and allow-same-origin for its sandbox attribute can escape its sandboxing` on the **outer** frame (`mcp-app-frame.component.ts:220`) — required so the bridge's `event.origin === sandboxOrigin` gate works. The warning is informational; the cross-origin boundary against the SPA is the real bound.
- `excalidraw.mjs:9 Unhandled element type "path"` — upstream Excalidraw bundle rejecting an element type the agent generated. Belongs to the Excalidraw MCP server / prompt, not the host renderer.

## Test plan

- [x] `mcp-app-bridge.spec.ts` — 24/24 pass with updated assertion.
- [ ] Deploy `mcp-sandbox` stack (for `proxy.js`) + frontend.
- [ ] Invoke an Excalidraw `create_view` and confirm: no `SecurityError` in the console; drawing fills the iframe; `size-changed` traffic settles at a sensible height.
- [ ] Smoke-check a non-Excalidraw MCP App still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)