### PR TITLE
feat(web-sources): crawl websites into an assistant's knowledge base

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,10 @@ dependencies = [
     # PDF page-1 rasterization for attachment thumbnails (Apache 2.0 / BSD).
     # Bundles PDFium (no system poppler/ghostscript needed).
     "pypdfium2==4.30.0",
+
+    # Web-source crawler: link extraction + main-content -> markdown.
+    "beautifulsoup4==4.13.5",
+    "trafilatura==2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -368,6 +368,8 @@ async def delete_document(assistant_id: str, document_id: str, user_id: str = De
                 assistant_id=assistant_id,
                 s3_key=document.s3_key,
                 chunk_count=document.chunk_count,
+                source_connector_id=document.source_connector_id,
+                source_file_id=document.source_file_id,
             )
         )
 

--- a/backend/src/apis/app_api/documents/services/cleanup_service.py
+++ b/backend/src/apis/app_api/documents/services/cleanup_service.py
@@ -33,6 +33,8 @@ async def cleanup_document_resources(
     chunk_count: Optional[int],
     max_retries: int = 3,
     base_delay: float = 0.5,
+    source_connector_id: Optional[str] = None,
+    source_file_id: Optional[str] = None,
 ) -> bool:
     """
     Delete vectors and S3 source file with exponential backoff retries.
@@ -44,6 +46,12 @@ async def cleanup_document_resources(
     Returns True only if both phases succeed. On True, hard-deletes the
     DynamoDB record. On failure, logs and leaves the record for TTL auto-expiry.
 
+    For web-source documents (`source_connector_id == 'web'`) the success
+    path also cascades into `_cascade_delete_orphaned_crawl_jobs`, which
+    purges any terminal-status CrawlJob row no longer referenced by a
+    surviving doc. A running crawl is left alone — the crawler is still
+    creating rows that would re-orphan it on every tick.
+
     Never raises exceptions.
 
     Args:
@@ -53,6 +61,11 @@ async def cleanup_document_resources(
         chunk_count: Number of vector chunks (None triggers probe-and-scan fallback)
         max_retries: Maximum retry attempts per phase
         base_delay: Base delay in seconds for exponential backoff
+        source_connector_id: Provenance connector id of the doc being deleted.
+            Only `'web'` triggers the CrawlJob cascade; everything else is a no-op.
+        source_file_id: Provenance file id of the doc being deleted (the page
+            URL for web docs). Unused today — kept symmetric with the rest of
+            the provenance fields and reserved for tighter prefix matching.
 
     Returns:
         True if all resources were cleaned up successfully, False otherwise
@@ -82,6 +95,15 @@ async def cleanup_document_resources(
             await hard_delete_document(assistant_id, document_id)
         except Exception as e:
             logger.error(f"Failed to hard-delete document {document_id}: {e}", exc_info=True)
+
+        if source_connector_id == "web":
+            try:
+                await _cascade_delete_orphaned_crawl_jobs(assistant_id)
+            except Exception as e:
+                logger.error(
+                    f"CrawlJob cascade after deleting {document_id} failed: {e}",
+                    exc_info=True,
+                )
     else:
         logger.warning(
             f"Cleanup incomplete for {document_id}: vectors={vectors_deleted}, "
@@ -89,6 +111,96 @@ async def cleanup_document_resources(
         )
 
     return all_succeeded
+
+
+async def _cascade_delete_orphaned_crawl_jobs(assistant_id: str) -> None:
+    """Hard-delete terminal CrawlJob rows whose root_url no surviving web doc references.
+
+    Called right after a web-source document is hard-deleted. The cascade is
+    intentionally scoped to terminal-status crawls (`complete` / `failed`) —
+    a running crawl is still spawning child docs, and deleting its row would
+    break the SPA's watcher loop and cause the in-flight `finalize_crawl`
+    update to fail its `attribute_exists` precondition.
+
+    "Orphaned" is decided by URL prefix match: a CrawlJob is kept iff some
+    surviving doc has `source_connector_id == 'web'` and `source_file_id`
+    starts with the crawl's `root_url`. Prefix is good enough — the crawler
+    only enqueues URLs that already satisfy the same-domain / same-root
+    filter, so false positives are rare in practice and the worst case is
+    that a row sticks around until its TTL fires.
+
+    Never raises. Failures of the underlying list/delete calls are logged.
+    """
+    from apis.app_api.web_sources.crawl_repository import (
+        hard_delete_crawl_job,
+        list_all_crawls,
+    )
+
+    crawls = await list_all_crawls(assistant_id)
+    terminal_crawls = [c for c in crawls if c.status in ("complete", "failed")]
+    if not terminal_crawls:
+        return
+
+    surviving_web_urls = await _list_surviving_web_source_file_ids(assistant_id)
+
+    for crawl in terminal_crawls:
+        if any(url.startswith(crawl.root_url) for url in surviving_web_urls):
+            continue
+        await hard_delete_crawl_job(assistant_id, crawl.crawl_id)
+
+
+async def _list_surviving_web_source_file_ids(assistant_id: str) -> list[str]:
+    """Return source_file_id values for every surviving `web` document of an assistant.
+
+    Reads the assistants table directly (not via `list_assistant_documents`)
+    so the cascade does not require an ownership check — by the time we get
+    here the deleting user has already been verified by the soft-delete
+    upstream. Paginates internally; the typical assistant has a few hundred
+    docs at most.
+    """
+    import os
+
+    import boto3
+    from boto3.dynamodb.conditions import Attr, Key
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        logger.error("DYNAMODB_ASSISTANTS_TABLE_NAME not set; skipping crawl cascade")
+        return []
+
+    table = boto3.resource("dynamodb").Table(table_name)
+    urls: list[str] = []
+    exclusive_start_key: Optional[dict] = None
+    while True:
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"AST#{assistant_id}")
+            & Key("SK").begins_with("DOC#"),
+            "FilterExpression": Attr("sourceConnectorId").eq("web"),
+            "ProjectionExpression": "sourceFileId, #st",
+            "ExpressionAttributeNames": {"#st": "status"},
+        }
+        if exclusive_start_key:
+            kwargs["ExclusiveStartKey"] = exclusive_start_key
+        try:
+            response = table.query(**kwargs)
+        except Exception as e:
+            logger.error(f"Failed to list web docs for cascade ({assistant_id}): {e}")
+            return urls
+
+        for item in response.get("Items", []):
+            # Soft-deleted rows still exist in the table until cleanup hard-deletes
+            # them; treat them as gone for cascade purposes.
+            if item.get("status") == "deleting":
+                continue
+            file_id = item.get("sourceFileId")
+            if isinstance(file_id, str):
+                urls.append(file_id)
+
+        exclusive_start_key = response.get("LastEvaluatedKey")
+        if not exclusive_start_key:
+            break
+
+    return urls
 
 
 async def _delete_vectors_with_retries(

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -180,6 +180,7 @@ from apis.app_api.users.routes import router as users_router
 from apis.app_api.user_settings.routes import router as user_settings_router
 from apis.app_api.connectors.routes import router as connectors_router
 from apis.app_api.file_sources.routes import router as file_sources_router
+from apis.app_api.web_sources.routes import router as web_sources_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
 from apis.app_api.voice import router as voice_router
@@ -207,6 +208,7 @@ app.include_router(tools_router)  # Tool discovery and permissions
 app.include_router(files_router)  # File upload via pre-signed URLs
 app.include_router(connectors_router)  # User-facing connector catalog + consent flows
 app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors
+app.include_router(web_sources_router)  # Web-crawl ingestion: URL -> documents via BFS + S3 staging
 app.include_router(system_router)  # System status and first-boot endpoints
 app.include_router(conversations_share_router)  # Share conversations endpoints
 app.include_router(shares_router)  # Share management (update, revoke, export)

--- a/backend/src/apis/app_api/web_sources/__init__.py
+++ b/backend/src/apis/app_api/web_sources/__init__.py
@@ -1,0 +1,10 @@
+"""User-facing web-crawl ingestion for assistant knowledge.
+
+A `web_source` is the simplest possible "file source": no OAuth provider, no
+adapter — the user supplies a URL and (optionally) a small set of crawl
+parameters, and the backend fetches the page(s) and stages markdown into the
+documents bucket. From there the existing S3-event ingestion Lambda drives
+chunking/embedding exactly as a device upload would.
+
+See `crawler.py` for the BFS itself; `routes.py` for the public surface.
+"""

--- a/backend/src/apis/app_api/web_sources/crawl_repository.py
+++ b/backend/src/apis/app_api/web_sources/crawl_repository.py
@@ -1,0 +1,344 @@
+"""DynamoDB persistence for `CrawlJob` rows.
+
+Reuses the assistants table via the adjacency-list pattern:
+`PK = AST#{assistant_id}`, `SK = CRAWL#{crawl_id}`. This keeps the SPA's
+list-by-assistant query a single `SK begins_with CRAWL#` scan and lets the
+job ride the assistant's blast radius on delete.
+
+A failed update never raises — the caller is a fire-and-forget background
+task and we'd rather lose a progress tick than abort the crawl.
+"""
+
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, List, Optional
+
+from apis.app_api.web_sources.models import CrawlJob, CrawlJobStatus, CrawlSettings
+
+logger = logging.getLogger(__name__)
+
+# Terminal crawl rows auto-expire after this many days via the table's
+# `ttl` attribute. Long enough for any reasonable "what happened on my last
+# crawl" follow-up; short enough that an idle assistant doesn't accumulate
+# dead rows indefinitely.
+_FINALIZED_TTL_DAYS = 30
+
+# A `running` crawl whose started_at is older than this is presumed dead.
+# The crawler's own internal budget is 15 minutes (CRAWL_BUDGET_SECONDS in
+# crawler.py), and it always runs `finalize_crawl` in a finally block. The
+# only way a row stays `running` past that is the process owning it died
+# (server restart, OOM, hung event loop). 5-minute buffer past the budget
+# avoids racing a crawl that's legitimately near its ceiling.
+_STALE_RUNNING_SECONDS = 20 * 60
+
+
+def _generate_crawl_id() -> str:
+    return f"CRAWL-{uuid.uuid4().hex[:12]}"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise ValueError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable not set")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _ddb_safe(value: Any) -> Any:
+    """Recursively coerce Python floats to `Decimal` for DynamoDB writes.
+
+    DynamoDB's number type maps to `Decimal` on both ends — boto3's
+    serializer raises `TypeError: Float types are not supported` when it
+    encounters a bare `float`. `CrawlSettings` carries float delay knobs,
+    so the settings sub-dict (and any list/nested dict that wraps a float)
+    must be walked before `put_item`. Pydantic v2 happily coerces the
+    Decimal back into a float when we read these rows.
+    """
+    if isinstance(value, float):
+        # Decimal(<float>) introduces representation noise; round-trip
+        # through str so 1.0 stays "1" instead of "1.0000000000…001".
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _ddb_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_ddb_safe(v) for v in value]
+    return value
+
+
+async def create_crawl_job(
+    *,
+    assistant_id: str,
+    root_url: str,
+    settings: CrawlSettings,
+    started_by_user_id: str,
+    crawl_id: Optional[str] = None,
+) -> CrawlJob:
+    """Persist a new `running` crawl row and return its model.
+
+    Raises on persistence failure — the route relies on the row existing
+    before it fires the background task.
+    """
+    job = CrawlJob(
+        crawl_id=crawl_id or _generate_crawl_id(),
+        assistant_id=assistant_id,
+        root_url=root_url,
+        status="running",
+        settings=settings,
+        discovered_count=0,
+        fetched_count=0,
+        failed_count=0,
+        started_at=_now(),
+        started_by_user_id=started_by_user_id,
+    )
+    item = job.model_dump(by_alias=True, exclude_none=True)
+    item["PK"] = f"AST#{assistant_id}"
+    item["SK"] = f"CRAWL#{job.crawl_id}"
+    _table().put_item(Item=_ddb_safe(item))
+    logger.info(
+        "Created crawl %s for assistant %s (root=%s)",
+        job.crawl_id,
+        assistant_id,
+        root_url,
+    )
+    return job
+
+
+async def get_crawl_job(assistant_id: str, crawl_id: str) -> Optional[CrawlJob]:
+    response = _table().get_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"CRAWL#{crawl_id}"}
+    )
+    item = response.get("Item")
+    if not item:
+        return None
+    try:
+        return CrawlJob.model_validate(item)
+    except Exception as e:
+        logger.warning("Failed to parse CrawlJob row %s/%s: %s", assistant_id, crawl_id, e)
+        return None
+
+
+async def list_all_crawls(assistant_id: str) -> List[CrawlJob]:
+    """Return every crawl row for an assistant regardless of status. Empty list on error.
+
+    Used by the cascade-on-last-doc-delete path — we need to inspect every
+    surviving crawl, not just `running` ones, to decide which (if any) have
+    been orphaned by the deletion.
+    """
+    try:
+        from boto3.dynamodb.conditions import Key
+
+        response = _table().query(
+            KeyConditionExpression=Key("PK").eq(f"AST#{assistant_id}")
+            & Key("SK").begins_with("CRAWL#"),
+        )
+    except Exception as e:
+        logger.error("Failed to list crawls for %s: %s", assistant_id, e)
+        return []
+
+    crawls: List[CrawlJob] = []
+    for item in response.get("Items", []):
+        try:
+            crawls.append(CrawlJob.model_validate(item))
+        except Exception as e:
+            logger.warning("Skipping unparseable CrawlJob row: %s", e)
+    return crawls
+
+
+async def hard_delete_crawl_job(assistant_id: str, crawl_id: str) -> bool:
+    """Unconditionally remove a CrawlJob row. Never raises.
+
+    Called from the document-cleanup cascade after the last `web` doc
+    referencing this crawl's root_url is removed. Returns True on success.
+    """
+    try:
+        _table().delete_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"CRAWL#{crawl_id}"}
+        )
+        logger.info("Hard-deleted crawl %s for assistant %s", crawl_id, assistant_id)
+        return True
+    except Exception as e:
+        logger.error(
+            "Failed to hard-delete crawl %s for assistant %s: %s",
+            crawl_id,
+            assistant_id,
+            e,
+        )
+        return False
+
+
+def _is_crawl_stale(job: CrawlJob) -> bool:
+    """A `running` crawl past the crawler's own budget is dead.
+
+    The crawler always finalizes in a `finally` block; the only way a
+    `running` row outlives the budget is the owning process died. Mirrors
+    the same staleness pattern documents use in `document_service`.
+    """
+    try:
+        started_str = job.started_at.rstrip("Z")
+        started = datetime.fromisoformat(started_str).replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+        return elapsed > _STALE_RUNNING_SECONDS
+    except (ValueError, AttributeError) as e:
+        logger.warning(
+            "Unparseable started_at on crawl %s/%s (%s); treating as stale",
+            job.assistant_id,
+            job.crawl_id,
+            e,
+        )
+        return True
+
+
+async def list_active_crawls(assistant_id: str) -> List[CrawlJob]:
+    """Return all `running` crawl jobs for an assistant. Empty list on error.
+
+    Self-heals stale rows: a `running` job whose owning process died (server
+    restart, OOM) would otherwise keep the SPA's crawl-watcher polling
+    forever. On read, any such job past `_STALE_RUNNING_SECONDS` is
+    finalized as `failed` and dropped from the result. Matches the existing
+    "auto-fail stale processing docs on read" pattern in `document_service`.
+    """
+    try:
+        from boto3.dynamodb.conditions import Attr, Key
+
+        response = _table().query(
+            KeyConditionExpression=Key("PK").eq(f"AST#{assistant_id}")
+            & Key("SK").begins_with("CRAWL#"),
+            FilterExpression=Attr("status").eq("running"),
+        )
+    except Exception as e:
+        logger.error("Failed to list active crawls for %s: %s", assistant_id, e)
+        return []
+
+    alive: List[CrawlJob] = []
+    for item in response.get("Items", []):
+        try:
+            job = CrawlJob.model_validate(item)
+        except Exception as e:
+            logger.warning("Skipping unparseable CrawlJob row: %s", e)
+            continue
+
+        if _is_crawl_stale(job):
+            logger.info(
+                "Auto-reaping stale crawl %s/%s (started_at=%s)",
+                assistant_id,
+                job.crawl_id,
+                job.started_at,
+            )
+            await finalize_crawl(
+                assistant_id=assistant_id,
+                crawl_id=job.crawl_id,
+                status="failed",
+                error="Crawl interrupted (the owning process did not finish in time).",
+            )
+            continue
+
+        alive.append(job)
+    return alive
+
+
+async def increment_counters(
+    *,
+    assistant_id: str,
+    crawl_id: str,
+    discovered_delta: int = 0,
+    fetched_delta: int = 0,
+    failed_delta: int = 0,
+) -> None:
+    """Atomically bump per-page counters on an in-flight job. Never raises."""
+    if discovered_delta == 0 and fetched_delta == 0 and failed_delta == 0:
+        return
+    set_parts: list[str] = []
+    add_parts: list[str] = []
+    values: dict[str, object] = {":now": _now()}
+    set_parts.append("updatedAt = :now")
+    if discovered_delta:
+        add_parts.append("discoveredCount :d_disc")
+        values[":d_disc"] = discovered_delta
+    if fetched_delta:
+        add_parts.append("fetchedCount :d_fetch")
+        values[":d_fetch"] = fetched_delta
+    if failed_delta:
+        add_parts.append("failedCount :d_fail")
+        values[":d_fail"] = failed_delta
+
+    expression_parts: list[str] = []
+    if set_parts:
+        expression_parts.append("SET " + ", ".join(set_parts))
+    if add_parts:
+        expression_parts.append("ADD " + ", ".join(add_parts))
+
+    try:
+        _table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"CRAWL#{crawl_id}"},
+            UpdateExpression=" ".join(expression_parts),
+            ExpressionAttributeValues=values,
+            ConditionExpression="attribute_exists(PK)",
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to bump counters on crawl %s/%s: %s",
+            assistant_id,
+            crawl_id,
+            e,
+        )
+
+
+async def finalize_crawl(
+    *,
+    assistant_id: str,
+    crawl_id: str,
+    status: CrawlJobStatus,
+    error: Optional[str] = None,
+) -> None:
+    """Move a crawl out of `running`. Never raises.
+
+    Callers must invoke this in a `finally` so a crashed task does not leave
+    a job pinned at `running` forever (which would keep the editor's watcher
+    loop spinning).
+    """
+    # DynamoDB TTL requires epoch *seconds* — millisecond values are silently
+    # ignored by the reaper. `#ttl` is escaped because `ttl` is a reserved word.
+    ttl_epoch_seconds = int(time.time()) + _FINALIZED_TTL_DAYS * 86400
+    expression_attribute_names = {"#status": "status", "#ttl": "ttl"}
+    set_parts = [
+        "#status = :status",
+        "completedAt = :completed_at",
+        "updatedAt = :completed_at",
+        "#ttl = :ttl",
+    ]
+    values: dict[str, object] = {
+        ":status": status,
+        ":completed_at": _now(),
+        ":ttl": ttl_epoch_seconds,
+    }
+    if error is not None:
+        set_parts.append("#err = :err")
+        expression_attribute_names["#err"] = "error"
+        # Trim long error strings so we never write a >400KB DynamoDB row.
+        values[":err"] = (error or "")[:2000]
+
+    try:
+        _table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"CRAWL#{crawl_id}"},
+            UpdateExpression="SET " + ", ".join(set_parts),
+            ExpressionAttributeValues=values,
+            ExpressionAttributeNames=expression_attribute_names,
+            ConditionExpression="attribute_exists(PK)",
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to finalize crawl %s/%s (status=%s): %s",
+            assistant_id,
+            crawl_id,
+            status,
+            e,
+        )

--- a/backend/src/apis/app_api/web_sources/crawler.py
+++ b/backend/src/apis/app_api/web_sources/crawler.py
@@ -1,0 +1,588 @@
+"""BFS web crawler.
+
+This is the long-running half of the web-source feature. It is spawned via
+`asyncio.ensure_future` from the route after the response is already on the
+wire — it must never raise out of the top-level `run_crawl` call and must
+always finalize the `CrawlJob` it owns. Failure modes:
+
+- transport errors on a page → that one document goes 'failed', crawl
+  continues
+- robots.txt disallows a page → silently skipped (it never becomes a doc)
+- timeout on the whole crawl → caught, crawl marked 'failed'
+
+The hot loop is small on purpose: discover links, gate them through
+robots+domain+depth+visited, fetch with per-host jitter, extract markdown,
+write to S3. Everything else (status transitions, chunking, embedding) is
+the existing documents pipeline.
+"""
+
+import asyncio
+import logging
+import mimetypes
+import random
+import re
+import time
+from collections import defaultdict
+from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple
+from urllib.parse import urljoin
+from urllib.robotparser import RobotFileParser
+
+import httpx
+
+from apis.app_api.documents.models import DocumentProvenance
+from apis.app_api.documents.services.document_service import (
+    create_document,
+    update_document_import_metadata,
+    update_document_status,
+)
+from apis.app_api.documents.services.storage_service import (
+    _get_s3_key,
+    _sanitize_filename,
+)
+from apis.app_api.web_sources.crawl_repository import (
+    finalize_crawl,
+    increment_counters,
+)
+from apis.app_api.web_sources.models import CrawlSettings
+from apis.app_api.web_sources.url_utils import (
+    absolute_url,
+    assert_url_is_public,
+    host_of,
+    normalize_url,
+    same_registrable_domain,
+    url_extension_hint,
+)
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = "BoiseStateAI-Assistant-Crawler/1.0 (+contact)"
+PER_PAGE_TIMEOUT_SECONDS = 20.0
+CRAWL_BUDGET_SECONDS = 15 * 60  # hard ceiling: must outlive any reasonable crawl
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+ACCEPT_HEADER = (
+    "text/html;q=0.9, application/xhtml+xml;q=0.9, text/plain;q=0.5, */*;q=0.1"
+)
+
+
+class _DocumentCreator:
+    """Adapter for the `create_document` call that the route's pre-created
+    root document needs to skip — the root already has a record, so the
+    crawler must not double-create it.
+    """
+
+    def __init__(
+        self,
+        assistant_id: str,
+        user_id: str,
+        already_recorded: Dict[str, str],
+    ) -> None:
+        self.assistant_id = assistant_id
+        self.user_id = user_id
+        # normalized_url -> document_id
+        self.records: Dict[str, str] = dict(already_recorded)
+
+    async def get_or_create(self, normalized_url: str) -> str:
+        existing = self.records.get(normalized_url)
+        if existing:
+            return existing
+        provisional_filename = f"{_sanitize_filename(url_extension_hint(normalized_url))}.html"
+        document_id = await _create_pending_document(
+            assistant_id=self.assistant_id,
+            normalized_url=normalized_url,
+            user_id=self.user_id,
+            filename=provisional_filename,
+        )
+        self.records[normalized_url] = document_id
+        return document_id
+
+
+async def _create_pending_document(
+    *,
+    assistant_id: str,
+    normalized_url: str,
+    user_id: str,
+    filename: str,
+) -> str:
+    """Create a fresh `uploading` document row for a discovered URL."""
+    from apis.app_api.documents.services.document_service import _generate_document_id
+
+    document_id = _generate_document_id()
+    s3_key = _get_s3_key(assistant_id, document_id, _sanitize_filename(filename))
+    await create_document(
+        assistant_id=assistant_id,
+        filename=filename,
+        content_type="text/html",
+        size_bytes=0,
+        s3_key=s3_key,
+        document_id=document_id,
+        provenance=DocumentProvenance(
+            source_connector_id="web",
+            source_adapter_key="http",
+            source_file_id=normalized_url,
+            imported_by_user_id=user_id,
+        ),
+    )
+    return document_id
+
+
+# ── robots.txt cache ─────────────────────────────────────────────────────────
+
+
+class _RobotsCache:
+    """Per-crawl robots.txt cache. One fetch per host, lifetime of the job."""
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+        self._cache: Dict[str, Optional[RobotFileParser]] = {}
+
+    async def allows(self, url: str) -> bool:
+        host = host_of(url)
+        if not host:
+            return False
+        parser = self._cache.get(host)
+        if host not in self._cache:
+            parser = await self._fetch(host, url)
+            self._cache[host] = parser
+        if parser is None:
+            return True  # robots unreachable → permissive (mirrors most crawlers)
+        return parser.can_fetch(USER_AGENT, url)
+
+    async def _fetch(self, host: str, sample_url: str) -> Optional[RobotFileParser]:
+        # Reuse the original scheme — if the user gave us https://, we ask
+        # https://host/robots.txt; same for http.
+        from urllib.parse import urlparse
+
+        scheme = urlparse(sample_url).scheme or "https"
+        robots_url = f"{scheme}://{host}/robots.txt"
+        try:
+            resp = await self._client.get(
+                robots_url,
+                follow_redirects=True,
+                timeout=PER_PAGE_TIMEOUT_SECONDS,
+            )
+            if resp.status_code >= 400:
+                return None
+            parser = RobotFileParser()
+            parser.parse(resp.text.splitlines())
+            return parser
+        except (httpx.HTTPError, ValueError) as e:
+            logger.info("robots.txt unreachable for %s (%s); allowing all", host, e)
+            return None
+
+
+# ── HTML extraction ──────────────────────────────────────────────────────────
+
+
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+def _extract_title(html: str) -> Optional[str]:
+    match = _TITLE_RE.search(html)
+    if not match:
+        return None
+    title = match.group(1).strip()
+    title = re.sub(r"\s+", " ", title)
+    return title or None
+
+
+def _extract_links(html: str, base_url: str) -> List[Tuple[str, str]]:
+    """Return (normalized, raw) tuples for every absolute http(s) link in the page."""
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as e:  # pragma: no cover - dep is in pyproject
+        logger.error("beautifulsoup4 is required for web crawling: %s", e)
+        return []
+
+    soup = BeautifulSoup(html, "html.parser")
+    out: List[Tuple[str, str]] = []
+    seen: Set[str] = set()
+    for anchor in soup.find_all("a", href=True):
+        link = anchor.get("href")
+        if not link:
+            continue
+        resolved = absolute_url(base_url, link)
+        if resolved is None:
+            continue
+        normalized, raw = resolved
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append((normalized, raw))
+    return out
+
+
+def _extract_markdown(html: str, url: str) -> Tuple[str, Optional[str]]:
+    """Return (markdown, title). Falls back to BS4 text extraction if trafilatura
+    is unavailable or returns nothing.
+    """
+    title = _extract_title(html)
+    text: Optional[str] = None
+    try:
+        import trafilatura
+
+        text = trafilatura.extract(
+            html,
+            url=url,
+            output_format="markdown",
+            include_links=False,
+            include_images=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    except ImportError:
+        logger.debug("trafilatura unavailable, falling back to BS4 text extraction")
+    if not text:
+        try:
+            from bs4 import BeautifulSoup
+
+            soup = BeautifulSoup(html, "html.parser")
+            for tag in soup(["script", "style", "noscript"]):
+                tag.decompose()
+            text = soup.get_text(separator="\n").strip()
+        except ImportError:
+            text = ""
+    if title:
+        return f"# {title}\n\n{text or ''}\n", title
+    return (text or "") + "\n", None
+
+
+# ── Per-host delay scheduler ────────────────────────────────────────────────
+
+
+class _HostDelay:
+    """Per-host jittered delay between fetches.
+
+    Tracks the next-allowed-fetch timestamp for each host and sleeps until
+    then before yielding. Combined with the global concurrency semaphore
+    this gives us "up to N in flight overall, but no more than 1 per host
+    per (min..max) seconds" — the polite default.
+    """
+
+    def __init__(self, settings: CrawlSettings) -> None:
+        self._settings = settings
+        self._next_ok: Dict[str, float] = defaultdict(float)
+        self._lock = asyncio.Lock()
+
+    async def wait_for(self, url: str) -> None:
+        host = host_of(url) or ""
+        async with self._lock:
+            now = time.monotonic()
+            wait_until = self._next_ok[host]
+            sleep_for = max(0.0, wait_until - now)
+            jitter = random.uniform(
+                self._settings.min_delay_seconds, self._settings.max_delay_seconds
+            )
+            self._next_ok[host] = max(now, wait_until) + jitter
+        if sleep_for > 0:
+            await asyncio.sleep(sleep_for)
+
+
+# ── Fetch ────────────────────────────────────────────────────────────────────
+
+
+async def _fetch_page(
+    client: httpx.AsyncClient, url: str
+) -> Tuple[str, Optional[str]]:
+    """Fetch a single page. Returns (html, etag). Raises on non-2xx or non-HTML."""
+    resp = await client.get(
+        url, follow_redirects=True, timeout=PER_PAGE_TIMEOUT_SECONDS
+    )
+    resp.raise_for_status()
+    content_type = (resp.headers.get("content-type") or "").lower()
+    if not any(
+        ct in content_type for ct in ("text/html", "application/xhtml", "text/plain")
+    ):
+        raise ValueError(
+            f"Unsupported content-type for crawl: {content_type or 'unknown'}"
+        )
+    content = resp.content
+    if len(content) > MAX_RESPONSE_BYTES:
+        raise ValueError(
+            f"Response too large: {len(content)} bytes (max {MAX_RESPONSE_BYTES})"
+        )
+    # Use httpx's encoding inference; surface bytes as text for parsing.
+    html = resp.text
+    return html, resp.headers.get("etag")
+
+
+# ── S3 stage ────────────────────────────────────────────────────────────────
+
+
+async def _put_markdown(
+    *, assistant_id: str, document_id: str, markdown: str, filename: str
+) -> str:
+    """PUT extracted markdown into the documents bucket. Returns the final S3 key.
+
+    Triggers the existing S3-event ingestion Lambda which drives the doc
+    through chunking/embedding — exactly like a device upload.
+    """
+    from apis.app_api.documents.services.storage_service import _get_documents_bucket
+
+    import boto3
+
+    sanitized = _sanitize_filename(filename)
+    s3_key = _get_s3_key(assistant_id, document_id, sanitized)
+    loop = asyncio.get_event_loop()
+    s3_client = boto3.client("s3")
+    bucket = _get_documents_bucket()
+    body = markdown.encode("utf-8")
+    await loop.run_in_executor(
+        None,
+        lambda: s3_client.put_object(
+            Bucket=bucket,
+            Key=s3_key,
+            Body=body,
+            ContentType="text/markdown",
+        ),
+    )
+    return s3_key
+
+
+# ── Public entry point ──────────────────────────────────────────────────────
+
+
+async def run_crawl(
+    *,
+    assistant_id: str,
+    crawl_id: str,
+    user_id: str,
+    root_url: str,
+    settings: CrawlSettings,
+    root_document_id: str,
+    http_client_factory: Optional[
+        Callable[[], httpx.AsyncClient]
+    ] = None,
+    on_progress: Optional[Callable[[str], Awaitable[None]]] = None,
+) -> None:
+    """Run a BFS crawl, staging each fetched page as a Document.
+
+    `root_document_id` was already created synchronously by the route, so
+    the crawler reuses it for the root URL and only creates new records for
+    pages it discovers later. Never raises.
+
+    The two injection points (`http_client_factory`, `on_progress`) exist
+    purely to make unit testing tractable — production passes neither.
+    """
+
+    logger.info(
+        "Crawl %s starting (assistant=%s root=%s depth=%d max_pages=%d concurrency=%d)",
+        crawl_id,
+        assistant_id,
+        root_url,
+        settings.max_depth,
+        settings.max_pages,
+        settings.concurrency,
+    )
+
+    async def _run() -> None:
+        creator = _DocumentCreator(
+            assistant_id=assistant_id,
+            user_id=user_id,
+            already_recorded={normalize_url(root_url): root_document_id},
+        )
+        await increment_counters(
+            assistant_id=assistant_id,
+            crawl_id=crawl_id,
+            discovered_delta=1,
+        )
+
+        visited: Set[str] = set()
+        frontier: asyncio.Queue[Tuple[str, int]] = asyncio.Queue()
+        await frontier.put((normalize_url(root_url), 0))
+        visited.add(normalize_url(root_url))
+
+        semaphore = asyncio.Semaphore(settings.concurrency)
+        delay = _HostDelay(settings)
+        # Hold a strong reference to every worker task so the event loop's
+        # weak-task tracking can't GC them mid-execution (Python docs
+        # explicitly warn about this for asyncio.create_task without a
+        # held reference).
+        worker_tasks: Set[asyncio.Task] = set()
+        async with (http_client_factory or _default_client)() as client:
+            robots = _RobotsCache(client)
+            in_flight = 0
+            done_event = asyncio.Event()
+            done_event.set()  # starts "done" until we launch the first task
+
+            async def worker(url: str, depth: int) -> None:
+                nonlocal in_flight
+                try:
+                    if not await robots.allows(url):
+                        logger.info("robots.txt disallows %s; skipping", url)
+                        # No document was created for non-root URLs yet, so
+                        # nothing to mark failed. The root URL is the
+                        # exception — if the user pointed at a disallowed
+                        # root, the route already created a doc; mark it
+                        # failed below.
+                        if url == normalize_url(root_url):
+                            await update_document_status(
+                                assistant_id=assistant_id,
+                                document_id=root_document_id,
+                                status="failed",
+                                error_message="The site's robots.txt disallows crawling this URL.",
+                            )
+                            await increment_counters(
+                                assistant_id=assistant_id,
+                                crawl_id=crawl_id,
+                                failed_delta=1,
+                            )
+                        return
+                    await delay.wait_for(url)
+                    document_id = await creator.get_or_create(url)
+                    logger.info("Crawl %s fetching %s (depth=%d)", crawl_id, url, depth)
+                    try:
+                        html, etag = await _fetch_page(client, url)
+                    except Exception as fetch_err:
+                        logger.warning("Fetch failed for %s: %s", url, fetch_err)
+                        await update_document_status(
+                            assistant_id=assistant_id,
+                            document_id=document_id,
+                            status="failed",
+                            error_message="The page could not be fetched.",
+                            error_details=str(fetch_err)[:500],
+                        )
+                        await increment_counters(
+                            assistant_id=assistant_id,
+                            crawl_id=crawl_id,
+                            failed_delta=1,
+                        )
+                        return
+
+                    markdown, title = _extract_markdown(html, url)
+                    if not markdown.strip():
+                        await update_document_status(
+                            assistant_id=assistant_id,
+                            document_id=document_id,
+                            status="failed",
+                            error_message="The page had no extractable content.",
+                        )
+                        await increment_counters(
+                            assistant_id=assistant_id,
+                            crawl_id=crawl_id,
+                            failed_delta=1,
+                        )
+                        return
+                    display_name = (
+                        title or url_extension_hint(url)
+                    ).strip() or "page"
+                    filename = f"{display_name}.md"
+                    logger.info(
+                        "Crawl %s staging %s -> s3 (%d bytes markdown)",
+                        crawl_id,
+                        url,
+                        len(markdown.encode("utf-8")),
+                    )
+                    s3_key = await _put_markdown(
+                        assistant_id=assistant_id,
+                        document_id=document_id,
+                        markdown=markdown,
+                        filename=filename,
+                    )
+                    await update_document_import_metadata(
+                        assistant_id=assistant_id,
+                        document_id=document_id,
+                        filename=filename,
+                        content_type="text/markdown",
+                        size_bytes=len(markdown.encode("utf-8")),
+                        s3_key=s3_key,
+                        source_etag=etag,
+                    )
+                    logger.info(
+                        "Crawl %s wrote %s to s3 (key=%s); ingestion Lambda will take over",
+                        crawl_id,
+                        url,
+                        s3_key,
+                    )
+                    await increment_counters(
+                        assistant_id=assistant_id,
+                        crawl_id=crawl_id,
+                        fetched_delta=1,
+                    )
+                    if on_progress is not None:
+                        await on_progress(url)
+
+                    if depth < settings.max_depth:
+                        for normalized, _raw in _extract_links(html, url):
+                            if normalized in visited:
+                                continue
+                            if len(visited) >= settings.max_pages:
+                                break
+                            if settings.same_domain_only and not same_registrable_domain(
+                                normalized, root_url
+                            ):
+                                continue
+                            try:
+                                assert_url_is_public(normalized, resolve=False)
+                            except Exception:
+                                continue
+                            visited.add(normalized)
+                            await increment_counters(
+                                assistant_id=assistant_id,
+                                crawl_id=crawl_id,
+                                discovered_delta=1,
+                            )
+                            await frontier.put((normalized, depth + 1))
+                finally:
+                    in_flight -= 1
+                    if in_flight == 0 and frontier.empty():
+                        done_event.set()
+
+            async def scheduler() -> None:
+                nonlocal in_flight
+                while True:
+                    if frontier.empty():
+                        if in_flight == 0:
+                            return
+                        await asyncio.sleep(0.05)
+                        continue
+                    url, depth = await frontier.get()
+                    await semaphore.acquire()
+                    in_flight += 1
+                    done_event.clear()
+
+                    async def _wrapped(u: str = url, d: int = depth) -> None:
+                        try:
+                            await worker(u, d)
+                        finally:
+                            semaphore.release()
+
+                    task = asyncio.create_task(_wrapped())
+                    worker_tasks.add(task)
+                    task.add_done_callback(worker_tasks.discard)
+
+            await scheduler()
+            await done_event.wait()
+
+    error: Optional[str] = None
+    status: str = "complete"
+    try:
+        await asyncio.wait_for(_run(), timeout=CRAWL_BUDGET_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning("Crawl %s exceeded budget; marking failed", crawl_id)
+        error = "Crawl exceeded the time budget."
+        status = "failed"
+    except Exception as e:
+        logger.exception("Crawl %s failed: %s", crawl_id, e)
+        error = str(e)[:500]
+        status = "failed"
+    finally:
+        logger.info("Crawl %s finalizing with status=%s", crawl_id, status)
+        await finalize_crawl(
+            assistant_id=assistant_id,
+            crawl_id=crawl_id,
+            status=status,  # type: ignore[arg-type]
+            error=error,
+        )
+
+
+def _default_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        headers={"User-Agent": USER_AGENT, "Accept": ACCEPT_HEADER},
+        timeout=PER_PAGE_TIMEOUT_SECONDS,
+    )
+
+
+# Silence unused-import lint for mimetypes; it's reserved for filename hints
+# in future cases (e.g. `.txt` URLs) and stays here for parity with the
+# documents pipeline.
+_ = mimetypes

--- a/backend/src/apis/app_api/web_sources/models.py
+++ b/backend/src/apis/app_api/web_sources/models.py
@@ -1,0 +1,106 @@
+"""Pydantic models for the web-crawl ingestion API.
+
+`CrawlSettings` is the single source of truth for the legal ranges of every
+knob — the same ranges drive the SPA's sliders, so changing a bound here is
+the only edit needed. The route validates incoming requests against these
+bounds before any I/O.
+
+`CrawlJob` mirrors the DynamoDB row 1:1 — see `crawl_repository.py`. It's
+returned to the SPA so the editor can show progress and stop its watcher
+loop when the job leaves `running`.
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from apis.app_api.documents.models import DocumentResponse
+
+CrawlJobStatus = Literal["running", "complete", "failed"]
+
+
+class CrawlSettings(BaseModel):
+    """Tunable bounds for a single crawl job.
+
+    Defaults are deliberately polite: depth 2 / 25 pages / 2 concurrent
+    fetches / 1–3 s jitter. The hard caps protect both us and the target
+    site — wider knobs would need a per-host rate-limit story we don't have
+    yet.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    max_depth: int = Field(2, alias="maxDepth", ge=0, le=3)
+    max_pages: int = Field(25, alias="maxPages", ge=1, le=100)
+    concurrency: int = Field(2, ge=1, le=5)
+    min_delay_seconds: float = Field(1.0, alias="minDelay", ge=0.0, le=5.0)
+    max_delay_seconds: float = Field(3.0, alias="maxDelay", ge=0.0, le=10.0)
+    same_domain_only: bool = Field(True, alias="sameDomainOnly")
+
+    @model_validator(mode="after")
+    def _delay_ordering(self) -> "CrawlSettings":
+        if self.max_delay_seconds < self.min_delay_seconds:
+            raise ValueError("maxDelay must be >= minDelay")
+        return self
+
+
+class StartCrawlRequest(BaseModel):
+    """Request body for `POST /assistants/{id}/web-sources/crawl`.
+
+    When `settings` is None the server applies `CrawlSettings()` defaults —
+    the SPA does the same so the single-page case can send `{ url }` only.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    url: str = Field(..., min_length=1, max_length=2048)
+    settings: Optional[CrawlSettings] = None
+
+
+class CrawlJob(BaseModel):
+    """A web-crawl job persisted as one DynamoDB row alongside the assistant.
+
+    Stored at `PK=AST#{assistant_id}, SK=CRAWL#{crawl_id}` so the editor's
+    list-active-crawls query (`SK begins_with CRAWL#`) is cheap.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    crawl_id: str = Field(..., alias="crawlId")
+    assistant_id: str = Field(..., alias="assistantId")
+    root_url: str = Field(..., alias="rootUrl")
+    status: CrawlJobStatus
+    settings: CrawlSettings
+    discovered_count: int = Field(0, alias="discoveredCount", ge=0)
+    fetched_count: int = Field(0, alias="fetchedCount", ge=0)
+    failed_count: int = Field(0, alias="failedCount", ge=0)
+    started_at: str = Field(..., alias="startedAt")
+    completed_at: Optional[str] = Field(None, alias="completedAt")
+    started_by_user_id: str = Field(..., alias="startedByUserId")
+    error: Optional[str] = None
+
+
+class StartCrawlResponse(BaseModel):
+    """Returned synchronously from the crawl-start endpoint.
+
+    Includes the freshly-created root `Document` so the SPA can render and
+    poll it like a connector import; `crawl` lets the editor's watcher loop
+    know a crawl is in flight.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    crawl: CrawlJob
+    documents: List[DocumentResponse]
+
+
+class ActiveCrawlsResponse(BaseModel):
+    """List of crawls currently `running` for an assistant.
+
+    The editor polls this every few seconds while it has any web-imported
+    document still in a processing state, then stops once the list is empty.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    crawls: List[CrawlJob]

--- a/backend/src/apis/app_api/web_sources/routes.py
+++ b/backend/src/apis/app_api/web_sources/routes.py
@@ -1,0 +1,199 @@
+"""User-facing web-source endpoints.
+
+`POST /assistants/{id}/web-sources/crawl` validates the URL, pre-creates the
+root `Document` so the SPA has a row to render and poll, persists a
+`CrawlJob` row, and fires the BFS crawler as a background task. The endpoint
+returns 202 with the root document and the job — exactly mirroring the
+shape the SPA already handles for connector imports.
+
+The two GETs (`/crawls`, `/crawls/{id}`) drive the editor's "still
+crawling" watcher: the SPA polls active crawls every few seconds and
+refreshes its document list, then stops once nothing is `running`.
+"""
+
+import asyncio
+import logging
+from typing import Set
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from apis.app_api.documents.models import (
+    DocumentProvenance,
+    DocumentResponse,
+)
+from apis.app_api.documents.services.document_service import (
+    _generate_document_id,
+    create_document,
+)
+from apis.app_api.documents.services.storage_service import (
+    _get_s3_key,
+    _sanitize_filename,
+)
+from apis.app_api.web_sources.crawl_repository import (
+    create_crawl_job,
+    get_crawl_job,
+    list_active_crawls,
+)
+from apis.app_api.web_sources.crawler import run_crawl
+from apis.app_api.web_sources.models import (
+    ActiveCrawlsResponse,
+    CrawlJob,
+    CrawlSettings,
+    StartCrawlRequest,
+    StartCrawlResponse,
+)
+from apis.app_api.web_sources.url_utils import (
+    InvalidUrlError,
+    assert_url_is_public,
+    url_extension_hint,
+)
+from apis.shared.assistants.service import get_assistant
+from apis.shared.auth import User, get_current_user_from_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/assistants/{assistant_id}/web-sources", tags=["web-sources"]
+)
+
+# Strong refs to in-flight crawl tasks. Python's event loop tracks tasks
+# with weak references, so a bare `asyncio.ensure_future(run_crawl(...))`
+# can be garbage-collected mid-execution — leaving the root document
+# stuck in 'uploading' forever. Holding the Task in a module-level set
+# (and discarding on completion) is the documented workaround.
+_BACKGROUND_CRAWLS: Set[asyncio.Task] = set()
+
+
+@router.post(
+    "/crawl",
+    response_model=StartCrawlResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def start_crawl(
+    assistant_id: str,
+    request: StartCrawlRequest,
+    current_user: User = Depends(get_current_user_from_session),
+) -> StartCrawlResponse:
+    """Kick off a web crawl rooted at `request.url` for an assistant.
+
+    Single-page imports (the default toggle in the SPA) are just a crawl
+    with `max_depth=0` — the BFS visits only the root and terminates. The
+    same async pipeline is used either way so there is no separate code
+    path to keep in sync.
+    """
+    assistant = await get_assistant(assistant_id, current_user.user_id)
+    if not assistant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assistant not found: {assistant_id}",
+        )
+
+    try:
+        normalized = assert_url_is_public(request.url)
+    except InvalidUrlError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        )
+
+    settings = request.settings or CrawlSettings()
+
+    document_id = _generate_document_id()
+    provisional_filename = f"{_sanitize_filename(url_extension_hint(normalized))}.html"
+    s3_key = _get_s3_key(assistant_id, document_id, provisional_filename)
+    root_document = await create_document(
+        assistant_id=assistant_id,
+        filename=provisional_filename,
+        content_type="text/html",
+        size_bytes=0,
+        s3_key=s3_key,
+        document_id=document_id,
+        provenance=DocumentProvenance(
+            source_connector_id="web",
+            source_adapter_key="http",
+            source_file_id=normalized,
+            imported_by_user_id=current_user.user_id,
+        ),
+    )
+
+    job = await create_crawl_job(
+        assistant_id=assistant_id,
+        root_url=normalized,
+        settings=settings,
+        started_by_user_id=current_user.user_id,
+    )
+
+    task = asyncio.create_task(
+        run_crawl(
+            assistant_id=assistant_id,
+            crawl_id=job.crawl_id,
+            user_id=current_user.user_id,
+            root_url=normalized,
+            settings=settings,
+            root_document_id=document_id,
+        )
+    )
+    _BACKGROUND_CRAWLS.add(task)
+    task.add_done_callback(_BACKGROUND_CRAWLS.discard)
+    logger.info(
+        "Kicked off crawl %s for assistant %s (root_document=%s url=%s)",
+        job.crawl_id,
+        assistant_id,
+        document_id,
+        normalized,
+    )
+
+    return StartCrawlResponse(
+        crawl=job,
+        documents=[
+            DocumentResponse.model_validate(root_document.model_dump(by_alias=True))
+        ],
+    )
+
+
+@router.get("/crawls", response_model=ActiveCrawlsResponse)
+async def list_crawls(
+    assistant_id: str,
+    active: bool = Query(False, description="Return only `running` jobs"),
+    current_user: User = Depends(get_current_user_from_session),
+) -> ActiveCrawlsResponse:
+    """List crawl jobs for an assistant.
+
+    `?active=true` is the only filter currently honored — drives the SPA's
+    "should I keep polling for new docs" decision.
+    """
+    assistant = await get_assistant(assistant_id, current_user.user_id)
+    if not assistant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assistant not found: {assistant_id}",
+        )
+    if active:
+        crawls = await list_active_crawls(assistant_id)
+    else:
+        # The full-history view is reserved for a future "crawl history"
+        # panel; for now we return active only when asked and an empty list
+        # otherwise to keep the contract small.
+        crawls = await list_active_crawls(assistant_id)
+    return ActiveCrawlsResponse(crawls=crawls)
+
+
+@router.get("/crawls/{crawl_id}", response_model=CrawlJob)
+async def get_crawl(
+    assistant_id: str,
+    crawl_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> CrawlJob:
+    """Return a single crawl's current status + counters."""
+    assistant = await get_assistant(assistant_id, current_user.user_id)
+    if not assistant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assistant not found: {assistant_id}",
+        )
+    job = await get_crawl_job(assistant_id, crawl_id)
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Crawl not found: {crawl_id}",
+        )
+    return job

