### PR TITLE
test(frontend): fix null HttpClientTestingModule in service specs

### DIFF
--- a/frontend/ai.client/src/app/admin/auth-providers/services/auth-providers.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/auth-providers/services/auth-providers.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { AuthProvidersService } from './auth-providers.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('AuthProvidersService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AuthProvidersService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/bedrock-models/services/bedrock-models.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/bedrock-models/services/bedrock-models.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { BedrockModelsService } from './bedrock-models.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('BedrockModelsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         BedrockModelsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/connectors/services/connectors.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/connectors/services/connectors.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ConnectorsService } from './connectors.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('ConnectorsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ConnectorsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { AdminCostHttpService } from './admin-cost-http.service';
 import { ConfigService } from '../../../services/config.service';
@@ -12,8 +13,9 @@ describe('AdminCostHttpService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AdminCostHttpService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/gemini-models/services/gemini-models.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/gemini-models/services/gemini-models.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { GeminiModelsService } from './gemini-models.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('GeminiModelsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         GeminiModelsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/manage-models/services/managed-models.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/services/managed-models.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ManagedModelsService } from './managed-models.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('ManagedModelsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ManagedModelsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/openai-models/services/openai-models.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/openai-models/services/openai-models.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { OpenAIModelsService } from './openai-models.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('OpenAIModelsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         OpenAIModelsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/quota-tiers/services/quota-http.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/quota-tiers/services/quota-http.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { QuotaHttpService } from './quota-http.service';
 import { ConfigService } from '../../../services/config.service';
@@ -12,8 +13,9 @@ describe('QuotaHttpService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         QuotaHttpService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/roles/services/app-roles.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/roles/services/app-roles.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { AppRolesService } from './app-roles.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('AppRolesService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AppRolesService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { AdminToolService } from './admin-tool.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('AdminToolService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AdminToolService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/tools/services/tools.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/tools.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { ToolsService } from './tools.service';
 import { ConfigService } from '../../../services/config.service';
@@ -11,8 +12,9 @@ describe('ToolsService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ToolsService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/admin/users/services/user-http.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/users/services/user-http.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { UserHttpService } from './user-http.service';
 import { ConfigService } from '../../../services/config.service';
@@ -12,8 +13,9 @@ describe('UserHttpService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         UserHttpService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/assistants/services/assistant-api.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/assistant-api.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { AssistantApiService } from './assistant-api.service';
 import { ConfigService } from '../../services/config.service';
@@ -12,8 +13,9 @@ describe('AssistantApiService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AssistantApiService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/assistants/services/assistant.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/assistant.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AssistantService } from './assistant.service';
 import { AssistantApiService } from './assistant-api.service';
@@ -26,8 +27,9 @@ describe('AssistantService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         AssistantService,
         { provide: AssistantApiService, useValue: mockApiService }
       ]

--- a/frontend/ai.client/src/app/assistants/services/document.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/document.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { DocumentService, DocumentUploadError } from './document.service';
 import { ConfigService } from '../../services/config.service';
@@ -12,8 +12,9 @@ describe('DocumentService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         DocumentService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SessionService } from './session.service';
@@ -69,8 +70,9 @@ describe('SessionService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         SessionService,
         { provide: ConfigService, useValue: configService },
       ],

--- a/frontend/ai.client/src/app/auth/user.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/user.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { UserService } from './user.service';
 import { SessionService } from './session.service';
@@ -40,8 +41,9 @@ describe('UserService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         UserService,
         { provide: SessionService, useValue: mockSessionService },
         { provide: ConfigService, useValue: mockConfigService },

--- a/frontend/ai.client/src/app/memory/services/memory.service.spec.ts
+++ b/frontend/ai.client/src/app/memory/services/memory.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { MemoryService } from './memory.service';
 import { ConfigService } from '../../services/config.service';
@@ -11,8 +12,9 @@ describe('MemoryService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         MemoryService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/services/file-upload/file-upload.service.spec.ts
+++ b/frontend/ai.client/src/app/services/file-upload/file-upload.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { 
   FileUploadService, 
@@ -27,8 +28,9 @@ describe('FileUploadService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ConfigService, useValue: mockConfigService }
       ]
     });

--- a/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { ToolService, Tool, ToolsResponse } from './tool.service';
 import { ConfigService } from '../config.service';
 import { signal } from '@angular/core';
@@ -18,8 +19,9 @@ describe('ToolService', () => {
 
   async function setup() {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ToolService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { ModelService } from './model.service';
 import { ConfigService } from '../../../services/config.service';
 import { UserSettingsService } from '../../../services/user-settings.service';
@@ -34,8 +35,9 @@ describe('ModelService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ModelService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
         { provide: UserSettingsService, useValue: mockUserSettings },

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MessageMapService } from './message-map.service';
 import { SessionService } from './session.service';
@@ -28,8 +29,9 @@ describe('MessageMapService', () => {
       requestConsent: vi.fn()
     };
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         MessageMapService,
         { provide: SessionService, useValue: mockSessionService },
         { provide: FileUploadService, useValue: mockFileUploadService },

--- a/frontend/ai.client/src/app/session/services/session/session.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { SessionService, SessionsListResponse, MessagesListResponse, BulkDeleteSessionsResponse } from './session.service';
 import { SessionService as BffSessionService } from '../../../auth/session.service';
@@ -22,8 +23,9 @@ describe('SessionService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         SessionService,
         { provide: BffSessionService, useValue: { isAuthenticated: signal(false) } },
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },

--- a/frontend/ai.client/src/app/session/services/visual-state/visual-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/visual-state/visual-state.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { VisualStateService } from './visual-state.service';
 import { SessionService } from '../session/session.service';
@@ -25,8 +26,9 @@ describe('VisualStateService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         VisualStateService,
         { provide: SessionService, useValue: mockSessionService }
       ]

--- a/frontend/ai.client/src/app/settings/pages/api-keys/api-key.service.spec.ts
+++ b/frontend/ai.client/src/app/settings/pages/api-keys/api-key.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { ApiKeyService, ApiKey, CreateApiKeyResponse } from './api-key.service';
 import { ConfigService } from '../../../services/config.service';
 
@@ -16,8 +17,9 @@ describe('ApiKeyService', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ApiKeyService,
         { provide: ConfigService, useValue: mockConfigService }
       ]

--- a/frontend/ai.client/src/app/settings/pages/usage/services/cost.service.spec.ts
+++ b/frontend/ai.client/src/app/settings/pages/usage/services/cost.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { TestRequest } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { CostService } from './cost.service';
@@ -12,8 +13,9 @@ describe('CostService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         CostService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],

--- a/frontend/ai.client/src/app/users/services/user-api.service.spec.ts
+++ b/frontend/ai.client/src/app/users/services/user-api.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { UserApiService } from './user-api.service';
 import { ConfigService } from '../../services/config.service';
@@ -12,8 +13,9 @@ describe('UserApiService', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         UserApiService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
       ],


### PR DESCRIPTION
## Summary
- `HttpClientTestingModule` resolves to `null` in the installed Angular version, crashing every `TestBed`-based service spec at setup with `TypeError: Cannot read properties of null (reading 'ngModule')`.
- Replaced the deprecated NgModule import with the function-based `provideHttpClient()` + `provideHttpClientTesting()` providers across all 27 affected `*.service.spec.ts` files.
- Test-infrastructure only — no application code changed.

## Test plan
- [x] `connectors.service.spec.ts` passes (5 tests)
- [x] Full service-spec suite passes — 59 files, 586 tests, 0 failures (`ng test --include='src/app/**/*.service.spec.ts'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)