### PR TITLE
fix(admin): model form redesign tokens + edit-mode loading indicator

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -1,29 +1,43 @@
 <div class="min-h-dvh">
-  <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
     <!-- Back Button -->
     <a
       routerLink="/admin/manage-models"
       class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
     >
-      <ng-icon name="heroArrowLeft" class="size-4" />
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
       Back to Manage Models
     </a>
 
     <!-- Page Header -->
     <div class="mb-8">
-      <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">{{ pageTitle() }}</h1>
-      <p class="mt-2 text-base/7 text-gray-600 dark:text-gray-400">
-        Configure model settings and access controls
+      <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">{{ pageTitle() }}</h1>
+      <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        Configure model settings and access controls.
       </p>
     </div>
 
-    <!-- Form -->
-    <form [formGroup]="modelForm" (ngSubmit)="onSubmit()" class="space-y-8">
-      <!-- Basic Information Section -->
-      <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-        <h2 class="mb-6 text-xl/8 font-semibold text-gray-900 dark:text-white">Basic Information</h2>
+    <!-- Loading State (edit-mode initial fetch) -->
+    @if (isLoading()) {
+      <div class="flex h-64 items-center justify-center rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col items-center gap-4">
+          <div
+            class="size-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            role="status"
+            aria-label="Loading model"
+          ></div>
+          <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+            Loading model…
+          </p>
+        </div>
+      </div>
+    } @else {
+      <!-- Form -->
+      <form [formGroup]="modelForm" (ngSubmit)="onSubmit()" class="space-y-8">
+        <!-- Basic Information Section -->
+        <section class="space-y-4">
+          <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Basic information</h2>
 
-        <div class="space-y-4">
           <!-- Model ID -->
           <div>
             <label for="modelId" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -34,7 +48,7 @@
               id="modelId"
               formControlName="modelId"
               placeholder="e.g., anthropic.claude-3-5-sonnet-20241022-v2:0"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
               [class.border-red-500]="modelForm.controls.modelId.invalid && modelForm.controls.modelId.touched"
             />
             @if (modelForm.controls.modelId.invalid && modelForm.controls.modelId.touched) {
@@ -52,7 +66,7 @@
               id="modelName"
               formControlName="modelName"
               placeholder="e.g., Claude 3.5 Sonnet v2"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
               [class.border-red-500]="modelForm.controls.modelName.invalid && modelForm.controls.modelName.touched"
             />
             @if (modelForm.controls.modelName.invalid && modelForm.controls.modelName.touched) {
@@ -60,42 +74,43 @@
             }
           </div>
 
-          <!-- Provider -->
-          <div>
-            <label for="provider" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-              Provider <span class="text-red-600">*</span>
-            </label>
-            <select
-              id="provider"
-              formControlName="provider"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              [class.border-red-500]="modelForm.controls.provider.invalid && modelForm.controls.provider.touched"
-            >
-              @for (provider of availableProviders; track provider) {
-                <option [value]="provider">{{ provider }}</option>
+          <!-- Provider + Provider Name Row -->
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label for="provider" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Provider <span class="text-red-600">*</span>
+              </label>
+              <select
+                id="provider"
+                formControlName="provider"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                [class.border-red-500]="modelForm.controls.provider.invalid && modelForm.controls.provider.touched"
+              >
+                @for (provider of availableProviders; track provider) {
+                  <option [value]="provider">{{ provider }}</option>
+                }
+              </select>
+              @if (modelForm.controls.provider.invalid && modelForm.controls.provider.touched) {
+                <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Provider is required</p>
               }
-            </select>
-            @if (modelForm.controls.provider.invalid && modelForm.controls.provider.touched) {
-              <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Provider is required</p>
-            }
-          </div>
+            </div>
 
-          <!-- Provider Name -->
-          <div>
-            <label for="providerName" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-              Provider Name <span class="text-red-600">*</span>
-            </label>
-            <input
-              type="text"
-              id="providerName"
-              formControlName="providerName"
-              placeholder="e.g., Anthropic"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
-              [class.border-red-500]="modelForm.controls.providerName.invalid && modelForm.controls.providerName.touched"
-            />
-            @if (modelForm.controls.providerName.invalid && modelForm.controls.providerName.touched) {
-              <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Provider name is required</p>
-            }
+            <div>
+              <label for="providerName" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Provider Name <span class="text-red-600">*</span>
+              </label>
+              <input
+                type="text"
+                id="providerName"
+                formControlName="providerName"
+                placeholder="e.g., Anthropic"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                [class.border-red-500]="modelForm.controls.providerName.invalid && modelForm.controls.providerName.touched"
+              />
+              @if (modelForm.controls.providerName.invalid && modelForm.controls.providerName.touched) {
+                <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Provider name is required</p>
+              }
+            </div>
           </div>
 
           <!-- Knowledge Cutoff Date -->
@@ -107,20 +122,18 @@
               type="date"
               id="knowledgeCutoffDate"
               formControlName="knowledgeCutoffDate"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:max-w-xs dark:border-gray-600 dark:bg-gray-800 dark:text-white"
             />
             <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-              The date when the model's training data was last updated
+              The date when the model's training data was last updated.
             </p>
           </div>
-        </div>
-      </div>
+        </section>
 
-      <!-- Capabilities Section -->
-      <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-        <h2 class="mb-6 text-xl/8 font-semibold text-gray-900 dark:text-white">Model Capabilities</h2>
+        <!-- Capabilities Section -->
+        <section class="space-y-6 border-t border-gray-200 pt-8 dark:border-gray-700">
+          <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Model capabilities</h2>
 
-        <div class="space-y-6">
           <!-- Input Modalities -->
           <div>
             <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -136,9 +149,9 @@
                   [class.bg-gray-100]="!isSelected('inputModalities', modality)"
                   [class.text-gray-700]="!isSelected('inputModalities', modality)"
                   [class.dark:bg-blue-500]="isSelected('inputModalities', modality)"
-                  [class.dark:bg-gray-700]="!isSelected('inputModalities', modality)"
+                  [class.dark:bg-gray-800]="!isSelected('inputModalities', modality)"
                   [class.dark:text-gray-300]="!isSelected('inputModalities', modality)"
-                  class="rounded-sm px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50"
+                  class="rounded-2xl px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
                 >
                   {{ modality }}
                 </button>
@@ -164,9 +177,9 @@
                   [class.bg-gray-100]="!isSelected('outputModalities', modality)"
                   [class.text-gray-700]="!isSelected('outputModalities', modality)"
                   [class.dark:bg-blue-500]="isSelected('outputModalities', modality)"
-                  [class.dark:bg-gray-700]="!isSelected('outputModalities', modality)"
+                  [class.dark:bg-gray-800]="!isSelected('outputModalities', modality)"
                   [class.dark:text-gray-300]="!isSelected('outputModalities', modality)"
-                  class="rounded-sm px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50"
+                  class="rounded-2xl px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
                 >
                   {{ modality }}
                 </button>
@@ -178,7 +191,7 @@
           </div>
 
           <!-- Token Limits -->
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <!-- Max Input Tokens -->
             <div>
               <label for="maxInputTokens" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -191,7 +204,7 @@
                 min="1"
                 step="1"
                 placeholder="e.g., 200000"
-                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                 [class.border-red-500]="modelForm.controls.maxInputTokens.invalid && modelForm.controls.maxInputTokens.touched"
               />
               @if (modelForm.controls.maxInputTokens.invalid && modelForm.controls.maxInputTokens.touched) {
@@ -211,7 +224,7 @@
                 min="1"
                 step="1"
                 placeholder="e.g., 16384"
-                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                 [class.border-red-500]="modelForm.controls.maxOutputTokens.invalid && modelForm.controls.maxOutputTokens.touched"
               />
               @if (modelForm.controls.maxOutputTokens.invalid && modelForm.controls.maxOutputTokens.touched) {
@@ -219,24 +232,22 @@
               }
             </div>
           </div>
-        </div>
-      </div>
+        </section>
 
-      <!-- Access Control Section -->
-      <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-        <h2 class="mb-6 text-xl/8 font-semibold text-gray-900 dark:text-white">Access Control</h2>
+        <!-- Access Control Section -->
+        <section class="space-y-6 border-t border-gray-200 pt-8 dark:border-gray-700">
+          <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Access control</h2>
 
-        <div class="space-y-6">
           <!-- Allowed AppRoles -->
           <div>
             <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
               Allowed Roles <span class="text-red-600">*</span>
             </label>
             <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-              Select which application roles can access this model
+              Select which application roles can access this model.
             </p>
             @if (rolesResource.isLoading()) {
-              <div class="mt-2 text-sm/6 text-gray-500 dark:text-gray-400">Loading roles...</div>
+              <div class="mt-2 text-sm/6 text-gray-500 dark:text-gray-400">Loading roles…</div>
             } @else if (rolesResource.error()) {
               <div class="mt-2 text-sm/6 text-red-600 dark:text-red-400">
                 Failed to load roles. Please refresh the page.
@@ -252,9 +263,9 @@
                     [class.bg-gray-100]="!isSelected('allowedAppRoles', role.roleId)"
                     [class.text-gray-700]="!isSelected('allowedAppRoles', role.roleId)"
                     [class.dark:bg-purple-500]="isSelected('allowedAppRoles', role.roleId)"
-                    [class.dark:bg-gray-700]="!isSelected('allowedAppRoles', role.roleId)"
+                    [class.dark:bg-gray-800]="!isSelected('allowedAppRoles', role.roleId)"
                     [class.dark:text-gray-300]="!isSelected('allowedAppRoles', role.roleId)"
-                    class="rounded-sm px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus:outline-hidden focus:ring-3 focus:ring-purple-500/50"
+                    class="rounded-2xl px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-500"
                     [title]="role.description"
                   >
                     {{ role.displayName }}
@@ -273,45 +284,43 @@
           </div>
 
           <!-- Enabled -->
-          <div class="flex items-center gap-3">
-            <input
-              type="checkbox"
-              id="enabled"
-              formControlName="enabled"
-              class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-            />
-            <label for="enabled" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-              Model Enabled (Users can select this model)
+          <div>
+            <label class="flex items-center gap-3">
+              <input
+                type="checkbox"
+                formControlName="enabled"
+                class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+              />
+              <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Model enabled (users can select this model)
+              </span>
             </label>
           </div>
 
           <!-- Default Model -->
           <div>
-            <div class="flex items-center gap-3">
+            <label class="flex items-center gap-3">
               <input
                 type="checkbox"
-                id="isDefault"
                 formControlName="isDefault"
-                class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
+                class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
               />
-              <label for="isDefault" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                Default Model (Auto-selected for new sessions)
-              </label>
-            </div>
+              <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Default model (auto-selected for new sessions)
+              </span>
+            </label>
             <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
               Only one model can be the default. Setting this will unset any previous default.
             </p>
           </div>
-        </div>
-      </div>
+        </section>
 
-      <!-- Pricing Section -->
-      <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
-        <h2 class="mb-6 text-xl/8 font-semibold text-gray-900 dark:text-white">Pricing</h2>
+        <!-- Pricing Section -->
+        <section class="space-y-6 border-t border-gray-200 pt-8 dark:border-gray-700">
+          <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Pricing</h2>
 
-        <div class="space-y-6">
           <!-- Standard Pricing -->
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <!-- Input Price -->
             <div>
               <label for="inputPricePerMillionTokens" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -328,7 +337,7 @@
                   step="0.01"
                   min="0"
                   placeholder="0.00"
-                  class="block w-full rounded-sm border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                  class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                   [class.border-red-500]="modelForm.controls.inputPricePerMillionTokens.invalid && modelForm.controls.inputPricePerMillionTokens.touched"
                 />
               </div>
@@ -353,7 +362,7 @@
                   step="0.01"
                   min="0"
                   placeholder="0.00"
-                  class="block w-full rounded-sm border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                  class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                   [class.border-red-500]="modelForm.controls.outputPricePerMillionTokens.invalid && modelForm.controls.outputPricePerMillionTokens.touched"
                 />
               </div>
@@ -365,32 +374,33 @@
 
           <!-- Prompt Caching (Bedrock Only) -->
           @if (modelForm.value.provider === 'bedrock') {
-            <div>
-              <h3 class="mb-3 text-base/7 font-medium text-gray-900 dark:text-white">
-                Prompt Caching (Bedrock Only)
+            <div class="space-y-4">
+              <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                Prompt caching (Bedrock only)
               </h3>
 
               <!-- Supports Caching Toggle -->
-              <div class="mb-4 flex items-center gap-3">
-                <input
-                  type="checkbox"
-                  id="supportsCaching"
-                  formControlName="supportsCaching"
-                  class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-                />
-                <label for="supportsCaching" class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                  Model Supports Prompt Caching
+              <div>
+                <label class="flex items-center gap-3">
+                  <input
+                    type="checkbox"
+                    formControlName="supportsCaching"
+                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                  />
+                  <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Model supports prompt caching
+                  </span>
                 </label>
+                <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                  Disable this if the model doesn't support prompt caching (e.g., some Amazon models). When disabled, the agent will skip cache-related API calls.
+                </p>
               </div>
-              <p class="mb-4 text-sm/6 text-gray-600 dark:text-gray-400">
-                Disable this if the model doesn't support prompt caching (e.g., some Amazon models). When disabled, the agent will skip cache-related API calls.
-              </p>
 
               @if (modelForm.value.supportsCaching) {
-                <p class="mb-4 text-sm/6 text-gray-600 dark:text-gray-400">
+                <p class="text-sm/6 text-gray-600 dark:text-gray-400">
                   Optional pricing for prompt caching. Cache writes typically cost ~25% more, while cache reads cost ~90% less than standard input tokens.
                 </p>
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <!-- Cache Write Price -->
                   <div>
                     <label for="cacheWritePricePerMillionTokens" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -407,7 +417,7 @@
                         step="0.01"
                         min="0"
                         placeholder="0.00 (optional)"
-                        class="block w-full rounded-sm border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                        class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                         [class.border-red-500]="modelForm.controls.cacheWritePricePerMillionTokens.invalid && modelForm.controls.cacheWritePricePerMillionTokens.touched"
                       />
                     </div>
@@ -432,7 +442,7 @@
                         step="0.01"
                         min="0"
                         placeholder="0.00 (optional)"
-                        class="block w-full rounded-sm border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                        class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-7 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                         [class.border-red-500]="modelForm.controls.cacheReadPricePerMillionTokens.invalid && modelForm.controls.cacheReadPricePerMillionTokens.touched"
                       />
                     </div>
@@ -444,358 +454,358 @@
               }
             </div>
           }
-        </div>
-      </div>
+        </section>
 
-      <!-- Inference Parameters Section -->
-      <div class="rounded-sm border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800">
-        <button
-          type="button"
-          (click)="toggleInferenceParams()"
-          [attr.aria-expanded]="inferenceParamsExpanded()"
-          aria-controls="inference-params-body"
-          class="flex w-full items-center justify-between gap-4 p-6 text-left hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:hover:bg-gray-700/50"
-        >
-          <div class="flex items-center gap-3">
-            <ng-icon
-              [name]="inferenceParamsExpanded() ? 'heroChevronDown' : 'heroChevronRight'"
-              class="size-5 text-gray-500 dark:text-gray-400"
-              aria-hidden="true"
-            />
-            <h2 class="text-xl/8 font-semibold text-gray-900 dark:text-white">Inference Parameters</h2>
-          </div>
-          <span class="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
-            @if (configuredParamCount() === 0) {
-              No parameters configured (passthrough)
-            } @else if (configuredParamCount() === 1) {
-              1 parameter configured
-            } @else {
-              {{ configuredParamCount() }} parameters configured
-            }
-          </span>
-        </button>
+        <!-- Inference Parameters Section -->
+        <section class="border-t border-gray-200 pt-8 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="toggleInferenceParams()"
+            [attr.aria-expanded]="inferenceParamsExpanded()"
+            aria-controls="inference-params-body"
+            class="flex w-full items-center justify-between gap-4 rounded-2xl text-left hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            <div class="flex items-center gap-3">
+              <ng-icon
+                [name]="inferenceParamsExpanded() ? 'heroChevronDown' : 'heroChevronRight'"
+                class="size-5 text-gray-500 dark:text-gray-400"
+                aria-hidden="true"
+              />
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Inference parameters</h2>
+            </div>
+            <span class="text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+              @if (configuredParamCount() === 0) {
+                No parameters configured (passthrough)
+              } @else if (configuredParamCount() === 1) {
+                1 parameter configured
+              } @else {
+                {{ configuredParamCount() }} parameters configured
+              }
+            </span>
+          </button>
 
-        @if (inferenceParamsExpanded()) {
-        <div id="inference-params-body" class="border-t border-gray-200 px-6 pb-6 pt-4 dark:border-gray-700">
-        <p class="mb-6 text-sm/6 text-gray-600 dark:text-gray-400">
-          Mark each parameter as supported or unsupported on this model, and set the default the runtime will send when the user doesn't override. Unsupported params are dropped from outbound requests. Untouched rows are treated as passthrough — the provider's server-side default applies.
-        </p>
+          @if (inferenceParamsExpanded()) {
+            <div id="inference-params-body" class="mt-4">
+              <p class="mb-6 text-sm/6 text-gray-600 dark:text-gray-400">
+                Mark each parameter as supported or unsupported on this model, and set the default the runtime will send when the user doesn't override. Unsupported params are dropped from outbound requests. Untouched rows are treated as passthrough — the provider's server-side default applies.
+              </p>
 
-        @if (inferenceParamRows().length === 0) {
-          <p class="text-sm/6 text-gray-500 dark:text-gray-400">No known parameters for this provider.</p>
-        }
+              @if (inferenceParamRows().length === 0) {
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">No known parameters for this provider.</p>
+              }
 
-        <div class="space-y-4" formArrayName="inferenceParams">
-          @for (meta of inferenceParamRows(); track meta.key; let i = $index) {
-            <div class="rounded-sm border border-gray-200 p-4 dark:border-gray-700" [formGroupName]="i">
-              <div class="flex items-start justify-between gap-4">
-                <div class="flex-1">
-                  <div class="font-medium text-gray-900 dark:text-white">{{ meta.label }}</div>
-                  <div class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-                    <span class="font-mono">{{ meta.key }}</span> — {{ meta.description }}
-                  </div>
-                </div>
-                <label class="flex items-center gap-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                  <input
-                    type="checkbox"
-                    formControlName="supported"
-                    class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-                  />
-                  Supported
-                </label>
-              </div>
-
-              @if (paramRowGroup(i).controls.supported.value) {
-                <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
-                  @if (meta.kind === 'number' || meta.kind === 'integer' || meta.kind === 'thinkingBudget') {
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Min</label>
-                      <input
-                        type="number"
-                        formControlName="min"
-                        [step]="meta.kind === 'number' ? 'any' : 1"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Max</label>
-                      <input
-                        type="number"
-                        formControlName="max"
-                        [step]="meta.kind === 'number' ? 'any' : 1"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">
-                        @if (meta.kind === 'thinkingBudget') {
-                          Budget (tokens)
-                        } @else {
-                          Default
-                        }
-                      </label>
-                      <input
-                        type="number"
-                        formControlName="defaultValue"
-                        [step]="meta.kind === 'number' ? 'any' : 1"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                  } @else if (meta.kind === 'toggle') {
-                    <div class="md:col-span-3">
-                      <label class="flex items-center gap-2 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+              <div class="space-y-3" formArrayName="inferenceParams">
+                @for (meta of inferenceParamRows(); track meta.key; let i = $index) {
+                  <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800" [formGroupName]="i">
+                    <div class="flex items-start justify-between gap-4">
+                      <div class="flex-1">
+                        <div class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ meta.label }}</div>
+                        <div class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                          <span class="font-mono">{{ meta.key }}</span> — {{ meta.description }}
+                        </div>
+                      </div>
+                      <label class="flex items-center gap-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
                         <input
                           type="checkbox"
-                          formControlName="defaultValue"
-                          class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
+                          formControlName="supported"
+                          class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
                         />
-                        Default to enabled
+                        Supported
                       </label>
                     </div>
-                  } @else if (meta.kind === 'select') {
-                    <div class="md:col-span-2">
-                      <span class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">
-                        Levels this model supports
-                      </span>
-                      <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
-                        @for (lvl of meta.options ?? []; track lvl) {
-                          <label class="flex items-center gap-2 text-xs/5 text-gray-700 dark:text-gray-300">
+
+                    @if (paramRowGroup(i).controls.supported.value) {
+                      <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
+                        @if (meta.kind === 'number' || meta.kind === 'integer' || meta.kind === 'thinkingBudget') {
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Min</label>
+                            <input
+                              type="number"
+                              formControlName="min"
+                              [step]="meta.kind === 'number' ? 'any' : 1"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Max</label>
+                            <input
+                              type="number"
+                              formControlName="max"
+                              [step]="meta.kind === 'number' ? 'any' : 1"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                              @if (meta.kind === 'thinkingBudget') {
+                                Budget (tokens)
+                              } @else {
+                                Default
+                              }
+                            </label>
+                            <input
+                              type="number"
+                              formControlName="defaultValue"
+                              [step]="meta.kind === 'number' ? 'any' : 1"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                        } @else if (meta.kind === 'toggle') {
+                          <div class="md:col-span-3">
+                            <label class="flex items-center gap-2 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                              <input
+                                type="checkbox"
+                                formControlName="defaultValue"
+                                class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                              />
+                              Default to enabled
+                            </label>
+                          </div>
+                        } @else if (meta.kind === 'select') {
+                          <div class="md:col-span-2">
+                            <span class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                              Levels this model supports
+                            </span>
+                            <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                              @for (lvl of meta.options ?? []; track lvl) {
+                                <label class="flex items-center gap-2 text-xs/5 text-gray-700 dark:text-gray-300">
+                                  <input
+                                    type="checkbox"
+                                    [checked]="isParamAllowed(i, lvl)"
+                                    (change)="toggleParamAllowed(i, lvl)"
+                                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                                  />
+                                  {{ lvl }}
+                                </label>
+                              }
+                            </div>
+                          </div>
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Default</label>
+                            <select
+                              formControlName="defaultValue"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            >
+                              <option [ngValue]="null">— none (API default) —</option>
+                              @for (lvl of paramRowGroup(i).controls.allowed.value ?? []; track lvl) {
+                                <option [ngValue]="lvl">{{ lvl }}</option>
+                              }
+                            </select>
+                          </div>
+                        }
+                        <div>
+                          <label class="flex items-center gap-2 pt-5 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
                             <input
                               type="checkbox"
-                              [checked]="isParamAllowed(i, lvl)"
-                              (change)="toggleParamAllowed(i, lvl)"
-                              class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
+                              formControlName="locked"
+                              class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
                             />
-                            {{ lvl }}
+                            Locked (no user override)
                           </label>
-                        }
+                        </div>
                       </div>
-                    </div>
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Default</label>
-                      <select
-                        formControlName="defaultValue"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      >
-                        <option [ngValue]="null">— none (API default) —</option>
-                        @for (lvl of paramRowGroup(i).controls.allowed.value ?? []; track lvl) {
-                          <option [ngValue]="lvl">{{ lvl }}</option>
-                        }
-                      </select>
-                    </div>
-                  }
-                  <div>
-                    <label class="flex items-center gap-2 pt-5 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
-                      <input
-                        type="checkbox"
-                        formControlName="locked"
-                        class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-                      />
-                      Locked (no user override)
-                    </label>
-                  </div>
-                </div>
-                @if (paramRowErrors(i, 'known').length > 0) {
-                  <ul role="alert" class="mt-3 list-disc space-y-0.5 pl-5 text-xs/5 text-red-600 dark:text-red-400">
-                    @for (err of paramRowErrors(i, 'known'); track err) {
-                      <li>{{ err }}</li>
-                    }
-                  </ul>
-                }
-              }
-            </div>
-          }
-        </div>
-
-        <!-- Custom parameters (escape hatch for params not in the catalog) -->
-        <div class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
-          <h3 class="mb-2 text-base/7 font-semibold text-gray-900 dark:text-white">Custom Parameters</h3>
-          <p class="mb-4 text-xs/5 text-gray-500 dark:text-gray-400">
-            Add a parameter the catalog doesn't yet recognize. The runtime will pass it through to the provider SDK if its translation table knows the key, otherwise it's silently dropped.
-          </p>
-
-          <div class="space-y-4" formArrayName="customInferenceParams">
-            @for (row of modelForm.controls.customInferenceParams.controls; track $index; let i = $index) {
-              <div class="rounded-sm border border-amber-200 bg-amber-50/50 p-4 dark:border-amber-900/40 dark:bg-amber-900/10" [formGroupName]="i">
-                <div class="flex items-start gap-4">
-                  <div class="flex-1">
-                    <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Parameter key</label>
-                    <input
-                      type="text"
-                      formControlName="key"
-                      placeholder="snake_case_key"
-                      class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 font-mono text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      [class.border-red-500]="customParamGroup(i).controls.key.invalid && customParamGroup(i).controls.key.touched"
-                    />
-                    @if (customParamGroup(i).controls.key.invalid && customParamGroup(i).controls.key.touched) {
-                      <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">Use snake_case: lowercase letters, digits, underscores; must start with a letter.</p>
-                    }
-                  </div>
-                  <label class="flex items-center gap-2 pt-5 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                    <input
-                      type="checkbox"
-                      formControlName="supported"
-                      class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-                    />
-                    Supported
-                  </label>
-                  <button
-                    type="button"
-                    (click)="removeCustomParam(i)"
-                    class="mt-5 rounded-sm border border-gray-300 bg-white px-2 py-1 text-xs/5 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-                    aria-label="Remove custom parameter"
-                  >
-                    Remove
-                  </button>
-                </div>
-
-                @if (customParamGroup(i).controls.supported.value) {
-                  <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Min</label>
-                      <input
-                        type="number"
-                        formControlName="min"
-                        step="any"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Max</label>
-                      <input
-                        type="number"
-                        formControlName="max"
-                        step="any"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                    <div>
-                      <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Default</label>
-                      <input
-                        type="number"
-                        formControlName="defaultValue"
-                        step="any"
-                        class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                      />
-                    </div>
-                    <div>
-                      <label class="flex items-center gap-2 pt-5 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
-                        <input
-                          type="checkbox"
-                          formControlName="locked"
-                          class="size-4 rounded-xs border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700"
-                        />
-                        Locked (no user override)
-                      </label>
-                    </div>
-                  </div>
-                  @if (paramRowErrors(i, 'custom').length > 0) {
-                    <ul role="alert" class="mt-3 list-disc space-y-0.5 pl-5 text-xs/5 text-red-600 dark:text-red-400">
-                      @for (err of paramRowErrors(i, 'custom'); track err) {
-                        <li>{{ err }}</li>
+                      @if (paramRowErrors(i, 'known').length > 0) {
+                        <ul role="alert" class="mt-3 list-disc space-y-0.5 pl-5 text-xs/5 text-red-600 dark:text-red-400">
+                          @for (err of paramRowErrors(i, 'known'); track err) {
+                            <li>{{ err }}</li>
+                          }
+                        </ul>
                       }
-                    </ul>
-                  }
+                    }
+                  </div>
                 }
               </div>
-            }
-          </div>
 
-          <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-end">
-            <div class="flex-1">
-              <label for="newCustomParamKey" class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">New parameter key</label>
-              <input
-                id="newCustomParamKey"
-                type="text"
-                placeholder="snake_case_key"
-                [value]="newCustomParamKey()"
-                (input)="onCustomKeyInput($any($event.target).value)"
-                (keydown.enter)="$event.preventDefault(); addCustomParam()"
-                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-2 py-1 font-mono text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              />
+              <!-- Custom parameters (escape hatch for params not in the catalog) -->
+              <div class="mt-8">
+                <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Custom parameters</h3>
+                <p class="mt-1 mb-4 text-xs/5 text-gray-500 dark:text-gray-400">
+                  Add a parameter the catalog doesn't yet recognize. The runtime will pass it through to the provider SDK if its translation table knows the key, otherwise it's silently dropped.
+                </p>
+
+                <div class="space-y-3" formArrayName="customInferenceParams">
+                  @for (row of modelForm.controls.customInferenceParams.controls; track $index; let i = $index) {
+                    <div class="rounded-2xl border border-amber-200 bg-amber-50/50 p-4 dark:border-amber-900/40 dark:bg-amber-900/10" [formGroupName]="i">
+                      <div class="flex items-start gap-4">
+                        <div class="flex-1">
+                          <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Parameter key</label>
+                          <input
+                            type="text"
+                            formControlName="key"
+                            placeholder="snake_case_key"
+                            class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-1.5 font-mono text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            [class.border-red-500]="customParamGroup(i).controls.key.invalid && customParamGroup(i).controls.key.touched"
+                          />
+                          @if (customParamGroup(i).controls.key.invalid && customParamGroup(i).controls.key.touched) {
+                            <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">Use snake_case: lowercase letters, digits, underscores; must start with a letter.</p>
+                          }
+                        </div>
+                        <label class="flex items-center gap-2 pt-5 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                          <input
+                            type="checkbox"
+                            formControlName="supported"
+                            class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                          />
+                          Supported
+                        </label>
+                        <button
+                          type="button"
+                          (click)="removeCustomParam(i)"
+                          class="mt-5 inline-flex items-center justify-center rounded-2xl px-2.5 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                          aria-label="Remove custom parameter"
+                        >
+                          Remove
+                        </button>
+                      </div>
+
+                      @if (customParamGroup(i).controls.supported.value) {
+                        <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Min</label>
+                            <input
+                              type="number"
+                              formControlName="min"
+                              step="any"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Max</label>
+                            <input
+                              type="number"
+                              formControlName="max"
+                              step="any"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <div>
+                            <label class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">Default</label>
+                            <input
+                              type="number"
+                              formControlName="defaultValue"
+                              step="any"
+                              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <div>
+                            <label class="flex items-center gap-2 pt-5 text-xs/5 font-medium text-gray-600 dark:text-gray-400">
+                              <input
+                                type="checkbox"
+                                formControlName="locked"
+                                class="size-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                              />
+                              Locked (no user override)
+                            </label>
+                          </div>
+                        </div>
+                        @if (paramRowErrors(i, 'custom').length > 0) {
+                          <ul role="alert" class="mt-3 list-disc space-y-0.5 pl-5 text-xs/5 text-red-600 dark:text-red-400">
+                            @for (err of paramRowErrors(i, 'custom'); track err) {
+                              <li>{{ err }}</li>
+                            }
+                          </ul>
+                        }
+                      }
+                    </div>
+                  }
+                </div>
+
+                <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-end">
+                  <div class="flex-1">
+                    <label for="newCustomParamKey" class="block text-xs/5 font-medium text-gray-600 dark:text-gray-400">New parameter key</label>
+                    <input
+                      id="newCustomParamKey"
+                      type="text"
+                      placeholder="snake_case_key"
+                      [value]="newCustomParamKey()"
+                      (input)="onCustomKeyInput($any($event.target).value)"
+                      (keydown.enter)="$event.preventDefault(); addCustomParam()"
+                      class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-1.5 font-mono text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    (click)="addCustomParam()"
+                    class="inline-flex items-center justify-center rounded-2xl px-3 py-1.5 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                  >
+                    Add custom parameter
+                  </button>
+                </div>
+                @if (newCustomParamError()) {
+                  <p class="mt-2 text-sm/6 text-red-600 dark:text-red-400">{{ newCustomParamError() }}</p>
+                }
+              </div>
             </div>
+          }
+        </section>
+
+        <!-- Form Actions -->
+        <div class="flex flex-col gap-4 border-t border-gray-200 pt-8 dark:border-gray-700">
+          @if (modelForm.invalid) {
+            <div class="rounded-2xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+              <p class="text-sm/6 font-medium text-amber-800 dark:text-amber-200">
+                Please fix the following before saving:
+              </p>
+              <ul class="mt-1 list-inside list-disc text-sm/6 text-amber-700 dark:text-amber-300">
+                @if (modelForm.controls.modelId.invalid) {
+                  <li>Model ID is required</li>
+                }
+                @if (modelForm.controls.modelName.invalid) {
+                  <li>Model Name is required</li>
+                }
+                @if (modelForm.controls.provider.invalid) {
+                  <li>Provider is required</li>
+                }
+                @if (modelForm.controls.providerName.invalid) {
+                  <li>Provider Name is required</li>
+                }
+                @if (modelForm.controls.inputModalities.invalid) {
+                  <li>Select at least one input modality</li>
+                }
+                @if (modelForm.controls.outputModalities.invalid) {
+                  <li>Select at least one output modality</li>
+                }
+                @if (modelForm.controls.maxInputTokens.invalid) {
+                  <li>Max Input Tokens must be 1 or greater</li>
+                }
+                @if (modelForm.controls.maxOutputTokens.invalid) {
+                  <li>Max Output Tokens must be 1 or greater</li>
+                }
+                @if (modelForm.controls.allowedAppRoles.invalid) {
+                  <li>Select at least one allowed role</li>
+                }
+                @if (modelForm.controls.inputPricePerMillionTokens.invalid) {
+                  <li>Input price is required (0 or greater)</li>
+                }
+                @if (modelForm.controls.outputPricePerMillionTokens.invalid) {
+                  <li>Output price is required (0 or greater)</li>
+                }
+              </ul>
+            </div>
+          }
+          <div class="flex gap-2">
+            <button
+              type="submit"
+              [disabled]="isSubmitting() || modelForm.invalid"
+              class="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              @if (isSubmitting()) {
+                Saving…
+              } @else {
+                {{ isEditMode() ? 'Update Model' : 'Add Model' }}
+              }
+            </button>
             <button
               type="button"
-              (click)="addCustomParam()"
-              class="rounded-sm bg-gray-200 px-3 py-1.5 text-sm/6 font-medium text-gray-800 hover:bg-gray-300 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+              (click)="onCancel()"
+              [disabled]="isSubmitting()"
+              class="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
             >
-              Add custom parameter
+              Cancel
             </button>
           </div>
-          @if (newCustomParamError()) {
-            <p class="mt-2 text-sm/6 text-red-600 dark:text-red-400">{{ newCustomParamError() }}</p>
-          }
         </div>
-        </div>
-        }
-      </div>
-
-      <!-- Form Actions -->
-      <div class="flex flex-col gap-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-        @if (modelForm.invalid) {
-          <div class="rounded-sm border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
-            <p class="text-sm/6 font-medium text-amber-800 dark:text-amber-200">
-              Please fix the following before saving:
-            </p>
-            <ul class="mt-1 list-inside list-disc text-sm/6 text-amber-700 dark:text-amber-300">
-              @if (modelForm.controls.modelId.invalid) {
-                <li>Model ID is required</li>
-              }
-              @if (modelForm.controls.modelName.invalid) {
-                <li>Model Name is required</li>
-              }
-              @if (modelForm.controls.provider.invalid) {
-                <li>Provider is required</li>
-              }
-              @if (modelForm.controls.providerName.invalid) {
-                <li>Provider Name is required</li>
-              }
-              @if (modelForm.controls.inputModalities.invalid) {
-                <li>Select at least one input modality</li>
-              }
-              @if (modelForm.controls.outputModalities.invalid) {
-                <li>Select at least one output modality</li>
-              }
-              @if (modelForm.controls.maxInputTokens.invalid) {
-                <li>Max Input Tokens must be 1 or greater</li>
-              }
-              @if (modelForm.controls.maxOutputTokens.invalid) {
-                <li>Max Output Tokens must be 1 or greater</li>
-              }
-              @if (modelForm.controls.allowedAppRoles.invalid) {
-                <li>Select at least one allowed role</li>
-              }
-              @if (modelForm.controls.inputPricePerMillionTokens.invalid) {
-                <li>Input price is required (0 or greater)</li>
-              }
-              @if (modelForm.controls.outputPricePerMillionTokens.invalid) {
-                <li>Output price is required (0 or greater)</li>
-              }
-            </ul>
-          </div>
-        }
-        <div class="flex gap-3">
-        <button
-          type="submit"
-          [disabled]="isSubmitting() || modelForm.invalid"
-          class="rounded-sm bg-blue-600 px-6 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-blue-500 dark:hover:bg-blue-600"
-        >
-          @if (isSubmitting()) {
-            Saving...
-          } @else {
-            {{ isEditMode() ? 'Update Model' : 'Add Model' }}
-          }
-        </button>
-        <button
-          type="button"
-          (click)="onCancel()"
-          [disabled]="isSubmitting()"
-          class="rounded-sm border border-gray-300 bg-white px-6 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-3 focus:ring-gray-500/50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-        >
-          Cancel
-        </button>
-        </div>
-      </div>
-    </form>
+      </form>
+    }
   </div>
 </div>

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -261,6 +261,7 @@ export class ModelFormPage implements OnInit {
   readonly isEditMode = signal<boolean>(false);
   readonly modelId = signal<string | null>(null);
   readonly isSubmitting = signal<boolean>(false);
+  readonly isLoading = signal<boolean>(false);
 
   // Inference-param row metadata, parallel to the ``inferenceParams`` FormArray.
   // Provider switch rebuilds both together so each row is paired with its
@@ -758,6 +759,7 @@ export class ModelFormPage implements OnInit {
    * Load model data for editing
    */
   private async loadModelData(id: string): Promise<void> {
+    this.isLoading.set(true);
     try {
       const model = await this.managedModelsService.getModel(id);
 
@@ -789,6 +791,8 @@ export class ModelFormPage implements OnInit {
       console.error('Error loading model data:', error);
       alert('Failed to load model data. Please try again.');
       this.router.navigate(['/admin/manage-models']);
+    } finally {
+      this.isLoading.set(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- Restyle the admin model edit/create form to match the redesigned list-page token set: `rounded-2xl` on inputs/selects/buttons, `text-2xl/8 font-bold` h1 with `mt-1 text-sm/6` subtitle, `focus:ring-2 focus:ring-blue-500` rings, `dark:bg-gray-800` input surfaces.
- Drop heavy section cards in favor of flat `<section>` blocks divided by `border-t border-gray-200 pt-8` with `text-base/7 font-semibold` section headings — same shape as the redesigned `tool-form.page.ts`.
- Add an `isLoading` signal that toggles around `loadModelData()` so the edit URL renders a spinner card (matching the manage-models list pattern) instead of flashing an empty form while the GET resolves.

## Why
The edit form (`/admin/manage-models/edit/<id>`) was using the pre-redesign tokens — `rounded-sm`, `text-3xl/9`, `ring-3 ring-blue-500/50`, `dark:bg-gray-700` — and wrapped each section in a bordered card. That visually drifted from the manage-models list, model catalog, and tool-form. The form also initialized blank in edit mode while the API request was in flight, which read as "this is a new model" to admins.

## Test plan
- [ ] Visit `/admin/manage-models/edit/<existing-id>`; confirm the spinner card shows briefly, then the form populates with the loaded model.
- [ ] Tokens visually match `/admin/manage-models` and `/admin/tools/new`: rounded-2xl inputs, no bordered section cards, focus ring is the thinner 2px blue.
- [ ] Light and dark mode both look correct (input surfaces, modality/role chips, inference-param sub-cards).
- [ ] Save flow still works (Update Model on edit, Add Model on `/new`), validation errors still surface, inference params section still expands/collapses with the correct configured-count summary.
- [ ] Custom-param add/remove + per-row error rendering still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)