### PR TITLE
fix(mcp-apps): align sandbox proxy <meta> CSP with the header (unblock App eval)

### DIFF
--- a/infrastructure/assets/mcp-sandbox/proxy.js
+++ b/infrastructure/assets/mcp-sandbox/proxy.js
@@ -87,12 +87,18 @@
   function defaultCsp() {
     return [
       "default-src 'none'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data:",
-      "media-src 'self' data:",
-      "font-src 'self'",
+      // Keyword sources ('unsafe-eval' blob: data:) MUST match the
+      // CloudFront-header CSP (assets/mcp-sandbox/csp-function.js). The
+      // browser enforces the INTERSECTION of this injected <meta> and that
+      // header, so any source the meta omits is silently re-denied even
+      // though the header allows it — that drift is what blocked App `eval`.
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:",
+      "style-src 'self' 'unsafe-inline' blob: data:",
+      "img-src 'self' data: blob:",
+      "media-src 'self' data: blob:",
+      "font-src 'self' data: blob:",
       "connect-src 'none'",
+      "worker-src 'self' blob:",
       "frame-src 'none'",
       "base-uri 'self'",
       "object-src 'none'",
@@ -114,12 +120,18 @@
     var base = list(csp.baseUriDomains).join(' ');
     return [
       "default-src 'none'",
-      ("script-src 'self' 'unsafe-inline'" + (res ? ' ' + res : '')),
-      ("style-src 'self' 'unsafe-inline'" + (res ? ' ' + res : '')),
-      ("img-src 'self' data:" + (res ? ' ' + res : '')),
-      ("font-src 'self'" + (res ? ' ' + res : '')),
-      ("media-src 'self' data:" + (res ? ' ' + res : '')),
+      // Keyword sources ('unsafe-eval' blob: data:) MUST match the
+      // CloudFront-header CSP (assets/mcp-sandbox/csp-function.js). The
+      // browser enforces the INTERSECTION of this <meta> and that header, so
+      // a source omitted here is silently re-denied regardless of the header
+      // — declared resourceDomains are appended on top, as before.
+      ("script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:" + (res ? ' ' + res : '')),
+      ("style-src 'self' 'unsafe-inline' blob: data:" + (res ? ' ' + res : '')),
+      ("img-src 'self' data: blob:" + (res ? ' ' + res : '')),
+      ("font-src 'self' data: blob:" + (res ? ' ' + res : '')),
+      ("media-src 'self' data: blob:" + (res ? ' ' + res : '')),
       ('connect-src ' + (conn || "'none'")),
+      ("worker-src 'self' blob:" + (res ? ' ' + res : '')),
       ('frame-src ' + (frame || "'none'")),
       ('base-uri ' + (base || "'self'")),
       "object-src 'none'",

--- a/infrastructure/test/mcp-sandbox-proxy-csp.test.ts
+++ b/infrastructure/test/mcp-sandbox-proxy-csp.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for the MCP Apps sandbox proxy's INJECTED <meta> CSP
+ * (`assets/mcp-sandbox/proxy.js`: `defaultCsp()` / `composeCsp()`).
+ *
+ * The App View runs under the INTERSECTION of two CSPs: the CloudFront-header
+ * CSP (`csp-function.js`) and the `<meta>` CSP `proxy.js` injects into the
+ * App HTML. If the `<meta>` omits a `script-src` keyword source the header
+ * grants (`'unsafe-eval'`, `blob:`, `data:`), the intersection silently
+ * re-denies it — which is exactly what blocked App `eval()` (e.g. Excalidraw)
+ * after PR #355 added those sources to the header but not to `proxy.js`.
+ *
+ * `proxy.js` is a browser IIFE (not Node-requireable), so we assert against
+ * its source text. `csp-function.js` exports `buildCspHeader`, so we derive
+ * the header's keyword sources programmatically rather than hard-coding them
+ * — the test then fails if the two sources drift apart again.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { buildCspHeader } = require('../assets/mcp-sandbox/csp-function');
+
+const PROXY_SRC = fs.readFileSync(
+  path.join(__dirname, '../assets/mcp-sandbox/proxy.js'),
+  'utf8',
+);
+
+// The two `script-src` directive literals proxy.js builds (one in
+// defaultCsp(), one in composeCsp()). Match on the literal start so prose
+// comments mentioning "script-src" can't false-match.
+const proxyScriptSrcDirectives = PROXY_SRC.split('\n').filter((line) =>
+  line.includes("script-src 'self'"),
+);
+
+// Keyword sources (quoted keywords like 'unsafe-eval' + scheme sources like
+// blob:) on a CSP's script-src — these are what an intersection can strip.
+// Domains and 'self'/'unsafe-inline' are shared by both policies; the drift
+// that bit us was the keyword sources.
+function scriptSrcKeywordSources(csp: string): string[] {
+  const directive = csp
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d.startsWith('script-src'));
+  if (!directive) return [];
+  return directive
+    .split(/\s+/)
+    .slice(1) // drop the "script-src" directive name
+    .filter((tok) => /^'[^']+'$/.test(tok) || /^[a-z]+:$/.test(tok));
+}
+
+describe('mcp-sandbox proxy.js injected <meta> CSP — no drift vs header', () => {
+  const headerKeywords = scriptSrcKeywordSources(
+    buildCspHeader({}, 'https://x.example'),
+  );
+
+  test('header (source of truth) grants unsafe-eval / blob: / data:', () => {
+    expect(headerKeywords).toEqual(
+      expect.arrayContaining(["'unsafe-eval'", 'blob:', 'data:']),
+    );
+  });
+
+  test('proxy.js builds two script-src directives (defaultCsp + composeCsp)', () => {
+    expect(proxyScriptSrcDirectives).toHaveLength(2);
+  });
+
+  test.each(["'unsafe-eval'", 'blob:', 'data:'])(
+    'every proxy.js script-src directive grants %s',
+    (token) => {
+      for (const directive of proxyScriptSrcDirectives) {
+        expect(directive).toContain(token);
+      }
+    },
+  );
+
+  test('every header script-src keyword source also appears in proxy.js', () => {
+    // The anti-drift guard: a keyword the header grants but proxy.js omits
+    // would be silently stripped by the intersection.
+    for (const keyword of headerKeywords) {
+      for (const directive of proxyScriptSrcDirectives) {
+        expect(directive).toContain(keyword);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Embedded MCP App UI (SEP-1865) runs inside the sandbox proxy's inner iframe under the **intersection of two Content-Security-Policies**:

1. The **CloudFront-header CSP** composed per-request by `assets/mcp-sandbox/csp-function.js`.
2. The **`<meta>` CSP** that `assets/mcp-sandbox/proxy.js` injects into the App HTML (`composeCsp()` / `defaultCsp()`).

PR #355 (dynamic per-resource CSP) added `'unsafe-eval' blob: data:` and a `worker-src` to the **header**, but never updated **proxy.js**. Because the browser enforces the intersection, the stricter `<meta>` silently re-denied those sources — so `eval()` / `new Function()` were blocked in eval-using Apps (e.g. **Excalidraw**, and most bundled SPAs). The symptom is a **blank-but-sized canvas with no top-frame error** (the CSP violation reports inside the cross-origin sandbox frame, not the top frame).

## Fix

Align the injected `<meta>` CSP in `proxy.js` with the header policy PR #355 already ships:

- `script-src`: add `'unsafe-eval' blob: data:`
- `style/img/font/media-src`: add `blob: data:`
- add `worker-src 'self' blob:` (was missing entirely → workers fell through to `default-src 'none'`)

The `<meta>`'s deny-by-default hardening is unchanged — `default-src 'none'`, and `connect-src` / `frame-src` / `base-uri` still restricted to the App's declared domains, with `resourceDomains` appended on top.

### This is not a weakening

The HTTP header is the "load-bearing security bound" (per proxy.js's own comment) and **already grants** `'unsafe-eval'` per PR #355's deliberate decision. The `<meta>` silently stripping it was the bug; aligning it **restores the intended policy** rather than relaxing a control. No new domains are allowed.

## Regression test

`infrastructure/test/mcp-sandbox-proxy-csp.test.ts` requires `csp-function.js`, derives the header's `script-src` keyword sources from `buildCspHeader`, and asserts the injected `<meta>` (both `defaultCsp()` and `composeCsp()`) grants each one — so the two CSP sources fail the build if they ever drift apart again.

## Testing

- Full infrastructure suite: **379 passed** (15 suites), including the new test.

## Deploy

Requires an **mcp-sandbox stack redeploy** to take effect — the `proxy.js` asset is shipped via `BucketDeployment`. After redeploy, eval-using Apps render (live and on reload).

## Scope

Independent of the UI-resource persistence work (#413) — different component, found while validating that feature end-to-end. The blank canvas was never about persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
