### PR TITLE
feat(tools): GatewayTargetService for Gateway target lifecycle (#419, PR2/5)

### DIFF
--- a/backend/src/apis/shared/tools/gateway_target_service.py
+++ b/backend/src/apis/shared/tools/gateway_target_service.py
@@ -1,0 +1,355 @@
+"""AgentCore Gateway target lifecycle service.
+
+Wraps `bedrock-agentcore-control` for managing MCP targets on the centralized
+AgentCore Gateway. An admin registers an externally deployed MCP server as a
+Gateway *target* (issue #419); this service is the thin AWS boundary that turns
+an `MCPGatewayConfig` into a live target and reconciles update/delete.
+
+Lives in `apis.shared` (not inference-api) — the admin route on app-api owns the
+lifecycle orchestration (create AWS target first, persist the catalog row only
+on success). This service is intentionally stateless apart from the boto3 client
+and the lazily-resolved gateway id, so it is safe to share across requests.
+
+Modeled on `apis.shared.oauth.agentcore_registrar.AgentCoreRegistrar`, which
+wraps the same control-plane service for OAuth2 credential providers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import (
+    GatewayCredentialType,
+    GatewayListingMode,
+    GatewayOAuthGrantType,
+    MCPGatewayConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Model enum string values → the `bedrock-agentcore-control` API enums (which
+# are uppercase). Keyed by the model's lowercase `.value` so the lookup works
+# whether the field holds the enum or its value (use_enum_values=True).
+_LISTING_MODE_TO_AWS: Dict[str, str] = {
+    GatewayListingMode.DEFAULT.value: "DEFAULT",
+    GatewayListingMode.DYNAMIC.value: "DYNAMIC",
+}
+
+_CREDENTIAL_TYPE_TO_AWS: Dict[str, str] = {
+    GatewayCredentialType.GATEWAY_IAM_ROLE.value: "GATEWAY_IAM_ROLE",
+    GatewayCredentialType.OAUTH.value: "OAUTH",
+    GatewayCredentialType.API_KEY.value: "API_KEY",
+}
+
+_GRANT_TYPE_TO_AWS: Dict[str, str] = {
+    GatewayOAuthGrantType.AUTHORIZATION_CODE.value: "AUTHORIZATION_CODE",
+    GatewayOAuthGrantType.CLIENT_CREDENTIALS.value: "CLIENT_CREDENTIALS",
+    GatewayOAuthGrantType.TOKEN_EXCHANGE.value: "TOKEN_EXCHANGE",
+}
+
+
+@dataclass(frozen=True)
+class GatewayTargetInfo:
+    """AgentCore Gateway record for one MCP target.
+
+    `gateway_arn` is empty for entries surfaced by `list_targets` (the list
+    summary shape does not echo it back).
+    """
+
+    target_id: str
+    gateway_arn: str
+    status: str
+    name: str
+
+
+class GatewayTargetNotFoundError(LookupError):
+    """Raised when a Gateway target does not exist."""
+
+
+class GatewayTargetConflictError(RuntimeError):
+    """Raised when creating a target whose name already exists on the gateway."""
+
+
+class GatewayTargetService:
+    """Thin wrapper around `bedrock-agentcore-control` for Gateway targets."""
+
+    def __init__(
+        self,
+        *,
+        region: Optional[str] = None,
+        gateway_id: Optional[str] = None,
+        project_prefix: Optional[str] = None,
+        client: Any = None,
+        ssm_client: Any = None,
+    ):
+        self._region = (
+            region
+            or os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+        )
+        self._client = client or boto3.client(
+            "bedrock-agentcore-control", region_name=self._region
+        )
+        # `gateway_id` may be supplied directly (tests / callers that already
+        # know it); otherwise it is resolved from SSM on first use and cached.
+        self._gateway_id = gateway_id
+        self._ssm_client = ssm_client
+        self._project_prefix = project_prefix or os.environ.get(
+            "PROJECT_PREFIX", "agentcore"
+        )
+
+    # ----------------------------------------------------- gateway id (SSM)
+    def _resolve_gateway_id(self) -> str:
+        """Return the gateway identifier, reading `/{prefix}/gateway/id` from
+        SSM on first use and caching it. The gateway construct publishes this
+        parameter; app-api reads it at runtime (boto3), which sidesteps the
+        same-stack deploy-time ordering deadlock.
+        """
+        if self._gateway_id:
+            return self._gateway_id
+
+        if self._ssm_client is None:
+            self._ssm_client = boto3.client("ssm", region_name=self._region)
+
+        param_name = f"/{self._project_prefix}/gateway/id"
+        try:
+            response = self._ssm_client.get_parameter(Name=param_name)
+        except ClientError as err:
+            raise RuntimeError(
+                f"Gateway id SSM parameter '{param_name}' is unavailable; is the "
+                f"gateway construct deployed? ({err})"
+            ) from err
+
+        self._gateway_id = response["Parameter"]["Value"]
+        return self._gateway_id
+
+    # ------------------------------------------------------------------ create
+    def create_target(
+        self, config: MCPGatewayConfig, *, description: str = ""
+    ) -> GatewayTargetInfo:
+        """Register `config` as a live target on the gateway.
+
+        Raises:
+            GatewayTargetConflictError: A target named `config.target_name`
+                already exists on the gateway.
+            botocore.exceptions.ClientError: Any other AWS error bubbles up so
+                the route can surface a 502 and log the failure.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.create_gateway_target(
+                gatewayIdentifier=gateway_id,
+                name=config.target_name,
+                description=description or f"MCP gateway target {config.target_name}",
+                targetConfiguration=self._build_target_configuration(config),
+                credentialProviderConfigurations=self._build_credential_configs(config),
+            )
+        except ClientError as err:
+            code = err.response.get("Error", {}).get("Code")
+            if code in ("ConflictException", "ResourceAlreadyExistsException"):
+                raise GatewayTargetConflictError(
+                    f"Gateway target '{config.target_name}' already exists"
+                ) from err
+            raise
+
+        return self._info_from_response(response, fallback_name=config.target_name)
+
+    # ------------------------------------------------------------------ update
+    def update_target(
+        self, *, target_id: str, config: MCPGatewayConfig, description: str = ""
+    ) -> GatewayTargetInfo:
+        """Replace the target's full configuration.
+
+        Like the OAuth provider update, `UpdateGatewayTarget` is not a partial
+        update — name and targetConfiguration are re-submitted in full.
+
+        Raises:
+            GatewayTargetNotFoundError: No such target.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.update_gateway_target(
+                gatewayIdentifier=gateway_id,
+                targetId=target_id,
+                name=config.target_name,
+                description=description or f"MCP gateway target {config.target_name}",
+                targetConfiguration=self._build_target_configuration(config),
+                credentialProviderConfigurations=self._build_credential_configs(config),
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                raise GatewayTargetNotFoundError(target_id) from err
+            raise
+
+        return self._info_from_response(
+            response, fallback_name=config.target_name, fallback_target_id=target_id
+        )
+
+    # --------------------------------------------------------------------- get
+    def get_target(self, *, target_id: str) -> GatewayTargetInfo:
+        """Fetch one target by id.
+
+        Raises:
+            GatewayTargetNotFoundError: No such target.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.get_gateway_target(
+                gatewayIdentifier=gateway_id, targetId=target_id
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                raise GatewayTargetNotFoundError(target_id) from err
+            raise
+
+        return self._info_from_response(response, fallback_target_id=target_id)
+
+    # ------------------------------------------------------------------ delete
+    def delete_target(self, *, target_id: str) -> None:
+        """Delete the target. A missing target is treated as success.
+
+        The route deletes the AWS target before the catalog row, so a 404 here
+        means the row's reconciliation is already done — log loudly (this is the
+        manual-repair signal in v1) and return.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            self._client.delete_gateway_target(
+                gatewayIdentifier=gateway_id, targetId=target_id
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                logger.warning(
+                    "Gateway target '%s' already absent on gateway '%s'; "
+                    "delete is a no-op",
+                    target_id,
+                    gateway_id,
+                )
+                return
+            raise
+
+    # -------------------------------------------------------------------- list
+    def list_targets(self) -> List[GatewayTargetInfo]:
+        """List every target on the gateway (paginates internally)."""
+        gateway_id = self._resolve_gateway_id()
+        targets: List[GatewayTargetInfo] = []
+        next_token: Optional[str] = None
+        while True:
+            kwargs: Dict[str, Any] = {"gatewayIdentifier": gateway_id}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = self._client.list_gateway_targets(**kwargs)
+            for item in response.get("items", []):
+                targets.append(self._info_from_response(item))
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+        return targets
+
+    # ------------------------------------------------------------- build helpers
+    @staticmethod
+    def _build_target_configuration(config: MCPGatewayConfig) -> Dict[str, Any]:
+        """Build `targetConfiguration.mcp.mcpServer` for an external endpoint."""
+        listing_value = (
+            config.listing_mode
+            if isinstance(config.listing_mode, str)
+            else config.listing_mode.value
+        )
+        return {
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": config.endpoint_url,
+                    "listingMode": _LISTING_MODE_TO_AWS[listing_value],
+                }
+            }
+        }
+
+    @staticmethod
+    def _build_credential_configs(config: MCPGatewayConfig) -> List[Dict[str, Any]]:
+        """Build `credentialProviderConfigurations` from the credential type.
+
+        The `MCPGatewayConfig` validator already guarantees the ARN/listing
+        invariants per credential type, so this only shapes the payload.
+        """
+        cred_value = (
+            config.credential_type
+            if isinstance(config.credential_type, str)
+            else config.credential_type.value
+        )
+        aws_type = _CREDENTIAL_TYPE_TO_AWS[cred_value]
+
+        if cred_value == GatewayCredentialType.OAUTH.value:
+            grant_value = (
+                config.grant_type
+                if isinstance(config.grant_type, str)
+                else config.grant_type.value
+            )
+            oauth_provider: Dict[str, Any] = {
+                "providerArn": config.credential_provider_arn,
+                "scopes": list(config.oauth_scopes),
+                "grantType": _GRANT_TYPE_TO_AWS[grant_value],
+            }
+            # customParameters are part of the token-vault key — only send them
+            # when set, and exactly as configured so target registration and
+            # token retrieval agree.
+            if config.custom_parameters:
+                oauth_provider["customParameters"] = dict(config.custom_parameters)
+            return [
+                {
+                    "credentialProviderType": aws_type,
+                    "credentialProvider": {"oauthCredentialProvider": oauth_provider},
+                }
+            ]
+        if cred_value == GatewayCredentialType.API_KEY.value:
+            return [
+                {
+                    "credentialProviderType": aws_type,
+                    "credentialProvider": {
+                        "apiKeyCredentialProvider": {
+                            "providerArn": config.credential_provider_arn,
+                        }
+                    },
+                }
+            ]
+        # GATEWAY_IAM_ROLE — the gateway signs with its own execution role; no
+        # nested credentialProvider is sent.
+        return [{"credentialProviderType": aws_type}]
+
+    # ----------------------------------------------------------- parse helpers
+    @staticmethod
+    def _info_from_response(
+        response: Dict[str, Any],
+        *,
+        fallback_name: str = "",
+        fallback_target_id: str = "",
+        fallback_gateway_arn: str = "",
+    ) -> GatewayTargetInfo:
+        return GatewayTargetInfo(
+            target_id=response.get("targetId") or fallback_target_id,
+            gateway_arn=response.get("gatewayArn") or fallback_gateway_arn,
+            status=response.get("status", ""),
+            name=response.get("name") or fallback_name,
+        )
+
+    @staticmethod
+    def _is_not_found(err: ClientError) -> bool:
+        code = err.response.get("Error", {}).get("Code")
+        return code in ("ResourceNotFoundException", "NotFoundException")
+
+
+_default_service: Optional[GatewayTargetService] = None
+
+
+def get_gateway_target_service() -> GatewayTargetService:
+    """Return the process-wide `GatewayTargetService` singleton."""
+    global _default_service
+    if _default_service is None:
+        _default_service = GatewayTargetService()
+    return _default_service

--- a/backend/tests/shared/test_gateway_target_service.py
+++ b/backend/tests/shared/test_gateway_target_service.py
@@ -1,0 +1,303 @@
+"""GatewayTargetService tests (issue #419, Phase 2).
+
+Mocks the `bedrock-agentcore-control` boto3 client directly — these verify our
+translation layer (MCPGatewayConfig → CreateGatewayTarget kwargs, listing-mode
+and credential-type mapping, 404 → no-op delete, conflict mapping, SSM gateway-id
+resolution), not AWS behaviour. Mirrors test_oauth_agentcore_registrar.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from apis.shared.tools.gateway_target_service import (
+    GatewayTargetConflictError,
+    GatewayTargetNotFoundError,
+    GatewayTargetService,
+)
+from apis.shared.tools.models import (
+    GatewayCredentialType,
+    GatewayListingMode,
+    GatewayOAuthGrantType,
+    MCPGatewayConfig,
+    MCPToolEntry,
+)
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": code}},
+        operation_name="op",
+    )
+
+
+def _create_response(**overrides):
+    base = {
+        "targetId": "TGT1",
+        "gatewayArn": "arn:aws:bedrock-agentcore:us-west-2:111:gateway/gw-test-id",
+        "status": "CREATING",
+        "name": "weather-target",
+    }
+    base.update(overrides)
+    return base
+
+
+def _iam_config(**overrides) -> MCPGatewayConfig:
+    base = dict(
+        target_name="weather-target",
+        endpoint_url="https://example.com/mcp",
+        listing_mode=GatewayListingMode.DEFAULT,
+        credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        tools=[MCPToolEntry(name="get_forecast")],
+    )
+    base.update(overrides)
+    return MCPGatewayConfig(**base)
+
+
+@pytest.fixture
+def boto_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def ssm_client():
+    ssm = MagicMock()
+    ssm.get_parameter.return_value = {"Parameter": {"Value": "gw-test-id"}}
+    return ssm
+
+
+@pytest.fixture
+def service(boto_client, ssm_client):
+    return GatewayTargetService(
+        client=boto_client,
+        ssm_client=ssm_client,
+        region="us-west-2",
+        project_prefix="myproj",
+    )
+
+
+class TestCreateTarget:
+    def test_iam_target_kwargs(self, service, boto_client, ssm_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+
+        info = service.create_target(_iam_config())
+
+        kwargs = boto_client.create_gateway_target.call_args.kwargs
+        assert kwargs["gatewayIdentifier"] == "gw-test-id"
+        assert kwargs["name"] == "weather-target"
+        assert kwargs["targetConfiguration"] == {
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": "https://example.com/mcp",
+                    "listingMode": "DEFAULT",
+                }
+            }
+        }
+        assert kwargs["credentialProviderConfigurations"] == [
+            {"credentialProviderType": "GATEWAY_IAM_ROLE"}
+        ]
+        # gateway id was read from /{prefix}/gateway/id
+        ssm_client.get_parameter.assert_called_once_with(Name="/myproj/gateway/id")
+        # response is surfaced
+        assert info.target_id == "TGT1"
+        assert info.gateway_arn.endswith("gateway/gw-test-id")
+        assert info.status == "CREATING"
+
+    def test_oauth_credential_config(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="github-target",
+            endpoint_url="https://gh/mcp",
+            listing_mode=GatewayListingMode.DEFAULT,
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/oauth2credentialprovider/gh",
+            oauth_scopes=["repo", "read:user"],
+        )
+
+        service.create_target(config)
+
+        creds = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ]
+        assert creds == [
+            {
+                "credentialProviderType": "OAUTH",
+                "credentialProvider": {
+                    "oauthCredentialProvider": {
+                        "providerArn": config.credential_provider_arn,
+                        "scopes": ["repo", "read:user"],
+                        # Defaults to the 3LO authorization-code grant.
+                        "grantType": "AUTHORIZATION_CODE",
+                    }
+                },
+            }
+        ]
+
+    def test_oauth_client_credentials_with_custom_parameters(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="m2m-target",
+            endpoint_url="https://m2m/mcp",
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/oauth2credentialprovider/m2m",
+            grant_type=GatewayOAuthGrantType.CLIENT_CREDENTIALS,
+            custom_parameters={"audience": "https://api.example.com"},
+        )
+
+        service.create_target(config)
+
+        oauth = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ][0]["credentialProvider"]["oauthCredentialProvider"]
+        assert oauth["grantType"] == "CLIENT_CREDENTIALS"
+        assert oauth["customParameters"] == {"audience": "https://api.example.com"}
+
+    def test_api_key_credential_config(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="weather-target",
+            endpoint_url="https://example.com/mcp",
+            credential_type=GatewayCredentialType.API_KEY,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/apikeycredentialprovider/wx",
+        )
+
+        service.create_target(config)
+
+        creds = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ]
+        assert creds == [
+            {
+                "credentialProviderType": "API_KEY",
+                "credentialProvider": {
+                    "apiKeyCredentialProvider": {
+                        "providerArn": config.credential_provider_arn,
+                    }
+                },
+            }
+        ]
+
+    def test_dynamic_listing_maps_to_uppercase(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        service.create_target(_iam_config(listing_mode=GatewayListingMode.DYNAMIC))
+        target_cfg = boto_client.create_gateway_target.call_args.kwargs[
+            "targetConfiguration"
+        ]
+        assert target_cfg["mcp"]["mcpServer"]["listingMode"] == "DYNAMIC"
+
+    def test_conflict_maps_to_conflict_error(self, service, boto_client):
+        boto_client.create_gateway_target.side_effect = _client_error(
+            "ConflictException"
+        )
+        with pytest.raises(GatewayTargetConflictError):
+            service.create_target(_iam_config())
+
+    def test_other_client_error_bubbles(self, service, boto_client):
+        boto_client.create_gateway_target.side_effect = _client_error(
+            "ValidationException"
+        )
+        with pytest.raises(ClientError):
+            service.create_target(_iam_config())
+
+
+class TestUpdateTarget:
+    def test_update_kwargs(self, service, boto_client):
+        boto_client.update_gateway_target.return_value = _create_response(
+            status="UPDATING"
+        )
+        info = service.update_target(target_id="TGT1", config=_iam_config())
+
+        kwargs = boto_client.update_gateway_target.call_args.kwargs
+        assert kwargs["gatewayIdentifier"] == "gw-test-id"
+        assert kwargs["targetId"] == "TGT1"
+        assert kwargs["name"] == "weather-target"
+        assert "targetConfiguration" in kwargs
+        assert "credentialProviderConfigurations" in kwargs
+        assert info.status == "UPDATING"
+
+    def test_update_not_found_raises(self, service, boto_client):
+        boto_client.update_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        with pytest.raises(GatewayTargetNotFoundError):
+            service.update_target(target_id="missing", config=_iam_config())
+
+
+class TestGetTarget:
+    def test_get_returns_info(self, service, boto_client):
+        boto_client.get_gateway_target.return_value = _create_response(status="READY")
+        info = service.get_target(target_id="TGT1")
+        boto_client.get_gateway_target.assert_called_once_with(
+            gatewayIdentifier="gw-test-id", targetId="TGT1"
+        )
+        assert info.target_id == "TGT1"
+        assert info.status == "READY"
+
+    def test_get_not_found_raises(self, service, boto_client):
+        boto_client.get_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        with pytest.raises(GatewayTargetNotFoundError):
+            service.get_target(target_id="missing")
+
+
+class TestDeleteTarget:
+    def test_delete_success(self, service, boto_client):
+        service.delete_target(target_id="TGT1")
+        boto_client.delete_gateway_target.assert_called_once_with(
+            gatewayIdentifier="gw-test-id", targetId="TGT1"
+        )
+
+    def test_delete_not_found_is_noop(self, service, boto_client):
+        boto_client.delete_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        # Must not raise — the catalog row is removed even when AWS is already clean.
+        service.delete_target(target_id="missing")
+
+    def test_delete_other_error_bubbles(self, service, boto_client):
+        boto_client.delete_gateway_target.side_effect = _client_error(
+            "ThrottlingException"
+        )
+        with pytest.raises(ClientError):
+            service.delete_target(target_id="TGT1")
+
+
+class TestListTargets:
+    def test_paginates(self, service, boto_client):
+        boto_client.list_gateway_targets.side_effect = [
+            {"items": [{"targetId": "a", "name": "na", "status": "READY"}], "nextToken": "t"},
+            {"items": [{"targetId": "b", "name": "nb", "status": "READY"}]},
+        ]
+        infos = service.list_targets()
+        assert [i.target_id for i in infos] == ["a", "b"]
+        assert boto_client.list_gateway_targets.call_count == 2
+        assert boto_client.list_gateway_targets.call_args_list[1].kwargs["nextToken"] == "t"
+
+
+class TestGatewayIdResolution:
+    def test_resolved_once_and_cached(self, service, boto_client, ssm_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        service.create_target(_iam_config())
+        service.delete_target(target_id="TGT1")
+        # SSM is read exactly once across multiple operations.
+        ssm_client.get_parameter.assert_called_once()
+
+    def test_explicit_gateway_id_skips_ssm(self, boto_client, ssm_client):
+        svc = GatewayTargetService(
+            client=boto_client, ssm_client=ssm_client, gateway_id="gw-explicit"
+        )
+        boto_client.create_gateway_target.return_value = _create_response()
+        svc.create_target(_iam_config())
+        ssm_client.get_parameter.assert_not_called()
+        assert (
+            boto_client.create_gateway_target.call_args.kwargs["gatewayIdentifier"]
+            == "gw-explicit"
+        )
+
+    def test_missing_ssm_param_raises_runtime_error(self, boto_client, ssm_client):
+        ssm_client.get_parameter.side_effect = _client_error("ParameterNotFound")
+        svc = GatewayTargetService(client=boto_client, ssm_client=ssm_client)
+        with pytest.raises(RuntimeError):
+            svc.create_target(_iam_config())


### PR DESCRIPTION
**Issue #419 — PR 2 of 5** (Gateway target lifecycle service). **Stacked on #450** — targets the PR1 branch; retarget to `develop` once #450 merges.

### What
- `GatewayTargetService` (`apis/shared/tools/gateway_target_service.py`) — thin `bedrock-agentcore-control` wrapper modeled on `AgentCoreRegistrar`. `create`/`update`/`get`/`delete`/`list_targets` returning a frozen `GatewayTargetInfo`.
- Maps the model's lowercase enums → AWS uppercase API enums (`listingMode`, `credentialProviderType`, `oauthCredentialProvider.grantType`). OAuth targets emit `grantType` (default `AUTHORIZATION_CODE`/3LO) and `customParameters` when set.
- `delete` treats a missing target as success (logs loudly — the v1 manual-repair signal); `create` maps `ConflictException` → `GatewayTargetConflictError`; not-found → `GatewayTargetNotFoundError`.
- Resolves the gateway id lazily from SSM `/{PROJECT_PREFIX}/gateway/id` and caches it (overridable via `gateway_id=`). Reading at **runtime** sidesteps the same-stack deploy-ordering deadlock; the construct + IAM grant land in PR3.

### Why it's safe to merge before the route
The service is **dormant** until PR4 wires it into the admin route — no runtime behavior changes between this PR and PR4.

### Boundaries
Lives in `apis.shared` (not inference-api), per the architecture rule. Import-boundary test green.

### Testing
18 stubbed-client tests (captured-kwargs boto3 + fake SSM) covering kwarg shaping per credential type, enum mapping, 404 no-op delete, conflict mapping, pagination, and gateway-id resolve-once caching. Full backend suite **3380 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)