### PR TITLE
docs(docs-site): add API Keys + Admin section to nav, flesh out Tools page

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
 				{ label: 'Deployment', items: [{ autogenerate: { directory: 'deployment' } }] },
 				{ label: 'Configuration', items: [{ autogenerate: { directory: 'configuration' } }] },
 				{ label: 'Features', items: [{ autogenerate: { directory: 'features' } }] },
+				{ label: 'Admin', items: [{ autogenerate: { directory: 'admin' } }] },
 				{ label: 'MCP & Integrations', items: [{ autogenerate: { directory: 'integrations' } }] },
 				{ label: 'Development', items: [{ autogenerate: { directory: 'development' } }] },
 				{ label: 'Reference', items: [{ autogenerate: { directory: 'reference' } }] },

--- a/docs-site/src/content/docs/admin/auth-providers.md
+++ b/docs-site/src/content/docs/admin/auth-providers.md
@@ -1,0 +1,12 @@
+---
+title: Auth Providers
+description: Configure sign-in identity providers.
+sidebar:
+  order: 10
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Identity & Access group. Manage the IdPs users authenticate with; backed by `admin/auth_providers` and the `/admin/auth-providers` pages.

--- a/docs-site/src/content/docs/admin/connectors.md
+++ b/docs-site/src/content/docs/admin/connectors.md
@@ -1,0 +1,12 @@
+---
+title: Connectors
+description: External OAuth connectors for tools.
+sidebar:
+  order: 7
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+AI Configuration group. Configure OAuth providers that tools connect through; backed by `admin/oauth` and the `/admin/connectors` pages.

--- a/docs-site/src/content/docs/admin/conversation-modes.md
+++ b/docs-site/src/content/docs/admin/conversation-modes.md
@@ -1,0 +1,12 @@
+---
+title: Conversation Modes
+description: System prompts that define conversation behaviors.
+sidebar:
+  order: 12
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Customization group. Author the system prompts behind selectable conversation modes; backed by `admin/system_prompts` and the `/admin/system-prompts` pages.

--- a/docs-site/src/content/docs/admin/cost-analytics.md
+++ b/docs-site/src/content/docs/admin/cost-analytics.md
@@ -1,0 +1,12 @@
+---
+title: Cost Analytics
+description: Track and analyze AI spend across users.
+sidebar:
+  order: 2
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Usage & Spend group. Aggregated token/cost reporting; backed by `admin/costs` and the `/admin/costs` page.

--- a/docs-site/src/content/docs/admin/fine-tuning.md
+++ b/docs-site/src/content/docs/admin/fine-tuning.md
@@ -1,0 +1,12 @@
+---
+title: Fine-Tuning
+description: Fine-tuning access and costs.
+sidebar:
+  order: 4
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Usage & Spend group. Grant fine-tuning access and review its spend; backed by `admin/fine_tuning` and the `/admin/fine-tuning` pages.

--- a/docs-site/src/content/docs/admin/models.md
+++ b/docs-site/src/content/docs/admin/models.md
@@ -1,0 +1,12 @@
+---
+title: Models
+description: Configure the models offered to users.
+sidebar:
+  order: 5
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+AI Configuration group. Manage the model catalog (Bedrock, Gemini, OpenAI); backed by the `/admin/manage-models` pages.

--- a/docs-site/src/content/docs/admin/overview.md
+++ b/docs-site/src/content/docs/admin/overview.md
@@ -1,0 +1,12 @@
+---
+title: Admin Overview
+description: The role-gated admin console and its endpoints.
+sidebar:
+  order: 1
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+The admin console lives at `/admin` in the SPA and is gated by `require_admin` (Admin or SuperAdmin role). Backend routes sit under `/admin/<domain>/`; the pages below mirror the console's navigation groups — Usage & Spend, AI Configuration, Identity & Access, and Customization.

--- a/docs-site/src/content/docs/admin/quotas.md
+++ b/docs-site/src/content/docs/admin/quotas.md
@@ -1,0 +1,12 @@
+---
+title: Quotas
+description: Rate limits and quota tiers.
+sidebar:
+  order: 3
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Usage & Spend group. Per-tier usage limits; backed by `admin/quota` and the `/admin/quota` pages.

