### PR TITLE
feat(infra): gateway id SSM param + app-api Gateway target IAM grants (#419, PR3/5)

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -404,6 +404,53 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── SSM read for the AgentCore Gateway id (issue #419) ──
+  // GatewayTargetService (shared/tools/gateway_target_service.py) resolves the
+  // gateway identifier from this parameter at runtime to manage MCP targets.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'SsmReadGatewayId',
+      effect: iam.Effect.ALLOW,
+      actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+      resources: [
+        `arn:aws:ssm:${cdk.Stack.of(scope).region}:${cdk.Stack.of(scope).account}:parameter/${config.projectPrefix}/gateway/id`,
+      ],
+    }),
+  );
+
+  // ── AgentCore Gateway target management (issue #419) ──
+  // The admin tools route registers an externally deployed MCP server as a
+  // target on the centralized AgentCore Gateway (protocol=mcp), then reconciles
+  // it on update/delete. These actions are scoped to the `gateway` resource type
+  // — there is no separate `gateway-target` resource; target operations are
+  // authorized through the parent gateway ARN.
+  //
+  // Action names verified against the control-plane API model and
+  //   https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html
+  // (checked 2026-06-05). Create/Get/Delete/ListGatewayTargets are listed there;
+  // UpdateGatewayTarget exists as a control-plane operation and follows the
+  // Update* IAM precedent above (UpdateOauth2CredentialProvider) but was not yet
+  // in the service-authorization reference at time of writing — included so the
+  // route's update path works once published; IAM tolerates the forward-looking
+  // name for a known service. If a deploy ever rejects it, drop Update and
+  // implement target updates as delete + recreate.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'AgentCoreGatewayTargetAccess',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'bedrock-agentcore:CreateGatewayTarget',
+        'bedrock-agentcore:GetGatewayTarget',
+        'bedrock-agentcore:UpdateGatewayTarget',
+        'bedrock-agentcore:DeleteGatewayTarget',
+        'bedrock-agentcore:ListGatewayTargets',
+      ],
+      resources: [
+        `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:gateway/*`,
+      ],
+    }),
+  );
+
   // ── S3 Vectors (RAG query) ──
   const vectorBucketName = props.refs.ragVectorBucketName;
   const vectorIndexName = props.refs.ragVectorIndexName;

--- a/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
+++ b/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
@@ -25,8 +25,12 @@ export interface AgentCoreGatewayConstructProps {
  *     authorizer and SEMANTIC search type
  *
  * SSM publications:
- *   /{prefix}/gateway/url   — for SigV4-authenticated remote invocation
- *   /{prefix}/gateway/id    — gateway identifier
+ *   /{prefix}/gateway/id    — gateway identifier, read at runtime by app-api's
+ *                             GatewayTargetService (issue #419) to manage MCP
+ *                             targets. Reading from SSM at runtime (not at CFN
+ *                             deploy time) sidesteps the same-stack ordering
+ *                             deadlock that forces sibling refs (e.g. Memory id)
+ *                             to be threaded as explicit props.
  *
  * Also emits CloudFormation outputs for deploy-time visibility:
  *   GatewayArn, GatewayUrl, GatewayId, GatewayStatus, UsageInstructions
@@ -96,7 +100,16 @@ export class AgentCoreGatewayConstruct extends Construct {
     const gatewayUrl = this.gateway.attrGatewayUrl;
     const gatewayId = this.gateway.attrGatewayIdentifier;
 
-
+    // Publish the gateway id so app-api (a sibling in this stack) can resolve
+    // it at runtime via SSM to manage MCP targets (issue #419). app-api reads
+    // this with `ssm:GetParameter` from the running container — never at CFN
+    // synth/deploy time — so there is no same-stack publish/consume ordering
+    // problem.
+    new ssm.StringParameter(this, 'GatewayIdParam', {
+      parameterName: `/${config.projectPrefix}/gateway/id`,
+      stringValue: gatewayId,
+      description: 'AgentCore Gateway identifier (consumed by app-api GatewayTargetService)',
+    });
 
     new cdk.CfnOutput(this, 'GatewayArn', {
       value: gatewayArn,

--- a/infrastructure/test/constructs.test.ts
+++ b/infrastructure/test/constructs.test.ts
@@ -289,9 +289,12 @@ describe('AgentCoreGatewayConstruct', () => {
     t.resourceCountIs('AWS::IAM::Role', 1);
   });
 
-  it('publishes gateway SSM parameters', () => {
+  it('publishes the gateway id SSM parameter for app-api (issue #419)', () => {
     const stack = testStack();
     new AgentCoreGatewayConstruct(stack, 'GW', { config: createMockConfig() });
     const t = Template.fromStack(stack);
+    t.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/test-project/gateway/id',
+    });
   });
 });


### PR DESCRIPTION
**Issue #419 — PR 3 of 5** (infrastructure). Independent of #450/#451 (TypeScript-only, no file overlap) — can merge in any order. Wires what the app-api `GatewayTargetService` (#451) reads/calls at runtime.

### What
- **`AgentCoreGatewayConstruct`** publishes **`/{prefix}/gateway/id`** as an SSM parameter. The construct header already documented this but only emitted CFN outputs; app-api reads it at **runtime** via `ssm:GetParameter` (never at CFN deploy time), so there's no same-stack publish/consume ordering deadlock.
- **`app-api-iam-grants`** adds:
  - `SsmReadGatewayId` — `ssm:GetParameter` on `/{projectPrefix}/gateway/id`.
  - `AgentCoreGatewayTargetAccess` — `bedrock-agentcore:{Create,Get,Update,Delete,List}GatewayTarget` scoped to the **gateway** resource type (`arn:aws:bedrock-agentcore:${region}:${account}:gateway/*`). Target ops are authorized through the parent gateway ARN — there is no `gateway-target` resource type.
- Completes the placeholder gateway-SSM-params construct test.

### Action-name verification (the issue flags a silent-no-op precedent)
Verified against the control-plane API model **and** the IAM [service-authorization reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html) (2026-06-05). `Create/Get/Delete/ListGatewayTargets` are in the reference. **`UpdateGatewayTarget`** is a real control-plane operation and follows the `Update*` IAM precedent already in this file (`UpdateOauth2CredentialProvider`), but was **not yet in the service-authorization reference** at time of writing — included with a code comment + fallback note (implement update as delete+recreate) in case any account rejects the forward-looking name. **Reviewer: please confirm against your account if you've seen newer docs.**

### Testing
`tsc --noEmit` clean; `jest` constructs / security-policy / ssm-safety / platform-stack green (full stack synthesizes with the new statements; no `Action:*`/`Resource:*` violations). Pre-existing, unrelated `config.test.ts` failures and the bare `cdk synth` artifacts-cert lookup error reproduce on clean `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)