### PR TITLE
chore(kaizen): weekly review prep 2026-06-05

### DIFF
--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -51,14 +51,6 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Unlocks**: fewer-step tool turns (lower per-turn cost), best-in-class computer-use, ~4× fewer code-flaw pass-throughs, the `effort` compute-depth knob
 - **Status**: open — verify Bedrock region availability (us-east-1 ✓) and the 4.8 context window on the model card before flipping the pin; confirm the beta.27 Opus-4.7 thinking/`temperature` handling still applies
 
-### [2026-05-29] Adopt Strands `Limits` for per-invocation cost/turn caps (supersedes hand-rolled runaway guardrail)
-- **Source**: research/2026-05-29.md ▸ Top 5 #2 — Strands PR #2360 (merged May 28, ships 1.42). **Supersedes** the 2026-05-22 ▸ Top 5 #5 "Runaway-session cost guardrail" item below.
-- **Surface**: backend (agent invocation in `inference_api`, SSE stop-reason handling for `limit_*`) + infrastructure (CloudWatch Bedrock-spend alarm)
-- **Effort × Impact**: L-M × M-H
-- **Subtracts**: yes — adopts library-native `limits=` instead of hand-rolling a hook; the queued "build our own guardrail" collapses to "adopt + alarm"
-- **Unlocks**: native per-turn cost ceiling + `limit_*` stop_reason (real protection against the $72-in-58-min / $30K-invoice failure mode; `stop_runtime_session` does not stop the microVM)
-- **Status**: open — gated on Strands 1.42 release (currently latest is 1.41.0). Pairs with the existing CloudWatch-alarm half of the 2026-05-22 item.
-
 ### [2026-05-29] Align MCP Apps capability advertisement to spec-canonical `io.modelcontextprotocol/ui`
 - **Source**: research/2026-05-29.md ▸ Top 5 #3 — SEP-1865 folded into the 2026-07-28 draft spec, PR #2791 (May 27)
 - **Surface**: backend (inference-api `initialize` capability advertisement — currently `experimental.ui`; the `ui_resource` SSE path)
@@ -81,14 +73,6 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Subtracts**: no — defensive; protects the shared event loop from being wedged by one user's request
 - **Status**: open — #399 already filed; kaizen value is the broader class-of-bug sweep (pairs with the queued SDK #482 guard)
 
-### [2026-05-22] Strands 1.40 → 1.41 bump + enable Bedrock prompt caching (closes issue #269)
-- **Source**: research/2026-05-22.md ▸ Top 5 #1 — Strands v1.41.0 (PR #2232 `cache_tools_ttl`) + open issue #269
-- **Surface**: backend (`pyproject.toml`, `uv.lock`, `BedrockModel` construction, `CacheConfig` wiring)
-- **Effort × Impact**: M × H
-- **Subtracts**: partial — adopts library-native `cache_tools_ttl` instead of a hand-rolled TTL workaround
-- **Unlocks**: end-to-end 1h prompt caching → lower input-token cost on multi-turn sessions, surfaced in the admin "Cache Savings" card
-- **Status**: open — gated on a `starlette` 1.x transitive-conflict audit (Strands 1.41 bumps starlette to the 1.x major line)
-
 ### [2026-05-22] Defensive guard against SDK #482 SSE-disconnect runtime deadlock
 - **Source**: research/2026-05-22.md ▸ Top 5 #2 — AgentCore SDK issue #482
 - **Surface**: backend (`inference-api` streaming worker — the `/invocations` SSE handler)
