### PR TITLE
feat(mcp-apps): persist UI resources so the mcp-app-frame survives a refresh

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -654,6 +654,8 @@ class StreamCoordinator:
                         event,
                         ui_tool_use_names,
                         ui_resource_emitted,
+                        session_id=session_id,
+                        user_id=user_id,
                     ):
                         yield sse
 
@@ -1181,6 +1183,8 @@ class StreamCoordinator:
         event: Dict[str, Any],
         tool_use_names: Dict[str, str],
         emitted: set,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> List[str]:
         """Yield a `ui_resource` SSE for a tool_result that ships an MCP App.
 
@@ -1230,6 +1234,39 @@ class StreamCoordinator:
                 return []
 
             emitted.add(tool_use_id)
+
+            # Persist for reload survival (best-effort). The `ui_resource`
+            # event is inline and never re-streams, so without this the
+            # `mcp-app-frame` falls back to a plain tool card after a refresh.
+            # Mirrors how artifacts persist + stamp from this same coordinator;
+            # the read side is the app-api messages endpoint's `uiResources`
+            # sidecar. Inert when the sessions-metadata table is absent (dev).
+            if session_id and user_id:
+                try:
+                    from apis.shared.mcp_apps.ui_resource_store import (
+                        get_ui_resource_store,
+                    )
+
+                    await asyncio.to_thread(
+                        get_ui_resource_store().store,
+                        user_id=user_id,
+                        session_id=session_id,
+                        tool_use_id=tool_use_id,
+                        resource_uri=payload.get("resourceUri", ""),
+                        html=payload.get("html", ""),
+                        mime_type=payload.get("mimeType", ""),
+                        csp=payload.get("csp", {}),
+                        permissions=payload.get("permissions", {}),
+                        sandbox_origin=payload.get("sandboxOrigin", ""),
+                    )
+                except Exception:  # noqa: BLE001 - persistence is best-effort
+                    logger.warning(
+                        "Failed to persist ui_resource for reload "
+                        "(toolUseId=%s)",
+                        tool_use_id,
+                        exc_info=True,
+                    )
+
             return [f"event: ui_resource\ndata: {json.dumps(payload)}\n\n"]
         except Exception as e:  # noqa: BLE001 - best-effort side channel
             logger.warning("Failed to emit ui_resource event: %s", e)

--- a/backend/src/apis/shared/mcp_apps/ui_resource_store.py
+++ b/backend/src/apis/shared/mcp_apps/ui_resource_store.py
@@ -1,0 +1,299 @@
+"""Reload persistence for model-initiated MCP App UI resources (SEP-1865).
+
+The `ui_resource` SSE event is INLINE — emitted once, right after the
+`tool_result` it correlates to, with the App's HTML fetched server-side via
+`resources/read` and inlined. It never re-streams, so on a page reload the
+SPA's `McpAppStateService` is empty and the `mcp-app-frame` falls back to a
+plain tool card. This store closes that gap exactly like the Artifacts
+feature and the PR #6 app-card store (`card_store.py`): a small per-session
+side-channel record the SPA replays on load to re-seed `McpAppStateService`
+and re-instantiate the frame.
+
+Unlike the PR #6 card store (app-INITIATED tool calls, surfaced as a static
+historical card), this persists the MODEL-initiated UI resource — the live
+iframe payload — so the App re-renders, not just a record of it.
+
+Storage (mirrors decision #4 of the card store): reuse the existing
+`sessions-metadata` DynamoDB table — its `SessionLookupIndex` GSI
+(`GSI_PK=SESSION#<id>`, Projection ALL) and the app-api task role's Query
+grant already exist, so this needs **zero new infra**. New `UIRES#` SK
+prefix alongside the `C#` (cost), `META`, and `APPCARD#` rows:
+
+    PK:     USER#<user_id>
+    SK:     UIRES#<tool_use_id>          (last-write-wins per toolUseId)
+    GSI_PK: SESSION#<session_id>         (SessionLookupIndex)
+    GSI_SK: UIRES#<created_at>
+
+The SK is keyed by `tool_use_id` (not a random id) so a tool that re-emits
+for the same invocation overwrites its prior resource — matching
+`McpAppStateService.recordLive`'s last-write-wins semantics.
+
+Boundary: the **write** runs from the agents stream coordinator (where the
+payload is born and where artifact stamping + per-message metadata writes
+already happen); the **read** runs on the app-api messages endpoint. Both
+reach this shared module and neither imports the other — import-boundary
+safe. Dev/local has no table — every method degrades to a no-op / empty
+list, consistent with the whole MCP Apps surface being gated by
+`AGENTCORE_MCP_APPS_HOST_ENABLED` (default true since PR #7).
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    Key = None  # type: ignore[assignment]
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# UI resources expire with the conversation; 90d matches the card store and
+# "conversation history" retention expectations.
+_CARD_TTL_DAYS = 90
+# DynamoDB item hard limit is 400KB (attribute names + values). The HTML
+# dominates the record, so we gzip it and store the compressed bytes as a
+# Binary attribute — App HTML (markup + inlined JS) typically compresses
+# ~4-5x, so a ~450KB App lands around ~100KB, well inside one item. The cap
+# is applied to the COMPRESSED size; an App still over it (original HTML
+# beyond ~1.3MB) is NOT persisted — a placeholder would frame as a broken
+# iframe, whereas skipping degrades to the plain tool card on reload. Those
+# rare giants are the only case that needs the S3-backed path.
+_MAX_HTML_GZ_BYTES = 380_000
+_KEY_ATTRS = ("PK", "SK", "GSI_PK", "GSI_SK", "ttl")
+
+
+def _floats_to_decimal(obj: Any) -> Any:
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: _floats_to_decimal(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_floats_to_decimal(v) for v in obj]
+    return obj
+
+
+def _decimal_to_native(obj: Any) -> Any:
+    if isinstance(obj, Decimal):
+        # int when whole, else float — keeps message-index style fields tidy.
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    if isinstance(obj, dict):
+        return {k: _decimal_to_native(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_decimal_to_native(v) for v in obj]
+    return obj
+
+
+def _to_bytes(value: Any) -> bytes:
+    """Coerce a DynamoDB Binary attribute to raw bytes.
+
+    boto3's resource API returns a `Binary` wrapper (with a `.value`); the
+    in-memory test fake stores plain `bytes`. Handle both.
+    """
+    return value.value if hasattr(value, "value") else bytes(value)
+
+
+class UiResourceStore:
+    """Per-session store of model-initiated MCP App UI resources."""
+
+    def __init__(self) -> None:
+        self._table = None
+        if boto3 is None:
+            return
+        table_name = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+        if not table_name:
+            return
+        try:
+            self._table = boto3.resource("dynamodb").Table(table_name)
+        except Exception:  # noqa: BLE001 - dev without AWS creds
+            logger.warning(
+                "mcp-apps ui-resource store: DynamoDB unavailable; "
+                "persistence disabled (Apps will be live-only).",
+                exc_info=True,
+            )
+            self._table = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._table is not None
+
+    def store(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        tool_use_id: str,
+        resource_uri: str,
+        html: str,
+        mime_type: str,
+        csp: Dict[str, Any],
+        permissions: Dict[str, Any],
+        sandbox_origin: str = "",
+        produced_by_message_index: Optional[int] = None,
+    ) -> None:
+        """Persist one MCP App UI resource. Best-effort.
+
+        Never raises into the stream — a failed persistence write must not
+        break the live turn (the App still rendered live via the
+        `ui_resource` SSE event; only the reload survival is lost).
+
+        The HTML is gzipped and stored as a Binary attribute; an App whose
+        COMPRESSED size still exceeds `_MAX_HTML_GZ_BYTES` is skipped entirely
+        (logged) rather than truncated — see the constant.
+        """
+        if self._table is None:
+            return
+
+        try:
+            raw = html.encode("utf-8")
+        except (AttributeError, UnicodeError):
+            logger.warning(
+                "mcp-apps ui-resource store: App for toolUseId=%s has "
+                "non-text HTML; not persisting.",
+                tool_use_id,
+            )
+            return
+        html_gz = gzip.compress(raw)
+        if len(html_gz) > _MAX_HTML_GZ_BYTES:
+            logger.warning(
+                "mcp-apps ui-resource store: App for toolUseId=%s is %d bytes "
+                "(%d gzipped, > %d cap); not persisting (will not survive "
+                "reload). Needs the S3-backed path.",
+                tool_use_id,
+                len(raw),
+                len(html_gz),
+                _MAX_HTML_GZ_BYTES,
+            )
+            return
+
+        created_at = datetime.now(timezone.utc).isoformat()
+        ttl = int(
+            (datetime.now(timezone.utc) + timedelta(days=_CARD_TTL_DAYS)).timestamp()
+        )
+        item = {
+            "PK": f"USER#{user_id}",
+            # Keyed by toolUseId so a re-emit for the same invocation
+            # overwrites (last-write-wins, matching recordLive).
+            "SK": f"UIRES#{tool_use_id}",
+            "GSI_PK": f"SESSION#{session_id}",
+            "GSI_SK": f"UIRES#{created_at}",
+            "userId": user_id,
+            "sessionId": session_id,
+            "toolUseId": tool_use_id,
+            "resourceUri": resource_uri,
+            # gzipped HTML as a Binary attribute (decompressed on read).
+            "htmlGz": html_gz,
+            "mimeType": mime_type,
+            "csp": csp or {},
+            "permissions": permissions or {},
+            # Persisted because the read side (app-api messages endpoint)
+            # cannot recompute it — it's the inference-side env config and
+            # app-api may not have it wired. Served back verbatim on reload.
+            "sandboxOrigin": sandbox_origin or "",
+            "createdAt": created_at,
+            "producedByMessageIndex": produced_by_message_index,
+            "ttl": ttl,
+        }
+        try:
+            self._table.put_item(Item=_floats_to_decimal(item))
+            logger.info(
+                "mcp-apps ui-resource store: persisted resource "
+                "(session=%s, toolUseId=%s, %d bytes html -> %d gzipped)",
+                session_id,
+                tool_use_id,
+                len(raw),
+                len(html_gz),
+            )
+        except Exception:  # noqa: BLE001 - persistence is best-effort
+            logger.warning(
+                "mcp-apps ui-resource store: failed to persist resource "
+                "(session=%s, toolUseId=%s)",
+                session_id,
+                tool_use_id,
+                exc_info=True,
+            )
+
+    def list_for_session(
+        self, *, session_id: str, user_id: str
+    ) -> List[Dict[str, Any]]:
+        """Return this user's MCP App UI resources for a session.
+
+        Queried off the session GSI then re-filtered by `userId` so a guessed
+        session id can't surface another user's resources (mirrors the card
+        store / Artifacts ownership re-check). Oldest-first for stable order.
+        """
+        if self._table is None:
+            return []
+        try:
+            items: List[Dict[str, Any]] = []
+            kwargs: Dict[str, Any] = {
+                "IndexName": "SessionLookupIndex",
+                "KeyConditionExpression": Key("GSI_PK").eq(f"SESSION#{session_id}")
+                & Key("GSI_SK").begins_with("UIRES#"),
+                "ScanIndexForward": True,
+            }
+            while True:
+                resp = self._table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                lek = resp.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                kwargs["ExclusiveStartKey"] = lek
+        except ClientError:
+            logger.warning(
+                "mcp-apps ui-resource store: query failed (session=%s)",
+                session_id,
+                exc_info=True,
+            )
+            return []
+
+        resources: List[Dict[str, Any]] = []
+        for item in items:
+            if item.get("userId") != user_id:
+                continue  # ownership re-check (guessed session id)
+            html_gz = item.get("htmlGz")
+            resource = _decimal_to_native(
+                {
+                    k: v
+                    for k, v in item.items()
+                    if k not in _KEY_ATTRS and k != "htmlGz"
+                }
+            )
+            # Decompress back to the inline `html` the SSE-event shape carries,
+            # so the messages-endpoint sidecar needs no special handling. A
+            # corrupt row is dropped rather than surfacing garbage to the App.
+            if html_gz is not None:
+                try:
+                    resource["html"] = gzip.decompress(_to_bytes(html_gz)).decode(
+                        "utf-8"
+                    )
+                except Exception:  # noqa: BLE001 - skip a corrupt row
+                    logger.warning(
+                        "mcp-apps ui-resource store: failed to decompress html "
+                        "(session=%s)",
+                        session_id,
+                        exc_info=True,
+                    )
+                    continue
+            resources.append(resource)
+        return resources
+
+
+_store: Optional[UiResourceStore] = None
+
+
+def get_ui_resource_store() -> UiResourceStore:
+    """Get or create the process-global UI-resource store."""
+    global _store
+    if _store is None:
+        _store = UiResourceStore()
+    return _store

--- a/backend/src/apis/shared/sessions/messages.py
+++ b/backend/src/apis/shared/sessions/messages.py
@@ -422,9 +422,28 @@ async def get_messages_from_cloud(
 
             return await get_pending_interrupts(session_id, user_id)
 
+        async def fetch_ui_resources():
+            """Fetch persisted MCP App UI resources (SEP-1865) for reload.
+
+            Sync DynamoDB query off the session GSI; runs in a thread pool.
+            Empty when the table is absent (dev) or the feature is off.
+            """
+            from apis.shared.mcp_apps.ui_resource_store import get_ui_resource_store
+
+            return await asyncio.to_thread(
+                get_ui_resource_store().list_for_session,
+                session_id=session_id,
+                user_id=user_id,
+            )
+
         # Run fetches in parallel
-        messages_raw, metadata_index, pending_interrupts = await asyncio.gather(
-            fetch_messages(), fetch_metadata(), fetch_pending_interrupts()
+        messages_raw, metadata_index, pending_interrupts, ui_resource_rows = (
+            await asyncio.gather(
+                fetch_messages(),
+                fetch_metadata(),
+                fetch_pending_interrupts(),
+                fetch_ui_resources(),
+            )
         )
 
         messages_raw = list(messages_raw or [])
@@ -473,10 +492,38 @@ async def get_messages_from_cloud(
 
         message_responses = [_convert_message_to_response(msg, session_id, start_seq + idx) for idx, msg in enumerate(paginated_messages)]
 
+        # MCP Apps (SEP-1865): replay persisted UI resources so the
+        # `mcp-app-frame` survives a reload. The inline `ui_resource` event
+        # never re-streams, so without this the App falls back to a plain
+        # tool card. Shape each row like the live SSE event the SPA already
+        # consumes, and prefer this process's sandbox origin when wired
+        # (freshest), else the value captured at write time. First page only:
+        # the SPA keys by toolUseId and holds them all regardless of which
+        # message page renders the correlated tool_use block.
+        ui_resources: List[Dict[str, Any]] = []
+        if not next_token:
+            fresh_origin = os.environ.get(
+                "AGENTCORE_MCP_APPS_SANDBOX_ORIGIN", ""
+            ).strip()
+            for row in ui_resource_rows:
+                ui_resources.append(
+                    {
+                        "type": "ui_resource",
+                        "toolUseId": row.get("toolUseId", ""),
+                        "resourceUri": row.get("resourceUri", ""),
+                        "html": row.get("html", ""),
+                        "mimeType": row.get("mimeType", ""),
+                        "csp": row.get("csp") or {},
+                        "permissions": row.get("permissions") or {},
+                        "sandboxOrigin": fresh_origin or row.get("sandboxOrigin", ""),
+                    }
+                )
+
         return MessagesListResponse(
             messages=message_responses,
             next_token=next_page_token,
             pending_interrupts=pending_interrupts,
+            ui_resources=ui_resources,
         )
 
     except Exception as e:

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -480,3 +480,8 @@ class MessagesListResponse(BaseModel):
         alias="pendingInterrupts",
         description="OAuth consent interrupts that paused agent turns in this session and are awaiting user action",
     )
+    ui_resources: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        alias="uiResources",
+        description="Persisted MCP App UI resources (SEP-1865) for this session, each shaped like the inline `ui_resource` SSE event ({type, toolUseId, resourceUri, html, mimeType, csp, permissions, sandboxOrigin}). Replayed on load to re-seed McpAppStateService and re-instantiate the mcp-app-frame iframe. Returned only on the first page.",
+    )

--- a/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
+++ b/backend/tests/agents/main_agent/streaming/test_ui_resource_events.py
@@ -27,6 +27,7 @@ from agents.main_agent.integrations.mcp_apps import (
     record_and_filter_ui_tools,
 )
 from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+from apis.shared.mcp_apps import ui_resource_store
 
 _ENV_FLAG = "AGENTCORE_MCP_APPS_HOST_ENABLED"
 _ENV_SANDBOX_ORIGIN = "AGENTCORE_MCP_APPS_SANDBOX_ORIGIN"
@@ -208,6 +209,90 @@ async def test_noop_for_non_ui_tool(coord, catalog_clean, monkeypatch):
         _tool_result_event("tu-1"), {"tu-1": "plain_tool"}, set()
     )
     assert out == []
+
+
+class _FakeUiResourceStore:
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def store(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_persists_resource_when_session_and_user_provided(
+    coord, catalog_clean, monkeypatch
+):
+    client = _FakeMCPClient(_html_result("<main>app</main>"))
+    _seed(monkeypatch, client)
+    fake = _FakeUiResourceStore()
+    monkeypatch.setattr(ui_resource_store, "get_ui_resource_store", lambda: fake)
+
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"),
+        {"tu-1": "widget"},
+        set(),
+        session_id="sess-1",
+        user_id="user-1",
+    )
+
+    # The live event still streams unchanged...
+    assert len(out) == 1
+    # ...and the resource is persisted for reload survival with the same
+    # fields the SPA re-seeds McpAppStateService from.
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["session_id"] == "sess-1"
+    assert call["user_id"] == "user-1"
+    assert call["tool_use_id"] == "tu-1"
+    assert call["resource_uri"] == "ui://srv/widget"
+    assert call["html"] == "<main>app</main>"
+    assert call["mime_type"] == MCP_APPS_UI_MIME_TYPE
+    assert call["csp"] == {"connectDomains": ["https://api.test"]}
+    assert call["permissions"] == {"clipboardWrite": {}}
+
+
+@pytest.mark.asyncio
+async def test_does_not_persist_without_session_or_user(
+    coord, catalog_clean, monkeypatch
+):
+    client = _FakeMCPClient(_html_result())
+    _seed(monkeypatch, client)
+    fake = _FakeUiResourceStore()
+    monkeypatch.setattr(ui_resource_store, "get_ui_resource_store", lambda: fake)
+
+    # No session/user (e.g. a context without a persisted conversation) →
+    # emit live but skip persistence.
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"), {"tu-1": "widget"}, set()
+    )
+    assert len(out) == 1
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_does_not_break_stream(
+    coord, catalog_clean, monkeypatch
+):
+    _seed(monkeypatch, _FakeMCPClient(_html_result()))
+
+    class _Boom:
+        def store(self, **kwargs):
+            raise RuntimeError("dynamo exploded")
+
+    monkeypatch.setattr(
+        ui_resource_store, "get_ui_resource_store", lambda: _Boom()
+    )
+
+    # A persistence failure is best-effort — the live event still streams.
+    out = await coord._extract_ui_resource_events(
+        _tool_result_event("tu-1"),
+        {"tu-1": "widget"},
+        set(),
+        session_id="sess-1",
+        user_id="user-1",
+    )
+    assert len(out) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/shared/test_mcp_apps_ui_resource_store.py
+++ b/backend/tests/shared/test_mcp_apps_ui_resource_store.py
@@ -1,0 +1,160 @@
+"""Tests for the model-initiated MCP App UI-resource store (SEP-1865).
+
+The store reuses the existing `sessions-metadata` table. No DynamoDB in
+tests — the no-table path is a silent no-op (matches dev), and a fake table
+asserts the record shape, gzip round-trip, the ownership re-check,
+last-write-wins keying, and the oversized (compressed) skip.
+"""
+
+from __future__ import annotations
+
+import gzip
+from decimal import Decimal
+
+from apis.shared.mcp_apps import ui_resource_store as mod
+from apis.shared.mcp_apps.ui_resource_store import UiResourceStore
+
+
+class _FakeTable:
+    def __init__(self, items=None) -> None:
+        self.items = items or []
+        self.puts: list = []
+
+    def put_item(self, Item):  # noqa: N803 - boto3 kwarg name
+        self.puts.append(Item)
+
+    def query(self, **kwargs):
+        return {"Items": self.items}
+
+
+def _store_with(table) -> UiResourceStore:
+    s = UiResourceStore()  # __init__ sets _table=None without the env var
+    s._table = table
+    return s
+
+
+def _store_kwargs(**overrides):
+    base = dict(
+        user_id="u1",
+        session_id="s1",
+        tool_use_id="tu1",
+        resource_uri="ui://srv/widget",
+        html="<h1>hi</h1>",
+        mime_type="text/html;profile=mcp-app",
+        csp={"connectDomains": ["https://api.test"]},
+        permissions={"clipboardWrite": {}},
+        sandbox_origin="https://sandbox.example",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_no_table_is_silent_noop():
+    s = UiResourceStore()
+    assert s.enabled is False
+    # Must not raise.
+    s.store(**_store_kwargs())
+    assert s.list_for_session(session_id="s1", user_id="u1") == []
+
+
+def test_store_writes_uires_record_shape():
+    table = _FakeTable()
+    s = _store_with(table)
+    s.store(**_store_kwargs(produced_by_message_index=3))
+
+    assert len(table.puts) == 1
+    item = table.puts[0]
+    assert item["PK"] == "USER#u1"
+    # Keyed by toolUseId (not a random id) so a re-emit overwrites.
+    assert item["SK"] == "UIRES#tu1"
+    assert item["GSI_PK"] == "SESSION#s1"
+    assert item["GSI_SK"].startswith("UIRES#")
+    assert item["toolUseId"] == "tu1"
+    assert item["resourceUri"] == "ui://srv/widget"
+    # HTML is gzipped into a Binary attribute, not stored raw.
+    assert "html" not in item
+    assert gzip.decompress(item["htmlGz"]).decode("utf-8") == "<h1>hi</h1>"
+    assert item["mimeType"] == "text/html;profile=mcp-app"
+    assert item["csp"] == {"connectDomains": ["https://api.test"]}
+    assert item["permissions"] == {"clipboardWrite": {}}
+    assert item["sandboxOrigin"] == "https://sandbox.example"
+    assert item["producedByMessageIndex"] == 3
+    assert "ttl" in item
+
+
+def test_store_skips_when_compressed_exceeds_cap(monkeypatch):
+    # A real App over the gzipped cap is skipped (a placeholder would frame as
+    # a broken iframe). Drive it with a tiny cap so the test is deterministic
+    # and doesn't depend on a hard-to-compress multi-MB fixture.
+    monkeypatch.setattr(mod, "_MAX_HTML_GZ_BYTES", 5)
+    table = _FakeTable()
+    s = _store_with(table)
+    s.store(**_store_kwargs(html="<h1>bigger than five bytes once gzipped</h1>"))
+    assert table.puts == []
+
+
+def test_store_compresses_large_html_that_old_raw_cap_rejected():
+    table = _FakeTable()
+    s = _store_with(table)
+    # A 450KB App — over DynamoDB's 400KB item limit raw, but highly
+    # compressible — now persists via gzip and round-trips intact.
+    html = "<div>" + ("padding " * 60_000) + "</div>"
+    assert len(html.encode("utf-8")) > 400_000
+    s.store(**_store_kwargs(html=html))
+    assert len(table.puts) == 1
+    stored = table.puts[0]["htmlGz"]
+    assert len(stored) < 400_000  # fits a single DynamoDB item
+    assert gzip.decompress(stored).decode("utf-8") == html
+
+
+def test_store_last_write_wins_same_tool_use_id():
+    table = _FakeTable()
+    s = _store_with(table)
+    s.store(**_store_kwargs(html="<v1/>"))
+    s.store(**_store_kwargs(html="<v2/>"))
+    # Same SK both times → DynamoDB overwrites; both puts target UIRES#tu1.
+    assert [p["SK"] for p in table.puts] == ["UIRES#tu1", "UIRES#tu1"]
+    assert gzip.decompress(table.puts[-1]["htmlGz"]).decode("utf-8") == "<v2/>"
+
+
+def test_list_decompresses_and_filters_by_owner():
+    items = [
+        {
+            "PK": "USER#u1",
+            "SK": "UIRES#tu1",
+            "GSI_PK": "SESSION#s1",
+            "GSI_SK": "UIRES#2026-01-01T00:00:00",
+            "ttl": 123,
+            "userId": "u1",
+            "sessionId": "s1",
+            "toolUseId": "tu1",
+            "resourceUri": "ui://srv/mine",
+            "htmlGz": gzip.compress(b"<h1>mine</h1>"),
+            "producedByMessageIndex": Decimal("4"),
+        },
+        {
+            "PK": "USER#someone-else",
+            "SK": "UIRES#tu2",
+            "GSI_PK": "SESSION#s1",
+            "GSI_SK": "UIRES#2026-01-01T00:00:01",
+            "userId": "other",
+            "toolUseId": "tu2",
+            "resourceUri": "ui://srv/not-mine",
+            "htmlGz": gzip.compress(b"<h1>not mine</h1>"),
+        },
+    ]
+    s = _store_with(_FakeTable(items))
+    resources = s.list_for_session(session_id="s1", user_id="u1")
+
+    assert len(resources) == 1
+    res = resources[0]
+    assert res["resourceUri"] == "ui://srv/mine"
+    # Decompressed back to the inline `html` the SSE-event shape carries.
+    assert res["html"] == "<h1>mine</h1>"
+    assert "htmlGz" not in res
+    # Key attributes are stripped from the returned record.
+    for k in ("PK", "SK", "GSI_PK", "GSI_SK", "ttl"):
+        assert k not in res
+    # Decimals are converted back to native ints.
+    assert res["producedByMessageIndex"] == 4
+    assert isinstance(res["producedByMessageIndex"], int)

--- a/backend/tests/shared/test_sessions_messages.py
+++ b/backend/tests/shared/test_sessions_messages.py
@@ -52,3 +52,76 @@ class TestGetMessages:
         with patch("apis.shared.sessions.messages.AGENTCORE_MEMORY_AVAILABLE", False):
             with pytest.raises(RuntimeError, match="bedrock_agentcore"):
                 await get_messages("s1", "u1")
+
+    @pytest.mark.asyncio
+    async def test_ui_resources_sidecar_hydrates_with_origin_override(self, monkeypatch):
+        """Persisted MCP App UI resources ride the first-page response shaped
+        like the live `ui_resource` event, with the process sandbox origin
+        preferred over the value captured at write time."""
+        monkeypatch.setenv("AGENTCORE_MEMORY_ID", "test-memory")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.setenv("AGENTCORE_MCP_APPS_SANDBOX_ORIGIN", "https://fresh.example")
+
+        mock_session_mgr = MagicMock()
+        mock_session_mgr.list_messages.return_value = [
+            MagicMock(message={"role": "assistant", "content": [{"text": "hi"}]}),
+        ]
+
+        fake_store = MagicMock()
+        fake_store.list_for_session.return_value = [
+            {
+                "toolUseId": "tu-1",
+                "resourceUri": "ui://srv/widget",
+                "html": "<main>app</main>",
+                "mimeType": "text/html;profile=mcp-app",
+                "csp": {"connectDomains": ["https://api.test"]},
+                "permissions": {"clipboardWrite": {}},
+                "sandboxOrigin": "https://stale.example",
+            }
+        ]
+
+        with patch("apis.shared.sessions.messages.AgentCoreMemorySessionManager", return_value=mock_session_mgr), \
+             patch("apis.shared.sessions.messages.AgentCoreMemoryConfig"), \
+             patch("apis.shared.sessions.messages.AGENTCORE_MEMORY_AVAILABLE", True), \
+             patch("apis.shared.sessions.metadata.get_all_message_metadata", new_callable=AsyncMock, return_value={}), \
+             patch("apis.shared.sessions.metadata.get_pending_interrupts", new_callable=AsyncMock, return_value=[]), \
+             patch("apis.shared.mcp_apps.ui_resource_store.get_ui_resource_store", return_value=fake_store):
+            from apis.shared.sessions.messages import get_messages_from_cloud
+            result = await get_messages_from_cloud("s1", "u1")
+
+        assert len(result.ui_resources) == 1
+        res = result.ui_resources[0]
+        assert res["type"] == "ui_resource"
+        assert res["toolUseId"] == "tu-1"
+        assert res["html"] == "<main>app</main>"
+        assert res["csp"] == {"connectDomains": ["https://api.test"]}
+        # Fresh process origin wins over the persisted (possibly stale) one.
+        assert res["sandboxOrigin"] == "https://fresh.example"
+
+    @pytest.mark.asyncio
+    async def test_ui_resources_omitted_on_subsequent_pages(self, monkeypatch):
+        """Resources ride only the first page (no incoming next_token) — the
+        SPA keys by toolUseId and holds them all regardless of page."""
+        monkeypatch.setenv("AGENTCORE_MEMORY_ID", "test-memory")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        mock_session_mgr = MagicMock()
+        mock_session_mgr.list_messages.return_value = [
+            MagicMock(message={"role": "user", "content": [{"text": f"m{i}"}]}) for i in range(5)
+        ]
+        fake_store = MagicMock()
+        fake_store.list_for_session.return_value = [{"toolUseId": "tu-1", "html": "<x/>"}]
+
+        import base64
+        page2 = base64.b64encode(b"2").decode()
+
+        with patch("apis.shared.sessions.messages.AgentCoreMemorySessionManager", return_value=mock_session_mgr), \
+             patch("apis.shared.sessions.messages.AgentCoreMemoryConfig"), \
+             patch("apis.shared.sessions.messages.AGENTCORE_MEMORY_AVAILABLE", True), \
+             patch("apis.shared.sessions.metadata.get_all_message_metadata", new_callable=AsyncMock, return_value={}), \
+             patch("apis.shared.sessions.metadata.get_pending_interrupts", new_callable=AsyncMock, return_value=[]), \
+             patch("apis.shared.mcp_apps.ui_resource_store.get_ui_resource_store", return_value=fake_store):
+            from apis.shared.sessions.messages import get_messages_from_cloud
+            result = await get_messages_from_cloud("s1", "u1", limit=2, next_token=page2)
+
+        assert result.ui_resources == []

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
@@ -58,4 +58,26 @@ describe('McpAppStateService', () => {
     expect(svc.hasApps()).toBe(false);
     expect(svc.has('tu-1')).toBe(false);
   });
+
+  describe('seedFromHydration', () => {
+    it('seeds persisted resources so the frame re-renders on reload', () => {
+      svc.seedFromHydration([ev('tu-1'), ev('tu-2')]);
+      expect(svc.has('tu-1')).toBe(true);
+      expect(svc.get('tu-2')?.resourceUri).toBe('ui://srv/tu-2');
+      expect(svc.hasApps()).toBe(true);
+    });
+
+    it('is a no-op for an empty list', () => {
+      svc.seedFromHydration([]);
+      expect(svc.hasApps()).toBe(false);
+    });
+
+    it('does not clobber a live recordLive entry (non-clobbering)', () => {
+      svc.recordLive(ev('tu-1', '<live>'));
+      // A slow hydration response arriving after the live event must not
+      // overwrite the fresher live resource.
+      svc.seedFromHydration([ev('tu-1', '<stale>')]);
+      expect(svc.get('tu-1')?.html).toBe('<live>');
+    });
+  });
 });

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
@@ -8,13 +8,15 @@ import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
  * the session page calls on conversation change.
  *
  * The `ui_resource` event is INLINE (it arrives right after its
- * `tool_result`), so unlike artifacts there is no session-load hydration
- * path — a refreshed conversation re-streams nothing, and a persisted MCP
- * App is out of scope until a later PR. Iframes persist for the lifetime of
- * the conversation per the scoping doc; teardown is on `reset()`.
+ * `tool_result`), so a refreshed conversation re-streams nothing. To survive
+ * a reload, app-api persists each resource and replays it on the
+ * `GET /messages` response's `uiResources` sidecar; `seedFromHydration`
+ * re-seeds this registry from that list so the `mcp-app-frame` re-renders.
+ * Iframes otherwise persist for the lifetime of the conversation per the
+ * scoping doc; teardown is on `reset()`.
  *
  * The whole surface is dark until the backend `AGENTCORE_MCP_APPS_HOST_ENABLED`
