### PR TITLE
fix(streaming): persist synthetic error messages so they survive refresh

### DIFF
--- a/backend/src/agents/main_agent/session/persistence.py
+++ b/backend/src/agents/main_agent/session/persistence.py
@@ -1,0 +1,85 @@
+"""Helper for persisting synthetic conversational messages to AgentCore Memory.
+
+Used by code paths that need to write a message to session history without
+going through Strands' ``MessageAddedEvent`` hook — error handlers in the
+streaming layer, quota-exceeded short-circuits, and similar.
+
+WHY THIS HELPER EXISTS:
+Three call sites had near-identical persistence code with the same broken
+guard (``hasattr(session_manager, "base_manager")``). The guard was always
+False against the current SDK — ``AgentCoreMemorySessionManager`` exposes
+``create_message`` directly, with no nested ``.base_manager`` wrapper — so
+every synthetic write was silently skipped. That was the root cause of
+the "assistant error visible live, gone after refresh" bug. Centralizing
+the contract here surfaces the failure mode loudly and prevents the same
+shape of bug from drifting back into individual call sites.
+"""
+
+import logging
+from typing import Any, List, Tuple
+
+from strands.types.content import Message
+from strands.types.session import SessionMessage
+
+logger = logging.getLogger(__name__)
+
+
+def persist_synthetic_messages(
+    session_manager: Any,
+    session_id: str,
+    messages: List[Tuple[str, str]],
+    *,
+    agent_id: str = "default",
+) -> bool:
+    """Write one or more synthetic ``(role, text)`` messages to a session.
+
+    Args:
+        session_manager: A session manager exposing ``create_message`` —
+            typically the object returned by ``SessionFactory.create_session_manager``.
+            A legacy nested ``.base_manager`` is also honored if the SDK
+            ever reintroduces that indirection.
+        session_id: AgentCore Memory session ID.
+        messages: List of ``(role, text)`` tuples in order. Use
+            ``[("assistant", ...)]`` for paths where the user turn was
+            already persisted by Strands' ``MessageAddedEvent`` hook at
+            turn start (any error fired from inside the agent stream).
+            Use ``[("user", ...), ("assistant", ...)]`` for paths where the
+            agent never ran (quota-exceeded short-circuit, etc.) and the
+            user turn has not been written yet.
+        agent_id: AgentCore Memory agent_id. Defaults to ``"default"`` to
+            match read paths in ``apis.shared.sessions.messages``.
+
+    Returns:
+        ``True`` if all messages were written. ``False`` (with an ERROR
+        log) if the session manager has no ``create_message`` method —
+        the failure mode that previously went silent.
+
+    Raises:
+        Whatever ``create_message`` raises is propagated. Callers wrap
+        with their own try/except so the failure appears in logs at
+        the call site rather than being swallowed here.
+    """
+    target_manager = next(
+        (
+            m
+            for m in (session_manager, getattr(session_manager, "base_manager", None))
+            if m is not None and hasattr(m, "create_message")
+        ),
+        None,
+    )
+    if target_manager is None:
+        logger.error(
+            f"Cannot persist messages to session {session_id}: "
+            f"session manager {type(session_manager).__name__} has no create_message method"
+        )
+        return False
+
+    for index, (role, text) in enumerate(messages):
+        msg: Message = {"role": role, "content": [{"text": text}]}
+        session_msg = SessionMessage.from_message(msg, index)
+        target_manager.create_message(session_id, agent_id, session_msg)
+
+    logger.info(
+        f"💾 Persisted {len(messages)} synthetic message(s) to session {session_id}"
+    )
+    return True

