### PR TITLE
Bind persisted roles to JWT in profile-sync handler

### DIFF
--- a/backend/src/apis/app_api/users/models.py
+++ b/backend/src/apis/app_api/users/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, ConfigDict
 
 class UserSearchResult(BaseModel):
     """User search result for sharing modal."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     user_id: str = Field(..., alias="userId", description="User identifier")
@@ -15,6 +16,7 @@ class UserSearchResult(BaseModel):
 
 class UserSearchResponse(BaseModel):
     """Response containing user search results."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     users: List[UserSearchResult] = Field(..., description="List of matching users")
@@ -22,6 +24,7 @@ class UserSearchResponse(BaseModel):
 
 class UserPermissionsResponse(BaseModel):
     """Response model for user effective permissions resolved from AppRoles."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     app_roles: List[str] = Field(..., alias="appRoles", description="Resolved application roles")
@@ -32,11 +35,23 @@ class UserPermissionsResponse(BaseModel):
 
 
 class UserProfileSyncRequest(BaseModel):
-    """Request to sync user profile from the frontend ID token."""
-    model_config = ConfigDict(populate_by_name=True)
+    """Request to sync user profile from the frontend ID token.
+
+    Identity-display fields only. Authorization-relevant fields (notably
+    ``roles``) are deliberately not accepted here — they flow from the
+    IdP via the BFF token-exchange path and the validated JWT, never from
+    a client-controlled request body.
+
+    ``extra="allow"`` keeps the endpoint compatible with legacy clients
+    that still send dropped fields like ``roles``: the extras are
+    accepted, exposed via ``model_extra``, and ignored when building the
+    persisted profile. The route handler logs a warning when it sees
+    them so stale clients can be chased down.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     email: str = Field(..., description="User email from ID token")
     name: str = Field("", description="User display name from ID token")
     picture: Optional[str] = Field(None, description="Profile picture URL from ID token")
-    roles: List[str] = Field(default_factory=list, description="User roles from ID token")
     provider_sub: Optional[str] = Field(None, alias="provider_sub", description="IdP user identifier from ID token")

--- a/backend/src/apis/app_api/users/routes.py
+++ b/backend/src/apis/app_api/users/routes.py
@@ -7,7 +7,7 @@ from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.users.repository import UserRepository
-from apis.shared.users.models import UserProfile, UserListItem, UserStatus
+from apis.shared.users.models import UserProfile, UserStatus
 from .models import UserSearchResult, UserSearchResponse, UserPermissionsResponse, UserProfileSyncRequest
 
 logger = logging.getLogger(__name__)
@@ -43,10 +43,7 @@ async def get_my_permissions(
         )
     except Exception as e:
         logger.error(f"Failed to resolve permissions for {current_user.user_id}: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to resolve user permissions"
-        )
+        raise HTTPException(status_code=500, detail="Failed to resolve user permissions")
 
 
 @router.post("/me/sync", status_code=204)
