### PR TITLE
fix(restore): base64-decode B/BS values before TypeDeserializer

### DIFF
--- a/scripts/restore-data/restore.py
+++ b/scripts/restore-data/restore.py
@@ -35,6 +35,7 @@ bucket names from SSM.
 from __future__ import annotations
 
 import argparse
+import base64
 import gzip
 import hashlib
 import io
@@ -314,10 +315,43 @@ def restore_dynamodb_table(ctx: RestoreContext, logical_name: str, component: di
     }
 
 
+def _decode_binary_values(value: Any) -> Any:
+    """Recursively convert DynamoDB-JSON binary attribute values from
+    base64-encoded strings to raw bytes, in place.
+
+    AWS's DynamoDB Export-to-S3 feature serializes binary attributes
+    (the ``B`` and ``BS`` types) as base64-encoded strings on disk.
+    boto3's :class:`TypeDeserializer`, however, expects ``B`` to already
+    be ``bytes``/``bytearray`` (because the live DynamoDB API path
+    base64-decodes the wire payload before the deserializer sees it).
+    Feeding it the raw base64 string raises::
+
+        TypeError: Value must be of the following types: <class 'bytearray'>, <class 'bytes'>
+
+    This helper walks an attribute-value tree (DynamoDB-JSON shape:
+    ``{"<type>": <value>}``) and decodes any ``B``/``BS`` strings into
+    bytes before deserialization. It also recurses into ``L`` and ``M``
+    so nested binary values inside lists/maps are handled.
+    """
+    if not isinstance(value, dict) or len(value) != 1:
+        return value
+    type_key = next(iter(value))
+    type_val = value[type_key]
+    if type_key == "B" and isinstance(type_val, str):
+        return {"B": base64.b64decode(type_val)}
+    if type_key == "BS" and isinstance(type_val, list):
+        return {"BS": [base64.b64decode(s) if isinstance(s, str) else s for s in type_val]}
+    if type_key == "L" and isinstance(type_val, list):
+        return {"L": [_decode_binary_values(v) for v in type_val]}
+    if type_key == "M" and isinstance(type_val, dict):
+        return {"M": {k: _decode_binary_values(v) for k, v in type_val.items()}}
+    return value
+
+
 def _deserialize_dynamodb_json(item: dict) -> dict:
     """Convert DynamoDB-JSON (typed attribute values) to plain Python dict."""
     deserializer = TypeDeserializer()