--- a/backend/src/agents/main_agent/session/tests/test_persistence.py
+++ b/backend/src/agents/main_agent/session/tests/test_persistence.py
@@ -1,0 +1,132 @@
+"""Unit tests for persist_synthetic_messages.
+
+The persist helper centralizes a previously-triplicated pattern whose
+hasattr() guard was always-False against the current SDK shape (the SDK
+exposes ``create_message`` directly on ``AgentCoreMemorySessionManager``,
+not via a nested ``.base_manager``). Locking that contract here prevents
+the silent-skip bug from drifting back into individual call sites.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from agents.main_agent.session.persistence import persist_synthetic_messages
+
+
+class _RecordingSessionManager:
+    """Mimics the modern SDK shape: ``create_message`` directly on the
+    session manager. No nested base_manager indirection."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def create_message(self, session_id: str, agent_id: str, session_message: Any) -> None:
+        self.calls.append(
+            {"session_id": session_id, "agent_id": agent_id, "message": session_message}
+        )
+
+
+class _LegacyNestedSessionManager:
+    """Mimics a hypothetical older SDK shape with a nested
+    ``.base_manager``. We honor this for forward-compat in case a future
+    SDK reintroduces the indirection."""
+
+    def __init__(self) -> None:
+        self.base_manager = _RecordingSessionManager()
+
+
+class _MissingCreateMessage:
+    """Has neither a direct ``create_message`` nor a usable
+    ``base_manager``. The helper must return False and log loudly rather
+    than silently skip — the failure mode that caused the original bug."""
+
+    pass
+
+
+def _extract(session_message: Any) -> Dict[str, Any]:
+    """Pull (role, text) out of a Strands SessionMessage."""
+    msg = getattr(session_message, "message", None)
+    assert msg is not None
+    role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+    content = msg.get("content", []) if isinstance(msg, dict) else []
+    text = "".join(block.get("text", "") for block in content if isinstance(block, dict))
+    return {"role": role, "text": text}
+
+
+def test_writes_single_assistant_message():
+    sm = _RecordingSessionManager()
+    ok = persist_synthetic_messages(sm, "sess-1", [("assistant", "hello there")])
+
+    assert ok is True
+    assert len(sm.calls) == 1
+    call = sm.calls[0]
+    assert call["session_id"] == "sess-1"
+    assert call["agent_id"] == "default"
+    extracted = _extract(call["message"])
+    assert extracted == {"role": "assistant", "text": "hello there"}
+
+
+def test_writes_user_then_assistant_pair():
+    """Used by the quota-exceeded path where the agent never ran."""
+    sm = _RecordingSessionManager()
+    ok = persist_synthetic_messages(
+        sm,
+        "sess-2",
+        [("user", "what's the weather"), ("assistant", "quota exceeded")],
+    )
+
+    assert ok is True
+    assert len(sm.calls) == 2
+    assert _extract(sm.calls[0]["message"]) == {"role": "user", "text": "what's the weather"}
+    assert _extract(sm.calls[1]["message"]) == {"role": "assistant", "text": "quota exceeded"}
+
+
+def test_honors_custom_agent_id():
+    sm = _RecordingSessionManager()
+    persist_synthetic_messages(sm, "sess-3", [("assistant", "hi")], agent_id="voice")
+    assert sm.calls[0]["agent_id"] == "voice"
+
+
+def test_returns_false_and_logs_on_missing_create_message(caplog):
+    """Regression guard for the original bug: previously the hasattr()
+    guard silently skipped writes when create_message wasn't found.
+    Now we surface it loudly."""
+    sm = _MissingCreateMessage()
+
+    with caplog.at_level("ERROR"):
+        ok = persist_synthetic_messages(sm, "sess-bad", [("assistant", "test")])
+
+    assert ok is False
+    assert any(
+        "no create_message method" in rec.message and "sess-bad" in rec.message
+        for rec in caplog.records
+    ), f"expected loud error log, got: {[r.message for r in caplog.records]}"
+
+
+def test_falls_back_to_nested_base_manager_for_forward_compat():
+    """If a future SDK reintroduces a ``.base_manager`` wrapper, the
+    helper should still find ``create_message`` and write to it."""
+    sm = _LegacyNestedSessionManager()
+    ok = persist_synthetic_messages(sm, "sess-4", [("assistant", "via legacy path")])
+
+    assert ok is True
+    assert len(sm.base_manager.calls) == 1
+    assert _extract(sm.base_manager.calls[0]["message"]) == {
+        "role": "assistant",
+        "text": "via legacy path",
+    }
+
+
+def test_create_message_exception_propagates():
+    """The helper does NOT swallow exceptions from ``create_message`` —
+    callers wrap with their own try/except so the failure is logged at
+    the call site with the right context, not hidden inside this helper."""
+
+    class _RaisingSessionManager:
+        def create_message(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("AgentCore Memory rejected the write")
+
+    sm = _RaisingSessionManager()
+    with pytest.raises(RuntimeError, match="rejected the write"):
+        persist_synthetic_messages(sm, "sess-x", [("assistant", "boom")])

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -11,9 +11,9 @@ from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from agents.main_agent.config.constants import EnvVars
-from apis.shared.errors import ErrorCode, StreamErrorEvent, build_conversational_error_event
+from apis.shared.errors import ConversationalErrorEvent, ErrorCode, StreamErrorEvent, build_conversational_error_event
 
-from .stream_processor import process_agent_stream
+from .stream_processor import _format_force_stop_message, process_agent_stream
 
 logger = logging.getLogger(__name__)
 
@@ -554,32 +554,38 @@ class StreamCoordinator:
                             f"(Strands already committed the recovered partial turn)"
                         )
                     else:
-                        try:
-                            from strands.types.content import Message
-                            from strands.types.session import SessionMessage
+                        # Persist ONLY the assistant turn. The user turn was
+                        # already persisted at turn start by Strands'
+                        # MessageAddedEvent hook (any error event reaching
+                        # this in-loop handler was emitted from inside
+                        # ``process_agent_stream``, after the agent stream
+                        # began iterating). Re-persisting the user turn
+                        # would either duplicate it or cause AgentCore
+                        # Memory to reject the conflicting write and drop
+                        # the assistant message along with it.
+                        #
+                        # For AGENT_ERROR (Strands force_stop, classified
+                        # by stream_processor), the friendly markdown is
+                        # already in ``error_message``. For other codes,
+                        # ``conv_error_event.message`` is the conversational
+                        # template assembled above.
+                        if error_code == ErrorCode.AGENT_ERROR:
+                            assistant_text = error_message or conv_error_event.message
+                        else:
+                            assistant_text = conv_error_event.message
 
+                        try:
+                            from agents.main_agent.session.persistence import persist_synthetic_messages
                             from agents.main_agent.session.session_factory import SessionFactory
 
                             persist_session_manager = SessionFactory.create_session_manager(session_id=session_id, user_id=user_id, caching_enabled=False)
