### PR TITLE
feat(file-sources): browse/search/import endpoints

### DIFF
--- a/backend/src/apis/app_api/documents/models.py
+++ b/backend/src/apis/app_api/documents/models.py
@@ -1,11 +1,29 @@
 """Document API request/response models"""
 
+from dataclasses import dataclass
 from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 # Type alias for document processing status
 DocumentStatus = Literal["uploading", "chunking", "embedding", "complete", "failed", "deleting"]
+
+
+@dataclass(frozen=True)
+class DocumentProvenance:
+    """Origin metadata for a document imported from an external file source.
+
+    Populated only on the import path; device uploads leave every provenance
+    field on `Document` unset. Captured at import time so a document can
+    later be re-indexed from its source — the information is unrecoverable
+    if skipped.
+    """
+
+    source_connector_id: str
+    source_adapter_key: str
+    source_file_id: str
+    imported_by_user_id: str
+    source_etag: Optional[str] = None
 
 
 class Document(BaseModel):
@@ -109,3 +127,40 @@ class ReportUploadFailureRequest(BaseModel):
 
     error: str = Field(..., description="User-friendly error message")
     details: Optional[str] = Field(None, description="Technical error details")
+
+
+class ImportFileRef(BaseModel):
+    """One file selected for import from a connected file source.
+
+    `name` is the display name the file browser already showed the user; it
+    seeds the document record so the row reads correctly during the brief
+    'uploading' window. The async import task overwrites it with the real
+    filename once the adapter download completes (Google-native docs change
+    extension on export).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    file_id: str = Field(..., alias="fileId", min_length=1, description="Provider-side opaque file identifier")
+    name: str = Field(..., min_length=1, description="Display name from the file browser")
+
+
+class ImportDocumentsRequest(BaseModel):
+    """Request body for importing files from a connected file source."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    connector_id: str = Field(..., alias="connectorId", min_length=1, description="OAuth connector to import from")
+    files: List[ImportFileRef] = Field(..., min_length=1, max_length=50, description="Files selected for import")
+
+
+class ImportDocumentsResponse(BaseModel):
+    """Response listing the document records created for an import request.
+
+    Each document starts in 'uploading' state; the SPA polls them the same
+    way it polls a device upload.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    documents: List[DocumentResponse] = Field(..., description="Created document records, each in 'uploading' state")

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -1,16 +1,41 @@
 """Document management API routes"""
 
+import asyncio
 import logging
+import mimetypes
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from apis.shared.assistants.service import get_assistant
-from apis.app_api.documents.models import CreateDocumentRequest, DocumentResponse, DocumentsListResponse, DownloadUrlResponse, UploadUrlResponse, ReportUploadFailureRequest
+from apis.app_api.documents.models import (
+    CreateDocumentRequest,
+    DocumentProvenance,
+    DocumentResponse,
+    DocumentsListResponse,
+    DownloadUrlResponse,
+    ImportDocumentsRequest,
+    ImportDocumentsResponse,
+    ReportUploadFailureRequest,
+    UploadUrlResponse,
+)
 from apis.app_api.documents.services.document_service import _generate_document_id, create_document, list_assistant_documents, update_document_status
 from apis.app_api.documents.services.document_service import get_document as get_document_service
-from apis.app_api.documents.services.storage_service import generate_download_url, generate_upload_url
+from apis.app_api.documents.services.import_service import run_import
+from apis.app_api.documents.services.storage_service import (
+    _get_s3_key,
+    _sanitize_filename,
+    generate_download_url,
+    generate_upload_url,
+)
+from apis.app_api.file_sources.service import require_file_source_token, resolve_file_source
+from apis.shared.auth import User, get_current_user_from_session
 from apis.shared.auth.dependencies import get_current_user_id
+from apis.shared.oauth.provider_repository import (
+    OAuthProviderRepository,
+    get_provider_repository,
+)
+from apis.shared.rbac.service import AppRoleService, get_app_role_service
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +101,93 @@ async def generate_upload_url_endpoint(
     except Exception as e:
         logger.error(f"Error generating upload URL: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to generate upload URL: {str(e)}")
+
+
+@router.post("/import", response_model=ImportDocumentsResponse, status_code=status.HTTP_202_ACCEPTED)
+async def import_documents(
+    assistant_id: str,
+    request: ImportDocumentsRequest,
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+) -> ImportDocumentsResponse:
+    """Import files from a connected file source into an assistant's index.
+
+    Creates one document record per file (status 'uploading', provenance
+    populated) and returns immediately. A fire-and-forget task then downloads
+    each file through the file-source adapter and stages it to S3, where the
+    existing S3-event ingestion Lambda drives chunking/embedding — exactly as
+    a device upload would.
+
+    Args:
+        assistant_id: Parent assistant identifier
+        request: Connector id and the files selected for import
+        current_user: Authenticated user from the session cookie
+    """
+    try:
+        # 1. Verify the caller owns the assistant the files land in.
+        assistant = await get_assistant(assistant_id, current_user.user_id)
+        if not assistant:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+
+        # 2. Resolve the connector to a usable adapter + access token. Raises
+        #    404/403 (not a visible file source), 409 (not connected), or 503
+        #    (workload context unavailable).
+        provider, adapter = await resolve_file_source(
+            request.connector_id, current_user, provider_repo, role_service
+        )
+        access_token = await require_file_source_token(provider, current_user.user_id)
+
+        # 3. Create a document record per file. Values are provisional — the
+        #    async task backfills the real filename/type/size/key after the
+        #    adapter download (Google-native docs change extension on export).
+        created: list = []
+        items: list = []
+        for file_ref in request.files:
+            document_id = _generate_document_id()
+            guessed_type, _ = mimetypes.guess_type(file_ref.name)
+            provisional_key = _get_s3_key(
+                assistant_id, document_id, _sanitize_filename(file_ref.name)
+            )
+            document = await create_document(
+                assistant_id=assistant_id,
+                filename=file_ref.name,
+                content_type=guessed_type or "application/octet-stream",
+                size_bytes=0,
+                s3_key=provisional_key,
+                document_id=document_id,
+                provenance=DocumentProvenance(
+                    source_connector_id=provider.provider_id,
+                    source_adapter_key=adapter.metadata.key,
+                    source_file_id=file_ref.file_id,
+                    imported_by_user_id=current_user.user_id,
+                ),
+            )
+            created.append(document)
+            items.append((document_id, file_ref.file_id))
+
+        # 4. Fire-and-forget the download + S3 stage (response already formed).
+        asyncio.ensure_future(
+            run_import(
+                assistant_id=assistant_id,
+                adapter=adapter,
+                access_token=access_token,
+                items=items,
+            )
+        )
+
+        return ImportDocumentsResponse(
+            documents=[
+                DocumentResponse.model_validate(doc.model_dump(by_alias=True))
+                for doc in created
+            ]
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error importing documents: {e}", exc_info=True)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to import documents: {str(e)}")
 
 
 @router.post("/{document_id}/upload-failed", response_model=DocumentResponse, status_code=status.HTTP_200_OK)
@@ -250,7 +362,6 @@ async def delete_document(assistant_id: str, document_id: str, user_id: str = De
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
 
         # Fire-and-forget cleanup (response already sent as 204)
-        import asyncio
         asyncio.ensure_future(
             cleanup_document_resources(
                 document_id=document.document_id,

--- a/backend/src/apis/app_api/documents/services/document_service.py
+++ b/backend/src/apis/app_api/documents/services/document_service.py
@@ -15,7 +15,7 @@ import uuid
 from typing import Optional, Tuple, List
 from datetime import datetime, timezone
 
-from apis.app_api.documents.models import Document, DocumentStatus
+from apis.app_api.documents.models import Document, DocumentProvenance, DocumentStatus
 
 logger = logging.getLogger(__name__)
 
@@ -91,21 +91,26 @@ async def create_document(
     content_type: str,
     size_bytes: int,
     s3_key: str,
-    document_id: Optional[str] = None
+    document_id: Optional[str] = None,
+    provenance: Optional[DocumentProvenance] = None
 ) -> Document:
     """
     Create a new document record in DynamoDB
