### PR TITLE
refactor(streaming): drop dead force_stop classifier from coordinator outer except

### DIFF
--- a/backend/src/agents/main_agent/session/persistence.py
+++ b/backend/src/agents/main_agent/session/persistence.py
@@ -13,6 +13,14 @@ every synthetic write was silently skipped. That was the root cause of
 the "assistant error visible live, gone after refresh" bug. Centralizing
 the contract here surfaces the failure mode loudly and prevents the same
 shape of bug from drifting back into individual call sites.
+
+CANONICAL REFERENCE for the "user turn already persisted" invariant:
+The ``messages`` argument's docstring below is the single source of truth
+for *which roles to pass* in each scenario (assistant-only for paths
+inside the agent stream; user+assistant for paths that short-circuit
+before the agent runs). Call sites in ``stream_coordinator`` and
+``chat/routes.py`` repeat the high-level reasoning inline; if you need to
+revisit the invariant, start here.
 """
 
 import logging

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -18,7 +18,7 @@ from apis.shared.errors import (
     build_conversational_error_event,
 )
 
-from .stream_processor import _format_force_stop_message, process_agent_stream
+from .stream_processor import process_agent_stream
 
 logger = logging.getLogger(__name__)
 
@@ -820,39 +820,22 @@ class StreamCoordinator:
             # Emergency flush: save buffered messages before losing them
             self._emergency_flush(session_manager)
 
-            # Some Bedrock errors (notably ValidationException for unsupported
-            # documents / images) propagate as raw exceptions instead of
-            # through Strands' force_stop event — Strands' `yield
-            # ForceStopEvent(reason=e)` hits a GeneratorExit when the
-            # consumer closes during the throw, so stream_processor's
-            # force_stop branch never fires. Run str(e) through the same
-            # classifier we use there so the user sees the same actionable
-            # message in both code paths instead of the generic
-            # "Something went wrong" STREAM_ERROR template.
-            classified_message, classified_recoverable = _format_force_stop_message(str(e))
-            is_classified = not classified_message.startswith("Agent force-stopped:")
-
-            if is_classified:
-                message_text = classified_message
-                recoverable = classified_recoverable
-                resolved_code = ErrorCode.AGENT_ERROR
-                error_event = ConversationalErrorEvent(
-                    code=resolved_code,
-                    message=message_text,
-                    recoverable=recoverable,
-                    metadata={"session_id": session_id} if session_id else None,
-                )
-            else:
-                # Fall back to the existing STREAM_ERROR template for errors
-                # the classifier doesn't recognize.
-                error_event = build_conversational_error_event(code=ErrorCode.STREAM_ERROR, error=e, session_id=session_id, recoverable=True)
-                message_text = error_event.message
-                resolved_code = ErrorCode.STREAM_ERROR
+            # This handler catches exceptions from stream_coordinator's own
+            # loop body (e.g. interrupt extraction, artifact lookup,
+            # metadata calculation). Exceptions from inside the agent
+            # stream are caught one level down by process_agent_stream's
+            # own `except Exception` and yielded as STREAM_ERROR events
+            # — the in-loop branch above handles those. See
+            # test_force_stop_persistence.py:217-235 for the trace path.
+            # Coordinator-internal failures don't carry Bedrock-y patterns
+            # the force_stop classifier could match, so use the generic
+            # STREAM_ERROR template directly.
+            error_event = build_conversational_error_event(code=ErrorCode.STREAM_ERROR, error=e, session_id=session_id, recoverable=True)
 
             # Emit message events so error appears in chat
             yield f'event: message_start\ndata: {{"role": "assistant"}}\n\n'
             yield f'event: content_block_start\ndata: {{"contentBlockIndex": 0, "type": "text"}}\n\n'
-            yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': message_text})}\n\n"
+            yield f"event: content_block_delta\ndata: {json.dumps({'contentBlockIndex': 0, 'type': 'text', 'text': error_event.message})}\n\n"
             yield f'event: content_block_stop\ndata: {{"contentBlockIndex": 0}}\n\n'
             yield f'event: message_stop\ndata: {{"stopReason": "error"}}\n\n'
             yield error_event.to_sse_format()
@@ -869,7 +852,7 @@ class StreamCoordinator:
                 persist_synthetic_messages(
                     persist_session_manager,
                     session_id,
-                    [("assistant", message_text)],
+                    [("assistant", error_event.message)],
                 )
             except Exception as persist_error:
                 logger.error(f"Failed to persist stream error to session: {persist_error}")

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -1490,14 +1490,19 @@ async def process_agent_stream(
         yield _create_event("done", {})
 
     except RuntimeError as e:
-        # RuntimeError may occur during generator cleanup or cancellation
-        # Check if it's related to generator state
+        # The "generator"/"async" matched branch is the load-bearing part of
+        # this clause — it swallows async-generator state errors that aren't
+        # real user-facing failures: e.g. "asynchronous generator is already
+        # running" (re-entry) or "generator ignored GeneratorExit" (cleanup
+        # races). Normal shutdown goes through the GeneratorExit handler
+        # above; this catches the residual edge cases that should not
+        # surface as visible error events to the consumer.
         if "generator" in str(e).lower() or "async" in str(e).lower():
             logger.debug(f"Generator runtime error (likely cleanup): {e}")
         else:
-            # Unexpected RuntimeError - treat as error
+            # Any other RuntimeError: emit a STREAM_ERROR event, same shape
+            # as the generic Exception handler below.
             logger.error(f"Runtime error processing agent stream: {e}", exc_info=True)
-            # Create structured error event
             error_event = StreamErrorEvent(
                 error="Runtime error during streaming",
                 code=ErrorCode.STREAM_ERROR,


### PR DESCRIPTION
## Summary

Follow-up cleanup after #388 and #389 landed the persistence + double-wrap fixes for the gpt-oss-120b "error visible live, gone on refresh" bug. Three small architectural smells in the error-handling layer:

- Removed a dead `_format_force_stop_message` invocation from `stream_coordinator`'s outer `except`. The classifier was added on the theory that Bedrock `ValidationException` (gpt-oss-120b + document) bypasses `stream_processor`'s `force_stop` branch via a `GeneratorExit` and escapes up here. The trace path documented in `test_force_stop_persistence.py:217-235` shows it actually doesn't — `process_agent_stream`'s own outer `except` catches `stream_async` exceptions first and yields STREAM_ERROR events, which the in-loop handler picks up. Path 3 only fires for failures in the coordinator's own loop body (interrupt extraction, artifact lookup, metadata calc), which don't carry Bedrock-y patterns the classifier could match.
- Tightened the comment on `stream_processor`'s `RuntimeError` vs `Exception` split. The split is load-bearing — the `"generator"`/`"async"` matched branch silently swallows async-generator state errors (e.g. `"asynchronous generator is already running"`, `"generator ignored GeneratorExit"`) that shouldn't surface as user-visible error events. Normal shutdown goes through the `GeneratorExit` handler above. Kept the structure, made the load-bearing part obvious in the comment.
- Added a canonical-reference pointer to `persistence.py`'s module docstring so future readers know the `messages` argument docstring is the single source of truth for the "user turn already persisted by `MessageAddedEvent` hook" invariant.

No behavior change for any covered path. Diff is +31/-35 across 3 files.

## Test plan

- [x] `uv run python -m pytest tests/agents/main_agent/streaming/ src/agents/main_agent/session/tests/test_persistence.py -q` — 161 passed
- [x] `uv run python -m pytest tests/routes/test_chat.py tests/apis/inference_api/test_chat_service.py tests/apis/app_api/chat/ -q` — 26 passed
- [x] Imports still resolve (`_format_force_stop_message` still exported from `stream_processor`; only the unused coordinator import was dropped)
- [ ] Manual smoke against the gpt-oss-120b + document repro on alpha — error message still appears live and survives refresh (no regression to the persistence fix from #389)

🤖 Generated with [Claude Code](https://claude.com/claude-code)