### PR TITLE
fix(messages): entry animation traps fixed/absolute descendants in a containing block

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -242,23 +242,35 @@ interface DisplayBlock {
       min-width: 0;
     }
 
+    /*
+     * Entry animation. Uses animation-fill-mode: BACKWARDS (not forwards),
+     * and the blocks' resting style is left transform-free.
+     *
+     * Why not forwards: forwards retains the 100% keyframe after the
+     * animation ends, and transform interpolation settles to an identity
+     * MATRIX (not the keyword none). Any retained transform — even identity
+     * — makes the element a containing block for fixed/absolute descendants.
+     * That silently re-anchored the MCP-app fullscreen overlay's
+     * position:fixed to the collapsed 0-height message block instead of the
+     * viewport (measured: 656x0 vs the expected full 1620x933). backwards
+     * applies the 0% frame only during the start delay and then reverts to
+     * the resting style, so no transform lingers.
+     */
     .message-block {
-      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-      opacity: 0;
-      transform: translateY(12px);
+      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
       min-width: 0;
     }
 
     .text-block {
-      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
     }
 
     .tool-use-block {
-      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
     }
 
     .reasoning-block {
-      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      animation: slideInFade 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
     }
 
     @keyframes slideInFade {


### PR DESCRIPTION
Required follow-up to #410. #410 landed the correct iframe overlay CSS, but **MCP-app fullscreen still breaks on develop** — clicking Edit collapses the App to a 0-height sliver (or nothing) and locks page scroll. Diagnosed and verified **live in-browser** (Chrome devtools bridge, local dev build).

## Root cause

The shared `.message-block` entry animation (`slideInFade`) uses `animation-fill-mode: forwards` with a resting `transform: translateY(12px)`. After the animation, the element **retains a transform** — and *any* transform value (including the identity matrix `forwards` keeps, since transform interpolation settles to a matrix, not the keyword `none`) makes the element a **containing block for `position:fixed` descendants** (CSS spec; same gotcha CLAUDE.md flags for dialogs).

So #410's `position:fixed; inset:0; width:100%; height:100%` overlay anchored to the collapsed 0-height message block instead of the viewport:

```
broken:  iframe rect = 656×0 at (626,220)
```

This affects **any** `fixed`/`absolute` descendant of a message block, not just MCP apps.

## Fix

Drop the resting-state `transform` and switch the four entry animations to `animation-fill-mode: backwards`. `backwards` shows the `0%` frame only during the start delay, then reverts to the (transform-free) resting style — so no transform lingers and no containing block is created. Visually identical.

## Live verification (Chrome devtools bridge, local dev build)

```
inline:      654×491
fullscreen:  (0,0) 1620×881  == exact viewport,  position:fixed  z-index:9999
body:        overflow:hidden (scroll locked)
exit:        displayMode→inline, position:static, scroll restored
all message-block computed transforms: none
```

`tsc` (app+spec) clean; `ng build` AOT clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)