### PR TITLE
chore(kaizen): weekly review prep 2026-05-29

### DIFF
--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -131,13 +131,6 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Subtracts**: no — additive but pattern-validated across Linear/ChatGPT/Cursor
 - **Status**: open — deferred 4 weeks in reviews/2026-05-15.md (revisit 2026-06-12). Earns its keep when an A2A construct lands.
 
-### [2026-05-22] Pin `backup-data.yml` runner + actions to restore the CI gate
-- **Source**: reviews/2026-05-22.md ▸ Proposal #1 (direct observation — CI failure analysis). `kaizen-research` did not run 2026-05-22; this item surfaced from review-prep's repo-activity scan.
-- **Surface**: infrastructure / CI — `.github/workflows/backup-data.yml`
-- **Effort × Impact**: L × H
-- **Subtracts**: no — corrective; restores the supply-chain pinning control currently bypassed by a red gate
-- **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #1 (Ship — recommended ship-first); no decision logged yet. CI red *now*: ~8+ Deploy App API / Deploy Inference API / Nightly failures since PR #361 (May 20).
-
 ### [2026-05-22] Re-bump `bedrock-agentcore` 1.9.1 → 1.11.0 + adopt `async_mode`
 - **Source**: reviews/2026-05-22.md ▸ Proposal #2 — re-evaluation of the `async_mode`/#452 risk the 2026-05-15 review explicitly deferred "to the 2026-05-22 review".
 - **Surface**: backend (`backend/pyproject.toml`, `backend/uv.lock`, `AgentCoreMemoryConfig` construction)
@@ -153,6 +146,11 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #6 (Ship scoped, or Defer 2 weeks); no decision logged yet.
 
 ## Resolved