@@ -62,6 +59,14 @@ async def sync_my_profile(
     contains identity claims (email, name, picture) that the access token
     lacks. This keeps the Users table current so the backend can resolve
     email for features like assistant sharing and fine-tuning access.
+
+    Identity-display fields only. ``roles`` are sourced exclusively from
+    the validated session (i.e. the JWT-derived ``current_user.roles``)
+    and are never read from the request body. The Users-table roles are
+    populated server-side by the BFF callback's
+    ``_sync_user_from_id_token`` off the ID token; this endpoint
+    refreshes the display fields without granting clients any influence
+    over authorization.
     """
     if not user_repo.enabled:
         return
@@ -70,15 +75,27 @@ async def sync_my_profile(
     if not email:
         raise HTTPException(status_code=422, detail="Email is required")
 
+    # Surface clients that are still sending the legacy ``roles`` field so
+    # we can chase down stale code. The model's ``extra="allow"`` config
+    # makes those extras visible via ``model_extra``; we don't act on them.
+    extras = getattr(body, "model_extra", None) or {}
+    if "roles" in extras:
+        logger.warning(
+            "Profile sync request from %s included a 'roles' field; ignoring (roles flow from JWT only)",
+            current_user.user_id,
+        )
+
     email_domain = email.split("@")[1] if "@" in email else ""
     from datetime import datetime, timezone
+
     now = datetime.now(timezone.utc).isoformat() + "Z"
 
     profile = UserProfile(
         user_id=current_user.user_id,
         email=email,
         name=body.name or current_user.name,
-        roles=body.roles if body.roles else current_user.roles or [],
+        # Always use JWT-derived roles, never the request body.
+        roles=current_user.roles or [],
         picture=body.picture,
         email_domain=email_domain,
         created_at=now,
@@ -91,6 +108,7 @@ async def sync_my_profile(
         # Invalidate the in-memory profile cache so the enrichment function
         # picks up the fresh roles on the very next request.
         from apis.shared.auth.dependencies import invalidate_user_profile_cache
+
         invalidate_user_profile_cache(current_user.user_id)
         logger.info("Synced profile for user %s", current_user.user_id)
     except Exception as e:
@@ -103,123 +121,103 @@ async def search_users(
     q: str = Query(..., description="Search query (email or name, partial match)"),
     limit: int = Query(20, ge=1, le=50, description="Maximum number of results"),
     current_user: User = Depends(get_current_user_from_session),
-    user_repo: UserRepository = Depends(get_user_repository)
+    user_repo: UserRepository = Depends(get_user_repository),
 ):
     """
     Search for users by email or name (partial match).
-    
+
     This endpoint is used by the sharing modal to find existing users in the system.
     Only returns active users. Search matches against:
     - Email prefix (case-insensitive)
     - Name contains (case-insensitive)
-    
+
     Requires JWT authentication. Available to all authenticated users (not admin-only).
-    
+
     Args:
         q: Search query string
         limit: Maximum number of results (1-50, default 20)
         current_user: Authenticated user from JWT token (injected by dependency)
         user_repo: User repository instance (injected by dependency)
-    
+
     Returns:
         UserSearchResponse with list of matching users
-    
+
     Raises:
         HTTPException:
             - 401 if not authenticated
             - 500 if server error
     """
     logger.info("GET /users/search")
-    
+
     if not user_repo.enabled:
         logger.debug("User repository not enabled - returning empty results")
         return UserSearchResponse(users=[])
-    
+
     try:
         # Normalize search query
         query_lower = q.lower().strip()
-        
+
         if not query_lower:
             return UserSearchResponse(users=[])
-        
+
         # Search by email prefix using EmailIndex
         # Note: DynamoDB doesn't support contains queries efficiently, so we'll use prefix matching
         # For name matching, we'll need to scan/query and filter (less efficient but acceptable for small orgs)
-        
+
         results = []
         seen_user_ids = set()
-        
+
         # Try exact email match first (most common case)
         user_by_email = await user_repo.get_user_by_email(query_lower)
         if user_by_email and user_by_email.status == UserStatus.ACTIVE:
             if user_by_email.user_id not in seen_user_ids:
-                results.append(UserSearchResult(
-                    user_id=user_by_email.user_id,
-                    email=user_by_email.email,
-                    name=user_by_email.name
-                ))
+                results.append(UserSearchResult(user_id=user_by_email.user_id, email=user_by_email.email, name=user_by_email.name))
                 seen_user_ids.add(user_by_email.user_id)
-        
+
         # If we already have enough results from exact match, return early
         if len(results) >= limit:
             return UserSearchResponse(users=results[:limit])
-        
+
         # Search by email prefix (if query looks like email start)
         # Note: DynamoDB EmailIndex doesn't support begins_with efficiently without a scan
         # For now, we'll use a simplified approach: if query contains @, try exact match
         # For broader search, we'd need to implement a scan with filter (acceptable for small user bases)
-        
+
         # Search by name contains (scan active users)
         # This is less efficient but necessary for name-based search
         # We'll limit to first 100 active users and filter by name
         active_users, _ = await user_repo.list_users_by_status(
-            status=UserStatus.ACTIVE.value,
-            limit=100,  # Scan up to 100 active users
-            last_evaluated_key=None
+            status=UserStatus.ACTIVE.value, limit=100, last_evaluated_key=None  # Scan up to 100 active users
         )
-        
+
         # Filter by name contains (case-insensitive)
         for user in active_users:
             if user.user_id in seen_user_ids:
                 continue
-            
+
             # Check if name contains query (case-insensitive)
             if query_lower in user.name.lower():
-                results.append(UserSearchResult(
-                    user_id=user.user_id,
-                    email=user.email,
-                    name=user.name
-                ))
+                results.append(UserSearchResult(user_id=user.user_id, email=user.email, name=user.name))
                 seen_user_ids.add(user.user_id)
-            
+
             # Also check if email contains query (for partial email matches)
             elif query_lower in user.email.lower():
-                results.append(UserSearchResult(
-                    user_id=user.user_id,
-                    email=user.email,
-                    name=user.name
-                ))
+                results.append(UserSearchResult(user_id=user.user_id, email=user.email, name=user.name))
                 seen_user_ids.add(user.user_id)
-            
+
             # Stop if we have enough results
             if len(results) >= limit:
                 break
-        
+
         # Sort results: exact email matches first, then by name
-        results.sort(key=lambda x: (
-            0 if query_lower == x.email.lower() else 1,  # Exact email match first
-            x.name.lower()  # Then by name
-        ))
-        
+        results.sort(key=lambda x: (0 if query_lower == x.email.lower() else 1, x.name.lower()))  # Exact email match first  # Then by name
+
         # Limit results
         results = results[:limit]
-        
+
         logger.info("User search completed")
         return UserSearchResponse(users=results)
-    
+
     except Exception as e:
         logger.error("Error searching users", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to search users: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to search users: {str(e)}")

--- a/backend/tests/routes/test_users_sync.py
+++ b/backend/tests/routes/test_users_sync.py
@@ -1,0 +1,229 @@
+"""Tests for the ``POST /users/me/sync`` endpoint.
+
+Asserts the positive invariant that the persisted ``UserProfile.roles``
+field is sourced from the validated JWT (i.e. ``current_user.roles``)
+and never from the request body. Legacy clients that still send a
+``roles`` field are accepted (no 4xx) but the field is dropped silently
+and a warning is logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, PropertyMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.users.routes import router, get_user_repository
+from tests.routes.conftest import mock_auth_user, mock_no_auth, mock_service
+
+
+def _make_repo() -> AsyncMock:
+    repo = AsyncMock()
+    type(repo).enabled = PropertyMock(return_value=True)
+    repo.upsert_user = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# JWT roles are the source of truth
+# ---------------------------------------------------------------------------
+
+
+def test_sync_persists_jwt_roles_not_body_roles(app, make_user) -> None:
+    """A client supplying ``roles: ["system_admin"]`` must not influence the
+    persisted profile — JWT-derived roles win regardless of the body."""
+    user = make_user(user_id="u-1", email="alice@example.com", name="Alice", roles=["default"])
+    mock_auth_user(app, user)
+
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/users/me/sync",
+        json={
+            "email": "alice@example.com",
+            "name": "Alice",
+            "roles": ["system_admin", "platform_admin"],  # malicious
+        },
+    )
+
+    assert resp.status_code == 204
+    repo.upsert_user.assert_called_once()
+    persisted = repo.upsert_user.call_args.args[0]
+    assert persisted.roles == ["default"]
+    assert "system_admin" not in persisted.roles
+
+
+def test_sync_with_no_jwt_roles_persists_empty_list(app, make_user) -> None:
+    """If the JWT has no roles, the persisted profile gets an empty list —
+    body ``roles`` cannot fill the gap."""
+    user = make_user(user_id="u-2", email="bob@example.com", name="Bob", roles=[])
+    mock_auth_user(app, user)
+
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/users/me/sync",
+        json={"email": "bob@example.com", "name": "Bob", "roles": ["system_admin"]},
+    )
+
+    assert resp.status_code == 204
+    persisted = repo.upsert_user.call_args.args[0]
+    assert persisted.roles == []
+
+
+def test_sync_warns_when_legacy_roles_field_present(app, make_user, caplog) -> None:
+    """The handler should log a WARNING when a request still carries the
+    legacy ``roles`` key, so operators can chase down stale clients."""
+    user = make_user(user_id="u-3", email="c@example.com", name="C", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    with caplog.at_level(logging.WARNING, logger="apis.app_api.users.routes"):
+        resp = client.post(
+            "/users/me/sync",
+            json={"email": "c@example.com", "roles": ["system_admin"]},
+        )
+
+    assert resp.status_code == 204
+    assert any("'roles' field" in rec.message and rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+def test_sync_without_legacy_roles_field_no_warning(app, make_user, caplog) -> None:
+    """A clean request (no ``roles`` key at all) should not emit the warning."""
+    user = make_user(user_id="u-4", email="d@example.com", name="D", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    with caplog.at_level(logging.WARNING, logger="apis.app_api.users.routes"):
+        resp = client.post("/users/me/sync", json={"email": "d@example.com", "name": "D"})
+
+    assert resp.status_code == 204
+    assert not any("'roles' field" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Other identity fields still work
+# ---------------------------------------------------------------------------
+
+
+def test_sync_persists_email_name_picture_from_body(app, make_user) -> None:
+    """Identity-display fields (email, name, picture) still come from the
+    body — the security boundary is roles only."""
+    user = make_user(user_id="u-5", email="e@example.com", name="E", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/users/me/sync",
+        json={
+            "email": "e@example.com",
+            "name": "Eddie",
+            "picture": "https://cdn.example.com/e.png",
+        },
+    )
+
+    assert resp.status_code == 204
+    persisted = repo.upsert_user.call_args.args[0]
+    assert persisted.email == "e@example.com"
+    assert persisted.name == "Eddie"
+    assert persisted.picture == "https://cdn.example.com/e.png"
+
+
+def test_sync_email_normalized_to_lowercase(app, make_user) -> None:
+    user = make_user(user_id="u-6", email="f@example.com", name="F", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/users/me/sync",
+        json={"email": "  F@Example.COM  ", "name": "F"},
+    )
+
+    assert resp.status_code == 204
+    persisted = repo.upsert_user.call_args.args[0]
+    assert persisted.email == "f@example.com"
+
+
+def test_sync_missing_email_returns_422(app, make_user) -> None:
+    user = make_user(user_id="u-7", email="g@example.com", name="G", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post("/users/me/sync", json={"name": "G"})
+
+    # FastAPI returns 422 for missing required body fields.
+    assert resp.status_code == 422
+
+
+def test_sync_blank_email_returns_422(app, make_user) -> None:
+    user = make_user(user_id="u-8", email="h@example.com", name="H", roles=["default"])
+    mock_auth_user(app, user)
+    repo = _make_repo()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post("/users/me/sync", json={"email": "   ", "name": "H"})
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated
+# ---------------------------------------------------------------------------
+
+
+def test_sync_requires_authentication(app) -> None:
+    mock_no_auth(app)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/users/me/sync",
+        json={"email": "x@example.com", "name": "X"},
+    )
+
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Repo disabled (graceful no-op)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_returns_204_when_repo_disabled(app, make_user) -> None:
+    user = make_user(user_id="u-9", email="i@example.com", name="I", roles=["default"])
+    mock_auth_user(app, user)
+
+    repo = AsyncMock()
+    type(repo).enabled = PropertyMock(return_value=False)
+    repo.upsert_user = AsyncMock()
+    mock_service(app, get_user_repository, repo)
+
+    client = TestClient(app)
+    resp = client.post("/users/me/sync", json={"email": "i@example.com", "name": "I"})
+
+    assert resp.status_code == 204
+    repo.upsert_user.assert_not_called()


### PR DESCRIPTION
POST /users/me/sync now derives the persisted roles list exclusively from current_user.roles (the validated JWT claims). Roles are already populated server-side by the BFF callback's _sync_user_from_id_token off the trusted ID-token decode, and per-request RBAC reads them from the access token's verified claims plus the Users table that the callback writes — the request body has no role to play in this path.

UserProfileSyncRequest no longer declares a 'roles' field. Pydantic's extra='allow' setting keeps the endpoint backwards-compatible with clients that still send extra keys (no 4xx; the extras surface via model_extra and are dropped when building the persisted profile). The handler logs a WARNING when it sees a legacy 'roles' key so stale clients can be tracked down.

Tests:
- test_sync_persists_jwt_roles_not_body_roles: body roles do not influence the persisted record.
- test_sync_with_no_jwt_roles_persists_empty_list: empty JWT roles cannot be filled in by the body.
- test_sync_warns_when_legacy_roles_field_present: legacy field emits the WARN log.
- Plus seven baseline tests covering email normalization, name and picture pass-through, validation errors, auth requirement, and the graceful no-op when the Users repository is disabled.