### PR TITLE
feat(file-sources): map connectors to file-source adapters (PR 2/4)

### DIFF
--- a/backend/src/apis/app_api/admin/file_sources/routes.py
+++ b/backend/src/apis/app_api/admin/file_sources/routes.py
@@ -1,0 +1,66 @@
+"""Admin API routes for file-source adapter discovery.
+
+Exposes the file-source adapter registry read-only so the admin connector
+form can render a dropdown for mapping a connector to an adapter. The
+registry is code-defined and immutable at runtime — adapters ship in
+releases and are never created through this API.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+
+from apis.shared.auth import User, require_admin
+
+from apis.app_api.file_sources.registry import registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/file-source-adapters", tags=["admin-file-sources"])
+
+
+class FileSourceAdapterInfo(BaseModel):
+    """Read-only description of a registered file-source adapter."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    key: str = Field(..., description="Stable adapter key stored on a connector")
+    display_name: str = Field(..., alias="displayName")
+    icon: str = Field(..., description="Icon hint the admin UI maps to an asset")
+    compatible_provider_types: List[str] = Field(
+        ...,
+        alias="compatibleProviderTypes",
+        description="OAuth provider types this adapter may be mapped to",
+    )
+    required_scopes: List[str] = Field(
+        ...,
+        alias="requiredScopes",
+        description="OAuth scopes the connector must grant for the adapter to work",
+    )
+
+
+class FileSourceAdapterListResponse(BaseModel):
+    adapters: List[FileSourceAdapterInfo]
+
+
+@router.get("/", response_model=FileSourceAdapterListResponse)
+async def list_file_source_adapters(
+    admin: User = Depends(require_admin),
+) -> FileSourceAdapterListResponse:
+    """List every file-source adapter shipped in this release. Admin only."""
+    logger.info("Admin listing file-source adapters")
+    adapters = [
+        FileSourceAdapterInfo(
+            key=a.metadata.key,
+            displayName=a.metadata.display_name,
+            icon=a.metadata.icon,
+            compatibleProviderTypes=[
+                pt.value for pt in a.metadata.compatible_provider_types
+            ],
+            requiredScopes=list(a.metadata.required_scopes),
+        )
+        for a in registry.all()
+    ]
+    return FileSourceAdapterListResponse(adapters=adapters)

--- a/backend/src/apis/app_api/admin/oauth/routes.py
+++ b/backend/src/apis/app_api/admin/oauth/routes.py
@@ -11,10 +11,12 @@ import logging
 import os
 from datetime import datetime, timezone
 from functools import lru_cache