-
-                            # Extract user text from prompt (can be string or ContentBlock list)
-                            if isinstance(prompt, str):
-                                user_text = prompt
-                            else:
-                                # Extract text from ContentBlock list
-                                user_text = " ".join(block.get("text", "") for block in prompt if isinstance(block, dict) and "text" in block)
-
-                            user_msg: Message = {"role": "user", "content": [{"text": user_text}]}
-                            assistant_msg: Message = {"role": "assistant", "content": [{"text": conv_error_event.message}]}
-
-                            if hasattr(persist_session_manager, "base_manager") and hasattr(persist_session_manager.base_manager, "create_message"):
-                                user_session_msg = SessionMessage.from_message(user_msg, 0)
-                                assistant_session_msg = SessionMessage.from_message(assistant_msg, 1)
-                                persist_session_manager.base_manager.create_message(session_id, "default", user_session_msg)
-                                persist_session_manager.base_manager.create_message(session_id, "default", assistant_session_msg)
-                                logger.info(f"💾 Saved intercepted error messages to session {session_id}")
+                            persist_synthetic_messages(
+                                persist_session_manager,
+                                session_id,
+                                [("assistant", assistant_text)],
+                            )
                         except Exception as persist_error:
-                            logger.error(f"Failed to persist intercepted error to session: {persist_error}")
+                            logger.error(f"Failed to persist intercepted error to session: {persist_error}", exc_info=True)
 
                     # Skip the original error event and exit the loop - we've handled the error
                     return
@@ -779,43 +785,57 @@ class StreamCoordinator:
             # Emergency flush: save buffered messages before losing them
             self._emergency_flush(session_manager)
 
-            # Stream error as conversational assistant message for better UX
-            error_event = build_conversational_error_event(code=ErrorCode.STREAM_ERROR, error=e, session_id=session_id, recoverable=True)
+            # Some Bedrock errors (notably ValidationException for unsupported
+            # documents / images) propagate as raw exceptions instead of
+            # through Strands' force_stop event — Strands' `yield
+            # ForceStopEvent(reason=e)` hits a GeneratorExit when the
+            # consumer closes during the throw, so stream_processor's
+            # force_stop branch never fires. Run str(e) through the same
+            # classifier we use there so the user sees the same actionable
+            # message in both code paths instead of the generic
+            # "Something went wrong" STREAM_ERROR template.
+            classified_message, classified_recoverable = _format_force_stop_message(str(e))
+            is_classified = not classified_message.startswith("Agent force-stopped:")
+
+            if is_classified:
+                message_text = classified_message
+                recoverable = classified_recoverable
+                resolved_code = ErrorCode.AGENT_ERROR
+                error_event = ConversationalErrorEvent(
+                    code=resolved_code,
+                    message=message_text,
+                    recoverable=recoverable,
+                    metadata={"session_id": session_id} if session_id else None,
+                )
+            else:
+                # Fall back to the existing STREAM_ERROR template for errors
+                # the classifier doesn't recognize.
+                error_event = build_conversational_error_event(code=ErrorCode.STREAM_ERROR, error=e, session_id=session_id, recoverable=True)
+                message_text = error_event.message
+                resolved_code = ErrorCode.STREAM_ERROR
 
             # Emit message events so error appears in chat
             yield f'event: message_start\ndata: {{"role": "assistant"}}\n\n'
             yield f'event: content_block_start\ndata: {{"contentBlockIndex": 0, "type": "text"}}\n\n'
-            yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': error_event.message})}\n\n"
+            yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': message_text})}\n\n"
             yield f'event: content_block_stop\ndata: {{"contentBlockIndex": 0}}\n\n'
             yield f'event: message_stop\ndata: {{"stopReason": "error"}}\n\n'
             yield error_event.to_sse_format()
             yield "event: done\ndata: {}\n\n"
 
-            # Persist error messages to session
+            # Persist ONLY the assistant turn. Same reasoning as the
+            # AGENT_ERROR path above — the user turn was already persisted
+            # at turn start by Strands' MessageAddedEvent hook.
             try:
-                from strands.types.content import Message
-                from strands.types.session import SessionMessage
-
+                from agents.main_agent.session.persistence import persist_synthetic_messages
                 from agents.main_agent.session.session_factory import SessionFactory
 
                 persist_session_manager = SessionFactory.create_session_manager(session_id=session_id, user_id=user_id, caching_enabled=False)
-
-                # Extract user text from prompt (can be string or ContentBlock list)
-                if isinstance(prompt, str):
-                    user_text = prompt
-                else:
-                    # Extract text from ContentBlock list
-                    user_text = " ".join(block.get("text", "") for block in prompt if isinstance(block, dict) and "text" in block)
-
-                user_msg: Message = {"role": "user", "content": [{"text": user_text}]}
-                assistant_msg: Message = {"role": "assistant", "content": [{"text": error_event.message}]}
-
-                if hasattr(persist_session_manager, "base_manager") and hasattr(persist_session_manager.base_manager, "create_message"):
-                    user_session_msg = SessionMessage.from_message(user_msg, 0)
-                    assistant_session_msg = SessionMessage.from_message(assistant_msg, 1)
-                    persist_session_manager.base_manager.create_message(session_id, "default", user_session_msg)
-                    persist_session_manager.base_manager.create_message(session_id, "default", assistant_session_msg)
-                    logger.info(f"💾 Saved stream error messages to session {session_id}")
+                persist_synthetic_messages(
+                    persist_session_manager,
+                    session_id,
+                    [("assistant", message_text)],
+                )
             except Exception as persist_error:
                 logger.error(f"Failed to persist stream error to session: {persist_error}")
         finally:

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -601,16 +601,14 @@ class StreamCoordinator:
                         # Memory to reject the conflicting write and drop
                         # the assistant message along with it.
                         #