-    
+
     Initial status is 'uploading'. Lambda will update to 'chunking' after
     S3 event is received.
-    
+
     Args:
         assistant_id: Parent assistant identifier
         filename: Original filename
         content_type: MIME type
         size_bytes: File size in bytes
         s3_key: S3 object key where file will be uploaded
-    
+        document_id: Optional pre-generated document identifier
+        provenance: Optional file-source origin metadata. Set only for
+            documents imported from an external connector; None for device
+            uploads.
+
     Returns:
         Document object with status='uploading'
     """
@@ -133,7 +138,12 @@ async def create_document(
         s3_key=s3_key,
         status='uploading',
         created_at=now,
-        updated_at=now
+        updated_at=now,
+        source_connector_id=provenance.source_connector_id if provenance else None,
+        source_adapter_key=provenance.source_adapter_key if provenance else None,
+        source_file_id=provenance.source_file_id if provenance else None,
+        source_etag=provenance.source_etag if provenance else None,
+        imported_by_user_id=provenance.imported_by_user_id if provenance else None,
     )
     
     dynamodb = boto3.resource('dynamodb')
@@ -356,6 +366,105 @@ async def update_document_status(
         return None
     except Exception as e:
         logger.error(f"Unexpected error updating document status: {e}", exc_info=True)
+        return None
+
+
+async def update_document_import_metadata(
+    assistant_id: str,
+    document_id: str,
+    *,
+    filename: str,
+    content_type: str,
+    size_bytes: int,
+    s3_key: str,
+    source_etag: Optional[str] = None,
+) -> Optional[Document]:
+    """
+    Backfill a document's file metadata after an async import download.
+
+    The import endpoint creates the record with provisional values (the
+    browser-supplied name, a placeholder content type, zero size) before the
+    bytes are fetched. Once the adapter download completes, the real
+    filename, content type, size, and S3 key are known — and for
+    Google-native docs the extension changes on export — so they are written
+    here just before the bytes are PUT to S3.
+
+    Status is intentionally left untouched: the S3-event ingestion Lambda
+    owns the 'uploading' -> 'chunking' transition once the object lands.
+
+    Args:
+        assistant_id: Parent assistant identifier
+        document_id: Document identifier
+        filename: Real filename after any provider-native export
+        content_type: Real MIME type of the downloaded bytes
+        size_bytes: Size of the downloaded bytes
+        s3_key: Final S3 object key the bytes are PUT to
+        source_etag: Provider-side version stamp at import time, if known
+
+    Returns:
+        Updated Document object, or None if the record no longer exists
+        (e.g. deleted between import request and download).
+    """
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+    except ImportError:
+        logger.error("boto3 is required for DynamoDB operations")
+        return None
+
+    table_name = os.environ.get('DYNAMODB_ASSISTANTS_TABLE_NAME')
+    if not table_name:
+        logger.error("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable not set")
+        return None
+
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table(table_name)
+
+    set_parts = [
+        "filename = :filename",
+        "contentType = :content_type",
+        "sizeBytes = :size_bytes",
+        "s3Key = :s3_key",
+        "updatedAt = :updated_at",
+    ]
+    expression_attribute_values = {
+        ":filename": filename,
+        ":content_type": content_type,
+        ":size_bytes": size_bytes,
+        ":s3_key": s3_key,
+        ":updated_at": _get_current_timestamp(),
+    }
+    if source_etag is not None:
+        set_parts.append("sourceEtag = :source_etag")
+        expression_attribute_values[":source_etag"] = source_etag
+
+    try:
+        response = table.update_item(
+            Key={
+                'PK': f'AST#{assistant_id}',
+                'SK': f'DOC#{document_id}'
+            },
+            UpdateExpression="SET " + ", ".join(set_parts),
+            ExpressionAttributeValues=expression_attribute_values,
+            ConditionExpression='attribute_exists(PK)',
+            ReturnValues='ALL_NEW',
+        )
+        if 'Attributes' in response:
+            try:
+                return Document.model_validate(response['Attributes'])
+            except Exception as e:
+                logger.warning(f"Failed to parse document from DynamoDB response: {e}")
+                return None
+        return None
+    except ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
+        if error_code == 'ConditionalCheckFailedException':
+            logger.info(f"Document {document_id} no longer exists, skipping import metadata update")
+            return None
+        logger.error(f"Failed to update document import metadata in DynamoDB: {error_code} - {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error updating document import metadata: {e}", exc_info=True)
         return None
 
 

--- a/backend/src/apis/app_api/documents/services/import_service.py
+++ b/backend/src/apis/app_api/documents/services/import_service.py
@@ -1,0 +1,175 @@
+"""Async file-source import: download from a connector, stage to S3.
+
+The import endpoint creates document records synchronously and returns,
+then schedules `run_import` as a fire-and-forget task (mirroring
+`cleanup_service`). For each file the task downloads the bytes through the
+file-source adapter, backfills the real file metadata onto the document
+record, and PUTs the bytes into the documents bucket — where the existing
+S3-event ingestion Lambda picks them up and drives the document through
+chunking/embedding exactly as a device upload would.
+
+Never raises: a per-file failure marks that one document 'failed' and the
+batch continues. The access token is held in memory for the life of the
+task only and is never logged.
+"""
+
+import asyncio
+import logging
+import os
+from typing import List, Tuple
+
+import boto3
+
+from apis.app_api.documents.services.document_service import (
+    update_document_import_metadata,
+    update_document_status,
+)
+from apis.app_api.documents.services.storage_service import (
+    _get_documents_bucket,
+    _get_s3_key,
+    _sanitize_filename,
+)
+from apis.app_api.file_sources.adapter import FileSourceAdapter
+from apis.app_api.file_sources.models import FileSourceError
+
+logger = logging.getLogger(__name__)
+
+
+async def run_import(
+    assistant_id: str,
+    adapter: FileSourceAdapter,
+    access_token: str,
+    items: List[Tuple[str, str]],
+) -> None:
+    """Download each imported file and stage it to S3 for ingestion.
+
+    `items` is a list of `(document_id, source_file_id)` pairs — one per
+    document record the import endpoint created. Processed sequentially so a
+    large batch doesn't open many provider connections at once. Never raises.
+
+    Args:
+        assistant_id: Parent assistant identifier
+        adapter: The resolved file-source adapter (registry singleton)
+        access_token: The importing user's OAuth access token
+        items: (document_id, source_file_id) pairs to import
+    """
+    for document_id, file_id in items:
+        try:
+            await _import_one(assistant_id, adapter, access_token, document_id, file_id)
+        except Exception as e:
+            # Defensive: _import_one already swallows its own errors, but a
+            # bug there must not abort the rest of the batch.
+            logger.error(
+                f"Unexpected error importing document {document_id}: {e}",
+                exc_info=True,
+            )
+
+
+async def _import_one(
+    assistant_id: str,
+    adapter: FileSourceAdapter,
+    access_token: str,
+    document_id: str,
+    file_id: str,
+) -> None:
+    """Import a single file: download, backfill metadata, PUT to S3."""
+    try:
+        downloaded = await adapter.download(access_token, file_id)
+    except FileSourceError as e:
+        logger.warning(f"File-source download failed for document {document_id}: {e}")
+        await _mark_failed(
+            assistant_id,
+            document_id,
+            "Could not download this file from the file source.",
+            str(e),
+        )
+        return
+    except Exception as e:
+        logger.error(
+            f"Unexpected download error for document {document_id}: {e}",
+            exc_info=True,
+        )
+        await _mark_failed(
+            assistant_id,
+            document_id,
+            "Could not download this file from the file source.",
+            str(e),
+        )
+        return
+
+    try:
+        # The real filename is known only after download — Google-native
+        # docs export to a different extension — so the final S3 key is
+        # computed here, not at import-request time.
+        s3_key = _get_s3_key(
+            assistant_id, document_id, _sanitize_filename(downloaded.filename)
+        )
+        updated = await update_document_import_metadata(
+            assistant_id,
+            document_id,
+            filename=downloaded.filename,
+            content_type=downloaded.content_type,
+            size_bytes=len(downloaded.content),
+            s3_key=s3_key,
+        )
+        if updated is None:
+            # Document was deleted between the import request and now —
+            # don't strand orphan bytes (and an orphan ingestion run) in S3.
+            logger.info(
+                f"Document {document_id} gone before S3 stage; skipping import"
+            )
+            return
+
+        await _put_object(s3_key, downloaded.content, downloaded.content_type)
+        logger.info(
+            f"Staged imported document {document_id} to S3; ingestion will start"
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to stage imported document {document_id} to S3: {e}",
+            exc_info=True,
+        )
+        await _mark_failed(
+            assistant_id,
+            document_id,
+            "Could not stage this file for ingestion.",
+            str(e),
+        )
+
+
+async def _put_object(s3_key: str, content: bytes, content_type: str) -> None:
+    """PUT bytes into the documents bucket, triggering S3-event ingestion."""
+    bucket = _get_documents_bucket()
+    loop = asyncio.get_event_loop()
+    s3_client = boto3.client("s3")
+    await loop.run_in_executor(
+        None,
+        lambda: s3_client.put_object(
+            Bucket=bucket,
+            Key=s3_key,
+            Body=content,
+            ContentType=content_type,
+        ),
+    )
+
+
+async def _mark_failed(
+    assistant_id: str,
+    document_id: str,
+    error_message: str,
+    error_details: str,
+) -> None:
+    """Mark a document 'failed' so the SPA stops polling. Never raises."""
+    try:
+        await update_document_status(
+            assistant_id=assistant_id,
+            document_id=document_id,
+            status="failed",
+            error_message=error_message,
+            error_details=error_details,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to mark imported document {document_id} as failed: {e}",
+            exc_info=True,
+        )

--- a/backend/src/apis/app_api/file_sources/routes.py
+++ b/backend/src/apis/app_api/file_sources/routes.py
@@ -1,0 +1,229 @@
+"""User-facing file-source endpoints: catalog, roots, browse, search.
+
+A connector becomes a *file source* only once an admin maps it to a
+file-source adapter (PR #367). These endpoints let a signed-in user discover
+which of their connectors are usable as file sources and walk the provider's
+folder tree so they can pick files to import into an assistant's RAG index.
+
+Browse/search/roots are mounted under `/connectors/{provider_id}` — the same
+namespace as the connector consent routes — because they operate on a
+connector; the catalog lives at `/file-sources`. Like the connector routes,
+they live on the app API: the AgentCore Runtime that fronts the inference API
+only proxies `/invocations` and `/ping`, so custom paths are unreachable
+there.
+"""
+
+import asyncio
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.oauth.agentcore_identity import (
+    CallbackUrlUnavailableError,
+    WorkloadTokenUnavailableError,
+)
+from apis.shared.oauth.disconnect_repository import (
+    OAuthDisconnectRepository,
+    get_disconnect_repository,
+)
+from apis.shared.oauth.models import OAuthProvider
+from apis.shared.oauth.provider_repository import (
+    OAuthProviderRepository,
+    get_provider_repository,
+)
+from apis.shared.rbac.service import AppRoleService, get_app_role_service
+
+from apis.app_api.file_sources.models import BrowseResult, FileSourceError, SourceRoot
+from apis.app_api.file_sources.service import (
+    connector_visible_to_user,
+    http_error_for_file_source_error,
+    require_file_source_token,
+    resolve_file_source,
+    resolve_file_source_token,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["file-sources"])
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+class FileSourceConnector(BaseModel):
+    """A connector the current user can use as a file source."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    provider_id: str = Field(..., alias="providerId")
+    display_name: str = Field(..., alias="displayName")
+    icon_name: str = Field(..., alias="iconName")
+    icon_data: Optional[str] = Field(None, alias="iconData")
+    # True when AgentCore's vault holds a usable token for this user — the SPA
+    # can browse straight away. False means it must run the consent flow first.
+    connected: bool
+
+
+class FileSourceListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    file_sources: List[FileSourceConnector] = Field(..., alias="fileSources")
+
+
+class SourceRootsResponse(BaseModel):
+    """The top-level browsing roots a file source exposes."""
+
+    roots: List[SourceRoot]
+
+
+async def _is_connected(
+    provider: OAuthProvider,
+    user_id: str,
+    disconnect_repo: OAuthDisconnectRepository,
+) -> bool:
+    """Best-effort check of whether the user has a usable token.
+
+    Mirrors `connector_status`: a prior disconnect wins over a still-valid
+    vault entry. Workload/callback misconfiguration is treated as
+    "not connected" rather than failing the whole catalog — the user gets the
+    actionable 503 when they click Connect.
+    """
+    if await disconnect_repo.is_disconnected(user_id, provider.provider_id):
+        return False
+    try:
+        result = await resolve_file_source_token(provider, user_id)
+    except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+        logger.warning(
+            "File-source connectivity check failed for %s: %s",
+            provider.provider_id,
+            err,
+        )
+        return False
+    return not result.requires_consent
+
+
+@router.get("/file-sources", response_model=FileSourceListResponse)
+async def list_file_sources(
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+    disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),
+) -> FileSourceListResponse:
+    """List the connectors the current user can use as a file source.
+
+    A connector qualifies when it is enabled, mapped to a file-source adapter,
+    and visible to the user's roles. `connected` reflects whether the user
+    already has a usable OAuth token, so the SPA can decide between "Browse"
+    and "Connect".
+    """
+    permissions = await role_service.resolve_user_permissions(current_user)
+    providers = await provider_repo.list_providers(enabled_only=True)
+    file_sources = [
+        p
+        for p in providers
+        if p.file_source_adapter_id
+        and connector_visible_to_user(p, permissions.app_roles)
+    ]
+
+    connected_flags = await asyncio.gather(
+        *(
+            _is_connected(p, current_user.user_id, disconnect_repo)
+            for p in file_sources
+        )
+    )
+
+    return FileSourceListResponse(
+        file_sources=[
+            FileSourceConnector(
+                provider_id=p.provider_id,
+                display_name=p.display_name,
+                icon_name=p.icon_name,
+                icon_data=p.icon_data,
+                connected=connected,
+            )
+            for p, connected in zip(file_sources, connected_flags)
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Browsing
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/connectors/{provider_id}/roots",
+    response_model=SourceRootsResponse,
+)
+async def list_file_source_roots(
+    provider_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+) -> SourceRootsResponse:
+    """List the top-level browsing roots for a file-source connector."""
+    provider, adapter = await resolve_file_source(
+        provider_id, current_user, provider_repo, role_service
+    )
+    access_token = await require_file_source_token(provider, current_user.user_id)
+    try:
+        roots = await adapter.list_roots(access_token)
+    except FileSourceError as err:
+        logger.warning("list_roots failed for connector %s: %s", provider_id, err)
+        raise http_error_for_file_source_error(err)
+    return SourceRootsResponse(roots=roots)
+
+
+@router.get(
+    "/connectors/{provider_id}/browse",
+    response_model=BrowseResult,
+)
+async def browse_file_source(
+    provider_id: str,
+    folder_id: str = Query(
+        ..., min_length=1, description="Folder (or root) id to list"
+    ),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor"),
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+) -> BrowseResult:
+    """List one page of a folder's contents in a file-source connector."""
+    provider, adapter = await resolve_file_source(
+        provider_id, current_user, provider_repo, role_service
+    )
+    access_token = await require_file_source_token(provider, current_user.user_id)
+    try:
+        return await adapter.browse(access_token, folder_id, cursor)
+    except FileSourceError as err:
+        logger.warning("browse failed for connector %s: %s", provider_id, err)
+        raise http_error_for_file_source_error(err)
+
+
+@router.get(
+    "/connectors/{provider_id}/search",
+    response_model=BrowseResult,
+)
+async def search_file_source(
+    provider_id: str,
+    query: str = Query(..., min_length=1, description="Free-text search query"),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor"),
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+) -> BrowseResult:
+    """Search a file-source connector by free-text query, one page at a time."""
+    provider, adapter = await resolve_file_source(
+        provider_id, current_user, provider_repo, role_service
+    )
+    access_token = await require_file_source_token(provider, current_user.user_id)
+    try:
+        return await adapter.search(access_token, query, cursor)
+    except FileSourceError as err:
+        logger.warning("search failed for connector %s: %s", provider_id, err)
+        raise http_error_for_file_source_error(err)

--- a/backend/src/apis/app_api/file_sources/service.py
+++ b/backend/src/apis/app_api/file_sources/service.py
@@ -1,0 +1,184 @@
+"""Helpers shared by the user-facing file-source endpoints.
+
+A connector becomes a *file source* only when an admin maps it to a
+file-source adapter. These helpers centralize the "resolve a connector to a
+usable adapter + token" steps so the browse/search routes and the document
+import flow stay consistent with each other and with the connector
+status/consent routes.
+"""
+
+import logging
+from typing import List, Tuple
+
+from fastapi import HTTPException, status
+
+from apis.shared.auth import User
+from apis.shared.oauth.agentcore_identity import (
+    CallbackUrlUnavailableError,
+    TokenResult,
+    WorkloadTokenUnavailableError,
+    custom_parameters_for,
+    get_agentcore_identity_client,
+)
+from apis.shared.oauth.models import OAuthProvider
+from apis.shared.oauth.provider_repository import OAuthProviderRepository
+from apis.shared.rbac.service import AppRoleService
+
+from apis.app_api.file_sources.adapter import FileSourceAdapter
+from apis.app_api.file_sources.models import (
+    FileSourceAuthError,
+    FileSourceError,
+    FileSourceNotFoundError,
+)
+from apis.app_api.file_sources.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def connector_visible_to_user(
+    provider: OAuthProvider, user_role_ids: List[str]
+) -> bool:
+    """True when an enabled connector is usable by a user with these roles.
+
+    An empty `allowed_roles` list means unrestricted access; a non-empty
+    list grants access to users who share at least one AppRole id. Mirrors
+    the visibility rule the connector catalog route applies.
+    """
+    if not provider.enabled:
+        return False
+    if not provider.allowed_roles:
+        return True
+    return bool(set(provider.allowed_roles) & set(user_role_ids))
+
+
+async def resolve_file_source(
+    connector_id: str,
+    current_user: User,
+    provider_repo: OAuthProviderRepository,
+    role_service: AppRoleService,
+) -> Tuple[OAuthProvider, FileSourceAdapter]:
+    """Resolve a connector id to its provider record and file-source adapter.
+
+    Raises `HTTPException` (404/403) when the connector is missing, disabled,
+    not visible to the caller, not configured as a file source, or mapped to
+    an adapter that is not shipped in this release. Request-context only —
+    the async import task does its own resolution.
+    """
+    provider = await provider_repo.get_provider(connector_id)
+    if not provider or not provider.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' not found",
+        )
+
+    permissions = await role_service.resolve_user_permissions(current_user)
+    if not connector_visible_to_user(provider, permissions.app_roles):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have access to this connector",
+        )
+
+    if not provider.file_source_adapter_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' is not configured as a file source",
+        )
+
+    adapter = registry.get(provider.file_source_adapter_id)
+    if adapter is None:
+        # An admin mapped an adapter key that no longer ships in this release.
+        # Indistinguishable from "not a file source" to the user.
+        logger.error(
+            "Connector %s maps to unknown file-source adapter '%s'",
+            connector_id,
+            provider.file_source_adapter_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' is not configured as a file source",
+        )
+    return provider, adapter
+
+
+async def resolve_file_source_token(
+    provider: OAuthProvider, user_id: str
+) -> TokenResult:
+    """Fetch the user's OAuth token for a file-source connector.
+
+    Returns a `TokenResult`: `access_token` is populated when the vault has a
+    usable token, `authorization_url` when the user still needs to consent.
+    Wires `custom_parameters` the same way the connector status route does,
+    so file-source token fetches behave identically to the settings page.
+    """
+    identity = get_agentcore_identity_client()
+    return await identity.get_token_for_user(
+        provider_name=provider.provider_id,
+        scopes=provider.scopes,
+        user_id=user_id,
+        custom_parameters=custom_parameters_for(
+            provider.provider_type.value, provider.custom_parameters
+        ),
+    )
+
+
+async def require_file_source_token(provider: OAuthProvider, user_id: str) -> str:
+    """Resolve a usable OAuth access token for a file-source connector.
+
+    Wraps `resolve_file_source_token` and turns its two non-token outcomes
+    into `HTTPException`s the route layer can return unchanged:
+
+    - the user has not completed OAuth consent -> 409 Conflict
+    - AgentCore workload/callback context is unavailable -> 503
+
+    Returns the bare access-token string on success. The browse/search and
+    import flows all require a real token, so there is no caller that wants
+    the `authorization_url` branch.
+    """
+    try:
+        result = await resolve_file_source_token(provider, user_id)
+    except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+        logger.warning(
+            "File-source token resolution failed for %s: %s",
+            provider.provider_id,
+            err,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(err),
+        )
+
+    if result.requires_consent or not result.access_token:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Connector '{provider.provider_id}' is not connected. "
+                "Complete the OAuth consent flow before using it as a file source."
+            ),
+        )
+    return result.access_token
+
+
+def http_error_for_file_source_error(err: FileSourceError) -> HTTPException:
+    """Map a file-source adapter error onto an HTTP response.
+
+    - `FileSourceAuthError` -> 403 (token rejected / missing scopes)
+    - `FileSourceNotFoundError` -> 404 (file or folder gone)
+    - any other `FileSourceError` -> 502 (the provider call itself failed)
+    """
+    if isinstance(err, FileSourceAuthError):
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "The file source rejected the request. Reconnect the "
+                "connector and try again."
+            ),
+        )
+    if isinstance(err, FileSourceNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The requested file or folder no longer exists.",
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="The file source could not be reached. Try again shortly.",
+    )

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -179,6 +179,7 @@ from apis.app_api.documents.routes import router as documents_router
 from apis.app_api.users.routes import router as users_router
 from apis.app_api.user_settings.routes import router as user_settings_router
 from apis.app_api.connectors.routes import router as connectors_router
