### PR TITLE
feat(tools): Gateway MCP targets — self-service registration, agent wiring & health UX (#419)

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -365,6 +365,36 @@ class BaseAgent(ABC):
             disconnected_lookup=disconnected_lookup,
         )
 
+    def _expand_gateway_tool_ids(self, gateway_tool_ids: List[str]) -> List[str]:
+        """Expand #419 catalog gateway tools into the gateway's runtime per-tool
+        ids (see `expand_gateway_tool_ids`), bridging the async catalog lookup
+        into this sync build path the same way `_register_external_mcp_tools`
+        does.
+        """
+        from apis.shared.tools.repository import get_tool_catalog_repository
+        from agents.main_agent.tools.gateway_integration import (
+            expand_gateway_tool_ids,
+        )
+
+        repo = get_tool_catalog_repository()
+
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    return executor.submit(
+                        asyncio.run, expand_gateway_tool_ids(gateway_tool_ids, repo)
+                    ).result()
+            return loop.run_until_complete(
+                expand_gateway_tool_ids(gateway_tool_ids, repo)
+            )
+        except RuntimeError:
+            return asyncio.run(expand_gateway_tool_ids(gateway_tool_ids, repo))
+
     def _build_filtered_tools(self) -> List:
         """
         Filter tools and load gateway/external MCP clients.
@@ -379,6 +409,10 @@ class BaseAgent(ABC):
 
         # Get gateway client and add to tools if available
         if gateway_tool_ids:
+            # #419 catalog tools (`gateway_<id>`) must be expanded to the
+            # gateway's runtime per-tool ids (`gateway_<target>___<tool>`)
+            # before the FilteredMCPClient can match them.
+            gateway_tool_ids = self._expand_gateway_tool_ids(gateway_tool_ids)
             gateway_client = self.gateway_integration.get_client(gateway_tool_ids)
             if gateway_client:
                 local_tools = self.gateway_integration.add_to_tool_list(local_tools)

--- a/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
@@ -5,12 +5,12 @@ Creates MCP client with SigV4 authentication for Gateway tools
 
 import logging
 import os
-import boto3
 from typing import Optional, List, Callable, Any
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
 from agents.main_agent.config.constants import EnvVars, Defaults
 from agents.main_agent.integrations.gateway_auth import get_sigv4_auth, get_gateway_region_from_url
+from apis.shared.tools.gateway_identity import resolve_gateway_id, gateway_url_from_id
 from agents.main_agent.integrations.mcp_apps import (
     UICapableMCPClient,
     ensure_ui_extension_session_patch,
@@ -97,32 +97,26 @@ class FilteredMCPClient(MCPClient):
         return PaginatedList(filtered_tools, token=paginated_result.pagination_token)
 
 
-def get_gateway_url_from_ssm(
-    project_name: str = "strands-agent-chatbot",
-    environment: str = "dev",
-    region: str = "us-west-2"
-) -> Optional[str]:
-    """
-    Retrieve Gateway URL from SSM Parameter Store.
+def get_gateway_url_from_ssm(region: Optional[str] = None) -> Optional[str]:
+    """Resolve the centralized Gateway's MCP URL from infra config.
 
-    Args:
-        project_name: Project name for SSM parameter path
-        environment: Environment name (dev, prod, etc.)
-        region: AWS region
+    Uses the SAME resolution as the admin-side ``GatewayTargetService``
+    (``AGENTCORE_GATEWAY_ID`` override → SSM ``/{PROJECT_PREFIX}/gateway/id``,
+    published by the gateway CDK construct), so the agent connects to exactly
+    the gateway that admin-registered targets live on. Previously this read a
+    hardcoded ``/strands-agent-chatbot/dev/mcp/gateway-url``, which pointed at a
+    *different* gateway than the one the admin form manages.
 
-    Returns:
-        Gateway URL or None if not found
+    Returns None (and logs) on failure so the agent degrades gracefully instead
+    of failing the turn when no gateway is configured.
     """
     try:
-        ssm = boto3.client('ssm', region_name=region)
-        response = ssm.get_parameter(
-            Name=f'/{project_name}/{environment}/mcp/gateway-url'
-        )
-        gateway_url = response['Parameter']['Value']
-        logger.info(f"✅ Gateway URL retrieved from SSM: {gateway_url}")
+        gateway_id = resolve_gateway_id(region=region)
+        gateway_url = gateway_url_from_id(gateway_id, region=region)
+        logger.info(f"✅ Gateway URL resolved from infra config: {gateway_url}")
         return gateway_url
     except Exception as e:
-        logger.warning(f"⚠️  Failed to get Gateway URL from SSM: {e}")
+        logger.warning(f"⚠️  Failed to resolve Gateway URL from infra config: {e}")
         return None
 
 

--- a/backend/src/agents/main_agent/tools/gateway_integration.py
+++ b/backend/src/agents/main_agent/tools/gateway_integration.py
@@ -8,6 +8,45 @@ from agents.main_agent.integrations.gateway_mcp_client import get_gateway_client
 logger = logging.getLogger(__name__)
 
 
+async def expand_gateway_tool_ids(
+    gateway_tool_ids: List[str], repository: Any
+) -> List[str]:
+    """Expand #419 catalog gateway tools into the gateway's per-tool ids.
+
+    A protocol='mcp' catalog tool carries a single id like
+    ``gateway_class_search``, but the AgentCore Gateway exposes its target's
+    tools as ``<targetName>___<toolName>`` (runtime id
+    ``gateway_<targetName>___<toolName>``) — which is what ``FilteredMCPClient``
+    matches on. Expand each catalog tool from the ``target_name`` + ``tools``
+    list on its ``mcp_gateway_config``.
+
+    Ids that already contain ``___`` are runtime gateway ids enabled directly
+    via RBAC (no catalog row) and pass through unchanged, as do catalog tools
+    with no curated tool list (e.g. DYNAMIC listing). Order-preserving and
+    de-duplicated.
+
+    Args:
+        gateway_tool_ids: enabled ids that the filter classified as gateway.
+        repository: tool-catalog repository exposing ``async get_tool(id)``.
+    """
+    expanded: List[str] = []
+    for tool_id in gateway_tool_ids:
+        if "___" in tool_id:
+            expanded.append(tool_id)
+            continue
+        tool = await repository.get_tool(tool_id)
+        cfg = getattr(tool, "mcp_gateway_config", None) if tool else None
+        target = getattr(cfg, "target_name", None) if cfg else None
+        entries = getattr(cfg, "tools", None) if cfg else None
+        if tool and tool.protocol == "mcp" and target and entries:
+            expanded.extend(f"gateway_{target}___{entry.name}" for entry in entries)
+        else:
+            expanded.append(tool_id)
+
+    seen: set = set()
+    return [x for x in expanded if not (x in seen or seen.add(x))]
+
+
 class GatewayIntegration:
     """Manages Gateway MCP client for Strands Managed Integration"""
 

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Optional
 
+import httpx
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -22,9 +23,11 @@ from apis.shared.tools.models import (
     AdminToolResponse,
     AdminToolListResponse,
     ToolDefinition,
+    ToolProtocol,
     MCPDiscoverRequest,
     MCPDiscoverResponse,
     DiscoveredMCPTool,
+    GatewayTargetStatusResponse,
     MCPAuthType,
 )
 