- * flag is flipped (PR #7), so in practice nothing is recorded here yet.
+ * flag is flipped, so when it's off nothing is recorded or hydrated.
  */
 @Injectable({ providedIn: 'root' })
 export class McpAppStateService {
@@ -33,6 +35,21 @@ export class McpAppStateService {
   recordLive(event: UiResourceEvent): void {
     const next = new Map(this.byToolUseId());
     next.set(event.toolUseId, event);
+    this.byToolUseId.set(next);
+  }
+
+  /**
+   * Seed resources persisted server-side, replayed on the `GET /messages`
+   * `uiResources` sidecar at conversation load. Non-clobbering by
+   * `toolUseId` so a slow response can't undo a live `recordLive` entry
+   * (matches `ArtifactStateService.seedFromHydration` semantics).
+   */
+  seedFromHydration(list: readonly UiResourceEvent[]): void {
+    if (!list.length) return;
+    const next = new Map(this.byToolUseId());
+    for (const event of list) {
+      if (!next.has(event.toolUseId)) next.set(event.toolUseId, event);
+    }
     this.byToolUseId.set(next);
   }
 

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -6,6 +6,7 @@ import { PendingInterrupt, SessionService } from './session.service';
 import { FileUploadService, FileMetadata } from '../../../services/file-upload';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
 import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
+import { McpAppStateService } from '../mcp-apps/mcp-app-state.service';
 
 /** Regex to match file attachment marker in message text: [Attached files: file1.pdf, file2.png] */
 const ATTACHED_FILES_PATTERN = /\n\n\[Attached files: ([^\]]+)\]$/;
@@ -57,6 +58,7 @@ export class MessageMapService {
   private fileUploadService = inject(FileUploadService);
   private oauthConsentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
+  private mcpAppState = inject(McpAppStateService);
 
   constructor() {
     // Reactive effect: automatically sync streaming messages to the message map
@@ -341,6 +343,14 @@ export class MessageMapService {
       // matching how the live SSE flow already attaches prompts. Authorization
       // URL is intentionally omitted — fresh URL is fetched lazily on Connect.
       this.hydratePendingInterrupts(sessionId, messagesResponse.pendingInterrupts, processedMessages);
+
+      // MCP Apps (SEP-1865): re-seed the App registry from the persisted
+      // resources the backend replays on this response. The inline
+      // `ui_resource` event never re-streams, so without this the
+      // `mcp-app-frame` falls back to a plain tool card after a refresh.
+      // session.page resets McpAppStateService before this load, so the
+      // non-clobbering seed lands cleanly.
+      this.mcpAppState.seedFromHydration(messagesResponse.uiResources ?? []);
     } catch (error) {
       console.error('Failed to load messages for session:', sessionId, error);
       throw error;

--- a/frontend/ai.client/src/app/session/services/session/session.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../../../services/config.service';
 import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { SessionMetadata, UpdateSessionMetadataRequest } from '../models/session-metadata.model';
 import { Message } from '../models/message.model';
+import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
 
 /**
  * Query parameters for listing sessions.
@@ -72,6 +73,12 @@ export interface MessagesListResponse {
   nextToken: string | null;
   /** OAuth consent interrupts that paused agent turns and are awaiting user action */
   pendingInterrupts?: PendingInterrupt[];
+  /**
+   * Persisted MCP App UI resources (SEP-1865), each shaped like the inline
+   * `ui_resource` SSE event. Replayed on load to re-seed McpAppStateService
+   * so the `mcp-app-frame` survives a refresh. Present only on the first page.
+   */
+  uiResources?: UiResourceEvent[];
 }
 
 /**

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -315,8 +315,10 @@ export class ConversationPage implements OnDestroy {
       this.artifactState.reset();
 
       // MCP App frames persist for the conversation's lifetime per the
-      // scoping doc; teardown is on conversation change. No re-hydration:
-      // the inline `ui_resource` event only arrives live during a stream.
+      // scoping doc; teardown is on conversation change. Clear before the
+      // next load — loadMessagesForSession re-seeds from the persisted
+      // `uiResources` sidecar on the messages response so frames survive a
+      // refresh (the inline `ui_resource` event itself only arrives live).
       this.mcpAppState.reset();
 
       // Option A (PR #6): app-initiated tool cards DO re-hydrate (the


### PR DESCRIPTION
## What & why

MCP App UI (SEP-1865) is delivered via an **inline** `ui_resource` SSE event — emitted once, right after its `tool_result`, with the App's HTML fetched server-side via `resources/read` and inlined. It never re-streams, so on a page reload `McpAppStateService` is empty and the `<mcp-app-frame>` falls back to a plain tool card. This PR persists each **model-initiated** UI resource and replays it on conversation load so the frame survives a refresh.

This is the "persisted MCP App" work the code previously deferred ("out of scope until a later PR").

## How

**Backend**
- **`UiResourceStore`** (`apis/shared/mcp_apps/ui_resource_store.py`) — reuses the existing `sessions-metadata` DynamoDB table (SK `UIRES#<toolUseId>`, `SessionLookupIndex` GSI, 90d TTL, ownership re-check), keyed by `toolUseId` so a re-emit overwrites (last-write-wins, matching `recordLive`). **Zero new infra**; silent no-op when the table is absent (dev), exactly like the PR #6 app-card store.
- **Write** from the agents stream coordinator (`_extract_ui_resource_events`), alongside the artifact stamp and per-message-metadata writes that already run on that path. Best-effort in a worker thread — never breaks the live stream.
- **Read** folded into the existing `GET /sessions/{id}/messages` response as a `uiResources` sidecar (shaped like the SSE event), so there's **no new endpoint and no extra round-trip**. First page only. Served `sandboxOrigin` prefers this process's env (freshest) over the value captured at write time.

**Frontend**
- `McpAppStateService.seedFromHydration()` — non-clobbering (won't overwrite a live `recordLive` entry), mirroring `ArtifactStateService`.
- `message-map.service` seeds the registry from `messagesResponse.uiResources` inside `loadMessagesForSession`. `session.page` already resets before load, so the seed lands cleanly and `displayBlocks` re-renders the frame reactively — no component changes.

## Reviewer notes

- **Storage is interim.** HTML is gzipped into a DynamoDB Binary attribute (an Excalidraw App ~443 KB → ~131 KB, fits comfortably; ceiling ~1.3 MB of source). A follow-up will move large App bundles to **S3 with a content-hash-deduped pointer** (the artifacts pattern) — the DynamoDB blob is a smell for big/redundant bundles and the 400 KB item limit is a hard wall. Tracked for a separate PR.
- **Read surface decision.** Chose the messages-endpoint sidecar over a dedicated `/mcp-apps/ui-resources` endpoint (no extra round-trip; UI resources are message-bound) and over the session-metadata item (single 400 KB item, reused by the session-list response).
- **Boundary.** The write lives in the agents stream coordinator because that's where the payload is born and where artifact stamping + metadata persistence already happen — it doesn't add a route to inference-api.
- **Rendering dependency.** A model-initiated App will hydrate with this PR, but an *eval-using* App (e.g. Excalidraw) won't visibly paint until the **separate sandbox CSP drift fix** (`proxy.js` `<meta>` CSP was missing `'unsafe-eval'` that the CloudFront header already grants) is deployed. That fix is its own PR.

## Testing

- `UiResourceStore` units: gzip round-trip, oversized-skip, ownership re-check, last-write-wins, no-table no-op.
- Stream-coordinator persistence: writes when session/user present, skips otherwise, swallows failures.
- Messages sidecar: hydration shape + sandbox-origin override + first-page-only.
- `McpAppStateService.seedFromHydration` spec (non-clobbering).
- **Full backend suite green: 3144 passed, 3 skipped.** Frontend touched specs pass via the Angular builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
