### PR TITLE
feat(tools): MCPGatewayConfig model for Gateway target registration (#419, PR1/5)

### DIFF
--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ToolCategory(str, Enum):
@@ -63,6 +63,48 @@ class A2AAuthType(str, Enum):
     AWS_IAM = "aws-iam"
     AGENTCORE = "agentcore"  # AgentCore Runtime auth
     API_KEY = "api-key"
+
+
+class GatewayListingMode(str, Enum):
+    """How an AgentCore Gateway target lists its tools.
+
+    Maps to the `bedrock-agentcore-control` `listingMode` enum (uppercased at
+    the AWS boundary by GatewayTargetService). DYNAMIC resolves tools at call
+    time but disables 3LO/OAuth and Gateway semantic search; DEFAULT lists
+    tools statically and is required for both.
+    """
+
+    DEFAULT = "default"
+    DYNAMIC = "dynamic"
+
+
+class GatewayCredentialType(str, Enum):
+    """How the Gateway authenticates outbound to a target's MCP endpoint.
+
+    Maps to the `bedrock-agentcore-control` `credentialProviderType` enum.
+    GATEWAY_IAM_ROLE signs with the gateway's own execution role (SigV4, no
+    ARN); OAUTH and API_KEY reference an existing AgentCore credential
+    provider by ARN (provider provisioning is out of scope in v1).
+    """
+
+    GATEWAY_IAM_ROLE = "gateway_iam_role"
+    OAUTH = "oauth"
+    API_KEY = "api_key"
+
+
+class GatewayOAuthGrantType(str, Enum):
+    """OAuth grant the Gateway uses when calling an OAUTH-credentialed target.
+
+    Maps to the `bedrock-agentcore-control` `oauthCredentialProvider.grantType`
+    enum. AUTHORIZATION_CODE is the on-behalf-of-user (3LO) flow that reuses our
+    existing AgentCore Identity consent path (USER_FEDERATION); CLIENT_CREDENTIALS
+    is machine-to-machine (2LO, no user consent). Only meaningful when
+    credential_type is OAUTH.
+    """
+
+    AUTHORIZATION_CODE = "authorization_code"
+    CLIENT_CREDENTIALS = "client_credentials"
+    TOKEN_EXCHANGE = "token_exchange"
 
 
 class ToolStatus(str, Enum):
@@ -206,6 +248,156 @@ class MCPServerConfig(BaseModel):
             tools=_parse_mcp_tools(data.get("tools", [])),
             health_check_enabled=data.get("healthCheckEnabled", False),
             health_check_interval_seconds=data.get("healthCheckIntervalSeconds", 300),
+        )
+
+    def approval_required_names(self) -> set[str]:
+        """Return the names of tools flagged as requiring user approval."""
+        return {entry.name for entry in self.tools if entry.needs_approval}
+
+
+class MCPGatewayConfig(BaseModel):
+    """
+    Configuration for an externally deployed MCP server registered as a
+    target on the centralized AgentCore Gateway.
+
+    Used when protocol is 'mcp' (ToolProtocol.MCP_GATEWAY). Unlike
+    `MCPServerConfig` (protocol 'mcp_external', which the agent connects to
+    directly), the agent never talks to this endpoint — the Gateway fronts it,
+    and the tool reaches agents through the existing Gateway discovery path.
+
+    `target_id` and `gateway_arn` are AWS-assigned identifiers stamped onto the
+    config by the admin route after the Gateway target is created; they are the
+    catalog↔AWS link that lets update/delete reconcile the live target.
+    """
+
+    # Gateway target identity
+    target_name: str = Field(
+        ..., description="Gateway target name (unique within the gateway)"
+    )
+    endpoint_url: str = Field(
+        ..., description="External MCP server endpoint the Gateway calls"
+    )
+    listing_mode: GatewayListingMode = Field(
+        default=GatewayListingMode.DEFAULT,
+        description="How the Gateway lists this target's tools",
+    )
+
+    # Outbound auth from the Gateway to the target
+    credential_type: GatewayCredentialType = Field(
+        default=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        description="How the Gateway authenticates to the target endpoint",
+    )
+    credential_provider_arn: Optional[str] = Field(
+        None,
+        description="ARN of an existing AgentCore credential provider "
+        "(required for OAUTH and API_KEY; unused for GATEWAY_IAM_ROLE)",
+    )
+    oauth_scopes: List[str] = Field(
+        default_factory=list,
+        description="OAuth scopes requested for OAUTH credential type",
+    )
+    grant_type: GatewayOAuthGrantType = Field(
+        default=GatewayOAuthGrantType.AUTHORIZATION_CODE,
+        description="OAuth grant for OAUTH credential type (3LO vs 2LO); "
+        "ignored for other credential types",
+    )
+    custom_parameters: Optional[Dict[str, str]] = Field(
+        None,
+        description="Extra parameters forwarded to the OAuth provider. These are "
+        "part of the AgentCore token-vault key, so they must match between "
+        "target registration and token retrieval.",
+    )
+
+    # Per-tool flags (only applied when listing_mode is DEFAULT — DYNAMIC
+    # listing resolves tool names at call time, so flags can't be matched)
+    tools: List[MCPToolEntry] = Field(
+        default_factory=list,
+        description="Tools exposed by this target, with per-tool flags. "
+        "Empty means rely on Gateway listing with no per-tool flags applied.",
+    )
+
+    # AWS-assigned identifiers (stamped on after target creation)
+    target_id: Optional[str] = Field(
+        None, description="Gateway target ID assigned by AgentCore on create"
+    )
+    gateway_arn: Optional[str] = Field(
+        None, description="ARN of the gateway the target lives on"
+    )
+
+    model_config = {"use_enum_values": True}
+
+    @model_validator(mode="after")
+    def _validate_credentials(self) -> "MCPGatewayConfig":
+        """Enforce the credential/listing-mode co-gating rules.
+
+        OAuth (3LO) and Gateway semantic search require DEFAULT listing — see
+        the listing-mode co-gating gotcha in issue #419. GATEWAY_IAM_ROLE uses
+        the gateway's execution role and takes no provider ARN.
+        """
+        if self.credential_type == GatewayCredentialType.OAUTH:
+            if not self.credential_provider_arn:
+                raise ValueError(
+                    "credential_type 'oauth' requires credential_provider_arn"
+                )
+            if self.listing_mode != GatewayListingMode.DEFAULT:
+                raise ValueError(
+                    "OAuth (3LO) targets require listing_mode 'default'; "
+                    "'dynamic' disables 3LO and Gateway semantic search"
+                )
+        elif self.credential_type == GatewayCredentialType.API_KEY:
+            if not self.credential_provider_arn:
+                raise ValueError(
+                    "credential_type 'api_key' requires credential_provider_arn"
+                )
+        elif self.credential_type == GatewayCredentialType.GATEWAY_IAM_ROLE:
+            if self.credential_provider_arn:
+                raise ValueError(
+                    "credential_type 'gateway_iam_role' signs with the gateway "
+                    "execution role and must not set credential_provider_arn"
+                )
+        return self
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for DynamoDB storage."""
+        return {
+            "targetName": self.target_name,
+            "endpointUrl": self.endpoint_url,
+            "listingMode": self.listing_mode
+            if isinstance(self.listing_mode, str)
+            else self.listing_mode.value,
+            "credentialType": self.credential_type
+            if isinstance(self.credential_type, str)
+            else self.credential_type.value,
+            "credentialProviderArn": self.credential_provider_arn,
+            "oauthScopes": list(self.oauth_scopes),
+            "grantType": self.grant_type
+            if isinstance(self.grant_type, str)
+            else self.grant_type.value,
+            "customParameters": self.custom_parameters,
+            "tools": [entry.to_dict() for entry in self.tools],
+            "targetId": self.target_id,
+            "gatewayArn": self.gateway_arn,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MCPGatewayConfig":
+        """Create from dictionary."""
+        return cls(
+            target_name=data.get("targetName", ""),
+            endpoint_url=data.get("endpointUrl", ""),
+            listing_mode=data.get("listingMode", GatewayListingMode.DEFAULT),
+            credential_type=data.get(
+                "credentialType", GatewayCredentialType.GATEWAY_IAM_ROLE
+            ),
+            credential_provider_arn=data.get("credentialProviderArn"),
+            oauth_scopes=data.get("oauthScopes") or [],
+            grant_type=data.get(
+                "grantType", GatewayOAuthGrantType.AUTHORIZATION_CODE
+            ),
+            custom_parameters=data.get("customParameters"),
+            tools=_parse_mcp_tools(data.get("tools", [])),
+            target_id=data.get("targetId"),
+            gateway_arn=data.get("gatewayArn"),
         )
 
     def approval_required_names(self) -> set[str]:
@@ -428,6 +620,10 @@ class ToolDefinition(BaseModel):
         None,
         description="A2A agent configuration (required when protocol is 'a2a')",
     )
+    mcp_gateway_config: Optional[MCPGatewayConfig] = Field(
+        None,
+        description="Gateway target configuration (required when protocol is 'mcp')",
+    )
 
     # MCP Apps (SEP-1865) — derived live from the MCP server's `tools/list`
     # `_meta.ui`, not admin-configured, so these are intentionally NOT
@@ -484,6 +680,8 @@ class ToolDefinition(BaseModel):
             item["mcpConfig"] = self.mcp_config.to_dict()
         if self.a2a_config:
             item["a2aConfig"] = self.a2a_config.to_dict()
+        if self.mcp_gateway_config:
+            item["mcpGatewayConfig"] = self.mcp_gateway_config.to_dict()
 
         return item
 
@@ -501,6 +699,10 @@ class ToolDefinition(BaseModel):
         a2a_config = None
         if item.get("a2aConfig"):
             a2a_config = A2AAgentConfig.from_dict(item["a2aConfig"])
+
+        mcp_gateway_config = None
+        if item.get("mcpGatewayConfig"):
+            mcp_gateway_config = MCPGatewayConfig.from_dict(item["mcpGatewayConfig"])
 
         # Handle legacy protocol values gracefully
         protocol_value = item.get("protocol", ToolProtocol.LOCAL)
@@ -532,6 +734,7 @@ class ToolDefinition(BaseModel):
             enabled_by_default=item.get("enabledByDefault", False),
             mcp_config=mcp_config,
             a2a_config=a2a_config,
+            mcp_gateway_config=mcp_gateway_config,
             created_at=datetime.fromisoformat(created_at.rstrip("Z")) if created_at else datetime.now(timezone.utc),
             updated_at=datetime.fromisoformat(updated_at.rstrip("Z")) if updated_at else datetime.now(timezone.utc),
             created_by=item.get("createdBy"),
@@ -697,6 +900,51 @@ class MCPServerConfigRequest(BaseModel):
         )
 
 
+class MCPGatewayConfigRequest(BaseModel):
+    """Request body for Gateway target configuration (protocol 'mcp').
+
+    Does not accept `targetId`/`gatewayArn` — those are AWS-assigned and
+    stamped onto the stored config by the admin route after the Gateway
+    target is created.
+    """
+
+    target_name: str = Field(..., alias="targetName")
+    endpoint_url: str = Field(..., alias="endpointUrl")
+    listing_mode: GatewayListingMode = Field(
+        default=GatewayListingMode.DEFAULT, alias="listingMode"
+    )
+    credential_type: GatewayCredentialType = Field(
+        default=GatewayCredentialType.GATEWAY_IAM_ROLE, alias="credentialType"
+    )
+    credential_provider_arn: Optional[str] = Field(
+        None, alias="credentialProviderArn"
+    )
+    oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
+    grant_type: GatewayOAuthGrantType = Field(
+        default=GatewayOAuthGrantType.AUTHORIZATION_CODE, alias="grantType"
+    )
+    custom_parameters: Optional[Dict[str, str]] = Field(
+        None, alias="customParameters"
+    )
+    tools: List[MCPToolEntryPayload] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "use_enum_values": True}
+
+    def to_model(self) -> MCPGatewayConfig:
+        """Convert to MCPGatewayConfig model (runs the co-gating validator)."""
+        return MCPGatewayConfig(
+            target_name=self.target_name,
+            endpoint_url=self.endpoint_url,
+            listing_mode=self.listing_mode,
+            credential_type=self.credential_type,
+            credential_provider_arn=self.credential_provider_arn,
+            oauth_scopes=self.oauth_scopes,
+            grant_type=self.grant_type,
+            custom_parameters=self.custom_parameters,
+            tools=[entry.to_model() for entry in self.tools],
+        )
+
+
 class A2AAgentConfigRequest(BaseModel):
     """Request body for A2A agent configuration."""
 
@@ -746,6 +994,9 @@ class ToolCreateRequest(BaseModel):
     # External tool configurations (optional based on protocol)
     mcp_config: Optional[MCPServerConfigRequest] = Field(None, alias="mcpConfig")
     a2a_config: Optional[A2AAgentConfigRequest] = Field(None, alias="a2aConfig")
+    mcp_gateway_config: Optional[MCPGatewayConfigRequest] = Field(
+        None, alias="mcpGatewayConfig"
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -768,6 +1019,9 @@ class ToolUpdateRequest(BaseModel):
     # External tool configurations (optional based on protocol)
     mcp_config: Optional[MCPServerConfigRequest] = Field(None, alias="mcpConfig")
     a2a_config: Optional[A2AAgentConfigRequest] = Field(None, alias="a2aConfig")
+    mcp_gateway_config: Optional[MCPGatewayConfigRequest] = Field(
+        None, alias="mcpGatewayConfig"
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -848,6 +1102,55 @@ class MCPServerConfigResponse(BaseModel):
         )
 
 
+class MCPGatewayConfigResponse(BaseModel):
+    """Response model for Gateway target configuration (protocol 'mcp').
+
+    Includes the AWS-assigned `targetId`/`gatewayArn` so the admin UI can show
+    the catalog↔Gateway linkage.
+    """
+
+    target_name: str = Field(..., alias="targetName")
+    endpoint_url: str = Field(..., alias="endpointUrl")
+    listing_mode: str = Field(..., alias="listingMode")
+    credential_type: str = Field(..., alias="credentialType")
+    credential_provider_arn: Optional[str] = Field(
+        None, alias="credentialProviderArn"
+    )
+    oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
+    grant_type: str = Field(..., alias="grantType")
+    custom_parameters: Optional[Dict[str, str]] = Field(
+        None, alias="customParameters"
+    )
+    tools: List[MCPToolEntryPayload] = Field(default_factory=list)
+    target_id: Optional[str] = Field(None, alias="targetId")
+    gateway_arn: Optional[str] = Field(None, alias="gatewayArn")
+
+    model_config = {"populate_by_name": True}
+
+    @classmethod
+    def from_model(cls, config: MCPGatewayConfig) -> "MCPGatewayConfigResponse":
+        """Create response from MCPGatewayConfig model."""
+        return cls(
+            target_name=config.target_name,
+            endpoint_url=config.endpoint_url,
+            listing_mode=config.listing_mode
+            if isinstance(config.listing_mode, str)
+            else config.listing_mode.value,
+            credential_type=config.credential_type
+            if isinstance(config.credential_type, str)
+            else config.credential_type.value,
+            credential_provider_arn=config.credential_provider_arn,
+            oauth_scopes=list(config.oauth_scopes),
+            grant_type=config.grant_type
+            if isinstance(config.grant_type, str)
+            else config.grant_type.value,
+            custom_parameters=config.custom_parameters,
+            tools=[MCPToolEntryPayload.from_model(entry) for entry in config.tools],
+            target_id=config.target_id,
+            gateway_arn=config.gateway_arn,
+        )
+
+
 class A2AAgentConfigResponse(BaseModel):
     """Response model for A2A agent configuration."""
 
@@ -901,6 +1204,9 @@ class AdminToolResponse(BaseModel):
     # External tool configurations
     mcp_config: Optional[MCPServerConfigResponse] = Field(None, alias="mcpConfig")
     a2a_config: Optional[A2AAgentConfigResponse] = Field(None, alias="a2aConfig")
+    mcp_gateway_config: Optional[MCPGatewayConfigResponse] = Field(
+        None, alias="mcpGatewayConfig"
+    )
 
     model_config = {"populate_by_name": True, "use_enum_values": True}
 
@@ -917,6 +1223,12 @@ class AdminToolResponse(BaseModel):
         a2a_config_response = None
         if tool.a2a_config:
             a2a_config_response = A2AAgentConfigResponse.from_model(tool.a2a_config)
+
+        mcp_gateway_config_response = None
+        if tool.mcp_gateway_config:
+            mcp_gateway_config_response = MCPGatewayConfigResponse.from_model(
+                tool.mcp_gateway_config
+            )
 
         return cls(
             tool_id=tool.tool_id,
@@ -936,6 +1248,7 @@ class AdminToolResponse(BaseModel):
             updated_by=tool.updated_by,
             mcp_config=mcp_config_response,
             a2a_config=a2a_config_response,
+            mcp_gateway_config=mcp_gateway_config_response,
         )
 
 

--- a/backend/tests/shared/test_tools_gateway_config.py
+++ b/backend/tests/shared/test_tools_gateway_config.py
@@ -1,0 +1,309 @@
+"""Phase 1 (issue #419): MCPGatewayConfig model, serialization, request/response
+wiring, and the credential/listing-mode co-gating validator.
+
+These are pure-model tests — no AWS. The GatewayTargetService that turns a
+config into a live Gateway target is covered separately in
+test_gateway_target_service.py.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from apis.shared.tools.models import (
+    AdminToolResponse,
+    GatewayCredentialType,
+    GatewayListingMode,
+    GatewayOAuthGrantType,
+    MCPGatewayConfig,
+    MCPGatewayConfigRequest,
+    MCPGatewayConfigResponse,
+    MCPToolEntry,
+    ToolDefinition,
+    ToolProtocol,
+)
+
+
+# ---------------------------------------------------------------- serialization
+
+
+class TestMCPGatewayConfigSerialization:
+    def test_iam_round_trip(self):
+        config = MCPGatewayConfig(
+            target_name="weather-target",
+            endpoint_url="https://example.com/mcp",
+            listing_mode=GatewayListingMode.DEFAULT,
+            credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+            tools=[
+                MCPToolEntry(name="get_forecast", needs_approval=False),
+                MCPToolEntry(name="set_alert", needs_approval=True, description="writes"),
+            ],
+            target_id="TGT123",
+            gateway_arn="arn:aws:bedrock-agentcore:us-west-2:111:gateway/gw-abc",
+        )
+
+        data = config.to_dict()
+        assert data["targetName"] == "weather-target"
+        assert data["endpointUrl"] == "https://example.com/mcp"
+        assert data["listingMode"] == "default"
+        assert data["credentialType"] == "gateway_iam_role"
+        assert data["credentialProviderArn"] is None
+        assert data["targetId"] == "TGT123"
+        assert data["gatewayArn"].endswith("gateway/gw-abc")
+        assert [t["name"] for t in data["tools"]] == ["get_forecast", "set_alert"]
+
+        restored = MCPGatewayConfig.from_dict(data)
+        assert restored.target_name == "weather-target"
+        assert restored.listing_mode == GatewayListingMode.DEFAULT
+        assert restored.credential_type == GatewayCredentialType.GATEWAY_IAM_ROLE
+        assert restored.target_id == "TGT123"
+        assert restored.gateway_arn == config.gateway_arn
+        assert restored.approval_required_names() == {"set_alert"}
+
+    def test_oauth_round_trip(self):
+        config = MCPGatewayConfig(
+            target_name="github-target",
+            endpoint_url="https://github-mcp.example.com/mcp",
+            listing_mode=GatewayListingMode.DEFAULT,
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/oauth2credentialprovider/github",
+            oauth_scopes=["repo", "read:user"],
+            custom_parameters={"audience": "https://api.github.com"},
+        )
+        # 3LO (authorization_code) is the default grant.
+        assert config.grant_type == GatewayOAuthGrantType.AUTHORIZATION_CODE
+
+        data = config.to_dict()
+        assert data["grantType"] == "authorization_code"
+        assert data["customParameters"] == {"audience": "https://api.github.com"}
+
+        restored = MCPGatewayConfig.from_dict(data)
+        assert restored.credential_type == GatewayCredentialType.OAUTH
+        assert restored.oauth_scopes == ["repo", "read:user"]
+        assert restored.credential_provider_arn == config.credential_provider_arn
+        assert restored.grant_type == GatewayOAuthGrantType.AUTHORIZATION_CODE
+        assert restored.custom_parameters == {"audience": "https://api.github.com"}
+
+    def test_client_credentials_grant_round_trip(self):
+        config = MCPGatewayConfig(
+            target_name="m2m-target",
+            endpoint_url="https://m2m.example.com/mcp",
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:...:oauth2credentialprovider/m2m",
+            grant_type=GatewayOAuthGrantType.CLIENT_CREDENTIALS,
+        )
+        restored = MCPGatewayConfig.from_dict(config.to_dict())
+        assert restored.grant_type == GatewayOAuthGrantType.CLIENT_CREDENTIALS
+        assert restored.custom_parameters is None
+
+    def test_from_dict_defaults_and_legacy_string_tools(self):
+        # Sparse dict (e.g. an older / minimal row) hydrates with safe defaults,
+        # and the legacy List[str] tools format is tolerated like MCPServerConfig.
+        restored = MCPGatewayConfig.from_dict(
+            {
+                "targetName": "t",
+                "endpointUrl": "https://e/mcp",
+                "tools": ["alpha", "beta"],
+            }
+        )
+        assert restored.listing_mode == GatewayListingMode.DEFAULT
+        assert restored.credential_type == GatewayCredentialType.GATEWAY_IAM_ROLE
+        assert [t.name for t in restored.tools] == ["alpha", "beta"]
+
+
+# ----------------------------------------------------------- ToolDefinition link
+
+
+class TestToolDefinitionGatewayConfig:
+    def _gateway_tool(self) -> ToolDefinition:
+        return ToolDefinition(
+            tool_id="gw_weather",
+            display_name="Weather (Gateway)",
+            description="Weather via the AgentCore Gateway",
+            protocol=ToolProtocol.MCP_GATEWAY,
+            mcp_gateway_config=MCPGatewayConfig(
+                target_name="weather-target",
+                endpoint_url="https://example.com/mcp",
+                target_id="TGT123",
+                gateway_arn="arn:aws:bedrock-agentcore:us-west-2:111:gateway/gw-abc",
+            ),
+        )
+
+    def test_to_dynamo_item_emits_gateway_config(self):
+        item = self._gateway_tool().to_dynamo_item()
+        assert "mcpGatewayConfig" in item
+        assert item["mcpGatewayConfig"]["targetId"] == "TGT123"
+        # The other protocol configs stay absent — no cross-contamination.
+        assert "mcpConfig" not in item
+        assert "a2aConfig" not in item
+
+    def test_dynamo_round_trip(self):
+        tool = self._gateway_tool()
+        restored = ToolDefinition.from_dynamo_item(tool.to_dynamo_item())
+        assert restored.protocol == ToolProtocol.MCP_GATEWAY
+        assert restored.mcp_gateway_config is not None
+        assert restored.mcp_gateway_config.target_name == "weather-target"
+        assert restored.mcp_gateway_config.target_id == "TGT123"
+        assert restored.mcp_config is None
+        assert restored.a2a_config is None
+
+    def test_non_gateway_tool_has_no_gateway_config_key(self):
+        tool = ToolDefinition(
+            tool_id="local_thing",
+            display_name="Local",
+            description="A local tool",
+            protocol=ToolProtocol.LOCAL,
+        )
+        item = tool.to_dynamo_item()
+        assert "mcpGatewayConfig" not in item
+        assert ToolDefinition.from_dynamo_item(item).mcp_gateway_config is None
+
+
+# ------------------------------------------------------------- request/response
+
+
+class TestRequestResponseWiring:
+    def test_request_to_model(self):
+        req = MCPGatewayConfigRequest(
+            **{
+                "targetName": "weather-target",
+                "endpointUrl": "https://example.com/mcp",
+                "listingMode": "default",
+                "credentialType": "gateway_iam_role",
+                "tools": [{"name": "get_forecast", "needsApproval": True}],
+            }
+        )
+        model = req.to_model()
+        assert isinstance(model, MCPGatewayConfig)
+        assert model.target_name == "weather-target"
+        assert model.approval_required_names() == {"get_forecast"}
+        # IAM target defaults to the authorization_code grant (inert for IAM).
+        assert model.grant_type == GatewayOAuthGrantType.AUTHORIZATION_CODE
+        # Request never carries AWS-assigned identifiers.
+        assert model.target_id is None
+        assert model.gateway_arn is None
+
+    def test_request_carries_oauth_grant_and_custom_parameters(self):
+        req = MCPGatewayConfigRequest(
+            **{
+                "targetName": "github-target",
+                "endpointUrl": "https://gh/mcp",
+                "credentialType": "oauth",
+                "credentialProviderArn": "arn:...:oauth2credentialprovider/gh",
+                "grantType": "client_credentials",
+                "customParameters": {"audience": "https://api.github.com"},
+            }
+        )
+        model = req.to_model()
+        assert model.grant_type == GatewayOAuthGrantType.CLIENT_CREDENTIALS
+        assert model.custom_parameters == {"audience": "https://api.github.com"}
+        resp = MCPGatewayConfigResponse.from_model(model)
+        assert resp.grant_type == "client_credentials"
+        assert resp.custom_parameters == {"audience": "https://api.github.com"}
+
+    def test_response_from_model_exposes_identifiers(self):
+        config = MCPGatewayConfig(
+            target_name="weather-target",
+            endpoint_url="https://example.com/mcp",
+            target_id="TGT123",
+            gateway_arn="arn:aws:bedrock-agentcore:us-west-2:111:gateway/gw-abc",
+        )
+        resp = MCPGatewayConfigResponse.from_model(config)
+        assert resp.target_id == "TGT123"
+        assert resp.listing_mode == "default"
+        assert resp.credential_type == "gateway_iam_role"
+
+    def test_admin_tool_response_includes_gateway_config(self):
+        tool = ToolDefinition(
+            tool_id="gw_weather",
+            display_name="Weather (Gateway)",
+            description="Weather via the AgentCore Gateway",
+            protocol=ToolProtocol.MCP_GATEWAY,
+            mcp_gateway_config=MCPGatewayConfig(
+                target_name="weather-target",
+                endpoint_url="https://example.com/mcp",
+                target_id="TGT123",
+            ),
+        )
+        resp = AdminToolResponse.from_tool_definition(tool, allowed_roles=[])
+        assert resp.mcp_gateway_config is not None
+        assert resp.mcp_gateway_config.target_name == "weather-target"
+        assert resp.mcp_config is None
+        assert resp.a2a_config is None
+
+
+# ------------------------------------------------------------------- validation
+
+
+class TestCoGatingValidator:
+    def test_oauth_requires_default_listing(self):
+        with pytest.raises(ValidationError):
+            MCPGatewayConfig(
+                target_name="t",
+                endpoint_url="https://e/mcp",
+                credential_type=GatewayCredentialType.OAUTH,
+                credential_provider_arn="arn:...:oauth2credentialprovider/x",
+                listing_mode=GatewayListingMode.DYNAMIC,
+            )
+
+    def test_oauth_requires_provider_arn(self):
+        with pytest.raises(ValidationError):
+            MCPGatewayConfig(
+                target_name="t",
+                endpoint_url="https://e/mcp",
+                credential_type=GatewayCredentialType.OAUTH,
+            )
+
+    def test_api_key_requires_provider_arn(self):
+        with pytest.raises(ValidationError):
+            MCPGatewayConfig(
+                target_name="t",
+                endpoint_url="https://e/mcp",
+                credential_type=GatewayCredentialType.API_KEY,
+            )
+
+    def test_iam_rejects_provider_arn(self):
+        with pytest.raises(ValidationError):
+            MCPGatewayConfig(
+                target_name="t",
+                endpoint_url="https://e/mcp",
+                credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+                credential_provider_arn="arn:...:oauth2credentialprovider/x",
+            )
+
+    def test_valid_configs_accepted(self):
+        # IAM with no ARN
+        MCPGatewayConfig(
+            target_name="t",
+            endpoint_url="https://e/mcp",
+            credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        )
+        # OAuth, DEFAULT listing, with ARN
+        MCPGatewayConfig(
+            target_name="t",
+            endpoint_url="https://e/mcp",
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:...:oauth2credentialprovider/x",
+            listing_mode=GatewayListingMode.DEFAULT,
+        )
+        # API key with ARN
+        MCPGatewayConfig(
+            target_name="t",
+            endpoint_url="https://e/mcp",
+            credential_type=GatewayCredentialType.API_KEY,
+            credential_provider_arn="arn:...:apikeycredentialprovider/x",
+        )
+
+    def test_request_to_model_propagates_validation(self):
+        # An invalid combination at the wire layer surfaces as a validation
+        # error when materialized — the route relies on this for its 400.
+        req = MCPGatewayConfigRequest(
+            **{
+                "targetName": "t",
+                "endpointUrl": "https://e/mcp",
+                "credentialType": "oauth",
+                "listingMode": "dynamic",
+                "credentialProviderArn": "arn:...:oauth2credentialprovider/x",
+            }
+        )
+        with pytest.raises(ValidationError):
+            req.to_model()


### PR DESCRIPTION
**Issue #419 — PR 1 of 5** (backend model foundation). Lets an admin register an externally deployed MCP server as a target on the centralized AgentCore Gateway (`protocol=mcp`).

### What
- `GatewayListingMode` (`default|dynamic`), `GatewayCredentialType` (`gateway_iam_role|oauth|api_key`), `GatewayOAuthGrantType` (`authorization_code|client_credentials|token_exchange`) enums — mirror the `bedrock-agentcore-control` `listingMode`/`credentialProviderType`/`grantType` surfaces (uppercased at the AWS boundary by the PR2 service).
- `MCPGatewayConfig` (mirrors `MCPServerConfig`): `target_name`, `endpoint_url`, `listing_mode`, `credential_type`, `credential_provider_arn`, `oauth_scopes`, `grant_type`, `custom_parameters`, per-tool `MCPToolEntry` flags, and AWS-assigned `target_id`/`gateway_arn` (the catalog↔AWS link for update/delete reconciliation).
- Co-gating validator: OAuth ⇒ `DEFAULT` listing + provider ARN; API key ⇒ provider ARN; gateway IAM role forbids an ARN. Encodes the listing-mode gotcha (DYNAMIC disables 3LO + semantic search).
- `ToolDefinition.mcp_gateway_config` + `to_dynamo_item`/`from_dynamo_item` round-trip under `mcpGatewayConfig`.
- `MCPGatewayConfigRequest`/`Response` wired into `ToolCreateRequest`, `ToolUpdateRequest`, `AdminToolResponse`.
- OAuth `grant_type` defaults to `authorization_code` (3LO) per AWS's June-2026 Gateway auth-code blueprint; `custom_parameters` carried because they're part of the AgentCore token-vault key and must match between target registration and token retrieval.

### Scope / not in this PR
Live target lifecycle (PR2 `GatewayTargetService`), infra SSM param + IAM grants (PR3), admin-route orchestration + consent linkage (PR4), and the admin form (PR5). No runtime behavior changes — pure model layer.

### Testing
17 new model/serialization/validator tests; full backend suite **3380 passed, 3 skipped** (pytest is the only correctness gate — not in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)