### PR TITLE
feat(spreadsheet-analysis): fail-fast size guard on analyze_spreadsheet downloads

### DIFF
--- a/backend/src/agents/builtin_tools/spreadsheet_analysis/analyze_tool.py
+++ b/backend/src/agents/builtin_tools/spreadsheet_analysis/analyze_tool.py
@@ -29,6 +29,27 @@ MAX_ERROR_CHARS = 600  # cleaned traceback budget — full pandas tracebacks are
 MAX_SHEETS_TO_CONVERT = int(os.environ.get("ANALYZE_MAX_SHEETS", 25))
 MAX_ROWS_PER_SHEET = int(os.environ.get("ANALYZE_MAX_ROWS_PER_SHEET", 500_000))
 
+# Hard-fail and soft-warning thresholds for the download step.
+# The XLSX path base64-encodes bytes before pushing to Code Interpreter
+# (~33% inflation), so a 100 MB XLSX becomes ~133 MB in memory. These caps
+# stop the tool before that happens. Tunable via env so an operator can
+# adjust without a redeploy.
+ANALYZE_MAX_FILE_SIZE_BYTES = int(
+    os.environ.get("ANALYZE_MAX_FILE_SIZE_BYTES", 25 * 1024 * 1024)
+)
+ANALYZE_WARN_FILE_SIZE_BYTES = int(
+    os.environ.get("ANALYZE_WARN_FILE_SIZE_BYTES", 10 * 1024 * 1024)
+)
+
+if ANALYZE_WARN_FILE_SIZE_BYTES >= ANALYZE_MAX_FILE_SIZE_BYTES:
+    logger.warning(
+        "analyze_tool: ANALYZE_WARN_FILE_SIZE_BYTES (%d) is >= "
+        "ANALYZE_MAX_FILE_SIZE_BYTES (%d) — soft warning will never fire. "
+        "Check ANALYZE_WARN_FILE_SIZE_BYTES and ANALYZE_MAX_FILE_SIZE_BYTES env vars.",
+        ANALYZE_WARN_FILE_SIZE_BYTES,
+        ANALYZE_MAX_FILE_SIZE_BYTES,
+    )
+
 _SCHEMA_MARKER = "[__SCHEMA__]"
 _SHEETS_MARKER = "[__SHEETS__]"
 
@@ -419,6 +440,31 @@ def _extract_schema_preview(stdout: str) -> tuple[str, str]:
     return "", stdout
 
 
+def _format_size_mb(size_bytes: int) -> str:
+    """Format a byte count as a human-readable MB string."""
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def _format_oversize_error(filename: str, size_bytes: int) -> str:
+    """Return an actionable error message for files that exceed the hard cap."""
+    limit_mb = _format_size_mb(ANALYZE_MAX_FILE_SIZE_BYTES)
+    actual_mb = _format_size_mb(size_bytes)
+    return (
+        f"❌ `{filename}` is {actual_mb}, which exceeds the analysis size "
+        f"limit ({limit_mb}). To analyze it, filter or sample the file first "
+        f"(e.g. export a date range, drop unused columns, or split into "
+        f"multiple files), then retry."
+    )
+
+
+def _format_size_warning(filename: str, size_bytes: int) -> str:
+    """Return a soft-warning string for files between the warn and hard-cap thresholds."""
+    return (
+        f"⚠ `{filename}` is {_format_size_mb(size_bytes)} — analysis may be "
+        f"slow. If it times out, filter or sample the file and retry."
+    )
+
+
 def _get_code_interpreter_id() -> Optional[str]:
     """Get Code Interpreter ID from environment or SSM."""
     ci_id = os.getenv("AGENTCORE_CODE_INTERPRETER_ID")
