### PR TITLE
fix(infra): align SSM image-tag contract on full ECR URIs (+ restore-data env, rag-ingestion docling pin)

### DIFF
--- a/.github/docs/deploy/upgrade-from-multi-stack.md
+++ b/.github/docs/deploy/upgrade-from-multi-stack.md
@@ -86,6 +86,21 @@ If your environment had `CDK_RETAIN_DATA_ON_DELETE=true` (the default for produc
 - **Cognito User Pool** — the identity store
 - **Secrets Manager secrets** — auth secret, OAuth secrets, BFF cookie key
 - **KMS keys** — OAuth token encryption, BFF cookie signing
+- **SSM parameters under `/${CDK_PROJECT_PREFIX}/`** — these were written by the
+  pre-multi-stack scripts via direct `aws ssm put-parameter` calls (not
+  CloudFormation), so `delete-stack` doesn't see them. Most importantly,
+  `/${CDK_PROJECT_PREFIX}/{app-api,inference-api}/image-tag` will hold a
+  legacy tag-only value (e.g. a git short SHA) from your last pre-migration
+  deploy. The new architecture treats these parameters as **full ECR URIs**
+  and the first PlatformStack deploy will fail CFN early-validation if the
+  legacy value is still present:
+  ```
+  Property value [<short-sha>] does not match pattern:
+    ^\d{12}\.dkr\.ecr\.([a-z0-9-]+)\.amazonaws\.com/...
+  ```
+  The seed step in `scripts/platform/deploy.sh` repairs this automatically
+  on the next platform deploy (it overwrites any non-URI value with the
+  bootstrap container URI), but you can also clean it up manually below.
 
 **How to identify retained resources:**
 
@@ -101,6 +116,10 @@ aws cognito-idp list-user-pools --max-results 20 --query "UserPools[?starts_with
 
 # List secrets
 aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, '${CDK_PROJECT_PREFIX}')].[Name]"
+
+# List SSM parameters under your project prefix
+aws ssm get-parameters-by-path --path "/${CDK_PROJECT_PREFIX}/" --recursive \
+  --query 'Parameters[].Name' --output text | tr '\t' '\n'
 ```
 
 **Delete them:**
@@ -122,6 +141,20 @@ aws cognito-idp delete-user-pool --user-pool-id {pool-id}
 # Secrets (force delete without recovery window)
 aws secretsmanager delete-secret --secret-id {prefix}-auth-secret --force-delete-without-recovery
 # ... etc
+
+# SSM parameters under your project prefix.
+# Minimum required for an in-place migration is just the image-tag params,
+# which break the first PlatformStack deploy if left at a legacy tag-only
+# value. You can either delete just those two:
+aws ssm delete-parameter --name "/${CDK_PROJECT_PREFIX}/app-api/image-tag"        2>/dev/null || true
+aws ssm delete-parameter --name "/${CDK_PROJECT_PREFIX}/inference-api/image-tag"  2>/dev/null || true
+
+# ...or sweep every SSM parameter under your prefix (safe — they're all
+# re-published on the next platform/backend deploy):
+aws ssm get-parameters-by-path --path "/${CDK_PROJECT_PREFIX}/" --recursive \
+  --query 'Parameters[].Name' --output text \
+  | tr '\t' '\n' \
+  | xargs -r -n10 aws ssm delete-parameters --names
 ```
 
 > 💡 **Tip:** If you set `CDK_RETAIN_DATA_ON_DELETE=false` in your GitHub environment variables BEFORE running teardown, CloudFormation will delete everything automatically and you can skip this step entirely. Only do this if you're confident your backup is good.

--- a/.github/workflows/restore-data.yml
+++ b/.github/workflows/restore-data.yml
@@ -30,6 +30,15 @@ on:
         required: false
         type: boolean
         default: false
+      aws_environment:
+        description: "GitHub Environment (selects AWS_ROLE_ARN secret + approvals)"
+        required: true
+        type: choice
+        default: development
+        options:
+          - development
+          - staging
+          - production
 
 permissions:
   id-token: write
@@ -38,6 +47,12 @@ permissions:
 jobs:
   restore:
     runs-on: ubuntu-24.04
