### PR TITLE
fix(test): make config.test env handling hermetic per test

### DIFF
--- a/infrastructure/test/config.test.ts
+++ b/infrastructure/test/config.test.ts
@@ -10,13 +10,45 @@ import { loadConfig, AppConfig } from '../lib/config';
  * **Validates: Requirements 4.1-4.10**
  */
 
+/**
+ * The `CDK_RAG_*` environment variables these tests manipulate. They are
+ * deleted before AND after every test so a value set in one test can never
+ * leak into the next and silently change loadConfig()'s outcome.
+ *
+ * This explicit per-key deletion — not whole-object `process.env = snapshot`
+ * reassignment — is the load-bearing teardown: assigning a plain object to
+ * `process.env` does NOT reliably *delete* keys on every Node version (some
+ * merge the object in rather than replacing the backing store). Relying on
+ * that alone let leaked `CDK_RAG_*` values mask the variable under test, so the
+ * validation cases (e.g. an empty embedding model) saw a stale valid value and
+ * loadConfig() never threw.
+ */
+const RAG_ENV_KEYS = [
+  'CDK_RAG_CORS_ORIGINS',
+  'CDK_RAG_LAMBDA_MEMORY',
+  'CDK_RAG_LAMBDA_TIMEOUT',
+  'CDK_RAG_EMBEDDING_MODEL',
+  'CDK_RAG_VECTOR_DIMENSION',
+  'CDK_RAG_DISTANCE_METRIC',
+] as const;
+
+function clearRagEnv(): void {
+  for (const key of RAG_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
 describe('RAG Ingestion Configuration', () => {
   let app: cdk.App;
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
-    // Save original environment
+    // Save the original environment, then start each test from a fresh copy so
+    // mutations never touch the snapshot we restore from.
     originalEnv = { ...process.env };
+    process.env = { ...originalEnv };
+    // Hermetic start: drop any RAG keys a prior test may have leaked.
+    clearRagEnv();
 
     // Create a fresh CDK app for each test
     app = new cdk.App();
@@ -76,7 +108,9 @@ describe('RAG Ingestion Configuration', () => {
   });
 
   afterEach(() => {
-    // Restore original environment
+    // Drop any RAG keys this test set so they can't leak forward, then restore
+    // the original environment object.
+    clearRagEnv();
     process.env = originalEnv;
   });
 


### PR DESCRIPTION
## Summary

`infrastructure/test/config.test.ts` could fail up to 9 of its RAG-config validation cases (e.g. `config.test.ts:446`, "validates embedding model is not whitespace only") because of **`process.env` leakage between test cases**. This makes `cd infrastructure && npx jest` a flaky gate. This PR makes the per-test environment handling hermetic.

## Root cause

Each test sets `process.env.CDK_RAG_*` vars, but teardown relied on whole-object reassignment (`process.env = originalEnv`) to clean up. Assigning a plain object to `process.env` does **not reliably delete added keys on every Node version** — some Node builds *merge* the object into the backing store rather than replacing it. When that happens, a `CDK_RAG_*` value set in one test leaks into a later test and silently changes `loadConfig()`'s outcome: the validation cases (which expect a throw) see a stale *valid* value via `||`/`??` fallbacks and `loadConfig()` never throws.

This is environment-dependent, which is why it reproduced on the reporter's setup but not on Node 22.12 (where `process.env = obj` does delete keys). To prove the failure mode and the fix, I simulated merge-only `process.env =` semantics via a jest `setupFiles` shim: **before the fix that shim produced 17 failures; after the fix, 49/49 pass** — so the suite is now green regardless of Node's whole-object-assignment behavior.

## Fix

- Add explicit per-key deletion of the `CDK_RAG_*` vars (`clearRagEnv()`) in **both** `beforeEach` and `afterEach`. `delete process.env[key]` is Node-version-independent, so it's the load-bearing teardown.
- Start each test from a fresh copy of the snapshot (`process.env = { ...originalEnv }`) so mutations never touch the object we restore from.

No production behavior changes — the validation rules in `lib/config.ts` (e.g. "RAG embedding model must be a non-empty string") are correct as-is; only the test harness was leaky.

## Verification

- `npx jest config.test` → **49 passed** (normal run)
- `npx jest config.test --setupFiles <merge-only shim>` → **49 passed** (was 17 failed before the fix)
- `npx jest` (full suite) → **381 passed, 16 suites**
- `npx tsc --noEmit` → clean

> Note: the pre-existing "A worker process has failed to exit gracefully" warning is present on `develop` independent of this change. It's about open handles/timers during CDK synthesis, not `process.env`, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)