### PR TITLE
chore(kaizen): weekly review prep 2026-05-22

### DIFF
--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -56,6 +56,27 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Subtracts**: no — additive but pattern-validated across Linear/ChatGPT/Cursor
 - **Status**: open — deferred 4 weeks in reviews/2026-05-15.md (revisit 2026-06-12). Earns its keep when an A2A construct lands.
 
+### [2026-05-22] Pin `backup-data.yml` runner + actions to restore the CI gate
+- **Source**: reviews/2026-05-22.md ▸ Proposal #1 (direct observation — CI failure analysis). `kaizen-research` did not run 2026-05-22; this item surfaced from review-prep's repo-activity scan.
+- **Surface**: infrastructure / CI — `.github/workflows/backup-data.yml`
+- **Effort × Impact**: L × H
+- **Subtracts**: no — corrective; restores the supply-chain pinning control currently bypassed by a red gate
+- **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #1 (Ship — recommended ship-first); no decision logged yet. CI red *now*: ~8+ Deploy App API / Deploy Inference API / Nightly failures since PR #361 (May 20).
+
+### [2026-05-22] Re-bump `bedrock-agentcore` 1.9.1 → 1.11.0 + adopt `async_mode`
+- **Source**: reviews/2026-05-22.md ▸ Proposal #2 — re-evaluation of the `async_mode`/#452 risk the 2026-05-15 review explicitly deferred "to the 2026-05-22 review".
+- **Surface**: backend (`backend/pyproject.toml`, `backend/uv.lock`, `AgentCoreMemoryConfig` construction)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: no — dep bump; adopting `async_mode` retires the latent #452 event-loop-blocking failure mode
+- **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #2 (Ship); no decision logged yet. Lag re-opened to 2 releases the week after #337 closed it.
+
+### [2026-05-22] Fast PR-gate for the deterministic `supply_chain` + `architecture` test subset
+- **Source**: reviews/2026-05-22.md ▸ Proposal #6 — root-cause of the Proposal #1 friction (policy violation merged clean because PR-merge CI runs no pytest).
+- **Surface**: CI — new lightweight job in the PR workflow
+- **Effort × Impact**: L × M
+- **Subtracts**: no — addition; converts a recurring post-merge friction class into a pre-merge block. Scoped to two deterministic dirs to avoid reopening the "no full pytest in PR CI" decision.
+- **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #6 (Ship scoped, or Defer 2 weeks); no decision logged yet.
+
 ## Resolved
 
 ### [2026-05-10] MCP Apps host renderer — multi-PR build (PRs #1–#7) → RESOLVED — shipped, host enabled