-    return {k: deserializer.deserialize(v) for k, v in item.items()}
+    return {k: deserializer.deserialize(_decode_binary_values(v)) for k, v in item.items()}
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/restore-data/test_restore.py
+++ b/scripts/restore-data/test_restore.py
@@ -1078,3 +1078,91 @@ def test_memory_replay_missing_events_file_skips_cleanly():
         results = restore.restore_agentcore_memory(ctx)
     assert results[0]["status"] == "skipped"
     assert "no events backup file" in results[0]["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# DynamoDB-JSON binary-attribute decoding                                      #
+# --------------------------------------------------------------------------- #
+def test_deserialize_dynamodb_json_decodes_binary_top_level():
+    """B-typed values arrive in the export as base64 strings. The
+    deserializer must decode them to bytes before handing the item to
+    boto3's TypeDeserializer (which raises TypeError on raw strings)."""
+    import base64
+    from boto3.dynamodb.types import Binary
+    payload = b"\x00\x01\x02\x03"
+    item = {
+        "PK": {"S": "SESSION#abc"},
+        "blob": {"B": base64.b64encode(payload).decode("ascii")},
+    }
+    result = restore._deserialize_dynamodb_json(item)
+    assert result["PK"] == "SESSION#abc"
+    assert result["blob"] == Binary(payload)
+
+
+def test_deserialize_dynamodb_json_decodes_binary_set():
+    """BS-typed values are lists of base64 strings; each member must be
+    decoded individually."""
+    import base64
+    parts = [b"\x10\x20", b"\x30\x40"]
+    item = {
+        "PK": {"S": "x"},
+        "blobs": {"BS": [base64.b64encode(p).decode("ascii") for p in parts]},
+    }
+    result = restore._deserialize_dynamodb_json(item)
+    assert {bytes(b) for b in result["blobs"]} == {bytes(p) for p in parts}
+
+
+def test_deserialize_dynamodb_json_decodes_nested_binary_in_map():
+    """Binary attributes nested inside an M (map) must be decoded too —
+    that's how DynamoDB exports represent struct-shaped fields like
+    `payload: {hash: <bytes>, body: <str>}`."""
+    import base64
+    from boto3.dynamodb.types import Binary
+    payload = b"\xde\xad\xbe\xef"
+    item = {
+        "PK": {"S": "x"},
+        "envelope": {"M": {
+            "hash": {"B": base64.b64encode(payload).decode("ascii")},
+            "label": {"S": "test"},
+        }},
+    }
+    result = restore._deserialize_dynamodb_json(item)
+    assert result["envelope"]["hash"] == Binary(payload)
+    assert result["envelope"]["label"] == "test"
+
+
+def test_deserialize_dynamodb_json_decodes_nested_binary_in_list():
+    """Binary attributes nested inside an L (list) must be decoded too."""
+    import base64
+    from boto3.dynamodb.types import Binary
+    payload = b"\xff\xfe"
+    item = {
+        "PK": {"S": "x"},
+        "items": {"L": [
+            {"B": base64.b64encode(payload).decode("ascii")},
+            {"S": "after"},
+        ]},
+    }
+    result = restore._deserialize_dynamodb_json(item)
+    assert result["items"][0] == Binary(payload)
+    assert result["items"][1] == "after"
+
+
+def test_deserialize_dynamodb_json_passes_through_non_binary_unchanged():
+    """The decoder must not alter S/N/BOOL/NULL/SS/NS values."""
+    item = {
+        "name":   {"S": "alice"},
+        "count":  {"N": "42"},
+        "active": {"BOOL": True},
+        "missing": {"NULL": True},
+        "tags":   {"SS": ["a", "b"]},
+        "scores": {"NS": ["1", "2"]},
+    }
+    result = restore._deserialize_dynamodb_json(item)
+    from decimal import Decimal
+    assert result["name"] == "alice"
+    assert result["count"] == Decimal("42")
+    assert result["active"] is True
+    assert result["missing"] is None
+    assert result["tags"] == {"a", "b"}
+    assert result["scores"] == {Decimal("1"), Decimal("2")}


### PR DESCRIPTION
## Summary

The restore tool crashed partway through the `sessions-metadata` table:

```
File ".../boto3/dynamodb/types.py", line 295, in _deserialize_b
    return Binary(value)
File ".../boto3/dynamodb/types.py", line 59, in __init__
    raise TypeError(f'Value must be of the following types: {types}')
TypeError: Value must be of the following types: <class 'bytearray'>, <class 'bytes'>
```

Every table after `sessions-metadata`, plus all S3 buckets and AgentCore Memory events, was skipped.

## Root cause

DynamoDB's Export-to-S3 feature serializes binary attributes (`B` and `BS` types) as **base64-encoded strings** on disk. boto3's `TypeDeserializer` expects `B` to already be `bytes` / `bytearray` because the live DynamoDB API path base64-decodes the wire payload before the deserializer sees it. Feeding it the raw base64 string raises `TypeError`.

The previous `_deserialize_dynamodb_json` did:

```python
return {k: deserializer.deserialize(v) for k, v in item.items()}
```

…with no preprocessing.

## Fix

Add `_decode_binary_values()` that walks an attribute-value tree and decodes any `B` / `BS` base64 strings to bytes before deserialization. Recurses into `L` and `M` so binary fields nested inside DynamoDB documents are handled. Other types (`S`/`N`/`BOOL`/`NULL`/`SS`/`NS`) are left untouched.

## Tests

5 new pytest cases:
- Top-level `B` value
- Top-level `BS` (binary set)
- `B` nested inside an `M` (map) — common for struct-shaped fields
- `B` nested inside an `L` (list)
- Non-binary types (`S`, `N`, `BOOL`, `NULL`, `SS`, `NS`) untouched

`uv run pytest test_restore.py -v` — **33 / 33 pass** (5 new + 28 existing).

## Deploy

This is a script-only change. After this PR merges, re-run `restore-data.yml` against the same backup manifest. The restore is idempotent (DynamoDB conditional writes, S3 sync naturally idempotent, Cognito IdPs/clients checked before creation, users use AdminCreateUser with MessageAction=SUPPRESS) so re-running picks up where it left off.