### PR TITLE
fix(infra): restore MCP sandbox cert deploy var dropped in #396

### DIFF
--- a/.github/workflows/nightly-deploy-pipeline.yml
+++ b/.github/workflows/nightly-deploy-pipeline.yml
@@ -91,6 +91,12 @@ jobs:
       CDK_COGNITO_DOMAIN_PREFIX: ${{ vars.CDK_COGNITO_DOMAIN_PREFIX }}
       CDK_ARTIFACTS_CERTIFICATE_ARN: ${{ vars.CDK_ARTIFACTS_CERTIFICATE_ARN }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
+      # MCP Apps sandbox-proxy origin (mcp-sandbox.{domain}). Without the
+      # cert ARN the construct silently falls back to the CloudFront default
+      # domain and creates no Route53 ALIAS — the SPA then frames a
+      # nonexistent host and MCP Apps fail to load. Cert MUST be in us-east-1.
+      CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
+      CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -79,6 +79,12 @@ jobs:
       CDK_COGNITO_SUPPORTED_IDPS: ${{ vars.CDK_COGNITO_SUPPORTED_IDPS }}
       CDK_ARTIFACTS_CERTIFICATE_ARN: ${{ vars.CDK_ARTIFACTS_CERTIFICATE_ARN }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
+      # MCP Apps sandbox-proxy origin (mcp-sandbox.{domain}). Without the
+      # cert ARN the construct silently falls back to the CloudFront default
+      # domain and creates no Route53 ALIAS — the SPA then frames a
+      # nonexistent host and MCP Apps fail to load. Cert MUST be in us-east-1.
+      CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
+      CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
       # Secrets
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
+++ b/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
@@ -130,10 +130,30 @@ export class McpSandboxDistributionConstruct extends Construct {
 
     const domainName = config.domainName;
     const certificateArn = config.mcpSandbox.certificateArn;
-    const useCustomDomain = Boolean(domainName && certificateArn);
     const proxySubdomain = domainName
       ? `${MCP_SANDBOX_SUBDOMAIN_LABEL}.${domainName}`
       : undefined;
+
+    // Fail loudly on the dangerous middle case: a real domain is configured
+    // but no cert. Without this the construct would silently fall back to the
+    // CloudFront default domain and create NO Route53 ALIAS — so the SPA
+    // frames `https://${proxySubdomain}`, which doesn't resolve (NXDOMAIN),
+    // and every MCP App fails to load. That is exactly the regression caused
+    // when the `CDK_MCP_SANDBOX_CERTIFICATE_ARN` deploy var was dropped from
+    // platform.yml. Mirrors the artifacts construct, which requires its cert
+    // whenever a domain is deployed. A domain-less stack (synth/unit tests,
+    // domain-less local) still falls back cleanly to the CloudFront default.
+    if (domainName && !certificateArn) {
+      throw new Error(
+        `MCP sandbox proxy requires an ACM certificate when a domain is configured. ` +
+          `domainName="${domainName}" is set but config.mcpSandbox.certificateArn is empty. ` +
+          `Set CDK_MCP_SANDBOX_CERTIFICATE_ARN to a us-east-1 cert covering ${proxySubdomain}. ` +
+          `Without it the proxy deploys on the CloudFront default domain with no Route53 ` +
+          `record, and the SPA cannot frame MCP Apps.`,
+      );
+    }
+
+    const useCustomDomain = Boolean(domainName && certificateArn);
 
     const frameAncestors = buildMcpSandboxFrameAncestors(
       domainName,

--- a/infrastructure/test/mcp-sandbox-cert-guard.test.ts
+++ b/infrastructure/test/mcp-sandbox-cert-guard.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Guard test for McpSandboxDistributionConstruct's domain/cert pairing.
+ *
+ * Regression cover for the #396 stack-consolidation bug: the
+ * `CDK_MCP_SANDBOX_CERTIFICATE_ARN` deploy var was dropped from the
+ * consolidated platform.yml, so the construct silently fell back to the
+ * CloudFront default domain and created no Route53 ALIAS — the SPA then
+ * framed a nonexistent `mcp-sandbox.{domain}` host (NXDOMAIN) and every
+ * MCP App failed to load. The construct now fails loudly on the
+ * domain-set-but-cert-missing case while preserving the documented
+ * domain-less fallback (synth/unit tests, local).
+ */
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { McpSandboxDistributionConstruct } from '../lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct';
+import { createMockConfig, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+const CERT = 'arn:aws:acm:us-east-1:123456789012:certificate/test';
+
+function buildConstruct(overrides: Parameters<typeof createMockConfig>[0]): void {
+  const config = createMockConfig(overrides);
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack', {
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  const bucket = new s3.Bucket(stack, 'ShellBucket');
+  new McpSandboxDistributionConstruct(stack, 'McpSandbox', { config, bucket });
+}
+
+describe('McpSandboxDistributionConstruct — domain/cert guard', () => {
+  it('throws when a domain is configured but the cert is missing', () => {
+    expect(() =>
+      buildConstruct({
+        domainName: 'example.com',
+        infrastructureHostedZoneDomain: 'example.com',
+        mcpSandbox: { extraFrameAncestors: [] }, // no certificateArn
+      }),
+    ).toThrow(/MCP sandbox proxy requires an ACM certificate/);
+  });
+
+  it('names the missing deploy var and the affected subdomain in the error', () => {
+    expect(() =>
+      buildConstruct({
+        domainName: 'example.com',
+        infrastructureHostedZoneDomain: 'example.com',
+        mcpSandbox: { extraFrameAncestors: [] },
+      }),
+    ).toThrow(/CDK_MCP_SANDBOX_CERTIFICATE_ARN.*mcp-sandbox\.example\.com/s);
+  });
+
+  it('does NOT throw for a domain-less stack (CloudFront default fallback)', () => {
+    expect(() =>
+      buildConstruct({
+        mcpSandbox: { extraFrameAncestors: [] }, // no domain, no cert
+      }),
+    ).not.toThrow();
+  });
+
+  it('does NOT throw when both a domain and cert are configured', () => {
+    expect(() =>
+      buildConstruct({
+        domainName: 'example.com',
+        infrastructureHostedZoneDomain: 'example.com',
+        mcpSandbox: { extraFrameAncestors: [], certificateArn: CERT },
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Loading an MCP App UI fails with a postMessage origin error citing the recipient origin `chrome-error://chromewebdata/`. Root cause: the sandbox proxy host has **no DNS record**.

```
nslookup mcp-sandbox.alpha.boisestate.ai  →  NXDOMAIN
nslookup mcp-sandbox.beta.boisestate.ai   →  NXDOMAIN
nslookup artifacts.alpha.boisestate.ai    →  resolves ✓   (sibling, same PlatformStack)
nslookup alpha.boisestate.ai (SPA)        →  resolves ✓
```

The `proxy.html` iframe can't load → the browser renders a `chrome-error://chromewebdata/` page → the SPA bridge's `postMessage` to that dead frame fails the origin check.

## Cause

PR #396 (stack-architecture simplification) deleted the standalone `mcp-sandbox.yml` workflow and folded the sandbox into the single `PlatformStack`, but the consolidated `platform.yml` / `nightly-deploy-pipeline.yml` carried over `CDK_ARTIFACTS_CERTIFICATE_ARN` / `CDK_FRONTEND_CERTIFICATE_ARN` and **dropped the entire `CDK_MCP_SANDBOX_*` trio** the old workflow passed.

With `CDK_MCP_SANDBOX_CERTIFICATE_ARN` unset, `McpSandboxDistributionConstruct`'s `useCustomDomain = Boolean(domainName && certificateArn)` goes false → it deploys on the CloudFront default domain with **no Route53 ALIAS**. Unlike the artifacts construct (which hard-asserts its cert and always creates the record), the sandbox construct **silently degraded** — and `validateConfig` deliberately skips cert validation — so the regression produced no synth/test failure. inference-api still emits `mcpSandboxProxyOrigin` unconditionally as `sandboxOrigin`, so the SPA always tries to frame the now-nonexistent host.

## Changes

- **Re-add `CDK_MCP_SANDBOX_CERTIFICATE_ARN` + `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS`** to `platform.yml` and `nightly-deploy-pipeline.yml`, mirroring the artifacts cert wiring. `CDK_MCP_SANDBOX_ENABLED` is intentionally **not** restored — it is now dead config (no `enabled` field in `McpSandboxConfig`; the sandbox is always provisioned).
- **Guard against silent regression:** `McpSandboxDistributionConstruct` now throws when a domain is configured but the cert is missing, instead of degrading to a recordless CloudFront default. Mirrors the artifacts construct's hard cert requirement; the domain-less synth/local fallback is preserved.
- **Test:** `mcp-sandbox-cert-guard.test.ts` covers the throw, the error message (names the missing var + affected subdomain), and both no-throw cases (domain-less, and domain+cert).

## ⚠️ Operational prerequisites (not covered by this PR)

1. The GitHub var `CDK_MCP_SANDBOX_CERTIFICATE_ARN` must be **set per environment** (`development` + `production`) to a **us-east-1** ACM cert covering `mcp-sandbox.{domain}`. Wildcard-depth gotcha: `*.boisestate.ai` does **not** cover `mcp-sandbox.alpha.boisestate.ai` (two labels deep) — needs `*.alpha.boisestate.ai` / `*.beta.boisestate.ai` (likely the same cert artifacts uses). With this guard in place, deploying without the var now **fails loudly** instead of silently shipping a broken sandbox.
2. A `PlatformStack` redeploy is required after the var is present, so the construct creates the `mcp-sandbox.{domain}` ALIAS record.

## Verification

- `npx tsc --noEmit` clean.
- `npx jest mcp-sandbox-cert-guard platform-stack.test mcp-sandbox-proxy-csp` → 44 passed.
- Pre-existing `config.test.ts` failures (9, `process.env` leakage) are unrelated — confirmed identical on a clean `develop` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)