### PR TITLE
feat(infra): grant AgentCore runtime role bedrock:CountTokens

### DIFF
--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -68,10 +68,17 @@ export function createRuntimeExecutionRole(
   }));
 
   // ── Bedrock model invocation ──
+  // CountTokens powers per-turn context attribution: Strands' native token
+  // counting (use_native_token_count) calls Bedrock's CountTokens API, which
+  // is the only way to decompose the otherwise-aggregate inputTokens into
+  // system / tools / messages partitions. It acts on the foundation-model
+  // resource, already covered below. Without this action a flipped native
+  // flag AccessDenies and caches the model into the no-count skip list for
+  // the process lifetime.
   role.addToPolicy(new iam.PolicyStatement({
     sid: 'BedrockModelInvocation',
     effect: iam.Effect.ALLOW,
-    actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+    actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream', 'bedrock:CountTokens'],
     resources: [`arn:aws:bedrock:*::foundation-model/*`, `arn:aws:bedrock:${config.awsRegion}:${config.awsAccount}:*`],
   }));
 

--- a/infrastructure/test/integration.test.ts
+++ b/infrastructure/test/integration.test.ts
@@ -5,7 +5,7 @@
  * in exactly one stack.
  */
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { PlatformStack } from '../lib/platform-stack';
 import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
 
@@ -63,6 +63,28 @@ describe('Single-stack integration', () => {
 
     it('creates the AgentCore Runtime', () => {
       template.resourceCountIs('AWS::BedrockAgentCore::Runtime', 1);
+    });
+
+    it('grants the AgentCore runtime role bedrock:CountTokens for context attribution', () => {
+      // CountTokens is the foundation of per-turn context attribution —
+      // Strands' native token counting decomposes the otherwise-aggregate
+      // inputTokens into system / tools / messages partitions via this API.
+      // The action lives in the BedrockModelInvocation statement alongside
+      // the invoke actions and reuses its foundation-model resource scope.
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'BedrockModelInvocation',
+              Action: [
+                'bedrock:InvokeModel',
+                'bedrock:InvokeModelWithResponseStream',
+                'bedrock:CountTokens',
+              ],
+            }),
+          ]),
+        },
+      });
     });
 
     it('creates the AgentCore Memory + CI + Browser + Gateway', () => {


### PR DESCRIPTION
## What

Adds `bedrock:CountTokens` to the `BedrockModelInvocation` statement on the AgentCore runtime execution role ([inference-api-iam-roles.ts](infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts)).

This is **PR 1 of 4** in the context-attribution foundation (IAM → native-count flag → backend hook + SSE → frontend badge).

## Why

Bedrock Converse only returns an **aggregate** `inputTokens`. The only way to decompose it into *system prompt / tool schemas / message history* partitions is the differential from Bedrock's native **CountTokens** API. Strands calls it via `agent.model.count_tokens()` when `use_native_token_count` is enabled (PR 2).

Without this IAM grant, flipping that flag would `AccessDenied` on the first count and Strands caches the model into its no-count skip list **for the process lifetime** — a silent, sticky failure. Granting the permission first (zero behavior change) de-risks that.

CountTokens acts on the `foundation-model` resource, which the statement already scopes — no new resource ARN needed.

## Scope / safety

- **Zero behavior change** until PR 2 sets the native flag. This is a pure capability grant.
- Standalone and independently deployable via `platform.yml`.

## Test

Asserted in the single-stack integration test ([integration.test.ts](infrastructure/test/integration.test.ts)) alongside the existing `AWS::BedrockAgentCore::Runtime` check — the integration suite is the one that calls `wireCompute()`, so it's the only place the runtime role is synthesized.

- `npx tsc --noEmit` ✅
- `npx jest integration.test` ✅ (23/23)
- Pre-existing `config.test.ts` failures (9) are unrelated — they reproduce identically on clean `develop` (env-var validation in `loadConfig`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)