### PR TITLE
fix(infra): re-ship artifact-render code when the live Lambda drifts from what we shipped

### DIFF
--- a/infrastructure/test/artifact-render-deploy-resilience.test.ts
+++ b/infrastructure/test/artifact-render-deploy-resilience.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Guard tests for the artifact-render zip-Lambda code deploy.
+ *
+ * Regression cover for the stranded-bootstrap-stub bug: the
+ * out-of-band code deploy (`deploy-lambda-code-if-changed.sh`) skipped
+ * `update-function-code` whenever the SOURCE hash was unchanged. But
+ * the SSM source hash is decoupled from the function's ACTUAL live
+ * code — a CFN/Platform deploy that replaces the Lambda (logical-id
+ * change, e.g. hoisting it into PlatformStack) reverts it to the
+ * bootstrap 503 stub WITHOUT changing the source. So the script
+ * skipped forever and the placeholder stayed live in production
+ * (artifacts.{domain} served "Artifact service is updating").
+ *
+ * The fix adds a liveness guard: the script also records the deployed
+ * CodeSha256 and compares it against the function's live CodeSha256
+ * each run, re-deploying when they diverge regardless of the source
+ * hash. These tests pin that the guard wiring stays in place — they
+ * mirror the file-shape style of the "Build scripts" suite in
+ * network-and-scripts.test.ts (the build scripts are intentionally
+ * not executed in unit tests so they don't depend on aws/zip/sha256sum
+ * being present locally).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BUILD = path.resolve(__dirname, '..', '..', 'scripts', 'build');
+const IF_CHANGED = path.join(BUILD, 'deploy-lambda-code-if-changed.sh');
+const ONE = path.join(BUILD, 'deploy-zip-lambda-one.sh');
+
+const read = (p: string): string => fs.readFileSync(p, 'utf-8');
+
+describe('deploy-lambda-code-if-changed.sh — liveness guard', () => {
+  let content: string;
+  beforeAll(() => {
+    content = read(IF_CHANGED);
+  });
+
+  it('exists and is executable', () => {
+    const stat = fs.statSync(IF_CHANGED);
+    expect(stat.isFile()).toBe(true);
+    expect(stat.mode & 0o111).toBeGreaterThan(0);
+  });
+
+  it('accepts a --code-sha256-ssm argument', () => {
+    expect(content).toContain('--code-sha256-ssm');
+    expect(content).toContain('CODE_SHA256_SSM');
+  });
+
+  it('requires --code-sha256-ssm (fails loudly if omitted)', () => {
+    expect(content).toMatch(/missing --code-sha256-ssm/);
+  });
+
+  it('reads the function’s live CodeSha256', () => {
+    expect(content).toContain('get-function-configuration');
+    expect(content).toContain("--query 'CodeSha256'");
+    expect(content).toContain('LIVE_SHA');
+  });
+
+  it('only skips when the source hash AND the live CodeSha256 both match the last deploy', () => {
+    // The skip condition must AND all three signals together; a
+    // source-hash-only skip is exactly the regression we are guarding.
+    expect(content).toMatch(
+      /if\s*\[\[\s*"\$HASH"\s*==\s*"\$PUBLISHED_HASH"\s*&&\s*-n\s*"\$RECORDED_SHA"\s*&&\s*"\$LIVE_SHA"\s*==\s*"\$RECORDED_SHA"\s*\]\]/,
+    );
+  });
+
+  it('re-deploys (does not skip) when the live code drifted from what we shipped', () => {
+    // The drift branch is what un-sticks a function that CFN reset to
+    // the bootstrap stub.
+    expect(content).toContain('LIVE DRIFT');
+  });
+
+  it('records the settled CodeSha256 to SSM after a successful deploy', () => {
+    // After update-function-code we must persist the new baseline so
+    // the next run can compare against it.
+    expect(content).toContain('NEW_SHA');
+    expect(content).toMatch(/put-parameter[\s\S]*?--name "\$CODE_SHA256_SSM"/);
+  });
+});
+
+describe('deploy-zip-lambda-one.sh — artifact-render wiring', () => {
+  let content: string;
+  beforeAll(() => {
+    content = read(ONE);
+  });
+
+  it('exists and is executable', () => {
+    const stat = fs.statSync(ONE);
+    expect(stat.isFile()).toBe(true);
+    expect(stat.mode & 0o111).toBeGreaterThan(0);
+  });
+
+  it('defines the render-code-sha256 SSM path for artifact-render', () => {
+    expect(content).toContain('/artifacts/render-code-sha256');
+    expect(content).toContain('CODE_SHA256_SSM=');
+  });
+
+  it('passes --code-sha256-ssm through to deploy-lambda-code-if-changed.sh', () => {
+    expect(content).toMatch(/--code-sha256-ssm "\$CODE_SHA256_SSM"/);
+  });
+});

