### PR TITLE
fix(restore): bump boto3 max_pool_connections + rename 'Backend Stack' workflow to 'Backend Deploy'

### DIFF
--- a/.github/docs/deploy/upgrade-from-multi-stack.md
+++ b/.github/docs/deploy/upgrade-from-multi-stack.md
@@ -173,8 +173,8 @@ With the old stacks gone and retained resources cleaned up, deploy the new singl
 
 This provisions all infrastructure in a single `PlatformStack` — VPC, ALB, DynamoDB tables, S3 buckets, Cognito, CloudFront, AgentCore, ECS, Lambdas, everything.
 
-4. After Platform succeeds, run **Backend Stack** to build and deploy application code:
-   - Go to **Actions** → **Backend Stack** → **Run workflow**
+4. After Platform succeeds, run **Backend Deploy** to build and deploy application code:
+   - Go to **Actions** → **Backend Deploy** → **Run workflow**
    - This builds Docker images, pushes to ECR, and updates ECS/Lambda/Runtime
 
 5. Run **Frontend Deploy** to deploy the Angular SPA:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,4 +1,4 @@
-name: Backend Stack
+name: Backend Deploy
 
 on:
   workflow_dispatch:

--- a/scripts/restore-data/restore.py
+++ b/scripts/restore-data/restore.py
@@ -64,6 +64,16 @@ LOG = logging.getLogger("restore")
 BOTO_CONFIG = BotoConfig(
     retries={"max_attempts": 10, "mode": "adaptive"},
     user_agent_extra="agentcore-restore/1.0",
+    # urllib3's default connection pool size is 10. The restore tool runs
+    # S3 copies and AgentCore Memory replays through a ThreadPoolExecutor
+    # with max_workers=16, so the default cap was forcing every request
+    # past the 10th to open a fresh TCP+TLS connection and discard it
+    # afterwards (the urllib3 "Connection pool is full, discarding
+    # connection" warnings). No data was lost — every request still
+    # completed — but the lack of connection reuse hurts throughput.
+    # Bump comfortably above max_workers so multi-call operations
+    # (e.g. CopyObject + tag fetch) and any side clients also fit.
+    max_pool_connections=32,
 )
 
 # Maps backup logical names → SSM parameter paths for the target table names.

--- a/scripts/restore-data/test_restore.py
+++ b/scripts/restore-data/test_restore.py
@@ -1166,3 +1166,19 @@ def test_deserialize_dynamodb_json_passes_through_non_binary_unchanged():
     assert result["missing"] is None
     assert result["tags"] == {"a", "b"}
     assert result["scores"] == {Decimal("1"), Decimal("2")}
+
+
+def test_boto_config_pool_size_covers_thread_workers():
+    """The BOTO_CONFIG max_pool_connections must be >= the
+    ThreadPoolExecutor worker count used by the S3 and Memory restore
+    paths; otherwise urllib3 emits "Connection pool is full, discarding
+    connection" warnings under load (no data loss but lots of wasted
+    TLS handshakes). Pinned here so a future BOTO_CONFIG edit doesn't
+    silently regress."""
+    pool_size = restore.BOTO_CONFIG.max_pool_connections
+    assert pool_size is not None
+    # The S3 copy and Memory replay paths both use max_workers=16.
+    assert pool_size >= 16, (
+        f"BOTO_CONFIG.max_pool_connections={pool_size} is below the "
+        f"ThreadPoolExecutor max_workers=16 used by S3 / Memory restore."
+    )


### PR DESCRIPTION
Two small unrelated cleanups on one branch.

## 1. `fix(restore)`: bump `max_pool_connections` to cover thread workers (commit `9dcb2f2c`)

### Symptom

Re-running the restore against a real backup produced repeating warnings:

```
[WARNING] urllib3.connectionpool: Connection pool is full, discarding
connection: dev-boisestateai-v2-artifacts-content.s3.us-west-2.amazonaws.com.
Connection pool size: 10
```

…across every S3 bucket and the AgentCore Memory replay.

### Diagnosis

**No data loss** — every request still completed. urllib3 was opening a fresh TCP+TLS connection for each over-the-cap request, using it once, and discarding it instead of caching it back.

The restore script's S3 copy (`restore_s3_bucket`) and AgentCore Memory replay (`restore_agentcore_memory`) both use `ThreadPoolExecutor(max_workers=16)`. `BOTO_CONFIG` was using urllib3's default `max_pool_connections=10`, so anything past the 10th concurrent request to the same host got the discard treatment.

### Fix

Set `max_pool_connections=32` on the shared `BOTO_CONFIG`. Comfortable headroom over `max_workers=16` for multi-call operations (e.g. CopyObject + tag fetch) and any side clients sharing the pool.

Added a unit test that pins `max_pool_connections >= 16` so a future `BOTO_CONFIG` edit doesn't silently regress and bring the warnings back.

`uv run pytest test_restore.py -q` — **34 / 34 pass**.

## 2. `chore(workflows)`: rename `Backend Stack` → `Backend Deploy` (commit `fcbbcefd`)

After PR #396's platform-as-bootstrap refactor, the workflow only does API-driven code deploys (ECR push → ECS service update / Lambda update-function-code / AgentCore Runtime update). No CFN involved — `Backend Stack` was a holdover from the pre-#396 per-service-stack architecture.

`Backend Deploy` matches what the workflow actually does and reads more clearly in the Actions sidebar alongside `Platform Stack` (CDK) and `Frontend Deploy` (S3 + CloudFront). Also updated the one stale reference in `upgrade-from-multi-stack.md`.

(The CDK construct `BackendStack` TypeScript class — referenced in `infrastructure/lib/constructs/README.md` — is unchanged; that's a different thing.)

## Deploy

Both changes are no-deploy. The renamed workflow keeps the same filename (`backend.yml`) so any branch protection rules / required-checks that key off the filename are unaffected; only the displayed name in the Actions UI changes.