### PR TITLE
feat(admin): Gateway target admin form for protocol=mcp (#419, PR5/5)

### DIFF
--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -35,6 +35,24 @@ export type MCPAuthType = 'none' | 'aws-iam' | 'api-key' | 'bearer-token' | 'oau
 export type A2AAuthType = 'none' | 'aws-iam' | 'agentcore' | 'api-key';
 
 /**
+ * AgentCore Gateway target listing mode. DYNAMIC disables 3LO + semantic search.
+ */
+export type GatewayListingMode = 'default' | 'dynamic';
+
+/**
+ * How the Gateway authenticates outbound to a target's MCP endpoint.
+ */
+export type GatewayCredentialType = 'gateway_iam_role' | 'oauth' | 'api_key';
+
+/**
+ * OAuth grant the Gateway uses for an OAUTH-credentialed target.
+ */
+export type GatewayOAuthGrantType =
+  | 'authorization_code'
+  | 'client_credentials'
+  | 'token_exchange';
+
+/**
  * Tool status enum
  */
 export type ToolStatus = 'active' | 'deprecated' | 'disabled' | 'coming_soon';
@@ -78,6 +96,25 @@ export interface A2AAgentConfig {
 }
 
 /**
+ * Gateway target configuration for protocol='mcp' tools. Mirrors the Python
+ * MCPGatewayConfig. `targetId`/`gatewayArn` are AWS-assigned (present on
+ * responses, omitted on create/update requests).
+ */
+export interface MCPGatewayConfig {
+  targetName: string;
+  endpointUrl: string;
+  listingMode: GatewayListingMode;
+  credentialType: GatewayCredentialType;
+  credentialProviderArn?: string | null;
+  oauthScopes: string[];
+  grantType: GatewayOAuthGrantType;
+  customParameters?: Record<string, string> | null;
+  tools: MCPToolEntry[];
+  targetId?: string | null;
+  gatewayArn?: string | null;
+}
+
+/**
  * Admin tool definition with role assignments.
  */
 export interface AdminTool {
@@ -99,6 +136,7 @@ export interface AdminTool {
   // External tool configurations
   mcpConfig?: MCPServerConfig | null;
   a2aConfig?: A2AAgentConfig | null;
+  mcpGatewayConfig?: MCPGatewayConfig | null;
 }
 
 /**
@@ -144,6 +182,7 @@ export interface ToolCreateRequest {
   enabledByDefault?: boolean;
   mcpConfig?: MCPServerConfig;
   a2aConfig?: A2AAgentConfig;
+  mcpGatewayConfig?: MCPGatewayConfig;
 }
 
 /**
@@ -161,6 +200,7 @@ export interface ToolUpdateRequest {
   enabledByDefault?: boolean;
   mcpConfig?: MCPServerConfig | null;
   a2aConfig?: A2AAgentConfig | null;
+  mcpGatewayConfig?: MCPGatewayConfig | null;
 }
 
 /**
@@ -287,6 +327,32 @@ export const A2A_AUTH_TYPES: { value: A2AAuthType; label: string; description?: 
   { value: 'aws-iam', label: 'AWS IAM (SigV4)', description: 'AWS IAM authentication with SigV4 signing' },
   { value: 'agentcore', label: 'AgentCore Runtime', description: 'AgentCore Runtime authentication' },
   { value: 'api-key', label: 'API Key', description: 'API key in request header' },
+];
+
+/**
+ * Available Gateway target listing modes for dropdowns.
+ */
+export const GATEWAY_LISTING_MODES: { value: GatewayListingMode; label: string; description?: string }[] = [
+  { value: 'default', label: 'Default', description: 'Static tool listing — required for OAuth (3LO) and semantic search' },
+  { value: 'dynamic', label: 'Dynamic', description: 'Resolve tools at call time — disables 3LO and semantic search' },
+];
+
+/**
+ * Available Gateway outbound credential types for dropdowns.
+ */
+export const GATEWAY_CREDENTIAL_TYPES: { value: GatewayCredentialType; label: string; description?: string }[] = [
+  { value: 'gateway_iam_role', label: 'Gateway IAM Role (SigV4)', description: 'The gateway signs with its own execution role — no provider ARN' },
+  { value: 'oauth', label: 'OAuth (3LO / 2LO)', description: 'Reference an existing OAuth credential provider by ARN' },
+  { value: 'api_key', label: 'API Key', description: 'Reference an existing API-key credential provider by ARN' },
+];
+
+/**
+ * Available Gateway OAuth grant types for dropdowns.
+ */
+export const GATEWAY_OAUTH_GRANT_TYPES: { value: GatewayOAuthGrantType; label: string; description?: string }[] = [
+  { value: 'authorization_code', label: 'Authorization Code (3LO)', description: 'On-behalf-of-user — requires the user to connect the provider' },
+  { value: 'client_credentials', label: 'Client Credentials (2LO)', description: 'Machine-to-machine — no user consent' },
+  { value: 'token_exchange', label: 'Token Exchange', description: 'Exchange an existing token' },
 ];
 
 /**

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
@@ -13,13 +13,19 @@ import { ConnectorsService } from '../../connectors/services/connectors.service'
  * distinctly from a 400 (validation).
  */
 describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
-  let adminToolService: { createTool: ReturnType<typeof vi.fn>; updateTool: ReturnType<typeof vi.fn>; fetchTool: ReturnType<typeof vi.fn> };
+  let adminToolService: {
+    createTool: ReturnType<typeof vi.fn>;
+    updateTool: ReturnType<typeof vi.fn>;
+    fetchTool: ReturnType<typeof vi.fn>;
+    discoverMCPTools: ReturnType<typeof vi.fn>;
+  };
 
   function makeComponent(): ToolFormPage {
     adminToolService = {
       createTool: vi.fn().mockResolvedValue({}),
       updateTool: vi.fn().mockResolvedValue({}),
       fetchTool: vi.fn(),
+      discoverMCPTools: vi.fn().mockResolvedValue({ tools: [] }),
     };
 
     TestBed.resetTestingModule();
@@ -95,6 +101,49 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
     expect(cfg.credentialProviderArn).toContain('oauth2credentialprovider/gh');
     expect(cfg.oauthScopes).toEqual(['repo', 'read:user']);
     expect(cfg.grantType).toBe('client_credentials');
+  });
+
+  it('discovers tools from the gateway endpoint and merges them into the rows', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    // Pre-existing manual row whose approval flag must be preserved on merge.
+    cmp.addGwTool();
+    cmp.gwToolsArray.at(0).patchValue({ name: 'get_forecast', needsApproval: true });
+
+    adminToolService.discoverMCPTools.mockResolvedValueOnce({
+      tools: [
+        { name: 'get_forecast', description: 'forecast' },
+        { name: 'set_alert', description: 'writes' },
+      ],
+    });
+
+    await cmp.discoverGatewayTools();
+
+    // IAM target → discovery signs with aws-iam against the endpoint URL.
+    expect(adminToolService.discoverMCPTools).toHaveBeenCalledWith(
+      expect.objectContaining({ serverUrl: 'https://example.com/mcp', authType: 'aws-iam' }),
+    );
+    const names = cmp.gwToolsArray.controls.map((c) => c.get('name')?.value);
+    expect(names).toEqual(['get_forecast', 'set_alert']);
+    // Existing approval flag preserved; not duplicated.
+    expect(cmp.gwToolsArray.at(0).get('needsApproval')?.value).toBe(true);
+  });
+
+  it('maps non-IAM credential types to an unauthenticated discovery attempt', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    cmp.form.patchValue({
+      gwCredentialType: 'oauth',
+      gwCredentialProviderArn: 'arn:...:oauth2credentialprovider/x',
+    });
+
+    await cmp.discoverGatewayTools();
+
+    expect(adminToolService.discoverMCPTools).toHaveBeenCalledWith(
+      expect.objectContaining({ authType: 'none' }),
+    );
   });
 
   it('surfaces a 502 (Gateway target failed) distinctly from a 400 (validation)', async () => {

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ToolFormPage } from './tool-form.page';
+import { AdminToolService } from '../services/admin-tool.service';
+import { ConnectorsService } from '../../connectors/services/connectors.service';
+
+/**
+ * Phase 5 (#419): the protocol='mcp' Gateway target section of the admin tool
+ * form — that onSubmit builds the correct mcpGatewayConfig payload per
+ * credential type, and that a 502 (Gateway target failed) is surfaced
+ * distinctly from a 400 (validation).
+ */
+describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
+  let adminToolService: { createTool: ReturnType<typeof vi.fn>; updateTool: ReturnType<typeof vi.fn>; fetchTool: ReturnType<typeof vi.fn> };
+
+  function makeComponent(): ToolFormPage {
+    adminToolService = {
+      createTool: vi.fn().mockResolvedValue({}),
+      updateTool: vi.fn().mockResolvedValue({}),
+      fetchTool: vi.fn(),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ToolFormPage],
+      providers: [
+        provideRouter([]),
+        { provide: AdminToolService, useValue: adminToolService },
+        { provide: ConnectorsService, useValue: { getEnabledConnectors: () => [] } },
+      ],
+    });
+    const cmp = TestBed.createComponent(ToolFormPage).componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    return cmp;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  function fillBaseGatewayForm(cmp: ToolFormPage): void {
+    cmp.form.patchValue({
+      toolId: 'gw_weather',
+      displayName: 'Weather (Gateway)',
+      description: 'Weather via the AgentCore Gateway',
+      protocol: 'mcp',
+      gwTargetName: 'weather-target',
+      gwEndpointUrl: 'https://example.com/mcp',
+    });
+  }
+
+  it('builds an IAM gateway config and submits it', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    cmp.addGwTool();
+    cmp.gwToolsArray.at(0).patchValue({ name: 'get_forecast', needsApproval: true });
+
+    await cmp.onSubmit();
+
+    expect(adminToolService.createTool).toHaveBeenCalledTimes(1);
+    const payload = adminToolService.createTool.mock.calls[0][0];
+    expect(payload.protocol).toBe('mcp');
+    expect(payload.mcpGatewayConfig).toEqual({
+      targetName: 'weather-target',
+      endpointUrl: 'https://example.com/mcp',
+      listingMode: 'default',
+      credentialType: 'gateway_iam_role',
+      credentialProviderArn: null,
+      oauthScopes: [],
+      grantType: 'authorization_code',
+      customParameters: null,
+      tools: [{ name: 'get_forecast', needsApproval: true, description: null }],
+    });
+  });
+
+  it('builds an OAuth gateway config (ARN + parsed scopes) and forces DEFAULT listing', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    // Set DYNAMIC first, then switch to OAuth — co-gating must force DEFAULT.
+    cmp.form.patchValue({ gwListingMode: 'dynamic' });
+    cmp.form.patchValue({
+      gwCredentialType: 'oauth',
+      gwCredentialProviderArn: 'arn:aws:bedrock-agentcore:us-west-2:1:token-vault/default/oauth2credentialprovider/gh',
+      gwOauthScopes: 'repo read:user',
+      gwGrantType: 'client_credentials',
+    });
+
+    await cmp.onSubmit();
+
+    const cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.credentialType).toBe('oauth');
+    expect(cfg.listingMode).toBe('default');
+    expect(cfg.credentialProviderArn).toContain('oauth2credentialprovider/gh');
+    expect(cfg.oauthScopes).toEqual(['repo', 'read:user']);
+    expect(cfg.grantType).toBe('client_credentials');
+  });
+
+  it('surfaces a 502 (Gateway target failed) distinctly from a 400 (validation)', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+
+    adminToolService.createTool.mockRejectedValueOnce(
+      new HttpErrorResponse({ status: 502, error: { detail: 'CreateGatewayTarget failed' } }),
+    );
+    await cmp.onSubmit();
+    expect(cmp.error()).toContain('Gateway target operation failed');
+    expect(cmp.error()).toContain('CreateGatewayTarget failed');
+
+    adminToolService.createTool.mockRejectedValueOnce(
+      new HttpErrorResponse({ status: 400, error: { detail: 'mcp_gateway_config required' } }),
+    );
+    await cmp.onSubmit();
+    expect(cmp.error()).toContain('Validation error');
+  });
+});

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -8,6 +8,7 @@ import {
   effect,
 } from '@angular/core';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FormArray, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -28,9 +29,13 @@ import {
   MCP_TRANSPORTS,
   MCP_AUTH_TYPES,
   A2A_AUTH_TYPES,
+  GATEWAY_LISTING_MODES,
+  GATEWAY_CREDENTIAL_TYPES,
+  GATEWAY_OAUTH_GRANT_TYPES,
   MCPServerConfig,
   MCPToolEntry,
   A2AAgentConfig,
+  MCPGatewayConfig,
   ToolProtocol,
 } from '../models/admin-tool.model';
 