+
+### [2026-05-22] Pin `backup-data.yml` runner + actions to restore the CI gate → RESOLVED — pinned, CI green
+- **Decision**: Resolved (not a logged kaizen decision — landed incidentally via the beta.27 release merge #365, May 21).
+- **Reasoning**: `.github/workflows/backup-data.yml` is now correctly pinned — `runs-on: ubuntu-24.04`, `actions/checkout@de0fac2…# v6.0.2`, `astral-sh/setup-uv@d0cc045…# v6.8.0`. Deploy App API / Deploy Inference API failures stopped after May 20; Nightly Build & Test is green (May 24, 25, 28, 29; one isolated May 27 failure). The supply-chain pinning gate is restored. Flagged in reviews/2026-05-29.md ▸ What Shipped: the fix came through the release branch, not a deliberate kaizen action.
+- **Reviewed-in**: reviews/2026-05-22.md ▸ Proposal #1 (verified resolved in reviews/2026-05-29.md)
 
 ### [2026-05-10] MCP Apps host renderer — multi-PR build (PRs #1–#7) → RESOLVED — shipped, host enabled
 - **Decision**: Ship — build-out of the multi-PR initiative scoped in reviews/2026-05-10.md ▸ Proposal #1

--- a/docs/kaizen/reviews/2026-05-29.md
+++ b/docs/kaizen/reviews/2026-05-29.md
@@ -1,0 +1,200 @@
+# Kaizen Review — Friday, May 29, 2026
+> Prepared 2:05pm MT. Review window: May 22 – 29, 2026 (7 days).
+> Source: research/2026-05-29.md + review-queue.md (19 open items) + this week's repo activity.
+
+## Week in Review
+
+The research input half is healthy again — `kaizen-research` ran this morning (#407) and surfaced strong signal: **Opus 4.8 on Bedrock**, **Strands `Limits`** (the runaway-guardrail we hand-specced, now upstream), and **MCP Apps graduating into the `2026-07-28` draft spec** as `io.modelcontextprotocol/ui`. But the *output* half stalled. Last week's review (2026-05-22) recommended **6 Ships**; one week later **5 of the 6 never shipped** — the lone exception (pin `backup-data.yml`) landed incidentally via the beta.27 release merge (#365), not as a deliberate kaizen action. Meanwhile ~23 feature/fix PRs merged (web-sources crawler, viewer/editor sharing #113, curated model catalog, devcontainer, streaming-error persistence). The system is shipping features fast and well; the kaizen hygiene backlog is the thing that keeps losing — and now compounding (bedrock-agentcore lag widened 2→3 minors; #288 rotted to ~17 days untriaged).
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **Kaizen hygiene proposals out-prioritized by feature throughput** (5 occurrences this week) — Proposals #2 (bedrock-agentcore re-bump + `async_mode`), #3 (#288 deploy triage), #4 (stream-cancel audit), #5 (`duration_ms`), and #6 (PR-gate) from the 2026-05-22 review were all recommended **Ship** and none shipped, while ~23 feature/fix PRs merged in the same window. `duration_ms` has now been carried *three* weeks (since 2026-05-15) without ever being actioned.
+  - *Hypothesis*: defensive bumps and audits have no visible product surface, so they lose to feature work every week when picked off one at a time. The cost is silent compounding — bedrock-agentcore lag went 1.9.1 (latest 1.12.0, 3 minors), #288 hit 17 days / 0 comments, Strands stayed at 1.40.
+  - *Candidate fix*: stop proposing cheap defensive items individually. **Bundle them into one PR** the way the #338 kaizen bundle (`/ping` + A2A guard + URL cleanup) shipped cleanly on 2026-05-18. Proposals #2/#5/#6/#7/#9 below are bundle-shaped.
+- **New features draw issues within days of shipping** (3 occurrences) — the web-sources crawler (#378) drew the #399 DoS *and* the #404 editor-RBAC gap within a day; file-upload drew #400/#405; the spreadsheet path needed the #397 size guard. Velocity is outpacing edge-case/RBAC/format hardening.
+  - *Hypothesis*: backend pytest isn't in PR CI (`project_pytest_not_in_ci.md`), so dependency regressions (docling 2.81.0 → #405 `.txt` break) and policy/edge gaps merge clean and surface in production.
+  - *Candidate fix*: the scoped PR-gate (Proposal #10) + the sync-in-async sweep (Proposal #6) both directly target this class.
+
+### One-offs worth watching
+- **Nightly Build & Test failed once (May 27)** — green on May 24, 25, 28, 29. Isolated; no action unless it recurs.
+- **Version Check failed 2× (May 28)** on the `fix-duplicate-document-name-upload` branch, pre-merge — that's the version gate *working*, not friction.
+
+### Silence that matters
+- **Zero comments on every kaizen PR for the third consecutive week** — #375 (research 05-22), #376 (review 05-22), #407, #406, #385 all have 0 comments / 0 reviews. The loop reads PR comments for weekend POC findings; there are none. **No POC findings could be folded into any proposal below — ranking is on Effort×Impact alone, with no POC boost available to break ties.** Either the weekend POC sessions aren't happening or findings live somewhere the loop can't see.
+- **`duration_ms` carried 3 weeks, never ranked, never declined** — silence is functioning as a de-facto decline without the decision being made. Forced below (Retirement Candidates).
+
+## Proposals — ranked
+
+### 1. Migrate inference-api model config Opus 4.7 → 4.8
+- **Source**: research/2026-05-29.md ▸ Top 5 #1 | review-queue.md (open 2026-05-29) — Opus 4.8 on Bedrock (May 28)
+- **Surface area**: backend (bound-model config in `inference_api`) + admin curated model catalog (landed beta.27, #393) + the `_shape_thinking_value` / `temperature` provider-translation path
+- **Change**: add `us.anthropic.claude-opus-4-8` to the curated catalog and default; verify us-east-1 availability (✓) and the 4.8 context window on the model card before flipping; confirm the beta.27 thinking/`effort` (#331) handling still applies and that the Opus-4.7 `temperature`-omission handling carries over; verify prompt caching incl. the new system-in-`messages` allowance. **Fold in the queued Opus-4.7 `temperature`-omission guard** (same provider-translation chokepoint) — one PR.
+- **Subtracts**: partial — the system-in-`messages` caching allowance simplifies the #269 caching wiring (system no longer must sit strictly outside `messages`)
+- **Unlocks**: fewer-step tool turns (lower per-turn cost), best-in-class computer-use, ~4× fewer code-flaw pass-throughs, the `effort` compute-depth knob
+- **Effort**: Med · **Impact**: High
+- **POC findings**: not POCed (no comments on any kaizen PR).
+- **Ship means**: PR adding 4.8 to the catalog + default, folding the temperature guard, after verifying region + context window.
+- **Decline means**: stay on 4.7; keep paying more steps/turn and miss the caching de-risk.
+- **Recommendation**: **Ship** — the one change Phil would notice first this week; recommended #1.
+
+### 2. Bump `bedrock-agentcore` 1.9.1 → 1.12.0 + adopt async `MemorySessionManager`
+- **Source**: research/2026-05-29.md (pin lag) | review-queue.md (open 2026-05-22, re-bump item) — **third consecutive Ship recommendation**; lag widened 2→3 minors
+- **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`, `AgentCoreMemoryConfig` construction)
+- **Change**: bump 1.9.1 → 1.12.0; confirm v1.12.0's async `MemorySessionManager` (PR #478) + LTM metadata (#481) landed; set `async_mode=True` to retire the #452 event-loop-blocking risk; smoke-test Memory write/read + identity OAuth in dev. No SSE/Identity fixes in 1.12.0 (#482/#484 still owed — see #7).
+- **Subtracts**: yes — adopting `async_mode` retires the latent #452 blocking failure mode rather than carrying it
+- **Effort**: Low-Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: PR bumping the pin + enabling `async_mode`; smoke-test; merge.
+- **Decline means**: lag widens a fourth week; #452 stays live under sustained Memory load.
+- **Recommendation**: **Ship** — overdue. Anchor the defensive bundle (see Take).
+
+### 3. Strands 1.40 → 1.41 bump + enable Bedrock prompt caching (closes #269)
+- **Source**: research/2026-05-29.md (pin lag) | review-queue.md (open 2026-05-22 ▸ Top 5 #1)
+- **Surface area**: backend (`pyproject.toml`, `uv.lock`, `BedrockModel` construction, `CacheConfig` wiring)
+- **Change**: bump 1.40 → 1.41 (gates `cache_tools_ttl`); run the owed `starlette` 1.x transitive-conflict audit; wire `CacheConfig` for 1h prompt caching; surface in the admin "Cache Savings" card. **Don't wait for 1.42** — 1.41 is what unblocks #269; `Limits` (1.42) is a separate item (#9).
+- **Subtracts**: partial — adopts library-native `cache_tools_ttl` instead of a hand-rolled TTL workaround
+- **Unlocks**: end-to-end 1h prompt caching → lower input-token cost on multi-turn sessions; de-risked further by Opus 4.8's system-in-`messages` allowance (#1)
+- **Effort**: Med · **Impact**: High
+- **POC findings**: not POCed.
+- **Ship means**: starlette audit → bump → `CacheConfig` PR.
+- **Decline means**: multi-turn input-token cost stays high; #269 stays open.
+- **Recommendation**: **Ship** — pairs naturally with #1 (both touch `BedrockModel`/caching).
+
+### 4. Align MCP Apps capability advertisement to spec-canonical `io.modelcontextprotocol/ui`
+- **Source**: research/2026-05-29.md ▸ Top 5 #3 | review-queue.md (open 2026-05-29) — SEP-1865 folded into the 2026-07-28 draft (PR #2791, May 27)
+- **Surface area**: backend (inference-api `initialize` capability advertisement — currently `experimental.ui`; the `ui_resource` SSE path)
+- **Change**: advertise `io.modelcontextprotocol/ui` (alongside or replacing `experimental.ui`); diff the merged draft for any change to the declare-templates-ahead / tool-list-prefetch shape we depend on.
+- **Subtracts**: yes — retires the pre-standard `experimental.ui` identifier for the conformant name
+- **Unlocks**: RC-conformant negotiation with future MCP hosts/servers once the spec stabilizes (~2026-07-28)
+- **Effort**: Low-Med · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: PR migrating the identifier + a draft-diff note.
+- **Decline means**: identifier drift; spec-conformant peers may not negotiate our UI extension post-RC.
+- **Recommendation**: **Ship** — cheap, subtractive, on our timeline (retirement-bias boost).
+
+### 5. Compaction summary prompt: preserve standing/sensitive user instructions
+- **Source**: research/2026-05-29.md ▸ Top 5 #4 | review-queue.md (open 2026-05-29) — Claude Code v2.1.152 compaction-prompt change
+- **Surface area**: backend (`TurnBasedSessionManager` summarization prompt)
+- **Change**: add an explicit clause instructing the summarizer to preserve standing/sensitive user instructions rather than summarize them away.
+- **Subtracts**: no — addition only. Justified: a one-clause defensive change that prevents long sessions silently dropping user constraints; dovetails with the PR #243 `compaction` SSE event.
+- **Effort**: Low · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: one-clause prompt edit + a regression assertion.
+- **Decline means**: long sessions can drop standing constraints on compaction.
+- **Recommendation**: **Ship** — cheapest item; ideal bundle filler.
+
+### 6. Sync-in-async defensive sweep (anchored by web-crawler DoS #399)
+- **Source**: research/2026-05-29.md ▸ Top 5 #5 | review-queue.md (open 2026-05-29) — issue #399 (May 28); same class as SDK #482
+- **Surface area**: backend (web-sources crawler immediate fix, then a sweep of sync-in-async call sites across `inference-api` / `app-api`)
+- **Change**: bound crawler concurrency with a semaphore + offload blocking HTTP/parse to a thread pool (#399); then audit for other blocking-on-the-shared-loop sites (the #482 class).
+- **Subtracts**: no — addition only. Justified: protects the shared event loop from being wedged by one user's request; #399 is a filed, live DoS vector.
+- **Effort**: Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: PR fixing #399 + a sweep note listing other sync-in-async sites.
+- **Decline means**: a single crawl can wedge the request loop for all users.
+- **Recommendation**: **Ship** the #399 fix at minimum; the broader sweep is the kaizen value-add.
+
+### 7. SSE-teardown defensive bundle — `BedrockModel.stream` cancel audit + SDK #482 guard
+- **Source**: review-queue.md (open since 2026-05-10 and 2026-05-22) — two carried items on the same hot path, consolidated
+- **Surface area**: backend (`agents/main_agent/` stream coordinator + the `/invocations` SSE handler)
+- **Change**: locate every `BedrockModel.stream` cancel path, `await` the inner task on cancel to avoid orphaning, add a dev-only "Task exception was never retrieved" detector; in the same PR add the defensive guard against the SDK #482 mid-stream-disconnect runtime deadlock. Track Strands PR #2269 (active May 29) as the upstream fix.
+- **Subtracts**: no — defensive; the SSE-disconnect path is hot
+- **Effort**: Med · **Impact**: High
+- **POC findings**: not POCed.
+- **Ship means**: one PR with the cancel audit + #482 guard + a cancel-triggering regression test.
+- **Decline means**: silent 78s+ microVM stalls on mid-stream disconnect persist; local workarounds stay load-bearing.
+- **Recommendation**: **Ship** — folds two carried items into one; bundle candidate.
+
+### 8. Triage inference-api deploy #288 — images reach ECR but Runtime isn't rolled
+- **Source**: review-queue.md (open since 2026-05-15) | issue #288 (OPEN, **0 comments — ~17 days untriaged**) — recommended Ship twice (05-15, 05-22)
+- **Surface area**: cross-cutting — `.github/workflows/deploy-inference-api.yml` + the bedrock-agentcore `update_agent_runtime` call shape
+- **Change**: trace the deploy workflow end-to-end; confirm whether it calls `update_agent_runtime` after the ECR push. A *silent no-op*, distinct from the red deploy runs that have since cleared.
+- **Subtracts**: possibly — removes the manual-redeploy band-aid workaround
+- **Effort**: Low-Med · **Impact**: Med-High (a security patch or model bump — e.g. the Opus 4.8 migration in #1 — must eventually ship via this path)
+- **POC findings**: not POCed.
+- **Ship means**: 1–2h triage + a small workflow PR; close #288 when verified.
+- **Decline means**: #288 rots into a fourth week; the Opus 4.8 rollout may silently no-op.
+- **Recommendation**: **Ship** — directly gates Proposal #1's rollout reaching production.
+
+### 9. Adopt Strands `Limits` for per-invocation cost/turn caps
+- **Source**: research/2026-05-29.md ▸ Top 5 #2 | review-queue.md (open 2026-05-29) — Strands PR #2360 (merged May 28, ships 1.42, **unreleased**)
+- **Surface area**: backend (agent invocation + SSE `limit_*` stop-reason handling) + infra (CloudWatch Bedrock-spend alarm)
+- **Change**: when 1.42 lands, pass `limits={turns, outputTokens, totalTokens}` and handle the `limit_*` stop_reason as clean termination; keep only the CloudWatch cost-alarm half of the old plan.
+- **Subtracts**: yes — replaces the hand-rolled runaway-session guardrail (the 2026-05-22 ▸ Top 5 #5 queue item collapses to "adopt + alarm")
+- **Unlocks**: a native per-turn cost ceiling (real protection against the $72-in-58-min / $30K-invoice failure mode; `stop_runtime_session` doesn't stop the microVM)
+- **Effort**: Low-Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: adopt on the 1.42 release; ship the CloudWatch alarm half now if Phil wants the infra protection early.
+- **Decline means**: no native per-turn cost ceiling.
+- **Recommendation**: **Defer until Strands 1.42 ships** (latest is 1.41). The CloudWatch-alarm half can ship independently now if desired.
+
+### 10. Fast PR-gate for the deterministic `supply_chain` + `architecture` test subset
+- **Source**: review-queue.md (open since 2026-05-22 ▸ Proposal #6) — reinforced this week by the docling #405 regression slipping through clean
+- **Surface area**: CI — a new lightweight PR-triggered job
+- **Change**: add a PR job running only `pytest tests/supply_chain/ tests/architecture/ -q` (deterministic, no AWS/LLM). Catches workflow-pinning + import-boundary violations pre-merge.
+- **Subtracts**: no — addition only. Justified: converts a recurring post-merge friction class into a pre-merge block without reopening the deliberate "no full pytest in PR CI" decision; scoped to two deterministic dirs only.
+- **Effort**: Low · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: PR adding the scoped job.
+- **Decline means**: the next `ubuntu-latest`/unpinned-action/import-boundary break merges clean and goes red post-merge.
+- **Recommendation**: **Ship (scoped)** or **Defer 2 weeks** — note the standing tension with `project_pytest_not_in_ci.md`; this threads it by gating only the two deterministic dirs.
+
+> **Below the cap, deferred to next week:** `duration_ms` per-tool timing into `tool_result` SSE (carried since 2026-05-15; capability-unlock for the context-attribution prototype, but never ranked top-3 — forced to a decision in Retirement Candidates).
+
+## Carried Over From Prior Reviews
+
+- **`oauth_required` SSE flow audit vs ref-repo's mid-tool-call 401/403 handling** (deferred 2026-05-10 until 2026-05-24) — **now due** (5 days past). BFF parade declared done via #297 (May 14); deferral conditions cleared and have held stable two weeks. The 2026-05-22 review recommended promoting it. *Recommendation*: promote to a proposal or Decline — no remaining reason to hold.
+- **AgentCore Runtime BYO filesystem (S3/EFS)** (deferred 2026-05-15 until 2026-06-12) — **not yet due** (14 days out). MCP Apps initiative has shipped, so the "don't double the open architectural surface" rationale has weakened; surfaces for re-decision 2026-06-12.
+- **Named A2A agent participants in the chat UI** (deferred 2026-05-15 until 2026-06-12) — **not yet due**. Earns its keep when an A2A *server* construct lands (none has).
+
+## Retirement Candidates
+
+- **`duration_ms` tool-timing item — commit or drop.** Carried since 2026-05-15, recommended Ship once, never actioned, never ranked top-3 across three reviews. Indefinite carry is the queue accreting a write-only log. *Recommendation*: either commit to it next week as a deliberate capability-unlock pick, or **drop it to `decisions.md`** with "deferred indefinitely — capability nice-to-have, repeatedly out-prioritized." Don't carry it a fourth week silently.
+- **Subtraction-by-adoption (already captured as proposals)**: Strands `Limits` (#9) retires the hand-rolled runaway-guardrail queue item; `io.modelcontextprotocol/ui` (#4) retires our `experimental.ui` identifier. The week's only genuine subtractions are upstream-driven, not dead-code removal.
+- **No dead skill/file/config candidate** — but PR #396 ("stack architecture simplification", ~7k lines removed, in flight) is the dominant subtraction signal; nothing for kaizen to add.
+
+## Risks Acknowledged But Not Acted On
+
+- **Editors blocked on shared-assistant web content (#404)** — ownership-only guard in the web-sources routes contradicts the #113 viewer/editor share model that shipped this week. — *what breaks*: shared-assistant editing is partially broken; editor-rights users silently can't add web sources. — **Address now** (predictable RBAC gap from the #113 work; small fix — swap the ownership guard for the shared viewer/editor check).
+- **docling 2.81.0 `.txt` regression (#405)** — a dependency bump introduced user-facing breakage CI didn't catch (backend pytest isn't in PR CI). — *what breaks*: plain-text uploads rejected as "File format not allowed." — **Address now** (user-facing); reinforces Proposal #10 + adding `docling` to the version-pin watch list.
+- **Web-crawler DoS (#399)** — → Proposal #6. **Address now.**
+- **MCP Apps capability-identifier drift** — → Proposal #4. **Watch until ~2026-07-28** (RC stabilization) or address on our timeline.
+- **SDK #482 (SSE-disconnect deadlock) + #484 still unfixed in 1.12.0** — → Proposal #7. **Address now** (guard); upstream fix tracked via Strands #2269.
+
+## What Shipped This Week
+
+- **web-sources crawler** (#378) — *crawl websites into an assistant's knowledge base; immediately drew #399/#404.*
+- **viewer/editor share permissions (#113)** (#383 backend, #384 UI) — *the collaborative-assistant-editing work; owner_id as access gate.*
+- **curated model catalog + provider logos** (#393/#394/#395) — *admin model-catalog redesign; the surface Proposal #1 plugs Opus 4.8 into.*
+- **streaming error persistence** (#388/#389/#390) — *synthetic error messages survive refresh; dropped dead force_stop classifier.*
+- **devcontainer (#391) + teardown workflow (#392)** — *reproducible toolchain; destroy-all-stacks workflow.*
+- **consumer chat grounded in KB only (#382)** + assistant-editor UX (#377/#379/#380/#381).
+- **file-upload dup-name fix (#403) + spreadsheet size guard (#397).**
+- **kaizen source tracking**: opencode (#406), LibreChat (#385).
+- **`backup-data.yml` now pinned + CI green** — resolves the 2026-05-22 ▸ Proposal #1 friction (landed via beta.27 release #365, not a deliberate kaizen PR).
+
+## Take
+
+The loop's input half recovered — research ran, signal is strong (Opus 4.8, Strands `Limits`, MCP Apps spec graduation). The problem is now squarely the **review→ship half**: 5 of 6 prior-week proposals didn't ship, and the unshipped ones are the kind that compound silently (bedrock-agentcore lag 2→3 minors, #288 at 17 days). Hygiene keeps losing to feature work because it's proposed one cheap item at a time and never wins the bandwidth coin-flip against a visible feature. **The one change that matters most this week is to ship a single defensive bundle** — bedrock-agentcore bump + `async_mode` (#2), the SSE-teardown audits (#7), compaction-preserve (#5), and the Opus temperature guard (folded into #1) — the way the #338 bundle shipped cleanly on May 18. If hygiene loses a second straight week, the queue stops being a backlog and becomes a write-only log; the `duration_ms` item (3 weeks unactioned) is already most of the way there. Don't sugarcoat it: the loop is generating good proposals and not converting them.
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min) — the headline is "5 of 6 last-week proposals didn't ship; bundle the cheap ones."
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **10 proposals**; my recommendations: 8 Ship, 1 Defer (#9, gated on 1.42), 1 Ship-scoped-or-Defer (#10).
+3. Resolve Carried Over: `oauth_required` audit is now due — Ship or Decline (1 min).
+4. Scan Retirement Candidates — decide `duration_ms`: commit or drop (1 min).
+5. Resolve the Risks block — #404 and #405 are address-now user-facing bugs (1-2 min).
+6. **Suggested 1–3 to ship**: **#1 (Opus 4.8 migration)** — the visible win; **a defensive bundle (#2 + #5 + #7)** — one PR, stops hygiene losing; **#6 (#399 DoS fix)** — a filed live risk. Hold #3/#4/#8/#10 for the following week if bandwidth is short.
+
+Target: 12-15 minutes.
+
+## Post-review (for Phil — separate PRs)
+
+- ✅ Ship items → individual feature PRs (or one defensive bundle) over the week. The decision is logged here; implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a revisit date; surface again when due.
+
+This skill produces the agenda. Implementation never happens here.


### PR DESCRIPTION
## Summary
- 10 proposals ranked Effort × Impact (retirement candidates boosted; no POC boost — zero comments on any kaizen PR for the 3rd straight week).
- **Headline friction**: 5 of 6 proposals from the 2026-05-22 review never shipped while ~23 feature PRs merged. Hygiene keeps losing to feature work when proposed one item at a time; recommend a single defensive bundle.
- Carried-over `oauth_required` SSE audit is now due for re-decision.
- `backup-data.yml` pin resolved (via beta.27 release #365); moved Open → Resolved in the queue.

## Review
1. Read Friction (2 min).
2. Mark each Proposal: ✅ Ship / ❌ Decline / ⏸ Defer.
3. Same for Carried Over, Retirement Candidates, Risks (#404/#405 are address-now bugs).
4. Pick 1-3 to ship this week.

Target: 12-15 minutes.

## Decision
Ship the doc to `develop`. Action on individual items happens in separate PRs over the week.
Declined items go to `docs/kaizen/decisions.md`; deferred items stay open in `review-queue.md` with a revisit date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)