### PR TITLE
fix(file-sources): resolve connector tokens with consent-matched customParameters

### DIFF
--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -316,8 +316,17 @@ async def connector_status(
             provider_name=provider.provider_id,
             scopes=provider.scopes,
             user_id=current_user.user_id,
+            # Match the customParameters `initiate_consent` used to grant the
+            # token. AgentCore factors `customParameters` into whether
+            # `get_resource_oauth2_token` short-circuits to a vaulted token, so
+            # a status read that omits Google's `prompt=consent` is treated as
+            # a fresh request and reports consent-required even when a usable
+            # token is vaulted. Pure read — `get_token_for_user` itself stays
+            # at `force_authentication=False`.
             custom_parameters=custom_parameters_for(
-                provider.provider_type.value, provider.custom_parameters
+                provider.provider_type.value,
+                provider.custom_parameters,
+                force_authentication=True,
             ),
         )
     except WorkloadTokenUnavailableError as err:

--- a/backend/src/apis/app_api/file_sources/service.py
+++ b/backend/src/apis/app_api/file_sources/service.py
@@ -107,8 +107,15 @@ async def resolve_file_source_token(
 
     Returns a `TokenResult`: `access_token` is populated when the vault has a
     usable token, `authorization_url` when the user still needs to consent.
-    Wires `custom_parameters` the same way the connector status route does,
-    so file-source token fetches behave identically to the settings page.
+
+    `custom_parameters` is built with `force_authentication=True` so it matches
+    the consent flow. AgentCore factors `customParameters` into whether
+    `get_resource_oauth2_token` short-circuits to a vaulted token: connector
+    consent always runs through `initiate_consent`, which sends Google's
+    `prompt=consent` extra — so a retrieval call that omits it is treated as a
+    different request and reports consent-required even though a usable token
+    is vaulted. This is a pure read; `force_authentication` stays False on
+    `get_token_for_user` itself.
     """
     identity = get_agentcore_identity_client()
     return await identity.get_token_for_user(
@@ -116,7 +123,9 @@ async def resolve_file_source_token(
         scopes=provider.scopes,
         user_id=user_id,
         custom_parameters=custom_parameters_for(
-            provider.provider_type.value, provider.custom_parameters
+            provider.provider_type.value,
+            provider.custom_parameters,
+            force_authentication=True,
         ),
     )
 

--- a/backend/tests/apis/app_api/test_connectors_routes.py
+++ b/backend/tests/apis/app_api/test_connectors_routes.py
@@ -403,9 +403,13 @@ class TestForceReauthLifecycle:
         identity.get_token_for_user.assert_called_once()
         assert identity.get_token_for_user.call_args.kwargs["force_authentication"] is False
 
-    def test_status_forwards_google_access_type_offline(self, app_with_deps):
-        # Per AgentCore docs, Google needs `access_type=offline` in
-        # customParameters so the vault gets a refresh token.
+    def test_status_matches_initiate_consent_custom_parameters(self, app_with_deps):
+        # AgentCore factors customParameters into whether get_resource_oauth2_token
+        # short-circuits to a vaulted token. Connector consent always runs through
+        # initiate_consent, which sends Google `prompt=consent`; a status read that
+        # omits it is treated as a fresh request and reports consent-required even
+        # when a usable token is vaulted. So /status MUST send the same
+        # customParameters initiate_consent uses.
         app, identity, _ = app_with_deps(
             "alice",
             provider=_make_provider(),  # default is OAuthProviderType.GOOGLE
@@ -416,6 +420,7 @@ class TestForceReauthLifecycle:
         identity.get_token_for_user.assert_called_once()
         assert identity.get_token_for_user.call_args.kwargs["custom_parameters"] == {
             "access_type": "offline",
+            "prompt": "consent",
         }
 
     def test_initiate_consent_forwards_google_access_type_offline_and_prompt_consent(
@@ -458,6 +463,7 @@ class TestForceReauthLifecycle:
         kwargs = identity.get_token_for_user.call_args.kwargs
         assert kwargs["custom_parameters"] == {
             "access_type": "offline",  # baseline wins
+            "prompt": "consent",  # matches the consent flow's customParameters
             "hd": "mycompany.com",
         }
 

--- a/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.html
+++ b/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.html
@@ -200,7 +200,29 @@
         } @else if (browserError()) {
           <div class="flex items-start gap-3 rounded-sm border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
             <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-red-600 dark:text-red-400" />
-            <p class="text-sm/6 text-red-700 dark:text-red-300">{{ browserError() }}</p>
+            <div>
+              <p class="text-sm/6 text-red-700 dark:text-red-300">{{ browserError() }}</p>
+              @if (browserErrorConnectable() && connector(); as conn) {
+                @let connecting = connectingId() === conn.providerId;
+                <button
+                  type="button"
+                  (click)="reconnect()"
+                  [disabled]="connecting"
+                  class="mt-3 inline-flex items-center gap-1.5 rounded-sm bg-blue-600 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  @if (connecting && connectPhase() === 'initiating') {
+                    <div class="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white"></div>
+                    Starting…
+                  } @else if (connecting && connectPhase() === 'awaiting') {
+                    <ng-icon name="heroArrowPath" class="size-4" />
+                    Awaiting consent
+                  } @else {
+                    <ng-icon name="heroLink" class="size-4" />
+                    Connect
+                  }
+                </button>
+              }
+            </div>
           </div>
         } @else if (displayedEntries().length === 0) {
           <p class="py-6 text-center text-sm/6 text-gray-500 dark:text-gray-400">

--- a/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.ts
@@ -142,6 +142,12 @@ export class FileSourceBrowserDialogComponent {
   protected readonly browserLoading = signal<boolean>(false);
   protected readonly loadingMore = signal<boolean>(false);
   protected readonly browserError = signal<string | null>(null);
+  /**
+   * True when {@link browserError} is a 409 the user can fix in place — the
+   * catalog reported the connector as connected, but its token expired or was
+   * revoked before they drilled in. Drives an inline Connect button.
+   */
+  protected readonly browserErrorConnectable = signal<boolean>(false);
 
   // --- Search ---------------------------------------------------------------
   protected readonly searchTerm = signal<string>('');
@@ -284,7 +290,18 @@ export class FileSourceBrowserDialogComponent {
       }
     } catch (err) {
       this.browserError.set(this.errorMessage(err));
+      this.browserErrorConnectable.set(
+        err instanceof FileSourceError && err.status === 409,
+      );
       this.browserLoading.set(false);
+    }
+  }
+
+  /** Re-run the consent flow for the connector currently failing in the browser. */
+  protected reconnect(): void {
+    const connector = this.connector();
+    if (connector) {
+      void this.connect(connector);
     }
   }
 
@@ -301,6 +318,7 @@ export class FileSourceBrowserDialogComponent {
     this.nextCursor.set(null);
     this.browserLoading.set(true);
     this.browserError.set(null);
+    this.browserErrorConnectable.set(false);
     try {
       const result = await this.fileSourceService.browse(connector.providerId, folderId);
       this.entries.set(result.entries);
@@ -322,6 +340,7 @@ export class FileSourceBrowserDialogComponent {
     this.breadcrumbs.set([]);
     this.nextCursor.set(null);
     this.browserError.set(null);
+    this.browserErrorConnectable.set(false);
   }
 
   protected onEntryActivate(entry: FileEntry): void {
@@ -370,6 +389,7 @@ export class FileSourceBrowserDialogComponent {
     this.nextCursor.set(null);
     this.browserLoading.set(true);
     this.browserError.set(null);
+    this.browserErrorConnectable.set(false);
     try {
       const result = await this.fileSourceService.search(connector.providerId, term);
       this.entries.set(result.entries);
@@ -457,6 +477,7 @@ export class FileSourceBrowserDialogComponent {
     this.entries.set([]);
     this.nextCursor.set(null);
     this.browserError.set(null);
+    this.browserErrorConnectable.set(false);
     this.searchTerm.set('');
     this.activeSearch.set(null);
     this.selected.set(new Map());

--- a/frontend/ai.client/src/app/assistants/services/file-source.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/file-source.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, inject, computed } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+  HttpParams,
+} from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
 import {
   BrowseResult,
   FileSourceConnector,
@@ -58,13 +64,30 @@ export class FileSourceService {
     return { OAuth2CallbackUrl: callback.toString() };
   }
 
+  /**
+   * Per-request options shared by every file-source call. `SUPPRESS_ERROR_TOAST`
+   * opts these requests out of the global error toast — the file-source browser
+   * dialog renders its own inline, actionable errors (e.g. a Connect button on
+   * a 409), so the generic toast would only be a confusing duplicate.
+   */
+  private requestOptions(): {
+    headers: Record<string, string>;
+    context: HttpContext;
+  } {
+    return {
+      headers: this.callbackHeaders(),
+      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),
+    };
+  }
+
   /** List the connectors the current user can use as a file source. */
   async listFileSources(): Promise<FileSourceConnector[]> {
     try {
       const response = await firstValueFrom(
-        this.http.get<FileSourceListResponse>(`${this.baseUrl()}/file-sources`, {
-          headers: this.callbackHeaders(),
-        }),
+        this.http.get<FileSourceListResponse>(
+          `${this.baseUrl()}/file-sources`,
+          this.requestOptions(),
+        ),
       );
       return response.fileSources;
     } catch (err) {
@@ -78,7 +101,7 @@ export class FileSourceService {
       const response = await firstValueFrom(
         this.http.get<SourceRootsResponse>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/roots`,
-          { headers: this.callbackHeaders() },
+          this.requestOptions(),
         ),
       );
       return response.roots;
@@ -101,7 +124,7 @@ export class FileSourceService {
       return await firstValueFrom(
         this.http.get<BrowseResult>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/browse`,
-          { params, headers: this.callbackHeaders() },
+          { ...this.requestOptions(), params },
         ),
       );
     } catch (err) {
@@ -123,7 +146,7 @@ export class FileSourceService {
       return await firstValueFrom(
         this.http.get<BrowseResult>(
           `${this.baseUrl()}/connectors/${encodeURIComponent(connectorId)}/search`,
-          { params, headers: this.callbackHeaders() },
+          { ...this.requestOptions(), params },
         ),
       );
     } catch (err) {
@@ -145,7 +168,7 @@ export class FileSourceService {
         this.http.post<ImportDocumentsResponse>(
           `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/documents/import`,
           { connectorId, files },
-          { headers: this.callbackHeaders() },
+          this.requestOptions(),
         ),
       );
     } catch (err) {

--- a/frontend/ai.client/src/app/auth/error.interceptor.ts
+++ b/frontend/ai.client/src/app/auth/error.interceptor.ts
@@ -1,8 +1,20 @@
-import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpContextToken,
+  HttpInterceptorFn,
+  HttpErrorResponse,
+} from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
 import { ErrorService } from '../services/error/error.service';
 import { SessionService } from './session.service';
+
+/**
+ * Set on a request's `HttpContext` to opt out of the global error toast.
+ * The caller takes responsibility for surfacing the failure itself — used
+ * where a feature renders its own inline, actionable error UI (e.g. the
+ * file-source browser handling a 409 with a Connect button).
+ */
+export const SUPPRESS_ERROR_TOAST = new HttpContextToken<boolean>(() => false);
 
 /**
  * HTTP interceptor that handles errors from non-streaming HTTP requests
@@ -50,7 +62,7 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         // toast — it just flashes before the redirect lands.
         if (error.status === 401) {
           sessionService.handleUnauthorized();
-        } else if (!isSilentEndpoint) {
+        } else if (!isSilentEndpoint && !req.context.get(SUPPRESS_ERROR_TOAST)) {
           // Use ErrorService to display the error
           errorService.handleHttpError(error);
         }


### PR DESCRIPTION
## Summary

Fixes a 409 "Connector is not connected" error in the assistant editor's file-source browser for connectors that are actually connected.

**Root cause:** AgentCore Identity factors the `customParameters` map into whether `get_resource_oauth2_token` short-circuits to a vaulted token. Connector consent always runs through `initiate_consent`, which sends Google `prompt=consent`. Every token *retrieval* path omitted it, so AgentCore treated the read as a fresh request and reported consent-required even though a usable token was vaulted. The file-source browser then looped: `initiate_consent` matched (reported connected) → `/roots` didn't (409).

This was confirmed from backend logs — for the same user/connector seconds apart, `initiate-consent` returned a token while `/file-sources` and `/roots` both logged "requires user consent" — and against the AgentCore SDK `get_token` source.

## Changes

**Backend (the fix)**
- `resolve_file_source_token` (covers `_is_connected`, which delegates) and `connector_status` now build `customParameters` with `force_authentication=True` so they match the consent flow. The calls stay pure reads — `get_token_for_user` itself remains `force_authentication=False`. Adding `prompt=consent` does not force re-consent (proven by `initiate_consent`, a `force_authentication=False` call that returns the cached token).
- Two `connector_status` tests updated to the new contract.

**Frontend (hardening — the dialog owns its error UX)**
- File-source requests opt out of the global error toast via a new `SUPPRESS_ERROR_TOAST` `HttpContext` token, so a handled 409 no longer also raises a raw technical toast.
- A 409 in the browser view now renders an actionable **Connect** button (wired to the existing OAuth consent flow) instead of dead-end red text.

## Known follow-up (out of scope)

Pre-connecting a connector on the Settings page is still not visible to the in-chat agent loop — the agent loop runs its own consent with plain `customParameters` and is internally consistent, so it was intentionally left untouched.

## Test plan

- [x] Backend: `pytest tests/apis/app_api tests/shared` — 748 passed
- [x] Frontend: full Vitest suite — 1093 passed; `tsc` clean
- [ ] Manual: open assistant editor → "Import from a connector" → browse a connected Google Drive connector; confirm `/roots` returns folders, no 409, no raw error toast
- [ ] Manual: Settings → Connectors shows an accurate "Connected" badge for the connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)