### PR TITLE
fix(file-sources): send OAuth2CallbackUrl header on file-source calls

### DIFF
--- a/frontend/ai.client/src/app/assistants/services/file-source.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/file-source.service.spec.ts
@@ -34,7 +34,11 @@ describe('FileSourceService', () => {
   it('lists file sources from the catalog response', async () => {
     const promise = service.listFileSources();
     await vi.waitFor(() => {
-      httpMock.expectOne(`${API}/file-sources`).flush({
+      const req = httpMock.expectOne(`${API}/file-sources`);
+      // app-api needs the callback URL to resolve OAuth tokens — without it
+      // the backend raises CallbackUrlUnavailableError (503).
+      expect(req.request.headers.get('OAuth2CallbackUrl')).toMatch(/\/oauth-complete$/);
+      req.flush({
         fileSources: [
           { providerId: 'google', displayName: 'Google Drive', iconName: 'heroCloud', connected: true },
         ],
@@ -44,6 +48,31 @@ describe('FileSourceService', () => {
     expect(result).toHaveLength(1);
     expect(result[0].providerId).toBe('google');
     expect(result[0].connected).toBe(true);
+  });
+
+  it('sends the OAuth2CallbackUrl header on every token-resolving call', async () => {
+    const calls = [
+      { trigger: () => service.listRoots('google'), url: `${API}/connectors/google/roots` },
+      { trigger: () => service.browse('google', 'f1'), url: `${API}/connectors/google/browse` },
+      { trigger: () => service.search('google', 'q'), url: `${API}/connectors/google/search` },
+    ];
+    for (const call of calls) {
+      const promise = call.trigger();
+      await vi.waitFor(() => {
+        const req = httpMock.expectOne((r) => r.url === call.url);
+        expect(req.request.headers.get('OAuth2CallbackUrl')).toMatch(/\/oauth-complete$/);
+        req.flush({ entries: [], breadcrumbs: [], roots: [] });
+      });
+      await promise;
+    }
+
+    const importPromise = service.importDocuments('AST-1', 'google', [{ fileId: 'f', name: 'n' }]);
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${API}/assistants/AST-1/documents/import`);
+      expect(req.request.headers.get('OAuth2CallbackUrl')).toMatch(/\/oauth-complete$/);
+      req.flush({ documents: [] });
+    });
+    await importPromise;
   });
 
   it('lists roots for a connector', async () => {

--- a/frontend/ai.client/src/app/assistants/services/file-source.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/file-source.service.ts
@@ -42,11 +42,29 @@ export class FileSourceService {
   private readonly config = inject(ConfigService);
   private readonly baseUrl = computed(() => this.config.appApiUrl());
 
+  /**
+   * Header app-api's `AgentCoreContextMiddleware` bridges into
+   * `BedrockAgentCoreContext` so the identity client has a callback URL for
+   * AgentCore Identity. Every file-source endpoint resolves an OAuth token
+   * server-side, so this must accompany every call — without it the backend
+   * raises `CallbackUrlUnavailableError` (503). Mirrors `UserConnectorsService`.
+   *
+   * The backend re-appends `provider_id` itself, and the middleware rejects
+   * URLs carrying a query string as a redirect-pivot guard — so we send a
+   * bare `/oauth-complete`.
+   */
+  private callbackHeaders(): Record<string, string> {
+    const callback = new URL('/oauth-complete', window.location.origin);
+    return { OAuth2CallbackUrl: callback.toString() };
+  }
+
   /** List the connectors the current user can use as a file source. */
   async listFileSources(): Promise<FileSourceConnector[]> {
     try {
       const response = await firstValueFrom(
-        this.http.get<FileSourceListResponse>(`${this.baseUrl()}/file-sources`),
+        this.http.get<FileSourceListResponse>(`${this.baseUrl()}/file-sources`, {
+          headers: this.callbackHeaders(),
+        }),
       );
       return response.fileSources;
     } catch (err) {
@@ -60,6 +78,7 @@ export class FileSourceService {
       const response = await firstValueFrom(
         this.http.get<SourceRootsResponse>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/roots`,
+          { headers: this.callbackHeaders() },
         ),
       );
       return response.roots;
@@ -82,7 +101,7 @@ export class FileSourceService {
       return await firstValueFrom(
         this.http.get<BrowseResult>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/browse`,
-          { params },
+          { params, headers: this.callbackHeaders() },
         ),
       );
     } catch (err) {
@@ -104,7 +123,7 @@ export class FileSourceService {
       return await firstValueFrom(
         this.http.get<BrowseResult>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/search`,
-          { params },
+          { params, headers: this.callbackHeaders() },
         ),
       );
     } catch (err) {
@@ -126,6 +145,7 @@ export class FileSourceService {
         this.http.post<ImportDocumentsResponse>(
           `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/documents/import`,
           { connectorId, files },
+          { headers: this.callbackHeaders() },
         ),
       );
     } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up fix for the file-source browser (#372). Browsing a connected file source failed immediately after a successful OAuth connect with:

> No OAuth2 callback URL available. App-api expects the `OAuth2CallbackUrl` header from the frontend…

**Cause:** every file-source endpoint resolves an OAuth token server-side (`resolve_file_source_token` → `get_token_for_user`), which needs a callback URL. app-api's `AgentCoreContextMiddleware` sources that from the `OAuth2CallbackUrl` request header. `UserConnectorsService` sends it on every call; `FileSourceService` did not — so `listFileSources` / `roots` / `browse` / `search` / `import` all hit `CallbackUrlUnavailableError` (503).

**Fix:** `FileSourceService` now attaches the `OAuth2CallbackUrl` header (a bare `/oauth-complete` on the current origin) to every request, mirroring `UserConnectorsService`.

## Test plan

- [x] `file-source.service.spec.ts` — header assertion added to the catalog test plus a dedicated test covering roots/browse/search/import (9 tests total)
- [x] `npm run test:ci` — 1093 passed
- [ ] Manual: connect a Google Drive file source in the assistant editor and confirm the browser loads folders instead of the 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)