### PR TITLE
chore(kaizen): weekly research scan 2026-06-05

### DIFF
--- a/docs/kaizen/research/2026-06-05.md
+++ b/docs/kaizen/research/2026-06-05.md
@@ -1,0 +1,244 @@
+# Kaizen Research — Friday, June 5, 2026
+> Scan window: May 29 – June 5, 2026 (7 days).
+> Web budget: ~71/50 used (overage — see Web Budget block).
+
+## TL;DR
+
+**Strands 1.42.0 shipped June 1** — the release that last week's queue was gated on. It carries `Limits` (the native per-invocation cost/turn cap that supersedes our hand-rolled runaway guardrail), `cache_tools_ttl` cache-token metadata plumbing (the #269 caching unblock), and a structured-output log downgrade. The single most valuable move this week is the **Strands 1.40 → 1.42 bump** — one keystone that converts two queued-but-gated items into actionable work (recommended **#1**). The most pressing internal signal is a brand-new Strands bug, **#2635 — `count_tokens` returns 0 for toolResult JSON blocks** — which directly threatens the context-attribution badge we *just* shipped (PR #428–433): tool-heavy turns would silently under-report the Tools partition and trip compaction late.
+
+## External Scan
+
+### What's moving this week
+
+The week is defined by **upstream landing what we queued**. Strands 1.42.0 (June 1) released `Limits` — exactly the cost ceiling we hand-specced two weeks ago and queued last week pending 1.42 — alongside the cache-token metadata path that unblocks #269. The right read is consolidation: the two gated Strands items on the queue collapse into a single 1.40 → 1.42 bump. The catch is the blast radius — `strands-agents-tools` jumped 0.5.2 → 0.8.0 (pre-1.0 minors can carry breaking tool-interface changes) and `starlette` is now 1.2.1 (the long-owed transitive-conflict audit comes due). So the keystone is high-impact but not a one-line bump.
+
+AWS had a busier AgentCore week than the model side. **AgentCore Identity can now reference your own Secrets Manager secrets** (June 1) — directly in our `agentcore_identity.py` OAuth-provider lane — and AWS published a **secure OAuth auth-code flow reference for Gateway + MCP clients** (June 1), which is the exact pattern behind our internally-filed #419 (admin-managed Gateway target registration). **bedrock-agentcore SDK v1.13.0** (June 2) shipped a Strands tool-search plugin but *no* SSE/Identity/Memory fixes — #482 (SSE-disconnect deadlock) stays unpatched and our pin lag widened to 4 minors. On the model front, **GPT-5.4/5.5 + Codex went GA on Bedrock** (June 1) — a catalog expansion our admin OpenAI browse page could finally populate, though our Anthropic-tuned CountTokens de-prefixing would need per-provider work. **Angular 22 went stable** (June 3) — the major we flagged as a future spike last week is now real.
+
+Quiet on the standards and reference tracks: the reference repo had **zero in-window commits** (HEAD unchanged for ~14 days), MCP Apps spec was stable (only `lazy-auth-server` example churn), and the python `mcp` SDK held at 1.27.2. The one MCP item worth a design look is **SEP-2663 (Tasks Extension) reaching Final** in the 2026-07-28 RC — standardized non-blocking execution for long-running tools, which is exactly our Gateway-Lambda case. UI-wise, **Cursor's interactive "Context Usage Report"** is a high-fit pattern: it's the clickable, actionable version of the context-breakdown badge we shipped last week.
+
+### Notable items by source
+
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens. What construct/file does this affect? What does it replace, simplify, or obsolete?
+> - `*unlocks*:` — capability-unlock lens. What net-new capability or enhancement does this make possible?
+
+#### AWS Bedrock / AgentCore
+- **AgentCore Identity — reference your own Secrets Manager secrets (June 1)** — Credential Providers can now point at an existing Secrets Manager secret ARN instead of service-managed storage, so you apply your own governance, CMK encryption, and tagging. — https://aws.amazon.com/about-aws/whats-new/2026/06/agentcore-identity-secrets-manager/ + https://aws.amazon.com/blogs/machine-learning/reference-your-own-aws-secrets-manager-secrets-in-amazon-bedrock-agentcore-identity/ — *relevance*: our OAuth provider wiring in `apis/shared/oauth/agentcore_identity.py` and the token-vault/customParameters key handling. — *unlocks*: we can own and govern OAuth client secrets (CMK, tagging, rotation policy) rather than depending on service-managed storage — pairs with #419.
+- **Secure OAuth auth-code flow with AgentCore Gateway + MCP clients (June 1)** — ML-blog walkthrough implementing the OAuth Authorization Code flow as the auth mechanism for MCP servers fronted by AgentCore Gateway. — https://aws.amazon.com/blogs/machine-learning/building-a-secure-auth-code-flow-setup-using-agentcore-gateway-with-mcp-clients/ — *relevance*: our Gateway MCP+SigV4 tool path and 3LO/OAuth consent flow. — *unlocks*: the reference pattern that de-risks internally-filed **#419 (admin-managed Gateway target registration, protocol=mcp)** — AWS just published the blueprint.
+- **GPT-5.4/5.5 + Codex GA on Amazon Bedrock (June 1)** — OpenAI models (incl. Codex) now generally available on Bedrock. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-openai-models-codex-generally-available/ — *relevance*: our admin model catalog already has an OpenAI browse page (beta.27) that could now surface real Bedrock-hosted models; **but** our `CountTokensBedrockModel` inference-profile de-prefixing is Anthropic-tuned and would need per-provider handling. — *unlocks*: non-Anthropic models behind the same Bedrock plumbing (strategic optionality; not a Claude-stack priority).
+- **bedrock-agentcore SDK v1.13.0 (June 2)** — first release past v1.12.0; headline is an AgentCore tool-search plugin for Strands Agents, rest is test/CI plumbing. **No SSE/runtime/microVM/Memory fixes** — #482/#484 remain unaddressed. — https://github.com/aws/bedrock-agentcore-sdk-python/releases/tag/v1.13.0 — *relevance*: our pin (1.9.1) is now **4 minors behind**; a bump buys the tool-search plugin but no relief on the deadlock/identity bugs we track.
+- **AWS Config adds AgentCore + Bedrock resource types (June 3)** — `AWS::BedrockAgentCore::RuntimeEndpoint`, `::GatewayTarget`, `::Evaluator`, `::OnlineEvaluationConfig`, `AWS::Bedrock::FlowAlias`. — https://aws.amazon.com/about-aws/whats-new/2026/05/aws-config-new-resource-types — *relevance*: optional drift-detection/compliance over our `PlatformStack` Runtime endpoint + Gateway targets; ops-only, no code change.
+
+#### Strands Agents
+- **v1.42.0 released June 1 — `Limits` shipped.** Our pin (1.40.0) is now **2 minors behind**. `Limits` is supported during `invoke`/`stream` with `turns`/`outputTokens`/`totalTokens` and a clean `limit_*` stop_reason. — https://github.com/strands-agents/sdk-python/releases/tag/python/v1.42.0 — *relevance*: directly unblocks queued **2026-05-29 Top 5 #2** (was gated on 1.42); maps to agent invocation in `inference_api` + SSE stop-reason handling. — *unlocks*: native per-turn cost ceiling (the real protection against the $72-in-58-min / $30K-invoice failure mode).
+- **Cache-token metadata plumbing + structured-output log downgrade (PR #2287, #2368) in 1.42.0** — cache tokens now flow through metadata events (added for Gemini, but it's the shared metadata path); structured-output validation failures dropped from `error` to `debug` logging. — https://github.com/strands-agents/sdk-python/releases/tag/python/v1.42.0 — *relevance*: touches our prompt-caching/`cache_tools_ttl` work (#269) and the `contextBreakdown` metadata surface; the log downgrade is a quiet behavior change to watch on upgrade.
+- **NEW bug: `count_tokens` returns 0 for toolResult JSON blocks (#2635, open)** — the heuristic token counter undercounts tool-result content containing JSON. — https://github.com/strands-agents/sdk-python/issues/2635 — *relevance*: **high — directly threatens the context-attribution badge we just shipped (PR #428–433)** and the compaction trigger, both of which lean on Strands native token counting. Need to confirm whether our `CountTokensBedrockModel` path (native Bedrock CountTokens) is immune or whether tool-heavy turns hit the heuristic fallback and under-report the Tools partition.
+- **NEW bug: non-ASCII tool-result serialization inconsistency (#2636, open)** — dict returns get `\uXXXX`-escaped, Pydantic-model returns don't. — https://github.com/strands-agents/sdk-python/issues/2636 — *relevance*: moderate — tool-result fidelity for non-ASCII output across `main_agent/tools/`; cosmetic but could surface in MCP/A2A results.
+- **`strands-agents-tools` 0.5.2 → 0.8.0 (June 3)** — pre-1.0 minor jump of ~3 versions. — https://pypi.org/pypi/strands-agents-tools/json — *relevance*: pre-1.0 minors can carry breaking tool-interface changes; **review before bumping** — this is part of the blast radius of the 1.42 keystone.
+- **No new movement** on PR #2269 (BedrockModel.stream cancellation) or PR #2147 (token-aware context management) — both still open/unmerged.
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **Zero in-window commits.** HEAD on `main` is still `ccfba7c` (2026-05-22, already reported); no activity for ~14 days. Confirmed via GitHub API (`since=2026-05-29&until=2026-06-05` → empty). — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main — *applicability*: nothing to port this week.
+
+#### MCP ecosystem
+- **SEP-2663 (Tasks Extension) reached "Final," now in the 2026-07-28 RC** — formalizes async tool execution: a server may answer a tool call with a task handle instead of blocking; clients poll `tasks/get`/`tasks/update`. Negotiated **per-request** (not the fragile per-tool opt-in), opt-in, ignorable by non-implementing hosts. Merged May 15, last touched June 4. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663 — *relevance*: our Gateway-fronted long-running Lambda tools are exactly this case — today we block on the call. — *unlocks*: a standardized non-blocking path for long tools (design look; opt-in, no forced action).
+- **python `mcp` SDK unchanged at 1.27.2 (May 29)** — nothing past 1.27.2 in-window. — https://pypi.org/pypi/mcp/json — *relevance*: our lock pin (1.26.0, ~125 days stale) is the laggard; 1.27.2 is current.
+- **`server/discover` caching (#2855, merged June 4, RC High Priority)** + SEP-2549 (TTL for list results) re-touched — RC hardening for the 2026-07-28 spec that carries our `io.modelcontextprotocol/ui` Apps work. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2855 — *relevance*: signals the RC (which our queued `experimental.ui` → `io.modelcontextprotocol/ui` migration targets) is approaching freeze.
+- **MCP Apps (`ext-apps`) — UI spec stable this week.** Only `lazy-auth-server` example churn (PKCE/redirect-uri binding, base-path mounting); no changes to `io.modelcontextprotocol/ui`, host rendering, capability negotiation, or templates. — https://github.com/modelcontextprotocol/ext-apps/commits/main — *relevance*: no Apps spec drift to track; the queued capability-identifier migration is on our timeline.
+- **servers registry / blog — nothing relevant.** Only memory-server doc edits + elicitation test cases; newest blog post still the May 21 RC announcement. — https://github.com/modelcontextprotocol/servers/commits/main
+
+#### FastMCP
+- **v3.4.0 "Remote Control" went stable (June 3)** — the 3.4.0b1 beta graduated; headline `fastmcp-remote` bridge is host-side only (stdio→HTTP), **no impact** on our Lambda-backed servers behind Gateway. — https://github.com/jlowin/fastmcp/releases/tag/v3.4.0 — *implications for our MCP servers*: none from the headline.
+- **`ToolResult` now accepts `is_error` (server-side primitive, in 3.4.0)** — maps to `CallToolResult.isError`, letting a tool return a structured error result instead of only raising (which flattened to text-only). Additive/opt-in. — https://github.com/jlowin/fastmcp/releases/tag/v3.4.0 — *implications*: if/when we want our externally-hosted MCP tools to surface structured error payloads through Gateway, this is the new idiomatic path. Proxy-forwarding + auth-refresh changes also landed but only touch FastMCP's own proxy layer (we use SigV4 behind Gateway, not the FastMCP proxy).
+
+#### Agentic UI/UX patterns
+- **Cursor "Context Usage Report" — interactive context explorer canvas** — renders the agent's token budget as an *interactive* report broken down by system prompt, tool definitions, rules, skills, etc., with a "Debug with Agent" button that spawns a conversation to find context-reduction opportunities. — https://cursor.com/changelog/canvas-improvements — *fit*: pattern-only, **high** (Angular equivalent: promote our static per-turn context-breakdown badge into a clickable affordance that opens the Artifacts panel with the full `contextBreakdown` partition list + a "what's eating context / how to trim it" follow-up action — the data already ships on the final metadata event). — *where it'd land*: context-breakdown badge component + Artifacts docked panel.
+- **Cursor "Canvas Design Mode" — point-and-annotate to direct edits** — select/annotate a rendered UI element directly and the agent edits from the annotation instead of a prose description. — https://cursor.com/changelog/canvas-improvements — *fit*: pattern-only (Angular equivalent: a selection/annotation overlay on the Artifacts preview / `<mcp-app-frame>` so a user clicks a rendered region and attaches a correction that feeds the next turn). — *where it'd land*: Artifacts docked side panel.
+- **assistant-ui — `"use generative"` compiler extracted + Vite plugin (0.0.97)** — the framework-agnostic generative-UI compiler (declare a backend toolkit → env-specific renderer, plus `defineToolkit`/`hitl` markers) pulled out of Next.js into a reusable package. — https://github.com/Yonom/assistant-ui/releases — *fit*: pattern-only, low priority (conceptual mirror of our tool renderer registry; React/Vite-specific. The `hitl` marker convention is worth noting for our consent/elicitation UX).
+- **Linear "Team documents" (June 3)** — team-scoped doc pages for shared context. — https://linear.app/blog — *fit*: not applicable (information-architecture, not an agentic-rendering/tool/consent pattern).
+
+#### Frontier model announcements
+- **Quiet week for harness-relevant capability deltas.** No new Bedrock-available frontier model with a new tool-use/caching/context/computer-use/structured-output API change in-window. Anthropic in-window posts are corporate/security (S-1 June 1, Project Glasswing + AI-Enabled Cyber Threats report June 2–3, Partner Network Services Track June 3). — https://www.anthropic.com/news — *relevance*: none to harness/model config; we stay on Opus 4.7/4.8.
+- **OpenAI — API housekeeping only** (container per-minute billing June 2, GPT-Image deprecation, reusable-prompt deprecation). GPT-5.4 (Mar 5) / GPT-5.5 (Apr 24) are out of window — flagged so they aren't mistaken for new. — https://developers.openai.com/api/docs/changelog — *relevance*: none directly, but see the GPT/Codex-on-Bedrock GA item above.
+- **Gemini / Llama — nothing in-window.** Gemini 3.5 Flash GA + Managed Agents date to ~May 19–20 (Google I/O); Gemini 3.5 Flash remains **not on Bedrock**. Meta silent. — *relevance*: no Bedrock change.
+
+#### Agent harness patterns
+- **Claude Code 2.1.163 — Stop/SubagentStop hooks return `hookSpecificOutput.additionalContext` (June 4–5)** — a subagent stop hook can now inject feedback/context back into the loop *without* signaling an error (previously the only feed-back channel was failing the hook). — https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md — *relevance*: a clean post-delegation hand-back channel for if/when we expose an A2A server or in-process sub-agents (append context on completion, not via the error path).
+- **Claude Code 2.1.160/161 — dynamic-workflow trigger renamed `workflow`→`ultracode`; worktree-isolated workflow agents can now edit their own worktree** — the Opus-4.8 code-as-orchestration mode is hardening (isolation + naming). — same CHANGELOG — *relevance*: reinforces evaluating code-as-orchestration for our `main_agent` loop; worktree isolation is a permissioning model for sandboxed sub-agents.
+- **Claude Code 2.1.161/162 — `claude agents --json` adds `waitingFor`; fan-out rows show `done/total`** — structured visibility into what a blocked agent is waiting on + per-batch progress. — same CHANGELOG — *relevance*: parallel to our per-turn context-breakdown badge — a structured "what is this agent blocked on / N of M done" surface we could mirror over SSE if we add delegation.
+- **Pydantic-AI 1.105/2.0.0b5 — on-demand (deferred) loading of instructions, tools, model settings, hooks (June 2)** — agent config (incl. the tool set) loaded lazily/per-run rather than all upfront. — https://github.com/pydantic/pydantic-ai/releases — *relevance*: idea-only; conceptually adjacent to our additive RBAC `enabled_tools` + ToolRegistry — deferred tool loading keeps tool-schema tokens out of context until needed (cf. the Tools partition in our context-breakdown badge).
+
+#### opencode
+- **v1.16.0 (June 5) — skill discovery + OpenAI models via AWS Bedrock + thinking-level selector for v2 prompts** (also: workspace cloning, cross-workspace session mobility, 38% startup improvement). — https://github.com/anomalyco/opencode/releases — *relevance*: **Tooling** (skill discovery = opencode's analog of how we surface/gate capabilities in ToolRegistry/`enabled_tools`); **Cost-effectiveness** (OpenAI-on-Bedrock routing + a user-facing thinking-level selector map to model selection + reasoning-budget controls in `inference_api`).
+- **v1.15.13 (May 30) — Opus 4.7+ adaptive reasoning now retains summarized thinking instead of empty thinking blocks** (+ session custom-metadata storage, hierarchical config loading). — https://github.com/anomalyco/opencode/releases — *relevance*: **Context engineering** — the summarized-thinking-retention fix is the same class as our compaction/summary handling (preserve condensed reasoning across turns rather than drop it).
+
+#### LibreChat
+- **v0.8.6 (June 1) — Agent Skills & Subagents + MCP remote-proxy/OAuth audience handling + inline office-file rendering** — — https://github.com/danny-avila/LibreChat/releases/tag/v0.8.6 — *relevance*: (b) **agent harness** — portable capability bundles (instructions + assets + permissions) + subagent delegation that preserves upload/user context; parallels our skills-as-bundles direction. (c) **MCP integration** — "OAuth audience handling" + "JWT expiry fallback" + per-tool permission enforcement are worth a look against our token-vault/customParameters consent model (graceful token-expiry UX instead of re-prompting consent). (a) inline DOCX/CSV/XLSX/PPTX preview + persistent agent resource files — UX reference (pattern-only, React) for our Artifacts panel + ui-resource persistence. Provider list bumped to Opus 4.8 / Gemini 3.5 Flash / Gemma 4 (table-stakes churn).
+
+#### Pricing / quota
+- **No in-window Bedrock price/quota change** affecting model selection. Opus 4.8 ($5/$25 per M) isn't separately rendered on the public pricing page; absence is not conclusive. — https://aws.amazon.com/bedrock/pricing/
+
+#### Community + GitHub issues
+- **Agyn — OSS AgentCore-alternative agent runtime (arXiv, June 5, 2 pts)** — signal-driven stateful serverless runtime on Kubernetes, a Terraform provider for agent/harness definition (IaC), and a zero-trust FS/network/credential isolation model; submitter frames it as an OSS alternative to AWS AgentCore. — https://arxiv.org/abs/2605.27575 — *relevance*: competitor framing to our AgentCore Runtime; the Terraform-IaC + K8s-serverless approach contrasts our single-CDK-stack + out-of-band image-update model; the explicit credential-isolation story is worth a look for our Runtime sandboxing posture.
+- **Lowfat — pluggable CLI context filter, claims 91.8% token savings (Show HN, June 5, 26 pts)** — a drop-in filter that strips/compresses LLM context before it hits the model. — https://github.com/zdk/lowfat — *relevance*: context-engineering + cost lens; a pre-model filtering pass is adjacent to our context-attribution/compaction work and the open cost-guardrail item.
+- **AgentRein — agent-spend rollback engine (Show HN, June 4, 1 pt)** — "agent charged us $5k by mistake," so they built a transactional rollback/guardrail layer for agent actions. — https://www.agentrein.com/ — *relevance*: another concrete agent-overspend failure narrative reinforcing the cost-guardrail thread (distinct from last week's AWS quota cluster).
+- **Cookbook — nothing new in-window.** In-window commits (#677 review fixes, #678 merge) are follow-ups to the already-known "Hosting your agent" Docker/Modal/K8s example. — https://github.com/anthropics/anthropic-cookbook — Reddit remains domain-blocked, not scanned.
+
+#### Cookbook / courses
+- See Community above — no new worked examples landed in-window.
+
+#### Seasonal
+- Out of window — no re:Invent / NeurIPS / ICLR / EMNLP items this week.
+
+### Patterns worth considering
+
+- **Upstream-landed-our-queue (Strands 1.42 `Limits` + `cache_tools_ttl`)** — the two Strands items we queued last week were both gated on 1.42, which is now out. The pattern: when a bump unblocks multiple queued items, the bump itself becomes the keystone — adopt the library primitive, retire the hand-rolled equivalents.
+  - **Where**: `pyproject.toml`/`uv.lock`, agent invocation in `inference_api`, `BedrockModel`/`CacheConfig` construction, SSE stop-reason handling.
+  - **Fit**: high — converts two "build/adopt later" queue items into one actionable bump. Blast radius: `strands-agents-tools` 0.5→0.8 + `starlette` 1.2.1 audit.
+  - **Verdict**: Worth trying — recommended #1.
+- **Verify-the-foundation after shipping a token-counting feature (#2635)** — Strands just disclosed that the heuristic `count_tokens` returns 0 for toolResult JSON. We shipped a context-attribution badge + compaction trigger on Strands token counting last week. The pattern: when upstream files a bug in a primitive you just built on, verify your path is immune before the next user hits it.
+  - **Where**: `CountTokensBedrockModel`, the `contextBreakdown` hook, the compaction trigger.
+  - **Fit**: high — defensive, protects freshly-shipped work; cheap to verify.
+  - **Verdict**: Worth trying.
+- **Interactive context-cost transparency (Cursor Context Usage Report)** — vendors are turning the token-budget breakdown from a static readout into an interactive, actionable surface. We have the data (the `contextBreakdown` partition list); the gap is interaction.
+  - **Where**: context-breakdown badge component + Artifacts panel.
+  - **Fit**: high — lands on a surface we shipped last week; pattern-only port.
+  - **Verdict**: Worth trying.
+- **Standardized async long-running tools (SEP-2663 Tasks)** — the spec is converging on a per-request, opt-in non-blocking tool path. Our Gateway Lambda tools block today. Not urgent (RC, opt-in) but the right long-term shape.
+  - **Verdict**: Monitor — design look when the RC stabilizes (~2026-07-28).
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: ~37 (heavily docs-site: brand redesign #440–445, architecture overview page; plus #443 shared security helpers, #411 conversation modes / admin-created system prompts, #438 artifact-render live-CodeSha256 guard, #428–433 context-attribution feature landing).
+- **PRs opened against develop**: **0 currently open** (last week's #396 stack-consolidation merged).
+- **PRs merged**: ~15+ squash-merges in window; **reverted**: 0.
+- **Issues opened**: 4 (#439 display session date, #427 export-to-google-docs, #426 API-key expiration reminder, #419 admin-managed Gateway target registration) — **closed**: none in-window.
+- **CI failures (workflow → count, sampled)**:
+  - **Nightly Build & Test: 4** (June 5, June 4, May 27, May 21) — **chronic**; recurring on `main` schedule, longest-running failure cluster on the list.
+  - Backend Deploy: 1 (June 2, workflow_dispatch); Restore Data: 2 (June 2, workflow_dispatch); Frontend Deploy (CloudFront): 1 (June 2, develop push).
+  - Dependency Graph (uv Graph Update): 2 (June 2–3) — tooling, low-signal.
+
+### Repeated friction signals
+- **Nightly Build & Test failing repeatedly (June 4, June 5, and back to May 21/27).** Four in-window failures on the scheduled `main` build, runs of 24–83 min. This is the most persistent CI signal and is unexplained in the in-window commits.
+  - **Hypothesis**: either a flaky/long-running test, an environment/credential drift on the nightly schedule, or a real regression that only the nightly full-suite catches (recall: backend pytest is **not** run in PR CI — the nightly is the only automated correctness gate).
+  - **Fix candidate**: pull the latest two nightly logs (`gh run view 27009390668 --log-failed`), classify flaky-vs-real, and either quarantine the flaky test or file the regression. Given pytest isn't a PR gate, a red nightly is a blind spot worth closing.
+- **Context-attribution feature shipped the same week Strands disclosed a token-counting bug (#2635).** Not a friction signal yet — a latent one. The feature's correctness depends on a primitive upstream just flagged.
+  - **Fix candidate**: confirm `CountTokensBedrockModel` uses native Bedrock CountTokens for all turns (incl. tool-heavy ones) and never falls back to the heuristic path that #2635 affects; add a regression test asserting non-zero token counts for a turn containing a JSON toolResult.
+
+### Version-pin lag
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| `strands-agents` | 1.40.0 | **1.42.0** (Jun 1) | 2 minors / 18 days | **1.42 carries `Limits` + cache-token metadata** — the keystone bump. Blast radius below. |
+| `strands-agents-tools` | 0.5.2 | **0.8.0** (Jun 3) | ~3 minors / 34 days | Pre-1.0 minors can carry breaking tool-interface changes — **review before bumping**; part of the 1.42 keystone blast radius. |
+| `starlette` | 1.0.0 | **1.2.1** (May 31) | 2 minors / ~70 days | Long-owed FastAPI-0.136.x transitive-compat audit comes due with the Strands bump. |
+| `bedrock-agentcore` | 1.9.1 | **1.13.0** (Jun 2) | **4 minors** / 21 days | Fastest-moving SDK (1.10 May19 / 1.11 May22 / 1.12 May28 / 1.13 Jun2). v1.13 adds a Strands tool-search plugin; **no SSE/Identity/Memory fixes** (#482 unpatched). |
+| `mcp` | 1.26.0 (lock) | 1.27.2 (May 29) | 1 minor + 2 patches / ~125 days | Stalest lock pin. Lock-only refresh; relevant to MCP Apps work. |
+| `boto3`/`botocore` | 1.43.9 | 1.43.23 (Jun 4) | 14 patches / 20 days | Routine; non-breaking. |
+| `fastapi` | 0.136.1 | 0.136.3 (May 23) | 2 patches | Non-breaking. |
+| `pydantic` | 2.12.5 (lock) | 2.13.4 (May 6) | pin already allows 2.13.x | Lock-only refresh. |
+| `docling` | 2.81.x (resolved) | **2.97.0** (Jun 3) | — | **Past the 2.81.0 content-sniffing defect** behind #405 — bump closes the `.txt`-upload bug. |
+| `@angular/core` / `@angular/build` | 21.2.11 / 21.2.9 | **22.0.0** (Jun 3) | major / 35 days | **Angular 22 stable shipped.** Coordinated framework upgrade across all `@angular/*` + tooling; reconcile with the Analog `alpha`-vs-`latest` channel question. Spike, not a bump. |
+| `@analogjs/vitest-angular` | 3.0.0-alpha.30 | alpha.57 (latest alpha); 2.6.0 (`latest` tag) | 27 alpha builds | Confirm which channel we follow, esp. with the Angular 22 jump. |
+| `vitest` | 4.1.5 | 4.1.8 (Jun 1) | 3 patches | Non-breaking. |
+| `aws-cdk-lib` | 2.251.0 | 2.258.0 (Jun 4) | 7 minors | CDK 2.x additive; accumulated drift. |
+| `aws-cdk` (CLI) | 2.1120.0 | 2.1126.0 (Jun 3) | 6 patches | Routine. |
+| `constructs` | 10.6.0 | 10.6.0 | 0 | Current. |
+
+### Retirement candidates
+- **Queue consolidation: the two gated Strands items collapse into one bump.** review-queue 2026-05-22 ("Strands 1.40→1.41 + caching #269") and 2026-05-29 #2 ("Adopt Strands `Limits`, gated on 1.42") are both satisfied by a single 1.40 → 1.42 bump now that 1.42 is out. Treat as one keystone, not two items.
+- **No dormant skills.** All `.claude/skills` SKILL.md files are either recently modified or actively referenced (kaizen pair May 11/29, cdk-infrastructure Jun 2, tailwind-ui May 22). `angualar-best-practices` (Dec 30) and `frontend-design` (Jan 18) are >60 days stale but both are first-class references for active frontend work — not retirement candidates.
+
+### Risks introduced this week
+<!-- Defensive scanning — things that could break us if ignored. -->
+- **#2635 (Strands `count_tokens` toolResult=0)** — https://github.com/strands-agents/sdk-python/issues/2635 — *what breaks if we ignore this*: the context-attribution badge under-reports tool-heavy turns and compaction trips late, silently degrading the feature we shipped last week.
+- **Strands 1.42 keystone blast radius** — `strands-agents-tools` 0.5→0.8 (possible breaking tool-interface changes) + `starlette` 1.2.1 (FastAPI transitive compat) — *what breaks if we ignore this*: a naive 1.42 bump could break tool registration or the ASGI stack; the bump needs the audit, not a one-liner.
+- **bedrock-agentcore 4 minors behind, #482 still unpatched** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/482 — *what breaks if we ignore this*: the SSE-disconnect microVM deadlock remains our risk to mitigate in-app; the SDK team has not fixed it across four releases.
+- **Angular 22 major drift** — staying on 21.x is fine short-term, but the longer the gap the harder the coordinated upgrade (esp. the Analog channel reconciliation). *Schedule a spike, don't let it accrete.*
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | Strands 1.40 → 1.42 bump — unblocks `Limits` (cost caps) + `cache_tools_ttl` (#269 caching) | backend (`pyproject.toml`/`uv.lock`, agent invocation, `BedrockModel`/`CacheConfig`, SSE stop-reason) + infra (CloudWatch alarm) | M | H | **yes** — adopts library-native `Limits` + `cache_tools_ttl`, retiring the hand-rolled runaway guardrail AND the hand-rolled TTL; collapses two queued items into one | native per-turn cost ceiling (`limit_*` stop_reason) + 1h prompt caching → lower input-token cost |
+| 2 | Guard the context-attribution path against Strands `count_tokens` toolResult=0 bug (#2635) | backend (`CountTokensBedrockModel`, `contextBreakdown` hook, compaction trigger) | L-M | M-H | no — defensive; protects freshly-shipped PR #428–433 | — |
+| 3 | Make the context-breakdown badge interactive (Cursor Context Usage Report pattern) | frontend (context-breakdown badge component + Artifacts docked panel) | M | M | no — addition; justified: lands on a surface we just shipped, data already on the wire | user-facing context-cost transparency + actionable "what's eating context / how to trim" follow-up |
+| 4 | Bump `docling` past the 2.81.0 content-sniffing defect → close #405 (`.txt` uploads fail) | backend (document ingestion dep pin) | L | M | **yes** — library-native bump closes an open user-facing bug | restores `.txt` upload support |
+| 5 | De-risk #419 (admin-managed Gateway target registration) against the new AWS auth-code-flow + BYO-secrets references | infrastructure + backend (Gateway target CRUD, `agentcore_identity.py` OAuth provider wiring) + frontend (admin) | H | H | partial — BYO Secrets Manager lets us own/govern OAuth client secrets instead of service-managed storage | admins register external MCP servers (protocol=mcp) without code changes — net-new admin surface, now blueprinted by AWS |
+
+### 1. Strands 1.40 → 1.42 bump — unblocks `Limits` + `cache_tools_ttl`
+- **Source**: external — Strands v1.42.0, June 1 — https://github.com/strands-agents/sdk-python/releases/tag/python/v1.42.0. Consolidates queued items review-queue 2026-05-22 (#269 caching) + 2026-05-29 #2 (`Limits`).
+- **Surface area**: `backend/pyproject.toml` + `uv.lock`; agent invocation in `inference_api` (pass `limits={turns, outputTokens, totalTokens}`, handle the `limit_*` stop_reason); `BedrockModel`/`CacheConfig` construction (`cache_tools_ttl` for #269); SSE stop-reason handling; infrastructure (CloudWatch Bedrock-spend alarm — the half the SDK can't provide).
+- **Change**: bump to 1.42 with the blast-radius audit — `strands-agents-tools` 0.5→0.8 tool-interface review + `starlette` 1.2.1 FastAPI-transitive-compat check; then wire `limits=` and `cache_tools_ttl` and recognize `limit_*` as a clean termination in the SSE path.
+- **Subtracts**: yes — replaces a hand-rolled runaway guardrail with `Limits` and a hand-rolled TTL with `cache_tools_ttl`; the two gated queue items become one bump.
+- **Unlocks**: native per-turn cost ceiling (real protection against the $72-in-58-min / $30K-invoice failure mode); end-to-end 1h prompt caching → lower input-token cost, surfaced in the admin "Cache Savings" card.
+- **Effort × Impact**: Med × High
+- **Verdict**: Worth trying — recommended #1.
+
+### 2. Guard the context-attribution path against Strands `count_tokens` toolResult=0 bug (#2635)
+- **Source**: external — Strands issue #2635 (open) — https://github.com/strands-agents/sdk-python/issues/2635. Internal: PR #428–433 (context-attribution feature, landed this window).
+- **Surface area**: `CountTokensBedrockModel`, the `contextBreakdown` hook/coordinator channel, the compaction trigger.
+- **Change**: confirm native Bedrock CountTokens is used for all turns (incl. tool-heavy ones with JSON toolResults) and the heuristic path #2635 affects is never hit; add a regression test asserting a non-zero count for a turn containing a JSON toolResult; if the heuristic is reachable, add a guard/fallback.
+- **Subtracts**: no — defensive; protects the feature we just shipped.
+- **Effort × Impact**: Low-Med × Med-High
+- **Verdict**: Worth trying — cheap, time-sensitive (verify before users hit it).
+
+### 3. Make the context-breakdown badge interactive (Cursor Context Usage Report pattern)
+- **Source**: external — Cursor "Context Usage Report" — https://cursor.com/changelog/canvas-improvements. Internal: PR #433 (context-breakdown badge).
+- **Surface area**: the context-breakdown badge component; the Artifacts docked panel.
+- **Change**: promote the static partition list into a clickable affordance that opens the full `contextBreakdown` breakdown (per-partition tokens) plus a "what's eating context / how to trim it" follow-up action; the partition data already ships on the final metadata event, so this is presentation, not new backend.
+- **Subtracts**: no — addition; justified because it lands on a surface we shipped last week and reuses data already on the wire.
+- **Unlocks**: user-facing context-cost transparency and an actionable trimming path (mirrors where Cursor/Claude Code are converging).
+- **Effort × Impact**: Med × Med
+- **Verdict**: Worth trying.
+
+### 4. Bump `docling` past the 2.81.0 content-sniffing defect → close #405
+- **Source**: external — docling 2.97.0 (June 3) — https://pypi.org/pypi/docling/json. Internal: issue #405 (`.txt` uploads fail with "File format not allowed").
+- **Surface area**: document-ingestion docling dep pin (`backend/.../documents/ingestion`).
+- **Change**: bump docling off the 2.81.x content-sniffing defect to a current release and verify `.txt` uploads succeed; close #405.
+- **Subtracts**: yes — a library-native bump that closes an open user-facing bug (no custom workaround needed).
+- **Effort × Impact**: Low × Med
+- **Verdict**: Worth trying — cleanest subtraction of the week.
+
+### 5. De-risk #419 (admin-managed Gateway target registration) against the new AWS references
+- **Source**: external — AWS "secure OAuth auth-code flow with Gateway + MCP clients" (June 1) https://aws.amazon.com/blogs/machine-learning/building-a-secure-auth-code-flow-setup-using-agentcore-gateway-with-mcp-clients/ + AgentCore Identity BYO Secrets Manager (June 1) https://aws.amazon.com/about-aws/whats-new/2026/06/agentcore-identity-secrets-manager/. Internal: issue #419.
+- **Surface area**: infrastructure (Gateway target CRUD / `gateway_target_*`) + backend (`apis/shared/oauth/agentcore_identity.py` OAuth provider wiring + token-vault customParameters) + frontend (admin registration UI).
+- **Change**: scope #419 against the now-published AWS auth-code-flow blueprint; use the BYO-Secrets-Manager capability so admin-registered external MCP servers' OAuth client secrets are customer-governed (CMK, tagging) rather than service-managed.
+- **Subtracts**: partial — BYO Secrets Manager lets us own/govern OAuth client secrets instead of depending on service-managed storage.
+- **Unlocks**: admins register external MCP servers (protocol=mcp) without code changes — a net-new admin surface, now blueprinted and de-risked by AWS.
+- **Effort × Impact**: High × High
+- **Verdict**: Worth trying — strategic; the AWS references materially de-risk an already-filed feature.
+
+## Take
+
+The week's shape is **upstream closing our backlog** — for the third time in a month. Strands 1.42 landed `Limits` and `cache_tools_ttl` together, collapsing two gated queue items into one keystone bump; the strongest move Phil could make is to schedule that bump (with its honest blast-radius audit) and retire the hand-rolled cost guardrail. The counterweight is a sharp internal reminder: we shipped a context-attribution feature the same week Strands disclosed a token-counting bug (#2635) that strikes exactly the primitive it stands on — verify the foundation before the next user does. What Phil would notice first if shipped: a native per-turn cost ceiling and 1h prompt caching, both visible in the admin cost cards. The quiet risk to watch is accretion — bedrock-agentcore is four minors behind with #482 still unpatched, and Angular 22 just went stable; neither is urgent, both get harder the longer they sit.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock/AgentCore What's New + ML blog | https://aws.amazon.com/about-aws/whats-new/recent/feed/ | 2026-06-05 | 5 |
+| 2 | Strands Agents SDK (releases/CHANGELOG/issues) | https://github.com/strands-agents/sdk-python/releases | 2026-06-05 | 6 |
+| 3 | Reference repo commits | https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main | 2026-06-05 | 0 (quiet) |
+| 4 | MCP ecosystem (spec PRs, servers, blog, SDK) | https://github.com/modelcontextprotocol/modelcontextprotocol/pulls | 2026-06-05 | 5 |
+| 4a | FastMCP releases | https://github.com/jlowin/fastmcp/releases | 2026-06-05 | 2 |
+| 4b | Agentic UI/UX (Cursor, assistant-ui, Linear, Anthropic, NN/g) | https://cursor.com/changelog/canvas-improvements | 2026-06-05 | 4 |
+| 5 | Frontier models (Anthropic/OpenAI/Google/Meta) | https://www.anthropic.com/news | 2026-06-05 | 3 (quiet) |
+| 6 | Agent harness (Claude Code CHANGELOG, Pydantic-AI) | https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md | 2026-06-05 | 4 |
+| 6a | opencode releases | https://github.com/anomalyco/opencode/releases | 2026-06-05 | 2 |
+| 7 | AWS Bedrock pricing | https://aws.amazon.com/bedrock/pricing/ | 2026-06-05 | 0 (no change) |
+| 8 | AgentCore SDK / starter-toolkit issues + releases | https://github.com/aws/bedrock-agentcore-sdk-python/releases | 2026-06-05 | 4 |
+| 9 | Community (HN Algolia) + cookbook | https://hn.algolia.com/api/v1/search_by_date | 2026-06-05 | 4 |
+| 10 | Anthropic cookbook commits | https://github.com/anthropics/anthropic-cookbook/commits/main | 2026-06-05 | 0 (quiet) |
+| 12 | LibreChat releases | https://github.com/danny-avila/LibreChat/releases | 2026-06-05 | 1 |
+| 11 | Seasonal | — | 2026-06-05 | 0 (out of window) |
+| 19 | Version-pin lag (PyPI + npm registries) | https://pypi.org/ , https://registry.npmjs.org/ | 2026-06-05 | 17 deps |
+
+## Web Budget
+
+Used: **~71 / 50 requests** (target; overage).
+Skipped (unreachable / rate-limited): Reddit (domain-blocked via WebFetch — not attempted, per decisions.md 2026-05-18).
+Skipped (other): none.
+Notes: Overage driven by the version-pin sweep (17 deps, ~8 requests), the frontier-model fan-out (11 requests across 4 vendors confirming a quiet week), and the MCP ecosystem deep-read (7 requests). Consistent with prior weeks (~80 last week); each request surfaced or ruled out real signal. PyPI `fastmcp` JSON returned stale cached data — fell back to GitHub releases (cross-checked, consistent).

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -5,6 +5,44 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 ## Open
 <!-- Newest at top. -->
 
+### [2026-06-05] Strands 1.40 → 1.42 bump — unblocks `Limits` (cost caps) + `cache_tools_ttl` (#269 caching)
+- **Source**: research/2026-06-05.md ▸ Top 5 #1 — Strands v1.42.0 (June 1). **Consolidates** the queued 2026-05-22 "Strands 1.40→1.41 + caching #269" item AND the 2026-05-29 #2 "Adopt Strands `Limits`" item — both were gated on 1.42, which is now out. Treat as one keystone bump, not two.
+- **Surface**: backend (`pyproject.toml`/`uv.lock`, agent invocation in `inference_api`, `BedrockModel`/`CacheConfig`, SSE `limit_*` stop-reason) + infrastructure (CloudWatch Bedrock-spend alarm)
+- **Effort × Impact**: M × H
+- **Subtracts**: yes — adopts library-native `Limits` (retires the hand-rolled runaway guardrail) + `cache_tools_ttl` (retires the hand-rolled TTL); two queued items collapse into one bump
+- **Unlocks**: native per-turn cost ceiling (`limit_*` stop_reason) + end-to-end 1h prompt caching → lower input-token cost, surfaced in the admin "Cache Savings" card
+- **Status**: open — 1.42 is released (no longer gated). Blast radius to audit first: `strands-agents-tools` 0.5→0.8 (possible breaking tool-interface changes) + `starlette` 1.2.1 (FastAPI 0.136.x transitive compat)
+
+### [2026-06-05] Guard the context-attribution path against Strands `count_tokens` toolResult=0 bug (#2635)
+- **Source**: research/2026-06-05.md ▸ Top 5 #2 — Strands issue #2635 (open) + internal PR #428–433 (context-attribution feature, shipped this window)
+- **Surface**: backend (`CountTokensBedrockModel`, the `contextBreakdown` hook/coordinator channel, the compaction trigger)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: no — defensive; protects the freshly-shipped context-breakdown badge
+- **Status**: open — time-sensitive; confirm native Bedrock CountTokens is used for all turns (incl. JSON toolResults) and the heuristic path #2635 affects is never hit; add a regression test asserting a non-zero count for a turn with a JSON toolResult
+
+### [2026-06-05] Make the context-breakdown badge interactive (Cursor Context Usage Report pattern)
+- **Source**: research/2026-06-05.md ▸ Top 5 #3 — Cursor "Context Usage Report" (https://cursor.com/changelog/canvas-improvements) + internal PR #433
+- **Surface**: frontend (context-breakdown badge component + Artifacts docked panel)
+- **Effort × Impact**: M × M
+- **Subtracts**: no — addition; justified because it lands on a surface we shipped last week and reuses `contextBreakdown` data already on the final metadata event
+- **Unlocks**: user-facing context-cost transparency + an actionable "what's eating context / how to trim it" follow-up
+- **Status**: open — presentation-layer work; no new backend (data already on the wire)
+
+### [2026-06-05] Bump `docling` past the 2.81.0 content-sniffing defect → close #405 (`.txt` uploads fail)
+- **Source**: research/2026-06-05.md ▸ Top 5 #4 — docling 2.97.0 (June 3) + internal issue #405
+- **Surface**: backend (document-ingestion docling dep pin)
+- **Effort × Impact**: L × M
+- **Subtracts**: yes — library-native bump closes an open user-facing bug; no custom workaround needed
+- **Status**: open — cleanest subtraction of the week; bump off 2.81.x, verify `.txt` upload, close #405
+
+### [2026-06-05] De-risk #419 (admin-managed Gateway target registration) against the new AWS auth-code-flow + BYO-secrets references
+- **Source**: research/2026-06-05.md ▸ Top 5 #5 — AWS "secure OAuth auth-code flow with Gateway + MCP clients" + AgentCore Identity BYO Secrets Manager (both June 1) + internal issue #419
+- **Surface**: infrastructure (Gateway target CRUD / `gateway_target_*`) + backend (`apis/shared/oauth/agentcore_identity.py` OAuth provider wiring + token-vault customParameters) + frontend (admin registration UI)
+- **Effort × Impact**: H × H
+- **Subtracts**: partial — BYO Secrets Manager lets us own/govern OAuth client secrets (CMK, tagging) instead of service-managed storage
+- **Unlocks**: admins register external MCP servers (protocol=mcp) without code changes — net-new admin surface, now blueprinted by AWS
+- **Status**: open — strategic; the AWS references materially de-risk an already-filed feature
+
 ### [2026-05-29] Migrate inference-api model config Opus 4.7 → 4.8
 - **Source**: research/2026-05-29.md ▸ Top 5 #1 — Claude Opus 4.8 on Bedrock (May 28)
 - **Surface**: backend (model config in `inference_api`) + admin model catalog + the `_shape_thinking_value` / `temperature` provider-translation path


### PR DESCRIPTION
## Summary
- External scan: AWS Bedrock/AgentCore, Strands Agents, FastMCP, reference repo, MCP, agentic UI/UX patterns, frontier models, agent-harness patterns, opencode, LibreChat, pricing.
- Internal audit: recent commits, open PRs, GitHub issues, CI failures, version-pin lag, retirement candidates.
- Top 5 ideas in the dated research doc and queued in `docs/kaizen/review-queue.md`.

**Headline:** Strands 1.42.0 shipped June 1 — the release last week's queue was gated on. It carries `Limits` (native cost/turn caps) + `cache_tools_ttl` (#269 caching unblock), collapsing two queued items into one keystone bump (#1). The pressing internal signal: a brand-new Strands bug (#2635, `count_tokens` returns 0 for toolResult JSON) directly threatens the context-attribution badge we just shipped (PR #428–433).

## Top 5
1. **Strands 1.40 → 1.42 bump** — unblocks `Limits` (cost caps) + `cache_tools_ttl` (#269 caching) — M × H — subtracts (library-native)
2. **Guard context-attribution vs Strands #2635** (count_tokens toolResult=0) — L-M × M-H — defensive
3. **Interactive context-breakdown badge** (Cursor Context Usage Report pattern) — M × M — unlocks
4. **Bump `docling` → close #405** (`.txt` uploads fail) — L × M — subtracts
5. **De-risk #419 Gateway target registration** vs new AWS auth-code-flow + BYO-secrets references — H × H — unlocks

## Review
- Read the research doc.
- Comment on the PR with reactions and any weekend POC findings — these become first-class signal for next Friday's `kaizen-review-prep`.
- POC promising ideas over the weekend.

## Decision
Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)