### PR TITLE
fix(infra): publish SSM params required by restore tooling + lambda deploy URI contract

### DIFF
--- a/infrastructure/lib/constructs/agentcore/memory-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/memory-construct.ts
@@ -143,6 +143,12 @@ export class AgentCoreMemoryConstruct extends Construct {
     memoryTracesDelivery.node.addDependency(memoryTracesSource);
     memoryTracesDelivery.node.addDependency(memoryTracesDestination);
 
-    // ── SSM publications ──
+    // ── SSM publications (consumed by restore tooling, runtime container env) ──
+    new ssm.StringParameter(this, 'MemoryIdParameter', {
+      parameterName: `/${config.projectPrefix}/inference-api/memory-id`,
+      stringValue: this.memoryId,
+      description: 'AgentCore Memory ID',
+      tier: ssm.ParameterTier.STANDARD,
+    });
   }
 }

--- a/infrastructure/lib/constructs/artifacts/artifacts-data-construct.ts
+++ b/infrastructure/lib/constructs/artifacts/artifacts-data-construct.ts
@@ -99,8 +99,20 @@ export class ArtifactsDataConstruct extends Construct {
       autoDeleteObjects: getAutoDeleteObjects(config),
     });
 
+    // ── SSM publications (consumed by restore tooling, app-api runtime) ──
+    new ssm.StringParameter(this, 'ArtifactsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/artifacts/table-name`,
+      stringValue: this.table.tableName,
+      description: 'Artifacts table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
-
+    new ssm.StringParameter(this, 'ArtifactsBucketNameParameter', {
+      parameterName: `/${config.projectPrefix}/artifacts/bucket-name`,
+      stringValue: this.bucket.bucketName,
+      description: 'Artifacts content S3 bucket name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/data/admin-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/admin-tables-construct.ts
@@ -52,6 +52,20 @@ export class AdminTablesConstruct extends Construct {
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
     });
 
+    // ── SSM publications (consumed by restore tooling, app-api runtime) ──
+    new ssm.StringParameter(this, 'UserSettingsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/settings/user-settings-table-name`,
+      stringValue: this.userSettingsTable.tableName,
+      description: 'User settings table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'UserMenuLinksTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/admin/user-menu-links-table-name`,
+      stringValue: this.userMenuLinksTable.tableName,
+      description: 'User menu links table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/data/auth-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/auth-tables-construct.ts
@@ -157,6 +157,20 @@ export class AuthTablesConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // ── SSM publications (consumed by restore tooling, app-api/inference-api runtime) ──
+    new ssm.StringParameter(this, 'UsersTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/users/users-table-name`,
+      stringValue: this.usersTable.tableName,
+      description: 'Users table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'ApiKeysTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/auth/api-keys-table-name`,
+      stringValue: this.apiKeysTable.tableName,
+      description: 'API keys table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/data/cost-tracking-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/cost-tracking-tables-construct.ts
@@ -139,5 +139,27 @@ export class CostTrackingTablesConstruct extends Construct {
       tier: ssm.ParameterTier.STANDARD,
     });
 
+    // Cost-tracking tables (consumed by restore tooling, app-api/inference-api runtime)
+    new ssm.StringParameter(this, 'SessionsMetadataTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/cost-tracking/sessions-metadata-table-name`,
+      stringValue: this.sessionsMetadataTable.tableName,
+      description: 'Sessions metadata table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'UserCostSummaryTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/cost-tracking/user-cost-summary-table-name`,
+      stringValue: this.userCostSummaryTable.tableName,
+      description: 'User cost summary table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'SystemCostRollupTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/cost-tracking/system-cost-rollup-table-name`,
+      stringValue: this.systemCostRollupTable.tableName,
+      description: 'System cost rollup table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
   }
 }

--- a/infrastructure/lib/constructs/data/file-upload-construct.ts
+++ b/infrastructure/lib/constructs/data/file-upload-construct.ts
@@ -129,8 +129,20 @@ export class FileUploadConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // ── SSM publications (consumed by restore tooling, app-api runtime) ──
+    new ssm.StringParameter(this, 'FileUploadTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/user-file-uploads/table-name`,
+      stringValue: this.table.tableName,
+      description: 'User file uploads table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
-
+    new ssm.StringParameter(this, 'FileUploadBucketNameParameter', {
+      parameterName: `/${config.projectPrefix}/user-file-uploads/bucket-name`,
+      stringValue: this.bucket.bucketName,
+      description: 'User file uploads S3 bucket name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/data/quota-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/quota-tables-construct.ts
@@ -99,6 +99,12 @@ export class QuotaTablesConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    new ssm.StringParameter(this, 'QuotaEventsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/quota/quota-events-table-name`,
+      stringValue: this.quotaEventsTable.tableName,
+      description: 'Quota events table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/data/shared-conversations-construct.ts
+++ b/infrastructure/lib/constructs/data/shared-conversations-construct.ts
@@ -62,6 +62,12 @@ export class SharedConversationsConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    new ssm.StringParameter(this, 'SharedConversationsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/shares/shared-conversations-table-name`,
+      stringValue: this.table.tableName,
+      description: 'Shared conversations table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/fine-tuning/fine-tuning-data-construct.ts
+++ b/infrastructure/lib/constructs/fine-tuning/fine-tuning-data-construct.ts
@@ -124,10 +124,27 @@ export class FineTuningDataConstruct extends Construct {
       ],
     });
 
+    // ── SSM publications (consumed by restore tooling, app-api runtime) ──
+    new ssm.StringParameter(this, 'FineTuningJobsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/fine-tuning/jobs-table-name`,
+      stringValue: this.jobsTable.tableName,
+      description: 'Fine-tuning jobs table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
+    new ssm.StringParameter(this, 'FineTuningAccessTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/fine-tuning/access-table-name`,
+      stringValue: this.accessTable.tableName,
+      description: 'Fine-tuning access table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
-
-
+    new ssm.StringParameter(this, 'FineTuningDataBucketNameParameter', {
+      parameterName: `/${config.projectPrefix}/fine-tuning/data-bucket-name`,
+      stringValue: this.dataBucket.bucketName,
+      description: 'Fine-tuning data S3 bucket name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/identity/auth-providers-construct.ts
+++ b/infrastructure/lib/constructs/identity/auth-providers-construct.ts
@@ -67,5 +67,12 @@ export class AuthProvidersConstruct extends Construct {
       },
     );
 
+    new ssm.StringParameter(this, 'AuthProvidersTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/auth/auth-providers-table-name`,
+      stringValue: this.providersTable.tableName,
+      description: 'Auth providers table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
   }
 }

--- a/infrastructure/lib/constructs/identity/oauth-tables-construct.ts
+++ b/infrastructure/lib/constructs/identity/oauth-tables-construct.ts
@@ -90,11 +90,20 @@ export class OAuthTablesConstruct extends Construct {
       },
     );
 
-    // SSM publications
+    // ── SSM publications (consumed by restore tooling, app-api/inference-api runtime) ──
+    new ssm.StringParameter(this, 'OAuthProvidersTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/oauth/providers-table-name`,
+      stringValue: this.providersTable.tableName,
+      description: 'OAuth providers table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
-
-
-
+    new ssm.StringParameter(this, 'OAuthUserTokensTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/oauth/user-tokens-table-name`,
+      stringValue: this.userTokensTable.tableName,
+      description: 'OAuth user tokens table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/lib/constructs/rag/rag-data-construct.ts
+++ b/infrastructure/lib/constructs/rag/rag-data-construct.ts
@@ -150,11 +150,20 @@ export class RagDataConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
-    // SSM publications
+    // ── SSM publications (consumed by restore tooling, app-api/inference-api runtime) ──
+    new ssm.StringParameter(this, 'RagAssistantsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/rag/assistants-table-name`,
+      stringValue: this.assistantsTable.tableName,
+      description: 'RAG assistants table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
-
-
-
+    new ssm.StringParameter(this, 'RagDocumentsBucketNameParameter', {
+      parameterName: `/${config.projectPrefix}/rag/documents-bucket-name`,
+      stringValue: this.documentsBucket.bucketName,
+      description: 'RAG documents S3 bucket name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
 
   }
 }

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -131,16 +131,22 @@ describe('PlatformStack', () => {
   });
 
   describe('SSM parameters', () => {
-    it('publishes only the SSM parameters deploy scripts and e2e tests need', () => {
-      // After the SSM cleanup, only ~12 publishes remain — these are the
-      // ones consumed by deploy scripts (build, deploy-ecs-service,
-      // deploy-runtime-image, deploy-image-lambda, frontend deploy) and
-      // e2e tests. Every other SSM publish was dead weight: the value
-      // was either consumed only by sibling CDK constructs (now sourced
-      // via typed PlatformComputeRefs) or never read by anyone.
+    it('publishes only the SSM parameters deploy scripts, restore tooling, and e2e tests need', () => {
+      // SSM publishes fall into a few buckets:
+      //   - Deploy-time discovery (build, deploy-ecs-service,
+      //     deploy-runtime-image, deploy-image-lambda, frontend deploy).
+      //   - e2e test discovery.
+      //   - Restore tooling (scripts/restore-data/restore.py): looks up
+      //     every backed-up DynamoDB table, S3 bucket, Cognito user pool,
+      //     and AgentCore Memory ID via SSM under /{prefix}/. These
+      //     are kept in sync with TABLE_SSM_MAP / BUCKET_SSM_MAP /
+      //     SSM_USER_POOL_ID / SSM_MEMORY_ID in restore.py.
+      // Every other SSM publish was dead weight: the value was either
+      // consumed only by sibling CDK constructs (now sourced via typed
+      // PlatformComputeRefs) or never read by anyone.
       const params = template.findResources('AWS::SSM::Parameter');
-      expect(Object.keys(params).length).toBeGreaterThanOrEqual(8);
-      expect(Object.keys(params).length).toBeLessThanOrEqual(20);
+      expect(Object.keys(params).length).toBeGreaterThanOrEqual(30);
+      expect(Object.keys(params).length).toBeLessThanOrEqual(45);
     });
   });
 

--- a/scripts/build/deploy-image-lambda-if-changed.sh
+++ b/scripts/build/deploy-image-lambda-if-changed.sh
@@ -20,8 +20,11 @@
 #
 # Pre-requisites:
 #   build-and-push-if-changed.sh has already run for this service
-#   and updated `--image-uri-ssm` with the latest content-hash tag.
-#   This script reads that tag from SSM and points the Lambda at it.
+#   and updated `--image-uri-ssm` with the FULL ECR URI
+#   (registry/repo:tag). The platform-as-bootstrap design treats this
+#   SSM parameter as a URI, not a tag — see scripts/build/build-one.sh
+#   and scripts/stack-bootstrap/seed-image-tags.sh. This script reads
+#   that URI from SSM and points the Lambda at it.
 #============================================================
 set -euo pipefail
 
@@ -59,12 +62,37 @@ log() { echo "[$SERVICE] $*" >&2; }
 
 # 1. Resolve the image tag from SSM (set by build-one.sh just before
 # this script runs).
-IMAGE_TAG="$(aws ssm get-parameter \
+# The image-uri SSM holds the FULL ECR URI (registry/repo:tag) per the
+# platform-as-bootstrap design — the CDK construct reads the same value
+# directly into the Lambda's Code.ImageUri at deploy time, and CFN's
+# regex validation rejects bare tags. build-one.sh is the canonical writer.
+NEW_IMAGE_URI="$(aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$IMAGE_URI_SSM" \
     --query 'Parameter.Value' \
     --output text)"
-NEW_IMAGE_URI="${ECR_REPO_URI}:${IMAGE_TAG}"
+
+# Sanity-check that the SSM value is a real ECR URI, not a stale tag-only
+# legacy value left over from a pre-platform-as-bootstrap deploy. The
+# platform deploy's seed script repairs these, but we'd rather fail loud
+# here than send AWS a bogus image URI.
+ECR_URI_REGEX='^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*[:@][^[:space:]]+$'
+if [[ ! "$NEW_IMAGE_URI" =~ $ECR_URI_REGEX ]]; then
+    log "SSM ${IMAGE_URI_SSM} = '${NEW_IMAGE_URI}' is not a valid ECR URI."
+    log "build-one.sh should have written REGISTRY/REPO:TAG. Re-run the build job, or run the platform deploy to re-seed the parameter."
+    exit 6
+fi
+if [[ "$NEW_IMAGE_URI" != "${ECR_REPO_URI}:"* && "$NEW_IMAGE_URI" != "${ECR_REPO_URI}@"* ]]; then
+    log "WARNING: SSM URI '${NEW_IMAGE_URI}' does not reference --ecr-repo-uri '${ECR_REPO_URI}'. Proceeding anyway."
+fi
+
+# Derive the tag for logging / GITHUB_OUTPUT echoing. Splits on the
+# rightmost ':' or '@' so digest-pinned URIs work too.
+if [[ "$NEW_IMAGE_URI" == *@* ]]; then
+    IMAGE_TAG="${NEW_IMAGE_URI##*@}"
+else
+    IMAGE_TAG="${NEW_IMAGE_URI##*:}"
+fi
 log "Target image URI: $NEW_IMAGE_URI"
 
 # 2. Resolve the function name (CDK-auto-generated).


### PR DESCRIPTION
Two follow-ups to PR #420 that landed too late to make the merge.

## 1. Missing SSM publications for the restore tool (commit `790515df`)

`scripts/restore-data/restore.py` looks up every backed-up DynamoDB table, S3 bucket, Cognito user pool, and AgentCore Memory ID via SSM under `/{prefix}/`. After PR #396's SSM cleanup, only ~12 of the ~26 paths it needs were still being published, so a fresh PlatformStack deploy made restore fail with `ParameterNotFound` on the first table lookup.

Added the missing publications inside the constructs that own each resource:

| Category | Paths added |
|---|---|
| Tables (17) | `/users/users-table-name`, `/auth/api-keys-table-name`, `/auth/auth-providers-table-name`, `/oauth/providers-table-name`, `/oauth/user-tokens-table-name`, `/quota/quota-events-table-name`, `/cost-tracking/sessions-metadata-table-name`, `/cost-tracking/user-cost-summary-table-name`, `/cost-tracking/system-cost-rollup-table-name`, `/admin/user-menu-links-table-name`, `/settings/user-settings-table-name`, `/user-file-uploads/table-name`, `/shares/shared-conversations-table-name`, `/rag/assistants-table-name`, `/artifacts/table-name`, `/fine-tuning/jobs-table-name`, `/fine-tuning/access-table-name` |
| Buckets (4) | `/user-file-uploads/bucket-name`, `/rag/documents-bucket-name`, `/artifacts/bucket-name`, `/fine-tuning/data-bucket-name` |
| AgentCore (1) | `/inference-api/memory-id` |

The restore tool's `TABLE_SSM_MAP` / `BUCKET_SSM_MAP` / `SSM_USER_POOL_ID` / `SSM_MEMORY_ID` maps stay unchanged — they were already pointing at these paths; the platform was just no longer publishing them.

`platform-stack.test.ts` updated: SSM-count ceiling raised from `<=20` to `<=45` with comment calling out the restore-tooling consumers.

## 2. SSM-as-full-URI contract drift in `deploy-image-lambda-if-changed.sh` (commit `ad515db8`)

Same bug PR #420 fixed in `deploy-runtime-image-if-changed.sh` and `deploy-ecs-service-if-changed.sh`. I missed the lambda variant, which produced a doubled-up URI on rag-ingestion deploys:

```
[rag-ingestion] Target image URI: 490617140655.dkr.ecr.us-west-2.amazonaws.com/dev-boisestateai-v2-rag-ingestion:490617140655.dkr.ecr.us-west-2.amazonaws.com/dev-boisestateai-v2-rag-ingestion:75462b620b19153d

Error: An error occurred (InvalidParameterValueException) when calling
the UpdateFunctionCode operation: Source image ... is not valid.
```

Read SSM as a full URI directly; validate with the ECR URI regex; fail loud (exit 6) on stale tag-only legacy values; derive the tag for logging by splitting on the rightmost `:` or `@` so digest-pinned URIs work too.

## Tests

`npx jest --maxWorkers=2` — 376 / 376 pass (verified before PR #420 was merged; same scope here).
`bash -n` clean on the patched lambda deploy script.

## Deploy order

1. Merge this PR.
2. Run `platform.yml` to publish the new SSM params.
3. Run `backend.yml` — the rag-ingestion lambda deploy step will now point at the correct image URI.
4. Run `restore-data.yml`.