--- a/docs-site/src/content/docs/admin/roles.md
+++ b/docs-site/src/content/docs/admin/roles.md
@@ -1,0 +1,12 @@
+---
+title: Roles
+description: Define roles and their permissions.
+sidebar:
+  order: 9
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Identity & Access group. Create roles and bind permissions used by RBAC; backed by `admin/roles` and the `/admin/roles` pages.

--- a/docs-site/src/content/docs/admin/tools.md
+++ b/docs-site/src/content/docs/admin/tools.md
@@ -1,0 +1,12 @@
+---
+title: Tools
+description: Register and manage agent tools.
+sidebar:
+  order: 6
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+AI Configuration group. Define tools (including Gateway MCP targets) and their visibility; backed by `admin/tools` and the `/admin/tools` pages.

--- a/docs-site/src/content/docs/admin/user-menu-links.md
+++ b/docs-site/src/content/docs/admin/user-menu-links.md
@@ -1,0 +1,12 @@
+---
+title: User Menu Links
+description: Custom links in the user menu.
+sidebar:
+  order: 11
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Customization group. Manage the extra links surfaced in the user menu; backed by `admin/user_menu_links` and the `/admin/manage-user-menu-links` pages.

--- a/docs-site/src/content/docs/admin/users.md
+++ b/docs-site/src/content/docs/admin/users.md
@@ -1,0 +1,12 @@
+---
+title: Users
+description: View and manage user accounts.
+sidebar:
+  order: 8
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Identity & Access group. Browse users and inspect their detail/sessions; backed by `admin/users` and the `/admin/users` pages.

--- a/docs-site/src/content/docs/features/api-keys.md
+++ b/docs-site/src/content/docs/features/api-keys.md
@@ -1,0 +1,12 @@
+---
+title: API Keys
+description: Programmatic access with X-API-Key.
+sidebar:
+  order: 9
+---
+
+:::caution[Draft]
+This page is a scaffolded placeholder — content to be written.
+:::
+
+Per-user keys minted at `/auth/api-keys` (create/list/revoke); requests authenticate with the `X-API-Key` header instead of the session cookie. The raw key value is shown only once at creation.

--- a/docs-site/src/content/docs/features/tools.md
+++ b/docs-site/src/content/docs/features/tools.md
@@ -1,12 +1,83 @@
 ---
 title: Tools and Multi-Protocol Architecture
-description: Direct, AWS SDK, MCP+SigV4, and A2A tools.
+description: Direct, AWS SDK, MCP+SigV4, and A2A tools — and why the default set is intentionally small.
 sidebar:
+  label: Tools
   order: 2
 ---
 
-:::caution[Draft]
-This page is a scaffolded placeholder — content to be written.
-:::
+Tools are how the agent does things beyond generating text — fetching a page,
+running a calculation, charting data, calling a remote service. The platform is
+**multi-protocol**: a single agent loop can call tools that live in very
+different places and authenticate in very different ways, all behind one uniform
+tool interface.
 