+from apis.app_api.file_sources.routes import router as file_sources_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
 from apis.app_api.voice import router as voice_router
@@ -205,6 +206,7 @@ app.include_router(memory_router)  # AgentCore Memory access endpoints
 app.include_router(tools_router)  # Tool discovery and permissions
 app.include_router(files_router)  # File upload via pre-signed URLs
 app.include_router(connectors_router)  # User-facing connector catalog + consent flows
+app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors
 app.include_router(system_router)  # System status and first-boot endpoints
 app.include_router(conversations_share_router)  # Share conversations endpoints
 app.include_router(shares_router)  # Share management (update, revoke, export)

--- a/backend/tests/apis/app_api/test_file_source_routes.py
+++ b/backend/tests/apis/app_api/test_file_source_routes.py
@@ -1,0 +1,399 @@
+"""Route-level tests for the user-facing file-source endpoints.
+
+Covers the catalog (`GET /file-sources`) and the browsing surface
+(`GET /connectors/{id}/{roots,browse,search}`). External boundaries — the
+provider repository, role service, disconnect repository, AgentCore identity
+client, and the adapter registry — are stubbed; we test our gating, error
+mapping, and response shape, not the downstream provider calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.file_sources import routes, service
+from apis.app_api.file_sources.adapter import AdapterMetadata, FileSourceAdapter
+from apis.app_api.file_sources.models import (
+    BrowseResult,
+    DownloadedFile,
+    FileEntry,
+    FileEntryType,
+    FileSourceAuthError,
+    FileSourceError,
+    FileSourceNotFoundError,
+    SourceRoot,
+)
+from apis.app_api.file_sources.registry import AdapterRegistry
+from apis.shared.auth.models import User
+from apis.shared.oauth.agentcore_identity import (
+    TokenResult,
+    WorkloadTokenUnavailableError,
+)
+from apis.shared.oauth.disconnect_repository import get_disconnect_repository
+from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
+from apis.shared.oauth.provider_repository import get_provider_repository
+from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.rbac.service import get_app_role_service
+
+ADAPTER_KEY = "stub-drive"
+
+
+class _StubAdapter(FileSourceAdapter):
+    """Adapter whose browse methods return canned values or raise on demand."""
+
+    def __init__(self) -> None:
+        self.roots = [SourceRoot(id="root", name="My Drive")]
+        self.browse_result = BrowseResult(
+            entries=[FileEntry(id="f1", name="notes.txt", type=FileEntryType.FILE)]
+        )
+        self.search_result = BrowseResult(
+            entries=[FileEntry(id="f2", name="hit.txt", type=FileEntryType.FILE)]
+        )
+        self.raise_error: FileSourceError | None = None
+
+    @property
+    def metadata(self) -> AdapterMetadata:
+        return AdapterMetadata(
+            key=ADAPTER_KEY,
+            display_name="Stub Drive",
+            icon="stub",
+            compatible_provider_types=(OAuthProviderType.GOOGLE,),
+            required_scopes=(),
+        )
+
+    async def list_roots(self, access_token):  # type: ignore[no-untyped-def]
+        if self.raise_error:
+            raise self.raise_error
+        return self.roots
+
+    async def browse(self, access_token, folder_id, cursor=None):  # type: ignore[no-untyped-def]
+        if self.raise_error:
+            raise self.raise_error
+        return self.browse_result
+
+    async def search(self, access_token, query, cursor=None):  # type: ignore[no-untyped-def]
+        if self.raise_error:
+            raise self.raise_error
+        return self.search_result
+
+    async def download(self, access_token, file_id):  # type: ignore[no-untyped-def]
+        return DownloadedFile(content=b"", filename="f", content_type="text/plain")
+
+
+def _make_user(user_id: str) -> User:
+    return User(
+        user_id=user_id,
+        email=f"{user_id}@example.com",
+        name=user_id.capitalize(),
+        roles=[],
+        raw_token="test-token",
+    )
+
+
+def _make_provider(
+    provider_id: str = "google",
+    *,
+    enabled: bool = True,
+    allowed_roles: list[str] | None = None,
+    file_source_adapter_id: str | None = ADAPTER_KEY,
+) -> OAuthProvider:
+    now = datetime.now(timezone.utc).isoformat() + "Z"
+    return OAuthProvider(
+        provider_id=provider_id,
+        display_name=provider_id.capitalize(),
+        provider_type=OAuthProviderType.GOOGLE,
+        scopes=["openid", "email"],
+        allowed_roles=allowed_roles or [],
+        enabled=enabled,
+        custom_parameters=None,
+        created_at=now,
+        updated_at=now,
+        file_source_adapter_id=file_source_adapter_id,
+    )
+
+
+def _make_permissions(
+    user_id: str, *, roles: list[str] | None = None
+) -> UserEffectivePermissions:
+    return UserEffectivePermissions(
+        user_id=user_id,
+        app_roles=roles or [],
+        tools=[],
+        models=[],
+        quota_tier=None,
+        resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+    )
+
+
+class _FakeDisconnectRepo:
+    """In-memory stand-in for the durable DDB-backed disconnect repository."""
+
+    def __init__(self) -> None:
+        self.disconnected: set[tuple[str, str]] = set()
+
+    async def is_disconnected(self, user_id: str, provider_id: str) -> bool:
+        return (user_id, provider_id) in self.disconnected
+
+    async def mark_disconnected(self, user_id: str, provider_id: str) -> None:
+        self.disconnected.add((user_id, provider_id))
+
+    async def clear_disconnected(self, user_id: str, provider_id: str) -> None:
+        self.disconnected.discard((user_id, provider_id))
+
+
+@pytest.fixture
+def app_with_deps(monkeypatch):
+    """Mount the router and stub every external boundary.
+
+    Returns a builder so each test wires the specific responses it needs.
+    """
+
+    def _build(
+        user_id: str,
+        *,
+        providers: list[OAuthProvider],
+        permissions: UserEffectivePermissions | None = None,
+        identity_result: TokenResult | None = None,
+        identity_raises: Exception | None = None,
+        adapter: FileSourceAdapter | None = None,
+        disconnect_repo: _FakeDisconnectRepo | None = None,
+    ) -> tuple[FastAPI, MagicMock, _FakeDisconnectRepo]:
+        app = FastAPI()
+        app.include_router(routes.router)
+        app.dependency_overrides[routes.get_current_user_from_session] = (
+            lambda: _make_user(user_id)
+        )
+
+        by_id = {p.provider_id: p for p in providers}
+        repo = MagicMock()
+        repo.list_providers = AsyncMock(return_value=list(providers))
+        repo.get_provider = AsyncMock(side_effect=lambda pid: by_id.get(pid))
+        app.dependency_overrides[get_provider_repository] = lambda: repo
+
+        role_service = MagicMock()
+        role_service.resolve_user_permissions = AsyncMock(
+            return_value=permissions or _make_permissions(user_id),
+        )
+        app.dependency_overrides[get_app_role_service] = lambda: role_service
+
+        disconnect_repo = disconnect_repo or _FakeDisconnectRepo()
+        app.dependency_overrides[get_disconnect_repository] = lambda: disconnect_repo
+
+        identity = MagicMock()
+        if identity_raises is not None:
+            identity.get_token_for_user = AsyncMock(side_effect=identity_raises)
+        else:
+            identity.get_token_for_user = AsyncMock(
+                return_value=identity_result or TokenResult(access_token="vault-token"),
+            )
+        monkeypatch.setattr(service, "get_agentcore_identity_client", lambda: identity)
+
+        reg = AdapterRegistry()
+        reg.register(adapter if adapter is not None else _StubAdapter())
+        monkeypatch.setattr(service, "registry", reg)
+
+        return app, identity, disconnect_repo
+
+    return _build
+
+
+class TestListFileSources:
+    def test_lists_only_mapped_visible_connectors(self, app_with_deps):
+        # google: mapped → included. slack: no adapter → excluded.
+        # secret: mapped but role-gated and the user lacks the role → excluded.
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[
+                _make_provider("google"),
+                _make_provider("slack", file_source_adapter_id=None),
+                _make_provider("secret", allowed_roles=["admins"]),
+            ],
+        )
+        response = TestClient(app).get("/file-sources")
+
+        assert response.status_code == 200
+        sources = response.json()["fileSources"]
+        assert [s["providerId"] for s in sources] == ["google"]
+        assert sources[0]["connected"] is True
+        assert sources[0]["displayName"] == "Google"
+
+    def test_includes_role_gated_connector_when_user_has_role(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("secret", allowed_roles=["admins"])],
+            permissions=_make_permissions("alice", roles=["admins"]),
+        )
+        response = TestClient(app).get("/file-sources")
+
+        assert response.status_code == 200
+        assert [s["providerId"] for s in response.json()["fileSources"]] == ["secret"]
+
+    def test_connected_false_when_consent_required(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google")],
+            identity_result=TokenResult(authorization_url="https://auth.example/x"),
+        )
+        response = TestClient(app).get("/file-sources")
+
+        assert response.status_code == 200
+        assert response.json()["fileSources"][0]["connected"] is False
+
+    def test_disconnect_overrides_connected(self, app_with_deps):
+        repo = _FakeDisconnectRepo()
+        repo.disconnected.add(("alice", "google"))
+        app, identity, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google")],
+            identity_result=TokenResult(access_token="vault-token"),
+            disconnect_repo=repo,
+        )
+        response = TestClient(app).get("/file-sources")
+
+        assert response.status_code == 200
+        assert response.json()["fileSources"][0]["connected"] is False
+        # A disconnected connector never consults AgentCore for its badge.
+        identity.get_token_for_user.assert_not_called()
+
+    def test_connected_false_when_workload_context_unavailable(self, app_with_deps):
+        # An environment misconfiguration must not 500 the whole catalog —
+        # the user just sees "Connect" and gets the actionable 503 then.
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google")],
+            identity_raises=WorkloadTokenUnavailableError("no workload token"),
+        )
+        response = TestClient(app).get("/file-sources")
+
+        assert response.status_code == 200
+        assert response.json()["fileSources"][0]["connected"] is False
+
+
+class TestListRoots:
+    def test_returns_roots(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[_make_provider("google")])
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 200
+        assert response.json() == {"roots": [{"id": "root", "name": "My Drive"}]}
+
+    def test_404_when_connector_not_a_file_source(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google", file_source_adapter_id=None)],
+        )
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 404
+
+    def test_404_when_connector_missing(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[])
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 404
+
+    def test_409_when_not_connected(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google")],
+            identity_result=TokenResult(authorization_url="https://auth.example/x"),
+        )
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 409
+
+    def test_502_on_file_source_error(self, app_with_deps):
+        adapter = _StubAdapter()
+        adapter.raise_error = FileSourceError("provider exploded")
+        app, _, _ = app_with_deps(
+            "alice", providers=[_make_provider("google")], adapter=adapter
+        )
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 502
+
+    def test_403_on_auth_error(self, app_with_deps):
+        adapter = _StubAdapter()
+        adapter.raise_error = FileSourceAuthError("token rejected")
+        app, _, _ = app_with_deps(
+            "alice", providers=[_make_provider("google")], adapter=adapter
+        )
+        response = TestClient(app).get("/connectors/google/roots")
+
+        assert response.status_code == 403
+
+
+class TestBrowse:
+    def test_returns_browse_page(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[_make_provider("google")])
+        response = TestClient(app).get(
+            "/connectors/google/browse", params={"folder_id": "root"}
+        )
+
+        assert response.status_code == 200
+        entries = response.json()["entries"]
+        assert entries[0]["id"] == "f1"
+
+    def test_422_when_folder_id_missing(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[_make_provider("google")])
+        response = TestClient(app).get("/connectors/google/browse")
+
+        assert response.status_code == 422
+
+    def test_404_on_not_found_error(self, app_with_deps):
+        adapter = _StubAdapter()
+        adapter.raise_error = FileSourceNotFoundError("folder gone")
+        app, _, _ = app_with_deps(
+            "alice", providers=[_make_provider("google")], adapter=adapter
+        )
+        response = TestClient(app).get(
+            "/connectors/google/browse", params={"folder_id": "missing"}
+        )
+
+        assert response.status_code == 404
+
+    def test_403_when_user_lacks_role(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google", allowed_roles=["admins"])],
+            permissions=_make_permissions("alice", roles=["users"]),
+        )
+        response = TestClient(app).get(
+            "/connectors/google/browse", params={"folder_id": "root"}
+        )
+
+        assert response.status_code == 403
+
+
+class TestSearch:
+    def test_returns_search_page(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[_make_provider("google")])
+        response = TestClient(app).get(
+            "/connectors/google/search", params={"query": "hit"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["entries"][0]["id"] == "f2"
+
+    def test_422_when_query_missing(self, app_with_deps):
+        app, _, _ = app_with_deps("alice", providers=[_make_provider("google")])
+        response = TestClient(app).get("/connectors/google/search")
+
+        assert response.status_code == 422
+
+    def test_503_when_workload_context_unavailable(self, app_with_deps):
+        app, _, _ = app_with_deps(
+            "alice",
+            providers=[_make_provider("google")],
+            identity_raises=WorkloadTokenUnavailableError("no workload token"),
+        )
+        response = TestClient(app).get(
+            "/connectors/google/search", params={"query": "hit"}
+        )
+
+        assert response.status_code == 503

--- a/backend/tests/routes/test_document_import.py
+++ b/backend/tests/routes/test_document_import.py
@@ -1,0 +1,227 @@
+"""Tests for POST /assistants/{assistant_id}/documents/import.
+
+The endpoint creates one document record per selected file (with provenance
+populated) and schedules a fire-and-forget download task. External boundaries
+— assistant ownership, file-source resolution, token resolution, the DynamoDB
+write, and the async import task — are patched; we test the gating, the
+provenance wiring, and the response shape.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from apis.app_api.documents.models import Document
+from apis.app_api.documents.routes import router
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.oauth.provider_repository import get_provider_repository
+from apis.shared.rbac.service import get_app_role_service
+
+ROUTES_MODULE = "apis.app_api.documents.routes"
+ASSISTANT_ID = "ast-001"
+USER_ID = "user-001"
+
+
+def _make_user(user_id: str = USER_ID) -> User:
+    return User(
+        user_id=user_id,
+        email=f"{user_id}@example.com",
+        name="User",
+        roles=[],
+        raw_token="test-token",
+    )
+
+
+def _make_document(document_id: str, filename: str) -> Document:
+    return Document.model_validate(
+        {
+            "documentId": document_id,
+            "assistantId": ASSISTANT_ID,
+            "filename": filename,
+            "contentType": "application/octet-stream",
+            "sizeBytes": 0,
+            "s3Key": f"assistants/{ASSISTANT_ID}/documents/{document_id}/{filename}",
+            "status": "uploading",
+            "createdAt": "2026-05-21T00:00:00Z",
+            "updatedAt": "2026-05-21T00:00:00Z",
+        }
+    )
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    _app.dependency_overrides[get_current_user_from_session] = lambda: _make_user()
+    # resolve_file_source is patched per-test, so the repo/role deps are inert.
+    _app.dependency_overrides[get_provider_repository] = lambda: MagicMock()
+    _app.dependency_overrides[get_app_role_service] = lambda: MagicMock()
+    return _app
+
+
+def _import_body() -> dict:
+    return {
+        "connectorId": "google",
+        "files": [
+            {"fileId": "drive-f1", "name": "report.pdf"},
+            {"fileId": "drive-f2", "name": "notes.txt"},
+        ],
+    }
+
+
+class TestImportDocuments:
+    def test_creates_documents_and_schedules_task(self, app):
+        provider = MagicMock()
+        provider.provider_id = "google"
+        adapter = MagicMock()
+        adapter.metadata.key = "google-drive"
+        created = [
+            _make_document("DOC-1", "report.pdf"),
+            _make_document("DOC-2", "notes.txt"),
+        ]
+
+        with patch(
+            f"{ROUTES_MODULE}._generate_document_id",
+            side_effect=["DOC-1", "DOC-2"],
+        ), patch(
+            f"{ROUTES_MODULE}.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_file_source",
+            new_callable=AsyncMock,
+            return_value=(provider, adapter),
+        ), patch(
+            f"{ROUTES_MODULE}.require_file_source_token",
+            new_callable=AsyncMock,
+            return_value="vault-token",
+        ), patch(
+            f"{ROUTES_MODULE}.create_document",
+            new_callable=AsyncMock,
+            side_effect=created,
+        ), patch(
+            f"{ROUTES_MODULE}.run_import", new_callable=AsyncMock
+        ) as mock_run:
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert [d["documentId"] for d in body["documents"]] == ["DOC-1", "DOC-2"]
+        # The download/stage work is scheduled, not awaited inline.
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["assistant_id"] == ASSISTANT_ID
+        assert kwargs["access_token"] == "vault-token"
+        assert kwargs["items"] == [("DOC-1", "drive-f1"), ("DOC-2", "drive-f2")]
+
+    def test_populates_provenance_on_each_document(self, app):
+        provider = MagicMock()
+        provider.provider_id = "google"
+        adapter = MagicMock()
+        adapter.metadata.key = "google-drive"
+
+        with patch(
+            f"{ROUTES_MODULE}.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_file_source",
+            new_callable=AsyncMock,
+            return_value=(provider, adapter),
+        ), patch(
+            f"{ROUTES_MODULE}.require_file_source_token",
+            new_callable=AsyncMock,
+            return_value="vault-token",
+        ), patch(
+            f"{ROUTES_MODULE}.create_document",
+            new_callable=AsyncMock,
+            side_effect=[
+                _make_document("DOC-1", "report.pdf"),
+                _make_document("DOC-2", "notes.txt"),
+            ],
+        ) as mock_create, patch(
+            f"{ROUTES_MODULE}.run_import", new_callable=AsyncMock
+        ):
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 202
+        first = mock_create.call_args_list[0].kwargs["provenance"]
+        assert first.source_connector_id == "google"
+        assert first.source_adapter_key == "google-drive"
+        assert first.source_file_id == "drive-f1"
+        assert first.imported_by_user_id == USER_ID
+
+    def test_404_when_assistant_not_owned(self, app):
+        with patch(
+            f"{ROUTES_MODULE}.get_assistant",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ) as mock_create:
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 404
+        mock_create.assert_not_called()
+
+    def test_409_propagates_when_connector_not_connected(self, app):
+        provider = MagicMock()
+        provider.provider_id = "google"
+
+        with patch(
+            f"{ROUTES_MODULE}.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_file_source",
+            new_callable=AsyncMock,
+            return_value=(provider, MagicMock()),
+        ), patch(
+            f"{ROUTES_MODULE}.require_file_source_token",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="not connected"
+            ),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ) as mock_create:
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 409
+        mock_create.assert_not_called()
+
+    def test_404_propagates_when_not_a_file_source(self, app):
+        with patch(
+            f"{ROUTES_MODULE}.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_file_source",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="not a file source"
+            ),
+        ):
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 404
+
+    def test_422_when_files_empty(self, app):
+        resp = TestClient(app).post(
+            f"/assistants/{ASSISTANT_ID}/documents/import",
+            json={"connectorId": "google", "files": []},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

PR 3 of the file-source connectors feature — wires connectors mapped to a file-source adapter (PR #367) into a usable feature surface.

- **`GET /file-sources`** — lists connectors that are enabled, mapped to a file-source adapter, and visible to the user's roles. `connected` reflects the user's OAuth vault state (honors the disconnect repo; degrades to not-connected on workload misconfig rather than failing the whole catalog).
- **`GET /connectors/{id}/roots` · `/browse` · `/search`** — resolve connector → adapter → OAuth token → adapter call. Adapter errors map to `403` / `404` / `502`; missing/expired consent returns `409`.
- **`POST /assistants/{id}/documents/import`** — body `{connectorId, files[]}`. Creates one `Document` per file with provenance populated (`source_connector_id`, `source_adapter_key`, `source_file_id`, `imported_by_user_id`), returns `202`, then fire-and-forgets `run_import` to download each file through the adapter and stage it to S3 — where the existing S3-event ingestion Lambda picks it up.

Adds `require_file_source_token` / `http_error_for_file_source_error` helpers to `file_sources/service.py`.

### Design notes
- Import uses a fire-and-forget `asyncio` task in app_api (mirrors `cleanup_document_resources`), not a dedicated Lambda — confirmed in the planning conversation.
- `/file-sources` exposes `iconName` + `iconData` (matching the existing `UserConnector` shape the SPA already consumes) rather than a single `icon` field.
- Browse/search/roots resolve the token directly; only the catalog's `connected` flag honors the disconnect repo, mirroring `connector_status`.

## Test plan

- [x] `test_file_source_routes.py` — catalog gating, `connected` flag, disconnect override, roots/browse/search error mapping (18 tests)
- [x] `test_document_import.py` — provenance wiring, fire-and-forget scheduling, 404/409 propagation, validation (6 tests)
- [x] Full backend suite: 3003 passed, 3 skipped
- [ ] Manual: browse a connected Google Drive connector and import a file end-to-end against a deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)