@@ -287,6 +290,69 @@ async def admin_delete_tool(
 # =============================================================================
 
 
+def _find_upstream_http_error(exc: BaseException) -> Optional[httpx.HTTPStatusError]:
+    """Recover the target's HTTP error from a discovery failure.
+
+    Strands' ``MCPClient`` wraps a target's HTTP rejection in an
+    ``MCPClientInitializationError`` whose cause is an ``ExceptionGroup`` of
+    anyio task errors; the real ``httpx.HTTPStatusError`` (which carries the
+    upstream status code) is buried inside. Walk the cause/context chain and
+    any ``ExceptionGroup`` members to find it, so discovery can report the
+    target's actual status (e.g. 403) instead of a generic 502.
+    """
+    seen: set[int] = set()
+    stack: list[Optional[BaseException]] = [exc]
+    while stack:
+        e = stack.pop()
+        if e is None or id(e) in seen:
+            continue
+        seen.add(id(e))
+        if isinstance(e, httpx.HTTPStatusError):
+            return e
+        nested = getattr(e, "exceptions", None)  # BaseExceptionGroup members
+        if nested:
+            stack.extend(nested)
+        stack.append(e.__cause__)
+        stack.append(e.__context__)
+    return None
+
+
+def _response_status_for_upstream(status: int) -> int:
+    """Map a target's HTTP status to the status this endpoint returns.
+
+    Echo the target's own 4xx so the admin sees an actionable status (e.g. 403
+    = wrong/absent outbound credential), with two guards:
+      - 401 → 400: the SPA treats a 401 as "your session expired" and redirects
+        to login, but a target's auth rejection is a tool-config problem, not
+        the admin's session.
+      - 5xx → 502: we are a failing gateway, not the origin of a server error.
+    """
+    if status == 401:
+        return 400
+    if 400 <= status < 500:
+        return status
+    return 502
+
+
+def _discovery_failure_detail(status: int) -> str:
+    """Actionable message for a target that rejected the discovery request."""
+    base = f"The MCP server rejected the discovery request with HTTP {status}."
+    if status == 403:
+        return (
+            f"{base} If the endpoint requires AWS IAM (e.g. a Lambda Function URL "
+            "with AuthType=AWS_IAM), set the outbound credential to 'Gateway IAM "
+            "Role (SigV4)' and make sure the gateway — or your local identity — is "
+            "authorized to invoke it."
+        )
+    if status in (401, 407):
+        return (
+            f"{base} The endpoint requires authentication the discovery request "
+            "didn't supply (OAuth or an API key). OAuth-gated servers can't be "
+            "discovered admin-side — list the tool names manually."
+        )
+    return base
+
+
 @router.post("/discover", response_model=MCPDiscoverResponse)
 async def admin_discover_mcp_tools(
     request: MCPDiscoverRequest,
@@ -344,6 +410,13 @@ async def admin_discover_mcp_tools(
         tools = await asyncio.to_thread(_list_tools)
     except Exception as exc:
         logger.exception("MCP discovery failed for %s", request.server_url)
+        upstream = _find_upstream_http_error(exc)
+        if upstream is not None:
+            status = upstream.response.status_code
+            raise HTTPException(
+                status_code=_response_status_for_upstream(status),
+                detail=_discovery_failure_detail(status),
+            )
         raise HTTPException(
             status_code=502,
             detail=f"MCP server did not respond to tools/list: {exc}",
@@ -361,6 +434,68 @@ async def admin_discover_mcp_tools(
         discovered.append(DiscoveredMCPTool(name=name, description=description))
 
     return MCPDiscoverResponse(tools=discovered)
+
+
+@router.get("/{tool_id}/gateway-status", response_model=GatewayTargetStatusResponse)
+async def admin_gateway_target_status(
+    tool_id: str,
+    admin: User = Depends(require_admin),
+):
+    """Return the live AgentCore Gateway health for a protocol='mcp' tool.
+
+    The gateway connects to and lists tools from a target *asynchronously*
+    after registration, so a tool can be 'active' in the catalog yet unusable
+    because its target FAILED to sync (e.g. the gateway role can't invoke the
+    endpoint). The admin UI polls this after save and renders a per-row health
+    badge, so a failed target is visible here instead of only surfacing later
+    as "the agent doesn't have that tool".
+
+    Args:
+        tool_id: Catalog tool id (must be a protocol='mcp' Gateway target tool)
+        admin: Authenticated admin user (injected)
+
+    Returns:
+        GatewayTargetStatusResponse with the live status + any failure reasons
+    """
+    service = get_tool_catalog_service()
+    tool = await service.get_tool(tool_id)
+    if not tool:
+        raise HTTPException(status_code=404, detail=f"Tool '{tool_id}' not found")
+
+    target_id = tool.mcp_gateway_config.target_id if tool.mcp_gateway_config else None
+    if tool.protocol != ToolProtocol.MCP_GATEWAY or not target_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Tool '{tool_id}' is not a Gateway target tool",
+        )
+
+    from apis.shared.tools.gateway_target_service import get_gateway_target_service
+
+    gateway = get_gateway_target_service()
+    try:
+        info = await asyncio.to_thread(gateway.get_target, target_id=target_id)
+    except GatewayTargetNotFoundError:
+        # The catalog references a target that no longer exists on the gateway
+        # (deleted out of band). Surface it distinctly so the badge can prompt
+        # a re-create rather than implying a transient sync failure.
+        return GatewayTargetStatusResponse(
+            target_id=target_id,
+            status="MISSING",
+            status_reasons=[
+                "The Gateway target no longer exists on the gateway. "
+                "Re-save the tool to recreate it."
+            ],
+            healthy=False,
+        )
+    except (ClientError, RuntimeError) as e:
+        raise _raise_gateway_http(e)
+
+    return GatewayTargetStatusResponse(
+        target_id=info.target_id or target_id,
+        status=info.status,
+        status_reasons=info.status_reasons,
+        healthy=info.status.upper() == "READY",
+    )
 
 
 # =============================================================================

--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -494,7 +494,8 @@ class ToolCatalogService:
             and existing.mcp_gateway_config.target_id
         ):
             self._get_gateway_target_service().delete_target(
-                target_id=existing.mcp_gateway_config.target_id
+                target_id=existing.mcp_gateway_config.target_id,
+                config=existing.mcp_gateway_config,
             )
             target_deleted = True
 

--- a/backend/src/apis/shared/tools/gateway_identity.py
+++ b/backend/src/apis/shared/tools/gateway_identity.py
@@ -1,0 +1,80 @@
+"""Resolve the centralized AgentCore Gateway's identity from infra config.
+
+One source of truth for "which gateway." Both the admin-side
+``GatewayTargetService`` (which *registers* targets) and the agent-side gateway
+MCP client (which *connects* to list/call tools) MUST resolve the same gateway —
+otherwise targets an admin registers land on a gateway the agent never connects
+to, and the tools silently never appear.
+
+The gateway CDK construct publishes ``/{PROJECT_PREFIX}/gateway/id``; that SSM
+parameter is authoritative in a deployed environment. ``AGENTCORE_GATEWAY_ID``
+is only a local/CI escape hatch for when SSM isn't reachable (or
+``PROJECT_PREFIX`` differs) — not part of the normal cloud path.
+"""
+
+import os
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def _default_region(region: Optional[str]) -> str:
+    return (
+        region
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+    )
+
+
+def resolve_gateway_id(
+    *,
+    gateway_id: Optional[str] = None,
+    project_prefix: Optional[str] = None,
+    region: Optional[str] = None,
+    ssm_client: Any = None,
+) -> str:
+    """Resolve the AgentCore Gateway identifier from infra config.
+
+    Resolution order: an explicit ``gateway_id`` → the ``AGENTCORE_GATEWAY_ID``
+    env override (local/CI escape hatch) → the SSM parameter
+    ``/{PROJECT_PREFIX}/gateway/id`` (published by the gateway CDK construct;
+    authoritative in a deployed environment).
+
+    Raises:
+        RuntimeError: if the SSM parameter is unavailable and no override is set.
+    """
+    if gateway_id:
+        return gateway_id
+
+    env_override = os.environ.get("AGENTCORE_GATEWAY_ID")
+    if env_override:
+        return env_override
+
+    prefix = project_prefix or os.environ.get("PROJECT_PREFIX", "agentcore")
+    region = _default_region(region)
+    ssm = ssm_client or boto3.client("ssm", region_name=region)
+
+    param_name = f"/{prefix}/gateway/id"
+    try:
+        response = ssm.get_parameter(Name=param_name)
+    except ClientError as err:
+        raise RuntimeError(
+            f"Gateway id SSM parameter '{param_name}' is unavailable; is the "
+            f"gateway construct deployed (and PROJECT_PREFIX correct)? Set "
+            f"AGENTCORE_GATEWAY_ID to override for local/CI. ({err})"
+        ) from err
+
+    return response["Parameter"]["Value"]
+
+
+def gateway_url_from_id(gateway_id: str, region: Optional[str] = None) -> str:
+    """Build the gateway's MCP endpoint URL from its identifier.
+
+    AgentCore Gateway URLs are deterministic:
+    ``https://{id}.gateway.bedrock-agentcore.{region}.amazonaws.com/mcp``.
+    """
+    return (
+        f"https://{gateway_id}.gateway.bedrock-agentcore."
+        f"{_default_region(region)}.amazonaws.com/mcp"
+    )

--- a/backend/src/apis/shared/tools/gateway_lambda_grant.py
+++ b/backend/src/apis/shared/tools/gateway_lambda_grant.py
@@ -1,0 +1,150 @@
+"""Per-target Lambda invoke grants for AgentCore Gateway IAM targets.
+
+When an admin registers an `mcpServer` Gateway target backed by an IAM-protected
+Lambda Function URL, the gateway's execution role must be authorized to invoke
+that specific function. Instead of a standing wildcard on the gateway role
+(which forces an infra change per off-convention server), the platform grants
+the gateway role `InvokeFunctionUrl` on exactly the registered function via the
+function's resource policy (`lambda:AddPermission`) at registration, and revokes
+it on delete. Verified: a role-specific resource grant authorizes the gateway
+role on its own — no identity-side grant required (same-account).
+
+Same-account only. A cross-account function can't be auto-authorized by us; the
+caller gets an actionable error telling the admin to make the endpoint public or
+use a credential provider instead.
+"""
+
+import re
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Lambda Function URL host: https://<url-id>.lambda-url.<region>.on.aws/...
+_LAMBDA_URL_RE = re.compile(
+    r"^https://[a-z0-9]+\.lambda-url\.[a-z0-9-]+\.on\.aws", re.IGNORECASE
+)
+
+
+class GatewayLambdaGrantError(ValueError):
+    """The target Lambda can't be auto-authorized — message is admin-actionable."""
+
+
+_CROSS_ACCOUNT_HINT = (
+    "Cross-account Lambda targets can't be auto-authorized for the gateway — make "
+    "the Function URL public (AuthType=NONE) with outbound credential 'None', or "
+    "front it with an API-key/OAuth credential provider."
+)
+
+
+def is_lambda_function_url(endpoint_url: Optional[str]) -> bool:
+    """True if the endpoint is a Lambda Function URL (the auto-grant applies)."""
+    return bool(endpoint_url and _LAMBDA_URL_RE.match(endpoint_url))
+
+
+def statement_id_for(seed: str) -> str:
+    """Stable resource-policy Sid for a target, from a seed (its target name).
+
+    Derived from the target name (known before the target id exists, so the
+    grant can be placed *before* CreateGatewayTarget and the gateway's async
+    connect never races a missing permission). Sids allow only [A-Za-z0-9-_],
+    so non-conforming characters collapse to '-'.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_-]", "-", seed)
+    return f"agentcore-gw-{safe}"
+
+
+def _account_of_arn(arn: str) -> Optional[str]:
+    parts = arn.split(":")
+    return parts[4] if len(parts) >= 5 and parts[0] == "arn" else None
+
+
+def grant_gateway_invoke(
+    *,
+    function_name: str,
+    endpoint_url: str,
+    gateway_role_arn: str,
+    statement_seed: str,
+    region: str,
+    lambda_client: Any = None,
+    sts_client: Any = None,
+) -> None:
+    """Authorize the gateway role to `InvokeFunctionUrl` on `function_name`.
+
+    Validates the function is in THIS account and its Function URL matches
+    `endpoint_url`, then adds (idempotently) a resource-policy statement granting
+    the gateway role. Raises `GatewayLambdaGrantError` with an admin-actionable
+    message for the cross-account / not-found / url-mismatch cases.
+    """
+    lam = lambda_client or boto3.client("lambda", region_name=region)
+    statement_id = statement_id_for(statement_seed)
+
+    # A pasted cross-account ARN is detectable without an API call.
+    if function_name.startswith("arn:"):
+        acct = _account_of_arn(function_name)
+        this_acct = (
+            sts_client or boto3.client("sts", region_name=region)
+        ).get_caller_identity()["Account"]
+        if acct and acct != this_acct:
+            raise GatewayLambdaGrantError(
+                f"Lambda '{function_name}' is in account {acct}, not this account "
+                f"({this_acct}). {_CROSS_ACCOUNT_HINT}"
+            )
+
+    # Validate the function is ours and its URL matches what the admin entered.
+    try:
+        url_cfg = lam.get_function_url_config(FunctionName=function_name)
+    except ClientError as err:
+        code = err.response.get("Error", {}).get("Code")
+        if code in ("ResourceNotFoundException", "AccessDeniedException"):
+            raise GatewayLambdaGrantError(
+                f"Lambda '{function_name}' was not found in this account (or isn't "
+                f"accessible). {_CROSS_ACCOUNT_HINT}"
+            ) from err
+        raise
+
+    # GetFunctionUrlConfig returns the base URL (e.g. https://<id>.lambda-url
+    # .../) while the gateway endpoint includes a path (e.g. .../mcp), so the
+    # endpoint must be *under* the function's URL (same scheme+host), not equal.
+    configured = (url_cfg.get("FunctionUrl") or "").rstrip("/")
+    if configured and not endpoint_url.rstrip("/").startswith(configured):
+        raise GatewayLambdaGrantError(
+            f"The endpoint URL doesn't match the Function URL of '{function_name}' "
+            f"({configured}). Check the Lambda function name."
+        )
+
+    # Idempotent: drop any stale statement with our Sid, then (re)add.
+    try:
+        lam.remove_permission(FunctionName=function_name, StatementId=statement_id)
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
+            raise
+
+    lam.add_permission(
+        FunctionName=function_name,
+        StatementId=statement_id,
+        Action="lambda:InvokeFunctionUrl",
+        Principal=gateway_role_arn,
+        FunctionUrlAuthType="AWS_IAM",
+    )
+
+
+def revoke_gateway_invoke(
+    *,
+    function_name: str,
+    statement_seed: str,
+    region: str,
+    lambda_client: Any = None,
+) -> None:
+    """Remove the gateway-role grant for a target. Idempotent — a missing
+    statement (or a deleted function) is treated as already revoked so target
+    deletion never blocks on cleanup."""
+    lam = lambda_client or boto3.client("lambda", region_name=region)
+    try:
+        lam.remove_permission(
+            FunctionName=function_name,
+            StatementId=statement_id_for(statement_seed),
+        )
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
+            raise

--- a/backend/src/apis/shared/tools/gateway_target_service.py
+++ b/backend/src/apis/shared/tools/gateway_target_service.py
@@ -155,14 +155,17 @@ class GatewayTargetService:
                 the route can surface a 502 and log the failure.
         """
         gateway_id = self._resolve_gateway_id()
+        kwargs: Dict[str, Any] = {
+            "gatewayIdentifier": gateway_id,
+            "name": config.target_name,
+            "description": description or f"MCP gateway target {config.target_name}",
+            "targetConfiguration": self._build_target_configuration(config),
+        }
+        creds = self._build_credential_configs(config)
+        if creds is not None:
+            kwargs["credentialProviderConfigurations"] = creds
         try:
-            response = self._client.create_gateway_target(
-                gatewayIdentifier=gateway_id,
-                name=config.target_name,
-                description=description or f"MCP gateway target {config.target_name}",
-                targetConfiguration=self._build_target_configuration(config),
-                credentialProviderConfigurations=self._build_credential_configs(config),
-            )
+            response = self._client.create_gateway_target(**kwargs)
         except ClientError as err:
             code = err.response.get("Error", {}).get("Code")
             if code in ("ConflictException", "ResourceAlreadyExistsException"):
@@ -186,15 +189,18 @@ class GatewayTargetService:
             GatewayTargetNotFoundError: No such target.
         """
         gateway_id = self._resolve_gateway_id()
+        kwargs: Dict[str, Any] = {
+            "gatewayIdentifier": gateway_id,
+            "targetId": target_id,
+            "name": config.target_name,
+            "description": description or f"MCP gateway target {config.target_name}",
+            "targetConfiguration": self._build_target_configuration(config),
+        }
+        creds = self._build_credential_configs(config)
+        if creds is not None:
+            kwargs["credentialProviderConfigurations"] = creds
         try:
-            response = self._client.update_gateway_target(
-                gatewayIdentifier=gateway_id,
-                targetId=target_id,
-                name=config.target_name,
-                description=description or f"MCP gateway target {config.target_name}",
-                targetConfiguration=self._build_target_configuration(config),
-                credentialProviderConfigurations=self._build_credential_configs(config),
-            )
+            response = self._client.update_gateway_target(**kwargs)
         except ClientError as err:
             if self._is_not_found(err):
                 raise GatewayTargetNotFoundError(target_id) from err
@@ -284,17 +290,25 @@ class GatewayTargetService:
         }
 
     @staticmethod
-    def _build_credential_configs(config: MCPGatewayConfig) -> List[Dict[str, Any]]:
+    def _build_credential_configs(
+        config: MCPGatewayConfig,
+    ) -> Optional[List[Dict[str, Any]]]:
         """Build `credentialProviderConfigurations` from the credential type.
 
-        The `MCPGatewayConfig` validator already guarantees the ARN/listing
-        invariants per credential type, so this only shapes the payload.
+        Returns None for a public (NONE) endpoint so the caller omits the
+        parameter entirely. The `MCPGatewayConfig` validator already guarantees
+        the ARN / aws_service / listing invariants per credential type, so this
+        only shapes the payload.
         """
         cred_value = (
             config.credential_type
             if isinstance(config.credential_type, str)
             else config.credential_type.value
         )
+
+        if cred_value == GatewayCredentialType.NONE.value:
+            return None
+
         aws_type = _CREDENTIAL_TYPE_TO_AWS[cred_value]
 
         if cred_value == GatewayCredentialType.OAUTH.value:
@@ -330,9 +344,20 @@ class GatewayTargetService:
                     },
                 }
             ]
-        # GATEWAY_IAM_ROLE — the gateway signs with its own execution role; no
-        # nested credentialProvider is sent.
-        return [{"credentialProviderType": aws_type}]
+        # GATEWAY_IAM_ROLE — the gateway signs with its own execution role.
+        # mcpServer targets require an explicit iamCredentialProvider naming the
+        # AWS service to sign for (unlike OpenAPI/Lambda targets, which accept a
+        # bare GATEWAY_IAM_ROLE). region is optional — AWS defaults it to the
+        # gateway's region.
+        iam_provider: Dict[str, Any] = {"service": config.aws_service}
+        if config.aws_region:
+            iam_provider["region"] = config.aws_region
+        return [
+            {
+                "credentialProviderType": aws_type,
+                "credentialProvider": {"iamCredentialProvider": iam_provider},
+            }
+        ]
 
     # ----------------------------------------------------------- parse helpers
     @staticmethod

--- a/backend/src/apis/shared/tools/gateway_target_service.py
+++ b/backend/src/apis/shared/tools/gateway_target_service.py
@@ -18,12 +18,18 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
+from .gateway_identity import resolve_gateway_id
+from .gateway_lambda_grant import (
+    grant_gateway_invoke,
+    is_lambda_function_url,
+    revoke_gateway_invoke,
+)
 from .models import (
     GatewayCredentialType,
     GatewayListingMode,
@@ -67,6 +73,11 @@ class GatewayTargetInfo:
     gateway_arn: str
     status: str
     name: str
+    # Human-readable explanations from the gateway when a target is unhealthy
+    # (e.g. ["Failed to connect and fetch tools from the provided MCP target
+    # server. Error - Authorization error when sending message"]). Empty for a
+    # healthy target. Surfaced to admins so a FAILED sync isn't invisible.
+    status_reasons: List[str] = field(default_factory=list)
 
 
 class GatewayTargetNotFoundError(LookupError):
@@ -88,6 +99,7 @@ class GatewayTargetService:
         project_prefix: Optional[str] = None,
         client: Any = None,
         ssm_client: Any = None,
+        lambda_client: Any = None,
     ):
         self._region = (
             region
@@ -97,9 +109,15 @@ class GatewayTargetService:
         self._client = client or boto3.client(
             "bedrock-agentcore-control", region_name=self._region
         )
+        # Lazily-created `lambda` client for the per-target invoke grant; may be
+        # injected for tests.
+        self._lambda_client = lambda_client
         # `gateway_id` may be supplied directly (tests / callers that already
         # know it); otherwise it is resolved from SSM on first use and cached.
         self._gateway_id = gateway_id
+        # Gateway execution role ARN, resolved from GetGateway on first use and
+        # cached — the principal granted InvokeFunctionUrl on IAM Lambda targets.
+        self._gateway_role_arn: Optional[str] = None
         self._ssm_client = ssm_client
         self._project_prefix = project_prefix or os.environ.get(
             "PROJECT_PREFIX", "agentcore"
@@ -107,40 +125,93 @@ class GatewayTargetService:
 
     # ----------------------------------------------------- gateway id (SSM)
     def _resolve_gateway_id(self) -> str:
-        """Return the gateway identifier.
+        """Return the gateway identifier (resolved once and cached).
 
-        Resolution order: an explicit `gateway_id` (constructor) → the
-        `AGENTCORE_GATEWAY_ID` env override → the SSM parameter
-        `/{prefix}/gateway/id` (read once and cached). The construct publishes
-        the SSM parameter and app-api reads it at runtime, which sidesteps the
-        same-stack deploy-time ordering deadlock; the env override exists for
-        local dev / CI, where the SSM parameter may not be present (or the
-        `PROJECT_PREFIX` may differ) — set it to the gateway identifier from
-        the deployed stack's `GatewayId` output or `list-gateways`.
+        Delegates to the shared `resolve_gateway_id` so the admin-side service
+        and the agent-side gateway client resolve the SAME gateway — the env
+        override → SSM `/{prefix}/gateway/id` order lives in one place.
         """
         if self._gateway_id:
             return self._gateway_id
 
-        env_override = os.environ.get("AGENTCORE_GATEWAY_ID")
-        if env_override:
-            self._gateway_id = env_override
-            return env_override
-
         if self._ssm_client is None:
             self._ssm_client = boto3.client("ssm", region_name=self._region)
 
-        param_name = f"/{self._project_prefix}/gateway/id"
-        try:
-            response = self._ssm_client.get_parameter(Name=param_name)
-        except ClientError as err:
-            raise RuntimeError(
-                f"Gateway id SSM parameter '{param_name}' is unavailable; is the "
-                f"gateway construct deployed (and PROJECT_PREFIX correct)? Set "
-                f"AGENTCORE_GATEWAY_ID to override for local/CI. ({err})"
-            ) from err
-
-        self._gateway_id = response["Parameter"]["Value"]
+        self._gateway_id = resolve_gateway_id(
+            project_prefix=self._project_prefix,
+            region=self._region,
+            ssm_client=self._ssm_client,
+        )
         return self._gateway_id
+
+    # ----------------------------------------------- gateway role + Lambda grant
+    def _resolve_gateway_role_arn(self) -> str:
+        """Return the gateway execution role ARN (GetGateway, cached)."""
+        if self._gateway_role_arn:
+            return self._gateway_role_arn
+        gateway_id = self._resolve_gateway_id()
+        response = self._client.get_gateway(gatewayIdentifier=gateway_id)
+        role_arn = response.get("roleArn")
+        if not role_arn:
+            raise RuntimeError(
+                f"Gateway '{gateway_id}' has no roleArn; cannot authorize Lambda "
+                "targets for the gateway execution role."
+            )
+        self._gateway_role_arn = role_arn
+        return role_arn
+
+    @staticmethod
+    def _needs_lambda_grant(config: MCPGatewayConfig) -> bool:
+        """True for a GATEWAY_IAM_ROLE target on a Lambda Function URL with a
+        named function — the only case the per-target grant applies to."""
+        cred = (
+            config.credential_type
+            if isinstance(config.credential_type, str)
+            else config.credential_type.value
+        )
+        return (
+            cred == GatewayCredentialType.GATEWAY_IAM_ROLE.value
+            and is_lambda_function_url(config.endpoint_url)
+            and bool(config.lambda_function_name)
+        )
+
+    def _grant_lambda_if_needed(self, config: MCPGatewayConfig) -> None:
+        """Authorize the gateway role to invoke an IAM Lambda-URL target.
+
+        Called *before* Create/UpdateGatewayTarget so the permission exists
+        before the gateway's async connect (no race). No-op for non-Lambda /
+        non-IAM targets. Raises GatewayLambdaGrantError (→ 400 at the route) for
+        a cross-account or unresolvable function.
+        """
+        if not self._needs_lambda_grant(config):
+            return
+        if self._lambda_client is None:
+            self._lambda_client = boto3.client("lambda", region_name=self._region)
+        grant_gateway_invoke(
+            function_name=config.lambda_function_name,
+            endpoint_url=config.endpoint_url,
+            gateway_role_arn=self._resolve_gateway_role_arn(),
+            statement_seed=config.target_name,
+            region=self._region,
+            lambda_client=self._lambda_client,
+        )
+
+    def _revoke_lambda_if_needed(self, config: Optional[MCPGatewayConfig]) -> None:
+        """Best-effort removal of a target's gateway-role grant (idempotent)."""
+        if (
+            config is None
+            or not config.lambda_function_name
+            or not is_lambda_function_url(config.endpoint_url)
+        ):
+            return
+        if self._lambda_client is None:
+            self._lambda_client = boto3.client("lambda", region_name=self._region)
+        revoke_gateway_invoke(
+            function_name=config.lambda_function_name,
+            statement_seed=config.target_name,
+            region=self._region,
+            lambda_client=self._lambda_client,
+        )
 
     # ------------------------------------------------------------------ create
     def create_target(
@@ -155,6 +226,11 @@ class GatewayTargetService:
                 the route can surface a 502 and log the failure.
         """
         gateway_id = self._resolve_gateway_id()
+        # Authorize the gateway role to invoke the target BEFORE creating it, so
+        # the gateway's async connect+list never races a missing permission.
+        # A cross-account / unresolvable function raises here, before any target
+        # is created (no orphan).
+        self._grant_lambda_if_needed(config)
         kwargs: Dict[str, Any] = {
             "gatewayIdentifier": gateway_id,
             "name": config.target_name,
@@ -189,6 +265,8 @@ class GatewayTargetService:
             GatewayTargetNotFoundError: No such target.
         """
         gateway_id = self._resolve_gateway_id()
+        # Re-grant before the update re-validates the target (idempotent).
+        self._grant_lambda_if_needed(config)
         kwargs: Dict[str, Any] = {
             "gatewayIdentifier": gateway_id,
             "targetId": target_id,
@@ -230,12 +308,18 @@ class GatewayTargetService:
         return self._info_from_response(response, fallback_target_id=target_id)
 
     # ------------------------------------------------------------------ delete
-    def delete_target(self, *, target_id: str) -> None:
+    def delete_target(
+        self, *, target_id: str, config: Optional[MCPGatewayConfig] = None
+    ) -> None:
         """Delete the target. A missing target is treated as success.
 
         The route deletes the AWS target before the catalog row, so a 404 here
         means the row's reconciliation is already done — log loudly (this is the
         manual-repair signal in v1) and return.
+
+        When `config` is supplied (the stored gateway config), the per-target
+        Lambda invoke grant is revoked too, so the gateway role's authorization
+        on that function is torn down with the target it was created for.
         """
         gateway_id = self._resolve_gateway_id()
         try:
@@ -250,8 +334,11 @@ class GatewayTargetService:
                     target_id,
                     gateway_id,
                 )
-                return
-            raise
+            else:
+                raise
+        # Revoke the gateway-role grant regardless of whether the target existed
+        # (idempotent) so we never leave a dangling resource-policy statement.
+        self._revoke_lambda_if_needed(config)
 
     # -------------------------------------------------------------------- list
     def list_targets(self) -> List[GatewayTargetInfo]:
@@ -373,6 +460,9 @@ class GatewayTargetService:
             gateway_arn=response.get("gatewayArn") or fallback_gateway_arn,
             status=response.get("status", ""),
             name=response.get("name") or fallback_name,
+            # `statusReasons` is present on get/update responses for an
+            # unhealthy target; the list-summary shape may omit it.
+            status_reasons=list(response.get("statusReasons") or []),
         )
 
     @staticmethod

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -307,6 +307,15 @@ class MCPGatewayConfig(BaseModel):
         description="AWS region for SigV4 signing (GATEWAY_IAM_ROLE only); "
         "defaults to the gateway's region when omitted",
     )
+    lambda_function_name: Optional[str] = Field(
+        None,
+        description="Name (or ARN) of the Lambda backing the endpoint, for a "
+        "GATEWAY_IAM_ROLE target on a Lambda Function URL. Lets the platform "
+        "grant the gateway role InvokeFunctionUrl on exactly this function at "
+        "registration (lambda:AddPermission) instead of a standing wildcard. "
+        "Same-account only; cross-account targets must be public or use a "
+        "credential provider.",
+    )
     oauth_scopes: List[str] = Field(
         default_factory=list,
         description="OAuth scopes requested for OAUTH credential type",
@@ -393,6 +402,7 @@ class MCPGatewayConfig(BaseModel):
             "credentialProviderArn": self.credential_provider_arn,
             "awsService": self.aws_service,
             "awsRegion": self.aws_region,
+            "lambdaFunctionName": self.lambda_function_name,
             "oauthScopes": list(self.oauth_scopes),
             "grantType": self.grant_type
             if isinstance(self.grant_type, str)
@@ -416,6 +426,7 @@ class MCPGatewayConfig(BaseModel):
             credential_provider_arn=data.get("credentialProviderArn"),
             aws_service=data.get("awsService"),
             aws_region=data.get("awsRegion"),
+            lambda_function_name=data.get("lambdaFunctionName"),
             oauth_scopes=data.get("oauthScopes") or [],
             grant_type=data.get(
                 "grantType", GatewayOAuthGrantType.AUTHORIZATION_CODE
@@ -947,6 +958,7 @@ class MCPGatewayConfigRequest(BaseModel):
     )
     aws_service: Optional[str] = Field(None, alias="awsService")
     aws_region: Optional[str] = Field(None, alias="awsRegion")
+    lambda_function_name: Optional[str] = Field(None, alias="lambdaFunctionName")
     oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
     grant_type: GatewayOAuthGrantType = Field(
         default=GatewayOAuthGrantType.AUTHORIZATION_CODE, alias="grantType"
@@ -968,6 +980,7 @@ class MCPGatewayConfigRequest(BaseModel):
             credential_provider_arn=self.credential_provider_arn,
             aws_service=self.aws_service,
             aws_region=self.aws_region,
+            lambda_function_name=self.lambda_function_name,
             oauth_scopes=self.oauth_scopes,
             grant_type=self.grant_type,
             custom_parameters=self.custom_parameters,
@@ -1148,6 +1161,7 @@ class MCPGatewayConfigResponse(BaseModel):
     )
     aws_service: Optional[str] = Field(None, alias="awsService")
     aws_region: Optional[str] = Field(None, alias="awsRegion")
+    lambda_function_name: Optional[str] = Field(None, alias="lambdaFunctionName")
     oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
     grant_type: str = Field(..., alias="grantType")
     custom_parameters: Optional[Dict[str, str]] = Field(
@@ -1174,6 +1188,7 @@ class MCPGatewayConfigResponse(BaseModel):
             credential_provider_arn=config.credential_provider_arn,
             aws_service=config.aws_service,
             aws_region=config.aws_region,
+            lambda_function_name=config.lambda_function_name,
             oauth_scopes=list(config.oauth_scopes),
             grant_type=config.grant_type
             if isinstance(config.grant_type, str)
@@ -1333,5 +1348,25 @@ class MCPDiscoverResponse(BaseModel):
     """Response body for POST /api/admin/tools/discover."""
 
     tools: List[DiscoveredMCPTool]
+
+
+class GatewayTargetStatusResponse(BaseModel):
+    """Live health of the Gateway target backing a protocol='mcp' tool.
+
+    Response body for GET /api/admin/tools/{tool_id}/gateway-status. The
+    AgentCore Gateway connects to and lists tools from the target
+    asynchronously after registration, so the catalog row alone can't tell an
+    admin whether the target is usable. `status` is the gateway target status
+    (CREATING / READY / FAILED / UPDATE_UNSUCCESSFUL / …); `status_reasons`
+    carries the gateway's explanation when unhealthy. `MISSING` is a synthetic
+    status used when the catalog references a target that no longer exists on
+    the gateway. `healthy` is a convenience the badge can render directly."""
+
+    target_id: str = Field(..., alias="targetId")
+    status: str
+    status_reasons: List[str] = Field(default_factory=list, alias="statusReasons")
+    healthy: bool
+
+    model_config = {"populate_by_name": True}
 
 

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -82,11 +82,15 @@ class GatewayCredentialType(str, Enum):
     """How the Gateway authenticates outbound to a target's MCP endpoint.
 
     Maps to the `bedrock-agentcore-control` `credentialProviderType` enum.
-    GATEWAY_IAM_ROLE signs with the gateway's own execution role (SigV4, no
-    ARN); OAUTH and API_KEY reference an existing AgentCore credential
-    provider by ARN (provider provisioning is out of scope in v1).
+    NONE registers a public endpoint with no outbound credentials (the API's
+    `credentialProviderConfigurations` is omitted). GATEWAY_IAM_ROLE signs with
+    the gateway's own execution role (SigV4) — for an mcpServer target this
+    requires an explicit `iamCredentialProvider` naming the AWS service to sign
+    for (see `aws_service`). OAUTH and API_KEY reference an existing AgentCore
+    credential provider by ARN (provider provisioning is out of scope in v1).
     """
 
+    NONE = "none"
     GATEWAY_IAM_ROLE = "gateway_iam_role"
     OAUTH = "oauth"
     API_KEY = "api_key"
@@ -284,13 +288,24 @@ class MCPGatewayConfig(BaseModel):
 
     # Outbound auth from the Gateway to the target
     credential_type: GatewayCredentialType = Field(
-        default=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        default=GatewayCredentialType.NONE,
         description="How the Gateway authenticates to the target endpoint",
     )
     credential_provider_arn: Optional[str] = Field(
         None,
         description="ARN of an existing AgentCore credential provider "
-        "(required for OAUTH and API_KEY; unused for GATEWAY_IAM_ROLE)",
+        "(required for OAUTH and API_KEY; unused for the others)",
+    )
+    aws_service: Optional[str] = Field(
+        None,
+        description="AWS service name for SigV4 signing (required for "
+        "GATEWAY_IAM_ROLE on an mcpServer target, e.g. 'lambda', 'execute-api', "
+        "'bedrock-agentcore'); unused for other credential types",
+    )
+    aws_region: Optional[str] = Field(
+        None,
+        description="AWS region for SigV4 signing (GATEWAY_IAM_ROLE only); "
+        "defaults to the gateway's region when omitted",
     )
     oauth_scopes: List[str] = Field(
         default_factory=list,
@@ -355,6 +370,13 @@ class MCPGatewayConfig(BaseModel):
                     "credential_type 'gateway_iam_role' signs with the gateway "
                     "execution role and must not set credential_provider_arn"
                 )
+            if not self.aws_service:
+                raise ValueError(
+                    "credential_type 'gateway_iam_role' requires aws_service "
+                    "(the AWS service name for SigV4 signing, e.g. 'lambda', "
+                    "'execute-api', 'bedrock-agentcore') — an mcpServer target's "
+                    "IAM credential provider must name the service to sign for"
+                )
         return self
 
     def to_dict(self) -> dict:
@@ -369,6 +391,8 @@ class MCPGatewayConfig(BaseModel):
             if isinstance(self.credential_type, str)
             else self.credential_type.value,
             "credentialProviderArn": self.credential_provider_arn,
+            "awsService": self.aws_service,
+            "awsRegion": self.aws_region,
             "oauthScopes": list(self.oauth_scopes),
             "grantType": self.grant_type
             if isinstance(self.grant_type, str)
@@ -387,9 +411,11 @@ class MCPGatewayConfig(BaseModel):
             endpoint_url=data.get("endpointUrl", ""),
             listing_mode=data.get("listingMode", GatewayListingMode.DEFAULT),
             credential_type=data.get(
-                "credentialType", GatewayCredentialType.GATEWAY_IAM_ROLE
+                "credentialType", GatewayCredentialType.NONE
             ),
             credential_provider_arn=data.get("credentialProviderArn"),
+            aws_service=data.get("awsService"),
+            aws_region=data.get("awsRegion"),
             oauth_scopes=data.get("oauthScopes") or [],
             grant_type=data.get(
                 "grantType", GatewayOAuthGrantType.AUTHORIZATION_CODE
@@ -914,11 +940,13 @@ class MCPGatewayConfigRequest(BaseModel):
         default=GatewayListingMode.DEFAULT, alias="listingMode"
     )
     credential_type: GatewayCredentialType = Field(
-        default=GatewayCredentialType.GATEWAY_IAM_ROLE, alias="credentialType"
+        default=GatewayCredentialType.NONE, alias="credentialType"
     )
     credential_provider_arn: Optional[str] = Field(
         None, alias="credentialProviderArn"
     )
+    aws_service: Optional[str] = Field(None, alias="awsService")
+    aws_region: Optional[str] = Field(None, alias="awsRegion")
     oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
     grant_type: GatewayOAuthGrantType = Field(
         default=GatewayOAuthGrantType.AUTHORIZATION_CODE, alias="grantType"
@@ -938,6 +966,8 @@ class MCPGatewayConfigRequest(BaseModel):
             listing_mode=self.listing_mode,
             credential_type=self.credential_type,
             credential_provider_arn=self.credential_provider_arn,
+            aws_service=self.aws_service,
+            aws_region=self.aws_region,
             oauth_scopes=self.oauth_scopes,
             grant_type=self.grant_type,
             custom_parameters=self.custom_parameters,
@@ -1116,6 +1146,8 @@ class MCPGatewayConfigResponse(BaseModel):
     credential_provider_arn: Optional[str] = Field(
         None, alias="credentialProviderArn"
     )
+    aws_service: Optional[str] = Field(None, alias="awsService")
+    aws_region: Optional[str] = Field(None, alias="awsRegion")
     oauth_scopes: List[str] = Field(default_factory=list, alias="oauthScopes")
     grant_type: str = Field(..., alias="grantType")
     custom_parameters: Optional[Dict[str, str]] = Field(
@@ -1140,6 +1172,8 @@ class MCPGatewayConfigResponse(BaseModel):
             if isinstance(config.credential_type, str)
             else config.credential_type.value,
             credential_provider_arn=config.credential_provider_arn,
+            aws_service=config.aws_service,
+            aws_region=config.aws_region,
             oauth_scopes=list(config.oauth_scopes),
             grant_type=config.grant_type
             if isinstance(config.grant_type, str)

--- a/backend/tests/agents/main_agent/tools/test_gateway_integration.py
+++ b/backend/tests/agents/main_agent/tools/test_gateway_integration.py
@@ -1,0 +1,87 @@
+"""Tests for gateway tool-id expansion (#419 Blocker 2).
+
+A protocol='mcp' catalog tool carries one id (`gateway_class_search`), but the
+AgentCore Gateway exposes its target's tools as `<targetName>___<toolName>`.
+`expand_gateway_tool_ids` bridges the two so the agent's FilteredMCPClient can
+match them; without it, an enabled #419 tool is silently dropped.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agents.main_agent.tools.gateway_integration import expand_gateway_tool_ids
+
+
+class _FakeRepo:
+    """Minimal async tool-catalog repository for the expansion helper."""
+
+    def __init__(self, tools: dict):
+        self._tools = tools
+
+    async def get_tool(self, tool_id: str):
+        return self._tools.get(tool_id)
+
+
+def _gateway_tool(target_name: str, tool_names: list[str]):
+    return SimpleNamespace(
+        protocol="mcp",
+        mcp_gateway_config=SimpleNamespace(
+            target_name=target_name,
+            tools=[SimpleNamespace(name=n) for n in tool_names],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_expands_catalog_tool_to_runtime_ids():
+    repo = _FakeRepo(
+        {"gateway_class_search": _gateway_tool("gateway-class-search", ["search_classes", "get_class_details"])}
+    )
+    out = await expand_gateway_tool_ids(["gateway_class_search"], repo)
+    assert out == [
+        "gateway_gateway-class-search___search_classes",
+        "gateway_gateway-class-search___get_class_details",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_ids_pass_through_without_lookup():
+    # A raw `___` id is already runtime — must not even hit the repo.
+    class _BoomRepo:
+        async def get_tool(self, tool_id):  # pragma: no cover - must not run
+            raise AssertionError("should not look up a runtime id")
+
+    out = await expand_gateway_tool_ids(
+        ["gateway_wikipedia-search___wikipedia_search"], _BoomRepo()
+    )
+    assert out == ["gateway_wikipedia-search___wikipedia_search"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_and_empty_tool_list_pass_through():
+    repo = _FakeRepo(
+        {
+            # catalog tool with no curated tools (e.g. DYNAMIC listing)
+            "gateway_empty": _gateway_tool("some-target", []),
+        }
+    )
+    out = await expand_gateway_tool_ids(["gateway_empty", "gateway_unknown"], repo)
+    assert out == ["gateway_empty", "gateway_unknown"]
+
+
+@pytest.mark.asyncio
+async def test_dedupes_preserving_order():
+    repo = _FakeRepo(
+        {
+            "gateway_a": _gateway_tool("t", ["one", "two"]),
+            # second catalog tool repeats one runtime id
+            "gateway_b": _gateway_tool("t", ["two", "three"]),
+        }
+    )
+    out = await expand_gateway_tool_ids(["gateway_a", "gateway_b"], repo)
+    assert out == [
+        "gateway_t___one",
+        "gateway_t___two",
+        "gateway_t___three",
+    ]

--- a/backend/tests/apis/app_api/admin/tools/test_discover_errors.py
+++ b/backend/tests/apis/app_api/admin/tools/test_discover_errors.py
@@ -1,0 +1,76 @@
+"""Tests for the MCP discovery error-translation helpers.
+
+The `/admin/tools/discover` route connects to an arbitrary MCP server and lists
+its tools. When the target rejects the request, Strands buries the real HTTP
+status inside an `MCPClientInitializationError` → `ExceptionGroup` chain; these
+helpers recover it and map it to an actionable response (instead of a blanket
+502). See `apis/app_api/admin/tools/routes.py`.
+"""
+
+import httpx
+import pytest
+
+from apis.app_api.admin.tools.routes import (
+    _discovery_failure_detail,
+    _find_upstream_http_error,
+    _response_status_for_upstream,
+)
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://x.lambda-url.us-west-2.on.aws/mcp")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def test_find_upstream_http_error_unwraps_exception_group():
+    """The httpx error is recovered from a nested ExceptionGroup + cause chain,
+    mirroring how Strands' MCPClient wraps a target's HTTP rejection."""
+    http_err = _http_status_error(403)
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [http_err])
+
+    class MCPClientInitializationError(Exception):
+        pass
+
+    try:
+        raise MCPClientInitializationError("the client initialization failed") from group
+    except MCPClientInitializationError as exc:
+        found = _find_upstream_http_error(exc)
+
+    assert found is http_err
+    assert found.response.status_code == 403
+
+
+def test_find_upstream_http_error_returns_none_without_http_error():
+    """A non-HTTP failure (e.g. a connection error) yields None so the caller
+    falls back to a generic 502."""
+    try:
+        raise TimeoutError("connect timed out")
+    except TimeoutError as exc:
+        assert _find_upstream_http_error(exc) is None
+
+
+@pytest.mark.parametrize(
+    "upstream,expected",
+    [
+        (403, 403),  # echoed — actionable config error
+        (404, 404),  # echoed — wrong path
+        (401, 400),  # remapped — a bare 401 would trip the SPA's logout/redirect
+        (500, 502),  # upstream server error — we are a failing gateway
+        (503, 502),
+    ],
+)
+def test_response_status_for_upstream(upstream, expected):
+    assert _response_status_for_upstream(upstream) == expected
+
+
+def test_discovery_failure_detail_mentions_credential_for_403():
+    detail = _discovery_failure_detail(403)
+    assert "403" in detail
+    assert "Gateway IAM Role" in detail
+
+
+def test_discovery_failure_detail_mentions_oauth_for_401():
+    detail = _discovery_failure_detail(401)
+    assert "401" in detail
+    assert "OAuth" in detail

--- a/backend/tests/apis/app_api/tools/test_tool_catalog_service_gateway.py
+++ b/backend/tests/apis/app_api/tools/test_tool_catalog_service_gateway.py
@@ -239,7 +239,11 @@ class TestDelete:
         ok = await _service(repo, gw).delete_tool("gw_weather", _admin(), soft=False)
 
         assert ok is True
-        gw.delete_target.assert_called_once_with(target_id="TGT1")
+        # Passes the stored config so the service can revoke the target's
+        # gateway-role Lambda grant alongside deleting the target.
+        gw.delete_target.assert_called_once_with(
+            target_id="TGT1", config=existing.mcp_gateway_config
+        )
         repo.delete_tool.assert_called_once_with("gw_weather")
 
     @pytest.mark.asyncio

--- a/backend/tests/shared/test_gateway_identity.py
+++ b/backend/tests/shared/test_gateway_identity.py
@@ -1,0 +1,60 @@
+"""Tests for shared gateway-identity resolution.
+
+One source of truth for "which gateway" — the admin-side GatewayTargetService
+and the agent-side gateway client both resolve through here so they can never
+diverge (the bug that left admin-registered targets on a gateway the agent never
+connected to).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from apis.shared.tools.gateway_identity import (
+    gateway_url_from_id,
+    resolve_gateway_id,
+)
+
+
+def _ssm(value="gw-from-ssm"):
+    ssm = MagicMock()
+    ssm.get_parameter.return_value = {"Parameter": {"Value": value}}
+    return ssm
+
+
+def test_explicit_gateway_id_wins_and_skips_ssm():
+    ssm = _ssm()
+    assert resolve_gateway_id(gateway_id="gw-explicit", ssm_client=ssm) == "gw-explicit"
+    ssm.get_parameter.assert_not_called()
+
+
+def test_env_override_skips_ssm(monkeypatch):
+    monkeypatch.setenv("AGENTCORE_GATEWAY_ID", "gw-from-env")
+    ssm = _ssm()
+    assert resolve_gateway_id(project_prefix="myproj", ssm_client=ssm) == "gw-from-env"
+    ssm.get_parameter.assert_not_called()
+
+
+def test_resolves_from_ssm_infra_param(monkeypatch):
+    monkeypatch.delenv("AGENTCORE_GATEWAY_ID", raising=False)
+    ssm = _ssm("dev-boisestateai-v2-mcp-gateway-abc123")
+    out = resolve_gateway_id(project_prefix="dev-boisestateai-v2", ssm_client=ssm)
+    assert out == "dev-boisestateai-v2-mcp-gateway-abc123"
+    ssm.get_parameter.assert_called_once_with(Name="/dev-boisestateai-v2/gateway/id")
+
+
+def test_missing_ssm_param_raises_runtime_error(monkeypatch):
+    monkeypatch.delenv("AGENTCORE_GATEWAY_ID", raising=False)
+    ssm = MagicMock()
+    ssm.get_parameter.side_effect = ClientError(
+        {"Error": {"Code": "ParameterNotFound", "Message": "x"}}, "GetParameter"
+    )
+    with pytest.raises(RuntimeError, match="gateway construct deployed"):
+        resolve_gateway_id(project_prefix="myproj", ssm_client=ssm)
+
+
+def test_gateway_url_from_id_is_deterministic():
+    assert gateway_url_from_id("gw-xyz", region="us-west-2") == (
+        "https://gw-xyz.gateway.bedrock-agentcore.us-west-2.amazonaws.com/mcp"
+    )

--- a/backend/tests/shared/test_gateway_lambda_grant.py
+++ b/backend/tests/shared/test_gateway_lambda_grant.py
@@ -1,0 +1,117 @@
+"""Tests for the per-target Lambda invoke grant (#419 admin self-service)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from apis.shared.tools.gateway_lambda_grant import (
+    GatewayLambdaGrantError,
+    grant_gateway_invoke,
+    is_lambda_function_url,
+    revoke_gateway_invoke,
+    statement_id_for,
+)
+
+ROLE = "arn:aws:iam::111122223333:role/gw-role"
+URL = "https://abc123.lambda-url.us-west-2.on.aws/mcp"
+# GetFunctionUrlConfig returns the *base* URL (no path) — the endpoint adds /mcp.
+BASE_URL = "https://abc123.lambda-url.us-west-2.on.aws/"
+
+
+def _client_error(code):
+    return ClientError({"Error": {"Code": code, "Message": code}}, "Op")
+
+
+def _lambda(url=BASE_URL):
+    lam = MagicMock()
+    lam.get_function_url_config.return_value = {"FunctionUrl": url}
+    # First-time grant: no prior statement to remove.
+    lam.remove_permission.side_effect = _client_error("ResourceNotFoundException")
+    return lam
+
+
+def test_is_lambda_function_url():
+    assert is_lambda_function_url(URL) is True
+    assert is_lambda_function_url("https://x.execute-api.us-west-2.amazonaws.com/p") is False
+    assert is_lambda_function_url("") is False
+    assert is_lambda_function_url(None) is False
+
+
+def test_statement_id_sanitizes():
+    assert statement_id_for("gateway-class-search") == "agentcore-gw-gateway-class-search"
+    # disallowed chars collapse to '-'
+    assert statement_id_for("a b/c") == "agentcore-gw-a-b-c"
+
+
+def test_grant_adds_role_principal_resource_grant():
+    lam = _lambda()
+    grant_gateway_invoke(
+        function_name="mcp-class-search-dev",
+        endpoint_url=URL,
+        gateway_role_arn=ROLE,
+        statement_seed="gateway-class-search",
+        region="us-west-2",
+        lambda_client=lam,
+    )
+    lam.add_permission.assert_called_once_with(
+        FunctionName="mcp-class-search-dev",
+        StatementId="agentcore-gw-gateway-class-search",
+        Action="lambda:InvokeFunctionUrl",
+        Principal=ROLE,
+        FunctionUrlAuthType="AWS_IAM",
+    )
+
+
+def test_grant_is_idempotent_removes_stale_statement_first():
+    lam = _lambda()
+    lam.remove_permission.side_effect = None  # a prior statement exists
+    grant_gateway_invoke(
+        function_name="fn", endpoint_url=URL, gateway_role_arn=ROLE,
+        statement_seed="t", region="us-west-2", lambda_client=lam,
+    )
+    lam.remove_permission.assert_called_once()
+    lam.add_permission.assert_called_once()
+
+
+def test_grant_rejects_cross_account_arn():
+    lam = _lambda()
+    sts = MagicMock()
+    sts.get_caller_identity.return_value = {"Account": "111122223333"}
+    with pytest.raises(GatewayLambdaGrantError, match="Cross-account"):
+        grant_gateway_invoke(
+            function_name="arn:aws:lambda:us-west-2:999988887777:function:foo",
+            endpoint_url=URL, gateway_role_arn=ROLE, statement_seed="t",
+            region="us-west-2", lambda_client=lam, sts_client=sts,
+        )
+    lam.add_permission.assert_not_called()
+
+
+def test_grant_rejects_function_not_in_account():
+    lam = MagicMock()
+    lam.get_function_url_config.side_effect = _client_error("ResourceNotFoundException")
+    with pytest.raises(GatewayLambdaGrantError, match="not found in this account"):
+        grant_gateway_invoke(
+            function_name="ghost", endpoint_url=URL, gateway_role_arn=ROLE,
+            statement_seed="t", region="us-west-2", lambda_client=lam,
+        )
+
+
+def test_grant_rejects_url_mismatch():
+    lam = _lambda(url="https://OTHER.lambda-url.us-west-2.on.aws/")
+    with pytest.raises(GatewayLambdaGrantError, match="doesn't match"):
+        grant_gateway_invoke(
+            function_name="fn", endpoint_url=URL, gateway_role_arn=ROLE,
+            statement_seed="t", region="us-west-2", lambda_client=lam,
+        )
+
+
+def test_revoke_removes_statement_and_tolerates_missing():
+    lam = MagicMock()
+    revoke_gateway_invoke(function_name="fn", statement_seed="t", region="us-west-2", lambda_client=lam)
+    lam.remove_permission.assert_called_once_with(
+        FunctionName="fn", StatementId="agentcore-gw-t"
+    )
+    # A missing statement is swallowed (idempotent).
+    lam.remove_permission.side_effect = _client_error("ResourceNotFoundException")
+    revoke_gateway_invoke(function_name="fn", statement_seed="t", region="us-west-2", lambda_client=lam)

--- a/backend/tests/shared/test_gateway_target_service.py
+++ b/backend/tests/shared/test_gateway_target_service.py
@@ -259,6 +259,22 @@ class TestGetTarget:
         )
         assert info.target_id == "TGT1"
         assert info.status == "READY"
+        # A healthy target reports no reasons.
+        assert info.status_reasons == []
+
+    def test_get_captures_status_reasons_for_failed_target(self, service, boto_client):
+        """A FAILED target's statusReasons must be surfaced so the admin UI can
+        explain the failure instead of leaving it invisible (issue #419 UX)."""
+        reason = (
+            "Failed to connect and fetch tools from the provided MCP target "
+            "server. Error - Authorization error when sending message"
+        )
+        boto_client.get_gateway_target.return_value = _create_response(
+            status="FAILED", statusReasons=[reason]
+        )
+        info = service.get_target(target_id="TGT1")
+        assert info.status == "FAILED"
+        assert info.status_reasons == [reason]
 
     def test_get_not_found_raises(self, service, boto_client):
         boto_client.get_gateway_target.side_effect = _client_error(
@@ -338,4 +354,56 @@ class TestGatewayIdResolution:
         assert (
             boto_client.create_gateway_target.call_args.kwargs["gatewayIdentifier"]
             == "gw-from-env"
+        )
+
+
+class TestLambdaGrant:
+    """Per-target gateway-role InvokeFunctionUrl grant (#419 admin self-service)."""
+
+    LAMBDA_URL = "https://abc123.lambda-url.us-west-2.on.aws/mcp"
+
+    def _lambda(self):
+        lam = MagicMock()
+        lam.get_function_url_config.return_value = {"FunctionUrl": self.LAMBDA_URL}
+        lam.remove_permission.side_effect = _client_error("ResourceNotFoundException")
+        return lam
+
+    def test_create_grants_role_before_creating_target(self, boto_client):
+        boto_client.get_gateway.return_value = {"roleArn": "arn:aws:iam::1:role/gw"}
+        boto_client.create_gateway_target.return_value = _create_response()
+        lam = self._lambda()
+        svc = GatewayTargetService(
+            client=boto_client, gateway_id="gw-test-id", lambda_client=lam
+        )
+        svc.create_target(
+            _iam_config(endpoint_url=self.LAMBDA_URL, lambda_function_name="mcp-foo-dev")
+        )
+        # Grant names the gateway role on exactly the target function...
+        lam.add_permission.assert_called_once()
+        assert lam.add_permission.call_args.kwargs["Principal"] == "arn:aws:iam::1:role/gw"
+        assert lam.add_permission.call_args.kwargs["Action"] == "lambda:InvokeFunctionUrl"
+        # ...and the target is still created.
+        boto_client.create_gateway_target.assert_called_once()
+
+    def test_non_lambda_iam_target_skips_grant(self, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        lam = MagicMock()
+        svc = GatewayTargetService(
+            client=boto_client, gateway_id="gw-test-id", lambda_client=lam
+        )
+        svc.create_target(_iam_config())  # endpoint is example.com, not a Lambda URL
+        lam.add_permission.assert_not_called()
+        boto_client.get_gateway.assert_not_called()
+
+    def test_delete_revokes_grant(self, boto_client):
+        lam = MagicMock()
+        svc = GatewayTargetService(
+            client=boto_client, gateway_id="gw-test-id", lambda_client=lam
+        )
+        cfg = _iam_config(
+            endpoint_url=self.LAMBDA_URL, lambda_function_name="mcp-foo-dev"
+        )
+        svc.delete_target(target_id="TGT1", config=cfg)
+        lam.remove_permission.assert_called_once_with(
+            FunctionName="mcp-foo-dev", StatementId="agentcore-gw-weather-target"
         )

--- a/backend/tests/shared/test_gateway_target_service.py
+++ b/backend/tests/shared/test_gateway_target_service.py
@@ -49,6 +49,7 @@ def _iam_config(**overrides) -> MCPGatewayConfig:
         endpoint_url="https://example.com/mcp",
         listing_mode=GatewayListingMode.DEFAULT,
         credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+        aws_service="lambda",
         tools=[MCPToolEntry(name="get_forecast")],
     )
     base.update(overrides)
@@ -95,7 +96,10 @@ class TestCreateTarget:
             }
         }
         assert kwargs["credentialProviderConfigurations"] == [
-            {"credentialProviderType": "GATEWAY_IAM_ROLE"}
+            {
+                "credentialProviderType": "GATEWAY_IAM_ROLE",
+                "credentialProvider": {"iamCredentialProvider": {"service": "lambda"}},
+            }
         ]
         # gateway id was read from /{prefix}/gateway/id
         ssm_client.get_parameter.assert_called_once_with(Name="/myproj/gateway/id")
@@ -177,6 +181,28 @@ class TestCreateTarget:
                 },
             }
         ]
+
+    def test_iam_includes_region_when_set(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        service.create_target(_iam_config(aws_service="execute-api", aws_region="us-east-1"))
+        iam = boto_client.create_gateway_target.call_args.kwargs[
+            "credentialProviderConfigurations"
+        ][0]["credentialProvider"]["iamCredentialProvider"]
+        assert iam == {"service": "execute-api", "region": "us-east-1"}
+
+    def test_none_credential_omits_configs(self, service, boto_client):
+        boto_client.create_gateway_target.return_value = _create_response()
+        config = MCPGatewayConfig(
+            target_name="public-target",
+            endpoint_url="https://public.example.com/mcp",
+            credential_type=GatewayCredentialType.NONE,
+        )
+        service.create_target(config)
+        # A public endpoint omits credentialProviderConfigurations entirely.
+        assert (
+            "credentialProviderConfigurations"
+            not in boto_client.create_gateway_target.call_args.kwargs
+        )
 
     def test_dynamic_listing_maps_to_uppercase(self, service, boto_client):
         boto_client.create_gateway_target.return_value = _create_response()

--- a/backend/tests/shared/test_tools_gateway_config.py
+++ b/backend/tests/shared/test_tools_gateway_config.py
@@ -33,6 +33,8 @@ class TestMCPGatewayConfigSerialization:
             endpoint_url="https://example.com/mcp",
             listing_mode=GatewayListingMode.DEFAULT,
             credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+            aws_service="lambda",
+            aws_region="us-west-2",
             tools=[
                 MCPToolEntry(name="get_forecast", needs_approval=False),
                 MCPToolEntry(name="set_alert", needs_approval=True, description="writes"),
@@ -47,6 +49,8 @@ class TestMCPGatewayConfigSerialization:
         assert data["listingMode"] == "default"
         assert data["credentialType"] == "gateway_iam_role"
         assert data["credentialProviderArn"] is None
+        assert data["awsService"] == "lambda"
+        assert data["awsRegion"] == "us-west-2"
         assert data["targetId"] == "TGT123"
         assert data["gatewayArn"].endswith("gateway/gw-abc")
         assert [t["name"] for t in data["tools"]] == ["get_forecast", "set_alert"]
@@ -55,6 +59,7 @@ class TestMCPGatewayConfigSerialization:
         assert restored.target_name == "weather-target"
         assert restored.listing_mode == GatewayListingMode.DEFAULT
         assert restored.credential_type == GatewayCredentialType.GATEWAY_IAM_ROLE
+        assert restored.aws_service == "lambda"
         assert restored.target_id == "TGT123"
         assert restored.gateway_arn == config.gateway_arn
         assert restored.approval_required_names() == {"set_alert"}
@@ -106,7 +111,8 @@ class TestMCPGatewayConfigSerialization:
             }
         )
         assert restored.listing_mode == GatewayListingMode.DEFAULT
-        assert restored.credential_type == GatewayCredentialType.GATEWAY_IAM_ROLE
+        # Default credential type is NONE (public) — the least-config path.
+        assert restored.credential_type == GatewayCredentialType.NONE
         assert [t.name for t in restored.tools] == ["alpha", "beta"]
 
 
@@ -169,15 +175,15 @@ class TestRequestResponseWiring:
                 "endpointUrl": "https://example.com/mcp",
                 "listingMode": "default",
                 "credentialType": "gateway_iam_role",
+                "awsService": "lambda",
                 "tools": [{"name": "get_forecast", "needsApproval": True}],
             }
         )
         model = req.to_model()
         assert isinstance(model, MCPGatewayConfig)
         assert model.target_name == "weather-target"
+        assert model.aws_service == "lambda"
         assert model.approval_required_names() == {"get_forecast"}
-        # IAM target defaults to the authorization_code grant (inert for IAM).
-        assert model.grant_type == GatewayOAuthGrantType.AUTHORIZATION_CODE
         # Request never carries AWS-assigned identifiers.
         assert model.target_id is None
         assert model.gateway_arn is None
@@ -210,7 +216,8 @@ class TestRequestResponseWiring:
         resp = MCPGatewayConfigResponse.from_model(config)
         assert resp.target_id == "TGT123"
         assert resp.listing_mode == "default"
-        assert resp.credential_type == "gateway_iam_role"
+        # Default credential type is the public (none) path.
+        assert resp.credential_type == "none"
 
     def test_admin_tool_response_includes_gateway_config(self):
         tool = ToolDefinition(
@@ -267,15 +274,29 @@ class TestCoGatingValidator:
                 target_name="t",
                 endpoint_url="https://e/mcp",
                 credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+                aws_service="lambda",
                 credential_provider_arn="arn:...:oauth2credentialprovider/x",
             )
 
+    def test_iam_requires_aws_service(self):
+        # mcpServer IAM targets need an explicit service for the
+        # iamCredentialProvider — without it AWS rejects CreateGatewayTarget.
+        with pytest.raises(ValidationError):
+            MCPGatewayConfig(
+                target_name="t",
+                endpoint_url="https://e/mcp",
+                credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+            )
+
     def test_valid_configs_accepted(self):
-        # IAM with no ARN
+        # None (public) — the default; minimal config.
+        MCPGatewayConfig(target_name="t", endpoint_url="https://e/mcp")
+        # IAM with aws_service, no ARN
         MCPGatewayConfig(
             target_name="t",
             endpoint_url="https://e/mcp",
             credential_type=GatewayCredentialType.GATEWAY_IAM_ROLE,
+            aws_service="lambda",
         )
         # OAuth, DEFAULT listing, with ARN
         MCPGatewayConfig(

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -42,7 +42,7 @@ export type GatewayListingMode = 'default' | 'dynamic';
 /**
  * How the Gateway authenticates outbound to a target's MCP endpoint.
  */
-export type GatewayCredentialType = 'gateway_iam_role' | 'oauth' | 'api_key';
+export type GatewayCredentialType = 'none' | 'gateway_iam_role' | 'oauth' | 'api_key';
 
 /**
  * OAuth grant the Gateway uses for an OAUTH-credentialed target.
@@ -106,6 +106,8 @@ export interface MCPGatewayConfig {
   listingMode: GatewayListingMode;
   credentialType: GatewayCredentialType;
   credentialProviderArn?: string | null;
+  awsService?: string | null;
+  awsRegion?: string | null;
   oauthScopes: string[];
   grantType: GatewayOAuthGrantType;
   customParameters?: Record<string, string> | null;
@@ -341,7 +343,8 @@ export const GATEWAY_LISTING_MODES: { value: GatewayListingMode; label: string; 
  * Available Gateway outbound credential types for dropdowns.
  */
 export const GATEWAY_CREDENTIAL_TYPES: { value: GatewayCredentialType; label: string; description?: string }[] = [
-  { value: 'gateway_iam_role', label: 'Gateway IAM Role (SigV4)', description: 'The gateway signs with its own execution role — no provider ARN' },
+  { value: 'none', label: 'None (public endpoint)', description: 'No outbound credentials — the endpoint is publicly reachable' },
+  { value: 'gateway_iam_role', label: 'Gateway IAM Role (SigV4)', description: 'The gateway signs with its execution role — requires the AWS service to sign for' },
   { value: 'oauth', label: 'OAuth (3LO / 2LO)', description: 'Reference an existing OAuth credential provider by ARN' },
   { value: 'api_key', label: 'API Key', description: 'Reference an existing API-key credential provider by ARN' },
 ];

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -108,6 +108,12 @@ export interface MCPGatewayConfig {
   credentialProviderArn?: string | null;
   awsService?: string | null;
   awsRegion?: string | null;
+  /**
+   * Name (or ARN) of the Lambda backing a GATEWAY_IAM_ROLE Function-URL target.
+   * Lets the platform grant the gateway role InvokeFunctionUrl on exactly this
+   * function at registration (no infra change). Same-account only.
+   */
+  lambdaFunctionName?: string | null;
   oauthScopes: string[];
   grantType: GatewayOAuthGrantType;
   customParameters?: Record<string, string> | null;
@@ -240,6 +246,21 @@ export interface MCPDiscoverResponse {
 }
 
 /**
+ * Live health of the AgentCore Gateway target backing a protocol='mcp' tool,
+ * from GET /api/admin/tools/{toolId}/gateway-status. The gateway connects to
+ * and lists the target's tools asynchronously after registration, so a tool
+ * can be 'active' yet unusable because its target FAILED to sync. `status` is
+ * the gateway target status (CREATING / READY / FAILED / UPDATE_UNSUCCESSFUL /
+ * MISSING); `statusReasons` explains an unhealthy target.
+ */
+export interface GatewayTargetStatus {
+  targetId: string;
+  status: string;
+  statusReasons: string[];
+  healthy: boolean;
+}
+
+/**
  * Form data model for creating/editing a tool.
  */
 export interface ToolFormData {
@@ -367,3 +388,30 @@ export const TOOL_STATUSES: { value: ToolStatus; label: string }[] = [
   { value: 'disabled', label: 'Disabled' },
   { value: 'coming_soon', label: 'Coming Soon' },
 ];
+
+/**
+ * Derive the AWS service name for SigV4 signing from a known AWS endpoint host.
+ *
+ * Mirrors the backend `detect_aws_service_from_url`, but returns `''` for an
+ * unrecognised host (so the Gateway form leaves the field for the admin to
+ * fill) rather than defaulting to `'lambda'` — the backend's last-resort
+ * default is only appropriate at signing time.
+ */
+export function detectAwsServiceFromUrl(url: string): string {
+  if (/\.lambda-url\.[a-z0-9-]+\.on\.aws/.test(url)) return 'lambda';
+  if (/\.execute-api\.[a-z0-9-]+\.amazonaws\.com/.test(url)) return 'execute-api';
+  if (/\.bedrock-agentcore\.[a-z0-9-]+\.amazonaws\.com/.test(url)) return 'bedrock-agentcore';
+  return '';
+}
+
+/**
+ * Extract the AWS region from a known AWS endpoint host, or `''` if the host
+ * doesn't encode one. Mirrors the backend `extract_region_from_url`.
+ */
+export function extractAwsRegionFromUrl(url: string): string {
+  const match =
+    url.match(/\.lambda-url\.([a-z0-9-]+)\.on\.aws/) ??
+    url.match(/\.execute-api\.([a-z0-9-]+)\.amazonaws\.com/) ??
+    url.match(/\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com/);
+  return match ? match[1] : '';
+}

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
@@ -5,6 +5,10 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ToolFormPage } from './tool-form.page';
 import { AdminToolService } from '../services/admin-tool.service';
 import { ConnectorsService } from '../../connectors/services/connectors.service';
+import {
+  detectAwsServiceFromUrl,
+  extractAwsRegionFromUrl,
+} from '../models/admin-tool.model';
 
 /**
  * Phase 5 (#419): the protocol='mcp' Gateway target section of the admin tool
@@ -171,5 +175,138 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
     );
     await cmp.onSubmit();
     expect(cmp.error()).toContain('Validation error');
+  });
+
+  it('auto-derives aws service + region from a Lambda URL when IAM is selected', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    // Pick IAM, then enter an AWS-hosted endpoint — fields should self-populate.
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role' });
+    cmp.form.patchValue({
+      gwEndpointUrl: 'https://abc123.lambda-url.us-east-1.on.aws/mcp',
+    });
+
+    expect(cmp.form.get('gwAwsService')?.value).toBe('lambda');
+    expect(cmp.form.get('gwAwsRegion')?.value).toBe('us-east-1');
+
+    await cmp.onSubmit();
+    const cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.awsService).toBe('lambda');
+    expect(cfg.awsRegion).toBe('us-east-1');
+  });
+
+  it('does not clobber a hand-edited aws service when the URL changes', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role' });
+    cmp.form.patchValue({ gwEndpointUrl: 'https://abc.lambda-url.us-west-2.on.aws/mcp' });
+    expect(cmp.form.get('gwAwsService')?.value).toBe('lambda');
+
+    // Admin overrides the service, then edits the URL — override must survive.
+    cmp.form.get('gwAwsService')?.setValue('my-private-service');
+    cmp.form.patchValue({ gwEndpointUrl: 'https://def.execute-api.eu-west-1.amazonaws.com/mcp' });
+
+    expect(cmp.form.get('gwAwsService')?.value).toBe('my-private-service');
+    // Region wasn't overridden, so it still tracks the URL.
+    expect(cmp.form.get('gwAwsRegion')?.value).toBe('eu-west-1');
+  });
+
+  it('falls back to deriving aws service at save when the field is blank', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    // Simulate legacy/edit state: IAM with a known URL but a blank service.
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role' });
+    cmp.form.patchValue({ gwEndpointUrl: 'https://gw.bedrock-agentcore.us-west-2.amazonaws.com/mcp' });
+    cmp.form.get('gwAwsService')?.setValue('', { emitEvent: false });
+    cmp.form.get('gwAwsRegion')?.setValue('', { emitEvent: false });
+
+    await cmp.onSubmit();
+    const cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.awsService).toBe('bedrock-agentcore');
+    expect(cfg.awsRegion).toBe('us-west-2');
+  });
+
+  it('leaves the aws service blank for an unrecognised (custom-domain) host', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role' });
+    cmp.form.patchValue({ gwEndpointUrl: 'https://mcp.mycorp.example.com/mcp' });
+
+    expect(cmp.form.get('gwAwsService')?.value).toBe('');
+    expect(cmp.form.get('gwAwsRegion')?.value).toBe('');
+  });
+
+  it('sends lambdaFunctionName for an IAM Lambda-URL target, null otherwise', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+
+    // IAM + Lambda URL → the function name is sent so the backend can grant invoke.
+    cmp.form.patchValue({
+      gwCredentialType: 'gateway_iam_role',
+      gwEndpointUrl: 'https://abc.lambda-url.us-west-2.on.aws/mcp',
+      gwLambdaFunctionName: 'mcp-class-search-dev',
+    });
+    expect(cmp.isLambdaUrlEndpoint()).toBe(true);
+    await cmp.onSubmit();
+    let cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.lambdaFunctionName).toBe('mcp-class-search-dev');
+
+    // Non-Lambda endpoint → not applicable, sent as null even if a stale value lingers.
+    adminToolService.createTool.mockClear();
+    cmp.form.patchValue({ gwEndpointUrl: 'https://mcp.example.com/mcp' });
+    expect(cmp.isLambdaUrlEndpoint()).toBe(false);
+    await cmp.onSubmit();
+    cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.lambdaFunctionName).toBeNull();
+  });
+
+  it('recommends IAM only when an AWS-hosted endpoint is left on None', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+
+    // None + AWS host → recommend IAM.
+    cmp.form.patchValue({
+      gwCredentialType: 'none',
+      gwEndpointUrl: 'https://abc.lambda-url.us-west-2.on.aws/mcp',
+    });
+    expect(cmp.showIamRecommendation()).toBe(true);
+
+    // None + custom domain → no recommendation (we can't tell it needs IAM).
+    cmp.form.patchValue({ gwEndpointUrl: 'https://mcp.example.com/mcp' });
+    expect(cmp.showIamRecommendation()).toBe(false);
+
+    // Already on IAM → nothing to recommend.
+    cmp.form.patchValue({
+      gwCredentialType: 'gateway_iam_role',
+      gwEndpointUrl: 'https://abc.lambda-url.us-west-2.on.aws/mcp',
+    });
+    expect(cmp.showIamRecommendation()).toBe(false);
+  });
+});
+
+describe('AWS endpoint derivation helpers', () => {
+  it('detects the AWS service from known endpoint hosts', () => {
+    expect(detectAwsServiceFromUrl('https://x.lambda-url.us-west-2.on.aws/mcp')).toBe('lambda');
+    expect(detectAwsServiceFromUrl('https://x.execute-api.us-east-1.amazonaws.com/p')).toBe('execute-api');
+    expect(detectAwsServiceFromUrl('https://g.bedrock-agentcore.eu-west-1.amazonaws.com/')).toBe(
+      'bedrock-agentcore',
+    );
+  });
+
+  it('returns empty string for an unrecognised host (no lambda default)', () => {
+    expect(detectAwsServiceFromUrl('https://mcp.example.com/mcp')).toBe('');
+    expect(detectAwsServiceFromUrl('')).toBe('');
+  });
+
+  it('extracts the region from known endpoint hosts', () => {
+    expect(extractAwsRegionFromUrl('https://x.lambda-url.ap-south-1.on.aws/mcp')).toBe('ap-south-1');
+    expect(extractAwsRegionFromUrl('https://x.execute-api.us-east-2.amazonaws.com/p')).toBe('us-east-2');
+    expect(extractAwsRegionFromUrl('https://mcp.example.com/mcp')).toBe('');
   });
 });

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
@@ -55,7 +55,7 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
     });
   }
 
-  it('builds an IAM gateway config and submits it', async () => {
+  it('builds a public (none) gateway config by default', async () => {
     const cmp = makeComponent();
     await cmp.ngOnInit();
     fillBaseGatewayForm(cmp);
@@ -65,19 +65,26 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
     await cmp.onSubmit();
 
     expect(adminToolService.createTool).toHaveBeenCalledTimes(1);
-    const payload = adminToolService.createTool.mock.calls[0][0];
-    expect(payload.protocol).toBe('mcp');
-    expect(payload.mcpGatewayConfig).toEqual({
-      targetName: 'weather-target',
-      endpointUrl: 'https://example.com/mcp',
-      listingMode: 'default',
-      credentialType: 'gateway_iam_role',
-      credentialProviderArn: null,
-      oauthScopes: [],
-      grantType: 'authorization_code',
-      customParameters: null,
-      tools: [{ name: 'get_forecast', needsApproval: true, description: null }],
-    });
+    const cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.credentialType).toBe('none');
+    expect(cfg.credentialProviderArn).toBeNull();
+    expect(cfg.awsService).toBeNull();
+    expect(cfg.tools).toEqual([{ name: 'get_forecast', needsApproval: true, description: null }]);
+  });
+
+  it('builds an IAM gateway config with aws service', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    fillBaseGatewayForm(cmp);
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role', gwAwsService: 'lambda', gwAwsRegion: 'us-west-2' });
+
+    await cmp.onSubmit();
+
+    const cfg = adminToolService.createTool.mock.calls[0][0].mcpGatewayConfig;
+    expect(cfg.credentialType).toBe('gateway_iam_role');
+    expect(cfg.awsService).toBe('lambda');
+    expect(cfg.awsRegion).toBe('us-west-2');
+    expect(cfg.credentialProviderArn).toBeNull();
   });
 
   it('builds an OAuth gateway config (ARN + parsed scopes) and forces DEFAULT listing', async () => {
@@ -107,6 +114,7 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
     const cmp = makeComponent();
     await cmp.ngOnInit();
     fillBaseGatewayForm(cmp);
+    cmp.form.patchValue({ gwCredentialType: 'gateway_iam_role', gwAwsService: 'lambda' });
     // Pre-existing manual row whose approval flag must be preserved on merge.
     cmp.addGwTool();
     cmp.gwToolsArray.at(0).patchValue({ name: 'get_forecast', needsApproval: true });

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -528,6 +528,39 @@ import {
                   </div>
                 </div>
 
+                <!-- AWS service + region (for gateway IAM role) -->
+                @if (form.get('gwCredentialType')?.value === 'gateway_iam_role') {
+                  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div>
+                      <label for="gwAwsService" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        AWS service <span class="text-red-600">*</span>
+                      </label>
+                      <input
+                        id="gwAwsService"
+                        type="text"
+                        formControlName="gwAwsService"
+                        placeholder="lambda, execute-api, bedrock-agentcore"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      />
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        The AWS service the endpoint belongs to, for SigV4 signing.
+                      </p>
+                    </div>
+                    <div>
+                      <label for="gwAwsRegion" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        AWS region
+                      </label>
+                      <input
+                        id="gwAwsRegion"
+                        type="text"
+                        formControlName="gwAwsRegion"
+                        placeholder="defaults to the gateway's region"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      />
+                    </div>
+                  </div>
+                }
+
                 <!-- Credential provider ARN (for oauth / api_key) -->
                 @if (form.get('gwCredentialType')?.value === 'oauth' || form.get('gwCredentialType')?.value === 'api_key') {
                   <div>
@@ -945,8 +978,10 @@ export class ToolFormPage implements OnInit {
     gwTargetName: [''],
     gwEndpointUrl: [''],
     gwListingMode: ['default'],
-    gwCredentialType: ['gateway_iam_role'],
+    gwCredentialType: ['none'],
     gwCredentialProviderArn: [''],
+    gwAwsService: [''],
+    gwAwsRegion: [''],
     gwOauthScopes: [''],
     gwGrantType: ['authorization_code'],
     gwTools: this.fb.array([] as FormGroup[]),
@@ -1210,6 +1245,8 @@ export class ToolFormPage implements OnInit {
           gwListingMode: tool.mcpGatewayConfig.listingMode,
           gwCredentialType: tool.mcpGatewayConfig.credentialType,
           gwCredentialProviderArn: tool.mcpGatewayConfig.credentialProviderArn || '',
+          gwAwsService: tool.mcpGatewayConfig.awsService || '',
+          gwAwsRegion: tool.mcpGatewayConfig.awsRegion || '',
           gwOauthScopes: (tool.mcpGatewayConfig.oauthScopes || []).join(' '),
           gwGrantType: tool.mcpGatewayConfig.grantType,
         });
@@ -1290,14 +1327,18 @@ export class ToolFormPage implements OnInit {
 
         const credentialType = formValue.gwCredentialType;
         const isOauth = credentialType === 'oauth';
+        const isIam = credentialType === 'gateway_iam_role';
         mcpGatewayConfig = {
           targetName: formValue.gwTargetName,
           endpointUrl: formValue.gwEndpointUrl,
           listingMode: formValue.gwListingMode,
           credentialType,
-          // IAM role uses the gateway's execution role — no ARN.
+          // ARN only applies to oauth / api_key.
           credentialProviderArn:
-            credentialType === 'gateway_iam_role' ? null : (formValue.gwCredentialProviderArn || null),
+            isOauth || credentialType === 'api_key' ? (formValue.gwCredentialProviderArn || null) : null,
+          // IAM role signs SigV4 against an AWS service.
+          awsService: isIam ? (formValue.gwAwsService || null) : null,
+          awsRegion: isIam ? (formValue.gwAwsRegion || null) : null,
           oauthScopes:
             isOauth && formValue.gwOauthScopes
               ? formValue.gwOauthScopes.split(/[\s,]+/).map((s: string) => s.trim()).filter((s: string) => s)

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -19,6 +19,7 @@ import {
   heroShieldCheck,
   heroPlus,
   heroTrash,
+  heroExclamationTriangle,
 } from '@ng-icons/heroicons/outline';
 import { AdminToolService } from '../services/admin-tool.service';
 import { ConnectorsService } from '../../connectors/services/connectors.service';
@@ -37,13 +38,15 @@ import {
   A2AAgentConfig,
   MCPGatewayConfig,
   ToolProtocol,
+  detectAwsServiceFromUrl,
+  extractAwsRegionFromUrl,
 } from '../models/admin-tool.model';
 
 @Component({
   selector: 'app-tool-form',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterLink, ReactiveFormsModule, NgIcon],
-  providers: [provideIcons({ heroArrowLeft, heroServer, heroUserGroup, heroLink, heroShieldCheck, heroPlus, heroTrash })],
+  providers: [provideIcons({ heroArrowLeft, heroServer, heroUserGroup, heroLink, heroShieldCheck, heroPlus, heroTrash, heroExclamationTriangle })],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
@@ -525,6 +528,15 @@ import {
                     <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
                       How the Gateway authenticates to the target endpoint.
                     </p>
+                    @if (showIamRecommendation()) {
+                      <p class="mt-1 flex items-start gap-1.5 text-xs/5 text-amber-700 dark:text-amber-400">
+                        <ng-icon name="heroExclamationTriangle" class="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                        <span>This looks like an AWS-hosted endpoint (Lambda / API Gateway /
+                        AgentCore). It likely requires IAM — pick <strong>Gateway IAM Role
+                        (SigV4)</strong>, or the gateway will get a 403 when it lists the
+                        target's tools.</span>
+                      </p>
+                    }
                   </div>
                 </div>
 
@@ -543,7 +555,8 @@ import {
                         class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                       />
                       <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-                        The AWS service the endpoint belongs to, for SigV4 signing.
+                        Auto-detected from the endpoint URL for Lambda / API Gateway /
+                        AgentCore hosts. Override only for a custom domain.
                       </p>
                     </div>
                     <div>
@@ -557,8 +570,33 @@ import {
                         placeholder="defaults to the gateway's region"
                         class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                       />
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        Optional — auto-detected from the endpoint URL; AWS defaults it
+                        to the gateway's region.
+                      </p>
                     </div>
                   </div>
+
+                  @if (isLambdaUrlEndpoint()) {
+                    <div>
+                      <label for="gwLambdaFunctionName" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                        Lambda function name <span class="text-red-600">*</span>
+                      </label>
+                      <input
+                        id="gwLambdaFunctionName"
+                        type="text"
+                        formControlName="gwLambdaFunctionName"
+                        placeholder="mcp-class-search-dev"
+                        class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                      />
+                      <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                        The Lambda behind this Function URL. We grant the gateway
+                        permission to invoke it at save — no infra change needed.
+                        <strong>Same-account only</strong>; a cross-account function is
+                        rejected at save (make it public or use a credential provider).
+                      </p>
+                    </div>
+                  }
                 }
 
                 <!-- Credential provider ARN (for oauth / api_key) -->
@@ -939,6 +977,13 @@ export class ToolFormPage implements OnInit {
   discovering = signal(false);
   discoverError = signal<string | null>(null);
 
+  // Last values auto-derived from the Gateway endpoint URL. We only overwrite
+  // the AWS service/region controls while they still hold what we derived (i.e.
+  // the admin hasn't hand-edited or a load hasn't supplied a value), so manual
+  // overrides and loaded config are never clobbered. See syncDerivedAwsFields.
+  private lastDerivedAwsService = '';
+  private lastDerivedAwsRegion = '';
+
   readonly isEditMode = computed(() => !!this.toolId());
   readonly selectedProtocol = signal<ToolProtocol>('local');
 
@@ -982,6 +1027,7 @@ export class ToolFormPage implements OnInit {
     gwCredentialProviderArn: [''],
     gwAwsService: [''],
     gwAwsRegion: [''],
+    gwLambdaFunctionName: [''],
     gwOauthScopes: [''],
     gwGrantType: ['authorization_code'],
     gwTools: this.fb.array([] as FormGroup[]),
@@ -1095,6 +1141,57 @@ export class ToolFormPage implements OnInit {
    * API-key endpoints can't be discovered admin-side — the server's error is
    * surfaced, and the admin can add tool names by hand).
    */
+  /**
+   * Auto-populate the AWS service + region for a Gateway IAM-role target from
+   * the endpoint URL. Both are mechanically derivable from a Lambda Function
+   * URL / API Gateway / AgentCore Gateway host, so the admin shouldn't have to
+   * type them — the fields stay editable as overrides. We only overwrite a
+   * field while it still equals the value we last derived, so a hand-edited
+   * override (or a value loaded in edit mode) is preserved.
+   */
+  /**
+   * Recommend the IAM outbound credential when the endpoint is an AWS-hosted
+   * host (Lambda URL / API Gateway / AgentCore) but the admin left the credential
+   * as "None". Such endpoints almost always require SigV4, so "None" would make
+   * the gateway 403 when it lists the target's tools. URL-pattern heuristic only
+   * — a definitive AuthType check would need a backend probe (a later preflight).
+   */
+  showIamRecommendation(): boolean {
+    const cred = this.form.get('gwCredentialType')?.value;
+    const url = this.form.get('gwEndpointUrl')?.value ?? '';
+    return cred === 'none' && detectAwsServiceFromUrl(url) !== '';
+  }
+
+  /**
+   * True when the endpoint is a Lambda Function URL — the only case that needs
+   * the function name, so the platform can grant the gateway role invoke on it
+   * at registration.
+   */
+  isLambdaUrlEndpoint(): boolean {
+    return detectAwsServiceFromUrl(this.form.get('gwEndpointUrl')?.value ?? '') === 'lambda';
+  }
+
+  private syncDerivedAwsFields(): void {
+    if (this.form.get('gwCredentialType')?.value !== 'gateway_iam_role') {
+      return;
+    }
+    const url = this.form.get('gwEndpointUrl')?.value ?? '';
+
+    const service = detectAwsServiceFromUrl(url);
+    const serviceCtrl = this.form.get('gwAwsService');
+    if (service && (serviceCtrl?.value ?? '') === this.lastDerivedAwsService) {
+      serviceCtrl?.setValue(service);
+      this.lastDerivedAwsService = service;
+    }
+
+    const region = extractAwsRegionFromUrl(url);
+    const regionCtrl = this.form.get('gwAwsRegion');
+    if (region && (regionCtrl?.value ?? '') === this.lastDerivedAwsRegion) {
+      regionCtrl?.setValue(region);
+      this.lastDerivedAwsRegion = region;
+    }
+  }
+
   async discoverGatewayTools(): Promise<void> {
     const formValue = this.form.getRawValue();
     if (!formValue.gwEndpointUrl) {
@@ -1175,6 +1272,14 @@ export class ToolFormPage implements OnInit {
       if (value === 'oauth' && this.form.get('gwListingMode')?.value !== 'default') {
         this.form.get('gwListingMode')?.setValue('default');
       }
+      // Populate AWS service/region as soon as the admin picks IAM role, so the
+      // fields aren't blank when their panel first appears.
+      this.syncDerivedAwsFields();
+    });
+
+    // Auto-derive the IAM service/region from the endpoint host as it's typed.
+    this.form.get('gwEndpointUrl')?.valueChanges.subscribe(() => {
+      this.syncDerivedAwsFields();
     });
 
     const id = this.route.snapshot.paramMap.get('toolId');
@@ -1247,6 +1352,7 @@ export class ToolFormPage implements OnInit {
           gwCredentialProviderArn: tool.mcpGatewayConfig.credentialProviderArn || '',
           gwAwsService: tool.mcpGatewayConfig.awsService || '',
           gwAwsRegion: tool.mcpGatewayConfig.awsRegion || '',
+          gwLambdaFunctionName: tool.mcpGatewayConfig.lambdaFunctionName || '',
           gwOauthScopes: (tool.mcpGatewayConfig.oauthScopes || []).join(' '),
           gwGrantType: tool.mcpGatewayConfig.grantType,
         });
@@ -1336,9 +1442,21 @@ export class ToolFormPage implements OnInit {
           // ARN only applies to oauth / api_key.
           credentialProviderArn:
             isOauth || credentialType === 'api_key' ? (formValue.gwCredentialProviderArn || null) : null,
-          // IAM role signs SigV4 against an AWS service.
-          awsService: isIam ? (formValue.gwAwsService || null) : null,
-          awsRegion: isIam ? (formValue.gwAwsRegion || null) : null,
+          // IAM role signs SigV4 against an AWS service. Both are normally
+          // auto-derived from the endpoint host into the form; fall back to
+          // deriving here so a blank field still saves a valid config.
+          awsService: isIam
+            ? (formValue.gwAwsService || detectAwsServiceFromUrl(formValue.gwEndpointUrl) || null)
+            : null,
+          awsRegion: isIam
+            ? (formValue.gwAwsRegion || extractAwsRegionFromUrl(formValue.gwEndpointUrl) || null)
+            : null,
+          // Only meaningful for an IAM target on a Lambda Function URL — lets the
+          // backend grant the gateway role invoke on exactly this function.
+          lambdaFunctionName:
+            isIam && detectAwsServiceFromUrl(formValue.gwEndpointUrl) === 'lambda'
+              ? (formValue.gwLambdaFunctionName?.trim() || null)
+              : null,
           oauthScopes:
             isOauth && formValue.gwOauthScopes
               ? formValue.gwOauthScopes.split(/[\s,]+/).map((s: string) => s.trim()).filter((s: string) => s)

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  gatewayBadgeFor,
+  gatewayFailureReasonsFor,
+  isTransientGatewayStatus,
+  type GatewayHealth,
+} from './tool-list.page';
+import { GatewayTargetStatus } from '../models/admin-tool.model';
+
+/**
+ * Gateway target health badge mapping (Tier-1 UX for issue #419): turn the live
+ * AgentCore Gateway target status into a row badge so a FAILED target is visible
+ * to admins instead of only surfacing later as "the agent can't see the tool".
+ */
+describe('gatewayBadgeFor', () => {
+  const status = (over: Partial<GatewayTargetStatus>): GatewayTargetStatus => ({
+    targetId: 't',
+    status: 'READY',
+    statusReasons: [],
+    healthy: true,
+    ...over,
+  });
+
+  it('returns null before health is known', () => {
+    expect(gatewayBadgeFor(undefined)).toBeNull();
+  });
+
+  it('maps the transient UI states', () => {
+    expect(gatewayBadgeFor('loading')?.label).toBe('Checking…');
+    expect(gatewayBadgeFor('loading')?.failed).toBe(false);
+    expect(gatewayBadgeFor('error')?.label).toBe('Unknown');
+    expect(gatewayBadgeFor('error')?.failed).toBe(false);
+  });
+
+  it('maps a healthy target to Ready', () => {
+    const badge = gatewayBadgeFor(status({ status: 'READY', healthy: true }));
+    expect(badge?.label).toBe('Ready');
+    expect(badge?.failed).toBe(false);
+    expect(badge?.cls).toContain('green');
+  });
+
+  it('maps a still-syncing target to Syncing', () => {
+    const badge = gatewayBadgeFor(status({ status: 'CREATING', healthy: false }));
+    expect(badge?.label).toBe('Syncing');
+    expect(badge?.failed).toBe(false);
+    expect(badge?.cls).toContain('blue');
+  });
+
+  it('maps a FAILED target to a red Failed badge carrying the reason in the title', () => {
+    const reason = 'Authorization error when sending message';
+    const badge = gatewayBadgeFor(
+      status({ status: 'FAILED', healthy: false, statusReasons: [reason] }),
+    );
+    expect(badge?.label).toBe('Failed');
+    expect(badge?.failed).toBe(true);
+    expect(badge?.cls).toContain('red');
+    expect(badge?.title).toBe(reason);
+  });
+
+  it('maps a MISSING target distinctly', () => {
+    const badge = gatewayBadgeFor(status({ status: 'MISSING', healthy: false }));
+    expect(badge?.label).toBe('Missing');
+    expect(badge?.failed).toBe(true);
+  });
+});
+
+describe('gatewayFailureReasonsFor', () => {
+  it('returns reasons only for an unhealthy target', () => {
+    expect(gatewayFailureReasonsFor(undefined)).toBeNull();
+    expect(gatewayFailureReasonsFor('loading')).toBeNull();
+    expect(
+      gatewayFailureReasonsFor({ targetId: 't', status: 'READY', statusReasons: [], healthy: true }),
+    ).toBeNull();
+    expect(
+      gatewayFailureReasonsFor({
+        targetId: 't',
+        status: 'FAILED',
+        statusReasons: ['a', 'b'],
+        healthy: false,
+      }),
+    ).toBe('a b');
+  });
+});
+
+describe('isTransientGatewayStatus', () => {
+  it('flags settling statuses case-insensitively', () => {
+    expect(isTransientGatewayStatus('CREATING')).toBe(true);
+    expect(isTransientGatewayStatus('updating')).toBe(true);
+    expect(isTransientGatewayStatus('SYNCHRONIZING')).toBe(true);
+    expect(isTransientGatewayStatus('READY')).toBe(false);
+    expect(isTransientGatewayStatus('FAILED')).toBe(false);
+  });
+});
+
+// Type-only guard: GatewayHealth must accept both the response and UI states.
+const _h: GatewayHealth[] = ['loading', 'error'];
+void _h;

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.ts
@@ -4,6 +4,8 @@ import {
   inject,
   signal,
   computed,
+  effect,
+  DestroyRef,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -18,15 +20,83 @@ import {
   heroTrash,
   heroUserGroup,
   heroGlobeAlt,
+  heroExclamationTriangle,
 } from '@ng-icons/heroicons/outline';
 import { heroStarSolid } from '@ng-icons/heroicons/solid';
 import { AdminToolService } from '../services/admin-tool.service';
 import {
   AdminTool,
+  GatewayTargetStatus,
   TOOL_CATEGORIES,
   TOOL_STATUSES,
   TOOL_PROTOCOLS,
 } from '../models/admin-tool.model';
+
+/** A gateway health value the row can render, including transient UI states. */
+export type GatewayHealth = GatewayTargetStatus | 'loading' | 'error';
+
+/** Compact badge descriptor derived from a tool's gateway health. */
+export interface GatewayBadge {
+  label: string;
+  cls: string;
+  title: string;
+  failed: boolean;
+}
+
+const GATEWAY_BADGE_BASE =
+  'shrink-0 inline-flex items-center gap-1 rounded-2xl px-2.5 py-0.5 text-xs/5 font-medium';
+
+/** Gateway target statuses that are still settling (not yet Ready/Failed). */
+const TRANSIENT_GATEWAY_STATUSES = ['CREATING', 'UPDATING', 'SYNCHRONIZING'];
+
+/** Map a tool's gateway health to a compact badge, or null if not yet known. */
+export function gatewayBadgeFor(health: GatewayHealth | undefined): GatewayBadge | null {
+  if (health === undefined) {
+    return null;
+  }
+  const muted = `${GATEWAY_BADGE_BASE} bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400`;
+  if (health === 'loading') {
+    return { label: 'Checking…', cls: muted, title: 'Checking gateway target health', failed: false };
+  }
+  if (health === 'error') {
+    return { label: 'Unknown', cls: muted, title: 'Could not fetch gateway target health', failed: false };
+  }
+  if (health.healthy) {
+    return {
+      label: 'Ready',
+      cls: `${GATEWAY_BADGE_BASE} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300`,
+      title: 'Gateway target is ready',
+      failed: false,
+    };
+  }
+  if (TRANSIENT_GATEWAY_STATUSES.includes(health.status.toUpperCase())) {
+    return {
+      label: 'Syncing',
+      cls: `${GATEWAY_BADGE_BASE} bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300`,
+      title: 'The gateway is connecting to the target and listing its tools…',
+      failed: false,
+    };
+  }
+  return {
+    label: health.status.toUpperCase() === 'MISSING' ? 'Missing' : 'Failed',
+    cls: `${GATEWAY_BADGE_BASE} bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300`,
+    title: health.statusReasons.join(' ') || 'Gateway target is not usable',
+    failed: true,
+  };
+}
+
+/** The joined failure reasons for an unhealthy gateway health, else null. */
+export function gatewayFailureReasonsFor(health: GatewayHealth | undefined): string | null {
+  if (!health || health === 'loading' || health === 'error' || health.healthy) {
+    return null;
+  }
+  return health.statusReasons.join(' ') || null;
+}
+
+/** Whether a gateway status string is still settling (drives re-polling). */
+export function isTransientGatewayStatus(status: string): boolean {
+  return TRANSIENT_GATEWAY_STATUSES.includes(status.toUpperCase());
+}
 import { AppRolesService } from '../../roles/services/app-roles.service';
 import { ToolRoleDialogComponent, ToolRoleDialogData, ToolRoleDialogResult } from '../components/tool-role-dialog.component';
 import { DeleteToolDialogComponent, DeleteToolDialogData, DeleteToolDialogResult } from '../components/delete-tool-dialog.component';
@@ -44,6 +114,7 @@ import { DeleteToolDialogComponent, DeleteToolDialogData, DeleteToolDialogResult
       heroTrash,
       heroUserGroup,
       heroGlobeAlt,
+      heroExclamationTriangle,
       heroStarSolid,
     }),
   ],
@@ -234,6 +305,16 @@ import { DeleteToolDialogComponent, DeleteToolDialogData, DeleteToolDialogResult
                       }
                     </span>
 
+                    <!-- Gateway target health (protocol=mcp only) -->
+                    @if (tool.protocol === 'mcp' && gatewayBadge(tool.toolId); as badge) {
+                      <span [class]="badge.cls" [title]="badge.title">
+                        @if (badge.failed) {
+                          <ng-icon name="heroExclamationTriangle" class="size-3.5" aria-hidden="true" />
+                        }
+                        {{ badge.label }}
+                      </span>
+                    }
+
                     <!-- Status -->
                     <span [class]="getStatusClass(tool.status)">
                       {{ tool.status }}
@@ -373,6 +454,35 @@ import { DeleteToolDialogComponent, DeleteToolDialogData, DeleteToolDialogResult
                             </dd>
                           </div>
                         }
+
+                        @if (tool.mcpGatewayConfig) {
+                          <div class="sm:col-span-3">
+                            <dt class="flex items-center gap-2 text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                              Gateway target
+                              @if (gatewayBadge(tool.toolId); as badge) {
+                                <span [class]="badge.cls" [title]="badge.title">
+                                  @if (badge.failed) {
+                                    <ng-icon name="heroExclamationTriangle" class="size-3.5" aria-hidden="true" />
+                                  }
+                                  {{ badge.label }}
+                                </span>
+                              }
+                            </dt>
+                            <dd class="mt-0.5 space-y-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                              <p class="break-all font-mono text-xs/5">{{ tool.mcpGatewayConfig.endpointUrl }}</p>
+                              <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                                target: {{ tool.mcpGatewayConfig.targetName }} ·
+                                outbound: {{ tool.mcpGatewayConfig.credentialType }} ·
+                                {{ tool.mcpGatewayConfig.tools.length }} tool{{ tool.mcpGatewayConfig.tools.length !== 1 ? 's' : '' }}
+                              </p>
+                              @if (gatewayFailureReasons(tool.toolId); as reasons) {
+                                <p class="mt-1 rounded-xl bg-red-50 px-2.5 py-1.5 text-xs/5 text-red-800 dark:bg-red-900/20 dark:text-red-200">
+                                  {{ reasons }}
+                                </p>
+                              }
+                            </dd>
+                          </div>
+                        }
                       </dl>
                     </div>
                   }
@@ -401,6 +511,32 @@ export class ToolListPage {
 
   // Row detail expansion state (set of tool ids currently expanded)
   private expandedIds = signal<ReadonlySet<string>>(new Set());
+
+  // Live gateway-target health per protocol='mcp' tool id. Lazily populated so
+  // a FAILED target (e.g. the gateway role can't invoke the endpoint) surfaces
+  // as a badge instead of only appearing later as "the agent can't see it".
+  private gatewayStatuses = signal<ReadonlyMap<string, GatewayHealth>>(new Map());
+  // Dedupe guard (plain field, not a signal, so the fetch effect doesn't depend
+  // on it and re-trigger itself).
+  private requestedStatusToolIds = new Set<string>();
+  private destroyRef = inject(DestroyRef);
+  private destroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+    });
+    // Fetch live gateway health for each protocol='mcp' tool once, as the
+    // catalog loads. Typically a handful of rows, so per-row lazy fetch is fine.
+    effect(() => {
+      for (const tool of this.tools()) {
+        if (tool.protocol === 'mcp' && !this.requestedStatusToolIds.has(tool.toolId)) {
+          this.requestedStatusToolIds.add(tool.toolId);
+          void this.loadGatewayStatus(tool.toolId);
+        }
+      }
+    });
+  }
 
   // Computed
   readonly tools = computed(() => this.adminToolService.getTools());
