### PR TITLE
fix(mcp-apps): fill App iframe height + support fullscreen display mode

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -24,7 +24,10 @@ import { McpAppMessageService } from '../../../../../services/mcp-apps/mcp-app-m
 import { McpAppConsentService } from '../../../../../services/mcp-apps/mcp-app-consent.service';
 import { buildProxyUrl } from '../../../../../services/mcp-apps/proxy-url';
 import { McpAppConsentPromptComponent } from '../../mcp-app-consent-prompt/mcp-app-consent-prompt.component';
-import type { CapabilityKey } from '../../../../../services/mcp-apps/mcp-app-protocol';
+import type {
+  CapabilityKey,
+  DisplayMode,
+} from '../../../../../services/mcp-apps/mcp-app-protocol';
 import { ChatRequestService } from '../../../../../services/chat/chat-request.service';
 import { SessionService } from '../../../../../services/session/session.service';
 
@@ -58,9 +61,23 @@ import { SessionService } from '../../../../../services/session/session.service'
     }
     @if (proxyUrl(); as url) {
       <div
-        #host
-        class="overflow-hidden rounded-sm border border-gray-300 dark:border-gray-600 bg-white"
-      ></div>
+        [class]="containerClasses()"
+        [attr.role]="displayMode() === 'fullscreen' ? 'dialog' : null"
+        [attr.aria-modal]="displayMode() === 'fullscreen' ? 'true' : null"
+        [attr.aria-label]="displayMode() === 'fullscreen' ? 'MCP App, fullscreen' : null"
+        (keydown.escape)="exitFullscreen()"
+      >
+        @if (displayMode() === 'fullscreen') {
+          <button
+            type="button"
+            class="absolute top-3 right-3 z-10 rounded-md bg-gray-900/80 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            (click)="exitFullscreen()"
+          >
+            Exit fullscreen
+          </button>
+        }
+        <div #host [class]="hostInnerClasses()"></div>
+      </div>
     }
   `,
 })
@@ -89,6 +106,26 @@ export class McpAppFrameComponent implements ToolResultRenderer {
 
   /** Initial height; the App drives it via `ui/notifications/size-changed`. */
   protected readonly frameHeight = signal(360);
+
+  /**
+   * Current display mode. The App requests changes via
+   * `ui/request-display-mode` (routed through the bridge); the user can
+   * leave fullscreen via the inline Exit button or Escape. `fullscreen`
+   * lifts the frame into a fixed full-viewport overlay.
+   */
+  protected readonly displayMode = signal<DisplayMode>('inline');
+
+  /** Outer container classes — fixed full-viewport overlay in fullscreen. */
+  protected readonly containerClasses = computed(() =>
+    this.displayMode() === 'fullscreen'
+      ? 'fixed inset-0 z-50 overflow-hidden bg-white dark:bg-gray-900'
+      : 'relative overflow-hidden rounded-sm border border-gray-300 bg-white dark:border-gray-600',
+  );
+
+  /** Inner host (holds the imperative iframe) — fills the overlay if fullscreen. */
+  protected readonly hostInnerClasses = computed(() =>
+    this.displayMode() === 'fullscreen' ? 'h-full w-full' : 'block',
+  );
 
   private bridge: McpAppBridge | null = null;
   private readonly nonce =
@@ -235,10 +272,14 @@ export class McpAppFrameComponent implements ToolResultRenderer {
       this.startBridge();
       iframe.src = url;
     });
-    // Keep the iframe height in sync as the App reports size changes.
+    // Keep the iframe height in sync as the App reports size changes. In
+    // fullscreen the iframe fills the fixed overlay (100% of the inset-0
+    // container) rather than tracking the App's reported content height.
     effect(() => {
       const h = this.frameHeight();
-      if (this.iframeEl) this.iframeEl.style.height = `${h}px`;
+      const mode = this.displayMode();
+      if (!this.iframeEl) return;
+      this.iframeEl.style.height = mode === 'fullscreen' ? '100%' : `${h}px`;
     });
     this.destroyRef.onDestroy(() => this.bridge?.dispose('component-destroyed'));
   }
@@ -285,11 +326,30 @@ export class McpAppFrameComponent implements ToolResultRenderer {
         this.openPromptId.set(id);
         return granted.finally(() => this.openPromptId.set(null));
       },
+      requestDisplayMode: (mode) => {
+        // This host supports inline + fullscreen; anything else (pip) stays
+        // inline. Return the mode actually applied — the bridge relays it
+        // back to the App as the resulting mode.
+        const resulting: DisplayMode = mode === 'fullscreen' ? 'fullscreen' : 'inline';
+        this.displayMode.set(resulting);
+        return resulting;
+      },
     });
     this.bridge.onSizeChanged((_w, h) => {
       if (h > 0) this.frameHeight.set(Math.ceil(h));
     });
     this.bridge.start();
+  }
+
+  /**
+   * Host-initiated exit from fullscreen (Exit button / Escape). Collapses
+   * back to inline and tells the App via `host-context-changed` so it can
+   * re-render its inline affordances.
+   */
+  protected exitFullscreen(): void {
+    if (this.displayMode() === 'inline') return;
+    this.displayMode.set('inline');
+    this.bridge?.notifyDisplayMode('inline');
   }
 
   /** Complete tool-call arguments, found by toolUseId in the live stream. */

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { McpAppBridge } from './mcp-app-bridge';
+import type { DisplayMode } from './mcp-app-protocol';
 import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
 
 const SANDBOX_ORIGIN = 'https://mcp-sandbox.example.com';
@@ -64,12 +65,13 @@ interface Harness {
   sendMessage: ReturnType<typeof vi.fn>;
   updateModelContext: ReturnType<typeof vi.fn>;
   requestConsent: ReturnType<typeof vi.fn>;
+  requestDisplayMode: ReturnType<typeof vi.fn>;
   warn: ReturnType<typeof vi.fn>;
   toolResult: { value: unknown | null };
 }
 
 function makeBridge(
-  opts: { withProxy?: boolean; pr6?: boolean } = {},
+  opts: { withProxy?: boolean; pr6?: boolean; displayMode?: boolean } = {},
 ): Harness {
   const host = new FakeHostWindow();
   const proxy = new FakeProxyWindow();
@@ -84,6 +86,9 @@ function makeBridge(
   const sendMessage = vi.fn(async () => undefined);
   const updateModelContext = vi.fn(async () => undefined);
   const requestConsent = vi.fn(async () => true);
+  // Echoes the requested mode (the real component clamps pip→inline; the
+  // bridge already only forwards inline/fullscreen here).
+  const requestDisplayMode = vi.fn((mode: DisplayMode): DisplayMode => mode);
   const warn = vi.fn();
   const toolResult: { value: unknown | null } = {
     value: { content: [{ type: 'text', text: 'ok' }], isError: false },
@@ -101,6 +106,7 @@ function makeBridge(
     // Default harness can proxy; opt out to assert the no-capability path.
     ...(opts.withProxy === false ? {} : { proxyToolCall }),
     ...(opts.pr6 ? { sendMessage, updateModelContext, requestConsent } : {}),
+    ...(opts.displayMode ? { requestDisplayMode } : {}),
     onWarn: warn,
   });
   bridge.start();
@@ -113,6 +119,7 @@ function makeBridge(
     sendMessage,
     updateModelContext,
     requestConsent,
+    requestDisplayMode,
     warn,
     toolResult,
   };
@@ -258,7 +265,7 @@ describe('McpAppBridge', () => {
     expect(h.proxy.byId('l2').error.code).toBe(-32000);
   });
 
-  it('answers ui/request-display-mode with the resulting mode', () => {
+  it('answers ui/request-display-mode with inline when the host lacks the dep', () => {
     handshake(h);
     h.host.deliver(
       {
@@ -270,8 +277,73 @@ describe('McpAppBridge', () => {
       },
       h.proxy,
     );
-    expect(h.proxy.byId('d1').result).toEqual({
-      mode: 'inline',
+    expect(h.proxy.byId('d1').result).toEqual({ mode: 'inline' });
+    // Mode never changed → no host-context-changed churn toward the View.
+    expect(h.proxy.byMethod('ui/notifications/host-context-changed')).toHaveLength(0);
+  });
+
+  describe('with the requestDisplayMode dep wired', () => {
+    beforeEach(() => {
+      h = makeBridge({ displayMode: true });
+    });
+
+    it('advertises inline + fullscreen at initialize', () => {
+      handshake(h);
+      h.host.deliver(
+        { jsonrpc: '2.0', id: 'i1', method: 'ui/initialize', nonce: NONCE, params: {} },
+        h.proxy,
+      );
+      const resp = h.proxy.byId('i1');
+      expect(resp.result.hostContext.displayMode).toBe('inline');
+      expect(resp.result.hostContext.availableDisplayModes).toEqual([
+        'inline',
+        'fullscreen',
+      ]);
+    });
+
+    it('honors a fullscreen request and mirrors it via host-context-changed', () => {
+      handshake(h);
+      // initialized so the host-context-changed notification flushes.
+      h.host.deliver(
+        { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+        h.proxy,
+      );
+      h.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'd1',
+          method: 'ui/request-display-mode',
+          nonce: NONCE,
+          params: { mode: 'fullscreen' },
+        },
+        h.proxy,
+      );
+      expect(h.requestDisplayMode).toHaveBeenCalledWith('fullscreen');
+      expect(h.proxy.byId('d1').result).toEqual({ mode: 'fullscreen' });
+      const changes = h.proxy.byMethod('ui/notifications/host-context-changed');
+      expect(changes.at(-1).params).toEqual({ displayMode: 'fullscreen' });
+    });
+
+    it('exposes host-initiated exit via notifyDisplayMode', () => {
+      handshake(h);
+      h.host.deliver(
+        { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+        h.proxy,
+      );
+      // Enter fullscreen, then the user dismisses it host-side.
+      h.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'd1',
+          method: 'ui/request-display-mode',
+          nonce: NONCE,
+          params: { mode: 'fullscreen' },
+        },
+        h.proxy,
+      );
+      h.bridge.notifyDisplayMode('inline');
+      const changes = h.proxy.byMethod('ui/notifications/host-context-changed');
+      expect(changes.at(-1).params).toEqual({ displayMode: 'inline' });
     });
   });
 

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -38,6 +38,7 @@ import type {
 } from '../../../shared/utils/stream-parser';
 import {
   ConsentRequest,
+  DisplayMode,
   HostContext,
   JsonRpcId,
   JsonRpcMessage,
@@ -49,6 +50,7 @@ import {
   M_OPEN_LINK,
   M_PING,
   M_REQUEST_DISPLAY_MODE,
+  RequestDisplayModeParams,
   M_RESOURCE_TEARDOWN,
   M_SANDBOX_PROXY_READY,
   M_SANDBOX_RESOURCE_READY,
@@ -132,6 +134,15 @@ export interface McpAppBridgeDeps {
    * the frame renders, so the bridge only ever asks for `open-link`.
    */
   requestConsent?: (req: ConsentRequest) => Promise<boolean>;
+  /**
+   * Apply an App-initiated `ui/request-display-mode` change (e.g. expand to
+   * fullscreen). The component owns the DOM, so it decides what it can
+   * honor and returns the mode it actually applied — the spec requires the
+   * host respond with the *resulting* mode, not the requested one. Absent
+   * (older hosts / tests) ⇒ the host stays inline-only and every request
+   * resolves to `inline`, advertising only `['inline']` at initialize.
+   */
+  requestDisplayMode?: (mode: DisplayMode) => DisplayMode;
   /** Non-fatal diagnostics (validation drops, protocol slips). */
   onWarn?: (message: string) => void;
 }
@@ -151,6 +162,9 @@ export class McpAppBridge {
 
   /** Whether tool-input was already pushed (spec: at most once). */
   private toolInputSent = false;
+
+  /** Current display mode (host-owned; mirrored to the View on change). */
+  private displayMode: DisplayMode = 'inline';
 
   /** Pending host→View requests awaiting a JSON-RPC response, by id. */
   private readonly pending = new Map<
@@ -342,9 +356,18 @@ export class McpAppBridge {
 
       case M_REQUEST_DISPLAY_MODE: {
         if (!isRequest(msg)) return;
-        // PR #4 host only renders inline; spec: MUST return the resulting
-        // mode (the current one when the request can't be honored).
-        this.respond(msg.id, { mode: 'inline' });
+        const requested = (msg.params as RequestDisplayModeParams | undefined)
+          ?.mode;
+        // Spec: MUST return the *resulting* mode (the current one when the
+        // request can't be honored). The component owns the DOM and decides;
+        // this host supports inline + fullscreen (pip falls back to inline).
+        const resulting: DisplayMode =
+          this.d.requestDisplayMode &&
+          (requested === 'fullscreen' || requested === 'inline')
+            ? this.d.requestDisplayMode(requested)
+            : 'inline';
+        this.setDisplayMode(resulting);
+        this.respond(msg.id, { mode: resulting });
         return;
       }
 
@@ -467,10 +490,32 @@ export class McpAppBridge {
       },
       hostContext: {
         ...this.d.getHostContext(),
-        displayMode: 'inline',
-        availableDisplayModes: ['inline'],
+        displayMode: this.displayMode,
+        availableDisplayModes: this.availableDisplayModes(),
       },
     });
+  }
+
+  /** Modes this host can switch to — fullscreen only when the dep is wired. */
+  private availableDisplayModes(): DisplayMode[] {
+    return this.d.requestDisplayMode ? ['inline', 'fullscreen'] : ['inline'];
+  }
+
+  /**
+   * Record the resulting display mode and, on an actual change, tell the
+   * View via `host-context-changed`. Covers both App-initiated requests
+   * (via `ui/request-display-mode`) and host-initiated exits (the user
+   * dismissing fullscreen — see `notifyDisplayMode`).
+   */
+  private setDisplayMode(mode: DisplayMode): void {
+    if (mode === this.displayMode) return;
+    this.displayMode = mode;
+    this.notifyHostContextChanged({ displayMode: mode });
+  }
+
+  /** Host-initiated display-mode change (e.g. the user exits fullscreen). */
+  notifyDisplayMode(mode: DisplayMode): void {
+    this.setDisplayMode(mode);
   }
 
   // --- outbound -----------------------------------------------------------

--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -55,6 +55,23 @@
   var innerReady = false;
   var pendingToInner = []; // host->View messages queued until inner loads
 
+  // Establish a 100%-height chain on this shell so the inner View iframe
+  // (height:100%, set in mountView) fills the OUTER iframe the host sized
+  // instead of collapsing to the CSS default replaced-element height
+  // (150px) — a percentage height resolves to `auto` when no ancestor has a
+  // resolved height. proxy.html ships zero inline styles to keep its served
+  // CSP posture tight; the CSSOM `.style` path here isn't governed by the
+  // `style-src` directive, so this is the CSP-safe place to do it.
+  var docEl = document.documentElement;
+  if (docEl && docEl.style) {
+    docEl.style.height = '100%';
+  }
+  if (document.body && document.body.style) {
+    document.body.style.height = '100%';
+    document.body.style.margin = '0';
+    document.body.style.overflow = 'hidden';
+  }
+
   // --- CSP composition (spec §"Sandbox proxy" point 5 + Host Behavior) ----
 
   function list(domains) {


### PR DESCRIPTION
Two residual MCP Apps (SEP-1865) host-renderer bugs found during dogfood, both fixed.

## 1. App content collapsed to 150px (`fix`)

The inner App iframe created by `proxy.js` is `height:100%`, but `proxy.html` shipped **no height on `<html>`/`<body>`**, so the percentage resolved to `auto` and the iframe fell back to the CSS default replaced-element height (**150px**). The App rendered in a 150px band at the top of an otherwise-empty (taller) outer frame.

**Fix:** establish the 100%-height chain in `proxy.js` at IIFE start (`documentElement`/`body` → `height:100%; margin:0; overflow:hidden`). Done via the CSSOM `.style` path rather than an inline `<style>` so `proxy.html` stays inline-free and its served CSP posture is unchanged.

> ⚠️ `proxy.js` is a CloudFront asset — this fix only takes effect after redeploying the **mcp-sandbox** stack and invalidating `/proxy.js`.

## 2. `ui/request-display-mode` always denied (`feat`)

The PR #4 bridge hardcoded `respond({mode:'inline'})` and advertised `availableDisplayModes:['inline']`, so an App requesting `fullscreen` (e.g. Excalidraw's **Edit** button) got inline back and nothing happened.

- `mcp-app-bridge.ts`: optional `requestDisplayMode` dep; the handler returns the *resulting* mode, advertises `['inline','fullscreen']` when wired, and mirrors changes to the App via `host-context-changed`. Dep-absent path still returns inline (back-compat for older hosts/tests).
- `mcp-app-frame.component.ts`: `fullscreen` lifts the frame into a `fixed inset-0 z-50` overlay with an **Exit fullscreen** button + Escape + `role="dialog"`. The iframe is **not** reparented (which would reload it and drop App state) — only CSS classes flip. `pip` falls back to inline.

## Verification

- Bridge spec: **all pass, +3 tests** (24 → 27; added honor-fullscreen, advertise, and host-initiated-exit paths).
- `tsc --noEmit` clean; `ng build` (AOT) clean.
- No new test failures — the pre-existing raw-`vitest` TestBed failures and the infra `loadMcpSandboxCspFunctionCode` failure were confirmed identical before/after via stash-and-rerun (those component/service specs need the project's `ng test` runner).

Not exercisable in local preview (MCP Apps need the deployed sandbox origin + a real App); manual test path is a deployed env with an Excalidraw-style App — resize fills the frame, **Edit** expands to fullscreen, **Exit fullscreen**/Escape collapses back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