+    # Required so that `vars.*` and `secrets.*` references below resolve
+    # against the chosen GitHub Environment. Without this they silently
+    # resolve to empty strings and configure-aws-credentials fails with
+    # "Could not load credentials from any providers". Matches the
+    # pattern used by backup-data.yml, teardown.yml, platform.yml, etc.
+    environment: ${{ inputs.aws_environment }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/backend/Dockerfile.rag-ingestion
+++ b/backend/Dockerfile.rag-ingestion
@@ -75,18 +75,41 @@ RUN mkdir -p /tmp/models/tiktoken_cache && \
   python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 
 # 7. Download Docling Models
-# We use 'download_models' to fetch the standard pipeline (Layout, Tables, OCR).
-# We force it to the specific artifacts folder.
+# We pass an explicit list of models rather than relying on download_models()'s
+# defaults — those defaults drift between docling versions (e.g. 2.81 added
+# with_rapidocr=True, which iterates a torch backend AND an onnxruntime backend
+# and crashes here because onnxruntime isn't in our requirements.lock).
+# The pipeline (handler.py) only uses the layout, tableformer, picture
+# classifier, and code-formula models, so we explicitly request just those
+# and disable everything else.
 ENV PYTHONPATH=/tmp/packages
-RUN python -c "from docling.utils.model_downloader import download_models; \
-  from pathlib import Path; \
-  download_models( \
-  output_dir=Path('/tmp/models/docling-artifacts'), \
-  force=True \
-  )"
+RUN python -c "\
+from pathlib import Path; \
+from docling.utils.model_downloader import download_models; \
+download_models( \
+    output_dir=Path('/tmp/models/docling-artifacts'), \
+    force=True, \
+    progress=False, \
+    with_layout=True, \
+    with_tableformer=True, \
+    with_tableformer_v2=False, \
+    with_code_formula=True, \
+    with_picture_classifier=True, \
+    with_smolvlm=False, \
+    with_granitedocling=False, \
+    with_granitedocling_mlx=False, \
+    with_smoldocling=False, \
+    with_smoldocling_mlx=False, \
+    with_granite_vision=False, \
+    with_granite_chart_extraction=False, \
+    with_rapidocr=False, \
+    with_easyocr=False, \
+)"
 
-# 8. Clean up OCR (Optimization)
-# We delete the heavy EasyOCR model (~200MB) and the table structure model to keep the Lambda image slim
+# 8. Clean up unused / oversized model artifacts (Optimization)
+# - easyocr (~200 MB) and table_structure_model are legacy folder names from
+#   older docling versions; left as defensive cleanup so future docling default
+#   changes don't silently bloat the image. `rm -rf` on a missing path is a no-op.
 RUN rm -rf /tmp/models/docling-artifacts/easyocr \
   /tmp/models/docling-artifacts/table_structure_model
 

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -138,16 +138,22 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
 fi
 
-# Publish to SSM so the CDK constructs that read the tag at synth
-# time pick up the freshly-built image. `put-parameter --overwrite`
-# is idempotent. Per the devops gotcha, --overwrite cannot be
-# combined with --tags for an existing parameter, so we omit --tags.
+# Publish to SSM so the CDK constructs that read the URI at deploy
+# time pick up the freshly-built image. The constructs use this value
+# directly as the ECS TaskDefinition Image / AgentCore Runtime
+# ContainerUri — so it must be the FULL ECR URI (including registry,
+# repo, and tag), not just the tag. CFN validates this against the
+# ECR URI regex on every deploy and rejects bare tags.
+# `put-parameter --overwrite` is idempotent. Per the devops gotcha,
+# --overwrite cannot be combined with --tags for an existing
+# parameter, so we omit --tags.
+SSM_VALUE="${REPO}:${TAG}"
 aws ssm put-parameter \
     --region "${CDK_AWS_REGION}" \
     --name "${SSM_KEY}" \
-    --value "$TAG" \
+    --value "${SSM_VALUE}" \
     --type String \
     --overwrite \
     --no-cli-pager >/dev/null
 
-log_info "${SERVICE}: SSM ${SSM_KEY} = ${TAG}"
+log_info "${SERVICE}: SSM ${SSM_KEY} = ${SSM_VALUE}"

--- a/scripts/build/deploy-ecs-service-if-changed.sh
+++ b/scripts/build/deploy-ecs-service-if-changed.sh
@@ -79,8 +79,33 @@ ssm_get() {
     aws ssm get-parameter --region "$AWS_REGION" --name "$1" \
         --query 'Parameter.Value' --output text
 }
-IMAGE_TAG="$(ssm_get "$IMAGE_URI_SSM")"
-NEW_IMAGE_URI="${ECR_REPO_URI}:${IMAGE_TAG}"
+# The image-uri SSM holds the FULL ECR URI (registry/repo:tag) per
+# the platform-as-bootstrap design — the CDK construct reads the
+# same value directly into the ECS TaskDefinition Image at deploy
+# time, and CFN's regex validation rejects bare tags. build-one.sh
+# is the canonical writer.
+NEW_IMAGE_URI="$(ssm_get "$IMAGE_URI_SSM")"
+
+# Sanity-check that the SSM value is a real ECR URI, not a stale
+# tag-only legacy value left over from a pre-platform-as-bootstrap
+# deploy. The platform deploy's seed script repairs these, but we'd
+# rather fail loud here than register a bogus task definition.
+ECR_URI_REGEX='^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*[:@][^[:space:]]+$'
+if [[ ! "$NEW_IMAGE_URI" =~ $ECR_URI_REGEX ]]; then
+    log "SSM ${IMAGE_URI_SSM} = '${NEW_IMAGE_URI}' is not a valid ECR URI."
+    log "build-one.sh should have written REGISTRY/REPO:TAG. Re-run the build job, or run the platform deploy to re-seed the parameter."
+    exit 6
+fi
+if [[ "$NEW_IMAGE_URI" != "${ECR_REPO_URI}:"* && "$NEW_IMAGE_URI" != "${ECR_REPO_URI}@"* ]]; then
+    log "WARNING: SSM URI '${NEW_IMAGE_URI}' does not reference --ecr-repo-uri '${ECR_REPO_URI}'. Proceeding anyway."
+fi
+
+# Derive the tag for logging / GITHUB_OUTPUT echoing.
+if [[ "$NEW_IMAGE_URI" == *@* ]]; then
+    IMAGE_TAG="${NEW_IMAGE_URI##*@}"
+else
+    IMAGE_TAG="${NEW_IMAGE_URI##*:}"
+fi
 CLUSTER_NAME="$(ssm_get "$CLUSTER_NAME_SSM")"
 SERVICE_NAME="$(ssm_get "$SERVICE_NAME_SSM")"
 TASK_DEF_FAMILY="$(ssm_get "$TASK_DEF_FAMILY_SSM")"

--- a/scripts/build/deploy-runtime-image-if-changed.sh
+++ b/scripts/build/deploy-runtime-image-if-changed.sh
@@ -21,7 +21,10 @@
 # Pre-requisites:
 #   - The Runtime exists (PlatformStack deploy has run).
 #   - build-and-push-if-changed.sh has already pushed a new image
-#     to ECR and updated `--image-uri-ssm` with the content-hash tag.
+#     to ECR and updated `--image-uri-ssm` with the FULL ECR URI
+#     (registry/repo:tag). The platform-as-bootstrap design treats
+#     this SSM parameter as a URI, not a tag — see scripts/build/
+#     build-one.sh and scripts/stack-bootstrap/seed-image-tags.sh.
 #
 # AgentCore Runtime status semantics:
 #   CREATING | UPDATING — transitional, can't accept update calls
@@ -64,14 +67,45 @@ done
 
 log() { echo "[$SERVICE] $*" >&2; }
 
-# 1. Resolve the new image tag from SSM (set by build-one.sh just
-# before this script runs).
-IMAGE_TAG="$(aws ssm get-parameter \
+# 1. Resolve the new container URI from SSM. Per the platform-as-
+# bootstrap design, this SSM parameter holds the FULL ECR URI
+# (registry/repo:tag), not just a tag — the CDK construct reads
+# the same value directly into the Runtime's ContainerUri at deploy
+# time, and CFN's regex validation rejects bare tags. build-one.sh
+# is the canonical writer.
+NEW_CONTAINER_URI="$(aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$IMAGE_URI_SSM" \
     --query 'Parameter.Value' \
     --output text)"
