### PR TITLE
feat(tools): AGENTCORE_GATEWAY_ID env override for local/CI testing (#419)

### DIFF
--- a/backend/src/apis/shared/tools/gateway_target_service.py
+++ b/backend/src/apis/shared/tools/gateway_target_service.py
@@ -107,13 +107,24 @@ class GatewayTargetService:
 
     # ----------------------------------------------------- gateway id (SSM)
     def _resolve_gateway_id(self) -> str:
-        """Return the gateway identifier, reading `/{prefix}/gateway/id` from
-        SSM on first use and caching it. The gateway construct publishes this
-        parameter; app-api reads it at runtime (boto3), which sidesteps the
-        same-stack deploy-time ordering deadlock.
+        """Return the gateway identifier.
+
+        Resolution order: an explicit `gateway_id` (constructor) → the
+        `AGENTCORE_GATEWAY_ID` env override → the SSM parameter
+        `/{prefix}/gateway/id` (read once and cached). The construct publishes
+        the SSM parameter and app-api reads it at runtime, which sidesteps the
+        same-stack deploy-time ordering deadlock; the env override exists for
+        local dev / CI, where the SSM parameter may not be present (or the
+        `PROJECT_PREFIX` may differ) — set it to the gateway identifier from
+        the deployed stack's `GatewayId` output or `list-gateways`.
         """
         if self._gateway_id:
             return self._gateway_id
+
+        env_override = os.environ.get("AGENTCORE_GATEWAY_ID")
+        if env_override:
+            self._gateway_id = env_override
+            return env_override
 
         if self._ssm_client is None:
             self._ssm_client = boto3.client("ssm", region_name=self._region)
@@ -124,7 +135,8 @@ class GatewayTargetService:
         except ClientError as err:
             raise RuntimeError(
                 f"Gateway id SSM parameter '{param_name}' is unavailable; is the "
-                f"gateway construct deployed? ({err})"
+                f"gateway construct deployed (and PROJECT_PREFIX correct)? Set "
+                f"AGENTCORE_GATEWAY_ID to override for local/CI. ({err})"
             ) from err
 
         self._gateway_id = response["Parameter"]["Value"]

--- a/backend/tests/shared/test_gateway_target_service.py
+++ b/backend/tests/shared/test_gateway_target_service.py
@@ -301,3 +301,15 @@ class TestGatewayIdResolution:
         svc = GatewayTargetService(client=boto_client, ssm_client=ssm_client)
         with pytest.raises(RuntimeError):
             svc.create_target(_iam_config())
+
+    def test_env_override_skips_ssm(self, boto_client, ssm_client, monkeypatch):
+        # AGENTCORE_GATEWAY_ID lets local/CI bypass the SSM lookup entirely.
+        monkeypatch.setenv("AGENTCORE_GATEWAY_ID", "gw-from-env")
+        svc = GatewayTargetService(client=boto_client, ssm_client=ssm_client)
+        boto_client.create_gateway_target.return_value = _create_response()
+        svc.create_target(_iam_config())
+        ssm_client.get_parameter.assert_not_called()
+        assert (
+            boto_client.create_gateway_target.call_args.kwargs["gatewayIdentifier"]
+            == "gw-from-env"
+        )


### PR DESCRIPTION
Follow-up to #419. Adds a local/CI escape hatch so `GatewayTargetService` can resolve the gateway id without the SSM parameter.

### Why
Testing the gateway create flow locally hits `ParameterNotFound` for `/agentcore/gateway/id`, because:
- The backend's prefix readers (this service, `fine_tuning`, `auth_providers`) read **`PROJECT_PREFIX`** (injected in cloud from `config.projectPrefix`). The local `.env` sets **`AGENTCORE_PROJECT_PREFIX`**, which nothing reads → the prefix falls back to `"agentcore"`, so the lookup path is wrong locally.
- And the `/{prefix}/gateway/id` parameter only exists once #452's infra is **deployed**.

The create-AWS-first lifecycle then correctly 502s (it won't save the catalog row without a gateway id) — working as designed, just unusable locally.

### What
- `_resolve_gateway_id` resolution order: explicit `gateway_id` → **`AGENTCORE_GATEWAY_ID`** env → SSM `/{PROJECT_PREFIX}/gateway/id`.
- The `ParameterNotFound` error message now names both likely causes + the override.

Set `AGENTCORE_GATEWAY_ID` to the deployed stack's `GatewayId` output (or from `aws bedrock-agentcore-control list-gateways`) to test locally. **Caveat:** the override only supplies the id — `CreateGatewayTarget` still calls real AWS, so local testing also needs creds for a real gateway with the GatewayTarget IAM permissions.

### Testing
+1 test (env override skips SSM); `test_gateway_target_service.py` 19/19 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)