### PR TITLE
fix(streaming): stop double-wrapping classified force_stop errors

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -11,7 +11,12 @@ from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from agents.main_agent.config.constants import EnvVars
-from apis.shared.errors import ErrorCode, StreamErrorEvent, build_conversational_error_event
+from apis.shared.errors import (
+    ConversationalErrorEvent,
+    ErrorCode,
+    StreamErrorEvent,
+    build_conversational_error_event,
+)
 
 from .stream_processor import process_agent_stream
 
@@ -492,13 +497,45 @@ class StreamCoordinator:
                     except ValueError:
                         error_code = ErrorCode.STREAM_ERROR
 
-                    # Create a synthetic exception for build_conversational_error_event
-                    synthetic_error = Exception(f"{error_message}: {error_detail}" if error_detail else error_message)
+                    # When stream_processor's force_stop classifier (in
+                    # _format_force_stop_message) already produced friendly
+                    # user-facing markdown — recognizable by the leading "⚠️"
+                    # — pass it through unwrapped. The generic
+                    # build_conversational_error_event template would
+                    # otherwise wrap it in a second "⚠️ Something went
+                    # wrong" + blockquote, double-marking the message and
+                    # appending a ceremonial "Please try again." The
+                    # unclassified "Agent force-stopped: {raw}" fallthrough
+                    # has no warning prefix and still goes through the
+                    # generic wrapper below.
+                    recoverable = error_data.get("recoverable", False)
+                    if (
+                        error_code == ErrorCode.AGENT_ERROR
+                        and error_message
+                        and error_message.lstrip().startswith("⚠️")
+                    ):
+                        metadata: Optional[Dict[str, Any]] = (
+                            {"session_id": session_id} if session_id else None
+                        )
+                        conv_error_event = ConversationalErrorEvent(
+                            code=error_code,
+                            message=error_message,
+                            recoverable=recoverable,
+                            metadata=metadata,
+                        )
+                    else:
+                        # Create a synthetic exception for build_conversational_error_event
+                        synthetic_error = Exception(
+                            f"{error_message}: {error_detail}" if error_detail else error_message
+                        )
 
-                    # Build conversational error event
-                    conv_error_event = build_conversational_error_event(
-                        code=error_code, error=synthetic_error, session_id=session_id, recoverable=error_data.get("recoverable", False)
-                    )
+                        # Build conversational error event
+                        conv_error_event = build_conversational_error_event(
+                            code=error_code,
+                            error=synthetic_error,
+                            session_id=session_id,
+                            recoverable=recoverable,
+                        )
 
                     if error_code == ErrorCode.MAX_TOKENS:
                         # No verbose assistant bubble for truncation. The model


### PR DESCRIPTION
## Summary

- The in-loop error handler in `stream_coordinator` was running text from the upstream force_stop classifier (in `stream_processor._format_force_stop_message`) through `build_conversational_error_event`, which for `AGENT_ERROR` falls into a generic template and produces a doubly-wrapped message: a second ⚠️ + the classified text inside a blockquote + a ceremonial \"Please try again.\"
- This PR detects the already-classified case (AGENT_ERROR with a leading ⚠️) and emits a `ConversationalErrorEvent` directly with the classifier's text intact. The unclassified \"Agent force-stopped: {raw}\" fallthrough keeps the generic wrapper.

## Before vs. After

Before (gpt-oss-120b + document repro):
\`\`\`
⚠️ Something went wrong.

> ⚠️ The selected model can't read attached files.
> ...

Please try again.
\`\`\`

After:
\`\`\`
⚠️ One of the attached files is too large for the model to read directly.

Bedrock limits inline documents to 4.5 MB...
\`\`\`

## Implementation notes

- Detection is by leading \"⚠️\" on `AGENT_ERROR` messages — that's the contract the classifier already produces (document size, throttling, access denied branches all start with ⚠️). The fallback \`f\"Agent force-stopped: {reason_str}\"\` has no warning prefix and still flows through the generic wrapper.
- Live SSE (`content_block_delta` + `stream_error`) and persistence both read `conv_error_event.message`, so they remain in sync. Refresh-survival of the error text is unchanged.
- No change to `MAX_TOKENS` handling, the `inference-api` catch-all use of `AGENT_ERROR`, or the generic `STREAM_ERROR` path.

## Test plan

- [x] `uv run python -m pytest tests/agents/main_agent/streaming/ -v` — 142 passed
- [x] `uv run python -m pytest tests/architecture/ -v` — 6 passed (import boundary intact after adding `ConversationalErrorEvent` import)
- [ ] Manual repro: gpt-oss-120b + a document → confirm clean classified text, no nested ⚠️, no blockquote, no trailing \"Please try again.\" on both the live message and after a page refresh
- [ ] Manual repro: size-limit case (\"⚠️ One of the attached files is too large…\") — same clean rendering
- [ ] Verify an unclassified force_stop (e.g. a raw \"Agent force-stopped: ...\") still gets the generic friendly wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)