+from typing import Optional
 
 import boto3
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from apis.app_api.file_sources.registry import registry
 from apis.shared.auth import User, require_admin
 from apis.shared.oauth.agentcore_registrar import (
     AgentCoreRegistrar,
@@ -29,6 +31,7 @@ from apis.shared.oauth.models import (
     OAuthProviderCreate,
     OAuthProviderListResponse,
     OAuthProviderResponse,
+    OAuthProviderType,
     OAuthProviderUpdate,
 )
 from apis.shared.oauth.provider_repository import (
@@ -188,6 +191,11 @@ async def create_provider(
             detail=f"Provider '{provider_data.provider_id}' already exists",
         )
 
+    # Fail fast on a bad file-source mapping, before any AgentCore side-effect.
+    _validate_file_source_adapter(
+        provider_data.file_source_adapter_id, provider_data.provider_type
+    )
+
     try:
         credential_info = registrar.create_credential_provider(
             provider_id=provider_data.provider_id,
@@ -256,6 +264,12 @@ async def update_provider(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Provider '{provider_id}' not found",
         )
+
+    # A populated adapter key must be valid for this connector's type; an
+    # empty string (clear the mapping) and None (unchanged) skip validation.
+    _validate_file_source_adapter(
+        updates.file_source_adapter_id, existing.provider_type
+    )
 
     rotating_credentials = bool(updates.client_id and updates.client_secret)
     changing_discovery = (
@@ -352,6 +366,34 @@ async def delete_provider(
 # =============================================================================
 
 
+def _validate_file_source_adapter(
+    adapter_id: Optional[str], provider_type: OAuthProviderType
+) -> None:
+    """Reject a file-source adapter mapping the registry cannot honor.
+
+    An empty/None value is a no-op — the connector simply isn't a file
+    source. A populated value must name an adapter shipped in the registry
+    whose `compatible_provider_types` includes this connector's type.
+    Raises `HTTPException` 400 on a bad mapping.
+    """
+    if not adapter_id:
+        return
+    adapter = registry.get(adapter_id)
+    if adapter is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown file-source adapter '{adapter_id}'",
+        )
+    if provider_type not in adapter.metadata.compatible_provider_types:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"File-source adapter '{adapter_id}' is not compatible with "
+                f"provider type '{provider_type.value}'"
+            ),
+        )
+
+
 def _build_provider_from_create(
     data: OAuthProviderCreate, credential_info: CredentialProviderInfo
 ) -> OAuthProvider:
@@ -375,6 +417,8 @@ def _build_provider_from_create(
         # so absent/empty are indistinguishable in DynamoDB and `from_*`
         # lookups round-trip identically.
         custom_parameters=data.custom_parameters or None,
+        # `""` from the form means "not a file source" — store as None.
+        file_source_adapter_id=data.file_source_adapter_id or None,
         created_at=now,
         updated_at=now,
     )

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -721,6 +721,11 @@ from .oauth.routes import router as oauth_admin_router
 
 router.include_router(oauth_admin_router)
 
+# ========== Include File-Source Adapters Admin Subrouter ==========
+from .file_sources.routes import router as file_sources_admin_router
+
+router.include_router(file_sources_admin_router)
+
 # ========== Include Auth Providers Admin Subrouter ==========
 from .auth_providers.routes import router as auth_providers_router
 

--- a/backend/src/apis/shared/oauth/models.py
+++ b/backend/src/apis/shared/oauth/models.py
@@ -121,6 +121,13 @@ class OAuthProvider:
     # `access_type=offline`) win on conflict — admins cannot accidentally
     # turn off a documented requirement.
     custom_parameters: Optional[Dict[str, str]] = None
+    # Maps this connector to a file-source adapter (e.g. "google-drive"),
+    # making it selectable as a file source in the assistant editor. The
+    # value is an adapter key from the backend adapter registry; admins set
+    # it via a dropdown. None means the connector is not a file source.
+    # Adapter existence / provider-type compatibility is validated in the
+    # admin route — `apis.shared` cannot import the app_api registry.
+    file_source_adapter_id: Optional[str] = None
     created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
     updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
 
@@ -148,6 +155,7 @@ class OAuthProvider:
             "oauthDiscoveryUrl": self.oauth_discovery_url,
             "authorizationServerMetadata": self.authorization_server_metadata,
             "customParameters": self.custom_parameters,
+            "fileSourceAdapterId": self.file_source_adapter_id,
             "createdAt": self.created_at,
             "updatedAt": self.updated_at,
         }
@@ -168,6 +176,7 @@ class OAuthProvider:
             oauth_discovery_url=item.get("oauthDiscoveryUrl"),
             authorization_server_metadata=item.get("authorizationServerMetadata"),
             custom_parameters=item.get("customParameters"),
+            file_source_adapter_id=item.get("fileSourceAdapterId"),
             created_at=item.get("createdAt", datetime.now(timezone.utc).isoformat() + "Z"),
             updated_at=item.get("updatedAt", datetime.now(timezone.utc).isoformat() + "Z"),
         )
@@ -203,6 +212,9 @@ class OAuthProviderCreate(BaseModel):
     oauth_discovery_url: Optional[str] = None
     authorization_server_metadata: Optional[Dict[str, Any]] = None
     custom_parameters: Optional[Dict[str, str]] = None
