### PR TITLE
feat(agents): native Bedrock CountTokens for context attribution (inference-profile aware)

### DIFF
--- a/backend/src/agents/main_agent/core/agent_factory.py
+++ b/backend/src/agents/main_agent/core/agent_factory.py
@@ -9,6 +9,7 @@ from strands.models import BedrockModel
 from strands.models.openai import OpenAIModel
 from strands.models.gemini import GeminiModel
 from strands.tools.executors import SequentialToolExecutor
+from agents.main_agent.core.bedrock_count_tokens import CountTokensBedrockModel
 from agents.main_agent.core.model_config import ModelConfig, ModelProvider
 from agents.main_agent.config.constants import EnvVars
 
@@ -27,10 +28,11 @@ class AgentFactory:
             model_config: Model configuration
 
         Returns:
-            BedrockModel: Configured Bedrock model
+            BedrockModel: Configured Bedrock model (a ``CountTokensBedrockModel``
+            so native CountTokens works for inference-profile model ids).
         """
         bedrock_config = model_config.to_bedrock_config()
-        return BedrockModel(**bedrock_config)
+        return CountTokensBedrockModel(**bedrock_config)
 
     @staticmethod
     def _create_openai_model(model_config: ModelConfig) -> OpenAIModel:

--- a/backend/src/agents/main_agent/core/bedrock_count_tokens.py
+++ b/backend/src/agents/main_agent/core/bedrock_count_tokens.py
@@ -1,0 +1,80 @@
+"""BedrockModel variant that makes native token counting work for our models.
+
+Bedrock's CountTokens API rejects cross-region inference-profile model ids
+(``us.anthropic.…`` / ``eu.…`` / ``apac.…`` / ``us-gov.…``) with a misleading
+``ValidationException: The provided model doesn't support counting tokens.`` —
+even though on-demand invocation of the newer Claude models *requires* the
+inference-profile id. CountTokens only accepts the base foundation-model id
+(``anthropic.…``). The inference profile is pure cross-region routing, so the
+base-id count is exact, not an approximation.
+
+This subclass de-prefixes the model id for the CountTokens call only;
+invocation (``stream`` / ``structured_output``) keeps the profile id untouched.
+Because Strands' per-turn estimate (``_estimate_input_tokens`` →
+``BeforeModelCallEvent.projected_input_tokens``) routes through
+``count_tokens``, making it authoritative improves proactive context-compaction
+decisions in addition to feeding the context-attribution hook — both stop
+relying on the chars/4 heuristic.
+"""
+
+import re
+
+from strands.models import BedrockModel
+from strands.types.content import Messages, SystemContentBlock
+from strands.types.tools import ToolSpec
+
+# Cross-region inference-profile geography prefixes. Closed set per AWS — we
+# only strip these exact codes so a real model id is never mangled.
+_INFERENCE_PROFILE_PREFIX = re.compile(r"^(us|eu|apac|us-gov)\.")
+
+
+def base_foundation_model_id(model_id: str) -> str:
+    """Return the base foundation-model id for ``model_id``.
+
+    Strips a leading cross-region inference-profile prefix (``us.`` / ``eu.`` /
+    ``apac.`` / ``us-gov.``). No-op for ids that are already base ids or that
+    belong to another provider — so it is safe to call unconditionally on the
+    Bedrock path.
+    """
+    return _INFERENCE_PROFILE_PREFIX.sub("", model_id, count=1)
+
+
+class CountTokensBedrockModel(BedrockModel):
+    """``BedrockModel`` that counts tokens against the base foundation-model id.
+
+    See the module docstring for why the inference-profile id can't be used for
+    CountTokens. Everything else (invocation, config, streaming) is inherited
+    unchanged.
+    """
+
+    async def count_tokens(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+    ) -> int:
+        """Count tokens using the de-prefixed base model id.
+
+        The SDK's native path reads ``self.config["model_id"]`` for the
+        CountTokens ``modelId`` arg, so we swap to the base id for the duration
+        of the count and restore it in ``finally``. Token counting and
+        invocation never overlap on a single model instance — the model is
+        per-session and the event loop awaits the estimate before streaming —
+        so the swap window is safe, and the profile id is always restored
+        before any ``stream`` call.
+        """
+        original_id = self.config["model_id"]
+        base_id = base_foundation_model_id(original_id)
+        if base_id == original_id:
+            return await super().count_tokens(
+                messages, tool_specs, system_prompt, system_prompt_content
+            )
+
+        self.config["model_id"] = base_id
+        try:
+            return await super().count_tokens(
+                messages, tool_specs, system_prompt, system_prompt_content
+            )
+        finally:
+            self.config["model_id"] = original_id

--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -287,6 +287,18 @@ class ModelConfig:
             config, self.inference_params, _BEDROCK_PARAM_MAP, "bedrock", self.model_id
         )
 
+        # Native Bedrock CountTokens. With this on, Strands' per-turn estimate
+        # (BeforeModelCallEvent.projected_input_tokens) and agent.model.count_tokens()
+        # return authoritative Bedrock counts instead of the chars/4 heuristic —
+        # the foundation for per-turn context attribution (decomposing the
+        # otherwise-aggregate inputTokens into system / tools / messages via the
+        # CountTokens differential). Every catalog model is Claude family and
+        # supports the API; the runtime-role IAM grant landed in #428. Strands
+        # falls back to the heuristic and caches the skip if a model ever
+        # AccessDenies or doesn't support counting, so this is safe to set
+        # unconditionally on the Bedrock path.
+        config["use_native_token_count"] = True
+
         # Bedrock prompt caching is intentionally deferred. The previous SDK
         # blocker — strands PR #1438, which fixed `cachePoint` blocks landing
         # alongside non-PDF document attachments — is resolved in

--- a/backend/tests/agents/main_agent/core/test_agent_factory.py
+++ b/backend/tests/agents/main_agent/core/test_agent_factory.py
@@ -45,7 +45,7 @@ class TestCreateAgentBedrock:
     """Validates: Requirement 4.1"""
 
     @patch("agents.main_agent.core.agent_factory.Agent")
-    @patch("agents.main_agent.core.agent_factory.BedrockModel")
+    @patch("agents.main_agent.core.agent_factory.CountTokensBedrockModel")
     def test_bedrock_provider_creates_bedrock_model(self, mock_bedrock_cls, mock_agent_cls):
         from agents.main_agent.core.agent_factory import AgentFactory
 
@@ -145,7 +145,7 @@ class TestRetryStrategy:
     """Validates: Requirements 4.6, 4.7"""
 
     @patch("agents.main_agent.core.agent_factory.Agent")
-    @patch("agents.main_agent.core.agent_factory.BedrockModel")
+    @patch("agents.main_agent.core.agent_factory.CountTokensBedrockModel")
     def test_bedrock_with_retry_config_passes_retry_strategy(
         self, mock_bedrock_cls, mock_agent_cls
     ):
@@ -166,7 +166,7 @@ class TestRetryStrategy:
         assert agent_kwargs["retry_strategy"] is not None
 
     @patch("agents.main_agent.core.agent_factory.Agent")
-    @patch("agents.main_agent.core.agent_factory.BedrockModel")
+    @patch("agents.main_agent.core.agent_factory.CountTokensBedrockModel")
     def test_bedrock_without_retry_config_passes_none(self, mock_bedrock_cls, mock_agent_cls):
         """Req 4.7 — no retry_config → retry_strategy is None."""
         from agents.main_agent.core.agent_factory import AgentFactory
@@ -229,7 +229,7 @@ class TestSequentialToolExecutor:
     """Validates: Requirement 4.8"""
 
     @patch("agents.main_agent.core.agent_factory.Agent")
-    @patch("agents.main_agent.core.agent_factory.BedrockModel")
+    @patch("agents.main_agent.core.agent_factory.CountTokensBedrockModel")
     def test_sequential_tool_executor_passed(self, mock_bedrock_cls, mock_agent_cls):
         from agents.main_agent.core.agent_factory import AgentFactory
         from strands.tools.executors import SequentialToolExecutor

--- a/backend/tests/agents/main_agent/core/test_bedrock_count_tokens.py
+++ b/backend/tests/agents/main_agent/core/test_bedrock_count_tokens.py
@@ -1,0 +1,121 @@
+"""Tests for CountTokensBedrockModel and base_foundation_model_id.
+
+The subclass exists because Bedrock's CountTokens API rejects cross-region
+inference-profile model ids (``us.anthropic.…``) but on-demand invocation
+requires them. The subclass de-prefixes for the count call only.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from strands.models import BedrockModel
+
+from agents.main_agent.core.bedrock_count_tokens import (
+    CountTokensBedrockModel,
+    base_foundation_model_id,
+)
+
+
+class TestBaseFoundationModelId:
+    """The pure de-prefix helper."""
+
+    @pytest.mark.parametrize(
+        "profile_id,expected",
+        [
+            ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "anthropic.claude-haiku-4-5-20251001-v1:0"),
+            ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            ("eu.anthropic.claude-x", "anthropic.claude-x"),
+            ("apac.anthropic.claude-x", "anthropic.claude-x"),
+            ("us-gov.anthropic.claude-x", "anthropic.claude-x"),
+        ],
+    )
+    def test_strips_known_geography_prefixes(self, profile_id, expected):
+        assert base_foundation_model_id(profile_id) == expected
+
+    @pytest.mark.parametrize(
+        "base_id",
+        [
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "amazon.nova-2-sonic-v1:0",
+            "gpt-4o",
+        ],
+    )
+    def test_noop_for_ids_without_a_geography_prefix(self, base_id):
+        assert base_foundation_model_id(base_id) == base_id
+
+    def test_strips_only_the_leading_prefix_once(self):
+        # A model name that merely contains "anthropic" is never mangled, and
+        # only a single leading geo segment is removed.
+        assert base_foundation_model_id("us.anthropic.claude") == "anthropic.claude"
+        # "us" as part of a longer first segment is not a prefix to strip.
+        assert base_foundation_model_id("uswest.anthropic.x") == "uswest.anthropic.x"
+
+
+@pytest.fixture
+def _aws_region(monkeypatch):
+    """boto3 needs a region to construct the bedrock-runtime client (no creds
+    needed for construction, no network calls in these tests)."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+class TestCountTokensModelIdSwap:
+    """count_tokens must count against the base id, then restore the profile id
+    so invocation keeps using the inference profile."""
+
+    @pytest.mark.asyncio
+    async def test_counts_against_base_id_and_restores_profile_id(self, _aws_region):
+        model = CountTokensBedrockModel(
+            model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            use_native_token_count=True,
+        )
+
+        seen = {}
+
+        async def fake_super_count(self, messages, tool_specs=None, system_prompt=None, system_prompt_content=None):
+            seen["model_id_during_count"] = self.config["model_id"]
+            return 4242
+
+        with patch.object(BedrockModel, "count_tokens", fake_super_count):
+            result = await model.count_tokens([], system_prompt="hi")
+
+        assert result == 4242
+        # The base id was used for the CountTokens call...
+        assert seen["model_id_during_count"] == "anthropic.claude-haiku-4-5-20251001-v1:0"
+        # ...and the profile id is restored for invocation afterward.
+        assert model.config["model_id"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    @pytest.mark.asyncio
+    async def test_no_swap_when_already_base_id(self, _aws_region):
+        model = CountTokensBedrockModel(
+            model_id="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            use_native_token_count=True,
+        )
+
+        seen = {}
+
+        async def fake_super_count(self, messages, tool_specs=None, system_prompt=None, system_prompt_content=None):
+            seen["model_id_during_count"] = self.config["model_id"]
+            return 7
+
+        with patch.object(BedrockModel, "count_tokens", fake_super_count):
+            await model.count_tokens([])
+
+        assert seen["model_id_during_count"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        assert model.config["model_id"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+    @pytest.mark.asyncio
+    async def test_profile_id_restored_even_when_count_raises(self, _aws_region):
+        model = CountTokensBedrockModel(
+            model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            use_native_token_count=True,
+        )
+
+        async def fake_super_count(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+        with patch.object(BedrockModel, "count_tokens", fake_super_count):
+            with pytest.raises(RuntimeError, match="boom"):
+                await model.count_tokens([])
+
+        assert model.config["model_id"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -117,6 +117,24 @@ class TestToBedrockConfig:
         assert result["model_id"] == cfg.model_id
         assert "cache_config" not in result
 
+    def test_bedrock_config_enables_native_token_count(self):
+        """Native Bedrock CountTokens is enabled on the Bedrock path so
+        projected_input_tokens / count_tokens() return authoritative counts
+        instead of the chars/4 heuristic — the foundation for per-turn context
+        attribution. The runtime-role IAM grant landed in #428. Set
+        unconditionally (Strands falls back + caches the skip if a model can't
+        count), so it holds regardless of caching or inference params."""
+        assert ModelConfig().to_bedrock_config()["use_native_token_count"] is True
+        assert (
+            ModelConfig(caching_enabled=True).to_bedrock_config()["use_native_token_count"]
+            is True
+        )
+        assert (
+            ModelConfig(inference_params={"temperature": 0.4})
+            .to_bedrock_config()["use_native_token_count"]
+            is True
+        )
+
     def test_bedrock_config_emits_temperature_only_when_set(self):
         """Inference params only ride along when explicitly configured."""
         cfg = ModelConfig(inference_params={"temperature": 0.4, "top_p": 0.9})


### PR DESCRIPTION
## What

Makes native Bedrock **CountTokens** actually work for our models, the load-bearing mechanism for context attribution. Two commits:

1. `use_native_token_count=True` in `to_bedrock_config()` ([model_config.py](backend/src/agents/main_agent/core/model_config.py)).
2. `CountTokensBedrockModel` ([bedrock_count_tokens.py](backend/src/agents/main_agent/core/bedrock_count_tokens.py)) — a `BedrockModel` subclass that counts against the **base foundation-model id**, wired in via `AgentFactory`.

**PR 2 of 4** in the context-attribution foundation (IAM → **native counting** → backend hook + SSE → frontend badge). Builds on #428.

## Why the subclass (the part that wasn't obvious)

A live probe against Bedrock surfaced that the flag flip **alone is inert in production**:

| `count_tokens(modelId=…)` | result |
|---|---|
| `us.anthropic.claude-haiku-4-5-…` (inference profile) | ❌ `ValidationException: model doesn't support counting tokens` |
| `anthropic.claude-haiku-4-5-…` (base FM id) | ✅ `inputTokens = 38` |
| `us.anthropic.claude-sonnet-4-5-…` | ❌ same |
| `anthropic.claude-sonnet-4-5-…` | ✅ |

It's **not the model — it's the ID form.** CountTokens rejects cross-region inference-profile ids, but on-demand invocation of the newer Claude models *requires* them. Strands' `count_tokens()` uses `self.config["model_id"]` (the profile id), so it always failed → the SDK cached the model into its no-count skip list → silent fall back to the `chars/4` heuristic for the process lifetime. The flag delivered nothing.

`CountTokensBedrockModel` strips the geography prefix (`us.`/`eu.`/`apac.`/`us-gov.`) to the base id for the **count call only**; invocation keeps the profile id. The inference profile is pure cross-region routing, so the base-id count is **exact, not an approximation** (confirmed live: native 720 vs heuristic 289 on a real request).

## Bonus payoff

Strands' per-turn estimate (`_estimate_input_tokens` → `BeforeModelCallEvent.projected_input_tokens`) routes through `count_tokens`. So making it authoritative also sharpens **proactive context-compaction** decisions — not just the attribution badge. PR3's hook can then use the standard `agent.model.count_tokens()` with no special-casing.

## Safety

- ID swap is guarded by `try/finally`; the profile id is always restored before any `stream` call.
- Safe because counting and invocation never overlap on a per-session model instance (the event loop `await`s the estimate before streaming).
- De-prefix matches a **closed set** of geo codes, so a real model id is never mangled; no-op for base ids and non-Bedrock providers (which never reach this path).
- PR1 (#428) granted `bedrock:CountTokens` on `foundation-model/*`, covering the base-id resource.

## Heads-up for reviewers / PR3

A second probe finding (recorded for PR3, **not addressed here**): the plan's empty-messages differential mis-attributes ~440 tokens of tool-use scaffolding to the "messages" partition (Bedrock only injects it when tools + a message coexist). PR3 must decompose the **real** request, not `messages=[]` baselines.

## Test

- `test_bedrock_count_tokens.py` — de-prefix helper (param matrix) + the swap/restore behavior (incl. restore-on-exception), all AWS-free.
- Repointed the 4 Bedrock-path `agent_factory` tests from `BedrockModel` → `CountTokensBedrockModel`.
- Gate (backend pytest is the only one, not in CI): `tests/agents/` + `tests/architecture/` → **1024 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)