@@ -108,13 +92,6 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Surface**: backend (provider-translation chokepoint — same site as `_shape_thinking_value` / #329 / #331)
 - **Effort × Impact**: L × M
 - **Subtracts**: no — defensive; Opus 4.7 rejects `temperature` on extended-thinking turns
-- **Status**: open
-
-### [2026-05-22] Runaway-session cost guardrail — `max_turns` + CloudWatch Bedrock-spend alarm
-- **Source**: research/2026-05-22.md ▸ Top 5 #5 — starter-toolkit issue #498 + in-window HN $30K-bill story
-- **Surface**: cross-cutting — agent loop (`backend/src/agents/main_agent/`) + infrastructure (CloudWatch alarm)
-- **Effort × Impact**: L-M × M-H
-- **Subtracts**: no — defensive/operational; `stop_runtime_session` does not stop the microVM
 - **Status**: open
 
 ### [2026-05-15] Wire per-tool `duration_ms` into `tool_result` SSE
@@ -184,6 +161,21 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Status**: open — surfaced in reviews/2026-05-22.md ▸ Proposal #6 (Ship scoped, or Defer 2 weeks); no decision logged yet.
 
 ## Resolved
+
+### [2026-05-29] Adopt Strands `Limits` for per-invocation cost/turn caps → RESOLVED — superseded (folded into the 2026-06-05 Strands 1.42 keystone)
+- **Decision**: Superseded — consolidated into the [2026-06-05] "Strands 1.40 → 1.42 keystone bump" Open item.
+- **Reasoning**: This item was gated on Strands 1.42, which released June 1. The 2026-06-05 research declared the consolidation: the keystone bump adopts `Limits` (cost cap) and `cache_tools_ttl` (#269) together. Tracking it as a separate item duplicates the keystone. The CloudWatch Bedrock-spend alarm half is carried in the keystone's surface area.
+- **Reviewed-in**: reviews/2026-06-05.md ▸ Proposal #1 + Retirement Candidates (queue consolidation).
+
+### [2026-05-22] Strands 1.40 → 1.41 bump + enable Bedrock prompt caching (#269) → RESOLVED — superseded (folded into the 2026-06-05 Strands 1.42 keystone)
+- **Decision**: Superseded — consolidated into the [2026-06-05] "Strands 1.40 → 1.42 keystone bump" Open item.
+- **Reasoning**: `cache_tools_ttl` (the #269 unblock this item targeted at 1.41) now ships in 1.42 alongside `Limits`. A single 1.40 → 1.42 bump covers both; the `starlette` 1.x transitive-conflict audit this item owed is folded into the keystone's blast-radius audit (`strands-agents-tools` 0.5→0.8 + `starlette` 1.2.1). #269 stays open as the work-tracking issue.
+- **Reviewed-in**: reviews/2026-06-05.md ▸ Proposal #1 + Retirement Candidates (queue consolidation).
+
+### [2026-05-22] Runaway-session cost guardrail — `max_turns` + CloudWatch Bedrock-spend alarm → RESOLVED — superseded (folded into the 2026-06-05 Strands 1.42 keystone)
+- **Decision**: Superseded — consolidated into the [2026-06-05] "Strands 1.40 → 1.42 keystone bump" Open item.
+- **Reasoning**: Strands `Limits` (1.42) is the library-native replacement for the hand-rolled `max_turns` guardrail this item proposed; the keystone adopts it and retires the hand-rolled equivalent. The CloudWatch Bedrock-spend alarm half is carried in the keystone's infrastructure surface area (the half the SDK can't provide).
+- **Reviewed-in**: reviews/2026-06-05.md ▸ Proposal #1 + Retirement Candidates (queue consolidation).
 
 ### [2026-05-22] Pin `backup-data.yml` runner + actions to restore the CI gate → RESOLVED — pinned, CI green
 - **Decision**: Resolved (not a logged kaizen decision — landed incidentally via the beta.27 release merge #365, May 21).

--- a/docs/kaizen/reviews/2026-06-05.md
+++ b/docs/kaizen/reviews/2026-06-05.md
@@ -1,0 +1,199 @@
+# Kaizen Review — Friday, June 5, 2026
+> Prepared 8:05am MT. Review window: May 29 – June 5, 2026 (7 days).
+> Source: research/2026-06-05.md + review-queue.md (20 open items, after folding 3 Strands-cluster items into the keystone) + this week's repo activity.
+
+## Week in Review
+
+Upstream closed our backlog for the third time in a month: **Strands 1.42.0 (June 1) shipped `Limits` + `cache_tools_ttl`**, collapsing two gated queue items into one keystone bump. But the *output* half stalled for the **third consecutive week** — **none** of the May 29 review's 8 Ship recommendations shipped as kaizen PRs, and all six tracked issues (#399, #404, #405, #288, #419, #269) are **still open**. Meanwhile the team shipped a lot of *feature* work well: the context-attribution feature landed (#428–433, now live in prod), a Starlight docs site got built and rebranded (#432, #440–445), MCP Apps polish (#409–418), and restore/deploy infra fixes (#420–425). Two things this week turn "defer" into "finish what we started": the context-attribution feature shipped the same week Strands disclosed **#2635** (a token-counting bug that strikes its foundation), and **#443 landed the exact security helpers** (`validate_external_url`, ownership checks) that close #399/#404 — the precondition is met; only the wiring remains.
+
+## Friction — the week's signal
+
+### Repeated patterns (≥2 occurrences)
+- **Kaizen hygiene loses to feature throughput — third consecutive week** (8 occurrences) — every Ship recommendation from reviews/2026-05-29.md (#1 Opus 4.8, #2 bedrock-agentcore, #3 Strands caching, #4 io.modelcontextprotocol/ui, #5 compaction-preserve, #6 #399 sweep, #7 SSE-teardown, #8 #288) failed to ship as a kaizen PR. All six referenced issues remain OPEN. The bundle strategy the May 29 Take explicitly prescribed ("ship one defensive bundle the way #338 did") did **not** convert.
+  - *Hypothesis*: same as last week, now confirmed twice — defensive bumps/audits have no product surface and lose the weekly bandwidth coin-flip. But there's a sharper read now: with **zero decisions logged anywhere** (no PR comments, no decisions.md entries since May 18), proposals aren't being *declined* — they're evaporating. The review is becoming a write-only log, exactly the failure the May 29 Take named.
+  - *Candidate fix*: stop ranking 10 items hoping 3 stick. Pick **one** keystone (Strands 1.42, this week) + **one** finish-what-we-started item (#443 → close #399/#404) and treat the rest as explicitly Deferred-with-date, so the queue shrinks instead of accreting.
+- **Nightly Build & Test chronically red** (2 in-window: Jun 4, Jun 5; recurring back to May 27, May 21) — the most persistent CI signal on the board. Backend pytest is **not** a PR gate (`project_pytest_not_in_ci.md`), so the nightly full-suite is the *only* automated backend correctness gate — and it's been dark for weeks, unexplained in the in-window commits.
+  - *Hypothesis*: flaky/long-running test, nightly-schedule credential/env drift, or a real regression only the full suite catches. Unknown because nobody's pulled the logs.
+  - *Candidate fix*: `gh run view <id> --log-failed` on the last two nightlies; classify flaky-vs-real; quarantine or file. **This matters more this week** because the Strands 1.42 keystone bump is about to land on a suite we can't currently trust.
+- **New features draw follow-on issues / leave wiring half-done** (2 occurrences) — context-attribution shipped (#428–433) and Strands immediately disclosed #2635 against its foundation; #443 landed the security helpers but #399/#404 stayed open because the web-sources routes weren't migrated onto them.
+
+### One-offs worth watching
+- **Restore Data + Backend Stack failures (Jun 2, workflow_dispatch)** — coincide with the SSM image-tag-contract churn (#420/#421); likely the deploy-contract work settling, not a new regression. Watch that they're green on the next scheduled run.
+- **Graph Update (uv) failures (Jun 2–3)** — tooling/low-signal, as in prior weeks.
+
+### Silence that matters
+- **Zero comments on every kaizen PR — fourth consecutive week** — #407, #408, #446 all have 0 comments / 0 reviews. **No POC findings exist to fold into any proposal; no Ship/Decline/Defer decision was logged anywhere.** Ranking is on Effort×Impact alone, no POC boost available. The loop is producing proposals and not closing the decision step — the single biggest threat to the loop's value.
+- **`duration_ms` tool-timing carried four reviews, never actioned** — forced to a decision in Retirement Candidates below; the May 29 review said "don't carry a fourth week silently," and this is the fourth.
+
+## Proposals — ranked
+
+### 1. Strands 1.40 → 1.42 keystone bump — unblocks `Limits` (cost caps) + `cache_tools_ttl` (#269)
+- **Source**: research/2026-06-05.md ▸ Top 5 #1 — Strands v1.42.0 (June 1). Consolidates queue items 2026-05-22 (#269 caching), 2026-05-29 #2 (`Limits`), and 2026-05-22 (runaway guardrail) — all now folded here.
+- **Surface area**: backend (`backend/pyproject.toml` + `uv.lock` — currently `strands-agents==1.40.0`; agent invocation in `inference_api`; `BedrockModel`/`CacheConfig`; SSE `limit_*` stop-reason) + infrastructure (CloudWatch Bedrock-spend alarm).
+- **Change**: bump to 1.42 **with the blast-radius audit** — `strands-agents-tools` 0.5.2→0.8.0 tool-interface review + `starlette` 1.2.1 FastAPI-0.136.x transitive-compat check; then wire `limits={turns, outputTokens, totalTokens}`, recognize `limit_*` as clean SSE termination, and wire `cache_tools_ttl` for #269.
+- **Subtracts**: **yes** — adopts library-native `Limits` (retires the hand-rolled runaway guardrail) + `cache_tools_ttl` (retires the hand-rolled TTL); three queued items collapse into one bump.
+- **Unlocks**: native per-turn cost ceiling (real protection against the $72-in-58-min / $30K-invoice failure mode); end-to-end 1h prompt caching → lower input-token cost, surfaced in the admin "Cache Savings" card.
+- **Effort**: Med · **Impact**: High
+- **POC findings**: not POCed (4th week of kaizen-PR silence).
+- **Ship means**: PR with the tool-interface + starlette audit, then `limits=` + `cache_tools_ttl` wiring + SSE `limit_*` handling. Gate behind a green nightly (see Risks).
+- **Decline means**: stay on 1.40; keep the hand-rolled guardrail and no cost ceiling; #269 stays open a fifth week.
+- **Recommendation**: **Ship** — the single highest-leverage move; one bump retires two hand-rolled mechanisms and unblocks #269. *Verify the nightly first — don't land a keystone bump on an untrusted suite.*
+
+### 2. Wire #443 security helpers into web-sources routes → close #399 + #404
+- **Source**: direct observation — PR #443 (June 4) landed `apis.shared.security` (`validate_external_url` with DNS-rebinding defense, `require_*_owner` ownership helpers, 404-not-403 enumeration-oracle fix). Issues #399 (crawler DoS/SSRF) + #404 (editor ownership guard) are **still OPEN**. Sharpens queue item 2026-05-29 "sync-in-async sweep #399."
+- **Surface area**: backend (web-sources crawler routes — swap the ownership-only guard for `require_session_owner`/the shared viewer-editor check; route the crawler's outbound fetch through `validate_external_url`; bound concurrency with a semaphore + offload blocking HTTP/parse to a thread pool).
+- **Change**: adopt the just-shipped helpers at the two call sites, fixing #404 (editors blocked on shared assistants) and the SSRF half of #399; add the concurrency bound for the DoS half.
+- **Subtracts**: **yes** — retires the bespoke ownership-only guard in favor of the shared `require_*_owner` helper; removes hand-rolled URL checks in favor of the shared validator.
+- **Effort**: Low-Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: one PR migrating the web-sources routes onto `apis.shared.security` + the semaphore/thread-pool fix; close #399 and #404.
+- **Decline means**: the helpers sit unused, #404 keeps editors locked out of shared assistants, and the #399 DoS/SSRF vector stays live.
+- **Recommendation**: **Ship** — the precondition just got met (cf. `feedback_kaizen_close_recommendations.md`: an adoption issue whose precondition is now met is live work, not phantom debt). Cheapest path to closing two open issues.
+
+### 3. Guard the context-attribution path against Strands `count_tokens` toolResult=0 (#2635)
+- **Source**: research/2026-06-05.md ▸ Top 5 #2 — Strands #2635 (open) + internal PR #428–433 (**shipped this window, live in prod**).
+- **Surface area**: backend (`CountTokensBedrockModel`, the `contextBreakdown` hook/coordinator channel, the compaction trigger).
+- **Change**: confirm native Bedrock CountTokens is used for **all** turns incl. tool-heavy ones with JSON toolResults, and the heuristic path #2635 affects is never hit; add a regression test asserting a non-zero count for a turn with a JSON toolResult; add a guard/fallback if the heuristic is reachable. (Per `project_context_attribution_prototype.md` our path de-prefixes `us.*` inference-profile ids to the base FM id and uses native Bedrock CountTokens — likely immune, but the Tools partition folds tool-use scaffolding, so verify before assuming.)
+- **Subtracts**: no — defensive; protects freshly-shipped PR #428–433.
+- **Effort**: Low-Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: a verification + a regression test (small PR), ideally bundled with #1's Strands bump since both touch the model/token path.
+- **Decline means**: tool-heavy turns may silently under-report the Tools partition and trip compaction late, degrading the feature we just shipped.
+- **Recommendation**: **Ship** — most time-sensitive item; the feature is live now. Cheap. Bundle with #1.
+
+### 4. Bump `docling` past the 2.81.0 content-sniffing defect → close #405
+- **Source**: research/2026-06-05.md ▸ Top 5 #4 — docling 2.97.0 (June 3) + issue #405 (still OPEN; `requirements.lock` confirmed pinned at `docling==2.81.0`).
+- **Surface area**: backend (`backend/src/apis/app_api/documents/ingestion/requirements.lock` + `requirements.txt`; cross-check `Dockerfile.rag-ingestion`).
+- **Change**: bump docling off 2.81.x to a current release; verify `.txt` uploads succeed; close #405. (#420 only added a *comment* about the 2.81 default drift — it did not bump the pin.)
+- **Subtracts**: **yes** — a library-native bump closes an open user-facing bug; no custom workaround.
+- **Effort**: Low · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: bump the lock pin, run the ingestion tests, verify `.txt`, close #405.
+- **Decline means**: `.txt` uploads stay rejected as "File format not allowed."
+- **Recommendation**: **Ship** — cleanest subtraction of the week; ideal bundle filler.
+
+### 5. Bump `bedrock-agentcore` 1.9.1 → 1.13.0 + adopt `async_mode`
+- **Source**: research/2026-06-05.md (pin lag) | review-queue.md (open since 2026-05-22) — **fourth consecutive Ship recommendation**; lag now **4 minors**.
+- **Surface area**: backend (`backend/pyproject.toml`, `backend/uv.lock`, `AgentCoreMemoryConfig` construction).
+- **Change**: bump 1.9.1 → 1.13.0; set `async_mode=True` to retire the #452 event-loop-blocking risk; smoke-test Memory write/read + identity OAuth in dev. v1.13 adds a Strands tool-search plugin; **no SSE/Identity/Memory fixes** — #482 stays unpatched (→ #7).
+- **Subtracts**: yes — adopting `async_mode` retires the latent #452 blocking failure mode.
+- **Effort**: Low-Med · **Impact**: Med-High
+- **POC findings**: not POCed.
+- **Ship means**: PR bumping the pin + `async_mode`; smoke-test; merge.
+- **Decline means**: lag widens a fifth week; #452 stays live under sustained Memory load.
+- **Recommendation**: **Ship** — overdue; anchor the defensive bundle.
+
+### 6. Compaction summary prompt: preserve standing/sensitive user instructions
+- **Source**: research/2026-05-29.md ▸ Top 5 #4 | review-queue.md (open since 2026-05-29).
+- **Surface area**: backend (`TurnBasedSessionManager` summarization prompt).
+- **Change**: add an explicit clause instructing the summarizer to preserve standing/sensitive user instructions rather than summarize them away.
+- **Subtracts**: no — addition only; justified as a one-clause defensive change that dovetails with the PR #243 `compaction` SSE event.
+- **Effort**: Low · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: one-clause prompt edit + a regression assertion.
+- **Decline means**: long sessions can silently drop standing user constraints on compaction.
+- **Recommendation**: **Ship** — cheapest item; ideal bundle filler.
+
+### 7. SSE-teardown defensive bundle — `BedrockModel.stream` cancel audit + SDK #482 guard
+- **Source**: review-queue.md (open since 2026-05-10 and 2026-05-22) — two carried items on the same hot path.
+- **Surface area**: backend (`agents/main_agent/` stream coordinator + the `/invocations` SSE handler).
+- **Change**: locate every `BedrockModel.stream` cancel path, `await` the inner task on cancel to avoid orphaning, add a dev-only "Task exception was never retrieved" detector; in the same PR add the guard against the SDK #482 mid-stream-disconnect microVM deadlock. Track Strands PR #2269 as the upstream fix.
+- **Subtracts**: no — defensive; the SSE-disconnect path is hot and #482 is unpatched across four SDK releases.
+- **Effort**: Med · **Impact**: High
+- **POC findings**: not POCed.
+- **Ship means**: one PR with the cancel audit + #482 guard + a cancel-triggering regression test.
+- **Decline means**: silent 78s+ microVM stalls on mid-stream disconnect persist.
+- **Recommendation**: **Ship** — folds two carried items into one; bundle candidate.
+
+### 8. Fast PR-gate for the deterministic `supply_chain` + `architecture` test subset
+- **Source**: review-queue.md (open since 2026-05-22 ▸ Proposal #6) — reinforced by the still-open docling #405 (a dep regression CI didn't catch) and the chronically-red nightly.
+- **Surface area**: CI — a new lightweight PR-triggered job.
+- **Change**: add a PR job running only `pytest tests/supply_chain/ tests/architecture/ -q` (deterministic, no AWS/LLM). Catches workflow-pinning + import-boundary violations pre-merge.
+- **Subtracts**: no — addition; converts a recurring post-merge friction class into a pre-merge block without reopening the deliberate "no full pytest in PR CI" decision (scoped to two deterministic dirs only).
+- **Effort**: Low · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: PR adding the scoped job.
+- **Decline means**: the next unpinned-action / import-boundary break merges clean and goes red post-merge — on the only suite (nightly) that catches it, which is itself currently red.
+- **Recommendation**: **Ship (scoped)** — note the standing tension with `project_pytest_not_in_ci.md`; this threads it by gating only the two deterministic dirs (cf. `feedback_resilient_ci_fixes.md`).
+
+### 9. Triage inference-api deploy #288 — images reach ECR but Runtime isn't rolled
+- **Source**: review-queue.md (open since 2026-05-15) | issue #288 (OPEN, **0 comments, ~24 days**) — recommended Ship three times (05-15, 05-22, 05-29).
+- **Surface area**: cross-cutting — `.github/workflows/deploy-inference-api.yml` + the bedrock-agentcore `update_agent_runtime` call shape.
+- **Change**: trace the deploy workflow end-to-end; confirm whether it calls `update_agent_runtime` after the ECR push. **Re-scope first**: heavy deploy-contract churn landed this window (#420 SSM image-tag contract, #421 SSM params + lambda deploy URI contract, "re-enable push triggers on deploy workflows") — confirm #288's root cause still stands before building a fix.
+- **Subtracts**: possibly — removes the manual-redeploy band-aid.
+- **Effort**: Low-Med · **Impact**: Med-High (Proposal #1's Strands bump must eventually reach the runtime via this path).
+- **POC findings**: not POCed.
+- **Ship means**: 1–2h triage against the post-#420/#421 deploy contract; close #288 if resolved, or a small workflow PR.
+- **Decline means**: #288 rots into a fifth week; the keystone bump (#1) may silently no-op in prod.
+- **Recommendation**: **Ship** — directly gates whether #1 reaches production; start with a re-scope given the deploy-contract churn.
+
+### 10. Align MCP Apps capability advertisement to spec-canonical `io.modelcontextprotocol/ui`
+- **Source**: research/2026-05-29.md ▸ Top 5 #3 | review-queue.md (open since 2026-05-29) — RC hardening continues (SEP-2549/#2855 merged June 4), 2026-07-28 RC approaching freeze.
+- **Surface area**: backend (inference-api `initialize` capability advertisement — currently `experimental.ui`; the `ui_resource` SSE path).
+- **Change**: advertise `io.modelcontextprotocol/ui` (alongside or replacing `experimental.ui`); diff the merged draft for any change to the declare-templates-ahead / tool-list-prefetch shape.
+- **Subtracts**: yes — retires the pre-standard `experimental.ui` identifier for the conformant name.
+- **Effort**: Low-Med · **Impact**: Med
+- **POC findings**: not POCed.
+- **Ship means**: PR migrating the identifier + a draft-diff note.
+- **Decline means**: identifier drift; spec-conformant peers may not negotiate our UI extension post-RC.
+- **Recommendation**: **Ship** or **Defer 2 weeks** — cheap, subtractive, on our timeline before the ~2026-07-28 RC freeze.
+
+> **Below the cap, deferred to next week with a note:**
+> - **Make the context-breakdown badge interactive (Cursor pattern)** (research #3, M×M, capability-unlock) — *Defer 1 week.* Lands on the same surface as #3's guard; let the #2635 correctness verification land before building more on the badge.
+> - **Migrate inference-api Opus 4.7 → 4.8** (queue 2026-05-29, M×H) — *Defer / verify.* Dropped from this week's research Top 5; confirm whether it partially landed (no bound-model id found in `inference_api` source — config likely in the curated catalog) before re-ranking.
+> - **De-risk #419 admin-managed Gateway target registration** (research #5, H×H) — *Defer 1 week,* pair with the BYO-filesystem re-decision due 2026-06-12; both are ADR-worthy architectural bets and shouldn't open simultaneously.
+
+## Carried Over From Prior Reviews
+
+- **`oauth_required` SSE flow audit vs ref-repo's mid-tool-call 401/403 handling** (deferred 2026-05-10 until 2026-05-24; flagged "now due" in reviews/2026-05-29.md but never decided) — **12 days overdue.** BFF parade done via #297; no remaining reason to hold. *Recommendation*: promote to a proposal next week or **Decline** to `decisions.md` — it must not carry a fourth review silently.
+- **AgentCore Runtime BYO filesystem (S3/EFS)** (deferred 2026-05-15 until **2026-06-12**) — due **next** review (7 days out). MCP Apps initiative has shipped, so the "don't double the open architectural surface" rationale has weakened; will surface for re-decision 2026-06-12.
+- **Named A2A agent participants in the chat UI** (deferred 2026-05-15 until **2026-06-12**) — due next review. Still gated on an A2A *server* construct landing (none has).
+
+## Retirement Candidates
+
+- **`duration_ms` tool-timing into `tool_result` SSE — DROP.** Carried since 2026-05-15, recommended Ship once, never actioned, never ranked top-3 across **four** reviews. The context-attribution feature (#428–433) shipped *without* it, removing its main "data substrate for the prototype" justification. *Recommendation*: drop to `decisions.md` ("deferred indefinitely — capability nice-to-have, repeatedly out-prioritized; context-attribution shipped without it"). The May 29 review said don't carry it a fourth week silently — this is the fourth.
+- **Strands cluster consolidation (queue hygiene, done in this PR)** — three queue items (2026-05-22 "Strands 1.40→1.41 + caching", 2026-05-29 "Adopt Strands Limits", 2026-05-22 "Runaway-session cost guardrail") are all subsumed by the 2026-06-05 keystone (#1). Moved to Resolved → Superseded in `review-queue.md` so the queue reflects one keystone, not four overlapping entries.
+- **No dead skill/file/config candidate** — all `.claude/skills` are recently modified or actively referenced; the week's genuine subtractions are upstream-adoption-driven (#1, #2, #4, #10), not dead-code removal.
+
+## Risks Acknowledged But Not Acted On
+
+- **Nightly Build & Test chronically red** — Jun 4, Jun 5 (in-window), recurring May 21/27. The only automated backend correctness gate, unexplained. — *what breaks*: a real regression hides in a red suite; worse, the Strands 1.42 keystone (#1) is about to land on a suite we can't trust. — **Address now** (1h: pull the last two nightly logs, classify flaky-vs-real, gate #1 behind a green run).
+- **#2635 (Strands `count_tokens` toolResult=0)** — → Proposal #3. — *what breaks*: the live context-attribution badge under-reports tool-heavy turns and compaction trips late. — **Address now.**
+- **Strands 1.42 keystone blast radius** — `strands-agents-tools` 0.5→0.8 + `starlette` 1.2.1. — *what breaks*: a naive bump could break tool registration or the ASGI stack. — **Address as part of #1** (audit, not a one-liner).
+- **bedrock-agentcore 4 minors behind; #482 unpatched** — → Proposals #5 + #7. — *what breaks*: the SSE-disconnect microVM deadlock stays our in-app risk. — **Address now** (guard); upstream unmoved across four releases.
+- **Angular 22 stable (June 3) — major drift** — staying on 21.x is fine short-term; the longer the gap, the harder the coordinated upgrade (esp. the Analog `alpha`-vs-`latest` channel reconciliation). — **Watch** — schedule a spike before it accretes; don't bump reactively.
+
+## What Shipped This Week
+
+- **Context-attribution feature** (#428–433) — *native Bedrock CountTokens → per-turn `contextBreakdown` over SSE → message badge + session popover; the foundation #2635 now threatens (→ Proposal #3).*
+- **Starlight docs site** (#432) + brand redesign / architecture overview (#440–445) — *public-facing documentation, frosted-glass brand theme, AWS architecture diagram.*
+- **Conversation Modes — admin-created system prompts, opt-in** (#411) — *net-new admin capability.*
+- **Shared security helpers** (#443) — *`apis.shared.security`: `validate_external_url` (DNS-rebinding defense), ownership helpers (404-not-403), AWS-error non-reflection. The foundation that closes #399/#404 (→ Proposal #2).*
+- **MCP Apps polish** (#409, #410, #412, #413, #414, #417, #418) — *fullscreen overlay, refresh-durable UI resources, partial tool-input streaming, reachable consent.*
+- **Restore/deploy infra fixes** (#420–425) — *SSM image-tag contract, restore-tooling params, cross-pool federated-user migration.*
+- **artifact-render live-CodeSha256 drift guard** (#438) — *closes the bootstrap-503-stub stranding.*
+
+## Take
+
+Hygiene lost a **third** straight week — precisely what the May 29 Take warned would turn the queue into a write-only log, and the four-week comment silence confirms it: proposals aren't being declined, they're evaporating. But this week is the most actionable in a while because two events convert "defer" into "finish": the context-attribution feature shipped *into production* the same week Strands disclosed #2635 against its foundation, and #443 landed the exact helpers that close #399/#404 — both are now finish-the-job, not start-from-scratch. The single highest-leverage move is the **Strands 1.42 keystone (#1)**: one bump retires two hand-rolled mechanisms and unblocks #269 + native cost caps. If Phil ships only two things this week, ship **#1 (keystone)** and **#2 (#443 → close #399/#404)** — and spend one hour on the **red nightly** first, because landing a keystone dependency bump on a backend suite that's been dark for weeks is how a silent regression ships. Don't bundle-and-hope this time: pick two, ship two, defer the rest with dates.
+
+---
+
+## Review Protocol (for Phil)
+
+1. Read Friction (2 min) — headline: "3rd straight week hygiene didn't ship; 4th week of zero logged decisions; nightly is red."
+2. Mark each Proposal ✅ Ship / ❌ Decline / ⏸ Defer (4-6 min). **10 proposals**; my recommendations: 9 Ship, 1 Ship-or-Defer (#10). The honest pick is **2, not 9** — see the Take.
+3. Resolve Carried Over: `oauth_required` audit is 12 days overdue — Ship or Decline (1 min).
+4. Scan Retirement Candidates — `duration_ms` is at its fourth week: **drop it** (1 min).
+5. Resolve the Risks block — the red **nightly** is the address-now item (1-2 min).
+6. **Suggested 1–3 to ship**: **#1 (Strands 1.42 keystone)** + **#2 (#443 → close #399/#404)**; if bandwidth allows, **#4 (docling → close #405)** as a one-line subtraction. Verify the nightly before #1 lands. Defer the rest with dates so the queue shrinks.
+
+Target: 12-15 minutes.
+
+## Post-review (for Phil — separate PRs)
+
+- ✅ Ship items → individual feature PRs (or one defensive bundle) over the week. The decision is logged here; implementation lives elsewhere.
+- ❌ Decline items → appended to `docs/kaizen/decisions.md` with reason so future research doesn't re-propose.
+- ⏸ Defer items → kept open in `review-queue.md` with a revisit date; surface again when due.
+
+This skill produces the agenda. Implementation never happens here.


### PR DESCRIPTION
## Summary
- 10 proposals ranked Effort × Impact (retirement candidates + capability-unlock boosted). Honest pick: **2, not 10** — see the Take.
- Friction headline: **3rd straight week kaizen hygiene didn't ship**; all six tracked issues (#399/#404/#405/#288/#419/#269) still open; **4th week of zero logged decisions** on any kaizen PR.
- Two items turn "defer" into "finish": context-attribution shipped to prod the same week Strands disclosed #2635 against its foundation; #443 landed the exact helpers that close #399/#404.
- Queue hygiene: 3 superseded Strands-cluster items folded into the 2026-06-05 1.42 keystone (Open → Resolved).
- Risk flagged: **Nightly Build & Test chronically red** — the only backend correctness gate — about to receive a keystone dep bump.

## Review
1. Read Friction (2 min).
2. Mark each Proposal: ✅ Ship / ❌ Decline / ⏸ Defer.
3. Same for Retirement Candidates (`duration_ms` → drop, 4th week) and Risks (red nightly → address now).
4. Pick 1-3 to ship: recommended **#1 (Strands 1.42 keystone) + #2 (#443 → close #399/#404)**, verify the nightly first.

Target: 12-15 minutes.

## Decision
Ship the doc to `develop`. Action on individual items happens in separate PRs over the week.
Declined items go to `docs/kaizen/decisions.md`; deferred items stay open in `review-queue.md` with a revisit date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)