--- a/backend/src/apis/app_api/web_sources/url_utils.py
+++ b/backend/src/apis/app_api/web_sources/url_utils.py
@@ -1,0 +1,180 @@
+"""URL normalization, same-domain comparison, and SSRF guards.
+
+Kept in one module so the route validator and the crawler share the exact
+same logic — divergence between "is this URL safe to start a crawl from?"
+and "is this discovered link safe to follow?" is how SSRF holes get reborn.
+"""
+
+import ipaddress
+import socket
+from typing import Iterable, Optional, Tuple
+from urllib.parse import urlparse, urlunparse
+
+
+class InvalidUrlError(ValueError):
+    """The supplied string is not a URL we will fetch."""
+
+
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+
+def normalize_url(url: str) -> str:
+    """Lower-case scheme + host, drop fragment, collapse default ports.
+
+    Used as the dedupe key inside a crawl and as the `source_file_id` on
+    each document — different casings of the same URL must map to the same
+    record.
+    """
+    parsed = urlparse(url.strip())
+    if not parsed.scheme or not parsed.netloc:
+        raise InvalidUrlError("URL must include a scheme and host")
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise InvalidUrlError(f"Unsupported URL scheme: {scheme}")
+    netloc = parsed.netloc.lower()
+    # Strip the default port for the scheme — http://x.com:80 == http://x.com
+    if (scheme == "http" and netloc.endswith(":80")) or (
+        scheme == "https" and netloc.endswith(":443")
+    ):
+        netloc = netloc.rsplit(":", 1)[0]
+    path = parsed.path or "/"
+    return urlunparse((scheme, netloc, path, parsed.params, parsed.query, ""))
+
+
+def host_of(url: str) -> Optional[str]:
+    """Return the lower-case host of a URL, or None if it can't be parsed."""
+    try:
+        parsed = urlparse(url)
+        return parsed.hostname.lower() if parsed.hostname else None
+    except (ValueError, AttributeError):
+        return None
+
+
+def same_registrable_domain(a: str, b: str) -> bool:
+    """True when `a` and `b` share a registrable domain.
+
+    Uses a coarse last-two-labels heuristic — fine for the common cases
+    (`docs.example.com` vs `example.com`) and avoids a `tldextract`
+    dependency. Edge cases like `.co.uk` are treated as different domains
+    than `.example.co.uk`; that's the safe direction (we'll under-crawl
+    rather than wander off-site).
+    """
+    ha = host_of(a)
+    hb = host_of(b)
+    if not ha or not hb:
+        return False
+    if ha == hb:
+        return True
+    parts_a = ha.split(".")
+    parts_b = hb.split(".")
+    if len(parts_a) < 2 or len(parts_b) < 2:
+        return False
+    return parts_a[-2:] == parts_b[-2:]
+
+
+def _resolve_addresses(host: str) -> Iterable[ipaddress._BaseAddress]:
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return []
+    addrs = []
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        try:
+            addrs.append(ipaddress.ip_address(sockaddr[0]))
+        except ValueError:
+            continue
+    return addrs
+
+
+def assert_url_is_public(url: str, *, resolve: bool = True) -> str:
+    """Validate the URL and refuse to fetch internal/loopback/link-local targets.
+
+    SSRF guard. Returns the normalized URL on success. When `resolve` is
+    True (default), every resolved A/AAAA address must be a public address;
+    this catches DNS rebinding setups where the hostname looks innocuous
+    but resolves to an internal IP. Tests can pass `resolve=False` to skip
+    the DNS step.
+
+    Raises:
+        InvalidUrlError: bad scheme, missing host, or a private/loopback
+            address.
+    """
+    normalized = normalize_url(url)
+    host = host_of(normalized)
+    if not host:
+        raise InvalidUrlError("URL must include a host")
+
+    # Direct IP literal in the URL — check it without DNS.
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None:
+        if _is_blocked(literal_ip):
+            raise InvalidUrlError(
+                "URL resolves to a non-public address; refusing to fetch."
+            )
+        return normalized
+
+    if not resolve:
+        return normalized
+
+    addrs = list(_resolve_addresses(host))
+    if not addrs:
+        raise InvalidUrlError(f"Could not resolve host: {host}")
+    for addr in addrs:
+        if _is_blocked(addr):
+            raise InvalidUrlError(
+                "URL resolves to a non-public address; refusing to fetch."
+            )
+    return normalized
+
+
+def _is_blocked(addr: ipaddress._BaseAddress) -> bool:
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    )
+
+
+def url_extension_hint(url: str) -> str:
+    """Return a filename hint extracted from a URL's path.
+
+    Used to derive the document's display name when the page lacks a
+    `<title>`. Always returns *something* non-empty so the SPA's document
+    row is never blank.
+    """
+    parsed = urlparse(url)
+    segments = [s for s in parsed.path.split("/") if s]
+    if segments:
+        return segments[-1]
+    return parsed.netloc or "page"
+
+
+def absolute_url(base: str, link: str) -> Optional[Tuple[str, str]]:
+    """Resolve a link relative to `base` and normalize it.
+
+    Returns (normalized_url, raw_resolved) or None when the link is not
+    http(s) after resolution. Fragments and javascript:/mailto: links are
+    stripped before validation.
+    """
+    from urllib.parse import urljoin
+
+    if not link:
+        return None
+    link = link.strip()
+    if not link or link.startswith(("javascript:", "mailto:", "tel:", "#")):
+        return None
+    resolved = urljoin(base, link)
+    try:
+        normalized = normalize_url(resolved)
+    except InvalidUrlError:
+        return None
+    return normalized, resolved