@@ -434,6 +439,215 @@ import {
               </section>
             }
 
+            <!-- MCP Gateway Target Configuration -->
+            @if (selectedProtocol() === 'mcp') {
+              <section class="space-y-4 border-t border-gray-200 pt-8 dark:border-gray-700">
+                <div class="flex items-center gap-2">
+                  <ng-icon name="heroServer" class="size-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+                  <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Gateway target configuration</h2>
+                </div>
+                <p class="text-sm/6 text-gray-600 dark:text-gray-400">
+                  Registers an externally deployed MCP server as a target on the centralized AgentCore Gateway.
+                  Saving creates the live Gateway target in AWS; if that fails the catalog entry is not saved.
+                </p>
+
+                <!-- Target name and endpoint -->
+                <div>
+                  <label for="gwTargetName" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Target name <span class="text-red-600">*</span>
+                  </label>
+                  <input
+                    id="gwTargetName"
+                    type="text"
+                    formControlName="gwTargetName"
+                    placeholder="weather-search"
+                    class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                  />
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Unique name for the target on the gateway.
+                  </p>
+                </div>
+
+                <div>
+                  <label for="gwEndpointUrl" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Endpoint URL <span class="text-red-600">*</span>
+                  </label>
+                  <input
+                    id="gwEndpointUrl"
+                    type="url"
+                    formControlName="gwEndpointUrl"
+                    placeholder="https://your-mcp-server.example.com/mcp"
+                    class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                  />
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    The external MCP server endpoint the Gateway will call.
+                  </p>
+                </div>
+
+                <!-- Listing mode and credential type -->
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label for="gwListingMode" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                      Listing mode
+                    </label>
+                    <select
+                      id="gwListingMode"
+                      formControlName="gwListingMode"
+                      [attr.disabled]="form.get('gwCredentialType')?.value === 'oauth' ? '' : null"
+                      class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    >
+                      @for (mode of gatewayListingModes; track mode.value) {
+                        <option [value]="mode.value">{{ mode.label }}</option>
+                      }
+                    </select>
+                    <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                      @if (form.get('gwCredentialType')?.value === 'oauth') {
+                        OAuth requires Default listing (Dynamic disables 3LO + semantic search).
+                      } @else {
+                        Dynamic resolves tools at call time but disables semantic search.
+                      }
+                    </p>
+                  </div>
+
+                  <div>
+                    <label for="gwCredentialType" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                      Outbound credential
+                    </label>
+                    <select
+                      id="gwCredentialType"
+                      formControlName="gwCredentialType"
+                      class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    >
+                      @for (cred of gatewayCredentialTypes; track cred.value) {
+                        <option [value]="cred.value">{{ cred.label }}</option>
+                      }
+                    </select>
+                    <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                      How the Gateway authenticates to the target endpoint.
+                    </p>
+                  </div>
+                </div>
+
+                <!-- Credential provider ARN (for oauth / api_key) -->
+                @if (form.get('gwCredentialType')?.value === 'oauth' || form.get('gwCredentialType')?.value === 'api_key') {
+                  <div>
+                    <label for="gwCredentialProviderArn" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                      Credential provider ARN <span class="text-red-600">*</span>
+                    </label>
+                    <input
+                      id="gwCredentialProviderArn"
+                      type="text"
+                      formControlName="gwCredentialProviderArn"
+                      placeholder="arn:aws:bedrock-agentcore:...:token-vault/default/oauth2credentialprovider/..."
+                      class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                    />
+                    <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                      An existing AgentCore credential provider. Provisioning providers is out of scope here — manage them in
+                      <a routerLink="/admin/connectors" class="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">Connectors</a>.
+                    </p>
+                  </div>
+                }
+
+                <!-- OAuth scopes + grant type (for oauth) -->
+                @if (form.get('gwCredentialType')?.value === 'oauth') {
+                  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div>
+                      <label for="gwOauthScopes" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        OAuth scopes
+                      </label>
+                      <input
+                        id="gwOauthScopes"
+                        type="text"
+                        formControlName="gwOauthScopes"
+                        placeholder="openid profile email"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      />
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        Space- or comma-separated.
+                      </p>
+                    </div>
+                    <div>
+                      <label for="gwGrantType" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        Grant type
+                      </label>
+                      <select
+                        id="gwGrantType"
+                        formControlName="gwGrantType"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                      >
+                        @for (grant of gatewayOauthGrantTypes; track grant.value) {
+                          <option [value]="grant.value">{{ grant.label }}</option>
+                        }
+                      </select>
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        Authorization Code (3LO) requires the user to connect the provider first.
+                      </p>
+                    </div>
+                  </div>
+                }
+
+                <!-- Gateway tools (per-tool approval flags) -->
+                <div formArrayName="gwTools">
+                  <div class="mb-2 flex items-center justify-between">
+                    <span class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                      Tools
+                    </span>
+                    <button
+                      type="button"
+                      (click)="addGwTool()"
+                      class="inline-flex items-center gap-1 rounded-2xl px-2.5 py-1 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                    >
+                      <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                      Add Tool
+                    </button>
+                  </div>
+
+                  @if (gwToolsArray.length === 0) {
+                    <p class="text-xs/5 italic text-gray-500 dark:text-gray-400">
+                      Optional. List the target's tool names to attach per-tool approval flags.
+                    </p>
+                  } @else {
+                    <div class="space-y-2">
+                      @for (row of gwToolsArray.controls; track $index) {
+                        <div [formGroupName]="$index" class="flex items-start gap-2 rounded-2xl border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-800">
+                          <div class="flex-1">
+                            <input
+                              type="text"
+                              formControlName="name"
+                              placeholder="tool_name"
+                              [attr.aria-label]="'Gateway tool name ' + ($index + 1)"
+                              class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-1.5 font-mono text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                            />
+                          </div>
+                          <label class="flex items-center gap-1.5 whitespace-nowrap pt-1.5 text-xs/5 text-gray-700 dark:text-gray-300">
+                            <input
+                              type="checkbox"
+                              formControlName="needsApproval"
+                              class="size-4 rounded border-gray-300 text-amber-600 focus:ring-2 focus:ring-amber-500 dark:border-gray-600 dark:bg-gray-800"
+                            />
+                            <span>Needs approval</span>
+                          </label>
+                          <button
+                            type="button"
+                            (click)="removeGwTool($index)"
+                            [attr.aria-label]="'Remove gateway tool ' + ($index + 1)"
+                            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                          >
+                            <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                          </button>
+                        </div>
+                      }
+                    </div>
+                  }
+                  <p class="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Note: per-tool approval flags are stored but not yet enforced for Gateway tools (tracked separately).
+                    For OAuth targets, users connect the provider via
+                    <a routerLink="/admin/connectors" class="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">Connectors</a>.
+                  </p>
+                </div>
+              </section>
+            }
+
             <!-- A2A Agent Configuration -->
             @if (selectedProtocol() === 'a2a') {
               <section class="space-y-4 border-t border-gray-200 pt-8 dark:border-gray-700">
@@ -666,6 +880,9 @@ export class ToolFormPage implements OnInit {
   readonly mcpTransports = MCP_TRANSPORTS;
   readonly mcpAuthTypes = MCP_AUTH_TYPES;
   readonly a2aAuthTypes = A2A_AUTH_TYPES;
+  readonly gatewayListingModes = GATEWAY_LISTING_MODES;
+  readonly gatewayCredentialTypes = GATEWAY_CREDENTIAL_TYPES;
+  readonly gatewayOauthGrantTypes = GATEWAY_OAUTH_GRANT_TYPES;
 
   loading = signal(false);
   saving = signal(false);
@@ -709,6 +926,15 @@ export class ToolFormPage implements OnInit {
     a2aCapabilities: [''],
     a2aTimeoutSeconds: [120],
     a2aMaxRetries: [3],
+    // MCP Gateway target configuration (protocol 'mcp')
+    gwTargetName: [''],
+    gwEndpointUrl: [''],
+    gwListingMode: ['default'],
+    gwCredentialType: ['gateway_iam_role'],
+    gwCredentialProviderArn: [''],
+    gwOauthScopes: [''],
+    gwGrantType: ['authorization_code'],
+    gwTools: this.fb.array([] as FormGroup[]),
   });
 
   constructor() {
@@ -745,6 +971,18 @@ export class ToolFormPage implements OnInit {
 
   removeMcpTool(index: number): void {
     this.mcpToolsArray.removeAt(index);
+  }
+
+  get gwToolsArray(): FormArray<FormGroup> {
+    return this.form.get('gwTools') as FormArray<FormGroup>;
+  }
+
+  addGwTool(): void {
+    this.gwToolsArray.push(this.buildMcpToolRow());
+  }
+
+  removeGwTool(index: number): void {
+    this.gwToolsArray.removeAt(index);
   }
 
   async discoverMcpTools(): Promise<void> {
@@ -816,6 +1054,14 @@ export class ToolFormPage implements OnInit {
       }
     });
 
+    // Co-gating: OAuth (3LO) targets require DEFAULT listing — DYNAMIC disables
+    // 3LO and semantic search. Force it so the backend doesn't 400.
+    this.form.get('gwCredentialType')?.valueChanges.subscribe(value => {
+      if (value === 'oauth' && this.form.get('gwListingMode')?.value !== 'default') {
+        this.form.get('gwListingMode')?.setValue('default');
+      }
+    });
+
     const id = this.route.snapshot.paramMap.get('toolId');
     if (id) {
       this.toolId.set(id);
@@ -876,6 +1122,23 @@ export class ToolFormPage implements OnInit {
         });
       }
 
+      // MCP Gateway target configuration
+      if (tool.mcpGatewayConfig) {
+        this.form.patchValue({
+          gwTargetName: tool.mcpGatewayConfig.targetName,
+          gwEndpointUrl: tool.mcpGatewayConfig.endpointUrl,
+          gwListingMode: tool.mcpGatewayConfig.listingMode,
+          gwCredentialType: tool.mcpGatewayConfig.credentialType,
+          gwCredentialProviderArn: tool.mcpGatewayConfig.credentialProviderArn || '',
+          gwOauthScopes: (tool.mcpGatewayConfig.oauthScopes || []).join(' '),
+          gwGrantType: tool.mcpGatewayConfig.grantType,
+        });
+        this.gwToolsArray.clear();
+        for (const entry of tool.mcpGatewayConfig.tools) {
+          this.gwToolsArray.push(this.buildMcpToolRow(entry));
+        }
+      }
+
       // Disable toolId in edit mode
       this.form.get('toolId')?.disable();
     } catch (err: unknown) {
@@ -934,6 +1197,37 @@ export class ToolFormPage implements OnInit {
         };
       }
 
