### PR TITLE
chore(infra): remove stale compiled test artifacts + stop tsc re-littering

### DIFF
--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -7,6 +7,11 @@
       "es2022"
     ],
     "declaration": true,
+    // The CDK app runs via ts-node (see cdk.json) and tests via ts-jest, so no
+    // emitted .js/.d.ts is ever consumed. noEmit makes `tsc` (npm run build /
+    // watch) a pure type-check and stops it from littering compiled artifacts
+    // next to the .ts sources (CI already type-checks with `tsc --noEmit`).
+    "noEmit": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Why

The #396 single-stack refactor deleted many `infrastructure/test/*.test.ts` sources but left their compiled `*.test.js` + `*.test.d.ts` behind on disk. These artifacts are:

- **git-ignored** (the `.gitignore` already has global `*.js` / `*.d.ts` rules) → they were **never tracked**, and
- **never executed** (`jest.config.js` `testMatch: ['**/*.test.ts']`),

…yet they carry **stale assertions** that mislead anyone grepping the test dir — e.g. `inference-api-stack.test.js` still asserts the AgentCore runtime role's Bedrock actions are only `bedrock:InvokeModel` + `bedrock:InvokeModelWithResponseStream` (now stale after `bedrock:CountTokens` was added).

## What changed

**1. Deleted 28 stale on-disk artifacts under `test/`** — every compiled `*.test.js` / `*.test.d.ts` plus `helpers/mock-config.{js,d.ts}`:

- **12 orphaned base names** (24 files) whose `.ts` source was removed in #396: `app-api-stack`, `cors`, `frontend-stack`, `gateway-stack`, `inference-api-stack`, `infrastructure-stack`, `infrastructure`, `mcp-sandbox-stack`, `rag-ingestion-stack`, `sagemaker-fine-tuning-stack`, `security-best-practices`, `stack-dependencies`.
- **2 still-live base names** (4 files) — compiled output of sources that *do* still exist (`config.test.ts`, `helpers/mock-config.ts`); their `.js`/`.d.ts` are equally stale litter.

Because these files were **untracked + git-ignored**, the deletion does not appear in this PR's diff — `git rm` did not apply (the task's assumption that they were tracked turned out false). They were cleaned off the working tree directly.

**2. Root-cause fix — `tsconfig.json` `"noEmit": true`** (the only tracked change). `tsconfig` previously had neither `noEmit` nor `outDir`, so `tsc` (`npm run build` / `npm run watch`) emits `.js`/`.d.ts` next to every `.ts` source. The CDK app runs via **ts-node** (`cdk.json`) and tests via **ts-jest**, so that emitted output is never consumed — `noEmit` makes `tsc` a pure type-check and stops it from re-littering the tree.

**3. `.gitignore` — no change needed.** Its existing global `*.js` / `*.d.ts` rules are strictly broader than the `test/**/*.js` the cleanup brief proposed and already block these artifacts from being re-tracked (verified with `git check-ignore`).

## Verification

- `npx tsc --noEmit` → exit 0 (and emits nothing).
- `npx jest --maxWorkers=2` → **14 suites / 367 tests pass**. The **9 failing tests are all pre-existing** `config.test.ts` `loadConfig` env-var-validation failures on `develop`, unrelated to this cleanup and intentionally left as-is.
- Confirmed neither command re-created any compiled artifacts under `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)