### PR TITLE
feat(tools): Gateway target service + admin route lifecycle (#419, PR4/5)

### DIFF
--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -4,10 +4,15 @@ import asyncio
 import logging
 from typing import Optional
 
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from apis.shared.auth import User, require_admin
 from apis.app_api.tools.service import get_tool_catalog_service
+from apis.shared.tools.gateway_target_service import (
+    GatewayTargetConflictError,
+    GatewayTargetNotFoundError,
+)
 from apis.shared.tools.models import (
     ToolCreateRequest,
     ToolUpdateRequest,
@@ -26,6 +31,28 @@ from apis.shared.tools.models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tools", tags=["admin-tools"])
+
+
+def _raise_gateway_http(err: Exception) -> "HTTPException":
+    """Map a Gateway target lifecycle failure to an HTTPException.
+
+    Distinguishes a name conflict / state divergence (409) from an AWS or
+    SSM-resolution failure (502). Validation errors (ValueError → 400) and the
+    catalog not-found path (404) are handled by the caller. Note
+    GatewayTargetConflictError subclasses RuntimeError, so it is matched first.
+    """
+    if isinstance(err, GatewayTargetConflictError):
+        return HTTPException(status_code=409, detail=str(err))
+    if isinstance(err, GatewayTargetNotFoundError):
+        return HTTPException(
+            status_code=409,
+            detail=f"Gateway target state diverged: {err}",
+        )
+    # ClientError (AWS) or RuntimeError (e.g. gateway-id SSM param missing).
+    logger.error("Gateway target operation failed", exc_info=True)
+    return HTTPException(
+        status_code=502, detail=f"Gateway target operation failed: {err}"
+    )
 
 
 @router.get("/", response_model=AdminToolListResponse)
@@ -113,29 +140,39 @@ async def admin_create_tool(
 
     service = get_tool_catalog_service()
 
-    # Convert MCP and A2A config requests to models if provided
-    mcp_config = request.mcp_config.to_model() if request.mcp_config else None
-    a2a_config = request.a2a_config.to_model() if request.a2a_config else None
-
-    tool = ToolDefinition(
-        tool_id=request.tool_id,
-        display_name=request.display_name,
-        description=request.description,
-        category=request.category,
-        protocol=request.protocol,
-        status=request.status,
-        requires_oauth_provider=request.requires_oauth_provider,
-        forward_auth_token=request.forward_auth_token,
-        is_public=request.is_public,
-        enabled_by_default=request.enabled_by_default,
-        mcp_config=mcp_config,
-        a2a_config=a2a_config,
-    )
-
     try:
+        # Convert MCP, A2A, and Gateway config requests to models. The Gateway
+        # to_model() runs the co-gating validator, so an invalid combination
+        # surfaces here as a ValueError (→ 400).
+        mcp_config = request.mcp_config.to_model() if request.mcp_config else None
+        a2a_config = request.a2a_config.to_model() if request.a2a_config else None
+        mcp_gateway_config = (
+            request.mcp_gateway_config.to_model()
+            if request.mcp_gateway_config
+            else None
+        )
+
+        tool = ToolDefinition(
+            tool_id=request.tool_id,
+            display_name=request.display_name,
+            description=request.description,
+            category=request.category,
+            protocol=request.protocol,
+            status=request.status,
+            requires_oauth_provider=request.requires_oauth_provider,
+            forward_auth_token=request.forward_auth_token,
+            is_public=request.is_public,
+            enabled_by_default=request.enabled_by_default,
+            mcp_config=mcp_config,
+            a2a_config=a2a_config,
+            mcp_gateway_config=mcp_gateway_config,
+        )
+
         created = await service.create_tool(tool, admin)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except (GatewayTargetConflictError, GatewayTargetNotFoundError, ClientError, RuntimeError) as e:
+        raise _raise_gateway_http(e)
 
     # Drop the all-tool-ids snapshot so the new tool is recognized by
     # ToolAccessService on the very next chat turn in this process.
@@ -173,16 +210,24 @@ async def admin_update_tool(
 
     updates = request.model_dump(exclude_unset=True, by_alias=False)
 
-    # Convert MCP and A2A config requests to models if provided
-    if "mcp_config" in updates and updates["mcp_config"] is not None:
-        updates["mcp_config"] = request.mcp_config.to_model()
-    if "a2a_config" in updates and updates["a2a_config"] is not None:
-        updates["a2a_config"] = request.a2a_config.to_model()
-
     try:
+        # Convert MCP, A2A, and Gateway config requests to models if provided.
+        # The Gateway to_model() runs the co-gating validator (→ 400 on failure).
+        if "mcp_config" in updates and updates["mcp_config"] is not None:
+            updates["mcp_config"] = request.mcp_config.to_model()
+        if "a2a_config" in updates and updates["a2a_config"] is not None:
+            updates["a2a_config"] = request.a2a_config.to_model()
+        if (
+            "mcp_gateway_config" in updates
+            and updates["mcp_gateway_config"] is not None
+        ):
+            updates["mcp_gateway_config"] = request.mcp_gateway_config.to_model()
+
         updated = await service.update_tool(tool_id, updates, admin)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except (GatewayTargetConflictError, GatewayTargetNotFoundError, ClientError, RuntimeError) as e:
+        raise _raise_gateway_http(e)
 
     if not updated:
         raise HTTPException(status_code=404, detail=f"Tool '{tool_id}' not found")
@@ -222,7 +267,10 @@ async def admin_delete_tool(
     logger.info("Admin deleting tool")
 
     service = get_tool_catalog_service()
-    deleted = await service.delete_tool(tool_id, admin, soft=not hard)
+    try:
+        deleted = await service.delete_tool(tool_id, admin, soft=not hard)
+    except (GatewayTargetConflictError, GatewayTargetNotFoundError, ClientError, RuntimeError) as e:
+        raise _raise_gateway_http(e)
 
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Tool '{tool_id}' not found")

--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -15,6 +15,7 @@ from apis.shared.rbac.admin_service import AppRoleAdminService, get_app_role_adm
 
 from apis.shared.tools.models import (
     ToolDefinition,
+    ToolProtocol,
     UserToolAccess,
     UserToolPreference,
     ToolCategory,
@@ -41,11 +42,25 @@ class ToolCatalogService:
         repository: Optional[ToolCatalogRepository] = None,
         app_role_service: Optional[AppRoleService] = None,
         app_role_admin_service: Optional[AppRoleAdminService] = None,
+        gateway_target_service: Optional[object] = None,
     ):
         """Initialize with dependencies."""
         self.repository = repository or get_tool_catalog_repository()
         self.app_role_service = app_role_service or get_app_role_service()
         self.app_role_admin_service = app_role_admin_service or get_app_role_admin_service()
+        # Lazily defaulted — only protocol='mcp' tools touch the Gateway, and we
+        # don't want to construct a bedrock-agentcore-control client for every
+        # ToolCatalogService. Injectable for tests.
+        self._gateway_target_service = gateway_target_service
+
+    def _get_gateway_target_service(self):
+        """Return the Gateway target service, defaulting to the singleton."""
+        if self._gateway_target_service is None:
+            from apis.shared.tools.gateway_target_service import (
+                get_gateway_target_service,
+            )
+            self._gateway_target_service = get_gateway_target_service()
+        return self._gateway_target_service
 
     # =========================================================================
     # User-Facing Methods
@@ -217,11 +232,39 @@ class ToolCatalogService:
                     "The OIDC token will use the Authorization header."
                 )
 
+    def _validate_protocol_config(self, tool: ToolDefinition) -> None:
+        """Validate that the protocol-specific config matches the protocol.
+
+        v1 only gates the Gateway protocol (mcp ⟺ mcp_gateway_config); the
+        mcp_external/a2a pairings are left untouched to avoid changing existing
+        create flows.
+
+        Raises:
+            ValueError: If protocol is 'mcp' without a gateway config, or a
+                gateway config is set on a non-'mcp' protocol.
+        """
+        is_gateway = tool.protocol == ToolProtocol.MCP_GATEWAY
+        if is_gateway and tool.mcp_gateway_config is None:
+            raise ValueError(
+                "protocol 'mcp' (MCP Gateway) requires mcp_gateway_config"
+            )
+        if not is_gateway and tool.mcp_gateway_config is not None:
+            raise ValueError(
+                "mcp_gateway_config is only valid for protocol 'mcp' (MCP Gateway)"
+            )
+
     async def create_tool(
         self, tool: ToolDefinition, admin: User
     ) -> ToolDefinition:
         """
         Create a new tool catalog entry.
+
+        For protocol='mcp' (MCP Gateway), the live Gateway target is created in
+        AWS *first*; the catalog row is persisted only on success, and the
+        AWS-assigned target_id/gateway_arn are stamped onto the stored config so
+        update/delete can reconcile the target later. If the AWS target is
+        created but persisting the row fails, the orphaned target id is logged
+        loudly (v1 repair is manual).
 
         Args:
             tool: Tool definition to create
@@ -231,14 +274,46 @@ class ToolCatalogService:
             Created ToolDefinition
 
         Raises:
-            ValueError: If auth configuration is invalid
+            ValueError: If auth or protocol configuration is invalid
+            GatewayTargetConflictError: If the Gateway target name already exists
+            botocore.exceptions.ClientError / RuntimeError: On AWS failure
         """
         self._validate_auth_config(tool)
+        self._validate_protocol_config(tool)
+
+        # Create the live Gateway target before persisting the row, so the
+        # catalog never references a target that doesn't exist.
+        if tool.protocol == ToolProtocol.MCP_GATEWAY:
+            info = self._get_gateway_target_service().create_target(
+                tool.mcp_gateway_config
+            )
+            tool.mcp_gateway_config.target_id = info.target_id
+            tool.mcp_gateway_config.gateway_arn = info.gateway_arn
 
         tool.created_by = admin.user_id
         tool.updated_by = admin.user_id
 
-        created = await self.repository.create_tool(tool)
+        try:
+            created = await self.repository.create_tool(tool)
+        except Exception:
+            if (
+                tool.protocol == ToolProtocol.MCP_GATEWAY
+                and tool.mcp_gateway_config
+                and tool.mcp_gateway_config.target_id
+            ):
+                logger.error(
+                    "ORPHANED GATEWAY TARGET: created Gateway target '%s' but "
+                    "failed to persist catalog row for tool '%s'. Manual cleanup "
+                    "required (delete-gateway-target).",
+                    tool.mcp_gateway_config.target_id,
+                    tool.tool_id,
+                    extra={
+                        "event": "gateway_target_orphaned",
+                        "orphaned_target_id": tool.mcp_gateway_config.target_id,
+                        "tool_id": tool.tool_id,
+                    },
+                )
+            raise
 
         logger.info(
             f"Admin {admin.email} created tool: {tool.tool_id}",
@@ -269,25 +344,61 @@ class ToolCatalogService:
         Raises:
             ValueError: If the resulting auth configuration is invalid
         """
-        # Pre-validate auth config if relevant fields are being updated
-        if "forward_auth_token" in updates or "requires_oauth_provider" in updates or "mcp_config" in updates:
-            existing = await self.repository.get_tool(tool_id)
-            if existing:
-                # Build a preview of the updated tool for validation
-                preview = ToolDefinition(
-                    tool_id=existing.tool_id,
-                    display_name=existing.display_name,
-                    description=existing.description,
-                    protocol=existing.protocol,
-                    forward_auth_token=updates.get("forward_auth_token", existing.forward_auth_token),
-                    requires_oauth_provider=updates.get("requires_oauth_provider", existing.requires_oauth_provider),
-                    mcp_config=updates.get("mcp_config", existing.mcp_config),
-                )
-                self._validate_auth_config(preview)
-
-        updated = await self.repository.update_tool(
-            tool_id, updates, admin_user_id=admin.user_id
+        # Fetch the existing row once if any field that needs it is changing.
+        needs_existing = any(
+            k in updates
+            for k in (
+                "forward_auth_token",
+                "requires_oauth_provider",
+                "mcp_config",
+                "protocol",
+                "mcp_gateway_config",
+            )
         )
+        existing = (
+            await self.repository.get_tool(tool_id) if needs_existing else None
+        )
+
+        # Pre-validate auth config if relevant fields are being updated
+        if existing and (
+            "forward_auth_token" in updates
+            or "requires_oauth_provider" in updates
+            or "mcp_config" in updates
+        ):
+            # Build a preview of the updated tool for validation
+            preview = ToolDefinition(
+                tool_id=existing.tool_id,
+                display_name=existing.display_name,
+                description=existing.description,
+                protocol=existing.protocol,
+                forward_auth_token=updates.get("forward_auth_token", existing.forward_auth_token),
+                requires_oauth_provider=updates.get("requires_oauth_provider", existing.requires_oauth_provider),
+                mcp_config=updates.get("mcp_config", existing.mcp_config),
+            )
+            self._validate_auth_config(preview)
+
+        # Reconcile the live Gateway target before persisting the row.
+        gateway_reconciled = False
+        if existing is not None and (
+            "protocol" in updates or "mcp_gateway_config" in updates
+        ):
+            gateway_reconciled = self._reconcile_gateway_target_for_update(
+                existing, updates
+            )
+
+        try:
+            updated = await self.repository.update_tool(
+                tool_id, updates, admin_user_id=admin.user_id
+            )
+        except Exception:
+            if gateway_reconciled:
+                logger.error(
+                    "Gateway target for tool '%s' was updated in AWS but the "
+                    "catalog row update failed; state diverged.",
+                    tool_id,
+                    extra={"event": "gateway_target_diverged", "tool_id": tool_id},
+                )
+            raise
 
         if updated:
             logger.info(
@@ -303,9 +414,59 @@ class ToolCatalogService:
 
         return updated
 
+    def _reconcile_gateway_target_for_update(
+        self, existing: ToolDefinition, updates: Dict
+    ) -> bool:
+        """Reconcile the live Gateway target for an update, mutating `updates`.
+
+        Returns True if an AWS target call was made. Raises ValueError on an
+        unsupported protocol transition; the AWS-assigned target_id is preserved
+        across the update.
+        """
+        new_protocol = updates.get("protocol", existing.protocol)
+        was_gateway = existing.protocol == ToolProtocol.MCP_GATEWAY
+        now_gateway = new_protocol == ToolProtocol.MCP_GATEWAY
+
+        if was_gateway != now_gateway:
+            raise ValueError(
+                "Cannot change a tool's protocol to or from 'mcp' (MCP Gateway) "
+                "via update; delete and recreate the tool instead."
+            )
+
+        if not now_gateway:
+            return False
+
+        new_config = updates.get("mcp_gateway_config")
+        if new_config is None:
+            # Gateway tool, but the target config isn't changing — leave the
+            # live target (and its stored target_id) untouched.
+            return False
+
+        existing_cfg = existing.mcp_gateway_config
+        target_id = existing_cfg.target_id if existing_cfg else None
+        gateway = self._get_gateway_target_service()
+        if target_id:
+            info = gateway.update_target(target_id=target_id, config=new_config)
+            new_config.target_id = target_id
+            new_config.gateway_arn = info.gateway_arn or (
+                existing_cfg.gateway_arn if existing_cfg else None
+            )
+        else:
+            # No stored target (shouldn't happen for a gateway row) — create one.
+            info = gateway.create_target(new_config)
+            new_config.target_id = info.target_id
+            new_config.gateway_arn = info.gateway_arn
+        updates["mcp_gateway_config"] = new_config
+        return True
+
     async def delete_tool(self, tool_id: str, admin: User, soft: bool = True) -> bool:
         """
         Delete a tool from the catalog.
+
+        For protocol='mcp' (MCP Gateway), a *hard* delete removes the live
+        Gateway target first (a 404 is tolerated as already-gone), then the
+        catalog row. A *soft* delete only disables the catalog row and leaves
+        the Gateway target in place so the tool can be re-enabled.
 
         Args:
             tool_id: Tool identifier
@@ -314,12 +475,46 @@ class ToolCatalogService:
 
         Returns:
             True if deleted/disabled, False if not found
+
+        Raises:
+            botocore.exceptions.ClientError: On a non-404 AWS failure deleting
+                the Gateway target (the catalog row is left intact).
         """
-        if soft:
-            result = await self.repository.soft_delete_tool(tool_id, admin.user_id)
-            deleted = result is not None
-        else:
-            deleted = await self.repository.delete_tool(tool_id)
+        existing = await self.repository.get_tool(tool_id)
+        if existing is None:
+            return False
+
+        # Remove the live Gateway target before the row, so we never delete the
+        # catalog row while a target still points at it.
+        target_deleted = False
+        if (
+            not soft
+            and existing.protocol == ToolProtocol.MCP_GATEWAY
+            and existing.mcp_gateway_config
+            and existing.mcp_gateway_config.target_id
+        ):
+            self._get_gateway_target_service().delete_target(
+                target_id=existing.mcp_gateway_config.target_id
+            )
+            target_deleted = True
+
+        try:
+            if soft:
+                result = await self.repository.soft_delete_tool(tool_id, admin.user_id)
+                deleted = result is not None
+            else:
+                deleted = await self.repository.delete_tool(tool_id)
+        except Exception:
+            if target_deleted:
+                logger.error(
+                    "Deleted Gateway target '%s' but failed to remove catalog "
+                    "row for tool '%s'; state diverged (manual cleanup of the "
+                    "row required).",
+                    existing.mcp_gateway_config.target_id,
+                    tool_id,
+                    extra={"event": "gateway_target_diverged", "tool_id": tool_id},
+                )
+            raise
 
         if deleted:
             logger.info(

--- a/backend/src/apis/shared/tools/gateway_target_service.py
+++ b/backend/src/apis/shared/tools/gateway_target_service.py
@@ -1,0 +1,355 @@
+"""AgentCore Gateway target lifecycle service.
+
+Wraps `bedrock-agentcore-control` for managing MCP targets on the centralized
+AgentCore Gateway. An admin registers an externally deployed MCP server as a
+Gateway *target* (issue #419); this service is the thin AWS boundary that turns
+an `MCPGatewayConfig` into a live target and reconciles update/delete.
+
+Lives in `apis.shared` (not inference-api) — the admin route on app-api owns the
+lifecycle orchestration (create AWS target first, persist the catalog row only
+on success). This service is intentionally stateless apart from the boto3 client
+and the lazily-resolved gateway id, so it is safe to share across requests.
+
+Modeled on `apis.shared.oauth.agentcore_registrar.AgentCoreRegistrar`, which
+wraps the same control-plane service for OAuth2 credential providers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import (
+    GatewayCredentialType,
+    GatewayListingMode,
+    GatewayOAuthGrantType,
+    MCPGatewayConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Model enum string values → the `bedrock-agentcore-control` API enums (which
+# are uppercase). Keyed by the model's lowercase `.value` so the lookup works
+# whether the field holds the enum or its value (use_enum_values=True).
+_LISTING_MODE_TO_AWS: Dict[str, str] = {
+    GatewayListingMode.DEFAULT.value: "DEFAULT",
+    GatewayListingMode.DYNAMIC.value: "DYNAMIC",
+}
+
+_CREDENTIAL_TYPE_TO_AWS: Dict[str, str] = {
+    GatewayCredentialType.GATEWAY_IAM_ROLE.value: "GATEWAY_IAM_ROLE",
+    GatewayCredentialType.OAUTH.value: "OAUTH",
+    GatewayCredentialType.API_KEY.value: "API_KEY",
+}
+
+_GRANT_TYPE_TO_AWS: Dict[str, str] = {
+    GatewayOAuthGrantType.AUTHORIZATION_CODE.value: "AUTHORIZATION_CODE",
+    GatewayOAuthGrantType.CLIENT_CREDENTIALS.value: "CLIENT_CREDENTIALS",
+    GatewayOAuthGrantType.TOKEN_EXCHANGE.value: "TOKEN_EXCHANGE",
+}
+
+
+@dataclass(frozen=True)
+class GatewayTargetInfo:
+    """AgentCore Gateway record for one MCP target.
+
+    `gateway_arn` is empty for entries surfaced by `list_targets` (the list
+    summary shape does not echo it back).
+    """
+
+    target_id: str
+    gateway_arn: str
+    status: str
+    name: str
+
+
+class GatewayTargetNotFoundError(LookupError):
+    """Raised when a Gateway target does not exist."""
+
+
+class GatewayTargetConflictError(RuntimeError):
+    """Raised when creating a target whose name already exists on the gateway."""
+
+
+class GatewayTargetService:
+    """Thin wrapper around `bedrock-agentcore-control` for Gateway targets."""
+
+    def __init__(
+        self,
+        *,
+        region: Optional[str] = None,
+        gateway_id: Optional[str] = None,
+        project_prefix: Optional[str] = None,
+        client: Any = None,
+        ssm_client: Any = None,
+    ):
+        self._region = (
+            region
+            or os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+        )
+        self._client = client or boto3.client(
+            "bedrock-agentcore-control", region_name=self._region
+        )
+        # `gateway_id` may be supplied directly (tests / callers that already
+        # know it); otherwise it is resolved from SSM on first use and cached.
+        self._gateway_id = gateway_id
+        self._ssm_client = ssm_client
+        self._project_prefix = project_prefix or os.environ.get(
+            "PROJECT_PREFIX", "agentcore"
+        )
+
+    # ----------------------------------------------------- gateway id (SSM)
+    def _resolve_gateway_id(self) -> str:
+        """Return the gateway identifier, reading `/{prefix}/gateway/id` from
+        SSM on first use and caching it. The gateway construct publishes this
+        parameter; app-api reads it at runtime (boto3), which sidesteps the
+        same-stack deploy-time ordering deadlock.
+        """
+        if self._gateway_id:
+            return self._gateway_id
+
+        if self._ssm_client is None:
+            self._ssm_client = boto3.client("ssm", region_name=self._region)
+
+        param_name = f"/{self._project_prefix}/gateway/id"
+        try:
+            response = self._ssm_client.get_parameter(Name=param_name)
+        except ClientError as err:
+            raise RuntimeError(
+                f"Gateway id SSM parameter '{param_name}' is unavailable; is the "
+                f"gateway construct deployed? ({err})"
+            ) from err
+
+        self._gateway_id = response["Parameter"]["Value"]
+        return self._gateway_id
+
+    # ------------------------------------------------------------------ create
+    def create_target(
+        self, config: MCPGatewayConfig, *, description: str = ""
+    ) -> GatewayTargetInfo:
+        """Register `config` as a live target on the gateway.
+
+        Raises:
+            GatewayTargetConflictError: A target named `config.target_name`
+                already exists on the gateway.
+            botocore.exceptions.ClientError: Any other AWS error bubbles up so
+                the route can surface a 502 and log the failure.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.create_gateway_target(
+                gatewayIdentifier=gateway_id,
+                name=config.target_name,
+                description=description or f"MCP gateway target {config.target_name}",
+                targetConfiguration=self._build_target_configuration(config),
+                credentialProviderConfigurations=self._build_credential_configs(config),
+            )
+        except ClientError as err:
+            code = err.response.get("Error", {}).get("Code")
+            if code in ("ConflictException", "ResourceAlreadyExistsException"):
+                raise GatewayTargetConflictError(
+                    f"Gateway target '{config.target_name}' already exists"
+                ) from err
+            raise
+
+        return self._info_from_response(response, fallback_name=config.target_name)
+
+    # ------------------------------------------------------------------ update
+    def update_target(
+        self, *, target_id: str, config: MCPGatewayConfig, description: str = ""
+    ) -> GatewayTargetInfo:
+        """Replace the target's full configuration.
+
+        Like the OAuth provider update, `UpdateGatewayTarget` is not a partial
+        update — name and targetConfiguration are re-submitted in full.
+
+        Raises:
+            GatewayTargetNotFoundError: No such target.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.update_gateway_target(
+                gatewayIdentifier=gateway_id,
+                targetId=target_id,
+                name=config.target_name,
+                description=description or f"MCP gateway target {config.target_name}",
+                targetConfiguration=self._build_target_configuration(config),
+                credentialProviderConfigurations=self._build_credential_configs(config),
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                raise GatewayTargetNotFoundError(target_id) from err
+            raise
+
+        return self._info_from_response(
+            response, fallback_name=config.target_name, fallback_target_id=target_id
+        )
+
+    # --------------------------------------------------------------------- get
+    def get_target(self, *, target_id: str) -> GatewayTargetInfo:
+        """Fetch one target by id.
+
+        Raises:
+            GatewayTargetNotFoundError: No such target.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            response = self._client.get_gateway_target(
+                gatewayIdentifier=gateway_id, targetId=target_id
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                raise GatewayTargetNotFoundError(target_id) from err
+            raise
+
+        return self._info_from_response(response, fallback_target_id=target_id)
+
+    # ------------------------------------------------------------------ delete
+    def delete_target(self, *, target_id: str) -> None:
+        """Delete the target. A missing target is treated as success.
+
+        The route deletes the AWS target before the catalog row, so a 404 here
+        means the row's reconciliation is already done — log loudly (this is the
+        manual-repair signal in v1) and return.
+        """
+        gateway_id = self._resolve_gateway_id()
+        try:
+            self._client.delete_gateway_target(
+                gatewayIdentifier=gateway_id, targetId=target_id
+            )
+        except ClientError as err:
+            if self._is_not_found(err):
+                logger.warning(
+                    "Gateway target '%s' already absent on gateway '%s'; "
+                    "delete is a no-op",
+                    target_id,
+                    gateway_id,
+                )
+                return
+            raise
+
+    # -------------------------------------------------------------------- list
+    def list_targets(self) -> List[GatewayTargetInfo]:
+        """List every target on the gateway (paginates internally)."""
+        gateway_id = self._resolve_gateway_id()
+        targets: List[GatewayTargetInfo] = []
+        next_token: Optional[str] = None
+        while True:
+            kwargs: Dict[str, Any] = {"gatewayIdentifier": gateway_id}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = self._client.list_gateway_targets(**kwargs)
+            for item in response.get("items", []):
+                targets.append(self._info_from_response(item))
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+        return targets
+
+    # ------------------------------------------------------------- build helpers
+    @staticmethod
+    def _build_target_configuration(config: MCPGatewayConfig) -> Dict[str, Any]:
+        """Build `targetConfiguration.mcp.mcpServer` for an external endpoint."""
+        listing_value = (
+            config.listing_mode
+            if isinstance(config.listing_mode, str)
+            else config.listing_mode.value
+        )
+        return {
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": config.endpoint_url,
+                    "listingMode": _LISTING_MODE_TO_AWS[listing_value],
+                }
+            }
+        }
+
+    @staticmethod
+    def _build_credential_configs(config: MCPGatewayConfig) -> List[Dict[str, Any]]:
+        """Build `credentialProviderConfigurations` from the credential type.
+
+        The `MCPGatewayConfig` validator already guarantees the ARN/listing
+        invariants per credential type, so this only shapes the payload.
+        """
+        cred_value = (
+            config.credential_type
+            if isinstance(config.credential_type, str)
+            else config.credential_type.value
+        )
+        aws_type = _CREDENTIAL_TYPE_TO_AWS[cred_value]
+
+        if cred_value == GatewayCredentialType.OAUTH.value:
+            grant_value = (
+                config.grant_type
+                if isinstance(config.grant_type, str)
+                else config.grant_type.value
+            )
+            oauth_provider: Dict[str, Any] = {
+                "providerArn": config.credential_provider_arn,
+                "scopes": list(config.oauth_scopes),
+                "grantType": _GRANT_TYPE_TO_AWS[grant_value],
+            }
+            # customParameters are part of the token-vault key — only send them
+            # when set, and exactly as configured so target registration and
+            # token retrieval agree.
+            if config.custom_parameters:
+                oauth_provider["customParameters"] = dict(config.custom_parameters)
+            return [
+                {
+                    "credentialProviderType": aws_type,
+                    "credentialProvider": {"oauthCredentialProvider": oauth_provider},
+                }
+            ]
+        if cred_value == GatewayCredentialType.API_KEY.value:
+            return [
+                {
+                    "credentialProviderType": aws_type,
+                    "credentialProvider": {
+                        "apiKeyCredentialProvider": {
+                            "providerArn": config.credential_provider_arn,
+                        }
+                    },
+                }
+            ]
+        # GATEWAY_IAM_ROLE — the gateway signs with its own execution role; no
+        # nested credentialProvider is sent.
+        return [{"credentialProviderType": aws_type}]
+
+    # ----------------------------------------------------------- parse helpers
+    @staticmethod
+    def _info_from_response(
+        response: Dict[str, Any],
+        *,
+        fallback_name: str = "",
+        fallback_target_id: str = "",
+        fallback_gateway_arn: str = "",
+    ) -> GatewayTargetInfo:
+        return GatewayTargetInfo(
+            target_id=response.get("targetId") or fallback_target_id,
+            gateway_arn=response.get("gatewayArn") or fallback_gateway_arn,
+            status=response.get("status", ""),
+            name=response.get("name") or fallback_name,
+        )
+
+    @staticmethod
+    def _is_not_found(err: ClientError) -> bool:
+        code = err.response.get("Error", {}).get("Code")
+        return code in ("ResourceNotFoundException", "NotFoundException")
+
+
+_default_service: Optional[GatewayTargetService] = None
+
+
+def get_gateway_target_service() -> GatewayTargetService:
+    """Return the process-wide `GatewayTargetService` singleton."""
+    global _default_service
+    if _default_service is None:
+        _default_service = GatewayTargetService()
+    return _default_service

--- a/backend/tests/apis/app_api/tools/test_tool_catalog_service_gateway.py
+++ b/backend/tests/apis/app_api/tools/test_tool_catalog_service_gateway.py
@@ -1,0 +1,308 @@
+"""Phase 4 (issue #419): ToolCatalogService Gateway-target lifecycle orchestration
+and the admin route's HTTP error mapping.
+
+The GatewayTargetService is stubbed (no AWS) — these verify the catalog<->AWS
+coupling: create the live target first, persist the row only on success, reconcile
+on update, remove the target before the row on hard delete, and log loudly on a
+partial failure.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+
+from apis.app_api.admin.tools.routes import _raise_gateway_http
+from apis.app_api.tools.service import ToolCatalogService
+from apis.shared.tools.gateway_target_service import (
+    GatewayTargetConflictError,
+    GatewayTargetInfo,
+    GatewayTargetNotFoundError,
+)
+from apis.shared.tools.models import (
+    MCPGatewayConfig,
+    ToolDefinition,
+    ToolProtocol,
+)
+
+
+def _admin():
+    return MagicMock(user_id="admin1", email="admin@example.com")
+
+
+def _gw_info(target_id="TGT1", gateway_arn="arn:aws:bedrock-agentcore:us-west-2:1:gateway/gw1"):
+    return GatewayTargetInfo(
+        target_id=target_id, gateway_arn=gateway_arn, status="CREATING", name="weather-target"
+    )
+
+
+def _gateway_config(**overrides) -> MCPGatewayConfig:
+    base = dict(target_name="weather-target", endpoint_url="https://example.com/mcp")
+    base.update(overrides)
+    return MCPGatewayConfig(**base)
+
+
+def _gateway_tool(config: MCPGatewayConfig | None = None) -> ToolDefinition:
+    return ToolDefinition(
+        tool_id="gw_weather",
+        display_name="Weather (Gateway)",
+        description="Weather via the AgentCore Gateway",
+        protocol=ToolProtocol.MCP_GATEWAY,
+        mcp_gateway_config=config or _gateway_config(),
+    )
+
+
+def _service(repo, gw):
+    return ToolCatalogService(
+        repository=repo,
+        app_role_service=MagicMock(),
+        app_role_admin_service=MagicMock(),
+        gateway_target_service=gw,
+    )
+
+
+# --------------------------------------------------------------------- create
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_creates_aws_target_first_then_stamps_ids_and_persists(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock(side_effect=lambda t: t)
+        gw = MagicMock()
+        gw.create_target = MagicMock(return_value=_gw_info())
+
+        created = await _service(repo, gw).create_tool(_gateway_tool(), _admin())
+
+        gw.create_target.assert_called_once()
+        # AWS-assigned identifiers are stamped onto the persisted config.
+        assert created.mcp_gateway_config.target_id == "TGT1"
+        assert created.mcp_gateway_config.gateway_arn.endswith("gateway/gw1")
+        # The row persisted carries the stamped target_id (stamp happened first).
+        persisted = repo.create_tool.call_args.args[0]
+        assert persisted.mcp_gateway_config.target_id == "TGT1"
+
+    @pytest.mark.asyncio
+    async def test_aws_failure_aborts_persist(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock()
+        gw = MagicMock()
+        gw.create_target = MagicMock(side_effect=ClientError({"Error": {"Code": "ValidationException"}}, "op"))
+
+        with pytest.raises(ClientError):
+            await _service(repo, gw).create_tool(_gateway_tool(), _admin())
+        repo.create_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_conflict_propagates(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock()
+        gw = MagicMock()
+        gw.create_target = MagicMock(side_effect=GatewayTargetConflictError("exists"))
+
+        with pytest.raises(GatewayTargetConflictError):
+            await _service(repo, gw).create_tool(_gateway_tool(), _admin())
+        repo.create_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_orphan_logged_when_persist_fails(self, caplog):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock(side_effect=RuntimeError("dynamo down"))
+        gw = MagicMock()
+        gw.create_target = MagicMock(return_value=_gw_info(target_id="TGT-ORPHAN"))
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RuntimeError):
+                await _service(repo, gw).create_tool(_gateway_tool(), _admin())
+
+        assert any(
+            "ORPHANED GATEWAY TARGET" in r.message and "TGT-ORPHAN" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_protocol_mcp_without_config_rejected(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock()
+        gw = MagicMock()
+        tool = ToolDefinition(
+            tool_id="gw_bad",
+            display_name="x",
+            description="d",
+            protocol=ToolProtocol.MCP_GATEWAY,
+            mcp_gateway_config=None,
+        )
+        with pytest.raises(ValueError):
+            await _service(repo, gw).create_tool(tool, _admin())
+        gw.create_target.assert_not_called()
+        repo.create_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_config_on_non_mcp_protocol_rejected(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock()
+        gw = MagicMock()
+        tool = ToolDefinition(
+            tool_id="local_bad",
+            display_name="x",
+            description="d",
+            protocol=ToolProtocol.LOCAL,
+            mcp_gateway_config=_gateway_config(),
+        )
+        with pytest.raises(ValueError):
+            await _service(repo, gw).create_tool(tool, _admin())
+        gw.create_target.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_gateway_tool_does_not_touch_gateway(self):
+        repo = MagicMock()
+        repo.create_tool = AsyncMock(side_effect=lambda t: t)
+        gw = MagicMock()
+        tool = ToolDefinition(
+            tool_id="local_thing", display_name="x", description="d", protocol=ToolProtocol.LOCAL
+        )
+        await _service(repo, gw).create_tool(tool, _admin())
+        gw.create_target.assert_not_called()
+        repo.create_tool.assert_called_once()
+
+
+# --------------------------------------------------------------------- update
+
+
+class TestUpdate:
+    @pytest.mark.asyncio
+    async def test_config_change_reconciles_target_and_preserves_target_id(self):
+        existing = _gateway_tool(_gateway_config(target_id="TGT1", gateway_arn="arn:old"))
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=existing)
+        repo.update_tool = AsyncMock(return_value=existing)
+        gw = MagicMock()
+        gw.update_target = MagicMock(return_value=_gw_info(gateway_arn="arn:new"))
+
+        new_cfg = _gateway_config(endpoint_url="https://new.example.com/mcp")
+        updates = {"mcp_gateway_config": new_cfg}
+        await _service(repo, gw).update_tool("gw_weather", updates, _admin())
+
+        gw.update_target.assert_called_once()
+        assert gw.update_target.call_args.kwargs["target_id"] == "TGT1"
+        # target_id preserved, gateway_arn refreshed from the update response.
+        assert updates["mcp_gateway_config"].target_id == "TGT1"
+        assert updates["mcp_gateway_config"].gateway_arn == "arn:new"
+
+    @pytest.mark.asyncio
+    async def test_protocol_transition_to_mcp_rejected(self):
+        existing = ToolDefinition(
+            tool_id="local_thing", display_name="x", description="d", protocol=ToolProtocol.LOCAL
+        )
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=existing)
+        repo.update_tool = AsyncMock()
+        gw = MagicMock()
+
+        with pytest.raises(ValueError):
+            await _service(repo, gw).update_tool(
+                "local_thing", {"protocol": ToolProtocol.MCP_GATEWAY}, _admin()
+            )
+        gw.update_target.assert_not_called()
+        repo.update_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_config_update_does_not_touch_gateway(self):
+        repo = MagicMock()
+        repo.update_tool = AsyncMock(return_value=_gateway_tool())
+        repo.get_tool = AsyncMock()
+        gw = MagicMock()
+
+        await _service(repo, gw).update_tool("gw_weather", {"display_name": "New"}, _admin())
+
+        gw.update_target.assert_not_called()
+        # display_name isn't a config/protocol field, so we don't even fetch existing.
+        repo.get_tool.assert_not_called()
+        repo.update_tool.assert_called_once()
+
+
+# --------------------------------------------------------------------- delete
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_hard_delete_removes_target_before_row(self):
+        existing = _gateway_tool(_gateway_config(target_id="TGT1"))
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=existing)
+        repo.delete_tool = AsyncMock(return_value=True)
+        gw = MagicMock()
+        gw.delete_target = MagicMock()
+
+        ok = await _service(repo, gw).delete_tool("gw_weather", _admin(), soft=False)
+
+        assert ok is True
+        gw.delete_target.assert_called_once_with(target_id="TGT1")
+        repo.delete_tool.assert_called_once_with("gw_weather")
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_leaves_target_in_place(self):
+        existing = _gateway_tool(_gateway_config(target_id="TGT1"))
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=existing)
+        repo.soft_delete_tool = AsyncMock(return_value=existing)
+        gw = MagicMock()
+
+        ok = await _service(repo, gw).delete_tool("gw_weather", _admin(), soft=True)
+
+        assert ok is True
+        gw.delete_target.assert_not_called()
+        repo.soft_delete_tool.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_false_without_touching_gateway(self):
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=None)
+        gw = MagicMock()
+
+        ok = await _service(repo, gw).delete_tool("nope", _admin(), soft=False)
+
+        assert ok is False
+        gw.delete_target.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_divergence_logged_when_row_delete_fails_after_target_delete(self, caplog):
+        existing = _gateway_tool(_gateway_config(target_id="TGT1"))
+        repo = MagicMock()
+        repo.get_tool = AsyncMock(return_value=existing)
+        repo.delete_tool = AsyncMock(side_effect=RuntimeError("dynamo down"))
+        gw = MagicMock()
+        gw.delete_target = MagicMock()
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RuntimeError):
+                await _service(repo, gw).delete_tool("gw_weather", _admin(), soft=False)
+
+        assert any("state diverged" in r.message for r in caplog.records)
+
+
+# ----------------------------------------------------- route HTTP error mapping
+
+
+class TestRouteErrorMapping:
+    def test_conflict_maps_to_409(self):
+        exc = _raise_gateway_http(GatewayTargetConflictError("exists"))
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 409
+
+    def test_not_found_maps_to_409(self):
+        exc = _raise_gateway_http(GatewayTargetNotFoundError("gone"))
+        assert exc.status_code == 409
+
+    def test_aws_client_error_maps_to_502(self):
+        exc = _raise_gateway_http(
+            ClientError({"Error": {"Code": "ThrottlingException"}}, "op")
+        )
+        assert exc.status_code == 502
+
+    def test_runtime_error_maps_to_502(self):
+        # e.g. the gateway-id SSM parameter is unavailable.
+        exc = _raise_gateway_http(RuntimeError("Gateway id SSM parameter unavailable"))
+        assert exc.status_code == 502

--- a/backend/tests/shared/test_gateway_target_service.py
+++ b/backend/tests/shared/test_gateway_target_service.py
@@ -1,0 +1,303 @@
+"""GatewayTargetService tests (issue #419, Phase 2).
+
+Mocks the `bedrock-agentcore-control` boto3 client directly — these verify our
+translation layer (MCPGatewayConfig → CreateGatewayTarget kwargs, listing-mode
+and credential-type mapping, 404 → no-op delete, conflict mapping, SSM gateway-id
+resolution), not AWS behaviour. Mirrors test_oauth_agentcore_registrar.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from apis.shared.tools.gateway_target_service import (
+    GatewayTargetConflictError,
+    GatewayTargetNotFoundError,
+    GatewayTargetService,
+)
+from apis.shared.tools.models import (
+    GatewayCredentialType,
+    GatewayListingMode,
+    GatewayOAuthGrantType,
+    MCPGatewayConfig,
+    MCPToolEntry,
+)
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": code}},
+        operation_name="op",
+    )
+
+
+def _create_response(**overrides):
+    base = {
+        "targetId": "TGT1",
+        "gatewayArn": "arn:aws:bedrock-agentcore:us-west-2:111:gateway/gw-test-id",
+        "status": "CREATING",
+        "name": "weather-target",
+    }
+    base.update(overrides)
+    return base
+
+
+def _iam_config(**overrides) -> MCPGatewayConfig:
+    base = dict(
+        target_name="weather-target",
+        endpoint_url="https://example.com/mcp",
+        listing_mode=GatewayListingMode.DEFAULT,
+        credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        tools=[MCPToolEntry(name="get_forecast")],
+    )
+    base.update(overrides)
+    return MCPGatewayConfig(**base)
+
+
+@pytest.fixture
+def boto_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def ssm_client():
+    ssm = MagicMock()
+    ssm.get_parameter.return_value = {"Parameter": {"Value": "gw-test-id"}}
+    return ssm
+
+
+@pytest.fixture
+def service(boto_client, ssm_client):
+    return GatewayTargetService(
+        client=boto_client,
+        ssm_client=ssm_client,
+        region="us-west-2",
+        project_prefix="myproj",
+    )
+
+
+class TestCreateTarget:
+    def test_iam_target_kwargs(self, service, boto_client, ssm_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+
+        info = service.create_target(_iam_config())
+
+        kwargs = boto_client.create_gateway_target.call_args.kwargs
+        assert kwargs["gatewayIdentifier"] == "gw-test-id"
+        assert kwargs["name"] == "weather-target"
+        assert kwargs["targetConfiguration"] == {
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": "https://example.com/mcp",
+                    "listingMode": "DEFAULT",
+                }
+            }
+        }
+        assert kwargs["credentialProviderConfigurations"] == [
+            {"credentialProviderType": "GATEWAY_IAM_ROLE"}
+        ]
+        # gateway id was read from /{prefix}/gateway/id
+        ssm_client.get_parameter.assert_called_once_with(Name="/myproj/gateway/id")
+        # response is surfaced
+        assert info.target_id == "TGT1"
+        assert info.gateway_arn.endswith("gateway/gw-test-id")
+        assert info.status == "CREATING"
+
+    def test_oauth_credential_config(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="github-target",
+            endpoint_url="https://gh/mcp",
+            listing_mode=GatewayListingMode.DEFAULT,
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/oauth2credentialprovider/gh",
+            oauth_scopes=["repo", "read:user"],
+        )
+
+        service.create_target(config)
+
+        creds = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ]
+        assert creds == [
+            {
+                "credentialProviderType": "OAUTH",
+                "credentialProvider": {
+                    "oauthCredentialProvider": {
+                        "providerArn": config.credential_provider_arn,
+                        "scopes": ["repo", "read:user"],
+                        # Defaults to the 3LO authorization-code grant.
+                        "grantType": "AUTHORIZATION_CODE",
+                    }
+                },
+            }
+        ]
+
+    def test_oauth_client_credentials_with_custom_parameters(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="m2m-target",
+            endpoint_url="https://m2m/mcp",
+            credential_type=GatewayCredentialType.OAUTH,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/oauth2credentialprovider/m2m",
+            grant_type=GatewayOAuthGrantType.CLIENT_CREDENTIALS,
+            custom_parameters={"audience": "https://api.example.com"},
+        )
+
+        service.create_target(config)
+
+        oauth = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ][0]["credentialProvider"]["oauthCredentialProvider"]
+        assert oauth["grantType"] == "CLIENT_CREDENTIALS"
+        assert oauth["customParameters"] == {"audience": "https://api.example.com"}
+
+    def test_api_key_credential_config(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="weather-target",
+            endpoint_url="https://example.com/mcp",
+            credential_type=GatewayCredentialType.API_KEY,
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:111:token-vault/default/apikeycredentialprovider/wx",
+        )
+
+        service.create_target(config)
+
+        creds = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ]
+        assert creds == [
+            {
+                "credentialProviderType": "API_KEY",
+                "credentialProvider": {
+                    "apiKeyCredentialProvider": {
+                        "providerArn": config.credential_provider_arn,
+                    }
+                },
+            }
+        ]
+
+    def test_dynamic_listing_maps_to_uppercase(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        service.create_target(_iam_config(listing_mode=GatewayListingMode.DYNAMIC))
+        target_cfg = boto_client.create_gateway_target.call_args.kwargs[
+            "targetConfiguration"
+        ]
+        assert target_cfg["mcp"]["mcpServer"]["listingMode"] == "DYNAMIC"
+
+    def test_conflict_maps_to_conflict_error(self, service, boto_client):
+        boto_client.create_gateway_target.side_effect = _client_error(
+            "ConflictException"
+        )
+        with pytest.raises(GatewayTargetConflictError):
+            service.create_target(_iam_config())
+
+    def test_other_client_error_bubbles(self, service, boto_client):
+        boto_client.create_gateway_target.side_effect = _client_error(
+            "ValidationException"
+        )
+        with pytest.raises(ClientError):
+            service.create_target(_iam_config())
+
+
+class TestUpdateTarget:
+    def test_update_kwargs(self, service, boto_client):
+        boto_client.update_gateway_target.return_value = _create_response(
+            status="UPDATING"
+        )
+        info = service.update_target(target_id="TGT1", config=_iam_config())
+
+        kwargs = boto_client.update_gateway_target.call_args.kwargs
+        assert kwargs["gatewayIdentifier"] == "gw-test-id"
+        assert kwargs["targetId"] == "TGT1"
+        assert kwargs["name"] == "weather-target"
+        assert "targetConfiguration" in kwargs
+        assert "credentialProviderConfigurations" in kwargs
+        assert info.status == "UPDATING"
+
+    def test_update_not_found_raises(self, service, boto_client):
+        boto_client.update_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        with pytest.raises(GatewayTargetNotFoundError):
+            service.update_target(target_id="missing", config=_iam_config())
+
+
+class TestGetTarget:
+    def test_get_returns_info(self, service, boto_client):
+        boto_client.get_gateway_target.return_value = _create_response(status="READY")
+        info = service.get_target(target_id="TGT1")
+        boto_client.get_gateway_target.assert_called_once_with(
+            gatewayIdentifier="gw-test-id", targetId="TGT1"
+        )
+        assert info.target_id == "TGT1"
+        assert info.status == "READY"
+
+    def test_get_not_found_raises(self, service, boto_client):
+        boto_client.get_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        with pytest.raises(GatewayTargetNotFoundError):
+            service.get_target(target_id="missing")
+
+
+class TestDeleteTarget:
+    def test_delete_success(self, service, boto_client):
+        service.delete_target(target_id="TGT1")
+        boto_client.delete_gateway_target.assert_called_once_with(
+            gatewayIdentifier="gw-test-id", targetId="TGT1"
+        )
+
+    def test_delete_not_found_is_noop(self, service, boto_client):
+        boto_client.delete_gateway_target.side_effect = _client_error(
+            "ResourceNotFoundException"
+        )
+        # Must not raise — the catalog row is removed even when AWS is already clean.
+        service.delete_target(target_id="missing")
+
+    def test_delete_other_error_bubbles(self, service, boto_client):
+        boto_client.delete_gateway_target.side_effect = _client_error(
+            "ThrottlingException"
+        )
+        with pytest.raises(ClientError):
+            service.delete_target(target_id="TGT1")
+
+
+class TestListTargets:
+    def test_paginates(self, service, boto_client):
+        boto_client.list_gateway_targets.side_effect = [
+            {"items": [{"targetId": "a", "name": "na", "status": "READY"}], "nextToken": "t"},
+            {"items": [{"targetId": "b", "name": "nb", "status": "READY"}]},
+        ]
+        infos = service.list_targets()
+        assert [i.target_id for i in infos] == ["a", "b"]
+        assert boto_client.list_gateway_targets.call_count == 2
+        assert boto_client.list_gateway_targets.call_args_list[1].kwargs["nextToken"] == "t"
+
+
+class TestGatewayIdResolution:
+    def test_resolved_once_and_cached(self, service, boto_client, ssm_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        service.create_target(_iam_config())
+        service.delete_target(target_id="TGT1")
+        # SSM is read exactly once across multiple operations.
+        ssm_client.get_parameter.assert_called_once()
+
+    def test_explicit_gateway_id_skips_ssm(self, boto_client, ssm_client):
+        svc = GatewayTargetService(
+            client=boto_client, ssm_client=ssm_client, gateway_id="gw-explicit"
+        )
+        boto_client.create_gateway_target.return_value = _create_response()
+        svc.create_target(_iam_config())
+        ssm_client.get_parameter.assert_not_called()
+        assert (
+            boto_client.create_gateway_target.call_args.kwargs["gatewayIdentifier"]
+            == "gw-explicit"
+        )
+
+    def test_missing_ssm_param_raises_runtime_error(self, boto_client, ssm_client):
+        ssm_client.get_parameter.side_effect = _client_error("ParameterNotFound")
+        svc = GatewayTargetService(client=boto_client, ssm_client=ssm_client)
+        with pytest.raises(RuntimeError):
+            svc.create_target(_iam_config())


### PR DESCRIPTION
**Issue #419 — the runtime lifecycle** (originally PR4/5, now rebased onto `develop`).

### ⚠️ Heads-up: this PR re-lands the stranded `GatewayTargetService`
When #450/#451/#452 were merged, the **stacked** PR #451 (`GatewayTargetService`) merged into its base branch `feature/mcp-gateway-config-model` *after* that base had already merged to `develop` — so **`gateway_target_service.py` never reached `develop`**. This PR re-lands it (verified absent from `develop`) **together with** the admin route + service lifecycle that depends on it. Merge is conflict-free; model (#450) and infra (#452) already on `develop` are untouched.

So this PR contains two commits:
1. `GatewayTargetService` — the stranded #451 (thin `bedrock-agentcore-control` wrapper; 18 stubbed-client tests).
2. Admin route + `ToolCatalogService` lifecycle orchestration.

### Lifecycle (the "hard part")
- **create**: AWS target first → stamp `target_id`/`gateway_arn` → persist row; orphan logged loudly if the row fails after the target is created.
- **update**: reconcile the live target (preserve `target_id`); reject protocol transitions to/from `mcp`.
- **delete**: hard delete removes the target first (404 tolerated) then the row; soft delete leaves the target.
- **route**: converts `mcp_gateway_config` (co-gating validator → 400); maps conflict/divergence → 409, AWS/`RuntimeError` → 502.

### Scope — honors "zero new agent-side runtime code"
No agent-loop changes. RBAC for gateway tools stays AppRole-based. Per-tool approval enforcement + mid-chat 3LO auto-consent for gateway tools are **deferred** (model stores the flags; OAuth targets rely on pre-connecting the provider via Connectors).

### Testing
36 new tests across the two commits. **Full backend suite: 3398 passed, 3 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)