-The four tool protocols and where each one lives.
+## Multi-protocol support
+
+The agent can reach a tool through any of four protocols. Each trades locality
+for reach: a direct Python function is the simplest and fastest; an A2A agent is
+a fully independent service you delegate to.
+
+| Protocol | Where the tool runs | Auth | Status |
+| --- | --- | --- | --- |
+| **Direct call** | In-process Python function in the agent (`agents/main_agent/tools/`) | None — same process | Available |
+| **AWS SDK** | In-process, but calling an AWS service via `boto3` | IAM (the runtime's task role) | Available |
+| **MCP + SigV4** | A Lambda behind the AgentCore **Gateway**, exposed as MCP | AWS SigV4 | Available |
+| **A2A** | A separate agent in its own AgentCore Runtime | AgentCore auth | Client-only today |
+
+A few notes on the edges:
+
+- **Direct** and **AWS SDK** tools are ordinary `@tool`-decorated functions. The
+  difference is only what they touch — local computation versus an AWS API.
+- **MCP + SigV4** tools are discovered dynamically from the Gateway, so the tool
+  list grows without a code change. See
+  [Gateway MCP Targets](/agentcore-public-stack/integrations/gateway-targets/)
+  for registering one.
+- **A2A** is **client-only** right now: the platform can call out to remote
+  agents, but does not yet expose itself as an A2A server.
+
+## An intentionally limited default set
+
+The platform ships with a **deliberately small** built-in tool set. This is a
+design choice, not an omission — the goal is a clean, dependency-light starting
+point you extend for your own deployment rather than a kitchen sink you have to
+prune.
+
+What's included out of the box:
+
+| Tool | Protocol | What it does |
+| --- | --- | --- |
+| **Calculator** | Direct (Strands built-in) | Evaluates mathematical expressions. |
+| **URL Fetcher** | Direct | Fetches and extracts text from web pages, articles, and docs. |
+| **Charts & Graphs** | Direct | Builds interactive bar, line, and pie charts from data. |
+| **Code Interpreter** | Direct (sandboxed) | Runs Python in a sandbox to generate diagrams and visualizations. |
+| **Spreadsheet tools** | Direct (sandboxed) | Lists and analyzes spreadsheet files from the knowledge base or attachments. |
+
+The built-in registry is assembled in `create_default_registry()`
+(`agents/main_agent/tools/tool_registry.py`); each tool's display metadata lives
+in the `TOOL_CATALOG` (`tool_catalog.py`).
+
+## Flexible by design
+
+The small default set is paired with several extension points, so capability is
+something you add rather than something you're stuck with:
+
+- **Add a code tool** — drop a `@tool` function into
+  `agents/main_agent/tools/`, register it in `__init__.py`, and it joins the
+  registry. (Direct or AWS SDK.)
+- **Add a remote tool without deploying agent code** — register a Gateway MCP
+  target; its tools are discovered at runtime and merged into the catalog.
+- **Delegate to another agent** — point the agent at a remote A2A agent for
+  whole workflows it can hand off.
+- **Control who sees what** — tool visibility is governed by RBAC and per-agent
+  `enabled_tools`, filtered through the `ToolFilter`. See
+  [RBAC and Permissions](/agentcore-public-stack/configuration/rbac/).
+- **Curate from the admin console** — the
+  [Tools admin page](/agentcore-public-stack/admin/tools/) manages the catalog
+  and Gateway targets without touching code.
+
+:::note
+Because tool selection is filtered per request, the *registered* set and the set
+a given user actually sees can differ — that's how the same deployment serves a
+locked-down audience and a power-user audience from one catalog.
+:::


### PR DESCRIPTION
## What changed

Documentation-site (Astro + Starlight) navigation and content updates:

- **Features → API Keys** — new `features/api-keys.md` page covering the `/auth/api-keys` create/list/revoke endpoints and `X-API-Key` auth.
- **New "Admin" sidebar section** — registered in `astro.config.mjs` (placed after Features, before MCP & Integrations). Its sub-menu mirrors the SPA admin console's nav order: Cost Analytics, Quotas, Fine-Tuning, Models, Tools, Connectors, Users, Roles, Auth Providers, User Menu Links, Conversation Modes — plus an Admin Overview landing page that explains the `require_admin` gating and `/admin/<domain>/` route shape.
- **Tools page fleshed out + menu label shortened** — the Features menu link is now just **Tools** (via `sidebar.label`) while the page keeps its full "Tools and Multi-Protocol Architecture" title. Replaced the Draft stub with real content: the four tool protocols (Direct, AWS SDK, MCP+SigV4, A2A) with where each runs/its auth/status, the intentionally-limited default tool set (from `TOOL_CATALOG` / `create_default_registry()`), and the extension points that make it flexible by design.

## Why

The Features menu was missing the API Keys capability, the admin console had no documentation entry point, and the Tools page was a scaffolded placeholder. These fill those gaps so the docs-site nav reflects the product's actual surface area.

## Reviewer notes

- New Admin pages follow the existing **Draft-stub convention** (`:::caution[Draft]` + a one-line pointer to the backing backend domain and SPA route) — they're scaffolds ready for content, not finished prose. Only the Tools page is fully written.
- The Admin sub-menu uses the SPA console's **user-facing labels**, which differ from backend domain names in two spots: "Conversation Modes" → `admin/system_prompts`, "Connectors" → `admin/oauth`. Each stub references the backend domain in its body.
- The default-tool table is described at the **product/catalog level** (e.g. the two spreadsheet tools are grouped into one "Spreadsheet tools" row) rather than enumerating every internal `tool_id`. Easy to expand to 1:1 if preferred.
- Verified locally: `astro build` completes clean (no errors / broken-link warnings), and the dev server renders the shortened "Tools" label, the API Keys entry, and the full 12-item Admin section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)