### PR TITLE
style(docs): make header GitHub icon neutral and larger

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -636,3 +636,20 @@ site-search button[data-open-modal] kbd {
 :root[data-has-hero] .sl-markdown-content {
 	margin-inline: auto;
 }
+
+/* Header GitHub (social) icon — neutral high-contrast instead of Starlight's
+   accent blue, and a touch larger. `--sl-color-white` is the maximally
+   contrasting neutral: near-black in light mode (the requested "black"),
+   white in dark mode so it stays legible against the dark surface. Brand blue
+   returns on hover for a hint of life. */
+.social-icons a {
+	color: var(--sl-color-white);
+}
+
+.social-icons a:hover {
+	color: var(--sl-color-text-accent);
+}
+
+.social-icons a svg {
+	font-size: 1.5rem; /* ~24px, up from the default 1em (~16px) */
+}


### PR DESCRIPTION
## What

Restyles the docs-site header GitHub (social) icon: it inherited Starlight's accent (Boise blue), so it's overridden to the high-contrast neutral token (`--sl-color-white`) and bumped up in size.

- **Color:** near-black in light mode (the requested "black"), white in dark mode so it stays legible against the dark frosted nav. Brand blue returns on hover.
- **Size:** `1.5rem` (~24px), up from the Starlight default of ~16px.

## Why

Direct request to make the header GitHub icon black (rather than blue) and larger.

## Reviewer notes

- Uses a **theme-aware** neutral rather than a hardcoded `#000` — pure black would be invisible against the dark nav. Verified rendered values: light `rgb(23,24,28)`, dark `rgb(255,255,255)`, 24×24px in both.
- Custom CSS in `docs-site/src/styles/custom.css` is intentionally **unlayered** so it wins over Starlight's `@layer starlight.*` defaults without specificity hacks.
- Rebased onto current `develop`: the frosted-glass redesign this branch originally carried already landed via #440, so this PR is now just the 17-line icon follow-up.
- Verified locally via `astro dev` in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)