### PR TITLE
feat(agents): per-turn context attribution breakdown over SSE

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -16,6 +16,7 @@ from agents.main_agent.session.hooks import (
     StopHook,
     OAuthConsentHook,
     MCPExternalApprovalHook,
+    ContextAttributionHook,
 )
 from agents.main_agent.tools import (
     create_default_registry,
@@ -272,6 +273,12 @@ class BaseAgent(ABC):
         # (`MCPServerConfig.tools[*].needs_approval`); a no-op for any tool
         # without a flag.
         hooks.append(self._build_mcp_external_approval_hook())
+
+        # Per-turn context-token attribution (system / tools / messages).
+        # Best-effort; computes the breakdown on BeforeModelCallEvent and
+        # stashes it on the agent for the stream coordinator to surface on the
+        # final metadata SSE event.
+        hooks.append(ContextAttributionHook())
 
         return hooks
 

--- a/backend/src/agents/main_agent/session/hooks/__init__.py
+++ b/backend/src/agents/main_agent/session/hooks/__init__.py
@@ -1,10 +1,12 @@
 """Hooks for Main Agent"""
 
+from agents.main_agent.session.hooks.context_attribution import ContextAttributionHook
 from agents.main_agent.session.hooks.oauth_consent import OAuthConsentHook
 from agents.main_agent.session.hooks.stop import StopHook
 from agents.main_agent.session.hooks.tool_approval import MCPExternalApprovalHook
 
 __all__ = [
+    "ContextAttributionHook",
     "OAuthConsentHook",
     "StopHook",
     "MCPExternalApprovalHook",

--- a/backend/src/agents/main_agent/session/hooks/context_attribution.py
+++ b/backend/src/agents/main_agent/session/hooks/context_attribution.py
@@ -1,0 +1,117 @@
+"""Hook that computes a per-turn context-token attribution breakdown.
+
+Splits the authoritative projected input-token count (Bedrock-native via
+``CountTokensBedrockModel``) into ``system`` / ``tools`` / ``messages``
+partitions and stashes the result on the agent. The stream coordinator reads
+it via :func:`get_context_breakdown` and attaches it to the turn's final
+``metadata`` SSE event as ``contextBreakdown`` — answering "what is filling the
+context window?" without an aggregate-only guess.
+
+Decomposition (convention validated live against Bedrock CountTokens):
+
+- ``systemTokens`` = ``count(system only)``
+- ``toolTokens``   = ``full - count(system + messages, no tools)`` — the tool
+  schemas **plus** the tool-use scaffolding Bedrock injects only when tools and
+  a conversation coexist (~400 tokens). Folded into Tools by design: it is the
+  true marginal cost of having tools enabled. An empty-messages baseline would
+  miss the scaffolding and mis-attribute it to messages.
+- ``messageTokens`` = ``full - systemTokens - toolTokens`` (residual; grows with
+  the conversation, scaffolding-free). Partitions sum to ``full`` by
+  construction.
+
+``systemTokens`` / ``toolTokens`` are stable across a session (the tool
+overhead is constant as the conversation grows — verified), so they are
+computed once per agent at cold start (two extra CountTokens calls) and cached;
+every turn afterward is pure arithmetic against the free, authoritative
+``projected_input_tokens``.
+
+Best-effort: any failure is swallowed so context attribution can never break a
+model call. For non-Bedrock models ``count_tokens`` falls back to a heuristic,
+so the numbers are approximate there.
+"""
+
+import logging
+from typing import Any, Optional
+
+from strands.hooks import BeforeModelCallEvent, HookProvider, HookRegistry
+
+logger = logging.getLogger(__name__)
+
+# Stashed on the per-session Strands agent instance.
+_SPLIT_ATTR = "_context_attribution_split"          # cached stable {systemTokens, toolTokens}
+_BREAKDOWN_ATTR = "_context_attribution_breakdown"  # latest per-turn breakdown dict
+
+
+def get_context_breakdown(agent: Any) -> Optional[dict]:
+    """Return the latest context breakdown stashed on ``agent``, or ``None``.
+
+    Used by the stream coordinator to enrich the final ``metadata`` SSE event.
+    """
+    return getattr(agent, _BREAKDOWN_ATTR, None)
+
+
+class ContextAttributionHook(HookProvider):
+    """Compute the system / tools / messages token breakdown each turn."""
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeModelCallEvent, self._on_before_model_call)
+
+    async def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+        try:
+            await self._compute(event)
+        except Exception as e:  # noqa: BLE001 - attribution must never break a turn
+            logger.debug("Context attribution skipped: %s", e)
+
+    async def _compute(self, event: BeforeModelCallEvent) -> None:
+        agent = event.agent
+        model = agent.model
+        system_prompt = getattr(agent, "system_prompt", None)
+        system_prompt_content = getattr(agent, "_system_prompt_content", None)
+        full = event.projected_input_tokens
+
+        split = getattr(agent, _SPLIT_ATTR, None)
+        if split is None:
+            system_tokens = await model.count_tokens(
+                messages=[],
+                system_prompt=system_prompt,
+                system_prompt_content=system_prompt_content,
+            )
+            # system + the current conversation, WITHOUT tools — so the
+            # difference from `full` captures tool schemas + the tool-use
+            # scaffolding (present only when tools and messages coexist).
+            no_tools = await model.count_tokens(
+                messages=agent.messages,
+                system_prompt=system_prompt,
+                system_prompt_content=system_prompt_content,
+            )
+            if full is None:
+                # projected estimate unavailable — count the full request once
+                # so cold start can still establish the split.
+                tool_specs = agent.tool_registry.get_all_tool_specs()
+                full = await model.count_tokens(
+                    messages=agent.messages,
+                    tool_specs=tool_specs,
+                    system_prompt=system_prompt,
+                    system_prompt_content=system_prompt_content,
+                )
+            split = {
+                "systemTokens": system_tokens,
+                "toolTokens": max(0, full - no_tools),
+            }
+            setattr(agent, _SPLIT_ATTR, split)
+
+        if full is None:
+            # No authoritative total this turn — can't place the messages
+            # partition. Leave the previous breakdown (if any) untouched.
+            return
+
+        message_tokens = max(0, full - split["systemTokens"] - split["toolTokens"])
+        breakdown = {
+            "total": full,
+            "partitions": [
+                {"key": "system", "label": "System prompt", "tokens": split["systemTokens"]},
+                {"key": "tools", "label": "Tools", "tokens": split["toolTokens"]},
+                {"key": "messages", "label": "Messages", "tokens": message_tokens},
+            ],
+        }
+        setattr(agent, _BREAKDOWN_ATTR, breakdown)

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -426,6 +426,21 @@ class StreamCoordinator:
                             except Exception as ctx_err:
                                 logger.debug(f"Skipping contextWindow lookup: {ctx_err}")
 
+                            # Per-turn context attribution (system / tools /
+                            # messages), computed by ContextAttributionHook at
+                            # BeforeModelCallEvent and stashed on the agent.
+                            # Partitions sum to `total`; the frontend pairs it
+                            # with `contextWindow` above for free-space.
+                            try:
+                                from agents.main_agent.session.hooks.context_attribution import (
+                                    get_context_breakdown,
+                                )
+                                breakdown = get_context_breakdown(agent)
+                                if breakdown is not None:
+                                    final_metadata["contextBreakdown"] = breakdown
+                            except Exception as br_err:
+                                logger.debug(f"Skipping contextBreakdown: {br_err}")
+
                         # Log cache metrics for performance monitoring
                         self._log_cache_metrics(usage=final_metadata.get("usage", {}), session_id=session_id)
 

--- a/backend/tests/agents/main_agent/session/test_context_attribution_hook.py
+++ b/backend/tests/agents/main_agent/session/test_context_attribution_hook.py
@@ -1,0 +1,166 @@
+"""Tests for ContextAttributionHook — per-turn system/tools/messages breakdown.
+
+The hook computes the split once at cold start (caching the stable
+system/tools tokens on the agent) and derives the messages partition each turn
+from the authoritative projected total. Tool overhead deliberately absorbs the
+tool-use scaffolding (full - count(system + messages, no tools)).
+"""
+
+import pytest
+from strands.hooks import BeforeModelCallEvent
+
+from agents.main_agent.session.hooks.context_attribution import (
+    ContextAttributionHook,
+    get_context_breakdown,
+)
+
+
+class FakeModel:
+    """Async count_tokens returning system + per-message + (tools→overhead).
+
+    Mirrors the real behavior the hook relies on: tool overhead is only counted
+    when tool_specs are supplied (the empty-messages / no-tools baselines never
+    include it).
+    """
+
+    def __init__(self, system=100, per_msg=10, tool_overhead=500, raise_on_count=False):
+        self.system = system
+        self.per_msg = per_msg
+        self.tool_overhead = tool_overhead
+        self.raise_on_count = raise_on_count
+        self.calls = []
+
+    async def count_tokens(self, messages, tool_specs=None, system_prompt=None, system_prompt_content=None):
+        self.calls.append({"n_messages": len(messages), "has_tools": bool(tool_specs)})
+        if self.raise_on_count:
+            raise RuntimeError("count failed")
+        total = self.system if system_prompt else 0
+        total += len(messages) * self.per_msg
+        total += self.tool_overhead if tool_specs else 0
+        return total
+
+
+class FakeToolRegistry:
+    def __init__(self, specs):
+        self._specs = specs
+
+    def get_all_tool_specs(self):
+        return self._specs
+
+
+class FakeAgent:
+    def __init__(self, model, messages, system_prompt="SYSTEM-PROMPT", tool_specs=None):
+        self.model = model
+        self.messages = messages
+        self.system_prompt = system_prompt
+        self._system_prompt_content = None
+        self.tool_registry = FakeToolRegistry(tool_specs if tool_specs is not None else [{"name": "t"}])
+
+
+def _event(agent, projected):
+    return BeforeModelCallEvent(agent=agent, projected_input_tokens=projected)
+
+
+def _parts(breakdown):
+    return {p["key"]: p["tokens"] for p in breakdown["partitions"]}
+
+
+class TestColdStart:
+    @pytest.mark.asyncio
+    async def test_computes_partitions_that_sum_to_total(self):
+        model = FakeModel(system=100, per_msg=10, tool_overhead=500)
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        await ContextAttributionHook()._on_before_model_call(_event(agent, projected=650))
+
+        bd = get_context_breakdown(agent)
+        parts = _parts(bd)
+        # system_only=100; no_tools(1 msg)=110; toolTokens=650-110=540; messages=650-100-540=10
+        assert parts == {"system": 100, "tools": 540, "messages": 10}
+        assert bd["total"] == 650
+        assert sum(parts.values()) == bd["total"]
+
+    @pytest.mark.asyncio
+    async def test_makes_exactly_two_count_calls_neither_with_tools(self):
+        model = FakeModel()
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        await ContextAttributionHook()._on_before_model_call(_event(agent, projected=650))
+
+        assert model.calls == [
+            {"n_messages": 0, "has_tools": False},  # system only
+            {"n_messages": 1, "has_tools": False},  # system + messages, no tools
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tool_partition_absorbs_scaffolding(self):
+        # full (projected) deliberately exceeds the no-tools baseline by more
+        # than bare schemas would — the surplus is the scaffolding, and it must
+        # land in `tools`, not `messages`.
+        model = FakeModel(system=100, per_msg=10)
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        await ContextAttributionHook()._on_before_model_call(_event(agent, projected=900))
+
+        parts = _parts(get_context_breakdown(agent))
+        assert parts["tools"] == 900 - 110  # = 790, all of it on tools
+        assert parts["messages"] == 10      # the actual single message, not inflated
+
+
+class TestWarmTurn:
+    @pytest.mark.asyncio
+    async def test_reuses_cached_split_without_recounting(self):
+        model = FakeModel(system=100, per_msg=10)
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        hook = ContextAttributionHook()
+        await hook._on_before_model_call(_event(agent, projected=650))
+        calls_after_cold = len(model.calls)
+
+        # Conversation grows; only the projected total changes.
+        agent.messages = agent.messages + [{"role": "assistant", "content": [{"text": "ok"}]}]
+        await hook._on_before_model_call(_event(agent, projected=700))
+
+        assert len(model.calls) == calls_after_cold  # no new CountTokens calls
+        parts = _parts(get_context_breakdown(agent))
+        assert parts["system"] == 100
+        assert parts["tools"] == 540
+        assert parts["messages"] == 700 - 100 - 540  # grows with the turn
+
+
+class TestProjectedUnavailable:
+    @pytest.mark.asyncio
+    async def test_cold_start_counts_full_with_tools_when_projected_none(self):
+        model = FakeModel(system=100, per_msg=10, tool_overhead=500)
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        await ContextAttributionHook()._on_before_model_call(_event(agent, projected=None))
+
+        bd = get_context_breakdown(agent)
+        parts = _parts(bd)
+        # full counted with tools = 100 + 10 + 500 = 610; tools = 610-110 = 500
+        assert bd["total"] == 610
+        assert parts == {"system": 100, "tools": 500, "messages": 10}
+        # 3 calls: system only, no-tools, then full WITH tools
+        assert len(model.calls) == 3
+        assert model.calls[2]["has_tools"] is True
+
+    @pytest.mark.asyncio
+    async def test_warm_turn_without_projected_leaves_breakdown_untouched(self):
+        model = FakeModel()
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        hook = ContextAttributionHook()
+        await hook._on_before_model_call(_event(agent, projected=650))
+        bd_before = get_context_breakdown(agent)
+
+        await hook._on_before_model_call(_event(agent, projected=None))
+        assert get_context_breakdown(agent) == bd_before
+
+
+class TestRobustness:
+    @pytest.mark.asyncio
+    async def test_count_failure_is_swallowed_and_yields_no_breakdown(self):
+        model = FakeModel(raise_on_count=True)
+        agent = FakeAgent(model, messages=[{"role": "user", "content": [{"text": "hi"}]}])
+        # Must not raise.
+        await ContextAttributionHook()._on_before_model_call(_event(agent, projected=650))
+        assert get_context_breakdown(agent) is None
+
+    def test_get_context_breakdown_is_none_when_absent(self):
+        agent = FakeAgent(FakeModel(), messages=[])
+        assert get_context_breakdown(agent) is None


### PR DESCRIPTION
## What

Adds `ContextAttributionHook` ([context_attribution.py](backend/src/agents/main_agent/session/hooks/context_attribution.py)) that decomposes each turn's input tokens into **system / tools / messages** partitions and surfaces them on the `metadata` SSE event as `contextBreakdown`.

**PR 3 of 4** in the context-attribution foundation (IAM → native counting → **backend hook + SSE** → frontend badge). Builds on #428, #430.

## Why

Answers the question that started this effort — *what is actually filling the context window?* Today we show one number (% used); this breaks it into the parts users can act on.

## How

- Hook fires on `BeforeModelCallEvent` (async — Strands dispatches it via `invoke_callbacks_async`), reads the now-authoritative `projected_input_tokens` (free, from PR2's `CountTokensBedrockModel`), and computes the split.
- It stashes the breakdown on the **per-session Strands agent**; the stream coordinator reads it via `get_context_breakdown(agent)` and attaches it to the turn's **final** `metadata` event (the same one that already carries `contextWindow`). `agent` in the coordinator and `event.agent` in the hook are the same object, so the stash is the channel.

## Decomposition convention (validated live)

| partition | formula | notes |
|---|---|---|
| `systemTokens` | `count(system only)` | |
| `toolTokens` | `full − count(system + messages, no tools)` | schemas **+** the ~400-tok tool-use scaffolding Bedrock injects only when tools + a conversation coexist |
| `messageTokens` | `full − systemTokens − toolTokens` | residual, scaffolding-free, grows with the conversation |

The scaffolding is **folded into Tools** by design (your decision) — it's the true marginal cost of having tools enabled. An empty-messages baseline would miss it and inflate "messages". Partitions sum to `total` by construction.

**Cost:** system/tools are constant across a session (tool overhead verified constant as the conversation grows: 630 tokens across 1/2/4/6 turns), so they're computed **once per agent at cold start** (2 extra CountTokens calls) and cached. Every turn after is pure arithmetic against the free projected total. Best-effort — any failure is swallowed so attribution can never break a model call.

## Contract / compatibility

`contextBreakdown` is an **additive, optional** field on the existing `metadata` event:
```jsonc
contextBreakdown: {
  total: 705,
  partitions: [
    { key: "system",   label: "System prompt", tokens: 16 },
    { key: "tools",    label: "Tools",         tokens: 655 },
    { key: "messages", label: "Messages",      tokens: 34 }
  ]
}
```
Backward compatible (FE ignores unknown fields). **PR4** adds the TS interface + badge that consume it. The partition-list shape is intentionally extensible — skills, per-server itemization, and cache splits are future *additive* partitions, not breaking changes.

## Test

- `test_context_attribution_hook.py` (8 tests): cold-start split + sum-to-total, scaffolding folds into tools, warm-turn reuse without recounting, projected-unavailable fallbacks, exception-swallow.
- **End-to-end against live Bedrock**: a real turn through `AgentFactory` (real `CountTokensBedrockModel` + registered hook + 2 tools) produced `system=16 / tools=655 / messages=34`, summing exactly to the projected total `705`, profile id restored after the turn.
- Gate (backend pytest is the only one, not in CI): `tests/agents/` + `tests/architecture/` → **1032 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)