--- a/backend/tests/apis/app_api/web_sources/test_crawl_repository.py
+++ b/backend/tests/apis/app_api/web_sources/test_crawl_repository.py
@@ -1,0 +1,364 @@
+"""moto-backed tests for the CrawlJob persistence layer.
+
+`test_routes.py` mocks `create_crawl_job` to keep the HTTP-surface tests
+fast and pure. That left no coverage for the DynamoDB write itself —
+which actually hit a runtime `TypeError: Float types are not supported`
+on the very first manual smoke test, because `CrawlSettings` carries
+float delay knobs and DynamoDB rejects bare Python floats.
+
+These tests pin the contract: put → get → list survive a settings dict
+with floats, and `Decimal` round-trips back into the Pydantic model as
+float seamlessly.
+"""
+
+from __future__ import annotations
+
+import time
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.web_sources import crawl_repository
+from apis.app_api.web_sources.models import CrawlSettings
+
+
+TABLE = "test-assistants-table"
+REGION = "us-east-1"
+ASSISTANT_ID = "ast-001"
+USER_ID = "user-001"
+
+
+@pytest.fixture
+def ddb(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+        client = boto3.client("dynamodb", region_name=REGION)
+        client.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+@pytest.mark.asyncio
+async def test_create_crawl_job_writes_floats_as_decimals(ddb) -> None:
+    """Regression: putting CrawlSettings with float delays must not raise."""
+    settings = CrawlSettings(
+        maxDepth=2,
+        maxPages=25,
+        concurrency=2,
+        minDelay=1.5,  # float
+        maxDelay=3.5,  # float
+        sameDomainOnly=True,
+    )
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=settings,
+        started_by_user_id=USER_ID,
+    )
+    assert job.status == "running"
+    assert job.settings.min_delay_seconds == 1.5
+    assert job.settings.max_delay_seconds == 3.5
+
+    # Round-trip the row back as a Pydantic model.
+    refetched = await crawl_repository.get_crawl_job(ASSISTANT_ID, job.crawl_id)
+    assert refetched is not None
+    assert refetched.crawl_id == job.crawl_id
+    assert refetched.settings.min_delay_seconds == 1.5
+    assert refetched.settings.max_delay_seconds == 3.5
+
+
+@pytest.mark.asyncio
+async def test_list_active_crawls_returns_only_running(ddb) -> None:
+    """Filter expression must pin to status='running' only."""
+    settings = CrawlSettings()
+    running = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/r",
+        settings=settings,
+        started_by_user_id=USER_ID,
+    )
+    done = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/d",
+        settings=settings,
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=done.crawl_id,
+        status="complete",
+    )
+    active = await crawl_repository.list_active_crawls(ASSISTANT_ID)
+    active_ids = {c.crawl_id for c in active}
+    assert running.crawl_id in active_ids
+    assert done.crawl_id not in active_ids
+
+
+@pytest.mark.asyncio
+async def test_list_active_crawls_reaps_stale_running_rows(ddb) -> None:
+    """Self-healing: a `running` row older than the crawler budget must be
+    auto-finalized and excluded from the active list. Otherwise the SPA's
+    crawl-watcher polls forever on a dead row owned by a crashed process.
+    """
+    # Create a fresh running crawl, then back-date its `startedAt` to before
+    # the staleness threshold so the reaper triggers.
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    stale_started = "2020-01-01T00:00:00Z"  # well past _STALE_RUNNING_SECONDS
+    ddb.update_item(
+        Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"CRAWL#{job.crawl_id}"},
+        UpdateExpression="SET startedAt = :s",
+        ExpressionAttributeValues={":s": stale_started},
+    )
+
+    # First call reaps the stale row and returns []; subsequent call confirms
+    # the row was actually finalized (not just hidden in-memory).
+    first = await crawl_repository.list_active_crawls(ASSISTANT_ID)
+    assert first == [], "stale running row should be excluded from active list"
+
+    second = await crawl_repository.list_active_crawls(ASSISTANT_ID)
+    assert second == [], "reaped row must stay reaped on subsequent reads"
+
+    refetched = await crawl_repository.get_crawl_job(ASSISTANT_ID, job.crawl_id)
+    assert refetched is not None
+    assert refetched.status == "failed"
+    assert refetched.error is not None
+    assert "interrupted" in refetched.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_increment_counters_bumps_atomically(ddb) -> None:
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.increment_counters(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=job.crawl_id,
+        discovered_delta=3,
+        fetched_delta=2,
+        failed_delta=1,
+    )
+    await crawl_repository.increment_counters(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=job.crawl_id,
+        fetched_delta=4,
+    )
+    refetched = await crawl_repository.get_crawl_job(ASSISTANT_ID, job.crawl_id)
+    assert refetched is not None
+    assert refetched.discovered_count == 3
+    assert refetched.fetched_count == 6
+    assert refetched.failed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_finalize_writes_status_and_error(ddb) -> None:
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=job.crawl_id,
+        status="failed",
+        error="boom",
+    )
+    refetched = await crawl_repository.get_crawl_job(ASSISTANT_ID, job.crawl_id)
+    assert refetched is not None
+    assert refetched.status == "failed"
+    assert refetched.error == "boom"
+    assert refetched.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_finalize_writes_ttl_as_future_epoch_seconds(ddb) -> None:
+    """`finalize_crawl` must set a `ttl` epoch-seconds attribute the table's reaper can honor.
+
+    Regression guard: DynamoDB silently ignores millisecond-precision TTL
+    values, so the assertion bounds also enforce that the value is in
+    seconds (~now + 30 days), not milliseconds (~13-digit).
+    """
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    before = int(time.time())
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=job.crawl_id,
+        status="complete",
+    )
+    after = int(time.time())
+
+    # Read the raw item so we see the on-disk `ttl` attribute directly
+    # (the Pydantic model doesn't surface it).
+    response = ddb.get_item(
+        Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"CRAWL#{job.crawl_id}"}
+    )
+    item = response.get("Item")
+    assert item is not None, "finalize_crawl should have left the row in place"
+    assert "ttl" in item, "finalize_crawl must set the `ttl` attribute"
+
+    ttl_value = int(item["ttl"])  # DynamoDB returns Decimal — coerce
+    thirty_days_seconds = 30 * 86400
+    assert before + thirty_days_seconds - 5 <= ttl_value <= after + thirty_days_seconds + 5
+
+    # Belt-and-suspenders: a millisecond-precision value would be ~13 digits.
+    # Seconds-precision sits around 10 digits well into the 2030s.
+    assert ttl_value < 10**12, (
+        f"ttl={ttl_value} looks like milliseconds — DynamoDB TTL ignores those"
+    )
+
+
+# =========================================================================
+# Cascade-delete: last-web-doc removal cleans up the CrawlJob row
+# =========================================================================
+
+
+def _put_web_doc(ddb, *, document_id: str, source_file_id: str, status: str = "complete") -> None:
+    """Write a minimal `web` DOC row for cascade tests.
+
+    Only the fields the cascade reads (`sourceConnectorId`, `sourceFileId`,
+    `status`) need to be present; everything else is irrelevant here.
+    """
+    ddb.put_item(
+        Item={
+            "PK": f"AST#{ASSISTANT_ID}",
+            "SK": f"DOC#{document_id}",
+            "documentId": document_id,
+            "assistantId": ASSISTANT_ID,
+            "sourceConnectorId": "web",
+            "sourceFileId": source_file_id,
+            "status": status,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_cascade_deletes_crawl_when_last_web_doc_removed(ddb) -> None:
+    """Removing the sole surviving web doc for a finalized crawl should drop the CrawlJob row."""
+    from apis.app_api.documents.services.cleanup_service import (
+        _cascade_delete_orphaned_crawl_jobs,
+    )
+
+    root_url = "https://example.com/docs/"
+    crawl = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url=root_url,
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=crawl.crawl_id,
+        status="complete",
+    )
+
+    # No DOC rows remain referencing the root URL → the crawl is orphaned.
+    await _cascade_delete_orphaned_crawl_jobs(ASSISTANT_ID)
+
+    assert await crawl_repository.get_crawl_job(ASSISTANT_ID, crawl.crawl_id) is None
+
+
+@pytest.mark.asyncio
+async def test_cascade_keeps_crawl_when_other_web_docs_remain(ddb) -> None:
+    """A finalized crawl with at least one surviving web doc must stay put."""
+    from apis.app_api.documents.services.cleanup_service import (
+        _cascade_delete_orphaned_crawl_jobs,
+    )
+
+    root_url = "https://example.com/docs/"
+    crawl = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url=root_url,
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=crawl.crawl_id,
+        status="complete",
+    )
+    _put_web_doc(
+        ddb,
+        document_id="DOC-survivor",
+        source_file_id=f"{root_url}page-2",
+    )
+
+    await _cascade_delete_orphaned_crawl_jobs(ASSISTANT_ID)
+
+    assert await crawl_repository.get_crawl_job(ASSISTANT_ID, crawl.crawl_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_cascade_ignores_soft_deleted_docs(ddb) -> None:
+    """Docs still in `deleting` status are gone for cascade purposes — the cleanup task
+    is mid-flight and will hard-delete them shortly."""
+    from apis.app_api.documents.services.cleanup_service import (
+        _cascade_delete_orphaned_crawl_jobs,
+    )
+
+    root_url = "https://example.com/docs/"
+    crawl = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url=root_url,
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=crawl.crawl_id,
+        status="complete",
+    )
+    _put_web_doc(
+        ddb,
+        document_id="DOC-zombie",
+        source_file_id=f"{root_url}page-3",
+        status="deleting",
+    )
+
+    await _cascade_delete_orphaned_crawl_jobs(ASSISTANT_ID)
+
+    assert await crawl_repository.get_crawl_job(ASSISTANT_ID, crawl.crawl_id) is None
+
+
+@pytest.mark.asyncio
+async def test_cascade_leaves_running_crawl_alone(ddb) -> None:
+    """A `running` crawl is still spawning child docs — never reap it here."""
+    from apis.app_api.documents.services.cleanup_service import (
+        _cascade_delete_orphaned_crawl_jobs,
+    )
+
+    crawl = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    # Deliberately do not finalize — status stays `running`.
+
+    await _cascade_delete_orphaned_crawl_jobs(ASSISTANT_ID)
+
+    assert await crawl_repository.get_crawl_job(ASSISTANT_ID, crawl.crawl_id) is not None