@@ -494,6 +630,49 @@ export class ToolListPage {
       default:
         return `${base} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300`;
     }
+  }
+
+  private async loadGatewayStatus(toolId: string, attempt = 0): Promise<void> {
+    if (attempt === 0) {
+      this.setGatewayStatus(toolId, 'loading');
+    }
+    try {
+      const status = await this.adminToolService.getGatewayTargetStatus(toolId);
+      if (this.destroyed) {
+        return;
+      }
+      this.setGatewayStatus(toolId, status);
+      // The gateway syncs a target asynchronously, so a freshly-saved tool is
+      // briefly transient. Re-poll a few times until it settles into
+      // Ready/Failed, so the badge converges without a manual reload.
+      if (isTransientGatewayStatus(status.status) && attempt < 5) {
+        setTimeout(() => void this.loadGatewayStatus(toolId, attempt + 1), 3000);
+      }
+    } catch {
+      // Keep any prior value on a re-poll failure; only the first attempt
+      // surfaces an explicit 'unknown'.
+      if (attempt === 0 && !this.destroyed) {
+        this.setGatewayStatus(toolId, 'error');
+      }
+    }
+  }
+
+  private setGatewayStatus(toolId: string, value: GatewayHealth): void {
+    this.gatewayStatuses.update(prev => {
+      const next = new Map(prev);
+      next.set(toolId, value);
+      return next;
+    });
+  }
+
+  /** Compact health badge for a gateway tool's row, or null if not yet known. */
+  gatewayBadge(toolId: string): GatewayBadge | null {
+    return gatewayBadgeFor(this.gatewayStatuses().get(toolId));
+  }
+
+  /** The joined failure reasons for an unhealthy gateway tool, else null. */
+  gatewayFailureReasons(toolId: string): string | null {
+    return gatewayFailureReasonsFor(this.gatewayStatuses().get(toolId));
   }
 
   async openRoleDialog(tool: AdminTool): Promise<void> {

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
@@ -11,6 +11,7 @@ import {
   ToolRoleAssignment,
   MCPDiscoverRequest,
   MCPDiscoverResponse,
+  GatewayTargetStatus,
 } from '../models/admin-tool.model';
 
 /**
@@ -211,6 +212,20 @@ export class AdminToolService {
   async discoverMCPTools(request: MCPDiscoverRequest): Promise<MCPDiscoverResponse> {
     return firstValueFrom(
       this.http.post<MCPDiscoverResponse>(`${this.baseUrl()}/discover`, request)
+    );
+  }
+
+  /**
+   * Fetch the live AgentCore Gateway health for a protocol='mcp' tool. The
+   * gateway syncs a target asynchronously after registration, so this is how
+   * the UI learns a target FAILED (e.g. the gateway role can't invoke the
+   * endpoint) rather than leaving it invisible.
+   */
+  async getGatewayTargetStatus(toolId: string): Promise<GatewayTargetStatus> {
+    return firstValueFrom(
+      this.http.get<GatewayTargetStatus>(
+        `${this.baseUrl()}/${toolId}/gateway-status`
+      )
     );
   }
 }

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -444,9 +444,36 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
         'bedrock-agentcore:UpdateGatewayTarget',
         'bedrock-agentcore:DeleteGatewayTarget',
         'bedrock-agentcore:ListGatewayTargets',
