### PR TITLE
fix(file-upload): fix duplicate document name error misclassified as size error

### DIFF
--- a/backend/src/agents/main_agent/multimodal/prompt_builder.py
+++ b/backend/src/agents/main_agent/multimodal/prompt_builder.py
@@ -3,7 +3,7 @@ Prompt builder for multimodal content (text, images, documents)
 """
 import logging
 import base64
-from typing import List, Optional, Union, Dict, Any
+from typing import List, Optional, Union, Dict, Any, Set
 from agents.main_agent.multimodal.image_handler import ImageHandler
 from agents.main_agent.multimodal.document_handler import DocumentHandler
 from agents.main_agent.multimodal.file_sanitizer import FileSanitizer
@@ -51,20 +51,27 @@ class PromptBuilder:
         else:
             content_blocks.append({"text": message})
 
+        # Track sanitized document names used in this turn to prevent
+        # Bedrock ValidationException: "Messages can't contain duplicate document names"
+        used_document_names: Set[str] = set()
+
         # Add each file as appropriate ContentBlock
         for file in files:
-            content_block = self._process_file(file)
+            content_block = self._process_file(file, used_document_names)
             if content_block:
                 content_blocks.append(content_block)
 
         return content_blocks
 
-    def _process_file(self, file: Any) -> Optional[Dict[str, Any]]:
+    def _process_file(self, file: Any, used_document_names: Optional[Set[str]] = None) -> Optional[Dict[str, Any]]:
         """
         Process a single file and create appropriate ContentBlock
 
         Args:
             file: FileContent object with content_type, filename, and base64 bytes
+            used_document_names: Set of already-used document names in this turn.
+                When provided, duplicate document names are made unique by appending
+                a counter suffix to prevent Bedrock ValidationException.
 
         Returns:
             dict: ContentBlock or None if unsupported
@@ -88,6 +95,15 @@ class PromptBuilder:
             # Sanitize filename for Bedrock
             sanitized_name = self.file_sanitizer.sanitize_filename(file.filename)
 