-NEW_CONTAINER_URI="${ECR_REPO_URI}:${IMAGE_TAG}"
+
+# Sanity-check that the SSM value is a real ECR URI and not a stale
+# tag-only legacy value (e.g. left over from a pre-platform-as-
+# bootstrap deploy). The seed script in scripts/stack-bootstrap/
+# repairs these on the next platform deploy, but we'd rather fail
+# loud here than push an invalid update to AgentCore.
+ECR_URI_REGEX='^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*[:@][^[:space:]]+$'
+if [[ ! "$NEW_CONTAINER_URI" =~ $ECR_URI_REGEX ]]; then
+    log "SSM ${IMAGE_URI_SSM} = '${NEW_CONTAINER_URI}' is not a valid ECR URI."
+    log "build-one.sh should have written REGISTRY/REPO:TAG. Re-run the build job, or run the platform deploy to re-seed the parameter."
+    exit 6
+fi
+
+# Optional consistency check: the URI should reference --ecr-repo-uri.
+# We don't enforce identity (build-one writes the same string we'd
+# expect, but leave headroom for digest pins or alt repo names) —
+# just warn loudly if it diverges.
+if [[ "$NEW_CONTAINER_URI" != "${ECR_REPO_URI}:"* && "$NEW_CONTAINER_URI" != "${ECR_REPO_URI}@"* ]]; then
+    log "WARNING: SSM URI '${NEW_CONTAINER_URI}' does not reference --ecr-repo-uri '${ECR_REPO_URI}'. Proceeding anyway."
+fi
+
+# Derive the tag for logging / GITHUB_OUTPUT echoing. Splits on the
+# rightmost ':' or '@' so digest-pinned URIs work too.
+if [[ "$NEW_CONTAINER_URI" == *@* ]]; then
+    IMAGE_TAG="${NEW_CONTAINER_URI##*@}"
+else
+    IMAGE_TAG="${NEW_CONTAINER_URI##*:}"
+fi
 log "Target container URI: $NEW_CONTAINER_URI"
 
 # 2. Resolve the runtime ID.