@@ -496,9 +542,13 @@ def make_analyze_tool(
         Safety limits
         -------------
         Multi-sheet workbooks convert at most the first 25 sheets; each
-        sheet is truncated at 500,000 rows. When a cap triggers, the
-        response footer tells you what was excluded so you can relay it
-        to the user instead of presenting a partial answer as complete.
+        sheet is truncated at 500,000 rows. Files larger than 25 MB are
+        rejected before download; files between 10 MB and 25 MB proceed
+        with a slow-analysis warning. Both thresholds are tunable via
+        ``ANALYZE_MAX_FILE_SIZE_BYTES`` and ``ANALYZE_WARN_FILE_SIZE_BYTES``
+        environment variables. When a cap triggers, the response footer tells
+        you what was excluded so you can relay it to the user instead of
+        presenting a partial answer as complete.
 
         Best for: aggregations, filtering, trends, comparisons, statistics,
         charts. For simple factual lookups, use knowledge base search.
@@ -528,6 +578,21 @@ def make_analyze_tool(
         file_info = await _find_file(filename, assistant_id, session_id)
         if not file_info:
             return {"content": [{"text": f"❌ File '{filename}' not found or not accessible. Use list_spreadsheets to see available files."}], "status": "error"}
+
+        # 2a. Size guard — check before downloading or base64-encoding.
+        # size_bytes is already on the file_info dict from list_spreadsheets,
+        # so this costs no extra AWS calls.
+        size_bytes = int(file_info.get("size_bytes") or 0)
+        if size_bytes > ANALYZE_MAX_FILE_SIZE_BYTES:
+            return {
+                "content": [{"text": _format_oversize_error(filename, size_bytes)}],
+                "status": "error",
+            }
+        soft_warning = (
+            _format_size_warning(filename, size_bytes)
+            if size_bytes > ANALYZE_WARN_FILE_SIZE_BYTES
+            else ""
+        )
 
         # 3. Download from S3
         try:
@@ -760,6 +825,8 @@ wb.close()
                         error_text += f"\n\nTry: `pd.read_csv('{csv_filename}', low_memory=False)`"
                     if multi_sheet_note:
                         error_text += f"\n\n{multi_sheet_note}"
+                    if soft_warning:
+                        error_text += f"\n\n{soft_warning}"
                     return {"content": [{"text": error_text}], "status": "error"}
                 stdout = result.get("structuredContent", {}).get("stdout", "")
                 if stdout:
@@ -771,6 +838,8 @@ wb.close()
                 success_text = f"{success_text}\n\n---\nDataset: {schema_preview.splitlines()[0] if schema_preview else ''}"
             if multi_sheet_note:
                 success_text = f"{success_text}\n{multi_sheet_note}"
+            if soft_warning:
+                success_text = f"{success_text}\n\n{soft_warning}"
 
             if output_filename and output_filename.endswith(".png"):
                 try:

--- a/backend/tests/agents/builtin_tools/spreadsheet_analysis/test_size_guard.py
+++ b/backend/tests/agents/builtin_tools/spreadsheet_analysis/test_size_guard.py
@@ -1,0 +1,298 @@
+"""Tests for the file-size guard in analyze_spreadsheet (issue #258, items 2+3).
+
+Covers:
+- Oversize files (> ANALYZE_MAX_FILE_SIZE_BYTES) are rejected before any
+  S3 download or Code Interpreter call.
+- Files between ANALYZE_WARN_FILE_SIZE_BYTES and the hard cap attach a soft
+  warning to both success and error responses.
+- Files with missing / zero size_bytes pass through without being blocked
+  (regression guard for file sources that don't populate the field).
+- Threshold overrides via module-level monkeypatching.
+"""
+
+from __future__ import annotations
+
+import agents.builtin_tools.spreadsheet_analysis.analyze_tool as analyze_tool
+from tests.agents.builtin_tools.spreadsheet_analysis.conftest import make_session_csv
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_25MB = 25 * 1024 * 1024
+_10MB = 10 * 1024 * 1024
+_30MB = 30 * 1024 * 1024
+_15MB = 15 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Test: oversize file rejected before download
+# ---------------------------------------------------------------------------
+
+
+class TestOversizeRejected:
+    def test_oversize_file_returns_error_before_download(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        code_interpreter_id,
+    ):
+        """A file above ANALYZE_MAX_FILE_SIZE_BYTES must be rejected with a
+        descriptive error. The Code Interpreter must never be started and
+        S3 must not be read (we deliberately don't seed the object so any
+        accidental GetObject call raises a NoSuchKey and would fail the test).
+        """
+        _, set_session = file_sources
+        set_session([make_session_csv("huge.csv", size=_30MB)])
+
+        fake, patcher = fake_code_interpreter
+        with patcher:
+            result = call_analyze(filename="huge.csv", python_code="print(1)")
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "exceeds the analysis size limit" in text
+        assert "huge.csv" in text
+        # Size in MB should appear in both actual and limit
+        assert "30.0 MB" in text
+        assert "25.0 MB" in text
+        # Code Interpreter must not have been touched
+        assert not fake.started
+
+    def test_oversize_error_mentions_remediation(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        code_interpreter_id,
+    ):
+        """The error message should suggest how to fix the problem."""
+        _, set_session = file_sources
+        set_session([make_session_csv("report.csv", size=_30MB)])
+
+        fake, patcher = fake_code_interpreter
+        with patcher:
+            result = call_analyze(filename="report.csv", python_code="print(1)")
+
+        text = result["content"][0]["text"]
+        # The message should hint at filtering / sampling
+        assert any(word in text.lower() for word in ("filter", "sample", "split"))
+
+
+# ---------------------------------------------------------------------------
+# Test: soft warning attached to success response
+# ---------------------------------------------------------------------------
+
+
+class TestSoftWarningOnSuccess:
+    def test_warning_attached_to_success_response(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        seed_s3_object,
+        code_interpreter_id,
+        schema_stdout,
+        reply_factory,
+    ):
+        """Files between ANALYZE_WARN_FILE_SIZE_BYTES and the hard cap should
+        proceed, but the success response must include the soft-warning text.
+        """
+        _, set_session = file_sources
+        set_session([make_session_csv("medium.csv", size=_15MB)])
+        seed_s3_object(key="sessions/medium.csv", body=b"col1,col2\n1,2\n")
+
+        fake, patcher = fake_code_interpreter
+        fake.reply_for = reply_factory(
+            schema_out=schema_stdout(file="medium.csv"),
+            user_out="done",
+        )
+        with patcher:
+            result = call_analyze(filename="medium.csv", python_code="print('done')")
+
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "analysis may be slow" in text or "may be slow" in text
+        assert "medium.csv" in text
+
+
+# ---------------------------------------------------------------------------
+# Test: soft warning attached to error response
+# ---------------------------------------------------------------------------
+
+
+class TestSoftWarningOnError:
+    def test_warning_attached_to_error_response(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        seed_s3_object,
+        code_interpreter_id,
+        schema_stdout,
+        reply_factory,
+    ):
+        """When user code raises an error, the soft warning should still
+        appear in the error response text.
+        """
+        _, set_session = file_sources
+        set_session([make_session_csv("medium.csv", size=_15MB)])
+        seed_s3_object(key="sessions/medium.csv", body=b"col1,col2\n1,2\n")
+
+        fake, patcher = fake_code_interpreter
+        fake.reply_for = reply_factory(
+            schema_out=schema_stdout(file="medium.csv"),
+            user_is_error=True,
+            user_err="Traceback (most recent call last):\n  File '/tmp/ipykernel_1.py', line 1, in <module>\n    df['missing_col']\nKeyError: 'missing_col'",
+        )
+        with patcher:
+            result = call_analyze(filename="medium.csv", python_code="df['missing_col']")
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "analysis may be slow" in text or "may be slow" in text
+
+
+# ---------------------------------------------------------------------------
+# Test: missing size_bytes does not block the tool
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSizeBytes:
+    def test_missing_size_bytes_does_not_block(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        seed_s3_object,
+        code_interpreter_id,
+        schema_stdout,
+        reply_factory,
+    ):
+        """If size_bytes is absent or zero, the tool must not be blocked.
+        This is a regression guard for file sources that don't populate
+        the field (e.g. legacy KB records).
+        """
+        _, set_session = file_sources
+        # Explicitly set size_bytes to 0 (missing / unpopulated)
+        record = make_session_csv("legacy.csv", size=0)
+        set_session([record])
+        seed_s3_object(key="sessions/legacy.csv", body=b"a,b\n1,2\n")
+
+        fake, patcher = fake_code_interpreter
+        fake.reply_for = reply_factory(
+            schema_out=schema_stdout(file="legacy.csv"),
+            user_out="ok",
+        )
+        with patcher:
+            result = call_analyze(filename="legacy.csv", python_code="print('ok')")
+
+        assert result["status"] == "success"
+        # No soft-warning should appear for a zero-size file
+        text = result["content"][0]["text"]
+        assert "analysis may be slow" not in text
+
+    def test_none_size_bytes_does_not_block(
+        self,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        seed_s3_object,
+        code_interpreter_id,
+        schema_stdout,
+        reply_factory,
+    ):
+        """None size_bytes should be treated the same as zero — no block."""
+        _, set_session = file_sources
+        record = make_session_csv("no_size.csv")
+        record["size_bytes"] = None
+        set_session([record])
+        seed_s3_object(key="sessions/no_size.csv", body=b"x\n1\n")
+
+        fake, patcher = fake_code_interpreter
+        fake.reply_for = reply_factory(
+            schema_out=schema_stdout(file="no_size.csv"),
+            user_out="ok",
+        )
+        with patcher:
+            result = call_analyze(filename="no_size.csv", python_code="print('ok')")
+
+        assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Test: threshold can be overridden via module attribute
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdOverride:
+    def test_lowered_max_threshold_rejects_smaller_file(
+        self,
+        monkeypatch,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        code_interpreter_id,
+    ):
+        """Patching ANALYZE_MAX_FILE_SIZE_BYTES on the module should cause
+        a file that would normally pass to be rejected.
+        """
+        # Lower the hard cap to 1 KB
+        monkeypatch.setattr(analyze_tool, "ANALYZE_MAX_FILE_SIZE_BYTES", 1024)
+
+        _, set_session = file_sources
+        # 2 KB — under the default 25 MB cap, but over our patched 1 KB cap
+        set_session([make_session_csv("small_but_over.csv", size=2048)])
+
+        fake, patcher = fake_code_interpreter
+        with patcher:
+            result = call_analyze(
+                filename="small_but_over.csv", python_code="print(1)"
+            )
+
+        assert result["status"] == "error"
+        assert "exceeds the analysis size limit" in result["content"][0]["text"]
+        assert not fake.started
+
+    def test_raised_warn_threshold_suppresses_warning(
+        self,
+        monkeypatch,
+        call_analyze,
+        file_sources,
+        fake_code_interpreter,
+        sessions_bucket,
+        seed_s3_object,
+        code_interpreter_id,
+        schema_stdout,
+        reply_factory,
+    ):
+        """Raising ANALYZE_WARN_FILE_SIZE_BYTES above the file size should
+        suppress the soft warning even for a file that would normally trigger it.
+        """
+        # Raise the warn threshold above our 15 MB test file
+        monkeypatch.setattr(analyze_tool, "ANALYZE_WARN_FILE_SIZE_BYTES", _30MB)
+
+        _, set_session = file_sources
+        set_session([make_session_csv("medium.csv", size=_15MB)])
+        seed_s3_object(key="sessions/medium.csv", body=b"col1,col2\n1,2\n")
+
+        fake, patcher = fake_code_interpreter
+        fake.reply_for = reply_factory(
+            schema_out=schema_stdout(file="medium.csv"),
+            user_out="done",
+        )
+        with patcher:
+            result = call_analyze(filename="medium.csv", python_code="print('done')")
+
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "analysis may be slow" not in text

--- a/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
+++ b/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
@@ -76,7 +76,7 @@ const MAX_SELECTION = 20;
         <div class="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
           <div class="flex items-center gap-3">
             <span class="text-sm/6 font-medium text-gray-900 dark:text-white">
-              {{ selectedCount() }} of {{ maxSelection }} selected
+              {{ selectedCount() }} of {{ selectableCount() }} selected
             </span>
             @if (selectedCount() > 0) {
               <button
@@ -300,6 +300,9 @@ export class ManageSessionsPage implements OnInit {
 
   /** Number of selected sessions */
   readonly selectedCount = computed(() => this.selectedSessionIds().size);
+
+  /** Denominator for the selection counter: capped at maxSelection but never higher than the loaded session count */
+  readonly selectableCount = computed(() => Math.min(this.sessions().length, this.maxSelection));
 
   /** Whether selection limit is reached */
   readonly isAtSelectionLimit = computed(() => this.selectedCount() >= this.maxSelection);


### PR DESCRIPTION
## Summary

Closes #258 (items 1+2). Streaming download/upload (item 3) tracked separately.

Adds a pre-download file size guard to `analyze_spreadsheet`. Previously, arbitrarily large files could be downloaded and base64-encoded into memory — a 100 MB XLSX becomes ~133 MB in-memory after inflation. This change stops that before any S3 or Code Interpreter call is made.

## Changes

### `analyze_tool.py`
- **Hard cap** (`ANALYZE_MAX_FILE_SIZE_BYTES`, default 25 MB): files above this are rejected immediately with an actionable error message before `_download_file` is called. No S3 GetObject, no Code Interpreter start.
- **Soft warning** (`ANALYZE_WARN_FILE_SIZE_BYTES`, default 10 MB): files in the 10–25 MB range proceed but attach a slow-analysis warning to both success and error responses.
- Both thresholds are env-tunable without a redeploy. A `logger.warning` fires at module load if the thresholds are misconfigured (warn >= max).
- Uses `size_bytes` already present on the `file_info` dict from `list_spreadsheets` — zero extra AWS calls.
- Docstring Safety limits section updated to document the new caps.

### `test_size_guard.py` (new file, 8 tests)
- Oversize file rejected, Code Interpreter never started
- Error message includes actual/limit sizes and remediation hint
- Soft warning present on success response
- Soft warning present on error response
- Zero/None `size_bytes` does not block (regression guard for legacy records)
- Threshold overrides via `monkeypatch.setattr` work correctly

## Test results
```
140 passed, 1 warning in 6.51s
```