+            # Deduplicate document names within this turn. Bedrock rejects
+            # requests where two document blocks share the same name, even
+            # across different messages in the conversation history. When the
+            # same (or similarly-named) file appears more than once, append
+            # a numeric suffix to make the name unique.
+            if used_document_names is not None:
+                sanitized_name = self._unique_document_name(sanitized_name, used_document_names)
+                used_document_names.add(sanitized_name)
+
             return self.document_handler.create_content_block(
                 file_bytes=file_bytes,
                 filename=filename,
@@ -97,6 +113,23 @@ class PromptBuilder:
         else:
             logger.warning(f"Unsupported file type: {filename} ({content_type})")
             return None
+
+    @staticmethod
+    def _unique_document_name(name: str, used_names: Set[str]) -> str:
+        """Return a name that is not already in used_names.
+
+        If ``name`` is already taken, appends ``_2``, ``_3``, … until a free
+        slot is found. This keeps names deterministic and human-readable while
+        satisfying Bedrock's uniqueness constraint.
+        """
+        if name not in used_names:
+            return name
+        counter = 2
+        while True:
+            candidate = f"{name}_{counter}"
+            if candidate not in used_names:
+                return candidate
+            counter += 1
 
     def get_content_type_summary(self, prompt: Union[str, List[Dict[str, Any]]]) -> str:
         """

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -769,6 +769,27 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
                     truncation_count += 1
                     total_chars_saved += original_size
 
+                # Replace document blocks with placeholder.
+                # Document bytes must be stripped from history just like images —
+                # leaving them in causes Bedrock ValidationException
+                # "Messages can't contain duplicate document names" when the user
+                # attaches a file with the same (sanitized) name in a later turn.
+                # The [Attached files: …] text marker already in the user message
+                # preserves the reference for the model without re-sending bytes.
+                elif "document" in block:
+                    doc_data = block["document"]
+                    doc_name = doc_data.get("name", "unknown")
+                    doc_format = doc_data.get("format", "unknown")
+                    source = doc_data.get("source", {})
+                    original_bytes = source.get("bytes", b"")
+                    original_size = len(original_bytes) if isinstance(original_bytes, bytes) else 0
+
+                    content[block_idx] = {
+                        "text": f"[Document placeholder: name={doc_name}, format={doc_format}, original_size={original_size} bytes]"
+                    }
+                    truncation_count += 1
+                    total_chars_saved += original_size
+
                 # Truncate toolUse input
                 elif "toolUse" in block:
                     tool_use = block["toolUse"]

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -196,6 +196,23 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         if not agent.messages:
             return
 
+        # Strip document bytes from history unconditionally — regardless of
+        # whether compaction is enabled. Document content blocks with inline
+        # bytes must never survive in restored history because Bedrock rejects
+        # any request where two document blocks share the same sanitized name
+        # across the conversation (ValidationException: "Messages can't contain
+        # duplicate document names"). This can happen on what feels like a
+        # "first turn" when the user returns to an existing session URL and
+        # re-attaches a file with the same name as one from a prior visit.
+        # The [Attached files: …] text marker already in the user message
+        # preserves the reference for the model without re-sending bytes.
+        # Images are handled the same way inside _truncate_tool_contents, but
+        # that method is gated on compaction being enabled — this one is not.
+        try:
+            agent.messages = self._strip_document_bytes(agent.messages)
+        except Exception as e:
+            logger.warning(f"Document byte stripping failed, continuing: {e}", exc_info=True)
+
         if not self.compaction_config or not self.compaction_config.enabled:
             return
 
@@ -721,6 +738,52 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
             return text
         return text[:max_length] + f"\n... [truncated, {len(text) - max_length} chars removed]"
 
+    def _strip_document_bytes(self, messages: List[Dict]) -> List[Dict]:
+        """Replace document content blocks' inline bytes with a text placeholder.
+
+        Called unconditionally on every session restore — independent of whether
+        compaction is enabled. Document blocks with ``source.bytes`` must never
+        survive in restored history because Bedrock rejects any request where two
+        document blocks share the same sanitized name across the conversation
+        (ValidationException: "Messages can't contain duplicate document names").
+
+        Images are handled the same way inside ``_truncate_tool_contents``, but
+        that method is gated on compaction being enabled. This one is not.
+
+        The ``[Attached files: …]`` text marker already present in the user
+        message preserves the reference for the model without re-sending bytes.
+        """
+        stripped_messages = copy.deepcopy(messages)
+        strip_count = 0
+
+        for msg in stripped_messages:
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                continue
+            for block_idx, block in enumerate(content):
+                if not isinstance(block, dict) or "document" not in block:
+                    continue
+                doc_data = block["document"]
+                source = doc_data.get("source", {})
+                # Only replace blocks that carry inline bytes — s3Location
+                # blocks (enhancement #401) have no bytes to strip and are
+                # safe to leave as-is since they don't accumulate in history.
+                if "bytes" not in source:
+                    continue
+                doc_name = doc_data.get("name", "unknown")
+                doc_format = doc_data.get("format", "unknown")
+                original_bytes = source.get("bytes", b"")
+                original_size = len(original_bytes) if isinstance(original_bytes, bytes) else 0
+                content[block_idx] = {
+                    "text": f"[Document placeholder: name={doc_name}, format={doc_format}, original_size={original_size} bytes]"
+                }
+                strip_count += 1
+
+        if strip_count > 0:
+            logger.debug(f"Stripped inline bytes from {strip_count} document block(s) in history")
+
+        return stripped_messages
+
     def _truncate_tool_contents(
         self,
         messages: List[Dict],
@@ -728,6 +791,10 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
     ) -> tuple:
         """
         Stage 1 Compaction: Truncate long tool inputs/results and replace images.
+
+        Note: document block byte-stripping is handled unconditionally by
+        ``_strip_document_bytes`` (called from ``initialize``) and is therefore
+        not repeated here.
 
         Returns:
             Tuple of (modified_messages, truncation_count, chars_saved)
@@ -765,27 +832,6 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
 
                     content[block_idx] = {
                         "text": f"[Image placeholder: format={image_format}, original_size={original_size} bytes]"
-                    }
-                    truncation_count += 1
-                    total_chars_saved += original_size
-
-                # Replace document blocks with placeholder.
-                # Document bytes must be stripped from history just like images —
-                # leaving them in causes Bedrock ValidationException
-                # "Messages can't contain duplicate document names" when the user
-                # attaches a file with the same (sanitized) name in a later turn.
-                # The [Attached files: …] text marker already in the user message
-                # preserves the reference for the model without re-sending bytes.
-                elif "document" in block:
-                    doc_data = block["document"]
-                    doc_name = doc_data.get("name", "unknown")
-                    doc_format = doc_data.get("format", "unknown")
-                    source = doc_data.get("source", {})
-                    original_bytes = source.get("bytes", b"")
-                    original_size = len(original_bytes) if isinstance(original_bytes, bytes) else 0
-
-                    content[block_idx] = {
-                        "text": f"[Document placeholder: name={doc_name}, format={doc_format}, original_size={original_size} bytes]"
                     }
                     truncation_count += 1
                     total_chars_saved += original_size

--- a/backend/src/agents/main_agent/streaming/stream_processor.py
+++ b/backend/src/agents/main_agent/streaming/stream_processor.py
@@ -329,6 +329,19 @@ def _format_force_stop_message(reason: Any) -> tuple[str, bool]:
     reason_str = str(reason or "")
     reason_lower = reason_str.lower()
 
+    # Bedrock rejects requests where two document blocks in the conversation
+    # share the same name. This can happen when the same file (or two files
+    # whose names sanitize identically) appears in both the current turn and
+    # a prior turn that is still in the active context window.
+    if "duplicate document name" in reason_lower or "can't contain duplicate document" in reason_lower:
+        return (
+            "⚠️ A file you attached has the same name as one already in this "
+            "conversation's context.\n\n"
+            "Try renaming the file before attaching it, or start a new "
+            "conversation.",
+            True,
+        )
+
     # Some Bedrock-hosted models (e.g. gpt-oss-120b) reject any document or
     # image content block outright with "This model doesn't support
     # documents." Check this BEFORE the size-limit branch — the AWS message

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -814,6 +814,35 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             logger.warning("Failed to resolve file upload IDs", exc_info=True)
             # Continue without files rather than failing the request
 
+    # Deduplicate files by (filename, content_type) before partitioning.
+    # The same file can arrive via both `files` (direct base64) and
+    # `file_upload_ids` (resolved from S3), or a client may submit the same
+    # upload ID twice. Sending two document blocks with the same sanitized
+    # name to Bedrock ConverseStream raises:
+    #   ValidationException: Messages can't contain duplicate document names.
+    # We keep the first occurrence and drop subsequent duplicates.
+    if all_files:
+        seen_file_keys: set = set()
+        deduped_files = []
+        for f in all_files:
+            key = (f.filename.lower(), f.content_type.lower())
+            if key not in seen_file_keys:
+                seen_file_keys.add(key)
+                deduped_files.append(f)
+            else:
+                logger.info(
+                    "Dropping duplicate file attachment: %s (%s)",
+                    f.filename,
+                    f.content_type,
+                )
+        if len(deduped_files) < len(all_files):
+            logger.info(
+                "Deduplicated %d -> %d file(s) before sending to Bedrock",
+                len(all_files),
+                len(deduped_files),
+            )
+        all_files = deduped_files
+
     files_to_send, diverted_tabular, oversized_inline = _partition_attachments(all_files)
     if diverted_tabular:
         logger.info(

--- a/backend/src/apis/shared/errors.py
+++ b/backend/src/apis/shared/errors.py
@@ -248,6 +248,18 @@ Please try again."""
 
 Please try again."""
 
+    # Override with specific actionable messages for known Bedrock errors
+    # that can arrive as raw exceptions (not force_stop events) depending
+    # on where in the call stack Strands surfaces them.
+    if "duplicate document name" in error_lower or "can't contain duplicate document" in error_lower:
+        message = (
+            "⚠️ A file you attached has the same name as one already in this "
+            "conversation's context.\n\n"
+            "Try renaming the file before attaching it, or start a new "
+            "conversation."
+        )
+        recoverable = True
+
     metadata: Dict[str, Any] = {}
     if session_id:
         metadata["session_id"] = session_id


### PR DESCRIPTION
Fixes #400

## What was happening

Users reported being unable to upload a 100kb file, seeing an error about the file being too large. The file size had nothing to do with it.

The actual Bedrock error was `ValidationException: Messages can't contain duplicate document names` — triggered when a user returned to an existing session and re-attached a file with the same name as one from a prior visit. The error was then misclassified by an overly broad condition in `_format_force_stop_message`:

```python
# old — matched any ValidationException that mentioned "document"
if "maximum document size" in reason_lower or (
    "validationexception" in reason_lower and "document" in reason_lower
):
```

This matched the duplicate-name error and rendered the wrong "file too large / enable Spreadsheet Analysis" message. The raw AWS exception text leaked into the `detail` field, so users saw both messages concatenated.

## Root cause

Document content blocks (with full inline bytes) were being persisted into AgentCore Memory and surviving session restores indefinitely. Images were already stripped to text placeholders during compaction, but documents were not. On a return visit to the same session, the SDK reloaded the prior document block from memory, and attaching a same-named file produced two document blocks with the same sanitized name — which Bedrock rejects.

## Changes

**`turn_based_session_manager.py`** — new `_strip_document_bytes()` method replaces document content blocks with text placeholders (`[Document placeholder: name=..., format=..., size=...]`) on every session restore, unconditionally. Decoupled from the compaction flag — it's a correctness fix, not an optimization, and runs regardless of whether `AGENTCORE_MEMORY_COMPACTION_ENABLED` is set.

**`stream_processor.py`** — added a specific `duplicate document name` branch above the size-limit classifier so the correct actionable message is shown.

**`errors.py`** — added the same duplicate-name override in `build_conversational_error_event` to cover the raw-exception path (when Strands surfaces the error as a Python exception rather than a `force_stop` event).

**`prompt_builder.py`** — deduplicates document names within a single turn using a counter suffix (`_2`, `_3`) as belt-and-suspenders.

**`routes.py`** — deduplicates files across the `files` + `file_upload_ids` merge paths before partitioning.

## Testing

All 802 agent/session/streaming tests and 917 shared/API tests pass.
