### PR TITLE
Add shared security helpers for URL validation, ownership checks, and…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,17 @@ scripts/stack-bootstrap/install.sh
 test-accounts
 manifest.json
 manifest.json:Zone.Identifier
+
+# Internal documents and reports (kept out of public repo by policy)
+*-internal.pdf
+*-internal.md
+*-internal.txt
+*-confidential.*
+internal-notes/
+internal-docs/
+*.private.pdf
+*.private.md
+*-report-*.pdf
+audit-*.pdf
+audit-*.md
+review-*.pdf

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -108,6 +108,13 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Centralized exception handlers: AWS ClientError responses are mapped to
+# generic 400/502 bodies (logged server-side) so AWS error messages, internal
+# parameter names, and reflected user input never leak into HTTP responses.
+from apis.shared.security import register_aws_client_error_handler
+register_aws_client_error_handler(app)
+logger.info("Registered AWS ClientError handler")
+
 # Add CORS middleware - origins from CDK-provided CORS_ORIGINS env var
 # NOTE: `allow_credentials=True` is required for the BFF cookie flow when the
 # SPA and BFF are cross-origin (e.g. local dev: SPA on :4200, BFF on :8000).

--- a/backend/src/apis/inference_api/main.py
+++ b/backend/src/apis/inference_api/main.py
@@ -110,6 +110,13 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Centralized exception handlers: AWS ClientError responses are mapped to
+# generic 400/502 bodies (logged server-side) so AWS error messages, internal
+# parameter names, and reflected user input never leak into HTTP responses.
+from apis.shared.security import register_aws_client_error_handler
+register_aws_client_error_handler(app)
+logger.info("Registered AWS ClientError handler")
+
 # Add GZip compression middleware for SSE streams
 # Compresses responses over 1KB, reducing bandwidth by 50-70%
 app.add_middleware(

--- a/backend/src/apis/shared/security/__init__.py
+++ b/backend/src/apis/shared/security/__init__.py
@@ -1,0 +1,34 @@
+"""Shared security utilities used across API services.
+
+This package contains cross-cutting helpers for input validation, ownership
+enforcement, and consistent error handling. Importable from ``app_api``,
+``inference_api``, and agent code.
+"""
+
+from apis.shared.security.url_validator import (
+    UrlValidationError,
+    validate_external_url,
+)
+from apis.shared.security.ownership import (
+    OwnershipError,
+    require_session_owner,
+    require_memory_owner,
+    require_file_owner,
+    register_ownership_handler,
+)
+from apis.shared.security.error_handler import (
+    register_aws_client_error_handler,
+    register_safe_500_handler,
+)
+
+__all__ = [
+    "UrlValidationError",
+    "validate_external_url",
+    "OwnershipError",
+    "require_session_owner",
+    "require_memory_owner",
+    "require_file_owner",
+    "register_ownership_handler",
+    "register_aws_client_error_handler",
+    "register_safe_500_handler",
+]

--- a/backend/src/apis/shared/security/error_handler.py
+++ b/backend/src/apis/shared/security/error_handler.py
@@ -1,0 +1,94 @@
+"""Centralized exception handlers for upstream-service and unhandled errors.
+
+These handlers ensure the response body never reflects internal details:
+
+* AWS API ``ClientError`` messages frequently contain regex patterns,
+  enum value sets, internal parameter names, and the user-supplied input
+  itself. Surfacing them to clients leaks implementation detail and provides
+  an XSS reflection sink. The handler maps validation-shaped errors to a
+  generic 400 and other client errors to a generic 502.
+* Unhandled exceptions are mapped to a generic 500 ``{"detail": "Internal
+  server error"}`` with the full traceback logged server-side.
+
+Both handlers use the module logger at WARN/ERROR for server-side visibility.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Botocore error codes that represent client-input problems and should
+# surface as HTTP 400 (with a generic body).
+_CLIENT_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "ValidationException",
+        "InvalidParameterValue",
+        "InvalidParameterCombination",
+        "InvalidArgumentException",
+        "InvalidRequestException",
+        "MalformedQueryString",
+    }
+)
+
+_GENERIC_BAD_REQUEST = "Invalid request parameters."
+_GENERIC_UPSTREAM_ERROR = "Upstream service error."
+_GENERIC_INTERNAL_ERROR = "Internal server error."
+
+
+def register_aws_client_error_handler(app: Any) -> None:
+    """Install a FastAPI handler for ``botocore.exceptions.ClientError``.
+
+    * ``ValidationException`` (and similar input-shape errors) → HTTP 400 with
+      ``{"detail": "Invalid request parameters."}``.
+    * Any other ``ClientError`` → HTTP 502 with
+      ``{"detail": "Upstream service error."}``.
+
+    The full AWS error message is logged at WARN; it never appears in the
+    response body.
+    """
+    from botocore.exceptions import ClientError
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    async def _handler(request: Request, exc: ClientError) -> JSONResponse:
+        error_response = exc.response.get("Error", {}) if hasattr(exc, "response") else {}
+        code = error_response.get("Code", "")
+        # Log the full message server-side for operators. Path is included so
+        # the entry is correlatable; the message itself never leaves the log.
+        logger.warning(
+            "AWS ClientError on %s %s: code=%s message=%r",
+            request.method,
+            request.url.path,
+            code,
+            error_response.get("Message", str(exc)),
+        )
+        if code in _CLIENT_ERROR_CODES:
+            return JSONResponse(status_code=400, content={"detail": _GENERIC_BAD_REQUEST})
+        return JSONResponse(status_code=502, content={"detail": _GENERIC_UPSTREAM_ERROR})
+
+    app.add_exception_handler(ClientError, _handler)
+
+
+def register_safe_500_handler(app: Any) -> None:
+    """Install a FastAPI handler that maps unhandled exceptions to a generic 500.
+
+    The handler is intentionally conservative: it only catches
+    :class:`Exception` (not :class:`BaseException`), so KeyboardInterrupt and
+    SystemExit propagate normally. The full traceback is logged at ERROR.
+    """
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    async def _handler(request: Request, exc: Exception) -> JSONResponse:
+        logger.exception(
+            "Unhandled exception on %s %s: %s",
+            request.method,
+            request.url.path,
+            type(exc).__name__,
+        )
+        return JSONResponse(status_code=500, content={"detail": _GENERIC_INTERNAL_ERROR})
+
+    app.add_exception_handler(Exception, _handler)

--- a/backend/src/apis/shared/security/ownership.py
+++ b/backend/src/apis/shared/security/ownership.py
@@ -1,0 +1,125 @@
+"""Resource-ownership helpers and consistent 404 mapping.
+
+Centralizes the "the requesting user does not own this object" check so every
+call site enforces the same invariant and produces the same response shape.
+The error is mapped to **HTTP 404, not 403**, deliberately: a 403 response
+leaks the existence of the resource to non-owners, providing an enumeration
+oracle. 404 makes a non-owner's request indistinguishable from a request for
+a non-existent resource.
+
+Helpers raise :class:`OwnershipError` on mismatch. Register
+:func:`register_ownership_handler` on the FastAPI app to convert these to
+404 responses with a generic detail.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Keys we know how to read ``owner_id``-style fields under, in priority order.
+# Records may come from DynamoDB (camelCase) or domain models (snake_case),
+# so accept both.
+_OWNER_FIELDS: tuple[str, ...] = (
+    "user_id",
+    "userId",
+    "owner_id",
+    "ownerId",
+    "owner",
+)
+
+
+class OwnershipError(Exception):
+    """Raised when a request targets a resource the caller does not own."""
+
+    def __init__(self, resource_kind: str = "resource") -> None:
+        super().__init__(f"{resource_kind} not found")
+        self.resource_kind = resource_kind
+
+
+def _extract_owner(record: Any) -> str | None:
+    """Return the owner identifier from *record*, or None if not present."""
+    if record is None:
+        return None
+    # Pydantic / dataclass / ORM
+    for attr in _OWNER_FIELDS:
+        val = getattr(record, attr, None)
+        if val is not None:
+            return str(val)
+    # Mapping (DynamoDB item, dict)
+    if isinstance(record, dict):
+        for key in _OWNER_FIELDS:
+            if key in record and record[key] is not None:
+                return str(record[key])
+    return None
+
+
+def _require_owner(user_id: str, record: Any, resource_kind: str) -> None:
+    """Internal: raise OwnershipError unless ``record`` belongs to ``user_id``.
+
+    Treats a missing record (None) and an owner mismatch identically — both
+    surface as a 404 to the caller. The distinction is logged server-side.
+    """
+    if not user_id:
+        raise OwnershipError(resource_kind)
+    if record is None:
+        raise OwnershipError(resource_kind)
+    owner = _extract_owner(record)
+    if owner is None:
+        # Defensive: a record without an identifiable owner is treated as
+        # not-found for safety. Log so this surfaces in operations.
+        logger.warning(
+            "Ownership check on %s record had no recognized owner field; treating as not found",
+            resource_kind,
+        )
+        raise OwnershipError(resource_kind)
+    if owner != user_id:
+        raise OwnershipError(resource_kind)
+
+
+def require_session_owner(user_id: str, session_record: Any) -> None:
+    """Raise OwnershipError unless *session_record* belongs to *user_id*."""
+    _require_owner(user_id, session_record, "session")
+
+
+def require_memory_owner(user_id: str, record: Any) -> None:
+    """Raise OwnershipError unless the memory *record* belongs to *user_id*.
+
+    Memory records are namespaced (e.g. ``/preferences/{user_id}``); pass the
+    record's namespace string as ``record`` and we'll match the trailing
+    segment, or pass an object with an ``owner_id``/``user_id`` attribute.
+    """
+    if isinstance(record, str):
+        # Namespace path — owner is the last path segment.
+        if not record:
+            raise OwnershipError("memory record")
+        owner_segment = record.rstrip("/").rsplit("/", 1)[-1]
+        if owner_segment != user_id:
+            raise OwnershipError("memory record")
+        return
+    _require_owner(user_id, record, "memory record")
+
+
+def require_file_owner(user_id: str, file_record: Any) -> None:
+    """Raise OwnershipError unless *file_record* belongs to *user_id*."""
+    _require_owner(user_id, file_record, "file")
+
+
+def register_ownership_handler(app: Any) -> None:
+    """Register a FastAPI exception handler that maps OwnershipError to 404.
+
+    Imported lazily so this module remains importable without FastAPI in
+    contexts that only need the helper functions.
+    """
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    async def _handler(_request: Request, exc: OwnershipError) -> JSONResponse:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"{exc.resource_kind.capitalize()} not found."},
+        )
+
+    app.add_exception_handler(OwnershipError, _handler)

