### PR TITLE
fix(restore): wire restored IdPs into Cognito app client SupportedIdentityProviders

### DIFF
--- a/scripts/restore-data/restore.py
+++ b/scripts/restore-data/restore.py
@@ -482,6 +482,7 @@ def restore_cognito(ctx: RestoreContext) -> list[dict]:
     # this restore code iterated the top-level dict directly, which
     # yielded the dict KEYS (strings) and triggered
     # `'str' object has no attribute 'get'`. Read the wrapped list.
+    idps: list[dict] = []  # populated below; referenced by app-client wiring
     try:
         idp_obj = s3.get_object(Bucket=ctx.backup_bucket, Key=f"{root}cognito/identity-providers.json")
         idp_blob = json.loads(idp_obj["Body"].read())
@@ -516,17 +517,85 @@ def restore_cognito(ctx: RestoreContext) -> list[dict]:
     # --- App Clients ---
     # Same wrapper-list shape as identity-providers — backup writes
     # {"clients": [...]}. See scripts/backup-data/backup.py:507.
+    #
+    # The app client is CDK-managed and already exists by the time
+    # restore runs. However, CDK creates it BEFORE IdPs are restored,
+    # so its SupportedIdentityProviders list only contains "COGNITO".
+    # Cognito's hosted UI will not show a login button for any IdP
+    # not in that list, producing the "Login option is not available"
+    # error immediately after a restore.
+    #
+    # Fix: after IdPs are created above, call update_user_pool_client
+    # for every CDK-managed client to add the restored provider names
+    # to SupportedIdentityProviders. We do a describe-first to avoid
+    # overwriting any other settings CDK has on the client.
+    restored_idp_names: list[str] = [
+        idp.get("ProviderName") for idp in idps
+        if idp.get("ProviderName")
+    ]
     try:
         clients_obj = s3.get_object(Bucket=ctx.backup_bucket, Key=f"{root}cognito/app-clients.json")
         clients_blob = json.loads(clients_obj["Body"].read())
         clients = clients_blob.get("clients", []) if isinstance(clients_blob, dict) else clients_blob
+        updated_clients = 0
         for client in clients:
             client_name = client.get("ClientName")
-            LOG.info(f"[Cognito] Noting app client: {client_name} (CDK manages creation; secrets preserved for reference)")
+            LOG.info(f"[Cognito] Noting app client: {client_name} (CDK manages creation; re-wiring IdP providers)")
+            if not restored_idp_names or ctx.dry_run:
+                continue
+            # Find the live CDK-created client by name.
+            live_client_id = None
+            paginator = cognito.get_paginator("list_user_pool_clients")
+            for page in paginator.paginate(UserPoolId=target_pool_id, MaxResults=60):
+                for c in page.get("UserPoolClients", []):
+                    if c["ClientName"] == client_name:
+                        live_client_id = c["ClientId"]
+                        break
+                if live_client_id:
+                    break
+            if not live_client_id:
+                LOG.warning(f"[Cognito] App client '{client_name}' not found in target pool — skipping IdP re-wire")
+                continue
+            # Describe the live client so we can patch SupportedIdentityProviders
+            # without clobbering any other CDK-managed settings.
+            live = cognito.describe_user_pool_client(
+                UserPoolId=target_pool_id, ClientId=live_client_id
+            )["UserPoolClient"]
+            current_idps: list[str] = live.get("SupportedIdentityProviders", [])
+            missing = [n for n in restored_idp_names if n not in current_idps]
+            if not missing:
+                LOG.info(f"[Cognito] App client '{client_name}' already has all restored IdPs — skipping")
+                continue
+            merged = list(current_idps) + missing
+            LOG.info(f"[Cognito] Updating app client '{client_name}': adding IdPs {missing}")
+            # update_user_pool_client requires re-sending the full set of
+            # mutable fields; omitting optional fields that are absent on
+            # the live client to avoid sending empty lists/dicts that
+            # override CDK's configured values.
+            update_kwargs: dict[str, Any] = {
+                "UserPoolId": target_pool_id,
+                "ClientId": live_client_id,
+                "SupportedIdentityProviders": merged,
+            }
+            for field in (
+                "RefreshTokenValidity", "AccessTokenValidity", "IdTokenValidity",
+                "TokenValidityUnits", "ReadAttributes", "WriteAttributes",
+                "ExplicitAuthFlows", "CallbackURLs", "LogoutURLs",
+                "AllowedOAuthFlows", "AllowedOAuthScopes",
+                "AllowedOAuthFlowsUserPoolClient", "AnalyticsConfiguration",
+                "PreventUserExistenceErrors", "EnableTokenRevocation",
+                "EnablePropagateAdditionalUserContextData", "AuthSessionValidity",
+            ):
+                val = live.get(field)
+                if val is not None:
+                    update_kwargs[field] = val
+            cognito.update_user_pool_client(**update_kwargs)
+            updated_clients += 1
         results.append({"component": "cognito-clients", "status": "ok", "count": len(clients),
-                       "note": "App clients are CDK-managed; backup preserves secrets for manual re-registration if needed"})
-    except ClientError:
-        results.append({"component": "cognito-clients", "status": "skipped"})
+                       "updated_idp_wiring": updated_clients})
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            results.append({"component": "cognito-clients", "status": "skipped"})
 
     # --- Users ---
     # This is the load-bearing section for the cross-pool migration.