+        // GetGateway resolves the gateway execution-role ARN, which the per-
+        // target Lambda grant names as the invoke principal.
+        'bedrock-agentcore:GetGateway',
       ],
       resources: [
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:gateway/*`,
+      ],
+    }),
+  );
+
+  // Per-target gateway-role invoke grant (issue #419): when an admin registers
+  // an IAM-protected Lambda-URL MCP target, app-api authorizes the gateway role
+  // to invoke exactly that function by adding a statement to its resource policy
+  // (and removes it on delete). This replaces a standing wildcard on the gateway
+  // role, so admins add same-account MCP servers through the form with no infra
+  // change. GetFunctionUrlConfig validates the function is same-account and its
+  // URL matches before granting (the cross-account guard). Scoped to the MCP
+  // server naming conventions. See apis/shared/tools/gateway_lambda_grant.py.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'McpTargetLambdaGrant',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'lambda:AddPermission',
+        'lambda:RemovePermission',
+        'lambda:GetFunctionUrlConfig',
+      ],
+      resources: [
+        `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:mcp-*`,
+        `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:${config.projectPrefix}-mcp-*`,
       ],
     }),
   );

--- a/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
+++ b/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
@@ -15,11 +15,14 @@ export interface AgentCoreGatewayConstructProps {
  * protocol and AWS_IAM (SigV4) authorization.
  *
  * Provides:
- *   - Gateway IAM execution role with `lambda:InvokeFunction` against
- *     `arn:aws:lambda:.../function:{prefix}-mcp-*` (MCP Lambda
- *     functions are owned by the external mcp-servers repo, not this
- *     CDK app — the role grants invoke rights against the naming
- *     convention)
+ *   - Gateway IAM execution role with NO standing Lambda-invoke grant. The
+ *     permission to invoke an `mcpServer` target's Lambda Function URL is
+ *     granted *per target* at registration time by app-api
+ *     (`lambda:AddPermission` on the function's resource policy, naming this
+ *     role), and revoked on delete — so an admin can register any same-account
+ *     MCP server through the form with no infra change, and the role can invoke
+ *     only the functions explicitly registered (no naming-convention wildcard).
+ *     See `apis/shared/tools/gateway_lambda_grant.py`.
  *   - CloudWatch Logs publish rights for gateway-scoped log groups
  *   - `agentcore.CfnGateway` configured for MCP protocol with AWS_IAM
  *     authorizer and SEMANTIC search type
@@ -55,16 +58,11 @@ export class AgentCoreGatewayConstruct extends Construct {
       description: 'Execution role for AgentCore Gateway',
     });
 
-    this.gatewayRole.addToPolicy(
-      new iam.PolicyStatement({
-        sid: 'LambdaInvokeAccess',
-        effect: iam.Effect.ALLOW,
-        actions: ['lambda:InvokeFunction'],
-        resources: [
-          `arn:aws:lambda:${stack.region}:${stack.account}:function:${config.projectPrefix}-mcp-*`,
-        ],
-      }),
-    );
+    // NOTE: no standing `lambda:Invoke*` grant. Invoke permission for each
+    // mcpServer target's Lambda Function URL is granted per-target at
+    // registration by app-api (lambda:AddPermission naming this role) and
+    // revoked on delete — least-privilege, and admins add servers with no infra
+    // change. See AgentCoreGatewayTargetAccess on the app-api role.
 
     this.gatewayRole.addToPolicy(
       new iam.PolicyStatement({

--- a/infrastructure/test/network-and-scripts.test.ts
+++ b/infrastructure/test/network-and-scripts.test.ts
@@ -265,15 +265,18 @@ describe('AgentCoreGatewayConstruct — detailed', () => {
     });
   });
 
-  it('gateway role allows lambda:InvokeFunction on mcp-* functions', () => {
+  it('gateway role has NO standing lambda:Invoke* grant (per-target only)', () => {
+    // Invoke is granted per-target by app-api at registration, not by a standing
+    // wildcard on the gateway role — so its only inline grant is CloudWatch Logs.
     t.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
-        Statement: Match.arrayWith([
-          Match.objectLike({
-            Action: 'lambda:InvokeFunction',
-            Effect: 'Allow',
-          }),
-        ]),
+        Statement: Match.not(
+          Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(['lambda:InvokeFunctionUrl']),
+            }),
+          ]),
+        ),
       },
     });
   });


### PR DESCRIPTION
Builds on the original mcpServer credential-config fix (`None` + IAM service) into an end-to-end, admin-self-service path for registering external MCP servers as AgentCore Gateway targets — and surfaces the failures that were previously silent.

## The problem
A registered + enabled `protocol=mcp` tool (`gateway_class_search`) produced *"I don't have that tool"* from the agent. Investigation found **three stacked blockers**, none of them obvious:

0. **Two gateways.** The agent resolved a hardcoded `/strands-agent-chatbot/dev/…` gateway; the admin form registered on the CDK gateway `/{PROJECT_PREFIX}/gateway/id`. Targets landed on a gateway the agent never connected to.
1. **Gateway role couldn't invoke the target.** The target's Lambda Function URL is `AuthType=AWS_IAM`; the gateway role lacked `lambda:InvokeFunctionUrl` (a distinct action from `InvokeFunction`) and the `{prefix}-mcp-*` wildcard didn't match the `mcp-<name>-<env>` naming → target stuck `FAILED`.
2. **Agent-side ID mismatch.** The gateway exposes `<targetName>___<toolName>`, but the catalog tool id `gateway_class_search` matched none of them → silent drop.

## What this PR does
**Unify the gateway (Blocker 0)** — shared `gateway_identity.resolve_gateway_id` (one source of truth: `AGENTCORE_GATEWAY_ID` override → SSM `/{PROJECT_PREFIX}/gateway/id`); the agent and `GatewayTargetService` both use it, so they can't diverge.

**Expand catalog tools (Blocker 2)** — `base_agent` expands a `protocol=mcp` tool into the gateway's runtime `gateway_<target>___<tool>` ids so the `FilteredMCPClient` matches; raw RBAC gateway ids pass through.

**Self-service per-target IAM grant (Blocker 1, done right)** — instead of a standing wildcard on the gateway role (an infra change per off-convention server), app-api grants the gateway role `InvokeFunctionUrl` on **exactly** the registered function at registration (`lambda:AddPermission` naming the role — a role-specific resource grant authorizes it same-account, no identity grant) and revokes it on delete. So an admin registers **any same-account Lambda-URL MCP server through the form with no infra change**, and the gateway role can invoke only what was explicitly registered.
- **Cross-account validation:** `GetFunctionUrlConfig` confirms same-account + that the endpoint is under the function URL; otherwise a **400** tells the admin to make it public or use a credential provider.
- CDK: gateway role loses its Lambda-invoke wildcard (logs only); app-api gains scoped `AddPermission`/`RemovePermission`/`GetFunctionUrlConfig` + `GetGateway`.
- New `MCPGatewayConfig.lambda_function_name` + a conditional "Lambda function name" form field (shown only for Lambda-URL endpoints).

**Health surfacing** — `GET /admin/tools/{id}/gateway-status` (+ `statusReasons`) and a **Ready/Syncing/Failed/Missing** badge on the tools list, so a failed target sync is visible instead of only appearing as a missing tool.

**Discovery + form polish** — MCP discovery errors unwrap the real upstream status (403 stays 403 with an actionable message; 401→400 to avoid tripping the SPA logout); awsService/awsRegion auto-derive from the endpoint; IAM is recommended when an AWS host is left on `None`.

## Security posture
The gateway's **inbound** SigV4 (`authorizerType=AWS_IAM`) is free and unchanged. **Outbound** IAM is the boundary that keeps an MCP server from being a public bypass of RBAC/approval — kept, but moved from a standing wildcard to a least-privilege per-target grant. Same-account Lambda-URL targets only; cross-account / API-Gateway / custom-domain targets must be public or use a credential provider (the form says so).

## Testing
- Backend: **3497 passed, 3 skipped** (full suite); new suites for the resolver, tool-id expansion, the Lambda grant, and discovery errors.
- Frontend: 30 admin-tools specs (badge mapping, IAM recommend, Lambda-name wiring); full `ng build` type-checks.
- Infra: 80 jest (gateway role has no standing invoke; app-api has the scoped grant); `tsc` clean.
- Live (dev): target `FAILED → READY` on the per-target grant alone; agent loads all 9 class-search tools end-to-end; `gateway_class_search` migrated to the new scheme.

## Deploy
1. `platform.yml` (CDK role changes — dev gateway is already in the end-state).
2. `backend.yml` (new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)