### PR TITLE
fix(mcp-apps): make fullscreen iframe a top-layer fixed overlay

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -70,13 +70,13 @@ import { SessionService } from '../../../../../services/session/session.service'
         @if (displayMode() === 'fullscreen') {
           <button
             type="button"
-            class="absolute top-3 right-3 z-10 rounded-md bg-gray-900/80 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            class="fixed top-3 right-3 z-[10000] rounded-md bg-gray-900/80 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
             (click)="exitFullscreen()"
           >
             Exit fullscreen
           </button>
         }
-        <div #host [class]="hostInnerClasses()"></div>
+        <div #host class="block"></div>
       </div>
     }
   `,
@@ -103,6 +103,9 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   private readonly hostRef =
     viewChild<ElementRef<HTMLDivElement>>('host');
   private iframeEl: HTMLIFrameElement | null = null;
+  /** Prior `body.overflow` saved while this frame holds the fullscreen lock
+   *  (null ⇒ this frame isn't locking — never restore what we didn't set). */
+  private lockedBodyOverflow: string | null = null;
 
   /** Initial height; the App drives it via `ui/notifications/size-changed`. */
   protected readonly frameHeight = signal(360);
@@ -110,21 +113,23 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   /**
    * Current display mode. The App requests changes via
    * `ui/request-display-mode` (routed through the bridge); the user can
-   * leave fullscreen via the inline Exit button or Escape. `fullscreen`
-   * lifts the frame into a fixed full-viewport overlay.
+   * leave fullscreen via the Exit button or Escape. In `fullscreen` the
+   * iframe ITSELF is promoted to a fixed full-viewport overlay (see the
+   * style effect) — sizing it via its own insets avoids a percentage-height
+   * chain, and a CSS change (unlike a DOM move) never reloads the iframe, so
+   * the running App keeps its state.
    */
   protected readonly displayMode = signal<DisplayMode>('inline');
 
-  /** Outer container classes — fixed full-viewport overlay in fullscreen. */
+  /**
+   * Outer wrapper classes. In fullscreen the iframe is lifted out of flow
+   * (fixed), so the wrapper collapses behind the overlay — drop its border
+   * and rounding so nothing peeks through.
+   */
   protected readonly containerClasses = computed(() =>
     this.displayMode() === 'fullscreen'
-      ? 'fixed inset-0 z-50 overflow-hidden bg-white dark:bg-gray-900'
+      ? 'relative'
       : 'relative overflow-hidden rounded-sm border border-gray-300 bg-white dark:border-gray-600',
-  );
-
-  /** Inner host (holds the imperative iframe) — fills the overlay if fullscreen. */
-  protected readonly hostInnerClasses = computed(() =>
-    this.displayMode() === 'fullscreen' ? 'h-full w-full' : 'block',
   );
 
   private bridge: McpAppBridge | null = null;
@@ -259,7 +264,11 @@ export class McpAppFrameComponent implements ToolResultRenderer {
       iframe.setAttribute('loading', 'lazy');
       const allow = this.allowAttr();
       if (allow) iframe.setAttribute('allow', allow);
-      iframe.className = 'block w-full border-0 bg-white';
+      // Width/height/position are driven entirely by the style effect below
+      // (so fullscreen can promote the iframe itself to a fixed overlay
+      // without a `w-full` class fighting the inset sizing).
+      iframe.className = 'block border-0 bg-white';
+      iframe.style.width = '100%';
       iframe.style.height = `${this.frameHeight()}px`;
       // Append BEFORE setting src so contentWindow exists, then start the
       // bridge so the host listener is registered before the proxy script
@@ -272,16 +281,64 @@ export class McpAppFrameComponent implements ToolResultRenderer {
       this.startBridge();
       iframe.src = url;
     });
-    // Keep the iframe height in sync as the App reports size changes. In
-    // fullscreen the iframe fills the fixed overlay (100% of the inset-0
-    // container) rather than tracking the App's reported content height.
+    // Size + position the iframe per display mode. Inline: a normal block
+    // tracking the App's reported height (`size-changed`). Fullscreen: the
+    // iframe itself becomes a fixed full-viewport overlay at z-[9999] (the
+    // app's top modal layer — matching the image/markdown lightboxes).
+    //
+    // An <iframe> is a REPLACED element: with width/height:auto it falls back
+    // to its intrinsic size (~300x150) and ignores right/bottom insets, so
+    // `inset:0` alone leaves a small sliver. It must get explicit dimensions.
+    // `100%` resolves against the viewport (the ICB is the fixed containing
+    // block) and, unlike `100vw/100vh`, excludes the scrollbar gutter.
     effect(() => {
       const h = this.frameHeight();
       const mode = this.displayMode();
-      if (!this.iframeEl) return;
-      this.iframeEl.style.height = mode === 'fullscreen' ? '100%' : `${h}px`;
+      const el = this.iframeEl;
+      if (!el) return;
+      if (mode === 'fullscreen') {
+        el.style.position = 'fixed';
+        el.style.top = '0';
+        el.style.left = '0';
+        el.style.right = '';
+        el.style.bottom = '';
+        el.style.width = '100%';
+        el.style.height = '100%';
+        el.style.zIndex = '9999';
+      } else {
+        el.style.position = '';
+        el.style.top = '';
+        el.style.left = '';
+        el.style.right = '';
+        el.style.bottom = '';
+        el.style.zIndex = '';
+        el.style.width = '100%';
+        el.style.height = `${h}px`;
+      }
     });
-    this.destroyRef.onDestroy(() => this.bridge?.dispose('component-destroyed'));
+    // Lock background scroll while fullscreen so the page scrollbar gutter
+    // doesn't show beside the overlay and the chat can't scroll behind it.
+    // Per-frame save/restore: only ever restore the value this frame saved.
+    effect(() => {
+      const fullscreen = this.displayMode() === 'fullscreen';
+      const body = this.doc.body;
+      if (!body) return;
+      if (fullscreen && this.lockedBodyOverflow === null) {
+        this.lockedBodyOverflow = body.style.overflow;
+        body.style.overflow = 'hidden';
+      } else if (!fullscreen && this.lockedBodyOverflow !== null) {
+        body.style.overflow = this.lockedBodyOverflow;
+        this.lockedBodyOverflow = null;
+      }
+    });
+    this.destroyRef.onDestroy(() => {
+      // Restore scroll if torn down while still fullscreen.
+      if (this.lockedBodyOverflow !== null && this.doc.body) {
+        this.doc.body.style.overflow = this.lockedBodyOverflow;
+        this.lockedBodyOverflow = null;
+      }
+      this.bridge?.dispose('component-destroyed');
+    });
   }
 
   private startBridge(): void {


### PR DESCRIPTION
Follow-up to #409 (squash-merged). Makes the MCP-app **Edit → fullscreen** display mode actually work. Diagnosed and verified **live in-browser** via the Chrome devtools bridge against a local dev build, after three failed blind attempts.

## Root cause (two layers)

**1. The iframe overlay itself.** #409 used a `fixed inset-0 z-50` *wrapper*; an `<iframe>` is a replaced element, so `inset:0` + auto W/H left it at its intrinsic ~300×150, and `z-50` sat below the chat chrome. Fixed in `7abf0a0e`: promote the **iframe itself** to `position:fixed; top:0; left:0; width:100%; height:100%; z-index:9999`, plus a body scroll-lock. (CSS-only change → no iframe reload → App state survives.)

**2. A trapped containing block (the real reason it "disappeared").** Even with correct overlay CSS, the iframe measured **656×0 at (626,220)** instead of filling the viewport. Live inspection found the cause: the shared `.message-block` entry animation (`slideInFade`) used `animation-fill-mode: forwards` with a resting `transform: translateY(12px)`. After the animation, the element **retains a transform** — and *any* transform (even the identity matrix `forwards` keeps, since transform interpolation settles to a matrix, not the keyword `none`) makes the element a **containing block for `position:fixed` descendants**. So the overlay anchored to the collapsed 0-height message block, not the viewport.

Fixed in `3f2028a3`: drop the resting-state transform and switch the entry animations to `animation-fill-mode: backwards` (shows the 0% frame during the start delay, then reverts to the transform-free resting style). Visually identical; fixes `fixed`/`absolute` anchoring for **every** descendant of a message block, not just MCP apps.

## Live verification (Chrome devtools bridge, local dev build)

```
inline:      654×491
fullscreen:  (0,0) 1620×881  == exact viewport   position:fixed  z-index:9999
body:        overflow:hidden (scroll locked)
exit:        displayMode→inline, position:static, scroll restored
```

## Notes
- `tsc` (app+spec) clean; `ng build` AOT clean; bridge spec green.
- Unrelated to the separate "no frame after refresh" — that's the known by-design reload gap (`mcp-app-state.service.ts`: `ui_resource` is live-only, no session-load hydration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