-                        # For AGENT_ERROR (Strands force_stop, classified
-                        # by stream_processor), the friendly markdown is
-                        # already in ``error_message``. For other codes,
-                        # ``conv_error_event.message`` is the conversational
-                        # template assembled above.
-                        if error_code == ErrorCode.AGENT_ERROR:
-                            assistant_text = error_message or conv_error_event.message
-                        else:
-                            assistant_text = conv_error_event.message
-
+                        # Persist what the user saw live: PR #388's
+                        # double-wrap fix above means ``conv_error_event.message``
+                        # is the un-wrapped friendly text for classified
+                        # AGENT_ERROR cases (leading "⚠️") and the wrapped
+                        # template for everything else — same string the
+                        # content_block_delta below yields to the SSE
+                        # stream. Persisting it keeps live and
+                        # refresh-hydrated views in sync.
                         try:
                             from agents.main_agent.session.persistence import persist_synthetic_messages
                             from agents.main_agent.session.session_factory import SessionFactory
@@ -619,7 +617,7 @@ class StreamCoordinator:
                             persist_synthetic_messages(
                                 persist_session_manager,
                                 session_id,
-                                [("assistant", assistant_text)],
+                                [("assistant", conv_error_event.message)],
                             )
                         except Exception as persist_error:
                             logger.error(f"Failed to persist intercepted error to session: {persist_error}", exc_info=True)

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -329,28 +329,53 @@ def _format_force_stop_message(reason: Any) -> tuple[str, bool]:
     reason_str = str(reason or "")
     reason_lower = reason_str.lower()
 
+    # Some Bedrock-hosted models (e.g. gpt-oss-120b) reject any document or
+    # image content block outright with "This model doesn't support
+    # documents." Check this BEFORE the size-limit branch — the AWS message
+    # contains "ValidationException" + "documents" and would otherwise be
+    # misclassified as a 4.5 MB overflow.
+    #
+    # Copy notes: keep the actionable advice deployment-agnostic — no brand
+    # names (model lineups change), no UI affordance names (might drift),
+    # no references to optional tools like Spreadsheet Analysis (not
+    # guaranteed enabled across forks/deployments).
+    if "doesn't support document" in reason_lower or "does not support document" in reason_lower:
+        return (
+            "⚠️ The selected model can't read attached files.\n\n"
+            "To work with this file, switch to a model that supports "
+            "documents.",
+            True,
+        )
+
+    if "doesn't support image" in reason_lower or "does not support image" in reason_lower:
+        return (
+            "⚠️ The selected model can't read attached images.\n\n"
+            "To work with this image, switch to a model that supports "
+            "images.",
+            True,
+        )
+
     # Bedrock ConverseStream rejects document content blocks over ~4.5 MB
     # internal size. Triggered most often by XLSX files that inflate