--- a/docs/kaizen/reviews/2026-05-22.md
+++ b/docs/kaizen/reviews/2026-05-22.md
@@ -1,0 +1,149 @@
+# Kaizen Review — Friday, May 22, 2026
+> Prepared 10:05am MT. Review window: May 15 – May 22, 2026 (7 days).
+> Source: research/2026-05-15.md (no fresh research run today — see Friction ▸ Silence) + review-queue.md (6 open items) + this week's repo activity.
+
+## Week in Review
+
+This was the highest-throughput week the loop has observed: the **MCP Apps host renderer initiative shipped end-to-end** (PRs #342–#360 — initialize extension, sandbox-proxy CDK stack, `ui_resource` SSE, postMessage bridge, app-initiated `tools/call` proxy, consent + reload persistence, dogfood pass, and a CSP/iframe fix cluster), the **Artifacts feature landed in full** (#308–#326), a new **file-sources feature** went in (#366–#373), and **7 of the 10 proposals from the 2026-05-15 review shipped** (#337–#341). Two release cuts (beta.26, beta.27). Against that backdrop the system absorbed a lot of change — and the cracks are in the deploy pipeline, not the product: the CI deploy + nightly gates are **red right now** because PR #361's new `backup-data.yml` workflow violates the repo's own supply-chain pinning policy. Net read: a "ship-heavy week; the loop's job this Friday is hygiene, not ambition" review.
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **Supply-chain pinning gate red since #361** (~8+ failed runs: Deploy App API + Deploy Inference API on `develop` May 20 and `release/beta.27` May 20 ×4; Nightly Build & Test on `main` May 21) — PR #361 ("Add backup tool…", May 20) added `.github/workflows/backup-data.yml` using `runs-on: ubuntu-latest` plus unpinned `actions/checkout@v4` and `astral-sh/setup-uv@v6`. The repo enforces SHA-pinned actions and pinned runners via `tests/supply_chain/test_action_pinning.py` + `test_runner_pinning.py`. Those tests run in the deploy workflows' `Test Python Code` step and Nightly's `Test Backend with Coverage` step — so the violation turns every deploy and the nightly red.
+  - *Hypothesis*: PR-merge CI does not run pytest (per `project_pytest_not_in_ci.md`) — only deploy + nightly do. So a workflow-file policy violation **merges clean and only goes red post-merge**. #361 is the first time that gap bit.
+  - *Candidate fix*: pin `backup-data.yml` (Proposal #1) — and add a fast PR-gate that runs the deterministic `tests/supply_chain/` + `tests/architecture/` subset so the next policy violation is caught pre-merge (Proposal #6).
+- **Docker apt-pin drift on deploy builds** (Deploy Inference API + App API failures May 16–17) — the Dockerfile pinned `curl=8.14.1-2+deb13u2`, which Debian dropped from its repo; builds failed `exit code 100`. Fixed by #327 (May 17, re-pin to `…u3`). Resolved — but this is the **second pin-drift class incident** in two weeks (the `backup-data.yml` policy break is the structural cousin). Pinned-but-mutable-upstream is a recurring shape worth a standing watch.
+
+### One-offs worth watching
+- **Deploy MCP Sandbox failed 2× on `develop`** (May 19) — the sandbox-proxy stack landed in #343 the same day; new-stack teething. Watch the next deploy; escalate only if it stays red.
+- **"Backup Data (Pre-Migration)" failed on its only run** (`release/beta.27`, May 20) — the backup workflow #361 introduced has never succeeded. Fold into Proposal #1's scope or it stays dead.
+
+### Silence that matters
+- **`kaizen-research` did not run this morning.** There is no `docs/kaizen/research/2026-05-22.md` and no `kaizen/research-2026-05-22` branch. This review is running on **week-old research (2026-05-15)** plus this week's repo activity. The loop's input half didn't fire — that is the single most important loop-health signal this week. Phil should check the `kaizen-research` scheduled task ran (and didn't silently fail).
+- **Zero comments on the kaizen PRs.** Research PR #302, review PR #304, and bundle #338 all have no comments. The skill expects last weekend's POC findings to accumulate as PR comments — there are none. Phil shipped a huge amount this week, but **no POC findings were captured in the channel the loop reads.** Either the weekend POC session didn't happen, or findings went somewhere the loop can't see. No POC findings could be folded into any proposal below.
+
+## Proposals — ranked
+
+### 1. Pin `backup-data.yml` runner + actions to restore the CI gate
+- **Source**: direct observation — CI failure analysis (Deploy App API run 26182241879, Nightly run 26225098951)
+- **Surface area**: infrastructure / CI — `.github/workflows/backup-data.yml`
+- **Change**: change `runs-on: ubuntu-latest` → the repo's pinned runner (`ubuntu-24.04`); SHA-pin `actions/checkout@v4` and `astral-sh/setup-uv@v6` to commit SHAs with `# vX.Y.Z` comments, matching the format `test_action_pinning.py` expects. While in the file, confirm why "Backup Data (Pre-Migration)" failed its only run and fix that too so the workflow actually works.
+- **Subtracts**: no — corrective; eliminates ~8 red runs/week of deploy + nightly noise and restores a security control that is currently bypassed.
+- **Effort**: Low
+- **Impact**: High (deploy pipeline + nightly are red *right now*; every release ships through a red gate)
+- **POC findings**: not POCed.
+- **Ship means**: open a PR pinning `backup-data.yml`; verify Deploy App API + Nightly go green.
+- **Decline means**: every deploy and nightly stays red; the supply-chain pinning control stays effectively disabled; release confidence erodes.
+- **Recommendation**: **Ship.** Cheapest, highest-impact item in the list — this is exactly the kind of cheap-but-load-bearing fix the loop exists to catch. Do it first.
+
+### 2. Re-bump `bedrock-agentcore` 1.9.1 → 1.11.0 and adopt `async_mode`
+- **Source**: review-queue.md risk re-evaluation (the 2026-05-15 review explicitly deferred the `async_mode`/#452 decision "to the 2026-05-22 review") | PyPI — latest is now **1.11.0**
+- **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`); `AgentCoreMemoryConfig` construction wherever `AgentCoreMemorySessionManager` is configured
+- **Change**: bump the pin 1.9.1 → 1.11.0 (lag re-opened to 2 releases the week after #337 closed it). Verify the 1.10.0/1.11.0 CHANGELOG landed PR #478's `async_mode` on `MemorySessionManager`; if so, set `async_mode=True` on our `AgentCoreMemoryConfig` — that resolves the long-flagged #452 event-loop-blocking risk. Smoke-test memory write/read + identity OAuth in dev.
+- **Subtracts**: no — dep bump. But adopting `async_mode` retires the latent #452 event-loop-blocking failure mode rather than carrying it.
+- **Effort**: Low-Medium
+- **Impact**: Medium-High
+- **POC findings**: not POCed.
+- **Ship means**: PR bumping the pin + enabling `async_mode` if it landed; smoke-test in dev; merge.
+- **Decline means**: lag widens again; #452 stays a live event-loop-blocking risk under sustained Memory load.
+- **Recommendation**: **Ship.** Closes the risk the last review explicitly punted to today. Pair with Proposal #4 — same SDK package owns `update_agent_runtime`.
+
+### 3. Investigate inference-api deploy issue #288 — images reach ECR but Runtime isn't rolled
+- **Source**: review-queue.md (open since 2026-05-15) | issue #288 (open, **0 comments — untriaged 10 days**) — carry-over from reviews/2026-05-15.md ▸ Proposal #10
+- **Surface area**: cross-cutting — `.github/workflows/deploy-inference-api.yml` + the bedrock-agentcore SDK `update_agent_runtime` call shape
+- **Change**: trace the deploy workflow end-to-end; confirm whether it calls `update_agent_runtime` after the ECR push. If missing, add it; if present but failing/no-op, surface why. Distinct from the curl-pin and backup-data.yml failures — #288 is a *silent* no-op, not a red run.
+- **Subtracts**: possibly — removes the manual-redeploy band-aid that's been the workaround.
+- **Effort**: Low-Medium
+- **Impact**: Medium-High (eventually a security patch or model-version bump must ship via this path)
+- **POC findings**: not POCed.
+- **Ship means**: 1–2 hour triage; small PR fixing the workflow + closing #288 when verified.
+- **Decline means**: continue manual redeploys; #288 rots untriaged into a third week.
+- **Recommendation**: **Ship.** Recommended Ship last review and not actioned; the issue now has 10 days and 0 comments. Pair with Proposal #2.
+
+### 4. Audit `BedrockModel.stream` cancellation path against Strands #2266
+- **Source**: review-queue.md (open since 2026-05-10) — carry-over from reviews/2026-05-15.md ▸ Proposal #8
+- **Surface area**: backend (`backend/src/agents/main_agent/` stream coordinator + SSE handler)
+- **Change**: locate every `BedrockModel.stream` cancellation path; ensure each `await`s the inner task on cancel so it doesn't orphan; add a dev-only assertion/log filter to detect "Task exception was never retrieved" before it reaches prod.
+- **Subtracts**: no — defensive (the SSE-disconnect path is hot).
+- **Effort**: Low
+- **Impact**: Medium-High
+- **POC findings**: not POCed.
+- **Ship means**: PR with the audit + fixes + a regression test that triggers cancel and asserts no orphan tasks.
+- **Decline means**: log a tech-debt issue; revisit if "Task exception was never retrieved" appears in CloudWatch.
+- **Recommendation**: **Ship.** Cheapest defensive carry-over; pairs with Proposal #2 (same backend area).
+
+### 5. Wire per-tool `duration_ms` into the `tool_result` SSE event
+- **Source**: research/2026-05-15.md ▸ Top 5 #5 | review-queue.md (open since 2026-05-15) — carry-over from reviews/2026-05-15.md ▸ Proposal #3
+- **Surface area**: backend (Strands `AfterToolCall` hook → SSE emitter) + frontend (`<tool-result>` component — faint inline timing badge above ~250ms)
+- **Change**: register a Strands `AfterToolCall` hook capturing `(end - start)` wall-clock per tool invocation; emit on the existing `tool_result` SSE event as `duration_ms`. Frontend renders an inline badge only above the noise threshold.
+- **Subtracts**: partial — single hook-driven field replaces any ad-hoc per-tool timing; pre-paves the planned context-attribution prototype.
+- **Unlocks**:
+  - Per-tool timing visibility in the UI — which tool is the bottleneck on this turn.
+  - The data substrate for the context-attribution prototype — separates tool latency from token cost.
+- **Effort**: Low-Medium
+- **Impact**: Medium-High
+- **POC findings**: not POCed.
+- **Ship means**: one PR — backend hook + SSE field + frontend badge + a unit test asserting the hook fires on tool completion.
+- **Decline means**: tool latency stays invisible; the context-attribution prototype starts with murkier inputs.
+- **Recommendation**: **Ship** — but as the *one* genuine engineering item to ride the week. After a ship-heavy week, hold this if Phil only has bandwidth for the three cheap fixes (#1, #3) plus one bump (#2).
+
+### 6. Add a fast PR-gate for the deterministic `supply_chain` + `architecture` test subset
+- **Source**: direct observation — root-cause of the Proposal #1 friction (a policy violation merged clean because PR-merge CI runs no pytest)
+- **Surface area**: CI — a new lightweight job in the PR workflow
+- **Change**: add a PR-triggered job running only `pytest tests/supply_chain/ tests/architecture/ -q` — the deterministic, non-flaky, fast subset (no AWS, no LLM). Catches workflow-pinning violations and import-boundary breaks pre-merge instead of post-merge in deploy/nightly.
+- **Subtracts**: no — addition only. Justified: it converts a recurring post-merge friction class (this week: #361) into a pre-merge block, without reopening the deliberate "no full pytest in PR CI" decision (`project_pytest_not_in_ci.md`) — the scope is explicitly the two deterministic directories, not the suite.
+- **Effort**: Low
+- **Impact**: Medium
+- **POC findings**: not POCed.
+- **Ship means**: PR adding the scoped job to the PR workflow.
+- **Decline means**: the next `ubuntu-latest` / unpinned-action / import-boundary violation merges clean and goes red post-merge again.
+- **Recommendation**: **Ship** (scoped) — or **Defer 2 weeks** if Phil wants to first confirm Proposal #1 alone is enough. Note the tension with the existing "pytest is not a PR gate" stance; this proposal threads it by gating only the two deterministic dirs.
+
+## Carried Over From Prior Reviews
+
+- **`oauth_required` SSE flow audit against ref-repo's mid-tool-call 401/403 handling** (deferred 2026-05-10 until 2026-05-24) — now due (revisit date is in 2 days). Original deferral was pending BFF auth settling; the BFF parade was declared done via #297 on May 14, so the deferral conditions cleared a week early and have now held stable for a full week. *Recommendation*: promote into next week's proposal set — no remaining reason to hold it. Phil: mark Ship / Defer here.
+
+## Retirement Candidates
+
+- **No clean retirement candidate this week** — and that is itself the finding. Two of this week's six proposals (#1 pin `backup-data.yml`, #6 PR-gate) are *control-restoration*, not subtraction; the rest are bumps, defensive audits, or a capability add. The subtraction muscle that exercised well over the prior two weeks (kaizen lens churn, dead URLs, Reddit RSS declined) had nothing to grip this week because the week was almost entirely net-new feature throughput (MCP Apps, Artifacts, file-sources). That's acceptable for one cycle — but if next week's review also finds nothing to retire, the scaffold is accreting faster than it's being pruned. Flagged in the Take.
+
+## Risks Acknowledged But Not Acted On
+
+- **`bedrock-agentcore` lag re-opened** — pinned 1.9.1 (via #337, May 18), latest **1.11.0**. — *what breaks if ignored*: lag widens; #452 event-loop-blocking stays unfixed. — *recommendation*: **Address now via Proposal #2.**
+- **Supply-chain pinning control effectively bypassed** — the gate is red, so it no longer protects anything until `backup-data.yml` is pinned. — *recommendation*: **Address now via Proposal #1.**
+- **Strands SDK monorepo consolidation** (issue #2286) — import paths may move in a future major. — *recommendation*: **Watch until v2.x messaging emerges**; re-evaluate at the next Strands minor.
+- **Deploy MCP Sandbox new-stack failures** (2× May 19) — the stack is two days old. — *recommendation*: **Watch the next deploy**; escalate to a proposal only if it stays red.
+
+## What Shipped This Week
+
+- **MCP Apps host renderer — initiative complete + enabled** (#342–#349 + fix cluster #352–#360) — *the dominant strategic initiative of the cycle landed and is dogfooded; `AGENTCORE_MCP_APPS_HOST_ENABLED` flipped on.*
+- **Artifacts feature — end-to-end** (#308–#326) — *SPA panel, `artifact` SSE event, create/update tools, version history, inline cards.*
+- **file-sources feature** (#366–#373) — *adapter framework, browse/search/import endpoints, assistant-editor browser.*
+- **Inference hardening** (#328–#331) — *recoverable `max_tokens` truncation with Continue affordance; int-coercion + model-ceiling caps; admin-configurable effort + adaptive thinking.*
+- **7 of 10 kaizen 2026-05-15 proposals** (#337 bedrock bump, #338 bundle, #339 renderer registry, #340 Strands 1.40, #341 queue resolution) — *strong loop absorption.*
+- **beta.26 + beta.27** release cuts.
+
+## Take
+
+The loop's review→ship side is in clear trust territory — 7 of 10 proposals shipped on top of three major features, the most the loop has seen absorbed in a week. The friction is entirely in deploy hygiene: the CI gate is red because a new workflow merged a policy violation that PR-merge CI structurally can't catch, and that gap (Proposal #6) is the real lesson, not the one broken file. **The single change that matters most this week is Proposal #1 — pin `backup-data.yml`** — because every release is currently shipping through a red gate and a bypassed security control. The genuine loop-health concern is on the *input* side: `kaizen-research` didn't run this morning and no POC findings landed on any kaizen PR all week. The loop is shipping well but flying on week-old radar — Phil should confirm the research scheduled task is firing before next Friday, or the review half starts synthesizing from staler and staler inputs.
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min) — note `kaizen-research` didn't run; check that scheduled task.
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **6 proposals**; my recommendations: 6 Ship (Proposal #6 has a Defer-2-weeks fallback).
+3. Resolve Carried Over: `oauth_required` SSE audit is now due — Ship or Defer (1 min).
+4. Scan Retirement Candidates — none this week; note the accretion flag (1 min).
+5. Resolve the Risks block (1-2 min).
+6. **Suggested 1–3 to ship**: **#1 (pin `backup-data.yml`)** — non-negotiable, CI is red; **#2 (bedrock-agentcore re-bump + `async_mode`)** — closes the risk last review punted to today; **#4 (stream-cancel audit)** — cheap defensive carry-over. Hold #5 (`duration_ms`) and #6 (PR gate) for next week if bandwidth is short after a ship-heavy cycle.
+
+Target: 10-12 minutes.
+
+## Post-review (separate PRs)
+
+- ✅ Ship items → individual feature PRs over the week. The decision is logged here; the implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a "revisit by" date; surface again in the next review when due.
+
+This skill produces the agenda. Implementation never happens here.


### PR DESCRIPTION
## Summary
- 6 proposals ranked Effort × Impact. CI deploy + nightly gates are **red right now** — Proposal #1 (pin `backup-data.yml`) is the ship-first item.
- `kaizen-research` did not run this morning — no fresh research doc; this review synthesizes from research/2026-05-15.md + this week's repo activity. Flagged as the week's top loop-health signal.
- 7 of 10 proposals from the 2026-05-15 review shipped, on top of three major features (MCP Apps host renderer, Artifacts, file-sources).
- Three new friction items appended to `review-queue.md`; one Carried Over item (`oauth_required` SSE audit) now due.
- No POC findings folded in — zero comments on any kaizen PR this week.

## Review
1. Read Friction (2 min) — note `kaizen-research` didn't run; check that scheduled task.
2. Mark each Proposal: ✅ Ship / ❌ Decline / ⏸ Defer.
3. Resolve the Carried Over item and the Risks block.
4. Pick 1-3 to ship this week.

Target: 10-12 minutes.

## Decision
Ship the doc to `develop`. Action on individual items happens in separate PRs over the week.
Declined items go to `docs/kaizen/decisions.md`; deferred items stay open in `review-queue.md` with a revisit date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)