+    # Adapter key that makes this connector a file source. Validated against
+    # the adapter registry in the admin route.
+    file_source_adapter_id: Optional[str] = None
 
     model_config = ConfigDict(json_schema_extra={
         "example": {
@@ -257,6 +269,9 @@ class OAuthProviderUpdate(BaseModel):
     oauth_discovery_url: Optional[str] = None
     authorization_server_metadata: Optional[Dict[str, Any]] = None
     custom_parameters: Optional[Dict[str, str]] = None
+    # `""` clears the file-source mapping (the connector stops being a file
+    # source); a populated adapter key sets it; `None` leaves it unchanged.
+    file_source_adapter_id: Optional[str] = None
 
     @model_validator(mode="after")
     def _validate_credential_pair(self) -> "OAuthProviderUpdate":
@@ -289,6 +304,7 @@ class OAuthProviderResponse(BaseModel):
     oauth_discovery_url: Optional[str] = None
     authorization_server_metadata: Optional[Dict[str, Any]] = None
     custom_parameters: Optional[Dict[str, str]] = None
+    file_source_adapter_id: Optional[str] = None
     created_at: str
     updated_at: str
 
@@ -308,6 +324,7 @@ class OAuthProviderResponse(BaseModel):
             oauth_discovery_url=provider.oauth_discovery_url,
             authorization_server_metadata=provider.authorization_server_metadata,
             custom_parameters=provider.custom_parameters,
+            file_source_adapter_id=provider.file_source_adapter_id,
             created_at=provider.created_at,
             updated_at=provider.updated_at,
         )

--- a/backend/src/apis/shared/oauth/provider_repository.py
+++ b/backend/src/apis/shared/oauth/provider_repository.py
@@ -154,6 +154,10 @@ class OAuthProviderRepository:
             # Empty dict (`{}`) explicitly clears the field; pass None on the
             # update model to leave the existing value alone.
             existing.custom_parameters = updates.custom_parameters or None
+        if updates.file_source_adapter_id is not None:
+            # Empty string (`""`) clears the file-source mapping; a populated
+            # adapter key sets it. `None` leaves the existing value alone.
+            existing.file_source_adapter_id = updates.file_source_adapter_id or None
 
         existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
         self._table.put_item(Item=existing.to_dynamo_item())

--- a/backend/tests/apis/app_api/test_file_source_adapters_admin.py
+++ b/backend/tests/apis/app_api/test_file_source_adapters_admin.py
@@ -1,0 +1,108 @@
+"""Tests for connector ↔ file-source-adapter mapping.
+
+Covers the OAuthProvider model round-trip, the admin-route validation
+helper, and the read-only GET /admin/file-source-adapters endpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import require_admin
+from apis.shared.auth.models import User
+from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
+
+from apis.app_api.admin.file_sources import routes as adapter_routes
+from apis.app_api.admin.oauth.routes import _validate_file_source_adapter
+
+
+def _admin() -> User:
+    return User(
+        user_id="admin-1",
+        email="admin@example.com",
+        name="Admin",
+        roles=["admin"],
+        raw_token="test-token",
+    )
+
+
+class TestOAuthProviderMapping:
+    def test_file_source_adapter_id_round_trips_through_dynamo(self):
+        provider = OAuthProvider(
+            provider_id="google",
+            display_name="Google",
+            provider_type=OAuthProviderType.GOOGLE,
+            scopes=["openid"],
+            allowed_roles=[],
+            file_source_adapter_id="google-drive",
+        )
+        restored = OAuthProvider.from_dynamo_item(provider.to_dynamo_item())
+        assert restored.file_source_adapter_id == "google-drive"
+
+    def test_unmapped_provider_round_trips_as_none(self):
+        provider = OAuthProvider(
+            provider_id="slack",
+            display_name="Slack",
+            provider_type=OAuthProviderType.SLACK,
+            scopes=[],
+            allowed_roles=[],
+        )
+        assert provider.file_source_adapter_id is None
+        restored = OAuthProvider.from_dynamo_item(provider.to_dynamo_item())
+        assert restored.file_source_adapter_id is None
+
+    def test_legacy_dynamo_item_without_field_defaults_to_none(self):
+        # Records written before this field existed have no fileSourceAdapterId.
+        item = OAuthProvider(
+            provider_id="github",
+            display_name="GitHub",
+            provider_type=OAuthProviderType.GITHUB,
+            scopes=[],
+            allowed_roles=[],
+        ).to_dynamo_item()
+        del item["fileSourceAdapterId"]
+        assert OAuthProvider.from_dynamo_item(item).file_source_adapter_id is None
+
+
+class TestValidateFileSourceAdapter:
+    def test_empty_or_none_is_a_noop(self):
+        _validate_file_source_adapter(None, OAuthProviderType.GOOGLE)
+        _validate_file_source_adapter("", OAuthProviderType.GOOGLE)
+
+    def test_valid_mapping_passes(self):
+        _validate_file_source_adapter("google-drive", OAuthProviderType.GOOGLE)
+
+    def test_unknown_adapter_is_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_file_source_adapter("dropbox", OAuthProviderType.GOOGLE)
+        assert exc.value.status_code == 400
+        assert "Unknown file-source adapter" in exc.value.detail
+
+    def test_incompatible_provider_type_is_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_file_source_adapter("google-drive", OAuthProviderType.SLACK)
+        assert exc.value.status_code == 400
+        assert "not compatible" in exc.value.detail
+
+
+class TestListFileSourceAdaptersEndpoint:
+    @pytest.fixture
+    def client(self) -> TestClient:
+        app = FastAPI()
+        app.include_router(adapter_routes.router)
+        app.dependency_overrides[require_admin] = _admin
+        return TestClient(app)
+
+    def test_lists_shipped_adapters(self, client: TestClient):
+        response = client.get("/file-source-adapters/")
+        assert response.status_code == 200
+        adapters = {a["key"]: a for a in response.json()["adapters"]}
+        assert "google-drive" in adapters
+        drive = adapters["google-drive"]
+        assert drive["displayName"] == "Google Drive"
+        assert drive["compatibleProviderTypes"] == ["google"]
+        assert drive["requiredScopes"] == [
+            "https://www.googleapis.com/auth/drive.readonly"
+        ]

--- a/frontend/ai.client/src/app/admin/connectors/models/connector.model.ts
+++ b/frontend/ai.client/src/app/admin/connectors/models/connector.model.ts
@@ -52,6 +52,12 @@ export interface Connector {
    * always win on conflict.
    */
   customParameters?: Record<string, string> | null;
+  /**
+   * File-source adapter key (e.g. `google-drive`) mapping this connector to
+   * a file source. When set, the connector appears as a file source in the
+   * assistant editor. Null/absent means it is not a file source.
+   */
+  fileSourceAdapterId?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -88,6 +94,8 @@ export interface ConnectorCreateRequest {
   oauthDiscoveryUrl?: string;
   authorizationServerMetadata?: Record<string, unknown>;
   customParameters?: Record<string, string>;
+  /** File-source adapter key; omit when the connector is not a file source. */
+  fileSourceAdapterId?: string;
 }
 
 /**
@@ -110,6 +118,30 @@ export interface ConnectorUpdateRequest {
   oauthDiscoveryUrl?: string;
   authorizationServerMetadata?: Record<string, unknown>;
   customParameters?: Record<string, string>;
+  /**
+   * `""` clears the file-source mapping (the connector stops being a file
+   * source); a populated adapter key sets it; `undefined` leaves it alone.
+   */
+  fileSourceAdapterId?: string;
+}
+
+/**
+ * A file-source adapter shipped in the backend registry, as returned by
+ * `GET /admin/file-source-adapters`. Read-only — adapters are code, not
+ * config; an admin can only map a connector to an existing one.
+ */
+export interface FileSourceAdapter {
+  key: string;
+  displayName: string;
+  icon: string;
+  /** OAuth provider types this adapter may be mapped to. */
+  compatibleProviderTypes: ConnectorType[];
+  /** OAuth scopes the connector must grant for the adapter to work. */
+  requiredScopes: string[];
+}
+
+export interface FileSourceAdapterListResponse {
+  adapters: FileSourceAdapter[];
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
+++ b/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
@@ -68,6 +68,11 @@ interface ConnectorFormGroup {
    * and lines without `=` are silently dropped.
    */
   customParameters: FormControl<string>;
+  /**
+   * File-source adapter key, or `''` when the connector is not a file
+   * source. On update, sending `''` clears an existing mapping.
+   */
+  fileSourceAdapterId: FormControl<string>;
 }
 
 const ICON_DATA_MAX_BYTES = 100 * 1024;
@@ -531,6 +536,47 @@ const ICON_ACCEPTED_MIME_TYPES = [
               </div>
             </div>
 
+            <div class="rounded-sm border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+              <h2 class="mb-2 text-xl/8 font-semibold text-gray-900 dark:text-white">File Source</h2>
+              <p class="mb-6 text-sm/6 text-gray-600 dark:text-gray-400">
+                Optionally map this connector to a file-source adapter so it can import
+                files into an assistant's knowledgebase from the assistant editor.
+              </p>
+              @if (compatibleAdapters().length > 0) {
+                <div>
+                  <label for="fileSourceAdapterId" class="mb-1.5 block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    File-source adapter
+                  </label>
+                  <select
+                    id="fileSourceAdapterId"
+                    formControlName="fileSourceAdapterId"
+                    class="block w-full rounded-sm border border-gray-300 bg-white px-3 py-2.5 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  >
+                    <option value="">Not a file source</option>
+                    @for (adapter of compatibleAdapters(); track adapter.key) {
+                      <option [value]="adapter.key">{{ adapter.displayName }}</option>
+                    }
+                  </select>
+                  <p class="mt-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+                    When set, this connector appears as a file source in the assistant editor
+                    for any user allowed to use it.
+                  </p>
+                  @if (scopeCoverageWarning(); as warning) {
+                    <div class="mt-3 rounded-sm border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+                      <div class="flex gap-2">
+                        <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                        <p class="text-sm/6 text-amber-700 dark:text-amber-300">{{ warning }}</p>
+                      </div>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                  No file-source adapter is available for this connector type.
+                </p>
+              }
+            </div>
+
             @if (isEditMode()) {
               <div class="rounded-sm border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
                 <div class="flex gap-3">
@@ -628,6 +674,7 @@ export class ConnectorFormPage implements OnInit {
     iconName: this.fb.control('heroLink', { nonNullable: true }),
     iconData: this.fb.control('', { nonNullable: true }),
     customParameters: this.fb.control('', { nonNullable: true }),
+    fileSourceAdapterId: this.fb.control('', { nonNullable: true }),
   });
 
   readonly pageTitle = computed(() => (this.isEditMode() ? 'Edit Connector' : 'Add Connector'));
@@ -665,6 +712,58 @@ export class ConnectorFormPage implements OnInit {
     return preset?.customParametersPlaceholder ?? 'key=value';
   });
 
+  // Form controls aren't signals, so mirror the two values the file-source
+  // section reacts to. Updated from valueChanges in ngOnInit.
+  private readonly scopesSignal = signal<string>('');
+  private readonly fileSourceAdapterIdSignal = signal<string>('');
+
+  /**
+   * The file-source adapter mapping loaded from the server, so update can
+   * tell a real change (send it, possibly `''` to clear) from a no-op.
+   */
+  private readonly adapterLoadedFromServer = signal<string>('');
+
+  /** Every file-source adapter shipped in the backend registry. */
+  readonly fileSourceAdapters = computed(() =>
+    this.connectorsService.getFileSourceAdapters()
+  );
+
+  /** Adapters that may be mapped to the currently-selected provider type. */
+  readonly compatibleAdapters = computed(() =>
+    this.fileSourceAdapters().filter(a =>
+      a.compatibleProviderTypes.includes(this.providerTypeSignal())
+    )
+  );
+
+  /** The adapter currently chosen in the dropdown, if any. */
+  readonly selectedAdapter = computed(() => {
+    const key = this.fileSourceAdapterIdSignal();
+    if (!key) return null;
+    return this.fileSourceAdapters().find(a => a.key === key) ?? null;
+  });
+
+  /**
+   * Warns when the connector's scopes don't cover what the selected adapter
+   * needs — a silent empty browse at runtime, caught here at config time.
+   */
+  readonly scopeCoverageWarning = computed<string | null>(() => {
+    const adapter = this.selectedAdapter();
+    if (!adapter) return null;
+    const granted = new Set(
+      this.scopesSignal()
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    );
+    const missing = adapter.requiredScopes.filter(s => !granted.has(s));
+    if (missing.length === 0) return null;
+    return (
+      `This connector's scopes are missing ${missing.join(', ')}, which ` +
+      `${adapter.displayName} needs to read files. Add them above or ` +
+      `browsing will return nothing.`
+    );
+  });
+
   /**
    * Returns a user-facing error string when clientId and clientSecret are
    * inconsistent. Rotation requires both or neither.
@@ -694,7 +793,34 @@ export class ConnectorFormPage implements OnInit {
     this.connectorForm.controls.providerType.valueChanges.subscribe((value) => {
       this.providerTypeSignal.set(value);
       this.applyDiscoveryValidator();
+      this.clearIncompatibleAdapter();
     });
+
+    this.connectorForm.controls.scopes.valueChanges.subscribe((value) => {
+      this.scopesSignal.set(value);
+    });
+    this.connectorForm.controls.fileSourceAdapterId.valueChanges.subscribe((value) => {
+      this.fileSourceAdapterIdSignal.set(value);
+    });
+  }
+
+  /**
+   * Drop the file-source mapping when the provider type changes such that
+   * the selected adapter is no longer compatible (e.g. switching a Google
+   * connector to Slack). Keeps the form from submitting an invalid mapping.
+   */
+  private clearIncompatibleAdapter(): void {
+    const current = this.connectorForm.controls.fileSourceAdapterId.value;
+    if (!current) return;
+    const adapter = this.connectorsService
+      .getFileSourceAdapters()
+      .find(a => a.key === current);
+    const stillCompatible = adapter?.compatibleProviderTypes.includes(
+      this.connectorForm.controls.providerType.value
+    );
+    if (!stillCompatible) {
+      this.connectorForm.controls.fileSourceAdapterId.setValue('');
+    }
   }
 
   private applyDiscoveryValidator(): void {
@@ -730,8 +856,10 @@ export class ConnectorFormPage implements OnInit {
         iconName: connector.iconName || 'heroLink',
         iconData: connector.iconData ?? '',
         customParameters: this.serializeCustomParameters(connector.customParameters ?? null),
+        fileSourceAdapterId: connector.fileSourceAdapterId ?? '',
       });
       this.iconLoadedFromServer.set(connector.iconData ?? null);
+      this.adapterLoadedFromServer.set(connector.fileSourceAdapterId ?? '');
       this.selectedRoles.set(connector.allowedRoles.length > 0 ? connector.allowedRoles : ['*']);
       this.applyDiscoveryValidator();
     } catch (error) {
@@ -865,6 +993,12 @@ export class ConnectorFormPage implements OnInit {
         if (currentIcon !== (previousIcon ?? '')) {
           updates.iconData = currentIcon;
         }
+        // Tri-state for the file-source mapping: send only on a real change.
+        // `''` clears an existing mapping; a key sets it; unchanged → omit.
+        const currentAdapter = formValue.fileSourceAdapterId || '';
+        if (currentAdapter !== this.adapterLoadedFromServer()) {
+          updates.fileSourceAdapterId = currentAdapter;
+        }
         if (formValue.clientId && formValue.clientSecret) {
           updates.clientId = formValue.clientId;
           updates.clientSecret = formValue.clientSecret;
@@ -894,6 +1028,9 @@ export class ConnectorFormPage implements OnInit {
         }
         if (Object.keys(customParameters).length > 0) {
           createData.customParameters = customParameters;
+        }
+        if (formValue.fileSourceAdapterId) {
+          createData.fileSourceAdapterId = formValue.fileSourceAdapterId;
         }
         const created = await this.connectorsService.createConnector(createData);
         this.createdConnector.set(created);

--- a/frontend/ai.client/src/app/admin/connectors/services/connectors.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/connectors/services/connectors.service.spec.ts
@@ -73,4 +73,26 @@ describe('ConnectorsService', () => {
     });
     await promise;
   });
+
+  it('should fetch file-source adapters without key translation', async () => {
+    const mockResponse = {
+      adapters: [
+        {
+          key: 'google-drive',
+          displayName: 'Google Drive',
+          icon: 'google-drive',
+          compatibleProviderTypes: ['google'],
+          requiredScopes: ['https://www.googleapis.com/auth/drive.readonly'],
+        },
+      ],
+    };
+    const promise = service.fetchFileSourceAdapters();
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/file-source-adapters/')
+        .flush(mockResponse);
+    });
+    // The endpoint already serializes camelCase — response passes through as-is.
+    expect(await promise).toEqual(mockResponse);
+  });
 });

--- a/frontend/ai.client/src/app/admin/connectors/services/connectors.service.ts
+++ b/frontend/ai.client/src/app/admin/connectors/services/connectors.service.ts
@@ -7,6 +7,8 @@ import {
   ConnectorListResponse,
   ConnectorCreateRequest,
   ConnectorUpdateRequest,
+  FileSourceAdapter,
+  FileSourceAdapterListResponse,
 } from '../models/connector.model';
 
 function toSnakeCase(obj: Record<string, any>): Record<string, any> {
@@ -44,10 +46,26 @@ export class ConnectorsService {
 
   private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/admin/oauth-providers`);
 
+  private readonly fileSourceAdaptersUrl = computed(
+    () => `${this.config.appApiUrl()}/admin/file-source-adapters`
+  );
+
   readonly connectorsResource = resource({
     loader: async () => {
       await Promise.resolve();
       return this.fetchConnectors();
+    }
+  });
+
+  /**
+   * The file-source adapter registry. Read-only and rarely changes — adapters
+   * ship in releases — so a single eager load when the admin service is first
+   * injected is sufficient.
+   */
+  readonly fileSourceAdaptersResource = resource({
+    loader: async () => {
+      await Promise.resolve();
+      return this.fetchFileSourceAdapters();
     }
   });
 
@@ -71,6 +89,20 @@ export class ConnectorsService {
       providers: response.providers.map((p: any) => toCamelCase(p) as Connector),
       total: response.total,
     };
+  }
+
+  getFileSourceAdapters(): FileSourceAdapter[] {
+    return this.fileSourceAdaptersResource.value()?.adapters ?? [];
+  }
+
+  /**
+   * Fetch the file-source adapter registry. This endpoint serializes
+   * camelCase already, so no key translation is applied.
+   */
+  async fetchFileSourceAdapters(): Promise<FileSourceAdapterListResponse> {
+    return firstValueFrom(
+      this.http.get<FileSourceAdapterListResponse>(`${this.fileSourceAdaptersUrl()}/`)
+    );
   }
 
   async fetchConnector(providerId: string): Promise<Connector> {


### PR DESCRIPTION
## Summary

Second PR in the **file source connectors** series. Builds on the adapter framework from #366 to let an admin mark a connector as a *file source* by mapping it to a registered adapter.

**Backend**
- `OAuthProvider` gains a nullable `file_source_adapter_id` — dataclass field, DynamoDB `to/from_dynamo_item` round-trip, `OAuthProviderCreate/Update/Response`, and `provider_repository.apply_metadata_update`. Legacy records without the field default to `None`.
- Admin create/update routes validate the mapping against the adapter registry: the adapter must exist **and** its `compatible_provider_types` must include the connector's type. Validation lives in the app_api route — `apis.shared` cannot import the app_api registry.
- New read-only **`GET /admin/file-source-adapters`** exposes the registry so the admin form can populate a dropdown.

**Frontend**
- The admin connector form gains a **"File Source"** section: an adapter dropdown filtered by provider-type compatibility, plus a **scope-coverage warning** when the connector's OAuth scopes don't cover what the adapter requires. Selecting an adapter is the opt-in; clearing it (`""`) removes the mapping.

## Design notes

- `file_source_adapter_id` *is* the opt-in — there's no separate "is file source" boolean. Set = file source; null = not.
- A connector ≠ a file source: the connector is OAuth; the file-source capability exists only when an adapter is mapped. The admin dropdown only offers adapters compatible with the connector's provider type, so e.g. a Slack connector is never offered Google Drive.

## Test plan

- [x] 88 backend tests pass — model round-trip (incl. legacy records), validation helper (unknown adapter / incompatible type / valid / no-op), `GET /admin/file-source-adapters` endpoint, plus connectors + oauth + architecture regression suites
- [x] `ruff` clean; `mypy` clean apart from the repo-wide pre-existing `import-untyped` noise
- [x] Frontend production build succeeds — connector form component + template type-check cleanly
- [x] Architecture import-boundary tests pass (registry validation is app_api-only)

## Known issue (pre-existing, not introduced here)

`connectors.service.spec.ts` fails on a clean `develop` checkout — its `TestBed` setup chokes on a null `HttpClientTestingModule` (Angular test-infra version drift). The new `fetchFileSourceAdapters` test was added in the same style and will pass once that environment issue is fixed. Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)