+      // Build Gateway target config if protocol is mcp
+      let mcpGatewayConfig: MCPGatewayConfig | undefined;
+      if (formValue.protocol === 'mcp' && formValue.gwTargetName && formValue.gwEndpointUrl) {
+        const gwTools: MCPToolEntry[] = (formValue.gwTools ?? [])
+          .map((row: { name?: string; needsApproval?: boolean; description?: string | null }) => ({
+            name: (row.name ?? '').trim(),
+            needsApproval: !!row.needsApproval,
+            description: row.description?.trim() || null,
+          }))
+          .filter((row: MCPToolEntry) => row.name.length > 0);
+
+        const credentialType = formValue.gwCredentialType;
+        const isOauth = credentialType === 'oauth';
+        mcpGatewayConfig = {
+          targetName: formValue.gwTargetName,
+          endpointUrl: formValue.gwEndpointUrl,
+          listingMode: formValue.gwListingMode,
+          credentialType,
+          // IAM role uses the gateway's execution role — no ARN.
+          credentialProviderArn:
+            credentialType === 'gateway_iam_role' ? null : (formValue.gwCredentialProviderArn || null),
+          oauthScopes:
+            isOauth && formValue.gwOauthScopes
+              ? formValue.gwOauthScopes.split(/[\s,]+/).map((s: string) => s.trim()).filter((s: string) => s)
+              : [],
+          grantType: formValue.gwGrantType,
+          customParameters: null,
+          tools: gwTools,
+        };
+      }
+
       // Get OAuth provider value (empty string becomes null)
       const requiresOauthProvider = formValue.requiresOauthProvider || null;
 
