### PR TITLE
feat(assistants): download uploaded documents from editor

### DIFF
--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -465,6 +465,17 @@
                           }
                         </div>
                       </div>
+                      @if (doc.status === 'complete') {
+                        <button
+                          type="button"
+                          (click)="downloadDocument(doc.documentId)"
+                          title="Download document"
+                          [attr.aria-label]="'Download ' + doc.filename"
+                          class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-blue-50 hover:text-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
+                        >
+                          <ng-icon name="heroArrowDownTray" class="size-4" aria-hidden="true" />
+                        </button>
+                      }
                       <button
                         type="button"
                         (click)="deleteDocument(doc.documentId)"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
@@ -24,6 +24,7 @@ import { Document, PROCESSING_STATUSES, STALE_DOCUMENT_THRESHOLD_MS } from '../m
 import { AssistantPreviewComponent } from './components/assistant-preview.component';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
+  heroArrowDownTray,
   heroArrowLeft,
   heroArrowPath,
   heroChevronRight,
@@ -75,6 +76,7 @@ import { ToastService } from '../../services/toast/toast.service';
   ],
   providers: [
     provideIcons({
+      heroArrowDownTray,
       heroArrowLeft,
       heroArrowPath,
       heroChevronRight,
@@ -827,6 +829,22 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       // Don't show error to user, just log it
     } finally {
       this.isLoadingDocuments.set(false);
+    }
+  }
+
+  async downloadDocument(documentId: string): Promise<void> {
+    const assistantId = this.assistantId();
+    if (!assistantId) {
+      return;
+    }
+
+    try {
+      const response = await this.documentService.getDownloadUrl(assistantId, documentId);
+      window.open(response.downloadUrl, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to get download URL.';
+      this.toast.error(message);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a download button next to the delete button in the assistant editor's uploaded documents list.
- Button is only rendered for documents in the `complete` status (no point downloading an in-flight or failed ingest).
- Reuses the existing `GET /assistants/{id}/documents/{docId}/download` endpoint — no backend changes.

## Why
Editors can upload knowledge-base files into an assistant but had no way to retrieve a copy from the editor UI. The backend endpoint and frontend `DocumentService.getDownloadUrl()` already existed (used by citation-source downloads); the editor UI just wasn't wired up.

## Implementation
- [`assistant-form.page.html`](frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html) — new `heroArrowDownTray` button rendered when `doc.status === 'complete'`, with appropriate `title`, `aria-label`, and focus-visible styles matching the existing trash button.
- [`assistant-form.page.ts`](frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts) — added `downloadDocument(documentId)` method that calls `documentService.getDownloadUrl()` and opens the presigned URL with `window.open(url, '_blank', 'noopener,noreferrer')`. Mirrors `citation-display.component.ts#onDownloadClick`. Errors surface via the existing `ToastService`.

## Behavior notes
The backend's presigned URL does **not** set `Content-Disposition: attachment`, so this matches existing citation-source behavior — PDFs/images preview in a new tab; other types download directly. If we want force-download on all types as a follow-up, the smallest change is passing `ResponseContentDisposition='attachment; filename="..."'` into `s3_client.generate_presigned_url` in `backend/.../documents/services/storage_service.py`.

## Test plan
- [ ] `npm start` the frontend with app-api running.
- [ ] Open an assistant in edit mode that has at least one document in `complete` status.
- [ ] Verify the new download icon appears to the left of the trash icon, with tooltip "Download document" and aria-label "Download <filename>".
- [ ] Click → new tab opens; file downloads (PDF/image previews).
- [ ] Verify the download button is absent for rows in `uploading`/`chunking`/`embedding`/`failed` states; trash button remains.
- [ ] Network tab shows one `GET /assistants/{id}/documents/{docId}/download` returning `downloadUrl`, then a request to the S3 presigned URL.
- [ ] Force an auth failure on the download endpoint (e.g. revoke session) → error toast appears, no tab opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)