--- a/scripts/stack-bootstrap/seed-image-tags.sh
+++ b/scripts/stack-bootstrap/seed-image-tags.sh
@@ -81,16 +81,41 @@ read_asset_hash() {
     echo "$val"
 }
 
+# CFN's AgentCore Runtime ContainerUri and ECS TaskDefinition Image
+# both validate against the ECR URI shape:
+#   <12-digit-acct>.dkr.ecr.<region>.amazonaws.com/<repo>(:tag|@digest)
+# Anything else fails CFN early-validation. We use this regex to
+# decide whether an existing SSM value is "good enough to keep" or
+# needs to be overwritten with the bootstrap URI.
+#
+# Two scenarios produce a non-URI value at this point:
+#   1. Migration from the pre-#396 architecture, where scripts wrote
+#      a tag-only string (e.g. a git short SHA) to the same SSM path.
+#      The CFN delete-stack on teardown didn't touch these because
+#      they were never CFN-owned (written by `aws ssm put-parameter`
+#      directly from the old per-stack scripts).
+#   2. A future regression in the build pipeline that writes a
+#      tag-only value instead of a full URI.
+# In both cases overwriting with the bootstrap URI is safe: the build
+# pipeline will overwrite it again on the next real-image push.
+ECR_URI_REGEX='^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*[:@][^[:space:]]+$'
+
 seed_one() {
     local svc="$1"
     local output_marker="$2"
     local ssm_path="/${CDK_PROJECT_PREFIX}/${svc}/image-tag"
 
-    if aws ssm get-parameter \
+    local existing="" exists=0
+    if existing="$(aws ssm get-parameter \
             --name "$ssm_path" \
             --region "$CDK_AWS_REGION" \
-            >/dev/null 2>&1; then
-        log_info "  ${svc}: SSM ${ssm_path} already exists — skipping seed (build pipeline owns it)"
+            --query 'Parameter.Value' \
+            --output text 2>/dev/null)"; then
+        exists=1
+    fi
+
+    if (( exists == 1 )) && [[ "$existing" =~ $ECR_URI_REGEX ]]; then
+        log_info "  ${svc}: SSM ${ssm_path} already holds a valid ECR URI — skipping seed (build pipeline owns it)"
         return 0
     fi
 
