### PR TITLE
feat: add teardown workflow to destroy all CDK stacks

### DIFF
--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -1,0 +1,100 @@
+name: "Teardown All Infrastructure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to tear down'
+        required: true
+        type: choice
+        options:
+          - development
+          - staging
+          - production
+      confirm:
+        description: 'Type DESTROY to confirm teardown'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CDK_REQUIRE_APPROVAL: never
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  LOAD_ENV_QUIET: true
+
+concurrency:
+  group: teardown-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate Confirmation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check confirmation input
+        if: github.event.inputs.confirm != 'DESTROY'
+        run: |
+          echo "::error::You must type DESTROY to confirm teardown. Got: '${{ github.event.inputs.confirm }}'"
+          exit 1
+
+  teardown:
+    name: Destroy All Stacks
+    runs-on: ubuntu-24.04
+    needs: validate
+    environment: ${{ github.event.inputs.environment }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      CDK_DOMAIN_NAME: ${{ vars.CDK_DOMAIN_NAME }}
+      CDK_CORS_ORIGINS: ${{ vars.CDK_CORS_ORIGINS }}
+      CDK_VPC_CIDR: ${{ vars.CDK_VPC_CIDR }}
+      CDK_ALB_SUBDOMAIN: ${{ vars.CDK_ALB_SUBDOMAIN }}
+      CDK_CERTIFICATE_ARN: ${{ vars.CDK_CERTIFICATE_ARN }}
+      CDK_HOSTED_ZONE_DOMAIN: ${{ vars.CDK_HOSTED_ZONE_DOMAIN }}
+      CDK_ARTIFACTS_ENABLED: ${{ vars.CDK_ARTIFACTS_ENABLED }}
+      CDK_ARTIFACTS_CERTIFICATE_ARN: ${{ vars.CDK_ARTIFACTS_CERTIFICATE_ARN }}
+      CDK_FINE_TUNING_ENABLED: ${{ vars.CDK_FINE_TUNING_ENABLED }}
+      CDK_RAG_ENABLED: ${{ vars.CDK_RAG_ENABLED }}
+      CDK_GATEWAY_ENABLED: ${{ vars.CDK_GATEWAY_ENABLED }}
+      CDK_FRONTEND_ENABLED: ${{ vars.CDK_FRONTEND_ENABLED }}
+      CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.CDK_AWS_REGION }}
+          role-session-name: GitHubActions-Teardown
+          aws-role-arn: ${{ env.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Install system dependencies
+        run: |
+          bash scripts/common/install-deps.sh
+
+      - name: Install CDK dependencies
+        run: |
+          cd infrastructure && npm ci
+
+      - name: Build CDK
+        run: |
+          cd infrastructure && npm run build
+
+      - name: Destroy all stacks
+        run: |
+          bash scripts/teardown/destroy.sh

--- a/scripts/teardown/destroy.sh
+++ b/scripts/teardown/destroy.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+#============================================================
+# Teardown - Destroy All CDK Stacks
+#
+# Destroys all CDK stacks in reverse deployment order.
+# Infrastructure stack is destroyed last since all others depend on it.
+#
+# Usage: bash scripts/teardown/destroy.sh
+#============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Source common utilities
+source "${PROJECT_ROOT}/scripts/common/load-env.sh"
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+# ===========================================================
+# Destroy all stacks (parallel where possible)
+#
+# Dependency graph:
+#   All application stacks depend on InfrastructureStack.
+#   Application stacks are independent of each other.
+#
+# Strategy:
+#   Phase 1: Destroy all application stacks in parallel
+#   Phase 2: Destroy InfrastructureStack (foundation)
+# ===========================================================
+
+cd "${PROJECT_ROOT}/infrastructure"
+
+# Ensure dependencies are installed
+if [ ! -d "node_modules" ]; then
+    log_info "Installing CDK dependencies..."
+    npm ci
+fi
+
+# Build CDK context params
+CDK_CONTEXT_PARAMS=$(build_cdk_context_params)
+
+# Phase 1: All application stacks (independent, can run in parallel)
+PARALLEL_STACKS=(
+    "SageMakerFineTuningStack"
+    "RagIngestionStack"
+    "GatewayStack"
+    "InferenceApiStack"
+    "AppApiStack"
+    "FrontendStack"
+    "McpSandboxStack"
+    "ArtifactsStack"
+)
+
+# Phase 2: Foundation stack (must be last)
+FOUNDATION_STACK="InfrastructureStack"
+
+log_info "============================================"
+log_info "  TEARDOWN: Destroying all CDK stacks"
+log_info "  Project: ${CDK_PROJECT_PREFIX}"
+log_info "  Region:  ${CDK_AWS_REGION}"
+log_info "  Account: ${CDK_AWS_ACCOUNT}"
+log_info "============================================"
+
+# --- Phase 1: Destroy application stacks in parallel ---
+log_info ""
+log_info "Phase 1: Destroying application stacks in parallel..."
+
+PIDS=()
+STACK_NAMES=()
+LOG_DIR=$(mktemp -d)
+
+for STACK in "${PARALLEL_STACKS[@]}"; do
+    FULL_STACK_NAME="${CDK_PROJECT_PREFIX}-${STACK}"
+    log_info "  Starting destroy: ${FULL_STACK_NAME}"
+
+    (
+        eval cdk destroy "${STACK}" \
+            ${CDK_CONTEXT_PARAMS} \
+            --force \
+            --exclusively > "${LOG_DIR}/${STACK}.log" 2>&1
+    ) &
+    PIDS+=($!)
+    STACK_NAMES+=("${STACK}")
+done
+
+# Wait for all parallel destroys and collect results
+FAILED_STACKS=()
+for i in "${!PIDS[@]}"; do
+    if wait "${PIDS[$i]}"; then
+        log_success "Destroyed ${CDK_PROJECT_PREFIX}-${STACK_NAMES[$i]}"
+    else
+        log_warn "Failed to destroy ${CDK_PROJECT_PREFIX}-${STACK_NAMES[$i]} (may not exist)"
+        FAILED_STACKS+=("${CDK_PROJECT_PREFIX}-${STACK_NAMES[$i]}")
+        # Show logs for failed stacks
+        if [ -f "${LOG_DIR}/${STACK_NAMES[$i]}.log" ]; then
+            log_warn "  Output: $(tail -5 "${LOG_DIR}/${STACK_NAMES[$i]}.log")"
+        fi
+    fi
+done
+
+# --- Phase 2: Destroy foundation stack ---
+log_info ""
+log_info "Phase 2: Destroying foundation stack..."
+FULL_STACK_NAME="${CDK_PROJECT_PREFIX}-${FOUNDATION_STACK}"
+log_info "  Destroying ${FULL_STACK_NAME}..."
+
+if eval cdk destroy "${FOUNDATION_STACK}" \
+    ${CDK_CONTEXT_PARAMS} \
+    --force \
+    --exclusively 2>&1; then
+    log_success "Destroyed ${FULL_STACK_NAME}"
+else
+    log_warn "Failed to destroy ${FULL_STACK_NAME}"
+    FAILED_STACKS+=("${FULL_STACK_NAME}")
+fi
+
+# Cleanup
+rm -rf "${LOG_DIR}"
+
+# --- Summary ---
+echo ""
+log_info "============================================"
+if [ ${#FAILED_STACKS[@]} -eq 0 ]; then
+    log_success "All stacks destroyed successfully!"
+else
+    log_warn "The following stacks failed to destroy (they may not have been deployed):"
+    for STACK in "${FAILED_STACKS[@]}"; do
+        log_warn "  - ${STACK}"
+    done
+fi
+log_info "============================================"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and shell script to tear down all CDK infrastructure with one click.

## What's included

- **`.github/workflows/teardown.yml`** — Manual-only workflow with safety confirmation (must type DESTROY)
- **`scripts/teardown/destroy.sh`** — Destroys all 9 stacks in two phases:
  - Phase 1: 8 application stacks destroyed in parallel
  - Phase 2: InfrastructureStack destroyed last (foundation layer)

## Safety

- Manual trigger only (`workflow_dispatch`)
- Requires selecting the target environment
- Requires typing `DESTROY` to confirm — typos abort the run
- Uses environment-scoped AWS credentials

## Testing

- Script syntax validated locally
- Follows existing workflow patterns (same credentials action, env vars, install steps)