--- a/scripts/build/deploy-lambda-code-if-changed.sh
+++ b/scripts/build/deploy-lambda-code-if-changed.sh
@@ -28,12 +28,31 @@
 #   ran it manually, but normal stack updates leave the Lambda
 #   alone.)
 #
+# Liveness guard (why a source hash alone is NOT enough):
+#   The source hash answers "did the code we ship change?" — but it
+#   is decoupled from what is ACTUALLY live on the function. A CFN /
+#   Platform deploy that replaces the Lambda (logical-id change) or
+#   otherwise resets its `Code` property reverts it to the bootstrap
+#   stub WITHOUT touching the source, so a source-hash-only check
+#   would skip forever and strand the stub in production. That is
+#   exactly what happened to the artifact-render Lambda after it was
+#   hoisted into PlatformStack: the function was replaced (reset to
+#   the 503 stub) while `render-code-hash` still held the previous
+#   real-code hash, so every workflow run logged "unchanged — skip"
+#   and the placeholder stayed live.
+#   So we ALSO record the CodeSha256 of what we shipped, and compare
+#   it against the function's LIVE CodeSha256 each run. If they
+#   differ, the live code drifted from what we shipped (someone reset
+#   the function out-of-band) and we re-deploy regardless of the
+#   source hash. Both must match to skip.
+#
 # Usage:
 #   deploy-lambda-code-if-changed.sh \
 #     --service        artifact-render \
 #     --source-dir     backend/src/lambdas/artifact_render \
 #     --function-name-ssm  /ai-sbmt-api/artifacts/render-function-name \
-#     --code-hash-ssm      /ai-sbmt-api/artifacts/render-code-hash
+#     --code-hash-ssm      /ai-sbmt-api/artifacts/render-code-hash \
+#     --code-sha256-ssm    /ai-sbmt-api/artifacts/render-code-sha256
 #
 # Required env:
 #   AWS_REGION          (e.g., us-west-2)
@@ -47,11 +66,13 @@ SERVICE=""
 SOURCE_DIR=""
 FUNCTION_NAME_SSM=""
 CODE_HASH_SSM=""
+CODE_SHA256_SSM=""
 
 usage() {
     cat <<EOF >&2
 Usage: $0 --service NAME --source-dir DIR \\
-          --function-name-ssm PATH --code-hash-ssm PATH
+          --function-name-ssm PATH --code-hash-ssm PATH \\
+          --code-sha256-ssm PATH
 EOF
     exit 1
 }
@@ -62,6 +83,7 @@ while [[ $# -gt 0 ]]; do
         --source-dir)         SOURCE_DIR="$2"; shift 2 ;;
         --function-name-ssm)  FUNCTION_NAME_SSM="$2"; shift 2 ;;
         --code-hash-ssm)      CODE_HASH_SSM="$2"; shift 2 ;;
+        --code-sha256-ssm)    CODE_SHA256_SSM="$2"; shift 2 ;;
         -h|--help)            usage ;;
         *)                    echo "Unknown arg: $1" >&2; usage ;;
     esac
