### PR TITLE
feat(assistants): viewer/editor share permissions UI (#113)

### DIFF
--- a/.claude/skills/tailwind-ui/references/app-conventions.md
+++ b/.claude/skills/tailwind-ui/references/app-conventions.md
@@ -61,6 +61,15 @@ Field:
 <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Error message</p>
 ```
 
+Select (`rounded-2xl` selects need a custom chevron — see "Selects" below):
+
+```html
+<div class="relative inline-flex">
+  <select class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white">…</select>
+  <ng-icon name="heroChevronDown" class="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+</div>
+```
+
 Buttons:
 
 ```html
@@ -76,6 +85,65 @@ Buttons:
 <!-- Icon-only (size-8, e.g. delete) -->
 <button class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400">…</button>
 ```
+
+## Tabs (segmented underline)
+
+Underline tabs inside a dialog or section — use `aria-selected` to drive the active
+state so styling rides an attribute-selector variant. Do **not** use parallel
+`[class.border-b-blue-600]` bindings (see "Common gotchas").
+
+```html
+<div class="flex gap-1 border-b border-gray-200 dark:border-gray-700" role="tablist">
+  <button
+    type="button"
+    role="tab"
+    [attr.aria-selected]="active()"
+    (click)="active.set(true)"
+    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 aria-selected:border-b-blue-600 aria-selected:font-semibold aria-selected:text-blue-600 dark:text-gray-400 dark:hover:text-white dark:aria-selected:border-b-blue-400 dark:aria-selected:text-blue-400"
+  >
+    Tab label
+  </button>
+</div>
+```
+
+- `-mb-px` on each tab pulls its 2px bottom border down 1px so the active underline
+  overlaps the container's 1px bottom border cleanly (no gray line peeking through).
+- `border-b-*` (bottom-only) — not `border-*` — so the cascade fight is on
+  `border-bottom-color` only.
+- Active state flips text color + font weight in addition to the underline — short
+  tab labels need the weight contrast to read at a glance.
+
+## Common gotchas
+
+### Conditional Tailwind classes can lose the cascade
+
+Two classes that set the same property at the same specificity (`border-b-transparent`
+base + `[class.border-b-blue-600]="active()"`) collide. Whichever Tailwind emits **later**
+in the stylesheet wins, regardless of class order in your `class="…"` string. In practice
+the transparent base wins and the active underline never appears.
+
+Fix: drive the active state with an attribute selector that has higher specificity than
+a plain class. Tailwind's built-in `aria-selected:`, `data-[…]:`, and `aria-*` variants all
+generate selectors like `[aria-selected="true"]` (specificity `0,1,1`) which beat the
+base utility (`0,1,0`):
+
+```html
+<button [attr.aria-selected]="active()"
+        class="border-b-2 border-b-transparent aria-selected:border-b-blue-600">…</button>
+```
+
+DevTools symptom: the conditional class IS on the DOM, but `getComputedStyle(el).borderBottomColor` returns `rgba(0, 0, 0, 0)`. If you see that, this is the bug.
+
+### Native `<select>` chevrons crowd `rounded-2xl` corners
+
+Browsers position the native dropdown chevron at a fixed offset from the right edge,
+ignoring `padding-right`. With `rounded-2xl` (1rem radius) the chevron overlaps the
+curve. Adding more `pr-*` just pushes the text further left without moving the chevron.
+
+Fix: `appearance-none` + an overlaid `heroChevronDown` icon (see the Select example
+under "Form pages"). The wrapper handles positioning so the chevron clears the
+rounded corner. `pointer-events-none` on the icon so clicks still fall through to the
+native select.
 
 ## List pages
 

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -23,11 +23,22 @@
             {{ form.get('status')?.value || 'DRAFT' }}
           </span>
         }
+
+        <!-- Editor banner: shown when the requester is an editor on someone else's assistant -->
+        @if (isEditorView()) {
+          <span
+            class="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs/5 font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+            title="You are editing as a collaborator. Only the owner can delete this assistant or change who has access."
+          >
+            <ng-icon name="heroUser" class="size-3" />
+            Shared by {{ ownerName() || 'owner' }}
+          </span>
+        }
       </div>
 
       <!-- Right: Action buttons -->
       <div class="flex items-center gap-2">
-        @if (mode() === 'edit') {
+        @if (mode() === 'edit' && canManageShares()) {
           <button
             type="button"
             (click)="openShareDialog()"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
@@ -32,6 +32,7 @@ import {
   heroGlobeAlt,
   heroLink,
   heroXMark,
+  heroUser,
   heroUserGroup,
   heroPlus,
   heroTrash,
@@ -84,6 +85,7 @@ import { ToastService } from '../../services/toast/toast.service';
       heroGlobeAlt,
       heroLink,
       heroXMark,
+      heroUser,
       heroUserGroup,
       heroPlus,
       heroTrash,
@@ -113,6 +115,13 @@ export class AssistantFormPage implements OnInit, OnDestroy {
 
   readonly assistantId = signal<string | null>(null);
   readonly mode = computed<'create' | 'edit'>(() => (this.assistantId() ? 'edit' : 'create'));
+  /** The requesting user's permission on the loaded assistant — populated by loadAssistant.
+   *  In create mode the user is implicitly the owner, so we seed it that way. */
+  readonly userPermission = signal<'owner' | 'editor' | 'viewer'>('owner');
+  /** Owner display name surfaced on the editor banner when the requester is an editor. */
+  readonly ownerName = signal<string>('');
+  readonly canManageShares = computed(() => this.userPermission() === 'owner');
+  readonly isEditorView = computed(() => this.userPermission() === 'editor');
 
   // Live form value signals — kept in sync via form.valueChanges so the
   // preview component (OnPush) receives updates as the user types.
@@ -301,6 +310,12 @@ export class AssistantFormPage implements OnInit, OnDestroy {
           emoji: assistant.emoji || '',
           status: assistant.status,
         });
+
+        // Cached assistants from the list view do not carry userPermission
+        // (the list synthesises it locally) — fall back to 'owner' for cache hits
+        // so the owner's editor experience stays identical.
+        this.userPermission.set(assistant.userPermission ?? 'owner');
+        this.ownerName.set(assistant.ownerName ?? '');
 
         // Populate starters FormArray
         this.starters.clear();

--- a/frontend/ai.client/src/app/assistants/components/assistant-list.component.html
+++ b/frontend/ai.client/src/app/assistants/components/assistant-list.component.html
@@ -150,6 +150,12 @@
               <ng-icon name="heroUser" class="mr-1 size-3" />
               {{ assistant.ownerName }}
             </span>
+            @if (isEditorShare(assistant)) {
+              <span [class]="getEditorBadgeClasses()" appTooltip="You can edit this assistant">
+                <ng-icon name="heroPencilSquare" class="mr-1 size-3" />
+                Editor
+              </span>
+            }
           } @else {
             <span [class]="getVisibilityBadgeClasses(assistant.visibility)">
               <ng-icon [name]="getVisibilityIcon(assistant.visibility)" class="mr-1 size-3" />
@@ -187,11 +193,11 @@
         <span>Chat</span>
       </button>
 
-      @if (isOwned) {
+      @if (isOwned || isEditorShare(assistant)) {
         <!-- Divider -->
         <div class="w-px h-5 bg-gray-100 dark:bg-gray-700/60"></div>
 
-        <!-- Edit button -->
+        <!-- Edit button (owners always; editors on shared assistants) -->
         <button
           type="button"
           (click)="onEditClick(assistant, $event)"
@@ -202,7 +208,9 @@
           <ng-icon name="heroPencilSquare" class="size-4" />
           <span>Edit</span>
         </button>
+      }
 
+      @if (isOwned) {
         <!-- Divider -->
         <div class="w-px h-5 bg-gray-100 dark:bg-gray-700/60"></div>
 

--- a/frontend/ai.client/src/app/assistants/components/assistant-list.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/assistant-list.component.ts
@@ -234,6 +234,14 @@ export class AssistantListComponent {
     return 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400';
   }
 
+  getEditorBadgeClasses(): string {
+    return 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400';
+  }
+
+  isEditorShare(assistant: Assistant): boolean {
+    return !!assistant.isSharedWithMe && assistant.userPermission === 'editor';
+  }
+
   private simpleHash(str: string): number {
     let hash = 0;
     for (let i = 0; i < str.length; i++) {

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+import { ShareAssistantDialogComponent } from './share-assistant-dialog.component';
+import { AssistantService } from '../services/assistant.service';
+import { UserApiService } from '../../users/services/user-api.service';
+import { ConfigService } from '../../services/config.service';
+import { ShareEntry, Assistant } from '../models/assistant.model';
+
+/**
+ * Why a component spec for delta logic instead of a service spec:
+ * the dialog owns the diff between "what was loaded" and "what the user
+ * pressed Save with". That delta drives which backend endpoints get called
+ * (POST share, DELETE unshare, PATCH update). Getting it wrong issues
+ * spurious writes — worth a focused unit test.
+ *
+ * We bypass vi.mock in favor of DI tokens (project convention) so this spec
+ * can't leak state into others through the shared worker pool.
+ */
+describe('ShareAssistantDialogComponent.computeDeltas', () => {
+  let component: ShareAssistantDialogComponent;
+
+  const fakeAssistant: Assistant = {
+    assistantId: 'ast-test',
+    ownerId: 'u1',
+    ownerName: 'Alice',
+    name: 'Test',
+    description: '',
+    instructions: '',
+    vectorIndexId: 'idx',
+    visibility: 'SHARED',
+    tags: [],
+    starters: [],
+    usageCount: 0,
+    createdAt: '',
+    updatedAt: '',
+    status: 'COMPLETE',
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        // ConfigService is pulled in transitively by AssistantApiService;
+        // stub the only signal it exposes so the component constructs cleanly.
+        { provide: ConfigService, useValue: { appApiUrl: () => 'http://test' } },
+        // Replace network-bound services with no-op doubles. We only exercise
+        // computeDeltas — none of these are called by it.
+        {
+          provide: AssistantService,
+          useValue: {
+            getAssistantShares: async () => [],
+            shareAssistant: async () => undefined,
+            unshareAssistant: async () => undefined,
+            updateSharePermission: async () => undefined,
+            updateAssistant: async () => undefined,
+          },
+        },
+        {
+          provide: UserApiService,
+          useValue: { searchUsers: () => ({ subscribe: () => ({}) }) },
+        },
+        { provide: DialogRef, useValue: { close: () => undefined } },
+        { provide: DIALOG_DATA, useValue: { assistant: fakeAssistant } },
+        ShareAssistantDialogComponent,
+      ],
+    });
+    component = TestBed.inject(ShareAssistantDialogComponent);
+  });
+
+  it('detects pure additions', () => {
+    const initial: ShareEntry[] = [];
+    const next: ShareEntry[] = [{ email: 'a@x.com', permission: 'viewer' }];
+
+    const result = (component as any).computeDeltas(initial, next);
+
+    expect(result.adds).toEqual([{ email: 'a@x.com', permission: 'viewer' }]);
+    expect(result.removes).toEqual([]);
+    expect(result.permissionChanges).toEqual([]);
+  });
+
+  it('detects pure removals', () => {
+    const initial: ShareEntry[] = [{ email: 'a@x.com', permission: 'viewer' }];
+    const next: ShareEntry[] = [];
+
+    const result = (component as any).computeDeltas(initial, next);
+
+    expect(result.adds).toEqual([]);
+    expect(result.removes).toEqual(['a@x.com']);
+    expect(result.permissionChanges).toEqual([]);
+  });
+
+  it('detects a permission upgrade on an already-shared email', () => {
+    const initial: ShareEntry[] = [{ email: 'a@x.com', permission: 'viewer' }];
+    const next: ShareEntry[] = [{ email: 'a@x.com', permission: 'editor' }];
+
+    const result = (component as any).computeDeltas(initial, next);
+
+    expect(result.adds).toEqual([]);
+    expect(result.removes).toEqual([]);
+    expect(result.permissionChanges).toEqual([{ email: 'a@x.com', permission: 'editor' }]);
+  });
+
+  it('emits no deltas when nothing changed', () => {
+    const same: ShareEntry[] = [
+      { email: 'a@x.com', permission: 'viewer' },
+      { email: 'b@x.com', permission: 'editor' },
+    ];
+
+    const result = (component as any).computeDeltas(same, [...same]);
+
+    expect(result.adds).toEqual([]);
+    expect(result.removes).toEqual([]);
+    expect(result.permissionChanges).toEqual([]);
+  });
+
+  it('handles mixed adds, removes, and permission changes in one save', () => {
+    const initial: ShareEntry[] = [
+      { email: 'keep-viewer@x.com', permission: 'viewer' },
+      { email: 'upgrade@x.com', permission: 'viewer' },
+      { email: 'remove@x.com', permission: 'editor' },
+    ];
+    const next: ShareEntry[] = [
+      { email: 'keep-viewer@x.com', permission: 'viewer' },
+      { email: 'upgrade@x.com', permission: 'editor' },
+      { email: 'new@x.com', permission: 'viewer' },
+    ];
+
+    const result = (component as any).computeDeltas(initial, next);
+
+    expect(result.adds).toEqual([{ email: 'new@x.com', permission: 'viewer' }]);
+    expect(result.removes).toEqual(['remove@x.com']);
+    expect(result.permissionChanges).toEqual([
+      { email: 'upgrade@x.com', permission: 'editor' },
+    ]);
+  });
+});

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -200,7 +200,10 @@ export type ShareAssistantDialogResult = {
                   </div>
                 </div>
 
-                <!-- Mode Toggle (segmented tabs) -->
+                <!-- Mode Toggle (segmented tabs).
+                     The negative bottom margin on each button pulls its border-b down 1px
+                     so the active underline overlaps the parent border cleanly — no thin
+                     gray line peeking through under the selected tab. -->
                 <div
                   class="flex gap-1 border-b border-gray-200 dark:border-gray-700"
                   role="tablist"
@@ -213,9 +216,10 @@ export type ShareAssistantDialogResult = {
                     (click)="searchMode.set(true)"
                     [class.border-blue-600]="searchMode()"
                     [class.text-blue-600]="searchMode()"
+                    [class.font-semibold]="searchMode()"
                     [class.dark:border-blue-400]="searchMode()"
                     [class.dark:text-blue-400]="searchMode()"
-                    class="inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
                   >
                     <ng-icon name="heroMagnifyingGlass" class="size-4" aria-hidden="true" />
                     Search users
@@ -227,9 +231,10 @@ export type ShareAssistantDialogResult = {
                     (click)="searchMode.set(false)"
                     [class.border-blue-600]="!searchMode()"
                     [class.text-blue-600]="!searchMode()"
+                    [class.font-semibold]="!searchMode()"
                     [class.dark:border-blue-400]="!searchMode()"
                     [class.dark:text-blue-400]="!searchMode()"
-                    class="inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
                   >
                     <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
                     Add by email
@@ -352,19 +357,17 @@ export type ShareAssistantDialogResult = {
                 </div>
 
                 @if (loadingShares()) {
-                  <!-- Skeleton: matches the real row layout (email + select + delete) so
-                       the container doesn't reflow when shares land. -->
+                  <!-- Skeleton: single row matching the real layout (email + select + delete)
+                       so the container doesn't reflow when shares land. -->
                   <ul
-                    class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                    class="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
                     aria-hidden="true"
                   >
-                    @for (placeholder of skeletonRows; track placeholder) {
-                      <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
-                        <div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-                        <div class="h-7 w-20 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
-                        <div class="size-8 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
-                      </li>
-                    }
+                    <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                      <div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                      <div class="h-7 w-20 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+                      <div class="size-8 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+                    </li>
                   </ul>
                   <span class="sr-only" role="status">Loading existing shares…</span>
                 } @else if (shares().length === 0) {

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -192,7 +192,7 @@ export type ShareAssistantDialogResult = {
                       id="new-permission-input"
                       [ngModel]="newPermission()"
                       (ngModelChange)="onNewPermissionChange($event)"
-                      class="rounded-2xl border border-gray-300 bg-white px-2.5 py-1 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                      class="rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-7 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                     >
                       <option value="viewer">Can view & chat</option>
                       <option value="editor">Can edit</option>
@@ -392,7 +392,7 @@ export type ShareAssistantDialogResult = {
                           [id]="'perm-' + entry.email"
                           [ngModel]="entry.permission"
                           (ngModelChange)="setPermission(entry.email, $event)"
-                          class="shrink-0 rounded-2xl border border-gray-300 bg-white px-2.5 py-1 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                          class="shrink-0 rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-7 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                         >
                           <option value="viewer">Can view</option>
                           <option value="editor">Can edit</option>

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroXMark, heroShare, heroLink, heroMagnifyingGlass, heroUserPlus, heroTrash } from '@ng-icons/heroicons/outline';
-import { Assistant, UserSearchResult } from '../models/assistant.model';
+import { Assistant, ShareEntry, SharePermission, UserSearchResult } from '../models/assistant.model';
 import { AssistantService } from '../services/assistant.service';
 import { UserApiService } from '../../users/services/user-api.service';
 import { Subject, debounceTime, distinctUntilChanged, switchMap, catchError, of } from 'rxjs';
@@ -267,22 +267,50 @@ export type ShareAssistantDialogResult = {
                 </div>
               }
 
+              <!-- Permission selector for new additions -->
+              <div class="flex items-center gap-3 rounded-sm bg-gray-50 px-3 py-2 dark:bg-gray-700/40">
+                <label for="new-permission-input" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Permission for new people:
+                </label>
+                <select
+                  id="new-permission-input"
+                  [ngModel]="newPermission()"
+                  (ngModelChange)="onNewPermissionChange($event)"
+                  class="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value="viewer">Can view & chat</option>
+                  <option value="editor">Can edit</option>
+                </select>
+              </div>
+
               <!-- Currently Shared List -->
-              @if (sharedEmails().length > 0) {
+              @if (shares().length > 0) {
                 <div class="space-y-2">
                   <h4 class="text-sm font-medium text-gray-900 dark:text-white">Currently shared with:</h4>
-                  <div class="space-y-1 max-h-32 overflow-y-auto">
-                    @for (email of sharedEmails(); track email) {
-                      <div class="flex items-center justify-between rounded-sm border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-700">
-                        <span class="text-sm text-gray-900 dark:text-white">{{ email }}</span>
-                        <button
-                          type="button"
-                          (click)="removeEmail(email)"
-                          class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                          aria-label="Remove {{ email }}"
-                        >
-                          <ng-icon name="heroTrash" class="size-4" />
-                        </button>
+                  <div class="space-y-1 max-h-40 overflow-y-auto">
+                    @for (entry of shares(); track entry.email) {
+                      <div class="flex items-center justify-between gap-2 rounded-sm border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-700">
+                        <span class="text-sm text-gray-900 dark:text-white truncate">{{ entry.email }}</span>
+                        <div class="flex items-center gap-2 shrink-0">
+                          <label class="sr-only" [attr.for]="'perm-' + entry.email">Permission for {{ entry.email }}</label>
+                          <select
+                            [id]="'perm-' + entry.email"
+                            [ngModel]="entry.permission"
+                            (ngModelChange)="setPermission(entry.email, $event)"
+                            class="rounded-sm border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                          >
+                            <option value="viewer">Can view</option>
+                            <option value="editor">Can edit</option>
+                          </select>
+                          <button
+                            type="button"
+                            (click)="removeEmail(entry.email)"
+                            class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                            [attr.aria-label]="'Remove ' + entry.email"
+                          >
+                            <ng-icon name="heroTrash" class="size-4" />
+                          </button>
+                        </div>
                       </div>
                     }
                   </div>
@@ -367,7 +395,12 @@ export class ShareAssistantDialogComponent {
   protected readonly searchMode = signal<boolean>(true); // true = search, false = manual email
   protected readonly searchQuery = signal<string>('');
   protected readonly emailInput = signal<string>('');
-  protected readonly sharedEmails = signal<string[]>([]);
+  /** Working set of shares for this dialog. Compared against `initialShares` on Save to compute deltas. */
+  protected readonly shares = signal<ShareEntry[]>([]);
+  /** Snapshot of shares loaded from the API — used to detect adds/removes/permission changes. */
+  private initialShares: ShareEntry[] = [];
+  /** Permission applied to newly added emails (toggle at top of the add-people section). */
+  protected readonly newPermission = signal<SharePermission>('viewer');
   protected readonly searchResults = signal<UserSearchResult[] | null>(null);
   protected readonly searching = signal<boolean>(false);
   protected readonly saving = signal<boolean>(false);
@@ -416,9 +449,14 @@ export class ShareAssistantDialogComponent {
     this.searchQuerySubject.next(value);
   }
 
+  protected onNewPermissionChange(value: SharePermission): void {
+    this.newPermission.set(value);
+  }
+
   protected addUserFromSearch(user: UserSearchResult): void {
-    if (!this.isEmailShared(user.email)) {
-      this.sharedEmails.update(emails => [...emails, user.email.toLowerCase()]);
+    const email = user.email.toLowerCase();
+    if (!this.isEmailShared(email)) {
+      this.shares.update(current => [...current, { email, permission: this.newPermission() }]);
       this.searchQuery.set('');
       this.searchResults.set(null);
     }
@@ -428,20 +466,18 @@ export class ShareAssistantDialogComponent {
     const input = this.emailInput();
     if (!input.trim()) return;
 
-    const emails = input
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const candidates = input
       .split(',')
       .map(e => e.trim().toLowerCase())
-      .filter(e => {
-        // Basic email validation
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        return emailRegex.test(e) && !this.isEmailShared(e);
-      });
+      .filter(e => emailRegex.test(e) && !this.isEmailShared(e));
 
-    if (emails.length > 0) {
-      this.sharedEmails.update(current => {
-        const newEmails = emails.filter(e => !current.includes(e));
-        return [...current, ...newEmails];
-      });
+    if (candidates.length > 0) {
+      const perm = this.newPermission();
+      this.shares.update(current => [
+        ...current,
+        ...candidates.map(email => ({ email, permission: perm })),
+      ]);
       this.emailInput.set('');
     } else {
       this.error.set('Please enter valid email addresses');
@@ -449,12 +485,19 @@ export class ShareAssistantDialogComponent {
     }
   }
 
+  protected setPermission(email: string, permission: SharePermission): void {
+    this.shares.update(current =>
+      current.map(entry => (entry.email === email ? { ...entry, permission } : entry)),
+    );
+  }
+
   protected removeEmail(email: string): void {
-    this.sharedEmails.update(emails => emails.filter(e => e !== email));
+    this.shares.update(current => current.filter(entry => entry.email !== email));
   }
 
   protected isEmailShared(email: string): boolean {
-    return this.sharedEmails().includes(email.toLowerCase());
+    const normalized = email.toLowerCase();
+    return this.shares().some(entry => entry.email === normalized);
   }
 
   protected async loadShares(): Promise<void> {
@@ -462,16 +505,18 @@ export class ShareAssistantDialogComponent {
       // Only try to load shares if assistant is SHARED
       // PRIVATE assistants won't have shares yet
       if (this.isShared()) {
-        const emails = await this.assistantService.getAssistantShares(this.data.assistant.assistantId);
-        this.sharedEmails.set(emails);
+        const entries = await this.assistantService.getAssistantShares(this.data.assistant.assistantId);
+        this.initialShares = entries.map(e => ({ ...e }));
+        this.shares.set(entries.map(e => ({ ...e })));
       } else {
-        // PRIVATE assistant - start with empty shares list
-        this.sharedEmails.set([]);
+        this.initialShares = [];
+        this.shares.set([]);
       }
     } catch (err) {
       console.error('Failed to load shares:', err);
       // Don't show error for initial load failure - just start with empty list
-      this.sharedEmails.set([]);
+      this.initialShares = [];
+      this.shares.set([]);
     }
   }
 
@@ -480,9 +525,9 @@ export class ShareAssistantDialogComponent {
     this.error.set(null);
 
     try {
-      const newShares = this.sharedEmails();
+      const next = this.shares();
       const isCurrentlyPrivate = !this.isShared();
-      const willHaveShares = newShares.length > 0;
+      const willHaveShares = next.length > 0;
 
       // If assistant is PRIVATE and we're adding shares, update visibility to SHARED
       if (isCurrentlyPrivate && willHaveShares) {
@@ -497,25 +542,29 @@ export class ShareAssistantDialogComponent {
         });
       }
 
-      // Get current shares from API (may be empty for PRIVATE assistants)
-      let currentShares: string[] = [];
-      try {
-        currentShares = await this.assistantService.getAssistantShares(this.data.assistant.assistantId);
-      } catch (err) {
-        // If assistant is PRIVATE, getAssistantShares might fail - that's okay, currentShares stays empty
-        console.debug('No existing shares (assistant may be PRIVATE)');
-      }
-      
-      // Find emails to add and remove
-      const toAdd = newShares.filter(e => !currentShares.includes(e));
-      const toRemove = currentShares.filter(e => !newShares.includes(e));
+      const deltas = this.computeDeltas(this.initialShares, next);
 
-      // Apply changes
-      if (toAdd.length > 0) {
-        await this.assistantService.shareAssistant(this.data.assistant.assistantId, toAdd);
+      // Apply each delta against the backend. The backend handles each grouped batch.
+      const id = this.data.assistant.assistantId;
+
+      // Permission changes use PATCH per-email (one record at a time keyed on email)
+      for (const change of deltas.permissionChanges) {
+        await this.assistantService.updateSharePermission(id, change.email, change.permission);
       }
-      if (toRemove.length > 0) {
-        await this.assistantService.unshareAssistant(this.data.assistant.assistantId, toRemove);
+
+      // Group adds by permission so we can POST in batches
+      const addsByPermission = new Map<SharePermission, string[]>();
+      for (const entry of deltas.adds) {
+        const bucket = addsByPermission.get(entry.permission) ?? [];
+        bucket.push(entry.email);
+        addsByPermission.set(entry.permission, bucket);
+      }
+      for (const [permission, emails] of addsByPermission) {
+        await this.assistantService.shareAssistant(id, emails, permission);
+      }
+
+      if (deltas.removes.length > 0) {
+        await this.assistantService.unshareAssistant(id, deltas.removes);
       }
 
       this.dialogRef.close({ action: 'shared' });
@@ -525,6 +574,39 @@ export class ShareAssistantDialogComponent {
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * Compare initial vs current shares to determine what API calls are needed.
+   * Adds, removes, and permission changes on already-shared emails are all distinct.
+   */
+  protected computeDeltas(
+    initial: ShareEntry[],
+    next: ShareEntry[],
+  ): { adds: ShareEntry[]; removes: string[]; permissionChanges: ShareEntry[] } {
+    const initialByEmail = new Map(initial.map(e => [e.email, e.permission]));
+    const nextByEmail = new Map(next.map(e => [e.email, e.permission]));
+
+    const adds: ShareEntry[] = [];
+    const removes: string[] = [];
+    const permissionChanges: ShareEntry[] = [];
+
+    for (const entry of next) {
+      const previous = initialByEmail.get(entry.email);
+      if (previous === undefined) {
+        adds.push(entry);
+      } else if (previous !== entry.permission) {
+        permissionChanges.push(entry);
+      }
+    }
+
+    for (const [email] of initialByEmail) {
+      if (!nextByEmail.has(email)) {
+        removes.push(email);
+      }
+    }
+
+    return { adds, removes, permissionChanges };
   }
 
   protected copyUrl(): void {

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -201,9 +201,11 @@ export type ShareAssistantDialogResult = {
                 </div>
 
                 <!-- Mode Toggle (segmented tabs).
-                     The negative bottom margin on each button pulls its border-b down 1px
-                     so the active underline overlaps the parent border cleanly — no thin
-                     gray line peeking through under the selected tab. -->
+                     Bottom-only border-b-* variant avoids a CSS collision between
+                     border-transparent (base) and border-blue-600 (active) — those
+                     are both border-color utilities at the same specificity, so
+                     using border-b-color targets a different property and lets the
+                     active state win cleanly. -->
                 <div
                   class="flex gap-1 border-b border-gray-200 dark:border-gray-700"
                   role="tablist"
@@ -214,12 +216,12 @@ export type ShareAssistantDialogResult = {
                     role="tab"
                     [attr.aria-selected]="searchMode()"
                     (click)="searchMode.set(true)"
-                    [class.border-blue-600]="searchMode()"
+                    [class.border-b-blue-600]="searchMode()"
                     [class.text-blue-600]="searchMode()"
                     [class.font-semibold]="searchMode()"
-                    [class.dark:border-blue-400]="searchMode()"
+                    [class.dark:border-b-blue-400]="searchMode()"
                     [class.dark:text-blue-400]="searchMode()"
-                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
                   >
                     <ng-icon name="heroMagnifyingGlass" class="size-4" aria-hidden="true" />
                     Search users
@@ -229,12 +231,12 @@ export type ShareAssistantDialogResult = {
                     role="tab"
                     [attr.aria-selected]="!searchMode()"
                     (click)="searchMode.set(false)"
-                    [class.border-blue-600]="!searchMode()"
+                    [class.border-b-blue-600]="!searchMode()"
                     [class.text-blue-600]="!searchMode()"
                     [class.font-semibold]="!searchMode()"
-                    [class.dark:border-blue-400]="!searchMode()"
+                    [class.dark:border-b-blue-400]="!searchMode()"
                     [class.dark:text-blue-400]="!searchMode()"
-                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
                   >
                     <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
                     Add by email

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -3,7 +3,16 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroShare, heroLink, heroMagnifyingGlass, heroUserPlus, heroTrash } from '@ng-icons/heroicons/outline';
+import {
+  heroXMark,
+  heroShare,
+  heroLink,
+  heroMagnifyingGlass,
+  heroUserPlus,
+  heroTrash,
+  heroPencilSquare,
+  heroEye,
+} from '@ng-icons/heroicons/outline';
 import { Assistant, ShareEntry, SharePermission, UserSearchResult } from '../models/assistant.model';
 import { AssistantService } from '../services/assistant.service';
 import { UserApiService } from '../../users/services/user-api.service';
@@ -33,7 +42,18 @@ export type ShareAssistantDialogResult = {
   selector: 'app-share-assistant-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, NgIcon],
-  providers: [provideIcons({ heroXMark, heroShare, heroLink, heroMagnifyingGlass, heroUserPlus, heroTrash })],
+  providers: [
+    provideIcons({
+      heroXMark,
+      heroShare,
+      heroLink,
+      heroMagnifyingGlass,
+      heroUserPlus,
+      heroTrash,
+      heroPencilSquare,
+      heroEye,
+    }),
+  ],
   host: {
     'class': 'block',
     '(keydown.escape)': 'onCancel()'
@@ -49,7 +69,7 @@ export type ShareAssistantDialogResult = {
     <!-- Dialog Panel -->
     <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
       <div
-        class="dialog-panel relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg sm:p-6 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+        class="dialog-panel relative transform overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg sm:p-6 dark:border-gray-700 dark:bg-gray-800"
         role="dialog"
         aria-modal="true"
         [attr.aria-labelledby]="'dialog-title'"
@@ -57,268 +77,321 @@ export type ShareAssistantDialogResult = {
         (click)="$event.stopPropagation()"
       >
         <!-- Close button (top-right) -->
-        <div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+        <div class="absolute top-3 right-3 hidden sm:block">
           <button
             type="button"
             (click)="onCancel()"
-            class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 dark:bg-gray-800 dark:hover:text-gray-300 dark:focus:outline-white"
+            class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             aria-label="Close dialog"
           >
             <span class="sr-only">Close</span>
-            <ng-icon name="heroXMark" class="size-6" aria-hidden="true" />
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
           </button>
         </div>
 
         <!-- Header with Icon -->
         <div class="sm:flex sm:items-start">
-          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-indigo-100 sm:mx-0 sm:size-10 dark:bg-indigo-500/10">
-            <ng-icon name="heroShare" class="size-6 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
+          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-2xl bg-blue-100 sm:mx-0 sm:size-10 dark:bg-blue-500/10">
+            <ng-icon name="heroShare" class="size-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
           </div>
           <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
             <h3
               id="dialog-title"
               class="text-base/7 font-semibold text-gray-900 dark:text-white"
             >
-              Share Assistant
+              Share assistant
             </h3>
-            <div class="mt-2">
-              <p
-                id="dialog-description"
-                class="text-sm/6 text-gray-500 dark:text-gray-400"
-              >
-                {{ data.assistant.name }}
-              </p>
-            </div>
+            <p
+              id="dialog-description"
+              class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400"
+            >
+              {{ data.assistant.name }}
+            </p>
           </div>
         </div>
 
         <!-- Content -->
-        <div class="mt-4">
+        <div class="mt-6">
           @if (isPublic()) {
             <!-- Public Assistant: Show shareable URL -->
-            <div class="space-y-3">
+            <section class="space-y-3">
               <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-                This assistant is public and discoverable by everyone. Share this URL to let others start a conversation with it:
+                This assistant is public and discoverable by everyone. Share this URL to let
+                others start a conversation with it.
               </p>
               <div class="flex gap-2">
+                <label for="share-url" class="sr-only">Shareable URL</label>
                 <input
+                  id="share-url"
                   type="text"
                   [value]="shareableUrl()"
                   readonly
-                  class="flex-1 rounded-sm border border-gray-300 bg-gray-50 px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:border-blue-400"
-                  id="share-url"
+                  class="flex-1 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                 />
                 <button
                   type="button"
                   (click)="copyUrl()"
-                  class="inline-flex items-center gap-2 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+                  class="inline-flex items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                 >
                   <ng-icon name="heroLink" class="size-4" aria-hidden="true" />
                   <span>{{ copied() ? 'Copied!' : 'Copy' }}</span>
                 </button>
               </div>
-            </div>
+            </section>
           } @else {
-            <!-- PRIVATE or SHARED Assistant: Show shareable URL and user search/email input -->
-            <div class="space-y-4">
-              <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-                Share this assistant with specific users. Only people you share with will be able to access it.
-                @if (!isShared()) {
-                  <span class="block mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    (Visibility will be automatically set to "SHARED" when you add people)
-                  </span>
-                }
-              </p>
-
-              <!-- Shareable URL -->
-              <div class="space-y-2">
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Shareable URL
-                </label>
-                <p class="text-xs text-gray-500 dark:text-gray-400">
-                  Share this URL with people you've added below. They'll need to be in the share list to access it.
-                </p>
+            <!-- PRIVATE or SHARED Assistant: shareable URL + add-people + current shares -->
+            <div class="space-y-8">
+              <!-- Shareable URL section -->
+              <section class="space-y-3">
+                <div>
+                  <label for="share-url-shared" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Shareable URL
+                  </label>
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Share this URL with people you've added below. They'll need to be on the list
+                    to access it.
+                  </p>
+                </div>
                 <div class="flex gap-2">
                   <input
+                    id="share-url-shared"
                     type="text"
                     [value]="shareableUrl()"
                     readonly
-                    class="flex-1 rounded-sm border border-gray-300 bg-gray-50 px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:border-blue-400"
-                    id="share-url-shared"
+                    class="flex-1 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />
                   <button
                     type="button"
                     (click)="copyUrl()"
-                    class="inline-flex items-center gap-2 rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+                    class="inline-flex items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                   >
                     <ng-icon name="heroLink" class="size-4" aria-hidden="true" />
                     <span>{{ copied() ? 'Copied!' : 'Copy' }}</span>
                   </button>
                 </div>
-              </div>
+              </section>
 
-              <!-- Divider -->
-              <div class="border-t border-gray-200 dark:border-gray-700 pt-4">
-                <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-3">
-                  Share with specific people
-                </h4>
-              </div>
-
-              <!-- Mode Toggle -->
-              <div class="flex gap-2 border-b border-gray-200 dark:border-gray-700">
-                <button
-                  type="button"
-                  (click)="searchMode.set(true)"
-                  [class.border-b-2]="searchMode()"
-                  [class.border-indigo-600]="searchMode()"
-                  [class.text-indigo-600]="searchMode()"
-                  [class.dark:border-indigo-400]="searchMode()"
-                  [class.dark:text-indigo-400]="searchMode()"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
-                >
-                  <ng-icon name="heroMagnifyingGlass" class="size-4 inline mr-1" />
-                  Search Users
-                </button>
-                <button
-                  type="button"
-                  (click)="searchMode.set(false)"
-                  [class.border-b-2]="!searchMode()"
-                  [class.border-indigo-600]="!searchMode()"
-                  [class.text-indigo-600]="!searchMode()"
-                  [class.dark:border-indigo-400]="!searchMode()"
-                  [class.dark:text-indigo-400]="!searchMode()"
-                  class="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
-                >
-                  <ng-icon name="heroUserPlus" class="size-4 inline mr-1" />
-                  Add Email
-                </button>
-              </div>
-
-              <!-- Mode 1: Search Users -->
-              @if (searchMode()) {
-                <div class="space-y-3">
+              <!-- Add people section -->
+              <section class="space-y-4 border-t border-gray-200 pt-6 dark:border-gray-700">
+                <div class="flex flex-wrap items-end justify-between gap-3">
                   <div>
-                    <label for="search-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Search for users
-                    </label>
-                    <input
-                      id="search-input"
-                      type="text"
-                      [ngModel]="searchQuery()"
-                      (ngModelChange)="onSearchQueryChange($event)"
-                      placeholder="Type name or email..."
-                      class="w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500 dark:focus:border-blue-400"
-                    />
+                    <h4 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                      Add people
+                    </h4>
+                    @if (!isShared()) {
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        Visibility switches to "Shared" automatically when you add someone.
+                      </p>
+                    }
                   </div>
-
-                  <!-- Search Results -->
-                  @if (searchResults() && searchResults()!.length > 0) {
-                    <div class="max-h-48 overflow-y-auto rounded-sm border border-gray-200 dark:border-gray-700">
-                      @for (user of searchResults(); track user.userId) {
-                        <button
-                          type="button"
-                          (click)="addUserFromSearch(user)"
-                          [disabled]="isEmailShared(user.email)"
-                          class="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-between"
-                        >
-                          <div>
-                            <div class="font-medium text-gray-900 dark:text-white">{{ user.name }}</div>
-                            <div class="text-xs text-gray-500 dark:text-gray-400">{{ user.email }}</div>
-                          </div>
-                          @if (isEmailShared(user.email)) {
-                            <span class="text-xs text-gray-500">Already shared</span>
-                          }
-                        </button>
-                      }
-                    </div>
-                  } @else if (searchQuery() && searchQuery().length >= 2 && !searching()) {
-                    <p class="text-sm text-gray-500 dark:text-gray-400 italic">
-                      No users found. Try adding their email manually.
-                    </p>
-                  }
-                </div>
-              }
-
-              <!-- Mode 2: Add Email Manually -->
-              @if (!searchMode()) {
-                <div class="space-y-3">
-                  <div>
-                    <label for="email-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Email addresses (comma-separated)
+                  <div class="flex items-center gap-2">
+                    <label for="new-permission-input" class="text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                      Default for new people
                     </label>
-                    <textarea
-                      id="email-input"
-                      [ngModel]="emailInput()"
-                      (ngModelChange)="emailInput.set($event)"
-                      placeholder="user1@example.com, user2@example.com"
-                      rows="3"
-                      class="w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500 dark:focus:border-blue-400"
-                    ></textarea>
+                    <select
+                      id="new-permission-input"
+                      [ngModel]="newPermission()"
+                      (ngModelChange)="onNewPermissionChange($event)"
+                      class="rounded-2xl border border-gray-300 bg-white px-2.5 py-1 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    >
+                      <option value="viewer">Can view & chat</option>
+                      <option value="editor">Can edit</option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- Mode Toggle (segmented tabs) -->
+                <div
+                  class="flex gap-1 border-b border-gray-200 dark:border-gray-700"
+                  role="tablist"
+                  aria-label="How to add people"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    [attr.aria-selected]="searchMode()"
+                    (click)="searchMode.set(true)"
+                    [class.border-blue-600]="searchMode()"
+                    [class.text-blue-600]="searchMode()"
+                    [class.dark:border-blue-400]="searchMode()"
+                    [class.dark:text-blue-400]="searchMode()"
+                    class="inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    <ng-icon name="heroMagnifyingGlass" class="size-4" aria-hidden="true" />
+                    Search users
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    [attr.aria-selected]="!searchMode()"
+                    (click)="searchMode.set(false)"
+                    [class.border-blue-600]="!searchMode()"
+                    [class.text-blue-600]="!searchMode()"
+                    [class.dark:border-blue-400]="!searchMode()"
+                    [class.dark:text-blue-400]="!searchMode()"
+                    class="inline-flex items-center gap-1.5 border-b-2 border-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                  >
+                    <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
+                    Add by email
+                  </button>
+                </div>
+
+                <!-- Mode 1: Search Users -->
+                @if (searchMode()) {
+                  <div class="space-y-3">
+                    <div>
+                      <label for="search-input" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        Search for users
+                      </label>
+                      <input
+                        id="search-input"
+                        type="text"
+                        [ngModel]="searchQuery()"
+                        (ngModelChange)="onSearchQueryChange($event)"
+                        placeholder="Type a name or email…"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      />
+                    </div>
+
+                    <!-- Search Results -->
+                    @if (searching()) {
+                      <!-- Skeleton: three rows matching the real result layout so the
+                           container doesn't shift size when results land. -->
+                      <ul
+                        class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                        aria-hidden="true"
+                      >
+                        @for (placeholder of skeletonRows; track placeholder) {
+                          <li class="flex items-center justify-between px-3 py-2.5 sm:px-4">
+                            <div class="flex-1 space-y-1.5">
+                              <div class="h-3 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                              <div class="h-2.5 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                            </div>
+                          </li>
+                        }
+                      </ul>
+                      <span class="sr-only" role="status">Searching for users…</span>
+                    } @else if (searchResults() && searchResults()!.length > 0) {
+                      <ul
+                        class="max-h-48 divide-y divide-gray-200 overflow-y-auto overflow-x-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                        role="listbox"
+                        aria-label="Search results"
+                      >
+                        @for (user of searchResults(); track user.userId) {
+                          <li>
+                            <button
+                              type="button"
+                              role="option"
+                              [attr.aria-selected]="isEmailShared(user.email)"
+                              (click)="addUserFromSearch(user)"
+                              [disabled]="isEmailShared(user.email)"
+                              class="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left text-sm/6 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 sm:px-4 dark:hover:bg-gray-700/50"
+                            >
+                              <div class="min-w-0 flex-1">
+                                <div class="truncate font-medium text-gray-900 dark:text-white">{{ user.name }}</div>
+                                <div class="truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ user.email }}</div>
+                              </div>
+                              @if (isEmailShared(user.email)) {
+                                <span class="shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">Already added</span>
+                              }
+                            </button>
+                          </li>
+                        }
+                      </ul>
+                    } @else if (searchQuery() && searchQuery().length >= 2) {
+                      <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                        No users found. Try adding their email manually instead.
+                      </p>
+                    }
+                  </div>
+                }
+
+                <!-- Mode 2: Add Email Manually -->
+                @if (!searchMode()) {
+                  <div class="space-y-3">
+                    <div>
+                      <label for="email-input" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        Email addresses
+                      </label>
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        Separate multiple addresses with commas.
+                      </p>
+                      <textarea
+                        id="email-input"
+                        [ngModel]="emailInput()"
+                        (ngModelChange)="emailInput.set($event)"
+                        placeholder="user1@example.com, user2@example.com"
+                        rows="3"
+                        class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      ></textarea>
+                    </div>
                     <button
                       type="button"
                       (click)="addEmailsFromInput()"
                       [disabled]="!emailInput().trim()"
-                      class="mt-2 inline-flex items-center gap-2 rounded-sm bg-indigo-600 px-3 py-2 text-sm/6 font-medium text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                      class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
                     >
-                      <ng-icon name="heroUserPlus" class="size-4" />
-                      Add Emails
+                      <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
+                      Add emails
                     </button>
                   </div>
+                }
+              </section>
+
+              <!-- Current Shares section -->
+              <section class="space-y-3 border-t border-gray-200 pt-6 dark:border-gray-700">
+                <div class="flex items-baseline justify-between">
+                  <h4 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                    Currently shared with
+                  </h4>
+                  <span class="text-xs/5 tabular-nums text-gray-500 dark:text-gray-400">
+                    {{ shares().length }}
+                  </span>
                 </div>
-              }
 
-              <!-- Permission selector for new additions -->
-              <div class="flex items-center gap-3 rounded-sm bg-gray-50 px-3 py-2 dark:bg-gray-700/40">
-                <label for="new-permission-input" class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Permission for new people:
-                </label>
-                <select
-                  id="new-permission-input"
-                  [ngModel]="newPermission()"
-                  (ngModelChange)="onNewPermissionChange($event)"
-                  class="rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                >
-                  <option value="viewer">Can view & chat</option>
-                  <option value="editor">Can edit</option>
-                </select>
-              </div>
-
-              <!-- Currently Shared List -->
-              @if (shares().length > 0) {
-                <div class="space-y-2">
-                  <h4 class="text-sm font-medium text-gray-900 dark:text-white">Currently shared with:</h4>
-                  <div class="space-y-1 max-h-40 overflow-y-auto">
-                    @for (entry of shares(); track entry.email) {
-                      <div class="flex items-center justify-between gap-2 rounded-sm border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-700">
-                        <span class="text-sm text-gray-900 dark:text-white truncate">{{ entry.email }}</span>
-                        <div class="flex items-center gap-2 shrink-0">
-                          <label class="sr-only" [attr.for]="'perm-' + entry.email">Permission for {{ entry.email }}</label>
-                          <select
-                            [id]="'perm-' + entry.email"
-                            [ngModel]="entry.permission"
-                            (ngModelChange)="setPermission(entry.email, $event)"
-                            class="rounded-sm border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                          >
-                            <option value="viewer">Can view</option>
-                            <option value="editor">Can edit</option>
-                          </select>
-                          <button
-                            type="button"
-                            (click)="removeEmail(entry.email)"
-                            class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                            [attr.aria-label]="'Remove ' + entry.email"
-                          >
-                            <ng-icon name="heroTrash" class="size-4" />
-                          </button>
-                        </div>
-                      </div>
-                    }
+                @if (shares().length === 0) {
+                  <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-6 text-center dark:border-gray-700 dark:bg-gray-800">
+                    <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                      Not shared with anyone yet.
+                    </p>
                   </div>
-                </div>
-              }
+                } @else {
+                  <ul
+                    class="max-h-56 divide-y divide-gray-200 overflow-y-auto rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    @for (entry of shares(); track entry.email) {
+                      <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                        <div class="min-w-0 flex-1">
+                          <p class="truncate text-sm/6 text-gray-900 dark:text-white">{{ entry.email }}</p>
+                        </div>
+                        <label class="sr-only" [attr.for]="'perm-' + entry.email">
+                          Permission for {{ entry.email }}
+                        </label>
+                        <select
+                          [id]="'perm-' + entry.email"
+                          [ngModel]="entry.permission"
+                          (ngModelChange)="setPermission(entry.email, $event)"
+                          class="shrink-0 rounded-2xl border border-gray-300 bg-white px-2.5 py-1 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                        >
+                          <option value="viewer">Can view</option>
+                          <option value="editor">Can edit</option>
+                        </select>
+                        <button
+                          type="button"
+                          (click)="removeEmail(entry.email)"
+                          class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                          [attr.aria-label]="'Remove ' + entry.email"
+                        >
+                          <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                        </button>
+                      </li>
+                    }
+                  </ul>
+                }
+              </section>
 
               @if (error()) {
-                <div class="rounded-sm bg-red-50 px-3 py-2 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-400">
+                <div class="rounded-2xl bg-red-50 px-3 py-2 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
                   {{ error() }}
                 </div>
               }
@@ -327,24 +400,24 @@ export type ShareAssistantDialogResult = {
         </div>
 
         <!-- Actions -->
-        <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            {{ isPublic() ? 'Close' : 'Cancel' }}
+          </button>
           @if (!isPublic()) {
             <button
               type="button"
               (click)="onSave()"
               [disabled]="saving()"
-              class="inline-flex w-full justify-center rounded-sm bg-indigo-600 px-3 py-2 text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed sm:ml-3 sm:w-auto dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400"
+              class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
             >
-              {{ saving() ? 'Saving...' : 'Save Changes' }}
+              {{ saving() ? 'Saving…' : 'Save changes' }}
             </button>
           }
-          <button
-            type="button"
-            (click)="onCancel()"
-            class="mt-3 inline-flex w-full justify-center rounded-sm bg-white px-3 py-2 text-sm/6 font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-white/10 dark:text-white dark:shadow-none dark:ring-white/5 dark:hover:bg-white/20"
-          >
-            {{ isPublic() ? 'Close' : 'Cancel' }}
-          </button>
         </div>
       </div>
     </div>
@@ -390,6 +463,9 @@ export class ShareAssistantDialogComponent {
   protected readonly data = inject<ShareAssistantDialogData>(DIALOG_DATA);
   protected readonly assistantService = inject(AssistantService);
   protected readonly userApiService = inject(UserApiService);
+
+  /** Stable identity array for the skeleton @for loop — keeps trackBy happy without per-render churn. */
+  protected readonly skeletonRows = [0, 1, 2];
 
   protected readonly copied = signal<boolean>(false);
   protected readonly searchMode = signal<boolean>(true); // true = search, false = manual email

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -12,6 +12,7 @@ import {
   heroTrash,
   heroPencilSquare,
   heroEye,
+  heroChevronDown,
 } from '@ng-icons/heroicons/outline';
 import { Assistant, ShareEntry, SharePermission, UserSearchResult } from '../models/assistant.model';
 import { AssistantService } from '../services/assistant.service';
@@ -52,6 +53,7 @@ export type ShareAssistantDialogResult = {
       heroTrash,
       heroPencilSquare,
       heroEye,
+      heroChevronDown,
     }),
   ],
   host: {
@@ -188,15 +190,26 @@ export type ShareAssistantDialogResult = {
                     <label for="new-permission-input" class="text-xs/5 font-medium text-gray-600 dark:text-gray-400">
                       Default for new people
                     </label>
-                    <select
-                      id="new-permission-input"
-                      [ngModel]="newPermission()"
-                      (ngModelChange)="onNewPermissionChange($event)"
-                      class="rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-7 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                    >
-                      <option value="viewer">Can view & chat</option>
-                      <option value="editor">Can edit</option>
-                    </select>
+                    <!-- appearance-none + overlaid chevron: the native chevron sits at a
+                         fixed offset from the right edge regardless of padding, which
+                         crowds the rounded-2xl corner. Owning the chevron lets us place
+                         it where we want. -->
+                    <div class="relative inline-flex">
+                      <select
+                        id="new-permission-input"
+                        [ngModel]="newPermission()"
+                        (ngModelChange)="onNewPermissionChange($event)"
+                        class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                      >
+                        <option value="viewer">Can view & chat</option>
+                        <option value="editor">Can edit</option>
+                      </select>
+                      <ng-icon
+                        name="heroChevronDown"
+                        class="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                        aria-hidden="true"
+                      />
+                    </div>
                   </div>
                 </div>
 
@@ -380,15 +393,22 @@ export type ShareAssistantDialogResult = {
                         <label class="sr-only" [attr.for]="'perm-' + entry.email">
                           Permission for {{ entry.email }}
                         </label>
-                        <select
-                          [id]="'perm-' + entry.email"
-                          [ngModel]="entry.permission"
-                          (ngModelChange)="setPermission(entry.email, $event)"
-                          class="shrink-0 rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-7 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                        >
-                          <option value="viewer">Can view</option>
-                          <option value="editor">Can edit</option>
-                        </select>
+                        <div class="relative inline-flex shrink-0">
+                          <select
+                            [id]="'perm-' + entry.email"
+                            [ngModel]="entry.permission"
+                            (ngModelChange)="setPermission(entry.email, $event)"
+                            class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                          >
+                            <option value="viewer">Can view</option>
+                            <option value="editor">Can edit</option>
+                          </select>
+                          <ng-icon
+                            name="heroChevronDown"
+                            class="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                            aria-hidden="true"
+                          />
+                        </div>
                         <button
                           type="button"
                           (click)="removeEmail(entry.email)"

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -201,11 +201,11 @@ export type ShareAssistantDialogResult = {
                 </div>
 
                 <!-- Mode Toggle (segmented tabs).
-                     Bottom-only border-b-* variant avoids a CSS collision between
-                     border-transparent (base) and border-blue-600 (active) — those
-                     are both border-color utilities at the same specificity, so
-                     using border-b-color targets a different property and lets the
-                     active state win cleanly. -->
+                     Active styling rides aria-selected="true" rather than [class.x] bindings —
+                     both border-b-blue-600 and border-b-transparent share class-selector
+                     specificity, and Tailwind's emit order made the transparent base win.
+                     aria-selected:* generates [aria-selected="true"] which has higher
+                     specificity and reliably beats the base utility. -->
                 <div
                   class="flex gap-1 border-b border-gray-200 dark:border-gray-700"
                   role="tablist"
@@ -216,12 +216,7 @@ export type ShareAssistantDialogResult = {
                     role="tab"
                     [attr.aria-selected]="searchMode()"
                     (click)="searchMode.set(true)"
-                    [class.border-b-blue-600]="searchMode()"
-                    [class.text-blue-600]="searchMode()"
-                    [class.font-semibold]="searchMode()"
-                    [class.dark:border-b-blue-400]="searchMode()"
-                    [class.dark:text-blue-400]="searchMode()"
-                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 aria-selected:border-b-blue-600 aria-selected:font-semibold aria-selected:text-blue-600 dark:text-gray-400 dark:hover:text-white dark:aria-selected:border-b-blue-400 dark:aria-selected:text-blue-400"
                   >
                     <ng-icon name="heroMagnifyingGlass" class="size-4" aria-hidden="true" />
                     Search users
@@ -231,12 +226,7 @@ export type ShareAssistantDialogResult = {
                     role="tab"
                     [attr.aria-selected]="!searchMode()"
                     (click)="searchMode.set(false)"
-                    [class.border-b-blue-600]="!searchMode()"
-                    [class.text-blue-600]="!searchMode()"
-                    [class.font-semibold]="!searchMode()"
-                    [class.dark:border-b-blue-400]="!searchMode()"
-                    [class.dark:text-blue-400]="!searchMode()"
-                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+                    class="-mb-px inline-flex items-center gap-1.5 border-b-2 border-b-transparent px-3 py-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 aria-selected:border-b-blue-600 aria-selected:font-semibold aria-selected:text-blue-600 dark:text-gray-400 dark:hover:text-white dark:aria-selected:border-b-blue-400 dark:aria-selected:text-blue-400"
                   >
                     <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
                     Add by email

--- a/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/share-assistant-dialog.component.ts
@@ -344,12 +344,30 @@ export type ShareAssistantDialogResult = {
                   <h4 class="text-base/7 font-semibold text-gray-900 dark:text-white">
                     Currently shared with
                   </h4>
-                  <span class="text-xs/5 tabular-nums text-gray-500 dark:text-gray-400">
-                    {{ shares().length }}
-                  </span>
+                  @if (!loadingShares()) {
+                    <span class="text-xs/5 tabular-nums text-gray-500 dark:text-gray-400">
+                      {{ shares().length }}
+                    </span>
+                  }
                 </div>
 
-                @if (shares().length === 0) {
+                @if (loadingShares()) {
+                  <!-- Skeleton: matches the real row layout (email + select + delete) so
+                       the container doesn't reflow when shares land. -->
+                  <ul
+                    class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                    aria-hidden="true"
+                  >
+                    @for (placeholder of skeletonRows; track placeholder) {
+                      <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                        <div class="h-3 flex-1 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                        <div class="h-7 w-20 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+                        <div class="size-8 shrink-0 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+                      </li>
+                    }
+                  </ul>
+                  <span class="sr-only" role="status">Loading existing shares…</span>
+                } @else if (shares().length === 0) {
                   <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-6 text-center dark:border-gray-700 dark:bg-gray-800">
                     <p class="text-sm/6 text-gray-500 dark:text-gray-400">
                       Not shared with anyone yet.
@@ -480,6 +498,9 @@ export class ShareAssistantDialogComponent {
   protected readonly searchResults = signal<UserSearchResult[] | null>(null);
   protected readonly searching = signal<boolean>(false);
   protected readonly saving = signal<boolean>(false);
+  /** True while loadShares() is in flight on dialog open — drives the shares-list skeleton.
+   *  Seeded `true` so the skeleton paints before the constructor's async fetch resolves. */
+  protected readonly loadingShares = signal<boolean>(true);
   protected readonly error = signal<string | null>(null);
 
   protected readonly isPublic = computed<boolean>(() => this.data.assistant.visibility === 'PUBLIC');
@@ -577,6 +598,7 @@ export class ShareAssistantDialogComponent {
   }
 
   protected async loadShares(): Promise<void> {
+    this.loadingShares.set(true);
     try {
       // Only try to load shares if assistant is SHARED
       // PRIVATE assistants won't have shares yet
@@ -593,6 +615,8 @@ export class ShareAssistantDialogComponent {
       // Don't show error for initial load failure - just start with empty list
       this.initialShares = [];
       this.shares.set([]);
+    } finally {
+      this.loadingShares.set(false);
     }
   }
 

--- a/frontend/ai.client/src/app/assistants/models/assistant.model.ts
+++ b/frontend/ai.client/src/app/assistants/models/assistant.model.ts
@@ -1,3 +1,6 @@
+export type SharePermission = 'viewer' | 'editor';
+export type UserPermission = 'owner' | SharePermission;
+
 export interface Assistant {
   assistantId: string;
   ownerId: string;
@@ -19,6 +22,7 @@ export interface Assistant {
   // Share metadata (only present for shared assistants)
   firstInteracted?: boolean;
   isSharedWithMe?: boolean;
+  userPermission?: UserPermission;
 }
 
 export interface CreateAssistantDraftRequest {
@@ -55,15 +59,26 @@ export interface AssistantsListResponse {
 
 export interface ShareAssistantRequest {
   emails: string[];
+  permission?: SharePermission;
 }
 
 export interface UnshareAssistantRequest {
   emails: string[];
 }
 
+export interface UpdateSharePermissionRequest {
+  email: string;
+  permission: SharePermission;
+}
+
+export interface ShareEntry {
+  email: string;
+  permission: SharePermission;
+}
+
 export interface AssistantSharesResponse {
   assistantId: string;
-  sharedWith: string[];
+  sharedWith: ShareEntry[];
 }
 
 export interface UserSearchResult {

--- a/frontend/ai.client/src/app/assistants/services/assistant-api.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/assistant-api.service.ts
@@ -1,15 +1,16 @@
 import { Injectable, inject, computed } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { 
-  Assistant, 
+import {
+  Assistant,
   CreateAssistantDraftRequest,
-  CreateAssistantRequest, 
+  CreateAssistantRequest,
   UpdateAssistantRequest,
   AssistantsListResponse,
   ShareAssistantRequest,
   UnshareAssistantRequest,
-  AssistantSharesResponse
+  UpdateSharePermissionRequest,
+  AssistantSharesResponse,
 } from '../models/assistant.model';
 import {
   CreateDocumentRequest,
@@ -91,6 +92,13 @@ export class AssistantApiService {
 
   unshareAssistant(id: string, request: UnshareAssistantRequest): Observable<AssistantSharesResponse> {
     return this.http.delete<AssistantSharesResponse>(`${this.baseUrl()}/${id}/shares`, { body: request });
+  }
+
+  updateSharePermission(
+    id: string,
+    request: UpdateSharePermissionRequest,
+  ): Observable<AssistantSharesResponse> {
+    return this.http.patch<AssistantSharesResponse>(`${this.baseUrl()}/${id}/shares`, request);
   }
 
   getAssistantShares(id: string): Observable<AssistantSharesResponse> {

--- a/frontend/ai.client/src/app/assistants/services/assistant.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/assistant.service.spec.ts
@@ -23,6 +23,7 @@ describe('AssistantService', () => {
       getAssistant: vi.fn(),
       shareAssistant: vi.fn(),
       unshareAssistant: vi.fn(),
+      updateSharePermission: vi.fn(),
       getAssistantShares: vi.fn()
     };
 
@@ -94,14 +95,29 @@ describe('AssistantService', () => {
     expect(service.assistants$()).toContain(mockAssistant);
   });
 
-  it('should share assistant', async () => {
-    const mockResponse = { sharedWith: ['user1@example.com'] };
+  it('should share assistant with default viewer permission', async () => {
+    const mockResponse = { sharedWith: [{ email: 'user1@example.com', permission: 'viewer' }] };
     mockApiService.shareAssistant.mockReturnValue(of(mockResponse));
 
     const result = await service.shareAssistant('1', ['user1@example.com']);
 
-    expect(mockApiService.shareAssistant).toHaveBeenCalledWith('1', { emails: ['user1@example.com'] });
+    expect(mockApiService.shareAssistant).toHaveBeenCalledWith('1', {
+      emails: ['user1@example.com'],
+      permission: 'viewer',
+    });
     expect(result).toEqual(mockResponse);
+  });
+
+  it('should share assistant with editor permission when supplied', async () => {
+    const mockResponse = { sharedWith: [{ email: 'user1@example.com', permission: 'editor' }] };
+    mockApiService.shareAssistant.mockReturnValue(of(mockResponse));
+
+    await service.shareAssistant('1', ['user1@example.com'], 'editor');
+
+    expect(mockApiService.shareAssistant).toHaveBeenCalledWith('1', {
+      emails: ['user1@example.com'],
+      permission: 'editor',
+    });
   });
 
   it('should unshare assistant', async () => {
@@ -114,13 +130,29 @@ describe('AssistantService', () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it('should get assistant shares', async () => {
-    const mockResponse = { sharedWith: ['user1@example.com', 'user2@example.com'] };
-    mockApiService.getAssistantShares.mockReturnValue(of(mockResponse));
+  it('should update share permission on an existing share', async () => {
+    const mockResponse = { sharedWith: [{ email: 'user1@example.com', permission: 'editor' }] };
+    mockApiService.updateSharePermission.mockReturnValue(of(mockResponse));
+
+    const result = await service.updateSharePermission('1', 'user1@example.com', 'editor');
+
+    expect(mockApiService.updateSharePermission).toHaveBeenCalledWith('1', {
+      email: 'user1@example.com',
+      permission: 'editor',
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should get assistant shares as ShareEntry[]', async () => {
+    const entries = [
+      { email: 'user1@example.com', permission: 'viewer' },
+      { email: 'user2@example.com', permission: 'editor' },
+    ];
+    mockApiService.getAssistantShares.mockReturnValue(of({ sharedWith: entries }));
 
     const result = await service.getAssistantShares('1');
 
     expect(mockApiService.getAssistantShares).toHaveBeenCalledWith('1');
-    expect(result).toEqual(['user1@example.com', 'user2@example.com']);
+    expect(result).toEqual(entries);
   });
 });

--- a/frontend/ai.client/src/app/assistants/services/assistant.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/assistant.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, signal, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { 
-  Assistant, 
+import {
+  Assistant,
   CreateAssistantDraftRequest,
-  CreateAssistantRequest, 
+  CreateAssistantRequest,
   UpdateAssistantRequest,
-  AssistantSharesResponse
+  AssistantSharesResponse,
+  ShareEntry,
+  SharePermission,
 } from '../models/assistant.model';
 import { AssistantApiService } from './assistant-api.service';
 
@@ -165,13 +167,17 @@ export class AssistantService {
     return this.assistants().find(assistant => assistant.assistantId === id);
   }
 
-  async shareAssistant(id: string, emails: string[]): Promise<AssistantSharesResponse> {
+  async shareAssistant(
+    id: string,
+    emails: string[],
+    permission: SharePermission = 'viewer',
+  ): Promise<AssistantSharesResponse> {
     this.loading.set(true);
     this.error.set(null);
 
     try {
       const response = await firstValueFrom(
-        this.apiService.shareAssistant(id, { emails })
+        this.apiService.shareAssistant(id, { emails, permission })
       );
       return response;
     } catch (err) {
@@ -201,7 +207,29 @@ export class AssistantService {
     }
   }
 
-  async getAssistantShares(id: string): Promise<string[]> {
+  async updateSharePermission(
+    id: string,
+    email: string,
+    permission: SharePermission,
+  ): Promise<AssistantSharesResponse> {
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.apiService.updateSharePermission(id, { email, permission })
+      );
+      return response;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to update share permission';
+      this.error.set(errorMessage);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async getAssistantShares(id: string): Promise<ShareEntry[]> {
     this.loading.set(true);
     this.error.set(null);
 


### PR DESCRIPTION
PR 2 of 2 for [#113](https://github.com/Boise-State-Development/agentcore-public-stack/issues/113) — consumes the backend contract shipped in [#383](https://github.com/Boise-State-Development/agentcore-public-stack/pull/383).

## Summary

- **Share dialog**: per-row "Can view / Can edit" selector on existing shares, a "permission for new people" toggle that applies to all newly added emails, and \`onSave\` delta-detection that separates **adds**, **removes**, and **permission upgrades on already-shared emails** — each routed to the right backend endpoint (\`POST\` / \`DELETE\` / new \`PATCH /assistants/{id}/shares\`).
- **Assistant list**: shared-with-me cards with \`userPermission === 'editor'\` now show an "Editor" badge and an Edit button alongside Chat (owners' actions unchanged).
- **Assistant form**: owner-only gating on the Share button; "Shared by {owner}" banner for editors; \`userPermission\` tracked from the loaded assistant (with a safe owner fallback for create mode).
- **Contract shape**: \`AssistantSharesResponse.sharedWith\` is now \`ShareEntry[]\` (\`{email, permission}\`) end-to-end. The pre-existing \`sharedEmails: string[]\` state in the dialog became \`shares: ShareEntry[]\`.

## Why this lands now

PR 1 changed \`AssistantSharesResponse.sharedWith\` from \`string[]\` to \`ShareEntry[]\` — the SPA was reading the old shape until this PR. Merging promptly closes that gap.

## Test plan

- [x] \`npm run test:ci\` → **1101 passed**. New spec coverage:
  - Service: \`shareAssistant\` default + explicit-permission, \`updateSharePermission\`, \`getAssistantShares\` returning \`ShareEntry[]\`.
  - Dialog: dedicated spec for the delta algorithm (pure add, pure remove, permission upgrade on existing email, no-change baseline, mixed adds + removes + upgrades). DI tokens used over \`vi.mock\` per project convention.
- [x] \`npm run build\` → clean (only pre-existing budget + unused-RouterLink warnings).
- [ ] Manual smoke (script below — \`SKIP_AUTH=false\` locally so I can't exercise it autonomously):

### Manual test script

**Setup:** two accounts. Alice owns an assistant; Bob has no shares yet.

1. **Owner shares Bob as viewer**
   - As Alice → open the assistant → Share → enter \`bob@…\` → permission toggle stays on "Can view & chat" → Save.
   - Expected: dialog closes, no error.
2. **Bob sees viewer state**
   - As Bob → assistants list → "Shared with Me" section shows the assistant card with the owner badge, **no** "Editor" badge, **no** Edit button (just Chat).
3. **Owner upgrades Bob to editor**
   - As Alice → Share dialog → Bob's row → flip permission select to "Can edit" → Save.
   - Network: a \`PATCH /assistants/{id}/shares\` should fire (not \`DELETE\` + \`POST\`).
4. **Bob sees editor state**
   - As Bob → reload list → his card now shows the **amber "Editor" badge** and an **Edit button** next to Chat.
5. **Bob edits as editor**
   - As Bob → click Edit → form opens with all fields editable, the amber "Shared by Alice" banner in the header, **no Share button**.
   - Change description, Save. Expected: 200; navigates back to list.
6. **Bob cannot change visibility**
   - As Bob → set visibility (via any indirect path that triggers \`visibility\` on the PUT, e.g. share dialog clear-all → it tries PRIVATE). Expected: backend 400 surfaces in the dialog as an error.
7. **Mixed save**
   - As Alice → Share dialog → add a new viewer email, remove an existing share, downgrade one editor → Save.
   - Expected: one \`POST\` (adds), one \`DELETE\` (removes), one \`PATCH\` per downgraded email. Watch network tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)