@@ -951,6 +1245,7 @@ export class ToolFormPage implements OnInit {
           forwardAuthToken: formValue.forwardAuthToken || false,
           mcpConfig: mcpConfig,
           a2aConfig: a2aConfig,
+          mcpGatewayConfig: mcpGatewayConfig,
         });
       } else {
         // Create new tool
@@ -967,16 +1262,43 @@ export class ToolFormPage implements OnInit {
           forwardAuthToken: formValue.forwardAuthToken || false,
           mcpConfig: mcpConfig,
           a2aConfig: a2aConfig,
+          mcpGatewayConfig: mcpGatewayConfig,
         });
       }
 
       await this.router.navigate(['/admin/tools']);
     } catch (err: unknown) {
       console.error('Error saving tool:', err);
-      const message = err instanceof Error ? err.message : 'Failed to save tool.';
-      this.error.set(message);
+      this.error.set(this.describeSaveError(err));
     } finally {
       this.saving.set(false);
     }
+  }
+
+  /**
+   * Build a friendly error message, distinguishing a Gateway target failure
+   * (502, the live AWS target couldn't be created/updated/deleted) from a
+   * validation error (400) and a conflict / state divergence (409). The
+   * service re-throws the HttpErrorResponse, whose `error.detail` carries the
+   * backend message.
+   */
+  private describeSaveError(err: unknown): string {
+    if (err instanceof HttpErrorResponse) {
+      const detail =
+        (err.error && typeof err.error === 'object' && 'detail' in err.error
+          ? String((err.error as { detail: unknown }).detail)
+          : '') || err.message;
+      switch (err.status) {
+        case 400:
+          return `Validation error: ${detail}`;
+        case 409:
+          return `Conflict: ${detail}`;
+        case 502:
+          return `Gateway target operation failed (the catalog entry was not saved): ${detail}`;
+        default:
+          return detail || 'Failed to save tool.';
+      }
+    }
+    return err instanceof Error ? err.message : 'Failed to save tool.';
   }
 }

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -592,19 +592,34 @@ import {
                     <span class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
                       Tools
                     </span>
-                    <button
-                      type="button"
-                      (click)="addGwTool()"
-                      class="inline-flex items-center gap-1 rounded-2xl px-2.5 py-1 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/20"
-                    >
-                      <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
-                      Add Tool
-                    </button>
+                    <div class="flex items-center gap-1">
+                      <button
+                        type="button"
+                        (click)="discoverGatewayTools()"
+                        [disabled]="discovering() || !form.get('gwEndpointUrl')?.value"
+                        class="inline-flex items-center gap-1 rounded-2xl px-2.5 py-1 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                      >
+                        {{ discovering() ? 'Discovering…' : 'Discover from server' }}
+                      </button>
+                      <button
+                        type="button"
+                        (click)="addGwTool()"
+                        class="inline-flex items-center gap-1 rounded-2xl px-2.5 py-1 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                      >
+                        <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                        Add Tool
+                      </button>
+                    </div>
                   </div>
+                  @if (discoverError()) {
+                    <p class="mb-2 text-sm/6 text-red-600 dark:text-red-400">
+                      {{ discoverError() }}
+                    </p>
+                  }
 
                   @if (gwToolsArray.length === 0) {
                     <p class="text-xs/5 italic text-gray-500 dark:text-gray-400">
-                      Optional. List the target's tool names to attach per-tool approval flags.
+                      Optional. Discover from the server or add tool names manually to attach per-tool approval flags.
                     </p>
                   } @else {
                     <div class="space-y-2">
@@ -1031,6 +1046,71 @@ export class ToolFormPage implements OnInit {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Discovery failed.';
       this.discoverError.set(message);
+    } finally {
+      this.discovering.set(false);
+    }
+  }
+
+  /**
+   * Discover the tools exposed by a Gateway target's MCP endpoint, by
+   * connecting to it directly (admin-side) via the same /discover endpoint
+   * used for mcp_external. The Gateway's outbound credential type maps to the
+   * direct-connection auth: a gateway-IAM-role target is SigV4-protected, so
+   * we sign with aws-iam; otherwise we attempt an unauthenticated list (OAuth /
+   * API-key endpoints can't be discovered admin-side — the server's error is
+   * surfaced, and the admin can add tool names by hand).
+   */
+  async discoverGatewayTools(): Promise<void> {
+    const formValue = this.form.getRawValue();
+    if (!formValue.gwEndpointUrl) {
+      return;
+    }
+
+    this.discovering.set(true);
+    this.discoverError.set(null);
+    try {
+      const authType = formValue.gwCredentialType === 'gateway_iam_role' ? 'aws-iam' : 'none';
+      const response = await this.adminToolService.discoverMCPTools({
+        serverUrl: formValue.gwEndpointUrl,
+        transport: 'streamable-http',
+        authType,
+        awsRegion: null,
+        apiKeyHeader: null,
+        secretArn: null,
+      });
+
+      // Merge: keep existing rows (and their needsApproval flag), append any
+      // newly-discovered names. Mirrors discoverMcpTools.
+      const existingByName = new Map<string, FormGroup>();
+      for (const ctrl of this.gwToolsArray.controls) {
+        const name = (ctrl.get('name')?.value ?? '').trim();
+        if (name) {
+          existingByName.set(name, ctrl);
+        }
+      }
+
+      for (const tool of response.tools) {
+        const existing = existingByName.get(tool.name);
+        if (existing) {
+          if (tool.description && !existing.get('description')?.value) {
+            existing.get('description')?.setValue(tool.description);
+          }
+        } else {
+          this.gwToolsArray.push(this.buildMcpToolRow({
+            name: tool.name,
+            needsApproval: false,
+            description: tool.description ?? null,
+          }));
+        }
+      }
+    } catch (err: unknown) {
+      const detail =
+        err instanceof HttpErrorResponse && err.error && typeof err.error === 'object' && 'detail' in err.error
+          ? String((err.error as { detail: unknown }).detail)
+          : err instanceof Error
+            ? err.message
+            : 'Discovery failed.';
+      this.discoverError.set(detail);
     } finally {
       this.discovering.set(false);
     }


### PR DESCRIPTION
**Issue #419 — PR 5 of 5 (final).** The admin UI for registering an externally deployed MCP server as a target on the centralized AgentCore Gateway. Frontend-only; `develop` already has the backend (#450, #452, #453).

### What
- **`admin-tool.model.ts`**: `MCPGatewayConfig` TS interface mirroring the Python model, `GatewayListingMode` / `GatewayCredentialType` / `GatewayOAuthGrantType` unions + dropdown constants, and `mcpGatewayConfig` on `AdminTool` / `ToolCreateRequest` / `ToolUpdateRequest` (same-PR cross-package contract).
- **`tool-form.page.ts`**: an `@if (selectedProtocol() === 'mcp')` section mirroring the `mcp_external` block — target name, endpoint URL, listing-mode selector, outbound-credential selector with conditional **provider-ARN + OAuth scopes + grant-type**, and per-tool approval-flag rows. Builds the config in `onSubmit`, restores in `loadTool`, and **forces DEFAULT listing when OAuth is selected** (client-side co-gating, so the backend doesn't 400).
- **Async/pending UX**: `describeSaveError` distinguishes **502** (Gateway target failed — catalog entry *not* saved) from **409** (conflict / divergence) and **400** (validation), reading `HttpErrorResponse.error.detail`. (The service re-throws the `HttpErrorResponse`, which isn't an `Error`, so the previous generic path swallowed the backend detail.)

### Honest scope note (surfaced in the form)
Per #419's "zero agent-side runtime code", per-tool approval flags are **stored but not yet enforced** for Gateway tools (tracked in **#454**); OAuth targets work by the user pre-connecting the provider via Connectors.

### Testing
New `tool-form.page.spec.ts` (3 tests via `ng test`): IAM + OAuth payload build, OAuth-forces-DEFAULT co-gating, and the 502-vs-400 error mapping. `ng build` clean (only the pre-existing bundle-budget warning).

**Manual UI check (needs the infra from #452 deployed + admin auth — a real save creates a live AWS Gateway target):** `/admin/tools/new` → protocol "MCP Gateway (AgentCore)" → the new section appears; switching credential to OAuth reveals ARN/scopes/grant and locks listing to Default; Create either succeeds (target created + row saved) or shows a distinct 502 if AWS rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)