@@ -71,6 +93,7 @@ done
 [[ -n "$SOURCE_DIR"        ]] || { echo "missing --source-dir" >&2; usage; }
 [[ -n "$FUNCTION_NAME_SSM" ]] || { echo "missing --function-name-ssm" >&2; usage; }
 [[ -n "$CODE_HASH_SSM"     ]] || { echo "missing --code-hash-ssm" >&2; usage; }
+[[ -n "$CODE_SHA256_SSM"   ]] || { echo "missing --code-sha256-ssm" >&2; usage; }
 [[ -n "${AWS_REGION:-}"    ]] || { echo "AWS_REGION env var required" >&2; exit 2; }
 [[ -d "$SOURCE_DIR"        ]] || { echo "source-dir not found: $SOURCE_DIR" >&2; exit 2; }
 
@@ -91,37 +114,76 @@ HASH="$(bash "$COMPUTE_HASH" \
     --source-dir "$SOURCE_DIR")"
 log "Content hash: $HASH"
 
-# 2. Compare with the published hash in SSM. Missing parameter
-# (first deploy) counts as "changed".
-PUBLISHED_HASH=""
-if PUBLISHED_HASH="$(aws ssm get-parameter \
-        --region "$AWS_REGION" \
-        --name "$CODE_HASH_SSM" \
-        --query 'Parameter.Value' \
-        --output text 2>/dev/null)"; then
-    log "Published hash: $PUBLISHED_HASH"
-else
-    log "No published hash yet (first deploy)."
-    PUBLISHED_HASH=""
-fi
-
-if [[ "$HASH" == "$PUBLISHED_HASH" ]]; then
-    log "Source unchanged since last deploy — skipping update-function-code."
-    echo "$HASH"
-    exit 0
-fi
-
-log "Source has changed — deploying."
-
-# 3. Resolve the function name from SSM. The Lambda's name is
+# 2. Resolve the function name from SSM. The Lambda's name is
 # CDK-auto-generated to avoid orphan-collisions, so we can't hard-
-# code it here.
+# code it here. Resolved up-front (before the skip decision) because
+# the liveness guard below needs to read the function's live
+# CodeSha256. CDK runs before this step and publishes the name, so
+# the parameter always exists by the time we get here.
 FUNCTION_NAME="$(aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$FUNCTION_NAME_SSM" \
     --query 'Parameter.Value' \
     --output text)"
 log "Function name: $FUNCTION_NAME"
+
+# 3. Gather the three signals the skip decision needs:
+#    a. PUBLISHED_HASH — source hash we last shipped (SSM).
+#    b. RECORDED_SHA   — CodeSha256 we recorded on that same deploy
+#                        (SSM). Empty on a first deploy or before this
+#                        liveness guard existed.
+#    c. LIVE_SHA       — the function's CURRENT CodeSha256 (live).
+# Missing SSM parameters (first deploy) count as "changed".
+PUBLISHED_HASH=""
+if PUBLISHED_HASH="$(aws ssm get-parameter \
+        --region "$AWS_REGION" \
+        --name "$CODE_HASH_SSM" \
+        --query 'Parameter.Value' \
+        --output text 2>/dev/null)"; then
+    log "Published source hash: $PUBLISHED_HASH"
+else
+    log "No published source hash yet (first deploy)."
+    PUBLISHED_HASH=""
+fi
+
+RECORDED_SHA=""
+if RECORDED_SHA="$(aws ssm get-parameter \
+        --region "$AWS_REGION" \
+        --name "$CODE_SHA256_SSM" \
+        --query 'Parameter.Value' \
+        --output text 2>/dev/null)"; then
+    log "Recorded CodeSha256: $RECORDED_SHA"
+else
+    log "No recorded CodeSha256 yet (first deploy / pre-liveness-guard)."
+    RECORDED_SHA=""
+fi
+
+LIVE_SHA="$(aws lambda get-function-configuration \
+    --region "$AWS_REGION" \
+    --function-name "$FUNCTION_NAME" \
+    --query 'CodeSha256' \
+    --output text)"
+log "Live CodeSha256: $LIVE_SHA"
+
+# Skip ONLY when the source is unchanged AND the live code is exactly
+# what we last shipped. The CodeSha256 comparison is the guard that
+# defends against a CFN/Platform deploy silently reverting the
+# function to the bootstrap stub: in that case LIVE_SHA != RECORDED_SHA
+# and we re-deploy even though the source never changed.
+if [[ "$HASH" == "$PUBLISHED_HASH" && -n "$RECORDED_SHA" && "$LIVE_SHA" == "$RECORDED_SHA" ]]; then
+    log "Source unchanged and live code matches last deploy — skipping update-function-code."
+    echo "$HASH"
+    exit 0
+fi
+
+# Log WHY we're deploying (the three triggers, in priority order).
+if [[ "$HASH" != "$PUBLISHED_HASH" ]]; then
+    log "Source changed (was '$PUBLISHED_HASH', now '$HASH') — deploying."
+elif [[ -z "$RECORDED_SHA" ]]; then
+    log "No recorded CodeSha256 — deploying to establish the liveness baseline."
+else
+    log "LIVE DRIFT: live CodeSha256 ($LIVE_SHA) != last-deployed ($RECORDED_SHA). The function was reset out-of-band — almost certainly a CFN/Platform deploy reverting it to the bootstrap stub — so the real handler is NOT live. Re-shipping."
+fi
 
 # 4. Zip the source directory. We run from inside the dir so the
 # zip entries are relative — Lambda extracts them at the runtime's