--- a/scripts/restore-data/test_restore.py
+++ b/scripts/restore-data/test_restore.py
@@ -1166,3 +1166,139 @@ def test_deserialize_dynamodb_json_passes_through_non_binary_unchanged():
     assert result["missing"] is None
     assert result["tags"] == {"a", "b"}
     assert result["scores"] == {Decimal("1"), Decimal("2")}
+
+
+# --------------------------------------------------------------------------- #
+# Cognito IdP → app-client wiring                                              #
+# --------------------------------------------------------------------------- #
+def test_cognito_restore_wires_idps_into_app_client():
+    """After restoring an IdP, the restore must call update_user_pool_client
+    to add the provider to SupportedIdentityProviders on every CDK-managed
+    app client. Without this step, Cognito's hosted UI shows
+    'Login option is not available' immediately after a restore."""
+    import io as _io, json as _json
+
+    # --- Build fake S3 responses ---
+    idp_json = _json.dumps({"providers": [
+        {"ProviderName": "ms-entra-id", "ProviderType": "OIDC",
+         "ProviderDetails": {"client_id": "abc", "oidc_issuer": "https://issuer", "client_secret": "s"},
+         "AttributeMapping": {}, "IdpIdentifiers": []}
+    ]}).encode()
+    client_json = _json.dumps({"clients": [
+        {"ClientId": "old-client-id", "ClientName": "my-prefix-bff-app-client"}
+    ]}).encode()
+    users_gz = gzip.compress(b"")
+
+    def s3_get(Bucket, Key):
+        m = {
+            "root/cognito/identity-providers.json": {"Body": _io.BytesIO(idp_json)},
+            "root/cognito/app-clients.json":        {"Body": _io.BytesIO(client_json)},
+            "root/cognito/users.jsonl.gz":          {"Body": _io.BytesIO(users_gz)},
+        }
+        if Key not in m:
+            from botocore.exceptions import ClientError as _CE
+            raise _CE({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return m[Key]
+
+    s3 = MagicMock()
+    s3.get_object.side_effect = s3_get
+
+    # Cognito mock: create_identity_provider succeeds, list returns
+    # the CDK-managed app client with only COGNITO in SupportedIdPs,
+    # describe returns a minimal but plausible client spec.
+    cognito = MagicMock()
+    cognito.create_identity_provider.return_value = {}
+    cognito.get_paginator.return_value.paginate.return_value = iter([{
+        "UserPoolClients": [{"ClientId": "live-client-id", "ClientName": "my-prefix-bff-app-client"}]
+    }])
+    cognito.describe_user_pool_client.return_value = {"UserPoolClient": {
+        "UserPoolId": "us-west-2_POOL",
+        "ClientId": "live-client-id",
+        "ClientName": "my-prefix-bff-app-client",
+        "SupportedIdentityProviders": ["COGNITO"],
+        "AllowedOAuthFlows": ["code"],
+        "AllowedOAuthScopes": ["openid"],
+        "AllowedOAuthFlowsUserPoolClient": True,
+        "CallbackURLs": ["https://example.com/callback"],
+        "ExplicitAuthFlows": ["ALLOW_REFRESH_TOKEN_AUTH"],
+    }}
+    cognito.update_user_pool_client.return_value = {}
+    # Users path
+    cognito.list_users.return_value = {"Users": []}
+    cognito.list_groups.return_value = {"Groups": []}
+
+    def client_factory(name, **_kw):
+        return s3 if name == "s3" else cognito
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    with patch.object(restore, "get_ssm_param", return_value="us-west-2_POOL"):
+        restore.restore_cognito(ctx)
+
+    # The critical assertion: update_user_pool_client must be called
+    # with the restored IdP in SupportedIdentityProviders.
+    cognito.update_user_pool_client.assert_called_once()
+    call_kwargs = cognito.update_user_pool_client.call_args.kwargs
+    assert "ms-entra-id" in call_kwargs["SupportedIdentityProviders"]
+    assert "COGNITO" in call_kwargs["SupportedIdentityProviders"]
+
+
+def test_cognito_restore_skips_idp_wiring_when_already_present():
+    """If the app client already has the IdP in SupportedIdentityProviders
+    (e.g. on a re-run), update_user_pool_client must NOT be called."""
+    import io as _io, json as _json
+
+    idp_json = _json.dumps({"providers": [
+        {"ProviderName": "ms-entra-id", "ProviderType": "OIDC",
+         "ProviderDetails": {"client_id": "abc", "oidc_issuer": "https://issuer", "client_secret": "s"},
+         "AttributeMapping": {}, "IdpIdentifiers": []}
+    ]}).encode()
+    client_json = _json.dumps({"clients": [
+        {"ClientId": "old-id", "ClientName": "my-prefix-bff-app-client"}
+    ]}).encode()
+    users_gz = gzip.compress(b"")
+
+    def s3_get(Bucket, Key):
+        m = {
+            "root/cognito/identity-providers.json": {"Body": _io.BytesIO(idp_json)},
+            "root/cognito/app-clients.json":        {"Body": _io.BytesIO(client_json)},
+            "root/cognito/users.jsonl.gz":          {"Body": _io.BytesIO(users_gz)},
+        }
+        if Key not in m:
+            from botocore.exceptions import ClientError as _CE
+            raise _CE({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return m[Key]
+
+    s3 = MagicMock()
+    s3.get_object.side_effect = s3_get
+    cognito = MagicMock()
+    cognito.create_identity_provider.side_effect = Exception("DuplicateProviderException")
+    cognito.get_paginator.return_value.paginate.return_value = iter([{
+        "UserPoolClients": [{"ClientId": "live-id", "ClientName": "my-prefix-bff-app-client"}]
+    }])
+    cognito.describe_user_pool_client.return_value = {"UserPoolClient": {
+        "UserPoolId": "us-west-2_POOL",
+        "ClientId": "live-id",
+        "SupportedIdentityProviders": ["COGNITO", "ms-entra-id"],  # already wired
+        "AllowedOAuthFlows": ["code"],
+        "AllowedOAuthScopes": ["openid"],
+        "AllowedOAuthFlowsUserPoolClient": True,
+        "ExplicitAuthFlows": ["ALLOW_REFRESH_TOKEN_AUTH"],
+    }}
+    cognito.list_users.return_value = {"Users": []}
+    cognito.list_groups.return_value = {"Groups": []}
+
+    def client_factory(name, **_kw):
+        return s3 if name == "s3" else cognito
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    with patch.object(restore, "get_ssm_param", return_value="us-west-2_POOL"):
+        try:
+            restore.restore_cognito(ctx)
+        except Exception:
+            pass  # create_identity_provider intentionally raises above
+
+    cognito.update_user_pool_client.assert_not_called()


### PR DESCRIPTION
## Symptom

After a successful restore cycle, Cognito's hosted UI showed:

> An error was encountered with the requested page. Login option is not available. Please try another one.

## Root cause

CDK provisions the BFF app client during `platform.yml` before any IdPs exist. It creates the client with `SupportedIdentityProviders: ["COGNITO"]`. `restore.py` then restores the IdP (`ms-entra-id`) but only "noted" the app client — it never called `update_user_pool_client`, so the provider list stayed `["COGNITO"]` and the hosted UI had nothing to show.

## Fix

After creating IdPs, the app-client section now:
1. Finds the live CDK-managed client by name via `list_user_pool_clients`
2. Reads its current config via `describe_user_pool_client` (non-destructive)
3. Calls `update_user_pool_client` with the merged provider list
4. Skips if the provider is already in the list (idempotent on re-runs)

## Immediate workaround (already applied)

```bash
aws --profile dev-ai --region us-west-2 cognito-idp update-user-pool-client \
  --user-pool-id us-west-2_4plbXIzA2 \
  --client-id 5r82k1v0th46h9ug1jm0mbt26l \
  --supported-identity-providers "COGNITO" "ms-entra-id" ...
```

Login is working again. This PR makes it automatic on every future restore.

## Tests

2 new pytest cases:
- `test_cognito_restore_wires_idps_into_app_client` — verifies `update_user_pool_client` is called with the restored IdP after a first-time restore
- `test_cognito_restore_skips_idp_wiring_when_already_present` — verifies no update is made on re-run when the IdP is already in the list

`uv run pytest test_restore.py -q` — **35 / 35 pass**.

## Deploy

Script-only change. No AWS re-deploy needed. Just merge and the next `restore-data.yml` run will wire the IdPs automatically.