-    # significantly during parsing. The fix-forward is to route tabular
-    # files through the spreadsheet analysis tools, but a turn with a
-    # non-tabular file this large (or history that accumulated past the
-    # limit) still needs a friendlier message than the raw AWS error. See
-    # issue #206.
-    if "maximum document size" in reason_lower or (
-        "validationexception" in reason_lower and "document" in reason_lower
+    # significantly during parsing. See issue #206. Narrowed from
+    # `"document" in reason` to size-specific markers so
+    # unsupported-modality errors don't false-positive here.
+    #
+    # Copy notes: keep guidance deployment-agnostic — no references to
+    # optional tools (Spreadsheet Analysis isn't guaranteed enabled across
+    # forks/deployments) and no UI affordance names that might drift.
+    if (
+        "maximum document size" in reason_lower
+        or "document size" in reason_lower
+        or ("document" in reason_lower and ("too large" in reason_lower or "exceeds" in reason_lower or "exceed the" in reason_lower))
     ):
         return (
             "⚠️ One of the attached files is too large for the model to read "
             "directly.\n\n"
-            "Bedrock limits inline documents to 4.5 MB of internal content, "
-            "and spreadsheets (especially XLSX) often expand past that when "
-            "parsed. To work with large data files, enable **Spreadsheet "
-            "Analysis** in the Tools section of the settings panel (gear "
-            "icon next to the message input) and re-attach the file — the "
-            "tool runs pandas on the real file and isn't limited by the "
-            "document size cap.\n\n"
-            "For large PDFs or docs, split them into smaller sections or "
-            "convert to plain text.",
+            "Bedrock limits inline documents to 4.5 MB after parsing, and "
+            "spreadsheets (especially XLSX) often expand past that. Try "
+            "splitting the file into smaller sections, converting to plain "
+            "text or CSV, or sharing only the relevant portion.",
             True,
         )
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -605,29 +605,22 @@ async def stream_conversational_message(
         logger.info("Preview session - skipping message persistence")
         return
 
-    # Save messages to session for persistence
+    # Persist user + assistant turns. Unlike the streaming error paths in
+    # stream_coordinator (which persist assistant-only because the agent
+    # loop's MessageAddedEvent hook already wrote the user turn), this
+    # path fires BEFORE any agent run — quota-exceeded short-circuits,
+    # etc. — so no hook has persisted the user turn yet.
     try:
-        from strands.types.content import Message
-        from strands.types.session import SessionMessage
+        from agents.main_agent.session.persistence import persist_synthetic_messages
 
         session_manager = SessionFactory.create_session_manager(session_id=session_id, user_id=user_id, caching_enabled=False)
+        persist_synthetic_messages(
+            session_manager,
+            session_id,
+            [("user", user_input), ("assistant", message)],
+        )
 
-        # Save user message
-        user_message: Message = {"role": "user", "content": [{"text": user_input}]}
-
-        # Save assistant message
-        assistant_message: Message = {"role": "assistant", "content": [{"text": message}]}
-
-        # Use base_manager's create_message for persistence (AgentCore Memory)
-        if hasattr(session_manager, "base_manager") and hasattr(session_manager.base_manager, "create_message"):
-            user_session_msg = SessionMessage.from_message(user_message, index=0)
-            assistant_session_msg = SessionMessage.from_message(assistant_message, index=1)
-
-            session_manager.base_manager.create_message(session_id, "default", user_session_msg)
-            session_manager.base_manager.create_message(session_id, "default", assistant_session_msg)
-            logger.info("Saved messages to session")
-
-    except Exception as e:
+    except Exception:
         logger.error("Failed to save messages to session", exc_info=True)
 
 

--- a/backend/tests/agents/main_agent/streaming/test_force_stop_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_force_stop_persistence.py
@@ -1,0 +1,312 @@
+"""Regression: force_stop errors persist the friendly classified markdown
+to AgentCore Memory verbatim, and only the assistant turn — not a
+duplicate user turn.
+
+When the Strands agent loop force-stops (Bedrock rejects a content block,
+throttling, access denied, etc.) ``stream_processor._format_force_stop_message``
+turns the raw AWS reason into user-facing markdown. ``StreamCoordinator``
+intercepts the resulting ``error`` event and writes a synthetic assistant
+message to the session repository so the model sees what happened on the
+next turn.
+
+USER-VISIBLE BUG GUARDED HERE: previously the AGENT_ERROR branch also
+re-persisted the user turn, even though Strands' MessageAddedEvent hook had
+already written it at turn start. AgentCore Memory rejected the duplicate
+write, the surrounding try/except caught the failure, and the assistant
+error message was abandoned along with it — so the user saw the error
+live, then saw it vanish on refresh. We now persist only the assistant
+turn (mirroring the MAX_TOKENS reasoning at lines 540-555). Other error
+codes (STREAM_ERROR, MODEL_ERROR, …) can fire before the user turn enters
+agent.messages and keep the prior persist-both shape with the wrapped
+message.
+"""
+
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+
+class _FakeAgent:
+    def __init__(self, raw_events: List[Dict[str, Any]]) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        self._raw_events = raw_events
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for ev in self._raw_events:
+                yield ev
+
+        return _gen()
+
+
+class _RaisingAgent:
+    """Mimics the path-B failure mode: Strands' Bedrock ValidationException
+    bypasses the force_stop event and propagates as a raw exception out of
+    stream_async into stream_response's outer except handler. Reproduces
+    the GeneratorExit-during-yield case described in the user's log.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        self._exc = exc
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        exc = self._exc
+
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            raise exc
+            yield  # pragma: no cover — make this an async generator
+
+        return _gen()
+
+
+class _NoopSessionManager:
+    """Outer session manager passed into stream_response. The persistence
+    path under test creates its OWN session manager via SessionFactory, so
+    this stub only needs to satisfy the surface stream_response touches
+    when no compaction is configured."""
+
+    async def update_after_turn(self, input_tokens: int, current_messages=None):
+        return None
+
+
+class _RecordingPersistSessionManager:
+    """Mimics the SDK's ``AgentCoreMemorySessionManager`` shape — exposes
+    ``create_message`` directly. The persist path used to require a nested
+    ``.base_manager`` wrapper that no longer exists in the current SDK;
+    keeping this stub flat catches a regression to that broken guard.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def create_message(self, session_id: str, agent_id: str, session_message: Any) -> None:
+        self.calls.append(
+            {
+                "session_id": session_id,
+                "agent_id": agent_id,
+                "message": session_message,
+            }
+        )
+
+
+async def _collect(agent: Any, sm: _NoopSessionManager) -> List[str]:
+    coordinator = StreamCoordinator()
+    frames: List[str] = []
+    async for sse in coordinator.stream_response(
+        agent=agent,
+        prompt="please read this file",
+        session_manager=sm,
+        session_id="sess-force-stop",
+        user_id="user-1",
+        main_agent_wrapper=None,
+    ):
+        frames.append(sse)
+    return frames
+
+
+def _force_stop_event(reason: str) -> Dict[str, Any]:
+    """Raw Strands event shape that triggers the force_stop branch in
+    stream_processor._handle_completion_events."""
+    return {"force_stop": True, "force_stop_reason": reason}
+
+
+@pytest.mark.asyncio
+async def test_unsupported_documents_force_stop_persists_only_assistant_turn():
+    """The gpt-oss-120b case: Bedrock rejects the document content block
+    outright.
+
+    Regression for the "error visible live, gone on refresh" bug:
+    - Exactly ONE create_message call (assistant), not two — the user
+      turn was already persisted by Strands' hook at turn start and
+      re-persisting caused AgentCore Memory to reject the conflicting
+      write and drop the assistant message along with it.
+    - The persisted text is the friendly classified markdown from
+      _format_force_stop_message, NOT the "Something went wrong" wrapper.
+    """
+    raw_reason = (
+        "An error occurred (ValidationException) when calling the "
+        "ConverseStream operation: This model doesn't support documents."
+    )
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_FakeAgent([_force_stop_event(raw_reason)]), _NoopSessionManager())
+
+    # Exactly one call — assistant only. Re-persisting the user turn
+    # here would conflict with the hook write and (in real AgentCore
+    # Memory) abort the assistant write too.
+    assert len(persist_sm.calls) == 1, (
+        f"expected exactly 1 create_message call (assistant only), got "
+        f"{len(persist_sm.calls)}: {persist_sm.calls}"
+    )
+
+    assistant_call = persist_sm.calls[0]
+    assert assistant_call["session_id"] == "sess-force-stop"
+
+    # Role must be assistant — not user. A regression where this writes
+    # the user turn would re-introduce the duplicate-write conflict.
+    persisted_msg = assistant_call["message"]
+    inner = getattr(persisted_msg, "message", None)
+    assert inner is not None, f"SessionMessage shape unexpected: {persisted_msg!r}"
+    role = inner.get("role") if isinstance(inner, dict) else getattr(inner, "role", None)
+    assert role == "assistant", f"expected role='assistant', got {role!r}"
+
+    # The persisted assistant text must be the friendly classified
+    # markdown from _format_force_stop_message, not the generic wrapper.
+    assistant_text = _extract_text(persisted_msg)
+    assert "can't read attached files" in assistant_text
+    assert "switch to a model that supports documents" in assistant_text
+    # Must NOT be wrapped in build_conversational_error_event's generic
+    # template — that template would add "Something went wrong" and a
+    # blockquote and "Please try again."
+    assert "Something went wrong" not in assistant_text
+    assert "Please try again." not in assistant_text
+
+
+@pytest.mark.asyncio
+async def test_document_size_force_stop_persists_only_assistant_turn():
+    """Size-limit force_stop persists the spreadsheet-analysis advice
+    verbatim, assistant-only, un-wrapped."""
+    raw_reason = (
+        "ValidationException: The provided document exceeds the maximum "
+        "document size."
+    )
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_FakeAgent([_force_stop_event(raw_reason)]), _NoopSessionManager())
+
+    assert len(persist_sm.calls) == 1
+    assistant_text = _extract_text(persist_sm.calls[0]["message"])
+    assert "too large" in assistant_text
+    assert "4.5 MB" in assistant_text
+    assert "Spreadsheet Analysis" not in assistant_text
+    assert "Something went wrong" not in assistant_text
+
+
+@pytest.mark.asyncio
+async def test_fallthrough_force_stop_still_persists_assistant_only():
+    """Force_stops that don't match any classified branch fall through
+    to "Agent force-stopped: <raw>". Per design, all force_stops are
+    persisted (matched + fallthrough), still assistant-only."""
+    raw_reason = "ServiceQuotaExceeded: some unfamiliar upstream condition"
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_FakeAgent([_force_stop_event(raw_reason)]), _NoopSessionManager())
+
+    assert len(persist_sm.calls) == 1
+    assistant_text = _extract_text(persist_sm.calls[0]["message"])
+    assert "force-stopped" in assistant_text
+    assert raw_reason in assistant_text
+
+
+# ---------------------------------------------------------------------------
+# Path B: raw exception inside process_agent_stream.
+#
+# Bedrock ValidationException (e.g. gpt-oss-120b + a document) doesn't reach
+# stream_processor's force_stop branch — Strands' `yield ForceStopEvent` hits
+# a GeneratorExit during the throw (visible as OpenTelemetry detach
+# tracebacks in inference-api logs). The raw exception propagates out of
+# agent.stream_async into process_agent_stream's outer `except Exception` at
+# stream_processor.py:1532, which emits a STREAM_ERROR event. That flows
+# into stream_coordinator's in-loop error handler — the SAME persistence
+# path as AGENT_ERROR. Before this fix it re-persisted the user turn there
+# too, AgentCore Memory rejected the conflicting write, and the assistant
+# error was abandoned along with it — so the user saw the error live and
+# then saw it vanish on refresh.
+#
+# Fix: in-loop handler persists assistant-only for ALL error codes (not just
+# AGENT_ERROR). The conversational template embeds the raw error in a
+# blockquote, so the model still has full context on follow-up turns.
+# ---------------------------------------------------------------------------
+
+
+def _last_assistant_call_text(persist_sm: "_RecordingPersistSessionManager") -> str:
+    assert len(persist_sm.calls) == 1, (
+        f"expected exactly 1 create_message call (assistant only), got "
+        f"{len(persist_sm.calls)}: {persist_sm.calls}"
+    )
+    return _extract_text(persist_sm.calls[0]["message"])
+
+
+@pytest.mark.asyncio
+async def test_stream_error_unsupported_documents_persists_assistant_only():
+    """gpt-oss-120b ValidationException path: raw exception caught by
+    process_agent_stream's outer except, emitted as STREAM_ERROR, flows
+    through the in-loop handler. Persisted exactly once, assistant role,
+    and the raw error must appear in the persisted text so the model has
+    context on follow-up turns."""
+    exc = Exception(
+        "An error occurred (ValidationException) when calling the "
+        "ConverseStream operation: This model doesn't support documents."
+    )
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_RaisingAgent(exc), _NoopSessionManager())
+
+    # Exactly one create_message call — assistant only. Re-persisting
+    # the user turn would conflict with the hook write in real
+    # AgentCore Memory and abort the assistant write too.
+    assistant_text = _last_assistant_call_text(persist_sm)
+
+    # Assistant role
+    persisted_msg = persist_sm.calls[0]["message"]
+    inner = getattr(persisted_msg, "message", None)
+    role = inner.get("role") if isinstance(inner, dict) else None
+    assert role == "assistant"
+
+    # The raw Bedrock reason is embedded (the STREAM_ERROR template
+    # places it in a blockquote). The model sees enough to know what
+    # happened on the next turn.
+    assert "This model doesn't support documents" in assistant_text
+
+
+@pytest.mark.asyncio
+async def test_stream_error_unknown_exception_persists_assistant_only():
+    """Unrecognized exception classes still persist assistant-only —
+    the duplicate-user-write bug applied to all STREAM_ERROR codes."""
+    exc = RuntimeError("some unfamiliar upstream condition")
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_RaisingAgent(exc), _NoopSessionManager())
+
+    assistant_text = _last_assistant_call_text(persist_sm)
+    assert "some unfamiliar upstream condition" in assistant_text
+
+
+def _extract_text(session_message: Any) -> str:
+    """Pull the text content out of a Strands SessionMessage, regardless
+    of whether the SDK exposes it as ``.message`` (dict) or
+    ``.message_content`` / ``.text``. The persistence path uses
+    ``SessionMessage.from_message`` so the round-tripped shape contains a
+    ``content`` list with ``{"text": ...}`` blocks."""
+    # SessionMessage stores the original Strands Message dict on .message
+    msg = getattr(session_message, "message", None)
+    if msg is None and isinstance(session_message, dict):
+        msg = session_message.get("message", session_message)
+    assert msg is not None, f"could not find message on {session_message!r}"
+    content = msg.get("content", []) if isinstance(msg, dict) else []
+    parts = [block.get("text", "") for block in content if isinstance(block, dict)]
+    return "".join(parts)