--- a/backend/src/apis/shared/security/url_validator.py
+++ b/backend/src/apis/shared/security/url_validator.py
@@ -1,0 +1,194 @@
+"""URL validation for outbound HTTP requests.
+
+Provides ``validate_external_url`` which parses a URL, resolves its hostname
+via DNS, and rejects targets that resolve to addresses the application has no
+business contacting from server-side code:
+
+* Loopback (``127.0.0.0/8``, ``::1``)
+* Link-local (``169.254.0.0/16``, ``fe80::/10``) — includes cloud metadata
+* Private networks (RFC1918, ``fc00::/7``)
+* Multicast, reserved, unspecified
+* Cloud metadata-service literal addresses (``169.254.169.254``,
+  ``fd00:ec2::254``)
+
+DNS rebinding is mitigated by resolving every result and rejecting the URL if
+*any* resolved address is forbidden. Callers can additionally restrict to a
+set of allowed domains via ``domain_allowlist``.
+
+Raises :class:`UrlValidationError` for any disallowed input. The error message
+is intentionally generic so it's safe to surface to callers without leaking
+internal network topology.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from typing import Iterable
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Cloud metadata-service literal addresses. Belt-and-suspenders alongside the
+# link-local check below — these are the ones we most care about.
+_METADATA_ADDRESSES: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS / GCP / Azure IMDSv1/v2
+        "fd00:ec2::254",  # AWS IMDS over IPv6
+        "100.100.100.200",  # Alibaba Cloud
+        "169.254.170.2",  # AWS ECS task metadata / credentials provider
+    }
+)
+
+_DEFAULT_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+
+class UrlValidationError(ValueError):
+    """Raised when a URL fails security validation.
+
+    Carries a short, generic message safe to surface to callers. Detailed
+    reasons are emitted via the module logger for operator visibility.
+    """
+
+
+def _normalize_host(host: str) -> str:
+    """Strip IPv6 brackets and lowercase the hostname."""
+    h = host.strip().lower()
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    return h
+
+
+def _is_forbidden_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if the resolved IP must not be contacted."""
+    if addr.is_loopback or addr.is_link_local or addr.is_private or addr.is_multicast or addr.is_reserved or addr.is_unspecified:
+        return True
+    # ``is_private`` covers RFC1918 and ULA, but some address ranges (e.g.
+    # carrier-grade NAT 100.64.0.0/10) only land in ``is_private`` in newer
+    # Python versions. Add an explicit guard for the CGNAT range so we behave
+    # consistently across runtime versions.
+    try:
+        if isinstance(addr, ipaddress.IPv4Address):
+            cgnat = ipaddress.IPv4Network("100.64.0.0/10")
+            if addr in cgnat:
+                return True
+    except ValueError:
+        pass
+    if str(addr) in _METADATA_ADDRESSES:
+        return True
+    return False
+
+
+def _resolve_all(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve every A/AAAA record for *host* and return parsed addresses.
+
+    Raises :class:`UrlValidationError` if resolution fails or yields no results.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        logger.warning("URL validation: DNS resolution failed for host=%r: %s", host, exc)
+        raise UrlValidationError("URL host could not be resolved.") from exc
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        sockaddr = info[4]
+        ip_str = sockaddr[0]
+        try:
+            addresses.append(ipaddress.ip_address(ip_str))
+        except ValueError:
+            # Should not occur — getaddrinfo returns numeric IPs — but be defensive.
+            logger.warning("URL validation: getaddrinfo returned non-IP %r for host=%r", ip_str, host)
+            raise UrlValidationError("URL host resolution returned an invalid address.")
+
+    if not addresses:
+        raise UrlValidationError("URL host could not be resolved.")
+    return addresses
+
+
+def validate_external_url(
+    url: str,
+    *,
+    allow_schemes: Iterable[str] = _DEFAULT_SCHEMES,
+    domain_allowlist: set[str] | None = None,
+) -> str:
+    """Validate that *url* is safe to fetch from server-side code.
+
+    Args:
+        url: Absolute URL to validate.
+        allow_schemes: Iterable of acceptable URL schemes. Defaults to
+            ``{"http", "https"}``.
+        domain_allowlist: Optional set of fully-qualified hostnames the URL
+            must match exactly (case-insensitive). Subdomains are *not*
+            implicitly allowed — pass each acceptable host explicitly.
+
+    Returns:
+        The original URL string (unmodified) when validation passes.
+
+    Raises:
+        UrlValidationError: when validation fails. The exception message is
+            intentionally generic; details are logged.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UrlValidationError("URL is required.")
+
+    schemes = {s.lower() for s in allow_schemes}
+
+    try:
+        parsed = urlparse(url.strip())
+    except (ValueError, AttributeError) as exc:
+        raise UrlValidationError("URL could not be parsed.") from exc
+
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in schemes:
+        logger.warning("URL validation: rejected scheme=%r for url=%r", scheme, url)
+        raise UrlValidationError("URL scheme is not permitted.")
+
+    host = parsed.hostname
+    if not host:
+        raise UrlValidationError("URL is missing a host.")
+
+    host = _normalize_host(host)
+
+    # Reject embedded credentials — they're never appropriate for a backend-
+    # initiated request to an internet endpoint.
+    if parsed.username or parsed.password:
+        logger.warning("URL validation: rejected URL with embedded credentials")
+        raise UrlValidationError("URL must not contain embedded credentials.")
+
+    if domain_allowlist is not None:
+        normalized_allow = {_normalize_host(h) for h in domain_allowlist}
+        if host not in normalized_allow:
+            logger.warning(
+                "URL validation: host=%r not in allowlist (size=%d)",
+                host,
+                len(normalized_allow),
+            )
+            raise UrlValidationError("URL host is not in the allowed domains.")
+
+    # If the host is itself an IP literal, validate it directly without DNS.
+    try:
+        literal_addr = ipaddress.ip_address(host)
+    except ValueError:
+        literal_addr = None
+
+    if literal_addr is not None:
+        if _is_forbidden_address(literal_addr):
+            logger.warning("URL validation: rejected literal address=%s", literal_addr)
+            raise UrlValidationError("URL host is not permitted.")
+        return url
+
+    # Otherwise, resolve and check every result.
+    addresses = _resolve_all(host)
+    for addr in addresses:
+        if _is_forbidden_address(addr):
+            logger.warning(
+                "URL validation: host=%r resolved to forbidden address=%s (one of %d results)",
+                host,
+                addr,
+                len(addresses),
+            )
+            raise UrlValidationError("URL host is not permitted.")
+
+    return url

--- a/backend/tests/security/__init__.py
+++ b/backend/tests/security/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``apis.shared.security`` package."""

--- a/backend/tests/security/test_error_handler.py
+++ b/backend/tests/security/test_error_handler.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``apis.shared.security.error_handler``.
+
+Verifies that AWS ``ClientError`` exceptions become generic JSON responses
+with no AWS message reflection, and that unhandled exceptions become a
+generic 500 with no traceback in the response body.
+"""
+
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.security.error_handler import (
+    register_aws_client_error_handler,
+    register_safe_500_handler,
+)
+
+
+def _validation_error(message: str) -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ValidationException",
+                "Message": message,
+            }
+        },
+        operation_name="ListFoundationModels",
+    )
+
+
+def _throttling_error() -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ThrottlingException",
+                "Message": "Rate exceeded for arn:aws:bedrock:us-west-2:123456789012:foundation-model/x",
+            }
+        },
+        operation_name="ListFoundationModels",
+    )
+
+
+def _make_app(*, register_500: bool = False) -> FastAPI:
+    app = FastAPI()
+    register_aws_client_error_handler(app)
+    if register_500:
+        register_safe_500_handler(app)
+
+    @app.get("/aws-validation")
+    async def _v() -> dict:
+        raise _validation_error(
+            "1 validation error detected: Value '<script>alert(1)</script>' at "
+            "'byProvider' failed to satisfy constraint: Member must satisfy "
+            "regular expression pattern: [A-Za-z0-9- ]{1,63}"
+        )
+
+    @app.get("/aws-other")
+    async def _o() -> dict:
+        raise _throttling_error()
+
+    @app.get("/boom")
+    async def _b() -> dict:
+        raise RuntimeError("internal detail that must not be leaked at /db/users")
+
+    return app
+
+
+def test_validation_client_error_maps_to_400_generic() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/aws-validation")
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Invalid request parameters."}
+
+
+def test_validation_response_does_not_reflect_user_input() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/aws-validation")
+    body_text = resp.text
+    # Reflected payload must not appear in the body.
+    assert "<script>" not in body_text
+    assert "byProvider" not in body_text
+    # Internal AWS regex pattern must not leak.
+    assert "[A-Za-z0-9-" not in body_text
+    # AWS error code must not leak.
+    assert "ValidationException" not in body_text
+
+
+def test_other_client_error_maps_to_502_generic() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/aws-other")
+    assert resp.status_code == 502
+    assert resp.json() == {"detail": "Upstream service error."}
+    # AWS error message containing an ARN must not leak.
+    body_text = resp.text
+    assert "arn:aws" not in body_text
+    assert "ThrottlingException" not in body_text
+
+
+def test_safe_500_handler_returns_generic_body_without_traceback() -> None:
+    client = TestClient(_make_app(register_500=True), raise_server_exceptions=False)
+    resp = client.get("/boom")
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "Internal server error."}
+    body_text = resp.text
+    assert "RuntimeError" not in body_text
+    assert "internal detail" not in body_text
+    assert "/db/users" not in body_text
+
+
+def test_safe_500_handler_preserves_aws_handler_when_registered_first() -> None:
+    """Both handlers can coexist; AWS errors still get the specific mapping."""
+    client = TestClient(_make_app(register_500=True))
+    resp = client.get("/aws-validation")
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Invalid request parameters."}

--- a/backend/tests/security/test_ownership.py
+++ b/backend/tests/security/test_ownership.py
@@ -1,0 +1,119 @@
+"""Unit tests for ``apis.shared.security.ownership``.
+
+Verifies the helpers raise :class:`OwnershipError` for non-owners (mapped
+to HTTP 404 by the registered handler) and accept owner-matched records.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.security.ownership import (
+    OwnershipError,
+    register_ownership_handler,
+    require_file_owner,
+    require_memory_owner,
+    require_session_owner,
+)
+
+# ---- require_session_owner ------------------------------------------------
+
+
+def test_session_owner_accepts_match_via_dict() -> None:
+    record = {"sessionId": "s1", "userId": "u1"}
+    require_session_owner("u1", record)
+
+
+def test_session_owner_accepts_match_via_attr() -> None:
+    class Rec:
+        user_id = "u1"
+
+    require_session_owner("u1", Rec())
+
+
+def test_session_owner_rejects_mismatch() -> None:
+    record = {"userId": "u2"}
+    with pytest.raises(OwnershipError):
+        require_session_owner("u1", record)
+
+
+def test_session_owner_rejects_none_record() -> None:
+    with pytest.raises(OwnershipError):
+        require_session_owner("u1", None)
+
+
+def test_session_owner_rejects_record_without_owner_field() -> None:
+    with pytest.raises(OwnershipError):
+        require_session_owner("u1", {"sessionId": "s1"})
+
+
+def test_session_owner_rejects_empty_user_id() -> None:
+    with pytest.raises(OwnershipError):
+        require_session_owner("", {"userId": "u1"})
+
+
+# ---- require_memory_owner -------------------------------------------------
+
+
+def test_memory_owner_namespace_match() -> None:
+    require_memory_owner("u1", "/preferences/u1")
+
+
+def test_memory_owner_namespace_mismatch() -> None:
+    with pytest.raises(OwnershipError):
+        require_memory_owner("u1", "/preferences/u2")
+
+
+def test_memory_owner_record_object_match() -> None:
+    require_memory_owner("u1", {"recordId": "mem-x", "owner_id": "u1"})
+
+
+def test_memory_owner_record_object_mismatch() -> None:
+    with pytest.raises(OwnershipError):
+        require_memory_owner("u1", {"recordId": "mem-x", "owner_id": "u2"})
+
+
+# ---- require_file_owner ---------------------------------------------------
+
+
+def test_file_owner_match() -> None:
+    require_file_owner("u1", {"upload_id": "f1", "user_id": "u1"})
+
+
+def test_file_owner_mismatch() -> None:
+    with pytest.raises(OwnershipError):
+        require_file_owner("u1", {"upload_id": "f1", "user_id": "u2"})
+
+
+# ---- FastAPI handler mapping ----------------------------------------------
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    register_ownership_handler(app)
+
+    @app.get("/test")
+    async def _route(kind: str = "session") -> dict:
+        raise OwnershipError(kind)
+
+    return app
+
+
+def test_ownership_error_maps_to_404() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/test")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Session not found."}
+
+
+def test_ownership_error_does_not_disclose_resource_existence() -> None:
+    """Response must read like a generic not-found, not a 403/forbidden."""
+    client = TestClient(_make_app())
+    resp = client.get("/test", params={"kind": "memory record"})
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "forbidden" not in body["detail"].lower()
+    assert "denied" not in body["detail"].lower()
+    assert "permission" not in body["detail"].lower()