@@ -170,8 +232,19 @@ aws lambda wait function-updated \
     --region "$AWS_REGION" \
     --function-name "$FUNCTION_NAME" >&2
 
-# 8. Publish the new hash so the next run can short-circuit.
-log "Publishing new hash to $CODE_HASH_SSM..."
+# 8. Read the settled CodeSha256 and publish BOTH trackers so the
+# next run can short-circuit — and, crucially, so the liveness guard
+# has a baseline to compare the live code against. Reading the
+# settled value (rather than trusting update-function-code's echo)
+# guarantees we record what AWS actually has live.
+log "Reading settled CodeSha256..."
+NEW_SHA="$(aws lambda get-function-configuration \
+    --region "$AWS_REGION" \
+    --function-name "$FUNCTION_NAME" \
+    --query 'CodeSha256' \
+    --output text)"
+
+log "Publishing source hash to $CODE_HASH_SSM and CodeSha256 to $CODE_SHA256_SSM..."
 aws ssm put-parameter \
     --region "$AWS_REGION" \
     --name "$CODE_HASH_SSM" \
@@ -179,6 +252,13 @@ aws ssm put-parameter \
     --type String \
     --overwrite \
     --no-cli-pager >/dev/null
+aws ssm put-parameter \
+    --region "$AWS_REGION" \
+    --name "$CODE_SHA256_SSM" \
+    --value "$NEW_SHA" \
+    --type String \
+    --overwrite \
+    --no-cli-pager >/dev/null
 
-log "Done. New code hash: $HASH"
+log "Done. Source hash: $HASH, CodeSha256: $NEW_SHA"
 echo "$HASH"

--- a/scripts/build/deploy-zip-lambda-one.sh
+++ b/scripts/build/deploy-zip-lambda-one.sh
@@ -38,6 +38,7 @@ case "$SERVICE" in
         SOURCE_DIR="backend/src/lambdas/artifact_render"
         FUNCTION_NAME_SSM="/${CDK_PROJECT_PREFIX}/artifacts/render-function-name"
         CODE_HASH_SSM="/${CDK_PROJECT_PREFIX}/artifacts/render-code-hash"
+        CODE_SHA256_SSM="/${CDK_PROJECT_PREFIX}/artifacts/render-code-sha256"
         ;;
     *)
         echo "Unknown service: $SERVICE" >&2
@@ -53,7 +54,8 @@ HASH="$(bash "$DEPLOY" \
     --service "$SERVICE" \
     --source-dir "$SOURCE_DIR" \
     --function-name-ssm "$FUNCTION_NAME_SSM" \
-    --code-hash-ssm "$CODE_HASH_SSM")"
+    --code-hash-ssm "$CODE_HASH_SSM" \
+    --code-sha256-ssm "$CODE_SHA256_SSM")"
 
 log_info "${SERVICE}: ${HASH}"
 