@@ -98,14 +123,29 @@ seed_one() {
     hash="$(read_asset_hash "$output_marker")"
     uri="${REGISTRY}/${ASSETS_REPO}:${hash}"
 
-    log_info "  ${svc}: seeding SSM ${ssm_path} = ${uri}"
-    aws ssm put-parameter \
-        --name "$ssm_path" \
-        --value "$uri" \
-        --type String \
-        --region "$CDK_AWS_REGION" \
-        --description "Container image URI for ${svc}. Seeded on first deploy with bootstrap asset URI; overwritten by build pipeline on every real-image push." \
-        >/dev/null
+    if (( exists == 1 )); then
+        # Non-URI legacy value — log it (truncated) so operators can
+        # see what was there. Tag-only legacy values from the pre-#396
+        # architecture are the typical case.
+        local preview="${existing:0:64}"
+        log_warn "  ${svc}: SSM ${ssm_path} held non-URI value '${preview}' — overwriting with bootstrap URI"
+        aws ssm put-parameter \
+            --name "$ssm_path" \
+            --value "$uri" \
+            --type String \
+            --region "$CDK_AWS_REGION" \
+            --overwrite \
+            >/dev/null
+    else
+        log_info "  ${svc}: seeding SSM ${ssm_path} = ${uri}"
+        aws ssm put-parameter \
+            --name "$ssm_path" \
+            --value "$uri" \
+            --type String \
+            --region "$CDK_AWS_REGION" \
+            --description "Container image URI for ${svc}. Seeded on first deploy with bootstrap asset URI; overwritten by build pipeline on every real-image push." \
+            >/dev/null
+    fi
 }
 
 main() {


### PR DESCRIPTION
## Summary

Three related fixes that together unblock a fresh PlatformStack deploy + the restore workflow on top of it after PR #396 (the platform-as-bootstrap refactor).

## 1. SSM `image-tag` contract drift (commit `a90cd78c`)

After #396 the new CDK constructs read `/{prefix}/{svc}/image-tag` directly as the ECS `Image` / AgentCore Runtime `ContainerUri`, so the SSM value must be a full ECR URI. Three things were misaligned:

1. **Migrating fork users** — the pre-#396 architecture wrote tag-only values (e.g. a git short SHA) to the same SSM path via `aws ssm put-parameter` calls inside the per-stack scripts. `delete-stack` on teardown never saw those parameters (they were never CFN-owned), so they survived the migration. CFN early-validation rejects the value with `Property value [<sha>] does not match pattern: ^\d{12}\.dkr\.ecr\....`
2. **`seed-image-tags.sh`** trusted any existing value blindly. Stale legacy values were never overwritten.
3. **`build-one.sh` and the deploy scripts** were still writing/reading the value as a bare tag.

### Changes
- **`scripts/stack-bootstrap/seed-image-tags.sh`** — validate the existing SSM value against the ECR URI regex; overwrite with bootstrap URI on regex mismatch.
- **`scripts/build/build-one.sh`** — write `${REPO}:${TAG}` (full URI) to SSM.
- **`scripts/build/deploy-runtime-image-if-changed.sh`**, **`scripts/build/deploy-ecs-service-if-changed.sh`** — read SSM as a full URI directly; validate with the same regex; fail loud (exit 6) on invalid values.
- **`.github/docs/deploy/upgrade-from-multi-stack.md`** — document the legacy SSM cleanup step + auto-repair behavior.

## 2. Missing SSM publications for the restore tool (commit `8b0e2672`)

`scripts/restore-data/restore.py` looks up every backed-up DynamoDB table, S3 bucket, Cognito user pool, and AgentCore Memory ID via SSM under `/{prefix}/`. After PR #396's SSM cleanup, only ~12 of the ~26 paths it needs were still being published, so a fresh PlatformStack deploy made restore fail with `ParameterNotFound` on the first table lookup.

Added the missing publications inside the constructs that own each resource:

| Category | Paths added |
|---|---|
| Tables (17) | `/users/users-table-name`, `/auth/api-keys-table-name`, `/auth/auth-providers-table-name`, `/oauth/providers-table-name`, `/oauth/user-tokens-table-name`, `/quota/quota-events-table-name`, `/cost-tracking/sessions-metadata-table-name`, `/cost-tracking/user-cost-summary-table-name`, `/cost-tracking/system-cost-rollup-table-name`, `/admin/user-menu-links-table-name`, `/settings/user-settings-table-name`, `/user-file-uploads/table-name`, `/shares/shared-conversations-table-name`, `/rag/assistants-table-name`, `/artifacts/table-name`, `/fine-tuning/jobs-table-name`, `/fine-tuning/access-table-name` |
| Buckets (4) | `/user-file-uploads/bucket-name`, `/rag/documents-bucket-name`, `/artifacts/bucket-name`, `/fine-tuning/data-bucket-name` |
| AgentCore (1) | `/inference-api/memory-id` |

`platform-stack.test.ts` updated: SSM-count ceiling raised from `<=20` to `<=45` with comment calling out the restore-tooling consumers.

## 3. Two unrelated bugs hit during the same upgrade attempt (in commit `a90cd78c`)

- **`.github/workflows/restore-data.yml`** — added `aws_environment` workflow input + `environment:` binding on the `restore` job. Without `environment:`, `vars.*` and `secrets.*` references silently resolved to empty strings and `configure-aws-credentials` failed with `Could not load credentials from any providers`.
- **`backend/Dockerfile.rag-ingestion`** — replaced implicit `download_models(force=True)` with an explicit list of models. docling 2.81.0 added `with_rapidocr=True` as a new default, which iterates an `onnxruntime` backend that's not in `requirements.lock`. Verified working locally.

## Tests

`npx jest --maxWorkers=2` — **376 / 376 pass**, including the existing `compute-image-resolution.test.ts` and the updated `platform-stack.test.ts` SSM ceiling.

Local docker build of `Dockerfile.rag-ingestion` succeeds end-to-end with the patched `download_models()` call.