--- a/backend/tests/agents/main_agent/streaming/test_stream_processor.py
+++ b/backend/tests/agents/main_agent/streaming/test_stream_processor.py
@@ -12,6 +12,7 @@ import pytest
 
 from agents.main_agent.streaming.stream_processor import (
     _create_event,
+    _format_force_stop_message,
     _handle_citation_events,
     _handle_content_block_events,
     _handle_lifecycle_events,
@@ -837,3 +838,104 @@ class TestProcessAgentStreamMaxTokens:
         data = error_events[0]["data"]
         assert data["code"] == "stream_error"
         assert data["recoverable"] is False
+
+
+class TestFormatForceStopMessage:
+    """Classifier for raw Bedrock force-stop reasons → user-facing markdown.
+
+    Regression coverage for the gpt-oss-120b case where the model rejects
+    documents outright and the message was being misclassified as a size
+    overflow because the substring `"document"` matched both branches.
+    """
+
+    def test_model_does_not_support_documents_is_not_size_error(self):
+        reason = (
+            "An error occurred (ValidationException) when calling the "
+            "ConverseStream operation: This model doesn't support documents."
+        )
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "can't read attached files" in message
+        assert "switch to a model that supports documents" in message
+        # Must NOT surface the 4.5 MB size message — that's a different problem
+        assert "4.5 MB" not in message
+        assert "too large" not in message
+        # No brand names (model lineups change) and no deployment-specific
+        # tool references (Spreadsheet Analysis may not be enabled).
+        assert "Claude" not in message
+        assert "Nova" not in message
+        assert "Spreadsheet Analysis" not in message
+        # No suggestions for actions the user can't actually take.
+        assert "remove the attachment" not in message
+        assert recoverable is True
+
+    def test_model_does_not_support_documents_alternate_phrasing(self):
+        """AWS sometimes phrases this as 'does not support' (no contraction)."""
+        reason = (
+            "ValidationException: This model does not support documents in "
+            "the request."
+        )
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "can't read attached files" in message
+        assert "4.5 MB" not in message
+        assert recoverable is True
+
+    def test_model_does_not_support_images(self):
+        reason = (
+            "An error occurred (ValidationException) when calling the "
+            "ConverseStream operation: This model doesn't support images."
+        )
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "can't read attached images" in message
+        assert "switch to a model that supports images" in message
+        assert "Claude" not in message
+        assert "Nova" not in message
+        assert "remove the image" not in message
+        assert recoverable is True
+
+    def test_document_size_limit_classic_message(self):
+        reason = (
+            "ValidationException: The provided document exceeds the maximum "
+            "document size."
+        )
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "too large" in message
+        assert "4.5 MB" in message
+        # Guidance is deployment-agnostic — no references to optional tools
+        # or UI affordances that might not exist in every deployment.
+        assert "Spreadsheet Analysis" not in message
+        assert "gear icon" not in message
+        assert recoverable is True
+
+    def test_document_size_limit_too_large_phrasing(self):
+        reason = "ValidationException: document content is too large to process"
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "too large" in message
+        assert "4.5 MB" in message
+        assert recoverable is True
+
+    def test_throttling(self):
+        reason = "ThrottlingException: Too many requests, please slow down."
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "too many requests" in message.lower()
+        assert recoverable is True
+
+    def test_access_denied(self):
+        reason = "AccessDeniedException: User is not authorized to invoke this model."
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "don't have access" in message
+        assert recoverable is False
+
+    def test_unknown_reason_falls_through(self):
+        reason = "Some unexpected transient error from upstream"
+        message, recoverable = _format_force_stop_message(reason)
+
+        assert "force-stopped" in message
+        assert reason in message
+        assert recoverable is False


### PR DESCRIPTION
## Summary

When a Bedrock `ValidationException` fired (most visibly: gpt-oss-120b + an attached document), users saw the error message in the chat live but it disappeared on refresh, and the live message itself was misclassified. Three connected bugs plus follow-on cleanup.

## What changed

### 1. Always-false persistence guard (the core "gone on refresh" bug)
Three sites guarded `create_message` behind `hasattr(session_manager, "base_manager")`. The current `bedrock_agentcore` SDK exposes `create_message` directly on `AgentCoreMemorySessionManager` — there is no nested `.base_manager` wrapper — so the guard was always False and every synthetic write was silently skipped. No log, no exception, just no write.

Found by adding diagnostic logging that proved the persist path ran to `DIAGNOSTIC[A3]: has base_manager=False` and then took the skip branch every time.

Extracted [`agents/main_agent/session/persistence.py`](backend/src/agents/main_agent/session/persistence.py) — `persist_synthetic_messages(session_manager, session_id, [(role, text), …])`. Asserts the real SDK contract (`create_message` is on the manager itself, with a legacy fallback to `.base_manager` for forward-compat) and logs loudly when the method is unavailable. Replaced the three near-identical copies:

- [`stream_coordinator.py`](backend/src/agents/main_agent/streaming/stream_coordinator.py) — in-loop error handler
- [`stream_coordinator.py`](backend/src/agents/main_agent/streaming/stream_coordinator.py) — outer except handler
- [`chat/routes.py`](backend/src/apis/inference_api/chat/routes.py) — `stream_conversational_message` (quota-exceeded path)

The third copy was broken the same way and is now working as a side effect.

### 2. Duplicate user-turn write (the conflicting-write bug)
The streaming error paths re-persisted the user turn even though Strands' `MessageAddedEvent` hook already wrote it at turn start (the property documented in the `MAX_TOKENS` comment, applied to no other branch). The conflicting second write caused AgentCore Memory to reject it (in practice) or duplicate it (in theory), dropping the assistant error message along with it.

The streaming paths now persist assistant-only. The quota-exceeded path keeps the persist-both shape because the agent never ran and the hook hasn't fired.

### 3. Misclassified error copy
`_format_force_stop_message` matched `ValidationException + "document"` as a 4.5 MB size overflow — but `"This model doesn't support documents"` also contains `"document"`, so unsupported-modality errors got the wrong message. Added explicit branches for `doesn't support document(s)` and `doesn't support image(s)` before the size check; narrowed the size matcher to size-specific markers (`maximum document size`, `document size`, `document + too large/exceeds`).

### 4. User-facing copy revised (per review feedback)
Dropped brand names (`Claude or Nova`), non-actionable suggestions (`remove the attachment` — no UI affordance for it), specific UI references (`gear icon next to the message input`), and the Spreadsheet Analysis hint (not guaranteed enabled across forks/deployments). Final copy is deployment-agnostic.

| Branch | Final message |
|---|---|
| Unsupported documents | ⚠️ The selected model can't read attached files. To work with this file, switch to a model that supports documents. |
| Unsupported images | ⚠️ The selected model can't read attached images. To work with this image, switch to a model that supports images. |
| Size limit | ⚠️ One of the attached files is too large for the model to read directly. Bedrock limits inline documents to 4.5 MB after parsing… Try splitting the file into smaller sections, converting to plain text or CSV, or sharing only the relevant portion. |

Tests now also assert these phrases are **not** present so regressions fail loudly.

## Out of scope (flagged as follow-up tasks)

- Consolidate the three streaming error-handler branches (force_stop event, stream_processor outer except, stream_coordinator outer except) into a single path — structural refactor.
- Clean up the double-⚠️ wrapping where `_format_force_stop_message` and `build_conversational_error_event` both add markers — UX cleanup.

## Test plan

- [x] `pytest tests/agents/main_agent/streaming/` — 155 pass
- [x] `pytest src/agents/main_agent/session/tests/test_persistence.py` — 6 new helper tests pass
- [x] `pytest tests/routes/test_chat.py tests/apis/inference_api/test_chat_service.py tests/apis/app_api/chat/` — 28 pass (chat surface)
- [x] `pytest tests/agents/main_agent/session/` — 243 pass (no session regressions)
- [x] Manual: gpt-oss-120b + a doc → error visible live, error survives refresh, model sees the error in context on the next turn
- [ ] Reviewer: spot-check that the new persistence helper is the only writer of synthetic error messages, and that `chat/routes.py:608-622` quota path works end-to-end (manually trigger quota exceeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)