### PR TITLE
feat(assistants): ground consumer chat in knowledge base only

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -960,6 +960,14 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         logger.info("Assistant RAG requested")
         logger.info("Processing for authenticated user")
 
+        # Assistants are KB-grounded with no external tools available to the consumer.
+        # Override any tools the client sent — server is the source of truth here.
+        if input_data.enabled_tools:
+            logger.warning(
+                "Ignoring enabled_tools on assistant chat (assistants are KB-only)"
+            )
+        input_data.enabled_tools = []
+
         # 1. Check if session already has an assistant attached
         # If it does, verify it's the same assistant (can't change assistants mid-session)
         # If it doesn't, verify session has no messages (can only attach to new sessions)
@@ -1068,6 +1076,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         preview_instructions_override = input_data.system_prompt if is_preview_session(input_data.session_id) and input_data.system_prompt else None
         effective_instructions = preview_instructions_override or assistant.instructions
 
+        kb_grounding_directive = (
+            "## Knowledge Base Grounding\n\n"
+            "Answer using only the knowledge base context provided with the user's message. "
+            "If the context does not cover the question, say so plainly rather than guessing. "
+            "You have no external tools available."
+        )
+
         if effective_instructions:
             # Import here to avoid circular dependency
             from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
@@ -1077,7 +1092,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             base_prompt = base_prompt_builder.build(include_date=True)
 
             # Append assistant instructions to the base prompt
-            system_prompt = f"{base_prompt}\n\n## Assistant-Specific Instructions\n\n{effective_instructions}"
+            system_prompt = f"{base_prompt}\n\n{kb_grounding_directive}\n\n## Assistant-Specific Instructions\n\n{effective_instructions}"
             if preview_instructions_override:
                 logger.info(
                     "Using live preview instructions override"
@@ -1090,13 +1105,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         else:
             # No assistant instructions - use base prompt if no system_prompt provided
             logger.warning("No instructions found on assistant!")
-            if not system_prompt:
-                from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
+            from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
 
-                base_prompt_builder = SystemPromptBuilder()
-                system_prompt = base_prompt_builder.build(include_date=True)
+            base_prompt_builder = SystemPromptBuilder()
+            base_prompt = base_prompt_builder.build(include_date=True)
+            system_prompt = f"{base_prompt}\n\n{kb_grounding_directive}"
             logger.info(
-                "Assistant has no instructions - using fallback system prompt"
+                "Assistant has no instructions - using fallback system prompt with KB grounding"
             )
 
         # 6. Save assistant_id to session preferences (persist for future loads)

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -96,6 +96,17 @@ describe('ChatRequestService', () => {
     );
   });
 
+  it('overrides enabled_tools to [] when an assistant ID is set (KB-only consumer chat)', async () => {
+    await service.submitChatRequest('Hello', 'session1', undefined, 'assistant1');
+
+    expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rag_assistant_id: 'assistant1',
+        enabled_tools: [],
+      })
+    );
+  });
+
   it('should throw error when no model selected', async () => {
     mockModelService.getSelectedModel.mockReturnValue(null);
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -230,6 +230,8 @@ export class ChatRequestService implements OnDestroy {
     // AgentCore Runtime's internal 'assistant_id' field handling (causes 424 error)
     if (assistantId) {
       requestObject['rag_assistant_id'] = assistantId;
+      // Assistants are KB-grounded with no external tools. Backend enforces this too.
+      requestObject['enabled_tools'] = [];
     }
 
     return requestObject;


### PR DESCRIPTION
## Summary

- When a consumer chats with an Assistant (request carries `rag_assistant_id`), the agent now runs with **zero external tools** and is steered to answer from the KB context already pre-stuffed into the prompt.
- Editor-side connectors are unchanged — owners still curate the KB by pulling in Drive docs, web crawls, and uploads. This change only affects the consumer/runtime side.
- Codifies a product split: **the main agent is the general-purpose, tool-using surface; assistants are the grounded, predictable, citation-friendly surface.**

## Why

Consumers of an assistant should get answers grounded in what the owner curated — not whatever the model decides to web-search mid-chat. That gives:
- predictable answers (same KB → same answer surface),
- easier evaluation (bounded retrieval surface),
- no consent/permission surprises mid-chat,
- cheaper turns (tool definitions don't ride along),
- and a clear contract with the end user.

Freshness was already an owner-scheduled concern after the web-sources crawl shipped (#378); this change finishes the picture by removing the runtime escape hatch.

## What changed

Three layers, smallest set of touchpoints:

1. **Backend enforcement** — `backend/src/apis/inference_api/chat/routes.py`
   - Inside the `rag_assistant_id` branch of `invocations()`, force `input_data.enabled_tools = []` before the agent is built.
   - Log a warning if the client sent a non-empty list (so we'd notice a misbehaving caller).
   - This is the real chokepoint: covers SPA, API-key, and any future caller through `/invocations`.

2. **System prompt grounding** — same file, prompt composition block
   - New `## Knowledge Base Grounding` section inserted between the base prompt and the owner's `## Assistant-Specific Instructions`.
   - Owner instructions still come last and take precedence; the directive just tells the model to ground in provided context and acknowledges no external tools are available.
   - Applies in both the with-instructions and no-instructions paths.

3. **Frontend cleanup** — `frontend/ai.client/src/app/session/services/chat/chat-request.service.ts`
   - SPA omits tools (sends `enabled_tools: []`) when `assistantId` is present.
   - Cosmetic given #1, but saves payload bytes and matches the existing `preview-chat.service.ts` behavior.
   - New unit test (`chat-request.service.spec.ts`) locks in the contract.

## Things falling out for free

- **MCP App UI events** — no tools → no `tool_result` → no `ui_resource` events. Nothing to gate.
- **Token usage** — tool definitions stop riding along on assistant turns. Modest but real.

## Out of scope (deliberate)

- **Existing assistants in production** — beta, no migration needed.
- **Voice / API-key parity** beyond what backend enforcement covers for free — revisit later.
- **`Assistant` model schema** — no new `enabled_tools` field needed; the decision is server-derived from `rag_assistant_id`.

## Test plan

- [x] Backend pytest — 35/35 pass across `tests/routes/test_chat.py`, `tests/routes/test_assistants.py`, `tests/shared/test_assistants*.py`, `tests/apis/inference_api/test_chat_service.py`, `tests/agents/main_agent/test_chat_agent_continue.py`.
- [ ] Frontend vitest — pre-existing TestBed null-`ngModule` failure on `develop` blocks all specs from compiling; reproduces with no local changes. Not addressed here; flagged separately.
- [ ] **Manual verification** (SKIP_AUTH=false locally, so end-to-end clickthrough rather than preview tooling):
  1. Open an assistant in the SPA, start a new chat session.
  2. DevTools → Network → `/invocations` POST → confirm `rag_assistant_id` is set and `enabled_tools: []`.
  3. Inference API logs → confirm `## Knowledge Base Grounding` appears above `## Assistant-Specific Instructions` in the final system prompt.
  4. Optionally curl with non-empty `enabled_tools` to confirm the `"Ignoring enabled_tools on assistant chat (assistants are KB-only)"` warning fires.
  5. SSE stream → no `tool_use` / `tool_result` events for any assistant chat.
  6. Out-of-KB question (e.g. "what's the weather right now?") → assistant says "not in my knowledge base" rather than searching.
  7. In-KB question → answer streams with citations as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)