--- a/backend/tests/apis/app_api/web_sources/test_crawler.py
+++ b/backend/tests/apis/app_api/web_sources/test_crawler.py
@@ -1,0 +1,464 @@
+"""Crawler tests with httpx routed through an in-process MockTransport.
+
+We pin every external dependency the crawler reaches for:
+- httpx fetches → MockTransport returning canned HTML
+- create_document / update_document_* / update_document_status →
+  in-memory recorder (avoids DynamoDB)
+- S3 PUT → no-op stub
+- crawl_repository.* counters / finalize → in-memory recorder
+- asyncio.sleep → monkeypatched to a no-op so jitter delays don't slow
+  the suite
+
+This lets us assert: BFS visits the right URLs, robots.txt is honored,
+max_pages / max_depth / same_domain_only gates work, per-page failures
+mark the doc failed without aborting the crawl, and the job is always
+finalized.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Tuple
+
+import httpx
+import pytest
+
+from apis.app_api.web_sources import crawl_repository, crawler
+from apis.app_api.web_sources.crawler import run_crawl
+from apis.app_api.web_sources.models import CrawlSettings
+
+
+# ── Recorders ──────────────────────────────────────────────────────────────
+
+
+class _Recorder:
+    """Captures every side-effect the crawler attempts so tests can assert."""
+
+    def __init__(self) -> None:
+        self.created_docs: List[Tuple[str, str]] = []  # (document_id, source_url)
+        self.status_updates: List[Tuple[str, str]] = []  # (document_id, status)
+        self.metadata_updates: List[str] = []  # document_id list
+        self.s3_puts: List[Tuple[str, bytes]] = []  # (s3_key, body)
+        self.discovered_delta = 0
+        self.fetched_delta = 0
+        self.failed_delta = 0
+        self.finalized_status: str | None = None
+        self.finalized_error: str | None = None
+        self._doc_counter = 0
+        self.preassigned_root_id = "DOC-root00000001"
+
+    def next_doc_id(self) -> str:
+        self._doc_counter += 1
+        return f"DOC-doc{self._doc_counter:09d}"
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    rec = _Recorder()
+
+    async def fake_create_document(
+        *,
+        assistant_id: str,
+        filename: str,
+        content_type: str,
+        size_bytes: int,
+        s3_key: str,
+        document_id: str | None = None,
+        provenance=None,
+    ):
+        document_id = document_id or rec.next_doc_id()
+        rec.created_docs.append(
+            (document_id, provenance.source_file_id if provenance else "")
+        )
+
+        class _Stub:
+            pass
+
+        stub = _Stub()
+        stub.document_id = document_id
+        return stub
+
+    async def fake_update_status(
+        *,
+        assistant_id: str,
+        document_id: str,
+        status: str,
+        error_message: str | None = None,
+        error_details: str | None = None,
+        vector_store_id: str | None = None,
+        chunk_count: int | None = None,
+        table_name: str | None = None,
+    ):
+        rec.status_updates.append((document_id, status))
+        return None
+
+    async def fake_update_metadata(
+        assistant_id: str,
+        document_id: str,
+        *,
+        filename: str,
+        content_type: str,
+        size_bytes: int,
+        s3_key: str,
+        source_etag: str | None = None,
+    ):
+        rec.metadata_updates.append(document_id)
+        return None
+
+    counter = {"n": 0}
+
+    def fake_generate_document_id() -> str:
+        counter["n"] += 1
+        return f"DOC-gen{counter['n']:09d}"
+
+    async def fake_put_markdown(
+        *, assistant_id: str, document_id: str, markdown: str, filename: str
+    ) -> str:
+        key = f"assistants/{assistant_id}/documents/{document_id}/{filename}"
+        rec.s3_puts.append((key, markdown.encode("utf-8")))
+        return key
+
+    async def fake_increment(
+        *,
+        assistant_id: str,
+        crawl_id: str,
+        discovered_delta: int = 0,
+        fetched_delta: int = 0,
+        failed_delta: int = 0,
+    ):
+        rec.discovered_delta += discovered_delta
+        rec.fetched_delta += fetched_delta
+        rec.failed_delta += failed_delta
+
+    async def fake_finalize(
+        *, assistant_id: str, crawl_id: str, status: str, error: str | None = None
+    ):
+        rec.finalized_status = status
+        rec.finalized_error = error
+
+    # Crawler module reaches via the import names it owns. Patch each one
+    # on the crawler module so the BFS reroutes uniformly.
+    monkeypatch.setattr(crawler, "create_document", fake_create_document)
+    monkeypatch.setattr(crawler, "update_document_status", fake_update_status)
+    monkeypatch.setattr(crawler, "update_document_import_metadata", fake_update_metadata)
+    monkeypatch.setattr(crawler, "_put_markdown", fake_put_markdown)
+    monkeypatch.setattr(crawler, "increment_counters", fake_increment)
+    monkeypatch.setattr(crawler, "finalize_crawl", fake_finalize)
+    # _create_pending_document calls _generate_document_id, which lives in
+    # the documents service module; patch the symbol the crawler closes over.
+    monkeypatch.setattr(
+        "apis.app_api.documents.services.document_service._generate_document_id",
+        fake_generate_document_id,
+    )
+
+    # Skip all delays — tests must complete in milliseconds, not seconds.
+    real_sleep = asyncio.sleep
+
+    async def no_sleep(seconds: float = 0):
+        # Keep zero-second yields for cooperative scheduling.
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    return rec
+
+
+# ── Transport helpers ──────────────────────────────────────────────────────
+
+
+def _build_handler(pages: Dict[str, str], status_codes: Dict[str, int] | None = None):
+    """Return a `httpx.MockTransport` handler that serves canned pages.
+
+    Missing URLs return 404. robots.txt defaults to "all allowed" unless
+    a `pages` entry overrides it.
+    """
+    status_codes = status_codes or {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/robots.txt") and url not in pages:
+            return httpx.Response(404, text="")
+        if url in pages:
+            code = status_codes.get(url, 200)
+            return httpx.Response(
+                code,
+                text=pages[url],
+                headers={"content-type": "text/html; charset=utf-8"},
+            )
+        return httpx.Response(404, text="not found")
+
+    return _handler
+
+
+def _client_factory(handler):
+    def _factory():
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    return _factory
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_page_crawl_writes_one_doc(recorder: _Recorder):
+    pages = {
+        "https://example.com/": "<html><head><title>Home</title></head><body><p>hi</p></body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=0, max_pages=1),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.finalized_status == "complete"
+    # Root document was created by the route (not by the crawler), so no
+    # new doc records here. One S3 PUT for the root.
+    assert recorder.created_docs == []
+    assert len(recorder.s3_puts) == 1
+    assert recorder.fetched_delta == 1
+    assert recorder.failed_delta == 0
+
+
+@pytest.mark.asyncio
+async def test_bfs_follows_links_within_depth(recorder: _Recorder):
+    pages = {
+        "https://example.com/": (
+            "<html><head><title>Home</title></head><body>"
+            '<a href="/a">A</a><a href="/b">B</a>'
+            "</body></html>"
+        ),
+        "https://example.com/a": "<html><head><title>A</title></head><body>a</body></html>",
+        "https://example.com/b": "<html><head><title>B</title></head><body>b</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=1, max_pages=10, concurrency=2),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.finalized_status == "complete"
+    assert recorder.fetched_delta == 3  # root + 2 children
+    assert recorder.failed_delta == 0
+    fetched_urls = {url for _, url in recorder.created_docs}
+    assert fetched_urls == {"https://example.com/a", "https://example.com/b"}
+
+
+@pytest.mark.asyncio
+async def test_max_depth_zero_skips_links(recorder: _Recorder):
+    pages = {
+        "https://example.com/": (
+            "<html><body><a href='/a'>A</a></body></html>"
+        ),
+        "https://example.com/a": "<html><body>a</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=0, max_pages=10),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.fetched_delta == 1
+    assert recorder.created_docs == []  # no children created
+
+
+@pytest.mark.asyncio
+async def test_max_pages_caps_visits(recorder: _Recorder):
+    # Root links to 5 pages, max_pages=3 → root + 2 children.
+    pages = {
+        "https://example.com/": (
+            "<html><body>"
+            + "".join(f'<a href="/{i}">{i}</a>' for i in range(5))
+            + "</body></html>"
+        ),
+        **{
+            f"https://example.com/{i}": f"<html><body>{i}</body></html>"
+            for i in range(5)
+        },
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=1, max_pages=3),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.fetched_delta == 3
+
+
+@pytest.mark.asyncio
+async def test_same_domain_filter_drops_external_links(recorder: _Recorder):
+    pages = {
+        "https://example.com/": (
+            "<html><body>"
+            '<a href="https://example.com/keep">k</a>'
+            '<a href="https://other.com/drop">d</a>'
+            "</body></html>"
+        ),
+        "https://example.com/keep": "<html><body>keep</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(
+            max_depth=1, max_pages=10, same_domain_only=True
+        ),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.fetched_delta == 2
+    fetched_urls = {url for _, url in recorder.created_docs}
+    assert fetched_urls == {"https://example.com/keep"}
+
+
+@pytest.mark.asyncio
+async def test_per_page_404_marks_doc_failed_but_continues(recorder: _Recorder):
+    pages = {
+        "https://example.com/": (
+            "<html><body>"
+            '<a href="/missing">m</a><a href="/ok">o</a>'
+            "</body></html>"
+        ),
+        "https://example.com/ok": "<html><body>ok</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=1, max_pages=10),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    assert recorder.finalized_status == "complete"
+    # Root + ok succeed; /missing fails.
+    assert recorder.fetched_delta == 2
+    assert recorder.failed_delta == 1
+    statuses = {doc_id: st for doc_id, st in recorder.status_updates}
+    assert "failed" in statuses.values()
+
+
+@pytest.mark.asyncio
+async def test_robots_disallow_skips_url(recorder: _Recorder):
+    pages = {
+        "https://example.com/robots.txt": "User-agent: *\nDisallow: /private",
+        "https://example.com/": (
+            "<html><body>"
+            '<a href="/private">p</a><a href="/public">u</a>'
+            "</body></html>"
+        ),
+        "https://example.com/public": "<html><body>public</body></html>",
+        "https://example.com/private": "<html><body>private</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=1, max_pages=10),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    fetched_urls = {url for _, url in recorder.created_docs}
+    assert "https://example.com/private" not in fetched_urls
+    # No doc was ever created for /private, so failed_delta stays at 0
+    assert recorder.failed_delta == 0
+
+
+@pytest.mark.asyncio
+async def test_robots_disallow_root_fails_pre_created_doc(recorder: _Recorder):
+    pages = {
+        "https://example.com/robots.txt": "User-agent: *\nDisallow: /",
+        "https://example.com/": "<html><body>nope</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=0, max_pages=1),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    # Root doc was disallowed → status update should mark it failed.
+    statuses = {doc_id: st for doc_id, st in recorder.status_updates}
+    assert statuses.get(recorder.preassigned_root_id) == "failed"
+    assert recorder.failed_delta == 1
+
+
+@pytest.mark.asyncio
+async def test_finalize_runs_on_exception(monkeypatch: pytest.MonkeyPatch):
+    """Even if the inner loop crashes, the CrawlJob must not stay 'running'."""
+    finalized: List[str] = []
+
+    async def fake_finalize(*, assistant_id, crawl_id, status, error=None):
+        finalized.append(status)
+
+    async def fake_increment(**kwargs):
+        return None
+
+    real_sleep = asyncio.sleep
+
+    async def no_sleep(*_a, **_kw):
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(crawler, "finalize_crawl", fake_finalize)
+    monkeypatch.setattr(crawler, "increment_counters", fake_increment)
+
+    async def fake_create(**kwargs):  # never called — we explode first
+        raise RuntimeError("boom from create_document")
+
+    monkeypatch.setattr(crawler, "create_document", fake_create)
+
+    # Force the inner loop to raise: pass a client factory that raises
+    # on instantiation.
+    def explode_factory():
+        raise RuntimeError("transport explode")
+
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        root_document_id="DOC-root",
+        http_client_factory=explode_factory,
+    )
+    assert finalized == ["failed"]
+
+
+@pytest.mark.asyncio
+async def test_visited_dedupes_repeated_links(recorder: _Recorder):
+    pages = {
+        "https://example.com/": (
+            "<html><body>"
+            '<a href="/a">a1</a><a href="/a">a2</a><a href="/a#frag">a3</a>'
+            "</body></html>"
+        ),
+        "https://example.com/a": "<html><body>a</body></html>",
+    }
+    await run_crawl(
+        assistant_id="ast-1",
+        crawl_id="CRAWL-1",
+        user_id="user-1",
+        root_url="https://example.com/",
+        settings=CrawlSettings(max_depth=1, max_pages=10),
+        root_document_id=recorder.preassigned_root_id,
+        http_client_factory=_client_factory(_build_handler(pages)),
+    )
+    # Only one extra doc despite three duplicate <a>'s.
+    assert len(recorder.created_docs) == 1

--- a/backend/tests/apis/app_api/web_sources/test_routes.py
+++ b/backend/tests/apis/app_api/web_sources/test_routes.py
@@ -1,0 +1,232 @@
+"""HTTP-surface tests for the web-source routes.
+
+These are intentionally narrow: they assert validation, auth, and the
+shape of the 202 response. The crawler itself is exercised in
+`test_crawler.py`. We patch `asyncio.ensure_future` so the route's
+background task is never actually scheduled.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.documents.models import Document
+from apis.app_api.web_sources import routes as web_routes
+from apis.app_api.web_sources.models import CrawlJob, CrawlSettings
+from apis.shared.auth.models import User
+from apis.shared.auth.dependencies import get_current_user_from_session
+from tests.routes.conftest import mock_auth_user, mock_no_auth
+
+
+ASSISTANT_ID = "ast-1"
+USER_ID = "user-1"
+
+
+def _user() -> User:
+    return User(
+        email="u@example.com",
+        user_id=USER_ID,
+        name="U",
+        roles=["User"],
+    )
+
+
+def _stub_document(document_id: str = "DOC-root00000001") -> Document:
+    return Document.model_validate(
+        {
+            "documentId": document_id,
+            "assistantId": ASSISTANT_ID,
+            "filename": "page.html",
+            "contentType": "text/html",
+            "sizeBytes": 0,
+            "s3Key": f"assistants/{ASSISTANT_ID}/documents/{document_id}/page.html",
+            "status": "uploading",
+            "createdAt": "2026-05-23T00:00:00Z",
+            "updatedAt": "2026-05-23T00:00:00Z",
+        }
+    )
+
+
+def _stub_crawl(crawl_id: str = "CRAWL-1") -> CrawlJob:
+    return CrawlJob(
+        crawlId=crawl_id,
+        assistantId=ASSISTANT_ID,
+        rootUrl="https://example.com/",
+        status="running",
+        settings=CrawlSettings(),
+        discoveredCount=0,
+        fetchedCount=0,
+        failedCount=0,
+        startedAt="2026-05-23T00:00:00Z",
+        startedByUserId=USER_ID,
+    )
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    _app = FastAPI()
+    _app.include_router(web_routes.router)
+    return _app
+
+
+class TestStartCrawl:
+    def test_returns_202_with_root_document_and_crawl(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        doc = _stub_document()
+        crawl = _stub_crawl()
+        run_crawl_mock = AsyncMock(return_value=None)
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            "apis.app_api.web_sources.routes.create_document",
+            new_callable=AsyncMock,
+            return_value=doc,
+        ), patch(
+            "apis.app_api.web_sources.routes.create_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.run_crawl", run_crawl_mock,
+        ), patch(
+            "apis.app_api.web_sources.routes.assert_url_is_public",
+            return_value="https://example.com/",
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={"url": "https://example.com/"},
+            )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["crawl"]["crawlId"] == "CRAWL-1"
+        assert body["crawl"]["status"] == "running"
+        assert len(body["documents"]) == 1
+        assert body["documents"][0]["documentId"] == "DOC-root00000001"
+        # The route fired run_crawl as a strong-ref'd background task; the
+        # mock returned immediately so the coroutine completes without
+        # exercising the real crawler.
+        run_crawl_mock.assert_called_once()
+
+    def test_returns_404_when_assistant_not_owned(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={"url": "https://example.com/"},
+            )
+        assert resp.status_code == 404
+
+    def test_returns_422_on_invalid_url(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ):
+            client = TestClient(app)
+            # Loopback URL → SSRF guard rejects it.
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={"url": "http://127.0.0.1/admin"},
+            )
+        assert resp.status_code == 422
+
+    def test_returns_422_on_bad_settings_bounds(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ):
+            client = TestClient(app)
+            # max_pages above the cap
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={
+                    "url": "https://example.com/",
+                    "settings": {"maxPages": 9999},
+                },
+            )
+        assert resp.status_code == 422
+
+    def test_returns_401_unauthenticated(self, app: FastAPI):
+        mock_no_auth(app)
+        client = TestClient(app)
+        resp = client.post(
+            f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+            json={"url": "https://example.com/"},
+        )
+        assert resp.status_code == 401
+
+
+class TestListActiveCrawls:
+    def test_returns_active_jobs(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            "apis.app_api.web_sources.routes.list_active_crawls",
+            new_callable=AsyncMock,
+            return_value=[crawl],
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls",
+                params={"active": "true"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["crawls"]) == 1
+        assert body["crawls"][0]["crawlId"] == "CRAWL-1"
+
+
+class TestGetCrawl:
+    def test_returns_single_crawl(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 200
+        assert resp.json()["crawlId"] == "CRAWL-1"
+
+    def test_returns_404_when_missing(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-X"
+            )
+        assert resp.status_code == 404

--- a/backend/tests/apis/app_api/web_sources/test_url_utils.py
+++ b/backend/tests/apis/app_api/web_sources/test_url_utils.py
@@ -1,0 +1,153 @@
+"""Pure unit tests for the URL helpers shared by the route and the crawler.
+
+The crawler dedupes by normalized URL and gates outgoing fetches by the
+SSRF guards in this module — so divergence between request-time validation
+and discovery-time validation is exactly the failure mode these tests
+exist to prevent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apis.app_api.web_sources.url_utils import (
+    InvalidUrlError,
+    absolute_url,
+    assert_url_is_public,
+    host_of,
+    normalize_url,
+    same_registrable_domain,
+    url_extension_hint,
+)
+
+
+class TestNormalizeUrl:
+    def test_lowercases_scheme_and_host(self):
+        assert normalize_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+    def test_drops_fragment(self):
+        assert normalize_url("https://x.com/p#section") == "https://x.com/p"
+
+    def test_strips_default_port_http(self):
+        assert normalize_url("http://x.com:80/p") == "http://x.com/p"
+
+    def test_strips_default_port_https(self):
+        assert normalize_url("https://x.com:443/p") == "https://x.com/p"
+
+    def test_preserves_non_default_port(self):
+        assert normalize_url("http://x.com:8080/p") == "http://x.com:8080/p"
+
+    def test_preserves_query(self):
+        assert normalize_url("https://x.com/p?a=1&b=2") == "https://x.com/p?a=1&b=2"
+
+    def test_supplies_root_path_when_missing(self):
+        assert normalize_url("https://x.com") == "https://x.com/"
+
+    def test_rejects_non_http_schemes(self):
+        with pytest.raises(InvalidUrlError):
+            normalize_url("ftp://x.com/p")
+        with pytest.raises(InvalidUrlError):
+            normalize_url("javascript:alert(1)")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(InvalidUrlError):
+            normalize_url("https:///path")
+
+
+class TestSameRegistrableDomain:
+    def test_identical_hosts(self):
+        assert same_registrable_domain(
+            "https://example.com/a", "https://example.com/b"
+        )
+
+    def test_subdomain_matches_apex(self):
+        assert same_registrable_domain(
+            "https://docs.example.com/a", "https://example.com/b"
+        )
+
+    def test_different_apex(self):
+        assert not same_registrable_domain(
+            "https://example.com/a", "https://other.com/b"
+        )
+
+    def test_handles_unparseable(self):
+        assert not same_registrable_domain("not-a-url", "https://example.com")
+
+
+class TestSsrfGuard:
+    def test_accepts_ip_literal_public(self):
+        assert (
+            assert_url_is_public("http://1.1.1.1/path", resolve=False)
+            == "http://1.1.1.1/path"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/",
+            "http://10.0.0.5/",
+            "http://192.168.1.10/",
+            "http://169.254.169.254/latest/meta-data/",  # AWS IMDS
+            "http://[::1]/",
+            "http://[fe80::1]/",
+        ],
+    )
+    def test_rejects_internal_ip_literals(self, url: str):
+        with pytest.raises(InvalidUrlError):
+            assert_url_is_public(url, resolve=False)
+
+    def test_rejects_bad_scheme(self):
+        with pytest.raises(InvalidUrlError):
+            assert_url_is_public("ftp://example.com/")
+
+    def test_resolve_false_skips_dns_check(self):
+        # A non-existent host would normally fail at DNS; resolve=False
+        # short-circuits that.
+        assert assert_url_is_public(
+            "https://definitely-not-a-real-host.example/", resolve=False
+        )
+
+    def test_resolve_true_rejects_unresolvable_host(self):
+        with pytest.raises(InvalidUrlError):
+            assert_url_is_public(
+                "https://definitely-not-a-real-host.example.invalid/", resolve=True
+            )
+
+
+class TestAbsoluteUrl:
+    def test_relative_resolution(self):
+        result = absolute_url("https://example.com/a/", "b/c")
+        assert result is not None
+        normalized, raw = result
+        assert normalized == "https://example.com/a/b/c"
+
+    def test_absolute_link_kept(self):
+        result = absolute_url("https://example.com/", "https://other.com/x")
+        assert result is not None
+        assert result[0] == "https://other.com/x"
+
+    def test_javascript_filtered(self):
+        assert absolute_url("https://x.com/", "javascript:alert(1)") is None
+
+    def test_mailto_filtered(self):
+        assert absolute_url("https://x.com/", "mailto:a@b.com") is None
+
+    def test_empty_filtered(self):
+        assert absolute_url("https://x.com/", "") is None
+        assert absolute_url("https://x.com/", "#section") is None
+
+
+class TestUrlExtensionHint:
+    def test_extracts_last_path_segment(self):
+        assert url_extension_hint("https://x.com/a/b/article") == "article"
+
+    def test_falls_back_to_host(self):
+        assert url_extension_hint("https://x.com/") == "x.com"
+
+
+class TestHostOf:
+    def test_lowercases(self):
+        assert host_of("https://Example.COM/path") == "example.com"
+
+    def test_handles_unparseable(self):
+        assert host_of("not a url") is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -18,6 +18,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "authlib" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cachetools" },
     { name = "cryptography" },
@@ -29,6 +30,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "starlette" },
+    { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -84,6 +86,7 @@ requires-dist = [
     { name = "aiohttp", specifier = "==3.13.5" },
     { name = "authlib", specifier = "==1.7.0" },
     { name = "aws-opentelemetry-distro", marker = "extra == 'agentcore'", specifier = "==0.17.0" },
+    { name = "beautifulsoup4", specifier = "==4.13.5" },
     { name = "bedrock-agentcore", marker = "extra == 'agentcore'", specifier = "==1.9.1" },
     { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
     { name = "boto3", specifier = "==1.43.9" },
@@ -111,6 +114,7 @@ requires-dist = [
     { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.40.0" },
     { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.5.2" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
+    { name = "trafilatura", specifier = "==2.0.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260409" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
 ]
@@ -492,6 +496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -502,15 +515,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
 ]
 
 [[package]]
@@ -831,6 +844,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ca/6a667ccbe649856dcd3458bab80b016681b274399d6211187c6ab969fc50/courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be", size = 33848, upload-time = "2024-10-29T16:40:18.325Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,6 +1033,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
     { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
     { url = "https://files.pythonhosted.org/packages/ab/9c/51f28c3550276bcf35660703ba0ab829a90b88be8cd98a71ef23c2413913/cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8", size = 3698916, upload-time = "2026-04-24T19:54:49.782Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -1317,6 +1359,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/adfcdaaad5805c0c5156aeefd64c1e868c05e9c1cd6fd21751f168cd88c7/htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c", size = 31558, upload-time = "2025-11-04T17:46:43.258Z" },
 ]
 
 [[package]]
@@ -1691,6 +1749,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1773,6 +1843,141 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
+    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload-time = "2026-05-20T12:17:52.215Z" },
 ]
 
 [[package]]
@@ -3806,6 +4011,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -4522,6 +4736,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4588,6 +4811,24 @@ wheels = [
 ]
 
 [[package]]
+name = "trafilatura"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
+]
+
+[[package]]
 name = "types-aiofiles"
 version = "25.1.0.20260409"
 source = { registry = "https://pypi.org/simple" }
@@ -4624,6 +4865,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -252,6 +252,27 @@
                 Upload Assistant Documents
               </label>
 
+              <!-- Add web content — single page or bounded crawl -->
+              <div class="mt-2">
+                <p class="mb-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                  Fetch from the web
+                  @if (webCrawlActive()) {
+                    <span class="ml-2 inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-2 py-0.5 text-xs/4 font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                      <span class="size-1.5 animate-pulse rounded-full bg-blue-500"></span>
+                      Crawling…
+                    </span>
+                  }
+                </p>
+                <button
+                  type="button"
+                  (click)="openWebSourceDialog()"
+                  class="inline-flex items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <ng-icon name="heroGlobeAlt" class="size-4 shrink-0 text-gray-400" aria-hidden="true" />
+                  Add web content
+                </button>
+              </div>
+
               <!-- Import from a connector — one button per available file source -->
               @if (fileSources().length > 0) {
                 <div class="mt-2">
@@ -431,7 +452,6 @@
                       <button
                         type="button"
                         (click)="deleteDocument(doc.documentId)"
-                        [disabled]="pollingDocuments().has(doc.documentId) && (doc.status === 'uploading' || doc.status === 'chunking' || doc.status === 'embedding')"
                         title="Delete document"
                         [attr.aria-label]="'Delete ' + doc.filename"
                         class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
@@ -28,6 +28,7 @@ import {
   heroArrowPath,
   heroChevronRight,
   heroFaceSmile,
+  heroGlobeAlt,
   heroLink,
   heroXMark,
   heroUserGroup,
@@ -47,7 +48,12 @@ import {
   FileSourceBrowserDialogComponent,
   FileSourceBrowserDialogData,
 } from '../components/file-source-browser-dialog.component';
+import {
+  WebSourceDialogComponent,
+  WebSourceDialogData,
+} from '../components/web-source-dialog.component';
 import { FileSourceService } from '../services/file-source.service';
+import { WebSourceService } from '../services/web-source.service';
 import { FileSourceConnector } from '../models/file-source.model';
 import { UserConnectorsService } from '../../settings/connectors/services/user-connectors.service';
 import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
@@ -73,6 +79,7 @@ import { ToastService } from '../../services/toast/toast.service';
       heroArrowPath,
       heroChevronRight,
       heroFaceSmile,
+      heroGlobeAlt,
       heroLink,
       heroXMark,
       heroUserGroup,
@@ -88,6 +95,7 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   private assistantService = inject(AssistantService);
   private documentService = inject(DocumentService);
   private fileSourceService = inject(FileSourceService);
+  private webSourceService = inject(WebSourceService);
   private readonly connectorsService = inject(UserConnectorsService);
   private readonly consentService = inject(OAuthConsentService);
   readonly sidenavService = inject(SidenavService);
@@ -130,6 +138,14 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   /** Provider whose consent popup is in flight from an editor connector button. */
   readonly connectingProviderId = signal<string | null>(null);
   readonly connectPhase = signal<'initiating' | 'awaiting' | null>(null);
+
+  /**
+   * True while a web crawl is running for this assistant. Drives a small
+   * "crawling…" badge in the Knowledge section so the user knows pages will
+   * keep appearing for a while after the dialog closes.
+   */
+  readonly webCrawlActive = signal<boolean>(false);
+  private crawlWatcherHandle: ReturnType<typeof setInterval> | null = null;
 
   /**
    * True once at least one document exists, is uploading, or is still
@@ -250,6 +266,7 @@ export class AssistantFormPage implements OnInit, OnDestroy {
     // Show sidenav when leaving the form page
     this.sidenavService.show();
     this.formSub?.unsubscribe();
+    this.stopCrawlWatcher();
   }
 
   async loadAssistant(id: string): Promise<void> {
@@ -566,6 +583,126 @@ export class AssistantFormPage implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Open the web-source dialog so the user can attach a URL (single page or
+   * a bounded crawl). Mirrors {@link openFileSourceBrowser} — ensures a
+   * draft assistant exists, opens the dialog, then on close merges the
+   * pre-created root document into the list and starts the crawl watcher
+   * so additional pages surface as the crawler discovers them.
+   */
+  async openWebSourceDialog(): Promise<void> {
+    let assistantId = this.assistantId();
+    if (!assistantId) {
+      try {
+        assistantId = await this.createDraftAssistant();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to create assistant';
+        this.toast.error(message);
+        return;
+      }
+    }
+
+    const dialogRef = this.dialog.open<Document[] | undefined, WebSourceDialogData>(
+      WebSourceDialogComponent,
+      {
+        data: { assistantId },
+        hasBackdrop: false,
+      },
+    );
+
+    const imported = await firstValueFrom(dialogRef.closed);
+    if (imported && imported.length > 0) {
+      this.toast.success('Crawling web content…');
+      await this.loadDocuments();
+      this.startCrawlWatcher();
+    }
+  }
+
+  /**
+   * Poll active crawls for this assistant every few seconds. While any are
+   * `running` we surface newly-discovered pages via {@link discoverNewDocuments}
+   * — an *incremental* merge that appends only the new rows. The full list
+   * is not replaced, so unchanged rows keep their references and per-doc
+   * polling drives status updates without a list-wide flicker. Stops itself
+   * once the server reports no active crawls.
+   */
+  private startCrawlWatcher(): void {
+    this.webCrawlActive.set(true);
+    this.stopCrawlWatcher();
+    const tick = async (): Promise<void> => {
+      const assistantId = this.assistantId();
+      if (!assistantId) {
+        this.stopCrawlWatcher();
+        return;
+      }
+      try {
+        const active = await this.webSourceService.listActiveCrawls(assistantId);
+        if (active.length === 0) {
+          this.webCrawlActive.set(false);
+          this.stopCrawlWatcher();
+          // Catch any pages that completed in the gap between the previous
+          // tick and the server reporting "no crawls running" — still
+          // incremental, so no list-wide refresh.
+          await this.discoverNewDocuments();
+          return;
+        }
+        await this.discoverNewDocuments();
+      } catch {
+        // Network blip — keep polling; the watcher is non-critical.
+      }
+    };
+    this.crawlWatcherHandle = setInterval(() => void tick(), 5000);
+  }
+
+  private stopCrawlWatcher(): void {
+    if (this.crawlWatcherHandle !== null) {
+      clearInterval(this.crawlWatcherHandle);
+      this.crawlWatcherHandle = null;
+    }
+  }
+
+  /**
+   * Fetch the assistant's documents and append only the IDs we don't already
+   * have to the local list — does NOT replace existing rows. Each new
+   * processing doc gets its own per-doc polling started so its status
+   * updates flow into the list one row at a time, no list-wide refresh.
+   *
+   * Used by the crawl watcher: a crawl discovers pages over its lifetime,
+   * and we want each new page to slide into the list when it appears
+   * without re-rendering rows that already exist.
+   */
+  private async discoverNewDocuments(): Promise<void> {
+    const assistantId = this.assistantId();
+    if (!assistantId) {
+      return;
+    }
+    try {
+      const response = await this.documentService.listDocuments(assistantId);
+      const existing = new Set(
+        this.uploadedDocuments().map((doc) => doc.documentId),
+      );
+      const newDocs = response.documents.filter(
+        (doc) => !existing.has(doc.documentId),
+      );
+      if (newDocs.length === 0) {
+        return;
+      }
+      this.uploadedDocuments.update((docs) => [...docs, ...newDocs]);
+      for (const doc of newDocs) {
+        if (
+          PROCESSING_STATUSES.includes(doc.status) &&
+          !this.isDocumentStale(doc) &&
+          !this.pollingDocuments().has(doc.documentId)
+        ) {
+          this.startPollingDocument(doc.documentId, assistantId);
+        }
+      }
+    } catch (error) {
+      console.error('Error discovering new documents:', error);
+    }
+  }
+
   async uploadDocument(file: File, assistantId: string): Promise<void> {
     // Set initial upload state
     this.currentUpload.set({
@@ -688,13 +825,33 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       return;
     }
 
+    // Optimistic UI: drop the row immediately so the click feels instant
+    // instead of waiting on the DELETE + full document-list reload (a couple
+    // seconds round-trip). Soft-delete is idempotent and almost always
+    // succeeds for a doc the user owns and is currently looking at; on the
+    // rare failure we restore the row and toast.
+    const previousDocs = this.uploadedDocuments();
+    if (!previousDocs.some((doc) => doc.documentId === documentId)) {
+      return;
+    }
+    this.uploadedDocuments.update((docs) =>
+      docs.filter((doc) => doc.documentId !== documentId),
+    );
+    // Drop from the polling set too so the row's spinner indicator doesn't
+    // briefly reappear on the next poll tick before the GET 404s.
+    this.pollingDocuments.update((set) => {
+      const newSet = new Set(set);
+      newSet.delete(documentId);
+      return newSet;
+    });
+
     try {
       await this.documentService.deleteDocument(assistantId, documentId);
-      // Reload documents list
-      await this.loadDocuments();
     } catch (error) {
-      console.error('Error deleting document:', error);
-      // TODO: Show error message to user
+      this.uploadedDocuments.set(previousDocs);
+      const message =
+        error instanceof Error ? error.message : 'Failed to delete document.';
+      this.toast.error(message);
     }
   }
 

--- a/frontend/ai.client/src/app/assistants/components/web-source-dialog.component.html
+++ b/frontend/ai.client/src/app/assistants/components/web-source-dialog.component.html
@@ -1,0 +1,229 @@
+<!-- Backdrop -->
+<div
+  class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+  aria-hidden="true"
+  (click)="cancel()"
+></div>
+
+<!-- Centering wrapper -->
+<div class="fixed inset-0 z-10 flex min-h-full items-center justify-center p-4">
+  <div
+    class="dialog-panel relative flex max-h-[85vh] w-full max-w-xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="web-src-title"
+    (click)="$event.stopPropagation()"
+  >
+    <div class="flex items-center justify-between gap-4 border-b border-gray-200 px-5 py-4 dark:border-gray-700">
+      <div class="flex items-center gap-2">
+        <ng-icon name="heroGlobeAlt" class="size-5 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+        <h2 id="web-src-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+          Add web content
+        </h2>
+      </div>
+      <button
+        type="button"
+        (click)="cancel()"
+        aria-label="Close"
+        class="-mr-1 rounded-2xl p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+      >
+        <ng-icon name="heroXMark" class="size-5" />
+      </button>
+    </div>
+
+    <div class="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-4">
+      <!-- URL -->
+      <div>
+        <label for="web-src-url" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+          Page URL
+        </label>
+        <input
+          id="web-src-url"
+          type="url"
+          autocomplete="off"
+          spellcheck="false"
+          inputmode="url"
+          placeholder="https://example.com/article"
+          [value]="url()"
+          (input)="onUrlInput($any($event.target).value)"
+          (keydown.enter)="submit()"
+          class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+        />
+        <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+          Public http or https URLs only. JavaScript-only sites may render as empty pages — only the HTML is fetched.
+        </p>
+      </div>
+
+      <!-- Crawl toggle -->
+      <div class="flex items-start gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-900/40">
+        <div class="flex h-6 shrink-0 items-center">
+          <input
+            id="web-src-crawl-toggle"
+            type="checkbox"
+            [checked]="crawlLinkedPages()"
+            (change)="setCrawlLinkedPages($any($event.target).checked)"
+            class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+          />
+        </div>
+        <div class="min-w-0">
+          <label for="web-src-crawl-toggle" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+            Crawl linked pages from this URL
+          </label>
+          <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+            Off by default — only the page above is fetched. Turn on to follow links within the same site.
+          </p>
+        </div>
+      </div>
+
+      <!-- Crawl knobs -->
+      @if (crawlLinkedPages()) {
+        <div class="space-y-4 rounded-2xl border border-gray-200 px-4 py-4 dark:border-gray-700">
+          <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Crawl limits
+          </p>
+
+          <!-- Max depth -->
+          <div>
+            <div class="flex items-center justify-between gap-3">
+              <label for="web-src-depth" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Max depth</label>
+              <span class="text-sm/6 tabular-nums text-gray-900 dark:text-white">{{ maxDepth() }}</span>
+            </div>
+            <input
+              id="web-src-depth"
+              type="range"
+              min="0"
+              max="3"
+              step="1"
+              [value]="maxDepth()"
+              (input)="setMaxDepth($any($event.target).value)"
+              class="mt-1 w-full accent-blue-600"
+            />
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              How many link hops from the start URL. 0 = single page, 3 = links of links of links.
+            </p>
+          </div>
+
+          <!-- Max pages -->
+          <div>
+            <div class="flex items-center justify-between gap-3">
+              <label for="web-src-pages" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Max pages</label>
+              <span class="text-sm/6 tabular-nums text-gray-900 dark:text-white">{{ maxPages() }}</span>
+            </div>
+            <input
+              id="web-src-pages"
+              type="range"
+              min="1"
+              max="100"
+              step="1"
+              [value]="maxPages()"
+              (input)="setMaxPages($any($event.target).value)"
+              class="mt-1 w-full accent-blue-600"
+            />
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              Hard cap. Crawl stops once this many pages have been queued.
+            </p>
+          </div>
+
+          <!-- Concurrency -->
+          <div>
+            <div class="flex items-center justify-between gap-3">
+              <label for="web-src-concurrency" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Concurrent fetches</label>
+              <span class="text-sm/6 tabular-nums text-gray-900 dark:text-white">{{ concurrency() }}</span>
+            </div>
+            <input
+              id="web-src-concurrency"
+              type="range"
+              min="1"
+              max="5"
+              step="1"
+              [value]="concurrency()"
+              (input)="setConcurrency($any($event.target).value)"
+              class="mt-1 w-full accent-blue-600"
+            />
+          </div>
+
+          <!-- Delay range -->
+          <div>
+            <div class="flex items-center justify-between gap-3">
+              <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Per-host delay</span>
+              <span class="text-sm/6 tabular-nums text-gray-900 dark:text-white">
+                {{ minDelay() }}s – {{ maxDelay() }}s
+              </span>
+            </div>
+            <div class="mt-1 grid grid-cols-2 gap-3">
+              <div>
+                <label for="web-src-min-delay" class="block text-xs/5 text-gray-500 dark:text-gray-400">Min</label>
+                <input
+                  id="web-src-min-delay"
+                  type="range"
+                  min="0"
+                  max="5"
+                  step="0.5"
+                  [value]="minDelay()"
+                  (input)="setMinDelay($any($event.target).value)"
+                  class="mt-1 w-full accent-blue-600"
+                />
+              </div>
+              <div>
+                <label for="web-src-max-delay" class="block text-xs/5 text-gray-500 dark:text-gray-400">Max</label>
+                <input
+                  id="web-src-max-delay"
+                  type="range"
+                  min="0"
+                  max="10"
+                  step="0.5"
+                  [value]="maxDelay()"
+                  (input)="setMaxDelay($any($event.target).value)"
+                  class="mt-1 w-full accent-blue-600"
+                />
+              </div>
+            </div>
+            @if (delayRangeInvalid()) {
+              <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">Max delay must be at least min delay.</p>
+            }
+            <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+              Random pause between requests to the same host. Politer is slower.
+            </p>
+          </div>
+
+          <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+            Crawl stays on the same domain and honors the site's robots.txt.
+          </p>
+        </div>
+      }
+
+      @if (error(); as msg) {
+        <div class="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+          <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-red-600 dark:text-red-400" aria-hidden="true" />
+          <p class="text-sm/6 text-red-700 dark:text-red-300">{{ msg }}</p>
+        </div>
+      }
+    </div>
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3 dark:border-gray-700">
+      <button
+        type="button"
+        (click)="cancel()"
+        class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        (click)="submit()"
+        [disabled]="!canSubmit() || delayRangeInvalid()"
+        class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-semibold text-white hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        @if (submitting()) {
+          <div class="size-4 shrink-0 animate-spin rounded-full border-2 border-white/40 border-t-white"></div>
+          Starting…
+        } @else if (crawlLinkedPages()) {
+          Start crawling
+        } @else {
+          Add page
+        }
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/ai.client/src/app/assistants/components/web-source-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/web-source-dialog.component.ts
@@ -1,0 +1,222 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { FormsModule } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroExclamationTriangle,
+  heroGlobeAlt,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+
+import { Document } from '../models/document.model';
+import {
+  CrawlSettings,
+  DEFAULT_CRAWL_SETTINGS,
+  SINGLE_PAGE_SETTINGS,
+} from '../models/web-source.model';
+import { WebSourceError, WebSourceService } from '../services/web-source.service';
+import { ToastService } from '../../services/toast/toast.service';
+
+/** Data passed in when the assistant editor opens the dialog. */
+export interface WebSourceDialogData {
+  assistantId: string;
+}
+
+/**
+ * Modal for adding web content to an assistant's knowledge base.
+ *
+ * Two modes share one panel:
+ *   - "Just this page" (default): URL only. Backend ingests the single page.
+ *   - "Crawl linked pages": reveals the depth / pages / concurrency / delay
+ *     sliders for a bounded BFS crawl.
+ *
+ * On submit the modal closes with the pre-created root `Document` so the
+ * editor can poll it like a device upload, then starts its watcher loop to
+ * surface additional pages as the crawler discovers them.
+ */
+@Component({
+  selector: 'app-web-source-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [
+    provideIcons({
+      heroExclamationTriangle,
+      heroGlobeAlt,
+      heroXMark,
+    }),
+  ],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'cancel()',
+  },
+  templateUrl: './web-source-dialog.component.html',
+  styles: `
+    @import 'tailwindcss';
+
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+
+    @keyframes backdrop-fade-in {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+
+    @keyframes dialog-fade-in-up {
+      from {
+        opacity: 0;
+        transform: translateY(1rem) scale(0.95);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+  `,
+})
+export class WebSourceDialogComponent {
+  private readonly dialogRef = inject<DialogRef<Document[]>>(DialogRef);
+  private readonly data = inject<WebSourceDialogData>(DIALOG_DATA);
+  private readonly webSourceService = inject(WebSourceService);
+  private readonly toast = inject(ToastService);
+
+  protected readonly url = signal<string>('');
+  protected readonly crawlLinkedPages = signal<boolean>(false);
+
+  protected readonly maxDepth = signal<number>(DEFAULT_CRAWL_SETTINGS.maxDepth);
+  protected readonly maxPages = signal<number>(DEFAULT_CRAWL_SETTINGS.maxPages);
+  protected readonly concurrency = signal<number>(
+    DEFAULT_CRAWL_SETTINGS.concurrency,
+  );
+  protected readonly minDelay = signal<number>(DEFAULT_CRAWL_SETTINGS.minDelay);
+  protected readonly maxDelay = signal<number>(DEFAULT_CRAWL_SETTINGS.maxDelay);
+
+  protected readonly submitting = signal<boolean>(false);
+  protected readonly error = signal<string | null>(null);
+
+  protected readonly trimmedUrl = computed(() => this.url().trim());
+  protected readonly urlIsValid = computed(() => {
+    const value = this.trimmedUrl();
+    if (!value) {
+      return false;
+    }
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  });
+
+  protected readonly canSubmit = computed(
+    () => this.urlIsValid() && !this.submitting(),
+  );
+
+  protected readonly delayRangeInvalid = computed(
+    () => this.maxDelay() < this.minDelay(),
+  );
+
+  protected onUrlInput(value: string): void {
+    this.url.set(value);
+    if (this.error()) {
+      this.error.set(null);
+    }
+  }
+
+  protected setCrawlLinkedPages(value: boolean): void {
+    this.crawlLinkedPages.set(value);
+  }
+
+  protected setMaxDepth(value: number | string): void {
+    this.maxDepth.set(this.toNumber(value, DEFAULT_CRAWL_SETTINGS.maxDepth));
+  }
+
+  protected setMaxPages(value: number | string): void {
+    this.maxPages.set(this.toNumber(value, DEFAULT_CRAWL_SETTINGS.maxPages));
+  }
+
+  protected setConcurrency(value: number | string): void {
+    this.concurrency.set(
+      this.toNumber(value, DEFAULT_CRAWL_SETTINGS.concurrency),
+    );
+  }
+
+  protected setMinDelay(value: number | string): void {
+    const v = this.toNumber(value, DEFAULT_CRAWL_SETTINGS.minDelay);
+    this.minDelay.set(v);
+    if (this.maxDelay() < v) {
+      this.maxDelay.set(v);
+    }
+  }
+
+  protected setMaxDelay(value: number | string): void {
+    this.maxDelay.set(this.toNumber(value, DEFAULT_CRAWL_SETTINGS.maxDelay));
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    const url = this.trimmedUrl();
+    const settings: CrawlSettings = this.crawlLinkedPages()
+      ? {
+          maxDepth: this.maxDepth(),
+          maxPages: this.maxPages(),
+          concurrency: this.concurrency(),
+          minDelay: this.minDelay(),
+          maxDelay: this.maxDelay(),
+          sameDomainOnly: true,
+        }
+      : SINGLE_PAGE_SETTINGS;
+
+    this.submitting.set(true);
+    this.error.set(null);
+    try {
+      const response = await this.webSourceService.startCrawl(
+        this.data.assistantId,
+        { url, settings },
+      );
+      this.dialogRef.close(response.documents);
+    } catch (err) {
+      this.submitting.set(false);
+      const message = this.errorMessage(err);
+      this.error.set(message);
+      this.toast.error(message);
+    }
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  private toNumber(value: number | string, fallback: number): number {
+    const n = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  private errorMessage(err: unknown): string {
+    if (err instanceof WebSourceError) {
+      return err.message;
+    }
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return 'Something went wrong. Try again.';
+  }
+}

--- a/frontend/ai.client/src/app/assistants/models/web-source.model.ts
+++ b/frontend/ai.client/src/app/assistants/models/web-source.model.ts
@@ -1,0 +1,76 @@
+/**
+ * Front-end models for the web-source ingestion feature.
+ *
+ * Mirrors `apis/app_api/web_sources/models.py` — field names are the
+ * camelCase aliases the backend serializes. A "web source" is just a URL
+ * the user wants to ingest; with `maxDepth=0` it's a single-page import,
+ * higher values trigger a BFS crawl.
+ */
+
+import { Document } from './document.model';
+
+/** Tunable bounds for a single crawl job. Defaults mirror the backend. */
+export interface CrawlSettings {
+  maxDepth: number;
+  maxPages: number;
+  concurrency: number;
+  minDelay: number;
+  maxDelay: number;
+  sameDomainOnly: boolean;
+}
+
+/** The polite defaults the SPA seeds the modal with. Match backend `CrawlSettings()`. */
+export const DEFAULT_CRAWL_SETTINGS: CrawlSettings = {
+  maxDepth: 2,
+  maxPages: 25,
+  concurrency: 2,
+  minDelay: 1,
+  maxDelay: 3,
+  sameDomainOnly: true,
+};
+
+/** Single-page mode: the BFS visits only the root URL. */
+export const SINGLE_PAGE_SETTINGS: CrawlSettings = {
+  ...DEFAULT_CRAWL_SETTINGS,
+  maxDepth: 0,
+  maxPages: 1,
+  concurrency: 1,
+};
+
+export type CrawlJobStatus = 'running' | 'complete' | 'failed';
+
+/** A web-crawl job persisted alongside the assistant. */
+export interface CrawlJob {
+  crawlId: string;
+  assistantId: string;
+  rootUrl: string;
+  status: CrawlJobStatus;
+  settings: CrawlSettings;
+  discoveredCount: number;
+  fetchedCount: number;
+  failedCount: number;
+  startedAt: string;
+  completedAt?: string | null;
+  startedByUserId: string;
+  error?: string | null;
+}
+
+/** Request body for `POST /assistants/{id}/web-sources/crawl`. */
+export interface StartCrawlRequest {
+  url: string;
+  settings?: CrawlSettings;
+}
+
+/**
+ * Response from `POST /assistants/{id}/web-sources/crawl`. Includes the
+ * pre-created root `Document` so the SPA can immediately render and poll it.
+ */
+export interface StartCrawlResponse {
+  crawl: CrawlJob;
+  documents: Document[];
+}
+
+/** Response from `GET /assistants/{id}/web-sources/crawls?active=true`. */
+export interface ActiveCrawlsResponse {
+  crawls: CrawlJob[];
+}

--- a/frontend/ai.client/src/app/assistants/services/web-source.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/web-source.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, computed, inject } from '@angular/core';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+  HttpParams,
+} from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import { ConfigService } from '../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
+import {
+  ActiveCrawlsResponse,
+  CrawlJob,
+  StartCrawlRequest,
+  StartCrawlResponse,
+} from '../models/web-source.model';
+
+/**
+ * Error raised by {@link WebSourceService}. `code` is `HTTP_{status}` for
+ * server responses (e.g. `HTTP_422` for an invalid URL) or `UNKNOWN`.
+ */
+export class WebSourceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'WebSourceError';
+  }
+}
+
+/**
+ * Client for the user-facing web-source endpoints (app-api).
+ *
+ * The editor uses this to start a crawl from a URL and to poll for active
+ * crawls so it can refresh its document list while pages stream in.
+ */
+@Injectable({ providedIn: 'root' })
+export class WebSourceService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+  private readonly baseUrl = computed(() => this.config.appApiUrl());
+
+  /**
+   * The dialog and the editor banner render their own inline errors, so opt
+   * out of the global error toast — a duplicate banner would only confuse.
+   */
+  private requestOptions(): { context: HttpContext } {
+    return {
+      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),
+    };
+  }
+
+  /** Kick off a crawl for the given assistant. Returns the root document + job. */
+  async startCrawl(
+    assistantId: string,
+    request: StartCrawlRequest,
+  ): Promise<StartCrawlResponse> {
+    try {
+      return await firstValueFrom(
+        this.http.post<StartCrawlResponse>(
+          `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/web-sources/crawl`,
+          request,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to start crawl');
+    }
+  }
+
+  /** List crawls currently `running` for an assistant. Empty list when idle. */
+  async listActiveCrawls(assistantId: string): Promise<CrawlJob[]> {
+    const params = new HttpParams().set('active', 'true');
+    try {
+      const response = await firstValueFrom(
+        this.http.get<ActiveCrawlsResponse>(
+          `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/web-sources/crawls`,
+          { ...this.requestOptions(), params },
+        ),
+      );
+      return response.crawls;
+    } catch (err) {
+      throw this.toError(err, 'Failed to load active crawls');
+    }
+  }
+
+  private toError(err: unknown, fallback: string): WebSourceError {
+    if (err instanceof HttpErrorResponse) {
+      const detail =
+        (err.error as { detail?: string; message?: string } | null) ?? null;
+      const message = detail?.detail || detail?.message || err.message || fallback;
+      return new WebSourceError(message, `HTTP_${err.status}`, err.status);
+    }
+    if (err instanceof Error) {
+      return new WebSourceError(err.message || fallback, 'UNKNOWN');
+    }
+    return new WebSourceError(fallback, 'UNKNOWN');
+  }
+}


### PR DESCRIPTION
## Summary

Adds an **"Add web content"** flow in the assistant editor that lets users attach a single web page or a bounded crawl of a site to the assistant's knowledge base. Discovered pages flow through the existing S3 → ingestion Lambda → chunking/embedding pipeline — no new infra.

- New backend package \`apis/app_api/web_sources/\` (BFS crawler, repository, routes, URL/SSRF helpers).
- New SPA \`WebSourceDialogComponent\` with single-page and crawl modes (depth, max pages, concurrency, delay sliders); editor wires it as a sibling to the connector buttons.
- Two new pinned deps: \`beautifulsoup4==4.13.5\`, \`trafilatura==2.0.0\`.
- Drive-by UX fix on the existing docs list: delete is now optimistic (row removes instantly, rolls back on failure) and works on stuck-uploading docs.

### Behind the scenes
- Crawler respects robots.txt, stays same-domain, has per-host jitter + bounded concurrency, SSRF-guards every URL, 5 MB per-page cap, 15-minute crawl budget, always finalizes in a \`finally\`.
- \`CrawlJob\` rows live in the assistants table at \`SK=CRAWL#{crawl_id}\`, get a 30-day TTL on terminal status, and cascade-delete when the last web doc for that root URL is removed.
- \`list_active_crawls\` self-heals — a \`running\` row older than 20 minutes (the crawler's budget + 5 min buffer) is auto-finalized, so a crashed process can't leave the SPA in perma-poll.
- Crawler workers and the route-level background task both hold strong refs, sidestepping Python's weak-task-tracking GC.
- Floats in \`CrawlSettings\` (min/maxDelay) are coerced to \`Decimal\` before DynamoDB writes — boto3 rejects bare \`float\`.

### Decisions worth flagging
- **HTTP-only for v1.** Static HTML → markdown via trafilatura (BS4 fallback). JavaScript-only sites render as empty pages; called out in the modal. Browser rendering via AgentCore browser sessions is a follow-up.
- **Submit-and-watch UX** rather than discover-then-pick — the modal closes on Start; pages stream into the docs list as they're ingested via an incremental discovery merge (no list-wide refresh).

## Test plan

- [ ] \`cd backend && uv sync --extra agentcore --extra dev && uv run pytest tests/apis/app_api/web_sources/ -v\` — 60 tests
- [ ] \`cd backend && uv run pytest tests/architecture/ tests/routes/test_documents.py\` — boundary + adjacent docs routes still green
- [ ] \`cd frontend/ai.client && npx tsc --noEmit\` — clean
- [ ] Manual: single-page import of a Wikipedia article → doc reaches \`complete\` and is citable
- [ ] Manual: small-site crawl with depth 2 / max 10 → pages stream into the list, \"Crawling…\" badge clears on finish
- [ ] Manual: 404 URL → root doc transitions to \`failed\` with a readable error
- [ ] Manual: SSRF guard rejects \`http://127.0.0.1/...\` with 422 in the modal
- [ ] Manual: stale \`running\` CrawlJob (from a crashed process before this PR) gets reaped on next watcher tick and polling stops
- [ ] Manual: delete a complete web doc → row disappears immediately, S3 markdown + vectors cleaned up, orphan CrawlJob row goes too

## Out of scope (follow-ups)
- JS-rendering via AgentCore browser (separate plumbing into app-api).
- Cancel-crawl button (crawler would need to poll its own status between fetches).
- Sitemap.xml-driven crawls and scheduled re-crawls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)