### PR TITLE
feat(assistants): viewer/editor share permissions — backend (#113)

### DIFF
--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -26,8 +26,10 @@ from apis.shared.assistants.models import (
     CreateAssistantDraftRequest,
     CreateAssistantRequest,
     ShareAssistantRequest,
+    ShareEntry,
     UnshareAssistantRequest,
     UpdateAssistantRequest,
+    UpdateSharePermissionRequest,
 )
 from apis.shared.assistants.service import (
     assistant_exists,
@@ -39,9 +41,11 @@ from apis.shared.assistants.service import (
     list_assistant_shares,
     list_shared_with_user,
     list_user_assistants,
+    resolve_assistant_permission,
     share_assistant,
     unshare_assistant,
     update_assistant,
+    update_share_permission,
 )
 from apis.shared.assistants.rag_service import augment_prompt_with_context, search_assistant_knowledgebase_with_formatting
 
@@ -194,6 +198,7 @@ async def list_assistants_endpoint(
         for assistant in assistants:
             assistant.is_shared_with_me = False
             assistant.first_interacted = None  # Not applicable for owned assistants
+            assistant.user_permission = "owner"
 
         # Also get assistants shared with this user
         shared_assistants = await list_shared_with_user(current_user.email)
@@ -205,7 +210,7 @@ async def list_assistants_endpoint(
         # Mark shared assistants with share metadata
         for assistant in unique_shared:
             assistant.is_shared_with_me = True
-            # first_interacted is already set by list_shared_with_user
+            # first_interacted and user_permission are already set by list_shared_with_user
 
         # Combine lists (user's own assistants first, then shared)
         all_assistants = assistants + unique_shared
@@ -267,11 +272,16 @@ async def get_assistant_endpoint(assistant_id: str, current_user: User = Depends
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
 
         # Assistant exists, now check access
-        assistant = await get_assistant_with_access_check(assistant_id=assistant_id, user_id=user_id, user_email=current_user.email)
+        assistant, permission = await get_assistant_with_access_check(
+            assistant_id=assistant_id, user_id=user_id, user_email=current_user.email
+        )
 
         if not assistant:
             # Assistant exists but access is denied
             raise HTTPException(status_code=403, detail=f"Access denied: You do not have permission to access this assistant")
+
+        # Surface permission so the SPA can decide what to render (e.g. show edit form for editors)
+        assistant.user_permission = permission
 
         # Convert to response model (excludes owner_id for privacy)
         assistant_dict = assistant.model_dump(by_alias=True, exclude={"ownerId"})
@@ -289,18 +299,17 @@ async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantR
     """
     Update an assistant (deep merge).
 
-    Requires JWT authentication. Users can only update their own assistants.
-    Only provided fields are updated; existing fields are preserved.
+    Requires JWT authentication. Owners and users with `editor` share permission
+    can update the assistant. Only provided fields are updated; existing fields
+    are preserved.
 
-    This can be used to:
-    - Complete a draft assistant (set status=COMPLETE with full fields)
-    - Update any assistant fields
-    - Transition status from DRAFT to COMPLETE
+    Editors cannot change `visibility` — sharing is an ownership action and
+    must be performed by the owner.
 
     Args:
         assistant_id: Assistant identifier from URL path
         request: UpdateAssistantRequest with fields to update (all optional)
-        current_user: Authenticated user from JWT token (injected by dependency)
+        current_user: Authenticated user from session cookie (injected by dependency)
 
     Returns:
         AssistantResponse with updated assistant information
@@ -308,7 +317,9 @@ async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantR
     Raises:
         HTTPException:
             - 401 if not authenticated
-            - 404 if assistant not found or not owned by user
+            - 403 if user has no edit permission (viewer or no share)
+            - 404 if assistant not found
+            - 400 if an editor attempts to change visibility
             - 500 if server error
     """
     user_id = current_user.user_id
@@ -316,11 +327,28 @@ async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantR
     logger.info("PUT /assistants/{assistant_id}")
 
     try:
-        # Update assistant
-        # Note: vector_index_id is not user-configurable - it's set automatically from environment
+        # Resolve permission and gate
+        assistant, permission = await resolve_assistant_permission(
+            assistant_id=assistant_id, user_id=user_id, user_email=current_user.email
+        )
+        if not assistant:
+            raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
+        if permission not in ("owner", "editor"):
+            raise HTTPException(
+                status_code=403, detail="You do not have permission to edit this assistant"
+            )
+
+        # Editors cannot change visibility (sharing is an ownership action)
+        if permission == "editor" and request.visibility is not None and request.visibility != assistant.visibility:
+            raise HTTPException(
+                status_code=400,
+                detail="Only the owner can change assistant visibility",
+            )
+
+        # Mutation functions are keyed on the assistant's real owner_id, not the requester
         updated_assistant = await update_assistant(
             assistant_id=assistant_id,
-            owner_id=user_id,
+            owner_id=assistant.owner_id,
             name=request.name,
             description=request.description,
             instructions=request.instructions,
@@ -334,6 +362,9 @@ async def update_assistant_endpoint(assistant_id: str, request: UpdateAssistantR
 
         if not updated_assistant:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
+
+        # Surface the requester's permission on the response so the SPA stays consistent
+        updated_assistant.user_permission = permission
 
         # Convert to response model
         return AssistantResponse.model_validate(updated_assistant.model_dump(by_alias=True))
@@ -419,16 +450,22 @@ async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatReques
     logger.info("POST /assistants/{assistant_id}/test-chat")
 
     try:
-        # 1. Get assistant and verify ownership
-        assistant = await get_assistant(assistant_id=assistant_id, owner_id=user_id)
+        # 1. Resolve permission — owner or editor may test-chat (editors need to preview their edits)
+        assistant, permission = await resolve_assistant_permission(
+            assistant_id=assistant_id, user_id=user_id, user_email=current_user.email
+        )
 
         if not assistant:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
+        if permission not in ("owner", "editor"):
+            raise HTTPException(
+                status_code=403, detail="You do not have permission to test-chat this assistant"
+            )
 
-        # 2. Check if assistant has processed documents
+        # 2. Check if assistant has processed documents (use the real owner_id)
         documents, _ = await list_assistant_documents(
             assistant_id=assistant_id,
-            owner_id=user_id,
+            owner_id=assistant.owner_id,
             limit=100,  # Check up to 100 documents
         )
 
@@ -525,18 +562,18 @@ async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatReques
 @router.post("/{assistant_id}/shares", response_model=AssistantSharesResponse)
 async def share_assistant_endpoint(assistant_id: str, request: ShareAssistantRequest, current_user: User = Depends(get_current_user_from_session)):
     """
-    Share an assistant with specified email addresses.
+    Share an assistant with specified email addresses at a given permission level.
 
     Requires JWT authentication. Only the owner can share their assistant.
     Creates share records for each email address. Emails are normalized to lowercase.
 
     Args:
         assistant_id: Assistant identifier
-        request: ShareAssistantRequest with list of email addresses
-        current_user: Authenticated user from JWT token (injected by dependency)
+        request: ShareAssistantRequest with emails and permission level
+        current_user: Authenticated user from session cookie (injected by dependency)
 
     Returns:
-        AssistantSharesResponse with updated list of shared emails
+        AssistantSharesResponse with updated list of shares (email + permission)
 
     Raises:
         HTTPException:
@@ -549,16 +586,22 @@ async def share_assistant_endpoint(assistant_id: str, request: ShareAssistantReq
     logger.info("POST /assistants/{assistant_id}/shares")
 
     try:
-        # Share assistant with emails
-        success = await share_assistant(assistant_id=assistant_id, owner_id=user_id, emails=request.emails)
+        # Share assistant with emails at the requested permission level
+        success = await share_assistant(
+            assistant_id=assistant_id,
+            owner_id=user_id,
+            emails=request.emails,
+            permission=request.permission,
+        )
 
         if not success:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
 
         # Get updated share list
-        shared_emails = await list_assistant_shares(assistant_id, user_id)
+        shares = await list_assistant_shares(assistant_id, user_id)
+        share_entries = [ShareEntry.model_validate(s) for s in shares]
 
-        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=shared_emails)
+        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=share_entries)
 
     except HTTPException:
         raise
@@ -577,10 +620,10 @@ async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistan
     Args:
         assistant_id: Assistant identifier
         request: UnshareAssistantRequest with list of email addresses to remove
-        current_user: Authenticated user from JWT token (injected by dependency)
+        current_user: Authenticated user from session cookie (injected by dependency)
 
     Returns:
-        AssistantSharesResponse with updated list of shared emails
+        AssistantSharesResponse with updated list of shares (email + permission)
 
     Raises:
         HTTPException:
@@ -593,16 +636,15 @@ async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistan
     logger.info("DELETE /assistants/{assistant_id}/shares")
 
     try:
-        # Unshare assistant from emails
         success = await unshare_assistant(assistant_id=assistant_id, owner_id=user_id, emails=request.emails)
 
         if not success:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
 
-        # Get updated share list
-        shared_emails = await list_assistant_shares(assistant_id, user_id)
+        shares = await list_assistant_shares(assistant_id, user_id)
+        share_entries = [ShareEntry.model_validate(s) for s in shares]
 
-        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=shared_emails)
+        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=share_entries)
 
     except HTTPException:
         raise
@@ -611,24 +653,74 @@ async def unshare_assistant_endpoint(assistant_id: str, request: UnshareAssistan
         raise HTTPException(status_code=500, detail=f"Failed to unshare assistant: {str(e)}")
 
 
-@router.get("/{assistant_id}/shares", response_model=AssistantSharesResponse)
-async def get_assistant_shares_endpoint(assistant_id: str, current_user: User = Depends(get_current_user_from_session)):
+@router.patch("/{assistant_id}/shares", response_model=AssistantSharesResponse)
+async def update_share_permission_endpoint(
+    assistant_id: str,
+    request: UpdateSharePermissionRequest,
+    current_user: User = Depends(get_current_user_from_session),
+):
     """
-    Get list of email addresses an assistant is shared with.
+    Update the permission level of an existing share on an assistant.
 
-    Requires JWT authentication. Only the owner can view the share list.
-
-    Args:
-        assistant_id: Assistant identifier
-        current_user: Authenticated user from JWT token (injected by dependency)
-
-    Returns:
-        AssistantSharesResponse with list of shared emails
+    Owner-only. Use this to upgrade a viewer to an editor (or downgrade) without
+    removing and re-adding the share — preserving createdAt / firstInteracted.
 
     Raises:
         HTTPException:
             - 401 if not authenticated
-            - 404 if assistant not found or not owned by user
+            - 404 if assistant not owned by user or share record does not exist
+            - 500 if server error
+    """
+    user_id = current_user.user_id
+
+    logger.info("PATCH /assistants/{assistant_id}/shares")
+
+    try:
+        success = await update_share_permission(
+            assistant_id=assistant_id,
+            owner_id=user_id,
+            email=request.email,
+            permission=request.permission,
+        )
+
+        if not success:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Assistant or share record not found",
+            )
+
+        shares = await list_assistant_shares(assistant_id, user_id)
+        share_entries = [ShareEntry.model_validate(s) for s in shares]
+
+        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=share_entries)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating share permission: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update share permission: {str(e)}")
+
+
+@router.get("/{assistant_id}/shares", response_model=AssistantSharesResponse)
+async def get_assistant_shares_endpoint(assistant_id: str, current_user: User = Depends(get_current_user_from_session)):
+    """
+    Get list of share records for an assistant.
+
+    Requires JWT authentication. Owners and editors can read the share list;
+    editors see it read-only (PATCH/POST/DELETE remain owner-only).
+
+    Args:
+        assistant_id: Assistant identifier
+        current_user: Authenticated user from session cookie (injected by dependency)
+
+    Returns:
+        AssistantSharesResponse with list of shares (email + permission)
+
+    Raises:
+        HTTPException:
+            - 401 if not authenticated
+            - 403 if user has no edit/view-share permission
+            - 404 if assistant not found
             - 500 if server error
     """
     user_id = current_user.user_id
@@ -636,15 +728,22 @@ async def get_assistant_shares_endpoint(assistant_id: str, current_user: User = 
     logger.info("GET /assistants/{assistant_id}/shares")
 
     try:
-        # Get share list
-        shared_emails = await list_assistant_shares(assistant_id, user_id)
-
-        # Verify ownership (list_assistant_shares checks this, but we want to return 404 if not found)
-        assistant = await get_assistant(assistant_id, user_id)
+        # Resolve the caller's permission — owners and editors may read the share list
+        assistant, permission = await resolve_assistant_permission(
+            assistant_id=assistant_id, user_id=user_id, user_email=current_user.email
+        )
         if not assistant:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
+        if permission not in ("owner", "editor"):
+            raise HTTPException(
+                status_code=403, detail="You do not have permission to view shares for this assistant"
+            )
 
-        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=shared_emails)
+        # list_assistant_shares accepts the assistant's real owner_id as a guard
+        shares = await list_assistant_shares(assistant_id, assistant.owner_id)
+        share_entries = [ShareEntry.model_validate(s) for s in shares]
+
+        return AssistantSharesResponse(assistant_id=assistant_id, shared_with=share_entries)
 
     except HTTPException:
         raise

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from apis.shared.assistants.service import get_assistant
+from apis.shared.assistants.service import resolve_assistant_permission
 from apis.app_api.documents.models import (
     CreateDocumentRequest,
     DocumentProvenance,
@@ -30,7 +30,6 @@ from apis.app_api.documents.services.storage_service import (
 )
 from apis.app_api.file_sources.service import require_file_source_token, resolve_file_source
 from apis.shared.auth import User, get_current_user_from_session
-from apis.shared.auth.dependencies import get_current_user_id
 from apis.shared.oauth.provider_repository import (
     OAuthProviderRepository,
     get_provider_repository,
@@ -42,33 +41,44 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/assistants/{assistant_id}/documents", tags=["documents"])
 
 
+async def _require_edit_permission(assistant_id: str, current_user: User) -> str:
+    """Resolve the requesting user's permission and require owner|editor.
+
+    Returns the assistant's real owner_id so existing document-service calls
+    (which are owner-keyed) pass cleanly. Raises HTTPException on 404/403.
+    """
+    assistant, permission = await resolve_assistant_permission(
+        assistant_id=assistant_id, user_id=current_user.user_id, user_email=current_user.email
+    )
+    if not assistant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+    if permission not in ("owner", "editor"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to manage documents for this assistant",
+        )
+    return assistant.owner_id
+
+
 @router.post("/upload-url", response_model=UploadUrlResponse, status_code=status.HTTP_200_OK)
 async def generate_upload_url_endpoint(
-    assistant_id: str, request: CreateDocumentRequest, user_id: str = Depends(get_current_user_id)
+    assistant_id: str,
+    request: CreateDocumentRequest,
+    current_user: User = Depends(get_current_user_from_session),
 ) -> UploadUrlResponse:
     """
     Generate presigned S3 URL for document upload
 
     Flow:
-    1. Verify user owns the assistant
+    1. Verify user is owner or editor of the assistant
     2. Generate document_id
     3. Create document record in DynamoDB (status='uploading')
     4. Generate presigned S3 URL
     5. Return URL to client
-
-    Args:
-        assistant_id: Parent assistant identifier
-        request: Document metadata (filename, content_type, size)
-        user_id: Authenticated user ID from JWT
-
-    Returns:
-        UploadUrlResponse with presigned URL and document_id
     """
     try:
-        # 1. Verify user owns the assistant
-        assistant = await get_assistant(assistant_id, user_id)
-        if not assistant:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+        # 1. Resolve permission — owner or editor may upload documents
+        await _require_edit_permission(assistant_id, current_user)
 
         # 2. Generate document_id and S3 key
         from apis.app_api.documents.services.storage_service import _get_s3_key, _sanitize_filename
@@ -125,10 +135,8 @@ async def import_documents(
         current_user: Authenticated user from the session cookie
     """
     try:
-        # 1. Verify the caller owns the assistant the files land in.
-        assistant = await get_assistant(assistant_id, current_user.user_id)
-        if not assistant:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+        # 1. Verify the caller is the owner or an editor of this assistant.
+        await _require_edit_permission(assistant_id, current_user)
 
         # 2. Resolve the connector to a usable adapter + access token. Raises
         #    404/403 (not a visible file source), 409 (not connected), or 503
@@ -192,7 +200,10 @@ async def import_documents(
 
 @router.post("/{document_id}/upload-failed", response_model=DocumentResponse, status_code=status.HTTP_200_OK)
 async def report_upload_failure(
-    assistant_id: str, document_id: str, request: ReportUploadFailureRequest, user_id: str = Depends(get_current_user_id)
+    assistant_id: str,
+    document_id: str,
+    request: ReportUploadFailureRequest,
+    current_user: User = Depends(get_current_user_from_session),
 ) -> DocumentResponse:
     """
     Report that a client-side S3 upload failed.
@@ -200,16 +211,13 @@ async def report_upload_failure(
     Marks the document as 'failed' in DynamoDB so the frontend stops polling
     and displays the error. Called by the client when the presigned URL upload
     to S3 fails (network error, permission error, etc.).
-
-    Args:
-        assistant_id: Parent assistant identifier
-        document_id: Document identifier
-        request: Error details from the client
-        user_id: Authenticated user ID from JWT
     """
     try:
-        # Verify document exists and user owns the assistant
-        document = await get_document_service(assistant_id, document_id, user_id)
+        # Verify caller has edit permission on the assistant
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
+
+        # Verify document exists (using the assistant's real owner_id)
+        document = await get_document_service(assistant_id, document_id, assistant_owner_id)
         if not document:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
 
@@ -243,32 +251,26 @@ async def report_upload_failure(
 
 @router.get("", response_model=DocumentsListResponse, status_code=status.HTTP_200_OK)
 async def list_documents(
-    assistant_id: str, limit: Optional[int] = None, next_token: Optional[str] = None, user_id: str = Depends(get_current_user_id)
+    assistant_id: str,
+    limit: Optional[int] = None,
+    next_token: Optional[str] = None,
+    current_user: User = Depends(get_current_user_from_session),
 ) -> DocumentsListResponse:
     """
-    List all documents for an assistant with pagination
+    List all documents for an assistant with pagination.
 
-    Query pattern:
+    Owners and editors can list documents. Query pattern:
     - PK = AST#{assistant_id}
     - SK begins_with DOC#
-
-    Args:
-        assistant_id: Parent assistant identifier
-        limit: Maximum number of documents to return
-        next_token: Pagination token
-        user_id: Authenticated user ID from JWT
-
-    Returns:
-        DocumentsListResponse with documents and pagination token
     """
     try:
-        # Verify assistant ownership
-        assistant = await get_assistant(assistant_id, user_id)
-        if not assistant:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+        # Verify owner/editor permission and get the assistant's real owner_id
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
 
         # List documents
-        documents, next_page_token = await list_assistant_documents(assistant_id=assistant_id, owner_id=user_id, limit=limit, next_token=next_token)
+        documents, next_page_token = await list_assistant_documents(
+            assistant_id=assistant_id, owner_id=assistant_owner_id, limit=limit, next_token=next_token
+        )
 
         # Convert to response models
         document_responses = [DocumentResponse.model_validate(doc.model_dump(by_alias=True)) for doc in documents]
@@ -283,21 +285,14 @@ async def list_documents(
 
 
 @router.get("/{document_id}", response_model=DocumentResponse, status_code=status.HTTP_200_OK)
-async def get_document(assistant_id: str, document_id: str, user_id: str = Depends(get_current_user_id)) -> DocumentResponse:
-    """
-    Get document details and processing status
-
-    Args:
-        assistant_id: Parent assistant identifier
-        document_id: Document identifier
-        user_id: Authenticated user ID from JWT
-
-    Returns:
-        DocumentResponse with current status and metadata
-    """
+async def get_document(
+    assistant_id: str, document_id: str, current_user: User = Depends(get_current_user_from_session)
+) -> DocumentResponse:
+    """Get document details and processing status. Owners and editors may read."""
     try:
-        # Verify assistant ownership and get document
-        document = await get_document_service(assistant_id, document_id, user_id)
+        # Verify owner/editor permission and use the assistant's real owner_id
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
+        document = await get_document_service(assistant_id, document_id, assistant_owner_id)
 
         if not document:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
@@ -312,24 +307,19 @@ async def get_document(assistant_id: str, document_id: str, user_id: str = Depen
 
 
 @router.get("/{document_id}/download", response_model=DownloadUrlResponse, status_code=status.HTTP_200_OK)
-async def get_download_url(assistant_id: str, document_id: str, user_id: str = Depends(get_current_user_id)) -> DownloadUrlResponse:
+async def get_download_url(
+    assistant_id: str, document_id: str, current_user: User = Depends(get_current_user_from_session)
+) -> DownloadUrlResponse:
     """
-    Generate presigned S3 URL for document download
+    Generate presigned S3 URL for document download.
 
-    This endpoint is called on-demand when a user clicks to view/download a source document
-    from a citation. The presigned URL is generated fresh each time to ensure it's valid.
-
-    Args:
-        assistant_id: Parent assistant identifier
-        document_id: Document identifier
-        user_id: Authenticated user ID from JWT
-
-    Returns:
-        DownloadUrlResponse with presigned URL and filename
+    Owners and editors may download. This endpoint is called on-demand when a
+    user clicks to view/download a source document from a citation. The presigned
+    URL is generated fresh each time to ensure it's valid.
     """
     try:
-        # Verify assistant ownership and get document
-        document = await get_document_service(assistant_id, document_id, user_id)
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
+        document = await get_document_service(assistant_id, document_id, assistant_owner_id)
 
         if not document:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
@@ -351,13 +341,16 @@ async def get_download_url(assistant_id: str, document_id: str, user_id: str = D
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_document(assistant_id: str, document_id: str, user_id: str = Depends(get_current_user_id)) -> None:
-    """Delete document using soft-delete + background cleanup pattern."""
+async def delete_document(
+    assistant_id: str, document_id: str, current_user: User = Depends(get_current_user_from_session)
+) -> None:
+    """Delete document using soft-delete + background cleanup pattern. Owners and editors may delete."""
     try:
         from apis.app_api.documents.services.document_service import soft_delete_document
         from apis.app_api.documents.services.cleanup_service import cleanup_document_resources
 
-        document = await soft_delete_document(assistant_id, document_id, user_id)
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
+        document = await soft_delete_document(assistant_id, document_id, assistant_owner_id)
         if not document:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1012,7 +1012,9 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
 
         # 2. Load assistant with access check
         logger.info("Loading assistant with access check...")
-        assistant = await get_assistant_with_access_check(assistant_id=input_data.rag_assistant_id, user_id=user_id, user_email=current_user.email)
+        assistant, _ = await get_assistant_with_access_check(
+            assistant_id=input_data.rag_assistant_id, user_id=user_id, user_email=current_user.email
+        )
 
         if not assistant:
             logger.warning("get_assistant_with_access_check returned None")

--- a/backend/src/apis/shared/assistants/__init__.py
+++ b/backend/src/apis/shared/assistants/__init__.py
@@ -12,7 +12,9 @@ from .models import (
     CreateAssistantDraftRequest,
     CreateAssistantRequest,
     ShareAssistantRequest,
+    ShareEntry,
     UnshareAssistantRequest,
+    UpdateSharePermissionRequest,
     AssistantSharesResponse,
     UpdateAssistantRequest,
 )
@@ -28,9 +30,11 @@ from .service import (
     list_shared_with_user,
     list_user_assistants,
     mark_share_as_interacted,
+    resolve_assistant_permission,
     share_assistant,
     unshare_assistant,
     update_assistant,
+    update_share_permission,
 )
 from .rag_service import (
     augment_prompt_with_context,
@@ -46,7 +50,9 @@ __all__ = [
     "CreateAssistantDraftRequest",
     "CreateAssistantRequest",
     "ShareAssistantRequest",
+    "ShareEntry",
     "UnshareAssistantRequest",
+    "UpdateSharePermissionRequest",
     "AssistantSharesResponse",
     "UpdateAssistantRequest",
     # Service functions
@@ -61,9 +67,11 @@ __all__ = [
     "list_shared_with_user",
     "list_user_assistants",
     "mark_share_as_interacted",
+    "resolve_assistant_permission",
     "share_assistant",
     "unshare_assistant",
     "update_assistant",
+    "update_share_permission",
     # RAG service functions
     "augment_prompt_with_context",
     "search_assistant_knowledgebase_with_formatting",

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -93,6 +93,9 @@ class AssistantResponse(BaseModel):
     is_shared_with_me: Optional[bool] = Field(
         None, alias="isSharedWithMe", description="Whether this assistant is shared with the requesting user (not owned)"
     )
+    user_permission: Optional[Literal["owner", "editor", "viewer"]] = Field(
+        None, alias="userPermission", description="Requesting user's permission level on this assistant"
+    )
 
 
 class AssistantsListResponse(BaseModel):
@@ -119,6 +122,9 @@ class ShareAssistantRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     emails: List[str] = Field(..., min_length=1, description="Email addresses to share with")
+    permission: Literal["viewer", "editor"] = Field(
+        "viewer", description="Permission level granted to each shared user"
+    )
 
 
 class UnshareAssistantRequest(BaseModel):
@@ -129,10 +135,32 @@ class UnshareAssistantRequest(BaseModel):
     emails: List[str] = Field(..., min_length=1, description="Email addresses to remove from shares")
 
 
+class UpdateSharePermissionRequest(BaseModel):
+    """Request body for changing an existing share's permission level"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    email: str = Field(..., description="Email address of the existing share to update")
+    permission: Literal["viewer", "editor"] = Field(..., description="New permission level")
+
+
+class ShareEntry(BaseModel):
+    """A single share record (email + permission level)"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    email: str = Field(..., description="Email address (normalized lowercase)")
+    permission: Literal["viewer", "editor"] = Field(
+        "viewer", description="Permission level granted to this user"
+    )
+
+
 class AssistantSharesResponse(BaseModel):
-    """Response containing list of emails an assistant is shared with"""
+    """Response containing share records for an assistant"""
 
     model_config = ConfigDict(populate_by_name=True)
 
     assistant_id: str = Field(..., alias="assistantId", description="Assistant identifier")
-    shared_with: List[str] = Field(..., alias="sharedWith", description="List of email addresses this assistant is shared with")
+    shared_with: List[ShareEntry] = Field(
+        ..., alias="sharedWith", description="List of share records (email + permission)"
+    )

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -200,25 +200,26 @@ async def get_assistant(assistant_id: str, owner_id: str) -> Optional[Assistant]
     return await _get_assistant_cloud(assistant_id, owner_id, assistants_table)
 
 
-async def get_assistant_with_access_check(assistant_id: str, user_id: str, user_email: str = None) -> Optional[Assistant]:
+async def get_assistant_with_access_check(
+    assistant_id: str, user_id: str, user_email: str = None
+) -> Tuple[Optional[Assistant], Optional[str]]:
     """
-    Retrieve assistant by ID with visibility-based access control
+    Retrieve assistant by ID with visibility-based access control.
 
     Checks visibility:
     - PRIVATE: Only owner can access
-    - PUBLIC: Anyone can access
+    - PUBLIC: Anyone can access (returns "viewer" for non-owners)
     - SHARED: Only owner or users with share records can access
 
-    Args:
-        assistant_id: Assistant identifier
-        user_id: User identifier requesting access
-        user_email: User's email address (required for SHARED visibility check)
-
     Returns:
-        Assistant object if found and access granted, None otherwise
-        None can mean either:
-        - Assistant not found (404)
-        - Access denied (403 for PRIVATE assistant not owned by user, or SHARED without share record)
+        Tuple of (assistant, permission). Permission is one of:
+        - "owner" — caller owns the assistant
+        - "editor" — caller has an editor share record
+        - "viewer" — caller has a viewer share record OR assistant is PUBLIC
+        - None — assistant not found or access denied
+
+        (None, None) means either not found (404) or access denied (403).
+        Caller must distinguish via assistant_exists() if it needs the distinction.
     """
     assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
     if not assistants_table:
@@ -228,32 +229,68 @@ async def get_assistant_with_access_check(assistant_id: str, user_id: str, user_
     assistant = await _get_assistant_cloud_without_ownership_check(assistant_id, assistants_table)
 
     if not assistant:
-        # Assistant not found
-        return None
+        return None, None
 
-    # Check visibility-based access
+    # Owner always has full access regardless of visibility
+    if assistant.owner_id == user_id:
+        return assistant, "owner"
+
+    # Non-owner access depends on visibility
     if assistant.visibility == "PRIVATE":
-        # Only owner can access PRIVATE assistants
-        if assistant.owner_id != user_id:
-            logger.warning(f"Access denied: user {user_id} attempted to access PRIVATE assistant {assistant_id} owned by {assistant.owner_id}")
-            return None
-    elif assistant.visibility == "SHARED":
-        # SHARED: owner or users with share records can access
-        if assistant.owner_id != user_id:
-            # Not the owner, check if user has share access
-            if not user_email:
-                logger.warning(f"Access denied: user_email required for SHARED assistant {assistant_id}")
-                return None
+        logger.warning(
+            f"Access denied: user {user_id} attempted to access PRIVATE assistant {assistant_id} owned by {assistant.owner_id}"
+        )
+        return None, None
 
-            has_share = await check_share_access(assistant_id, user_email)
-            if not has_share:
-                logger.warning(
-                    f"Access denied: user {user_id} ({user_email}) attempted to access SHARED assistant {assistant_id} without share record"
-                )
-                return None
-    # PUBLIC is accessible by anyone
+    if assistant.visibility == "SHARED":
+        if not user_email:
+            logger.warning(f"Access denied: user_email required for SHARED assistant {assistant_id}")
+            return None, None
 
-    return assistant
+        share_permission = await check_share_access(assistant_id, user_email)
+        if not share_permission:
+            logger.warning(
+                f"Access denied: user {user_id} ({user_email}) attempted to access SHARED assistant {assistant_id} without share record"
+            )
+            return None, None
+        return assistant, share_permission
+
+    # PUBLIC: non-owners are viewers
+    return assistant, "viewer"
+
+
+async def resolve_assistant_permission(
+    assistant_id: str, user_id: str, user_email: Optional[str] = None
+) -> Tuple[Optional[Assistant], Optional[str]]:
+    """
+    Resolve the requesting user's permission on an assistant.
+
+    Unlike get_assistant_with_access_check (which gates on visibility), this
+    helper resolves *any* permission the user has regardless of visibility —
+    so an editor share on a PRIVATE assistant still resolves to "editor".
+    Returns (assistant, permission) or (assistant, None) if the user has no
+    permission, or (None, None) if the assistant doesn't exist.
+
+    Used by write routes that need to gate on permission level (owner/editor)
+    rather than visibility.
+    """
+    assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not assistants_table:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+
+    assistant = await _get_assistant_cloud_without_ownership_check(assistant_id, assistants_table)
+    if not assistant:
+        return None, None
+
+    if assistant.owner_id == user_id:
+        return assistant, "owner"
+
+    if user_email:
+        share_permission = await check_share_access(assistant_id, user_email)
+        if share_permission:
+            return assistant, share_permission
+
+    return assistant, None
 
 
 async def assistant_exists(assistant_id: str) -> bool:
@@ -811,7 +848,9 @@ async def _delete_assistant_cloud(assistant_id: str, table_name: str) -> bool:
 # ========== Share Management Functions ==========
 
 
-async def share_assistant(assistant_id: str, owner_id: str, emails: List[str]) -> bool:
+async def share_assistant(
+    assistant_id: str, owner_id: str, emails: List[str], permission: str = "viewer"
+) -> bool:
     """
     Share an assistant with specified email addresses.
 
@@ -822,10 +861,16 @@ async def share_assistant(assistant_id: str, owner_id: str, emails: List[str]) -
         assistant_id: Assistant identifier
         owner_id: User identifier (must be the owner)
         emails: List of email addresses to share with
+        permission: Permission level granted to each new share ("viewer" or "editor").
+            Existing share records for the same email are overwritten with this value.
 
     Returns:
         True if shares were created successfully, False otherwise
     """
+    if permission not in ("viewer", "editor"):
+        logger.warning(f"Invalid permission '{permission}' for share_assistant; rejecting")
+        return False
+
     # Verify ownership first
     assistant = await get_assistant(assistant_id, owner_id)
     if not assistant:
@@ -863,9 +908,10 @@ async def share_assistant(assistant_id: str, owner_id: str, emails: List[str]) -
                         "email": email,
                         "createdAt": _get_current_timestamp(),
                         "firstInteracted": False,
+                        "permission": permission,
                     }
                 )
-                logger.info(f"Created share record for assistant {assistant_id} with {email}")
+                logger.info(f"Created share record ({permission}) for assistant {assistant_id} with {email}")
             except ClientError as e:
                 logger.error(f"Failed to create share record for {email}: {e}")
                 # Continue with other emails even if one fails
@@ -874,6 +920,77 @@ async def share_assistant(assistant_id: str, owner_id: str, emails: List[str]) -
 
     except Exception as e:
         logger.error(f"Error sharing assistant {assistant_id}: {e}", exc_info=True)
+        return False
+
+
+async def update_share_permission(
+    assistant_id: str, owner_id: str, email: str, permission: str
+) -> bool:
+    """
+    Update the permission level of an existing share record.
+
+    Only the owner can change share permissions. Returns False if the assistant
+    is not owned by `owner_id`, the share record does not exist, or `permission`
+    is invalid.
+
+    Args:
+        assistant_id: Assistant identifier
+        owner_id: User identifier (must be the owner)
+        email: Email of the existing share to update (normalized lowercase)
+        permission: New permission level ("viewer" or "editor")
+
+    Returns:
+        True on success, False otherwise
+    """
+    if permission not in ("viewer", "editor"):
+        logger.warning(f"Invalid permission '{permission}' for update_share_permission")
+        return False
+
+    assistant = await get_assistant(assistant_id, owner_id)
+    if not assistant:
+        logger.warning(
+            f"Cannot update share permission on {assistant_id}: not found or not owned by {owner_id}"
+        )
+        return False
+
+    assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not assistants_table:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+
+    normalized_email = email.lower().strip()
+    if not normalized_email:
+        return False
+
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(assistants_table)
+
+        table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SHARE#{normalized_email}"},
+            UpdateExpression="SET #perm = :perm",
+            ExpressionAttributeNames={"#perm": "permission"},
+            ExpressionAttributeValues={":perm": permission},
+            ConditionExpression="attribute_exists(PK)",
+        )
+        logger.info(
+            f"Updated share permission for assistant {assistant_id}, email {normalized_email} -> {permission}"
+        )
+        return True
+
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "ConditionalCheckFailedException":
+            logger.warning(
+                f"Share record not found: assistant={assistant_id}, email={normalized_email}"
+            )
+        else:
+            logger.error(f"Failed to update share permission: {error_code} - {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Error updating share permission: {e}", exc_info=True)
         return False
 
 
@@ -931,23 +1048,26 @@ async def unshare_assistant(assistant_id: str, owner_id: str, emails: List[str])
         return False
 
 
-async def list_assistant_shares(assistant_id: str, owner_id: str) -> List[str]:
+async def list_assistant_shares(assistant_id: str, owner_id: str) -> List[dict]:
     """
-    List all email addresses an assistant is shared with.
+    List all share records (email + permission) for an assistant.
 
-    Only the owner can view the share list.
+    Caller has already verified they're permitted to read the share list
+    (owners and editors); we still verify the assistant exists.
 
     Args:
         assistant_id: Assistant identifier
-        owner_id: User identifier (must be the owner)
+        owner_id: True owner of the assistant — used to fetch the assistant.
+            Pass the assistant's real ownerId (not the requesting user).
 
     Returns:
-        List of email addresses (lowercase, normalized)
+        List of dicts shaped like {"email": str, "permission": "viewer"|"editor"}.
+        Missing `permission` on legacy records defaults to "viewer".
     """
-    # Verify ownership first
+    # Verify the assistant exists (and the supplied owner_id matches it)
     assistant = await get_assistant(assistant_id, owner_id)
     if not assistant:
-        logger.warning(f"Cannot list shares for assistant {assistant_id}: not found or not owned by {owner_id}")
+        logger.warning(f"Cannot list shares for assistant {assistant_id}: not found or owner mismatch")
         return []
 
     assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
@@ -963,16 +1083,19 @@ async def list_assistant_shares(assistant_id: str, owner_id: str) -> List[str]:
         table = dynamodb.Table(assistants_table)
 
         # Query all share records for this assistant
-        response = table.query(KeyConditionExpression=Key("PK").eq(f"AST#{assistant_id}") & Key("SK").begins_with("SHARE#"))
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(f"AST#{assistant_id}") & Key("SK").begins_with("SHARE#")
+        )
 
-        emails = []
+        shares: List[dict] = []
         for item in response.get("Items", []):
             email = item.get("email")
-            if email:
-                emails.append(email)
+            if not email:
+                continue
+            shares.append({"email": email, "permission": item.get("permission", "viewer")})
 
-        logger.info(f"Found {len(emails)} shares for assistant {assistant_id}")
-        return emails
+        logger.info(f"Found {len(shares)} shares for assistant {assistant_id}")
+        return shares
 
     except ClientError as e:
         logger.error(f"Error listing shares for assistant {assistant_id}: {e}")
@@ -982,16 +1105,17 @@ async def list_assistant_shares(assistant_id: str, owner_id: str) -> List[str]:
         return []
 
 
-async def check_share_access(assistant_id: str, user_email: str) -> bool:
+async def check_share_access(assistant_id: str, user_email: str) -> Optional[str]:
     """
-    Check if a user has share access to an assistant.
+    Look up a user's share permission on an assistant.
 
     Args:
         assistant_id: Assistant identifier
         user_email: User's email address (will be normalized to lowercase)
 
     Returns:
-        True if share record exists, False if not found
+        "viewer" or "editor" if the user has a share record, None otherwise.
+        Legacy share records without a `permission` attribute resolve to "viewer".
 
     Raises:
         Exception: On DynamoDB errors (not ResourceNotFoundException)
@@ -1013,7 +1137,15 @@ async def check_share_access(assistant_id: str, user_email: str) -> bool:
         # Check if share record exists
         response = table.get_item(Key={"PK": f"AST#{assistant_id}", "SK": f"SHARE#{normalized_email}"})
 
-        return "Item" in response
+        item = response.get("Item")
+        if not item:
+            return None
+
+        permission = item.get("permission", "viewer")
+        if permission not in ("viewer", "editor"):
+            # Defensive: unknown stored value -> treat as viewer
+            return "viewer"
+        return permission
 
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
@@ -1021,7 +1153,7 @@ async def check_share_access(assistant_id: str, user_email: str) -> bool:
 
         if error_code == "ResourceNotFoundException":
             logger.debug(f"Table {assistants_table} not found")
-            return False
+            return None
         else:
             # Don't suppress real errors like AccessDeniedException
             logger.error(f"DynamoDB error checking share access for {assistant_id}: {error_code} - {error_message}")
@@ -1115,6 +1247,7 @@ async def list_shared_with_user(user_email: str) -> List[Assistant]:
         for item in response.get("Items", []):
             assistant_id = item.get("assistantId")
             first_interacted = item.get("firstInteracted", False)  # Default to False if not present
+            share_permission = item.get("permission", "viewer")  # Legacy records default to viewer
 
             if assistant_id:
                 # Get the full assistant metadata
@@ -1122,6 +1255,7 @@ async def list_shared_with_user(user_email: str) -> List[Assistant]:
                 if assistant:
                     # Attach share metadata as dynamic attributes
                     assistant.first_interacted = first_interacted
+                    assistant.user_permission = share_permission
                     assistants.append(assistant)
 
         logger.info(f"Found {len(assistants)} assistants shared with {normalized_email}")

--- a/backend/tests/routes/test_delete_endpoints.py
+++ b/backend/tests/routes/test_delete_endpoints.py
@@ -7,6 +7,7 @@ Endpoints under test:
 Requirements: 2.1, 2.2, 8.1, 8.2
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -18,6 +19,11 @@ from apis.app_api.assistants.routes import router as assistants_router
 from apis.app_api.documents.models import Document
 from apis.shared.auth.dependencies import get_current_user_id, get_current_user_from_session
 from apis.shared.auth.models import User
+
+
+def _owner_resolve(user_id: str):
+    """Build a resolve_assistant_permission return value for an owner."""
+    return (SimpleNamespace(owner_id=user_id), "owner")
 
 
 # ---------------------------------------------------------------------------
@@ -75,14 +81,19 @@ class TestDocumentDeleteEndpoint:
     def app(self):
         _app = FastAPI()
         _app.include_router(documents_router)
-        _app.dependency_overrides[get_current_user_id] = lambda: USER_ID
+        _app.dependency_overrides[get_current_user_from_session] = _make_user
         return _app
 
     def test_delete_returns_204_after_soft_delete(self, app):
         """Req 2.1: Endpoint returns 204 after successful soft-delete."""
         doc = _make_document()
+        routes_module = "apis.app_api.documents.routes"
 
         with patch(
+            f"{routes_module}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner_resolve(USER_ID),
+        ), patch(
             f"{DOC_SERVICE}.soft_delete_document",
             new_callable=AsyncMock,
             return_value=doc,
@@ -99,7 +110,12 @@ class TestDocumentDeleteEndpoint:
 
     def test_delete_returns_404_when_not_found(self, app):
         """Req 1.5: Returns 404 when soft_delete_document returns None."""
+        routes_module = "apis.app_api.documents.routes"
         with patch(
+            f"{routes_module}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner_resolve(USER_ID),
+        ), patch(
             f"{DOC_SERVICE}.soft_delete_document",
             new_callable=AsyncMock,
             return_value=None,
@@ -112,8 +128,13 @@ class TestDocumentDeleteEndpoint:
     def test_delete_fires_cleanup_in_background(self, app):
         """Req 2.2: Cleanup is scheduled as a background task via asyncio.ensure_future."""
         doc = _make_document()
+        routes_module = "apis.app_api.documents.routes"
 
         with patch(
+            f"{routes_module}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner_resolve(USER_ID),
+        ), patch(
             f"{DOC_SERVICE}.soft_delete_document",
             new_callable=AsyncMock,
             return_value=doc,

--- a/backend/tests/routes/test_document_import.py
+++ b/backend/tests/routes/test_document_import.py
@@ -7,6 +7,7 @@ write, and the async import task — are patched; we test the gating, the
 provenance wiring, and the response shape.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,6 +24,11 @@ from apis.shared.rbac.service import get_app_role_service
 ROUTES_MODULE = "apis.app_api.documents.routes"
 ASSISTANT_ID = "ast-001"
 USER_ID = "user-001"
+
+
+def _owner_resolve(user_id: str = USER_ID):
+    """Build a resolve_assistant_permission return value for an owner."""
+    return (SimpleNamespace(owner_id=user_id), "owner")
 
 
 def _make_user(user_id: str = USER_ID) -> User:
@@ -87,9 +93,9 @@ class TestImportDocuments:
             f"{ROUTES_MODULE}._generate_document_id",
             side_effect=["DOC-1", "DOC-2"],
         ), patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.resolve_file_source",
             new_callable=AsyncMock,
@@ -126,9 +132,9 @@ class TestImportDocuments:
         adapter.metadata.key = "google-drive"
 
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.resolve_file_source",
             new_callable=AsyncMock,
@@ -159,10 +165,28 @@ class TestImportDocuments:
         assert first.imported_by_user_id == USER_ID
 
     def test_404_when_assistant_not_owned(self, app):
+        # Caller is neither owner nor editor — resolve returns (assistant, None)
+        # which our _require_edit_permission helper maps to 403.
+        not_permitted = (SimpleNamespace(owner_id="someone-else"), None)
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value=None,
+            return_value=not_permitted,
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ) as mock_create:
+            resp = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/documents/import", json=_import_body()
+            )
+
+        assert resp.status_code == 403
+        mock_create.assert_not_called()
+
+    def test_404_when_assistant_not_found(self, app):
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(None, None),
         ), patch(
             f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
         ) as mock_create:
@@ -178,9 +202,9 @@ class TestImportDocuments:
         provider.provider_id = "google"
 
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.resolve_file_source",
             new_callable=AsyncMock,
@@ -203,9 +227,9 @@ class TestImportDocuments:
 
     def test_404_propagates_when_not_a_file_source(self, app):
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.resolve_file_source",
             new_callable=AsyncMock,

--- a/backend/tests/routes/test_documents.py
+++ b/backend/tests/routes/test_documents.py
@@ -7,6 +7,7 @@ Endpoints under test:
 Requirements: 14.1, 14.2
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,7 +16,8 @@ from fastapi.testclient import TestClient
 
 from apis.app_api.documents.routes import router
 from apis.app_api.documents.models import Document
-from apis.shared.auth.dependencies import get_current_user_id
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
 from tests.routes.conftest import mock_no_auth
 
 
@@ -60,8 +62,15 @@ def app():
 
 
 def _override_user_id(app: FastAPI, user_id: str = USER_ID) -> None:
-    """Override get_current_user_id to return a fixed user_id string."""
-    app.dependency_overrides[get_current_user_id] = lambda: user_id
+    """Override the session-cookie dependency with a fixed User."""
+    app.dependency_overrides[get_current_user_from_session] = lambda: User(
+        user_id=user_id, email=f"{user_id}@example.com", name="Test User", roles=["User"]
+    )
+
+
+def _owner_resolve(user_id: str = USER_ID):
+    """Build a resolve_assistant_permission return value for an owner."""
+    return (SimpleNamespace(owner_id=user_id), "owner")
 
 
 # ---------------------------------------------------------------------------
@@ -77,12 +86,11 @@ class TestListDocumentsAuthenticated:
         _override_user_id(app)
 
         sample = _make_document()
-        mock_assistant = AsyncMock(return_value={"assistantId": ASSISTANT_ID})
 
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value=mock_assistant.return_value,
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.list_assistant_documents",
             new_callable=AsyncMock,
@@ -102,9 +110,9 @@ class TestListDocumentsAuthenticated:
         _override_user_id(app)
 
         with patch(
-            f"{ROUTES_MODULE}.get_assistant",
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_owner_resolve(),
         ), patch(
             f"{ROUTES_MODULE}.list_assistant_documents",
             new_callable=AsyncMock,

--- a/backend/tests/shared/test_assistants.py
+++ b/backend/tests/shared/test_assistants.py
@@ -83,8 +83,8 @@ class TestAssistantsService:
             description="d", instructions="hi",
         )
         assert await share_assistant(created.assistant_id, "u1", ["bob@example.com"]) is True
-        assert await check_share_access(created.assistant_id, "bob@example.com") is True
-        assert await check_share_access(created.assistant_id, "eve@example.com") is False
+        assert await check_share_access(created.assistant_id, "bob@example.com") == "viewer"
+        assert await check_share_access(created.assistant_id, "eve@example.com") is None
 
     @pytest.mark.asyncio
     async def test_unshare(self, assistants_table):
@@ -95,7 +95,7 @@ class TestAssistantsService:
         )
         await share_assistant(created.assistant_id, "u1", ["bob@example.com"])
         await unshare_assistant(created.assistant_id, "u1", ["bob@example.com"])
-        assert await check_share_access(created.assistant_id, "bob@example.com") is False
+        assert await check_share_access(created.assistant_id, "bob@example.com") is None
 
     @pytest.mark.asyncio
     async def test_list_shared_with_user(self, assistants_table):
@@ -107,6 +107,272 @@ class TestAssistantsService:
         await share_assistant(created.assistant_id, "u1", ["bob@example.com"])
         shared = await list_shared_with_user("bob@example.com")
         assert len(shared) == 1
+
+
+class TestSharePermissions:
+    """Issue #113 — viewer/editor permission levels on shares."""
+
+    @pytest.fixture(autouse=True)
+    def _set_env(self, monkeypatch):
+        monkeypatch.setenv("S3_ASSISTANTS_VECTOR_STORE_INDEX_NAME", "test-index")
+
+    @pytest.mark.asyncio
+    async def test_share_with_explicit_viewer_permission(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            check_share_access,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assert await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="viewer"
+        ) is True
+        assert await check_share_access(created.assistant_id, "bob@example.com") == "viewer"
+
+    @pytest.mark.asyncio
+    async def test_share_with_editor_permission(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            check_share_access,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assert await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="editor"
+        ) is True
+        assert await check_share_access(created.assistant_id, "bob@example.com") == "editor"
+
+    @pytest.mark.asyncio
+    async def test_share_rejects_invalid_permission(self, assistants_table):
+        from apis.shared.assistants.service import create_assistant, share_assistant
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assert await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="admin"
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_legacy_share_without_permission_defaults_to_viewer(self, assistants_table):
+        """Existing share records that pre-date this feature lack the `permission`
+        attribute. Reads must default them to viewer for backward compatibility.
+        """
+        import boto3
+        from apis.shared.assistants.service import create_assistant, check_share_access
+
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+
+        # Write a legacy-shaped share record directly (no `permission` attribute)
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        ddb.Table("test-assistants").put_item(
+            Item={
+                "PK": f"AST#{created.assistant_id}",
+                "SK": "SHARE#legacy@example.com",
+                "GSI3_PK": "SHARE#legacy@example.com",
+                "GSI3_SK": f"AST#{created.assistant_id}",
+                "assistantId": created.assistant_id,
+                "email": "legacy@example.com",
+                "createdAt": "2024-01-01T00:00:00Z",
+                "firstInteracted": False,
+            }
+        )
+
+        assert await check_share_access(created.assistant_id, "legacy@example.com") == "viewer"
+
+    @pytest.mark.asyncio
+    async def test_resolve_assistant_permission_owner(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            resolve_assistant_permission,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assistant, permission = await resolve_assistant_permission(
+            created.assistant_id, "u1", "alice@test.com"
+        )
+        assert assistant is not None
+        assert permission == "owner"
+
+    @pytest.mark.asyncio
+    async def test_resolve_assistant_permission_editor(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            resolve_assistant_permission,
+            share_assistant,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="editor"
+        )
+        assistant, permission = await resolve_assistant_permission(
+            created.assistant_id, "u2", "bob@example.com"
+        )
+        assert assistant is not None
+        assert permission == "editor"
+
+    @pytest.mark.asyncio
+    async def test_resolve_assistant_permission_viewer(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            resolve_assistant_permission,
+            share_assistant,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="viewer"
+        )
+        assistant, permission = await resolve_assistant_permission(
+            created.assistant_id, "u2", "bob@example.com"
+        )
+        assert assistant is not None
+        assert permission == "viewer"
+
+    @pytest.mark.asyncio
+    async def test_resolve_assistant_permission_no_share(self, assistants_table):
+        """Non-owner with no share record resolves to (assistant, None) — caller
+        gates this as a 403. Returning the assistant lets the caller distinguish
+        no-permission from not-found without a second DB read.
+        """
+        from apis.shared.assistants.service import (
+            create_assistant,
+            resolve_assistant_permission,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assistant, permission = await resolve_assistant_permission(
+            created.assistant_id, "u2", "eve@example.com"
+        )
+        assert assistant is not None
+        assert permission is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_assistant_permission_not_found(self, assistants_table):
+        from apis.shared.assistants.service import resolve_assistant_permission
+        assistant, permission = await resolve_assistant_permission(
+            "ast-nope", "u1", "alice@example.com"
+        )
+        assert assistant is None
+        assert permission is None
+
+    @pytest.mark.asyncio
+    async def test_update_share_permission_upgrades_viewer_to_editor(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            check_share_access,
+            update_share_permission,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(created.assistant_id, "u1", ["bob@example.com"], permission="viewer")
+        assert await check_share_access(created.assistant_id, "bob@example.com") == "viewer"
+
+        assert await update_share_permission(
+            created.assistant_id, "u1", "bob@example.com", "editor"
+        ) is True
+        assert await check_share_access(created.assistant_id, "bob@example.com") == "editor"
+
+    @pytest.mark.asyncio
+    async def test_update_share_permission_requires_owner(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            update_share_permission,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(created.assistant_id, "u1", ["bob@example.com"], permission="viewer")
+        # u2 is not the owner — update should fail
+        assert await update_share_permission(
+            created.assistant_id, "u2", "bob@example.com", "editor"
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_update_share_permission_missing_share(self, assistants_table):
+        from apis.shared.assistants.service import create_assistant, update_share_permission
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        assert await update_share_permission(
+            created.assistant_id, "u1", "noone@example.com", "editor"
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_update_share_permission_rejects_invalid(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            update_share_permission,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(created.assistant_id, "u1", ["bob@example.com"])
+        assert await update_share_permission(
+            created.assistant_id, "u1", "bob@example.com", "admin"
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_list_assistant_shares_returns_email_and_permission(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            list_assistant_shares,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(created.assistant_id, "u1", ["bob@example.com"], permission="editor")
+        await share_assistant(created.assistant_id, "u1", ["carol@example.com"], permission="viewer")
+
+        shares = await list_assistant_shares(created.assistant_id, "u1")
+        by_email = {s["email"]: s["permission"] for s in shares}
+        assert by_email == {"bob@example.com": "editor", "carol@example.com": "viewer"}
+
+    @pytest.mark.asyncio
+    async def test_list_shared_with_user_surfaces_permission(self, assistants_table):
+        from apis.shared.assistants.service import (
+            create_assistant,
+            share_assistant,
+            list_shared_with_user,
+        )
+        created = await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+        await share_assistant(
+            created.assistant_id, "u1", ["bob@example.com"], permission="editor"
+        )
+        shared = await list_shared_with_user("bob@example.com")
+        assert len(shared) == 1
+        assert getattr(shared[0], "user_permission", None) == "editor"
 
 
 class TestRAGService:

--- a/backend/tests/shared/test_assistants_extended.py
+++ b/backend/tests/shared/test_assistants_extended.py
@@ -16,8 +16,9 @@ class TestAssistantsServiceExtended:
             owner_id="u1", owner_name="Alice", name="Bot",
             description="d", instructions="hi",
         )
-        result = await get_assistant_with_access_check(created.assistant_id, "u1", "alice@test.com")
-        assert result is not None
+        assistant, permission = await get_assistant_with_access_check(created.assistant_id, "u1", "alice@test.com")
+        assert assistant is not None
+        assert permission == "owner"
 
     @pytest.mark.asyncio
     async def test_get_assistant_with_access_check_not_owner(self):
@@ -26,8 +27,9 @@ class TestAssistantsServiceExtended:
             owner_id="u1", owner_name="Alice", name="Bot",
             description="d", instructions="hi",
         )
-        result = await get_assistant_with_access_check(created.assistant_id, "u2", "bob@test.com")
-        assert result is None  # private, not shared
+        assistant, permission = await get_assistant_with_access_check(created.assistant_id, "u2", "bob@test.com")
+        assert assistant is None  # private, not shared
+        assert permission is None
 
     @pytest.mark.asyncio
     async def test_list_user_assistants_pagination(self):
@@ -50,6 +52,10 @@ class TestAssistantsServiceExtended:
         await share_assistant(created.assistant_id, "u1", ["a@test.com", "b@test.com"])
         shares = await list_assistant_shares(created.assistant_id, "u1")
         assert len(shares) == 2
+        # Each share is now a dict with email + permission (default viewer)
+        emails = {s["email"] for s in shares}
+        assert emails == {"a@test.com", "b@test.com"}
+        assert all(s["permission"] == "viewer" for s in shares)
 
     @pytest.mark.asyncio
     async def test_create_with_tags_and_starters(self):


### PR DESCRIPTION
Implements **PR 1 (backend)** of the phased plan in [#113](https://github.com/Boise-State-Development/agentcore-public-stack/issues/113#issuecomment-4510124783) for collaborative assistant editing. Frontend follows in PR 2.

## Summary

- Adds a `permission` (\`viewer\` | \`editor\`) attribute to share records and surfaces it on every read path. Legacy share records without the attribute default to \`viewer\` — no migration needed.
- Adds \`resolve_assistant_permission\` as the single chokepoint write routes use to gate on \`owner\`/\`editor\` access.
- \`PUT /assistants/{id}\` and \`POST /assistants/{id}/test-chat\` now accept \`editor\` callers. Editors explicitly cannot change \`visibility\` (400) — that's an ownership action.
- Document routes (\`upload-url\`, \`import\`, \`upload-failed\`, list/get/download, \`delete\`) gate on owner|editor and feed the assistant's real \`owner_id\` into the existing document-service functions — no document-service signature changes.
- New \`PATCH /assistants/{id}/shares\` so owners can upgrade viewer ↔ editor without re-creating the share (preserves \`createdAt\` / \`firstInteracted\`).
- \`GET /assistants/{id}/shares\` now allows editors to read the share list (still owner-only for POST/DELETE/PATCH).
- \`AssistantResponse\` gains \`userPermission\` so the SPA can decide what to render per assistant.
- \`AssistantSharesResponse.sharedWith\` is now \`ShareEntry[]\` (\`{email, permission}\`) instead of \`string[]\` — **breaking change for the SPA**, which is why PR 2 needs to land close behind.

## Key architectural decision

DynamoDB mutation functions (\`update_assistant\`, \`delete_assistant\`, document-service writes) are all keyed only on \`assistant_id\`; the \`owner_id\` they accept is purely an access gate. So routes resolve permission, then pass the assistant's *real* \`owner_id\` into the existing mutations — no mutation signature changes needed.

## Test plan

- [x] Run \`uv run python -m pytest tests/ -q\` locally → **3112 passed, 3 skipped**.
- [x] New \`TestSharePermissions\` covers: viewer/editor share writes, invalid permission rejection, legacy record back-compat, \`resolve_assistant_permission\` (owner/editor/viewer/none/not-found), \`update_share_permission\` (upgrade, owner-required, missing share, invalid), \`list_assistant_shares\` shape, \`list_shared_with_user\` permission surfacing.
- [x] Updated \`get_assistant_with_access_check\` tests for the new tuple return.
- [x] Updated route tests that previously patched the removed \`get_assistant\` import to patch \`resolve_assistant_permission\` instead.
- [ ] Manual smoke once PR 2 lands: owner shares as editor → editor logs in → can update instructions & docs → cannot delete or change visibility.

## Follow-up (PR 2)

Share dialog permission toggle, edit-form gating, list "Editor" badge, vitest specs for the dialog delta logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)