### PR TITLE
chore(frontend): drop unused RouterLink imports on admin pages

### DIFF
--- a/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
@@ -6,7 +6,7 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -28,7 +28,6 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
 @Component({
   selector: 'app-admin-costs',
   imports: [
-    RouterLink,
     NgIcon,
     PeriodSelectorComponent,
     SystemSummaryCardComponent,

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.ts
@@ -1,6 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -16,7 +15,7 @@ import { FineTuningAdminStateService } from './services/fine-tuning-admin-state.
 
 @Component({
   selector: 'app-fine-tuning-access-page',
-  imports: [FormsModule, RouterLink, NgIcon, TooltipDirective],
+  imports: [FormsModule, NgIcon, TooltipDirective],
   providers: [
     provideIcons({
       heroArrowLeft,

--- a/frontend/ai.client/src/app/admin/fine-tuning-costs/fine-tuning-costs.page.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-costs/fine-tuning-costs.page.ts
@@ -6,7 +6,6 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
-import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -26,7 +25,7 @@ type SortField = 'email' | 'total_cost_usd' | 'total_gpu_hours' | 'training_job_
 
 @Component({
   selector: 'app-fine-tuning-costs-page',
-  imports: [RouterLink, FormsModule, NgIcon],
+  imports: [FormsModule, NgIcon],
   providers: [
     provideIcons({
       heroArrowLeft,

--- a/frontend/ai.client/src/app/admin/users/pages/user-list/user-list.page.ts
+++ b/frontend/ai.client/src/app/admin/users/pages/user-list/user-list.page.ts
@@ -4,7 +4,7 @@ import {
   inject,
   OnInit,
 } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -20,7 +20,7 @@ import { UserListItem, UserStatus } from '../../models';
 @Component({
   selector: 'app-user-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, NgIcon, RouterLink],
+  imports: [FormsModule, NgIcon],
   providers: [
     provideIcons({ heroMagnifyingGlass, heroUser, heroChevronRight, heroXMark, heroArrowLeft }),
   ],


### PR DESCRIPTION
## Summary
- Removes unused `RouterLink` imports (and matching entries in component `imports:` arrays) from four admin pages where the template never actually uses the directive.
- Silences four `NG8113: RouterLink is not used within the template` warnings emitted on every frontend build.

Files touched:
- `frontend/ai.client/src/app/admin/costs/admin-costs.page.ts` (kept `Router` — still injected)
- `frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.ts`
- `frontend/ai.client/src/app/admin/fine-tuning-costs/fine-tuning-costs.page.ts`
- `frontend/ai.client/src/app/admin/users/pages/user-list/user-list.page.ts` (kept `Router` — still injected)

## Test plan
- [ ] `npm run start` in `frontend/ai.client` — confirm the four NG8113 warnings are gone and no new ones appear.
- [ ] Smoke-check the four affected admin pages render without runtime errors (they didn't depend on RouterLink to begin with, so this is just a sanity pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)