### PR TITLE
fix(manage-sessions): replace 'x of x selected' with 'x items selected'

### DIFF
--- a/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
+++ b/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
@@ -76,7 +76,7 @@ const MAX_SELECTION = 20;
         <div class="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
           <div class="flex items-center gap-3">
             <span class="text-sm/6 font-medium text-gray-900 dark:text-white">
-              {{ selectedCount() }} of {{ selectableCount() }} selected
+              {{ selectedCount() }} {{ selectedCount() === 1 ? 'item' : 'items' }} selected
             </span>
             @if (selectedCount() > 0) {
               <button
@@ -300,9 +300,6 @@ export class ManageSessionsPage implements OnInit {
 
   /** Number of selected sessions */
   readonly selectedCount = computed(() => this.selectedSessionIds().size);
-
-  /** Denominator for the selection counter: capped at maxSelection but never higher than the loaded session count */
-  readonly selectableCount = computed(() => Math.min(this.sessions().length, this.maxSelection));
 
   /** Whether selection limit is reached */
   readonly isAtSelectionLimit = computed(() => this.selectedCount() >= this.maxSelection);


### PR DESCRIPTION
## Summary

Closes #163

## Problem

The selection counter showed `0 of 20 selected` — the denominator was hardcoded to `MAX_SELECTION` (20). A prior fix introduced a `selectableCount` signal capped at the number of loaded sessions, but with lazy loading the total is never known — the denominator jumps as the user loads more pages, making it confusing and not meaningfully accurate.

## Fix

Removes the denominator entirely. The counter now reads **`2 items selected`** instead of `2 of 10 selected`. Also removes the now-unused `selectableCount` computed signal.

The existing selection limit warning banner (`isAtSelectionLimit`) and the subtitle copy ("You can delete up to 20 conversations at a time") are unchanged — those correctly describe the feature limit, not a count.

## Changes

- `manage-sessions.page.ts` — template: `{{ selectedCount() }} {{ selectedCount() === 1 ? 'item' : 'items' }} selected`
- `manage-sessions.page.ts` — removed `selectableCount` computed signal