### PR TITLE
feat: surface per-turn context breakdown (message badge + session popover, refresh-durable)

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.spec.ts
@@ -1,0 +1,97 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessageMetadataBadgesComponent } from './message-metadata-badges.component';
+import { LocalSettingsService } from '../../../../services/local-settings.service';
+
+const BREAKDOWN = {
+  total: 705,
+  partitions: [
+    { key: 'system', label: 'System prompt', tokens: 16 },
+    { key: 'tools', label: 'Tools', tokens: 655 },
+    { key: 'messages', label: 'Messages', tokens: 34 },
+  ],
+};
+
+describe('MessageMetadataBadgesComponent — context breakdown', () => {
+  let fixture: ComponentFixture<MessageMetadataBadgesComponent>;
+  let settings: LocalSettingsService;
+
+  function text(): string {
+    return fixture.nativeElement.textContent ?? '';
+  }
+
+  function badge(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[title]');
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessageMetadataBadgesComponent],
+    }).compileComponents();
+
+    settings = TestBed.inject(LocalSettingsService);
+    settings.showTokenCount.set(true);
+
+    fixture = TestBed.createComponent(MessageMetadataBadgesComponent);
+  });
+
+  it('renders the total and every partition when token count is enabled', () => {
+    fixture.componentRef.setInput('metadata', { contextBreakdown: BREAKDOWN });
+    fixture.detectChanges();
+
+    const t = text();
+    expect(t).toContain('Context: 705');
+    expect(t).toContain('System prompt');
+    expect(t).toContain('16');
+    expect(t).toContain('Tools');
+    expect(t).toContain('655');
+    expect(t).toContain('Messages');
+    expect(t).toContain('34');
+  });
+
+  it('exposes the breakdown as an accessible title summary', () => {
+    fixture.componentRef.setInput('metadata', { contextBreakdown: BREAKDOWN });
+    fixture.detectChanges();
+
+    expect(badge()?.getAttribute('title')).toBe(
+      'System prompt: 16 · Tools: 655 · Messages: 34',
+    );
+  });
+
+  it('renders whatever partitions arrive (open-ended contract)', () => {
+    fixture.componentRef.setInput('metadata', {
+      contextBreakdown: {
+        total: 100,
+        partitions: [{ key: 'skills', label: 'Skills', tokens: 100 }],
+      },
+    });
+    fixture.detectChanges();
+
+    expect(text()).toContain('Skills');
+    expect(text()).toContain('Context: 100');
+  });
+
+  it('hides the breakdown when token count is disabled', () => {
+    settings.showTokenCount.set(false);
+    fixture.componentRef.setInput('metadata', { contextBreakdown: BREAKDOWN });
+    fixture.detectChanges();
+
+    expect(text()).not.toContain('Context: 705');
+  });
+
+  it('renders nothing for an empty partition list', () => {
+    fixture.componentRef.setInput('metadata', {
+      contextBreakdown: { total: 0, partitions: [] },
+    });
+    fixture.detectChanges();
+
+    expect(text()).not.toContain('Context:');
+  });
+
+  it('is absent when no metadata is provided', () => {
+    fixture.componentRef.setInput('metadata', null);
+    fixture.detectChanges();
+
+    expect(text()).not.toContain('Context:');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-metadata-badges.component.ts
@@ -6,6 +6,7 @@ import {
     input,
 } from '@angular/core';
 import { LocalSettingsService } from '../../../../services/local-settings.service';
+import { ContextBreakdown } from '../../../services/models/content-types';
 
 interface CostBreakdown {
     total: number;
@@ -16,6 +17,7 @@ interface CostBreakdown {
 }
 
 interface MessageMetadata {
+    contextBreakdown?: ContextBreakdown;
     latency?: {
         // null = not measured (provider didn't emit timeToFirstByteMs and
         // we couldn't compute it locally). Distinct from 0, which is
@@ -45,6 +47,23 @@ interface MessageMetadata {
     imports: [],
     template: `
         @if (localSettings.showTokenCount() && hasMetadata()) {
+                <!-- Context Breakdown Badge (system / tools / messages) -->
+                @if (contextBreakdown(); as cb) {
+                    <div
+                        class="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800/60 dark:text-slate-300"
+                        [title]="contextBreakdownTitle()"
+                    >
+                        <!-- squares-2x2 (context partitions) icon -->
+                        <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6Zm0 9.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25Zm9.75-9.75A2.25 2.25 0 0 1 15.75 3.75H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6Zm0 9.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
+                        </svg>
+                        <span>Context: {{ formatNumber(cb.total) }}</span>
+                        @for (p of cb.partitions; track p.key) {
+                            <span class="text-slate-500 dark:text-slate-400">· {{ p.label }} {{ formatNumber(p.tokens) }}</span>
+                        }
+                    </div>
+                }
+
             <!-- TTFT Badge -->
                 @if (ttft()) {
                     <div class="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
@@ -173,8 +192,30 @@ export class MessageMetadataBadgesComponent {
             !!meta.latency?.timeToFirstToken ||
             !!meta.latency?.endToEndLatency ||
             !!meta.tokenUsage ||
+            !!meta.contextBreakdown ||
             meta.cost !== undefined && meta.cost !== null
         );
+    });
+
+    /** Per-turn context attribution (system / tools / messages). Null unless
+     *  the backend emitted a breakdown with at least one partition. */
+    contextBreakdown = computed<ContextBreakdown | null>(() => {
+        const meta = this.typedMetadata();
+        const cb = meta?.contextBreakdown;
+        if (!cb || !Array.isArray(cb.partitions) || cb.partitions.length === 0) {
+            return null;
+        }
+        return cb;
+    });
+
+    /** Accessible, hover-text summary of the breakdown, e.g.
+     *  "System prompt: 16 · Tools: 655 · Messages: 34". */
+    contextBreakdownTitle = computed(() => {
+        const cb = this.contextBreakdown();
+        if (!cb) return '';
+        return cb.partitions
+            .map((p) => `${p.label}: ${this.formatNumber(p.tokens)}`)
+            .join(' · ');
     });
 
     ttft = computed(() => {

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -891,13 +891,17 @@ export class StreamParserService {
       cacheWriteInputTokens?: number;
     } | undefined;
 
+    const existingBreakdown = existingMetadata['contextBreakdown'];
+    const newBreakdown = newMetadata['contextBreakdown'];
+
     const needsUpdate =
       (!existingTTFT && newTTFT) ||
       (existingCost === undefined && newCost !== undefined) ||
       (existingTokenUsage?.cacheReadInputTokens === undefined &&
         newTokenUsage?.cacheReadInputTokens !== undefined) ||
       (existingTokenUsage?.cacheWriteInputTokens === undefined &&
-        newTokenUsage?.cacheWriteInputTokens !== undefined);
+        newTokenUsage?.cacheWriteInputTokens !== undefined) ||
+      (existingBreakdown === undefined && newBreakdown !== undefined);
 
     if (needsUpdate) {
       this.completedMessages.update((messages) => {
@@ -982,6 +986,10 @@ export class StreamParserService {
 
     if (metadataEvent.cost !== undefined) {
       result['cost'] = metadataEvent.cost;
+    }
+
+    if (metadataEvent.contextBreakdown !== undefined) {
+      result['contextBreakdown'] = metadataEvent.contextBreakdown;
     }
 
     if (metadataEvent.trace !== undefined) {

--- a/frontend/ai.client/src/app/session/services/models/content-types.ts
+++ b/frontend/ai.client/src/app/session/services/models/content-types.ts
@@ -244,6 +244,24 @@ export interface CostBreakdown {
   cacheWriteCost?: number;
 }
 
+/** One partition of the per-turn context-token attribution. The list is
+ *  open-ended (system / tools / messages today; skills, per-server detail, and
+ *  cache splits are future additive partitions), so consumers render whatever
+ *  partitions arrive rather than reading fixed fields. */
+export interface ContextPartition {
+  key: string;
+  label: string;
+  tokens: number;
+}
+
+/** Per-turn breakdown of what is filling the context window. `partitions` sum
+ *  to `total` (the authoritative projected input-token count). Emitted by the
+ *  backend ContextAttributionHook on the final metadata event. */
+export interface ContextBreakdown {
+  total: number;
+  partitions: ContextPartition[];
+}
+
 export interface MetadataEvent {
   metrics?: Metrics;
   trace?: any;
@@ -254,6 +272,8 @@ export interface MetadataEvent {
    *  the streaming coordinator alongside cost so the cost badge can compute
    *  "% of context used" without an extra round-trip. */
   contextWindow?: number;
+  /** Per-turn system / tools / messages token breakdown. */
+  contextBreakdown?: ContextBreakdown;
 }
 
 export interface ExceptionEvent {


### PR DESCRIPTION
## What

Surfaces the `contextBreakdown` from #431 in the UI and makes it **survive a reload**:

1. **Per-message badge** — a `Context: <total>` pill on assistant message metadata.
2. **Session-cost popover** — itemizes the conversation's current System / Tools / Messages under the token total.
3. **Refresh durability** — the breakdown is persisted on the stored message metadata and re-hydrated on load, so neither surface goes blank after a refresh (matching the %-used badge).

**PR 4 of 4** in the context-attribution foundation (IAM → native counting → backend hook + SSE → **UI + persistence**). Builds on #428, #430, #431.

## Display

- `ContextPartition` / `ContextBreakdown` types + optional `contextBreakdown` on `MetadataEvent` — an **open-ended partition list**, so skills / per-server / cache splits are future *additive* partitions.
- Both surfaces render the partitions **generically** (`@for`), so new backend partitions appear with no FE change.
- Popover copy frames it as the **whole conversation currently in context** (it's inherently cumulative — every turn's input is the full history; verified the messages partition grows turn-over-turn).

## Persistence (refresh survival)

- Backend: new optional `context_breakdown` field on `MessageMetadata` (alias `contextBreakdown`); `_store_message_metadata` stamps it from the hook's stash. The storage path gets the ChatAgent **wrapper**, so it reaches the raw Strands agent (where the hook stashed) via `.agent`.
- Round-trips: stored by alias → reloaded via `MessageMetadata(**dict)` → re-dumped to the SPA. **Per-message badges survive refresh with no FE change** (same restored-metadata dict that already carries tokens/cost).
- Frontend: the session badge hydrates its signal from the most recent restored assistant message on load (`hydrateContextBreakdown`, **non-clobbering** so a live turn wins), mirroring the artifact/MCP-app card hydration. Cleared on navigation.

## Fixes found mid-review

- **Breakdown vanished at turn completion**: the post-turn title update re-fired the `seedSessionAggregates` effect, which was clearing the live breakdown. Fixed — `seedSessionAggregates` no longer touches it; clearing moved to a dedicated `resetContextBreakdown()` on route change. Regression test added.

## Test

- Backend: round-trip persistence tests (dump-alias / reload / re-dump); **929 + 3** pass.
- Frontend: badge render, session popover, chat-state lifecycle (incl. seed-must-not-clobber + hydrate-non-clobber) — **49** pass via `ng test`; `tsc` strict clean.

> Caveat: cloud continuity rides the agent cache (Memory is write-only there); if the agent is evicted mid-session a turn's breakdown could momentarily under-count until it rebuilds — known cloud restore limitation, separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)