### PR DESCRIPTION
## Problem

The artifact origin (`artifacts.{domain}`) was serving the CDK **bootstrap 503 stub** ("Artifact service is updating") instead of the real handler, so the SPA's artifact panel never rendered (`Failed to load resource: … 503`, and earlier a frame error).

This is **not** the #434 failure mode — DNS, the ACM cert, and `frame-ancestors` for `artifacts.{domain}` are all correct. The render Lambda was simply running the placeholder.

## Root cause — a stale, decoupled content-hash skip

Artifact-render code is shipped out-of-band by `deploy-lambda-code-if-changed.sh`, gated on a source hash in SSM (`/<prefix>/artifacts/render-code-hash`). That hash is written by the **deploy script**, but the Lambda is owned by **CDK**.

When a PlatformStack deploy **replaces** the Lambda (logical-id change — e.g. the hoist-into-`PlatformStack` refactor), the function reverts to the byte-stable bootstrap stub and CDK republishes `render-function-name`, but `render-code-hash` keeps the previous real-code value. Source unchanged ⇒ every workflow run logs *"unchanged — skipping"* ⇒ the stub stays live forever. The deploy could not self-heal.

Same family as #434: an infra refactor leaves stale out-of-band-deploy state that a silent skip masks.

### Confirmed against dev (`dev-boisestateai-v2`, us-west-2)

| Signal | Value | Meaning |
|---|---|---|
| Live Lambda `CodeSize` | **1334 bytes** | the bootstrap stub (real handler is ~19KB) |
| Live `LastModified` | Jun 2 **15:32 UTC** | a PlatformStack deploy reset the code |
| `render-function-name` modified | Jun 2 **15:32** | CDK republished it → function was replaced |
| `render-code-hash` | `9cc7194ab9bab24f` (Jun 2 **10:50**) | from the earlier real-code deploy, never updated since |
| current source hash | **`9cc7194ab9bab24f`** | identical → next dispatch SKIPS → stub stays live |

## Fix — a CodeSha256 liveness guard

The script now also records the deployed `CodeSha256` (`/<prefix>/artifacts/render-code-sha256`) and compares it against the function's **live** `CodeSha256` each run:

- **Skip only** when the source hash is unchanged **AND** the live code equals what we last shipped.
- If they diverge (function reset out-of-band), **re-deploy** regardless of the source hash.
- A missing baseline (this env, or any first deploy) forces a deploy → re-ships the real handler and un-sticks the stub.

### Changes
- `scripts/build/deploy-lambda-code-if-changed.sh` — read live `CodeSha256`, dual-gate the skip, record the sha256 baseline after deploy, accept `--code-sha256-ssm`.
- `scripts/build/deploy-zip-lambda-one.sh` — define `render-code-sha256` SSM path and thread `--code-sha256-ssm` through.
- `infrastructure/test/artifact-render-deploy-resilience.test.ts` — new guard tests (skip-only-on-both-match, drift re-deploy, sha256 recording, arg wiring).

## Verification
- Behavioral run against a stubbed `aws`: stranded-stub→deploy, live-drift→deploy, steady-state→skip, source-changed→deploy — all pass.
- Full infra suite **387/387**, `tsc --noEmit` clean, `bash -n` clean.

## Reviewer notes
- **Deploying this won't auto-fix dev.** `backend.yml`'s push triggers are still in the TEMPORARY-disabled block, so after merge you must **manually dispatch** `backend.yml`. On that run the empty `render-code-sha256` baseline forces `update-function-code` and ships the real handler.
- After that, the deploy **self-heals**: any future Lambda replacement leaves a live `CodeSha256` that no longer matches the recorded baseline, so the next dispatch re-ships instead of silently skipping.
- Generalizes to any future bootstrap-zip Lambda using this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)