--- a/backend/tests/security/test_url_validator.py
+++ b/backend/tests/security/test_url_validator.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``apis.shared.security.url_validator``.
+
+These tests assert the *positive invariant* that the validator exists to
+enforce: server-side outbound HTTP requests must not target loopback,
+link-local (including cloud metadata), private, multicast, reserved, or
+otherwise unroutable addresses, and must defeat DNS-rebinding.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from apis.shared.security.url_validator import (
+    UrlValidationError,
+    validate_external_url,
+)
+
+
+def _fake_getaddrinfo(host_to_addrs: dict[str, list[str]]):
+    """Build a getaddrinfo replacement that returns canned IPs per host."""
+
+    def _impl(host, *args, **kwargs):
+        if host not in host_to_addrs:
+            raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        results = []
+        for ip in host_to_addrs[host]:
+            family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+            results.append((family, socket.SOCK_STREAM, 0, "", (ip, 0)))
+        return results
+
+    return _impl
+
+
+# ---- IP-literal hosts: validated directly without DNS ---------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://127.0.0.1:8080/foo",
+        "https://localhost.localdomain/x",
+        "http://[::1]/",
+    ],
+)
+def test_loopback_addresses_rejected(url: str) -> None:
+    # localhost.localdomain isn't an IP literal; rely on DNS resolution
+    # returning a loopback address. For the IP-literal cases the validator
+    # should reject without DNS at all.
+    if "localhost.localdomain" in url:
+        with patch(
+            "apis.shared.security.url_validator.socket.getaddrinfo",
+            _fake_getaddrinfo({"localhost.localdomain": ["127.0.0.1"]}),
+        ):
+            with pytest.raises(UrlValidationError):
+                validate_external_url(url)
+    else:
+        with pytest.raises(UrlValidationError):
+            validate_external_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://169.254.169.254:80/",
+        "http://[fd00:ec2::254]/latest/meta-data/",
+        "http://[fe80::1]/",
+    ],
+)
+def test_link_local_and_metadata_rejected(url: str) -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.0.0.1/",
+        "http://10.255.255.255/",
+        "http://172.16.0.1/",
+        "http://172.31.255.254/",
+        "http://192.168.1.1/",
+        "http://[fc00::1]/",
+        "http://[fd00::1]/",
+    ],
+)
+def test_rfc1918_and_ula_rejected(url: str) -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://224.0.0.1/",  # multicast IPv4
+        "http://[ff02::1]/",  # multicast IPv6
+        "http://0.0.0.0/",  # unspecified
+        "http://100.64.0.1/",  # carrier-grade NAT
+        "http://169.254.170.2/",  # ECS task metadata literal
+    ],
+)
+def test_other_unroutable_ranges_rejected(url: str) -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url(url)
+
+
+# ---- DNS resolution + rebinding defense -----------------------------------
+
+
+def test_public_url_resolved_to_public_ip_passes() -> None:
+    fake = _fake_getaddrinfo({"example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        assert validate_external_url("https://example.com/path") == "https://example.com/path"
+
+
+def test_public_hostname_resolving_to_private_ip_rejected() -> None:
+    fake = _fake_getaddrinfo({"sneaky.example.com": ["10.0.0.42"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url("https://sneaky.example.com/")
+
+
+def test_dns_rebinding_resistance_mixed_results_rejected() -> None:
+    """If any resolved address is forbidden, the URL must be rejected."""
+    fake = _fake_getaddrinfo({"rebind.example.com": ["93.184.216.34", "169.254.169.254"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url("https://rebind.example.com/")
+
+
+def test_dns_resolution_failure_rejected() -> None:
+    fake = _fake_getaddrinfo({})  # nothing resolves
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url("https://nope.invalid/")
+
+
+# ---- Schemes and inputs ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/",
+        "file:///etc/passwd",
+        "gopher://example.com/",
+        "data:text/plain,hi",
+        "javascript:alert(1)",
+    ],
+)
+def test_disallowed_schemes_rejected(url: str) -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url(url)
+
+
+def test_empty_input_rejected() -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url("")
+
+
+def test_missing_host_rejected() -> None:
+    with pytest.raises(UrlValidationError):
+        validate_external_url("http:///path")
+
+
+def test_embedded_credentials_rejected() -> None:
+    fake = _fake_getaddrinfo({"example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url("https://user:pass@example.com/")
+
+
+# ---- Domain allowlist -----------------------------------------------------
+
+
+def test_allowlist_allows_listed_host() -> None:
+    fake = _fake_getaddrinfo({"accounts.google.com": ["142.250.190.46"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        url = "https://accounts.google.com/.well-known/openid-configuration"
+        assert validate_external_url(url, domain_allowlist={"accounts.google.com"}) == url
+
+
+def test_allowlist_rejects_unlisted_host() -> None:
+    fake = _fake_getaddrinfo({"evil.example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url(
+                "https://evil.example.com/",
+                domain_allowlist={"accounts.google.com"},
+            )
+
+
+def test_allowlist_does_not_match_subdomain_implicitly() -> None:
+    """Subdomains must be listed explicitly."""
+    fake = _fake_getaddrinfo({"sub.example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        with pytest.raises(UrlValidationError):
+            validate_external_url(
+                "https://sub.example.com/",
+                domain_allowlist={"example.com"},
+            )
+
+
+def test_allowlist_case_insensitive() -> None:
+    fake = _fake_getaddrinfo({"example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        assert validate_external_url("https://EXAMPLE.com/", domain_allowlist={"Example.com"}) == "https://EXAMPLE.com/"
+
+
+# ---- Custom schemes -------------------------------------------------------
+
+
+def test_custom_allowed_schemes() -> None:
+    fake = _fake_getaddrinfo({"example.com": ["93.184.216.34"]})
+    with patch("apis.shared.security.url_validator.socket.getaddrinfo", fake):
+        assert validate_external_url("https://example.com/", allow_schemes={"https"}) == "https://example.com/"
+        with pytest.raises(UrlValidationError):
+            validate_external_url("http://example.com/", allow_schemes={"https"})


### PR DESCRIPTION
… AWS error mapping

Introduces a small apis.shared.security package providing three reusable utilities used across app_api, inference_api, and agent code:

- url_validator.validate_external_url: parses and DNS-resolves a URL, rejecting loopback, link-local (including cloud metadata addresses), RFC1918/ULA, multicast, reserved, unspecified, and CGNAT targets. Resolves every result to defeat DNS rebinding. Supports an optional exact-match domain allowlist and configurable scheme set.

- ownership: OwnershipError plus require_session_owner / require_memory_owner / require_file_owner helpers. The accompanying FastAPI handler maps OwnershipError to HTTP 404 (not 403) so non-owner responses are indistinguishable from not-found, removing an enumeration oracle.

- error_handler: register_aws_client_error_handler installs a FastAPI handler that maps botocore ClientError responses to generic 400 (for ValidationException-class codes) or 502 with no AWS message reflection. register_safe_500_handler maps unhandled exceptions to a generic 500. Both APIs now register the AWS handler at startup.

Also adds an Internal documents section to .gitignore for sensitive material that should never enter the public repo.

Tests: 56 new unit tests covering DNS rebinding defense, every unroutable IP range class, scheme rejection, allowlist semantics, ownership invariants, AWS error message non-reflection, and 500 body sanitization.