### PR TITLE
feat(skills): shared data layer for admin-managed skills (PR-1)

### DIFF
--- a/backend/src/apis/shared/skills/__init__.py
+++ b/backend/src/apis/shared/skills/__init__.py
@@ -1,0 +1,34 @@
+"""Shared skill-catalog utilities used by both app_api and the runtime.
+
+The skills parallel of ``apis/shared/tools``: the DynamoDB-backed catalog of
+admin-authored Skills (instruction bundles that bind catalog tools). Consumed
+by ``app_api`` (admin authoring) and the runtime (``agents``/``inference_api``);
+it never imports from either, per the import boundary.
+"""
+
+from .freshness import (
+    get_all_skill_ids,
+    get_freshness_hash,
+    get_skill_updated_at,
+    invalidate,
+)
+from .models import (
+    SKILL_ID_PATTERN,
+    SkillDefinition,
+    SkillStatus,
+    SkillVisibility,
+)
+from .repository import SkillCatalogRepository, get_skill_catalog_repository
+
+__all__ = [
+    "SKILL_ID_PATTERN",
+    "SkillDefinition",
+    "SkillStatus",
+    "SkillVisibility",
+    "SkillCatalogRepository",
+    "get_skill_catalog_repository",
+    "get_all_skill_ids",
+    "get_freshness_hash",
+    "get_skill_updated_at",
+    "invalidate",
+]

--- a/backend/src/apis/shared/skills/freshness.py
+++ b/backend/src/apis/shared/skills/freshness.py
@@ -1,0 +1,145 @@
+"""Per-process TTL caches over the skill catalog.
+
+The skills parallel of ``apis/shared/tools/freshness.py``. Two caches live
+here, both backed by DynamoDB reads of the skill catalog:
+
+1. **Per-skill freshness tokens** (``get_skill_updated_at``,
+   ``get_freshness_hash``). Cheap change-detection signal for the agent
+   cache: any admin edit to a skill bumps its ``updated_at``, so including
+   the freshness hash in a cache key causes the next build to miss and
+   rebuild with the fresh config (the runtime ``skills_hash`` in spec §8.3).
+
+2. **All-known-skill-ids snapshot** (``get_all_skill_ids``). The set of
+   skill IDs known to the catalog — the source of truth that RBAC's
+   wildcard (``"*"``) skill access needs to enumerate.
+
+Reads are TTL-cached so the per-turn overhead is bounded to at most one
+DynamoDB read per cache key per TTL window, per process. Admin routes call
+``invalidate(skill_id)`` after a write so same-process visibility is
+immediate; other processes see the change within one TTL window.
+``invalidate`` clears the all-skill-ids snapshot too, since any
+create/delete shifts that set.
+"""
+
+import asyncio
+import hashlib
+import logging
+import time
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# skill_id -> (updated_at_iso_or_none, monotonic_fetched_at)
+# None is stored when the skill is missing, so negative lookups are also
+# TTL-cached — a deleted skill doesn't trigger a DynamoDB read every turn.
+_cache: Dict[str, Tuple[Optional[str], float]] = {}
+
+# Single-slot snapshot of (frozen_set_of_skill_ids, monotonic_fetched_at).
+# Held in a list so we mutate index 0 in place rather than rebinding the
+# module-level name — same pattern as `_cache` above.
+_all_skill_ids_cache: List[Optional[Tuple[FrozenSet[str], float]]] = [None]
+
+_TTL_SECONDS = 10.0
+
+
+def _reset_for_tests() -> None:
+    _cache.clear()
+    _all_skill_ids_cache[0] = None
+
+
+async def _fetch_updated_at(skill_id: str) -> Optional[str]:
+    from apis.shared.skills.repository import get_skill_catalog_repository
+
+    repo = get_skill_catalog_repository()
+    skill = await repo.get_skill(skill_id)
+    if skill is None or skill.updated_at is None:
+        return None
+    return skill.updated_at.isoformat() + "Z"
+
+
+async def get_skill_updated_at(skill_id: str) -> Optional[str]:
+    """Return the `updated_at` for one skill, TTL-cached per process."""
+    now = time.monotonic()
+    cached = _cache.get(skill_id)
+    if cached is not None and now - cached[1] < _TTL_SECONDS:
+        return cached[0]
+
+    try:
+        updated_at = await _fetch_updated_at(skill_id)
+    except Exception:
+        logger.exception("Failed to fetch updated_at for skill %s", skill_id)
+        # On failure, return the last-known value if we have one, else
+        # None. Never raise — freshness is advisory for cache keying and
+        # must not break the chat turn.
+        return cached[0] if cached is not None else None
+
+    _cache[skill_id] = (updated_at, now)
+    return updated_at
+
+
+async def get_freshness_hash(skill_ids: List[str]) -> str:
+    """Return a stable 16-char hash of (skill_id -> updated_at).
+
+    Changes when any of the given skills' config is edited. Empty list
+    returns the empty string so callers can short-circuit.
+    """
+    if not skill_ids:
+        return ""
+
+    sorted_ids = sorted(skill_ids)
+    values = await asyncio.gather(
+        *(get_skill_updated_at(sid) for sid in sorted_ids)
+    )
+
+    payload = "|".join(
+        f"{sid}={val or 'none'}" for sid, val in zip(sorted_ids, values)
+    )
+    return hashlib.md5(payload.encode()).hexdigest()[:16]
+
+
+async def get_all_skill_ids() -> FrozenSet[str]:
+    """Return the set of all known skill IDs, TTL-cached per process.
+
+    Listed once per TTL window via `repository.list_skills()` and reused
+    across that window. Used by RBAC skill access to enumerate "every skill
+    the system knows about" (e.g. expanding a `"*"` wildcard grant) without
+    scanning DynamoDB on every chat turn.
+
+    On a repository error, returns the last-known set if available, else an
+    empty frozenset — never raises (auth must not break on a transient DB
+    blip).
+    """
+    now = time.monotonic()
+    cached = _all_skill_ids_cache[0]
+    if cached is not None and now - cached[1] < _TTL_SECONDS:
+        return cached[0]
+
+    from apis.shared.skills.repository import get_skill_catalog_repository
+
+    try:
+        repo = get_skill_catalog_repository()
+        skills = await repo.list_skills()
+        ids = frozenset(s.skill_id for s in skills)
+    except Exception:
+        logger.exception("Failed to list skill IDs for catalog snapshot")
+        return cached[0] if cached is not None else frozenset()
+
+    _all_skill_ids_cache[0] = (ids, now)
+    return ids
+
+
+def invalidate(skill_id: Optional[str] = None) -> None:
+    """Drop an entry (or the whole cache) from the TTL store.
+
+    Always clears the all-skill-ids snapshot too, since any create/delete
+    shifts that set (and an admin write is the only reason to invalidate
+    anyway).
+
+    Call this from admin write paths so changes are visible in the same
+    process on the very next turn, without waiting for the TTL to lapse.
+    """
+    if skill_id is None:
+        _cache.clear()
+    else:
+        _cache.pop(skill_id, None)
+    _all_skill_ids_cache[0] = None

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -1,0 +1,183 @@
+"""
+Skill Catalog Models
+
+Pydantic models for the admin-managed Skill catalog. A Skill is an
+instruction bundle (a SKILL.md body) that binds a curated set of existing
+catalog tools and is exposed to user roles via RBAC — mirroring how tools
+are gated today.
+
+This module is the skills parallel of ``apis/shared/tools/models.py``
+(``ToolDefinition``). It is consumed by ``app_api`` (admin authoring) and the
+runtime (``agents``/``inference_api``); it never imports from either, to
+respect the import boundary (``tests/architecture/test_import_boundaries.py``).
+
+See ``docs/specs/admin-skills-rbac-tool-binding.md`` (§4 Data model, §5
+Persistence).
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# Regex for a skill_id — identical shape to tool_id (see ToolCreateRequest).
+SKILL_ID_PATTERN = r"^[a-z][a-z0-9_]{2,49}$"
+
+
+class SkillStatus(str, Enum):
+    """Availability status of a skill (mirrors ToolStatus)."""
+
+    ACTIVE = "active"
+    DRAFT = "draft"
+    DISABLED = "disabled"
+
+
+class SkillVisibility(str, Enum):
+    """Ownership visibility of a skill.
+
+    Reserved for Phase 2 (user-authored & shared skills). v1 always writes
+    ``ADMIN`` — admin-authored, RBAC-gated skills. See spec §10.
+    """
+
+    ADMIN = "admin"
+    PRIVATE = "private"
+    SHARED = "shared"
+
+
+# =============================================================================
+# Database Models (stored in DynamoDB)
+# =============================================================================
+
+
+class SkillDefinition(BaseModel):
+    """
+    Catalog entry for a skill stored in DynamoDB.
+
+    Mirrors ``ToolDefinition``: identity + display metadata + bound
+    capabilities + audit, with snake_case→camelCase (de)serialization via
+    ``to_dynamo_item`` / ``from_dynamo_item``.
+
+    NOTE: Access control is managed via AppRoles (RBAC — PR-2 of this
+    feature), not stored directly on the skill. ``allowed_app_roles`` is
+    computed for display purposes only and is intentionally NOT persisted
+    (same precedent as ``ToolDefinition.allowed_app_roles``).
+    """
+
+    # Identity
+    skill_id: str = Field(
+        ...,
+        pattern=SKILL_ID_PATTERN,
+        description="Unique identifier (e.g., 'pdf_workflows')",
+    )
+
+    # Display + instruction payload (progressive-disclosure levels)
+    display_name: str = Field(..., description="Human-readable name")
+    description: str = Field(
+        ..., description="Level-1 catalog line, injected into the prompt (token-cheap)"
+    )
+    instructions: str = Field(
+        ..., description="Level-2 SKILL.md body, loaded on dispatch"
+    )
+
+    # Bound capabilities
+    bound_tool_ids: List[str] = Field(
+        default_factory=list,
+        description="Catalog tool_ids bound to this skill (span all protocols)",
+    )
+    compose: List[str] = Field(
+        default_factory=list,
+        description="skill_ids composed into this skill (composite skills)",
+    )
+
+    # Lifecycle / grouping
+    status: SkillStatus = Field(default=SkillStatus.ACTIVE)
+    category: Optional[str] = Field(
+        default=None, description="Optional grouping label"
+    )
+
+    # Forward-compat (reserved; enforced ADMIN-scope in v1) — see spec §10
+    owner_id: str = Field(
+        default="system",
+        description="Author identity; reserved for Phase 2 user-authored skills",
+    )
+    visibility: SkillVisibility = Field(
+        default=SkillVisibility.ADMIN,
+        description="Ownership visibility; reserved for Phase 2",
+    )
+
+    # Computed field — which AppRoles grant this skill (for admin UI display).
+    # Populated by the admin service from RBAC; not round-tripped to DynamoDB.
+    allowed_app_roles: List[str] = Field(
+        default_factory=list,
+        description="AppRole IDs that grant this skill (computed from AppRoles)",
+    )
+
+    # Audit
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    created_by: Optional[str] = Field(
+        None, description="User ID of admin who created this entry"
+    )
+    updated_by: Optional[str] = Field(
+        None, description="User ID of admin who last updated this"
+    )
+
+    model_config = {"use_enum_values": True}
+
+    def to_dynamo_item(self) -> dict:
+        """Convert to DynamoDB item format (mirrors ToolDefinition)."""
+        return {
+            "PK": f"SKILL#{self.skill_id}",
+            "SK": "METADATA",
+            # SkillOwnerIndex (GSI4) — provisioned now so a Phase-2 "list my
+            # skills" query needs no table migration. v1 admin lists scan by
+            # PK begins_with("SKILL#") instead.
+            "GSI4PK": f"OWNER#{self.owner_id}",
+            "GSI4SK": f"SKILL#{self.skill_id}",
+            "skillId": self.skill_id,
+            "displayName": self.display_name,
+            "description": self.description,
+            "instructions": self.instructions,
+            "boundToolIds": list(self.bound_tool_ids),
+            "compose": list(self.compose),
+            "status": self.status
+            if isinstance(self.status, str)
+            else self.status.value,
+            "category": self.category,
+            "ownerId": self.owner_id,
+            "visibility": self.visibility
+            if isinstance(self.visibility, str)
+            else self.visibility.value,
+            "createdAt": self.created_at.isoformat() + "Z" if self.created_at else None,
+            "updatedAt": self.updated_at.isoformat() + "Z" if self.updated_at else None,
+            "createdBy": self.created_by,
+            "updatedBy": self.updated_by,
+        }
+
+    @classmethod
+    def from_dynamo_item(cls, item: dict) -> "SkillDefinition":
+        """Create from DynamoDB item (mirrors ToolDefinition)."""
+        created_at = item.get("createdAt")
+        updated_at = item.get("updatedAt")
+        return cls(
+            skill_id=item.get("skillId", ""),
+            display_name=item.get("displayName", ""),
+            description=item.get("description", ""),
+            instructions=item.get("instructions", ""),
+            bound_tool_ids=list(item.get("boundToolIds") or []),
+            compose=list(item.get("compose") or []),
+            status=item.get("status", SkillStatus.ACTIVE),
+            category=item.get("category"),
+            owner_id=item.get("ownerId", "system"),
+            visibility=item.get("visibility", SkillVisibility.ADMIN),
+            created_at=datetime.fromisoformat(created_at.rstrip("Z"))
+            if created_at
+            else datetime.now(timezone.utc),
+            updated_at=datetime.fromisoformat(updated_at.rstrip("Z"))
+            if updated_at
+            else datetime.now(timezone.utc),
+            created_by=item.get("createdBy"),
+            updated_by=item.get("updatedBy"),
+        )

--- a/backend/src/apis/shared/skills/repository.py
+++ b/backend/src/apis/shared/skills/repository.py
@@ -1,0 +1,277 @@
+"""
+Skill Catalog Repository
+
+DynamoDB operations for the admin-managed Skill catalog. Mirrors
+``ToolCatalogRepository`` and reuses the same table as AppRoles
+(``DYNAMODB_APP_ROLES_TABLE_NAME``) with a distinct PK pattern:
+
+  - Skill: PK=SKILL#{skill_id}, SK=METADATA
+
+``SkillOwnerIndex`` (GSI4: GSI4PK=OWNER#{owner_id}, GSI4SK=SKILL#{skill_id})
+is provisioned for a Phase-2 "list my skills" query; v1 admin lists scan by
+``begins_with(PK, "SKILL#")``. See
+``docs/specs/admin-skills-rbac-tool-binding.md`` (§5).
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import SkillDefinition, SkillStatus
+
+logger = logging.getLogger(__name__)
+
+
+class SkillCatalogRepository:
+    """
+    Repository for Skill Catalog CRUD operations in DynamoDB.
+
+    Uses the AppRoles table with a distinct PK pattern:
+    - Skill: PK=SKILL#{skill_id}, SK=METADATA
+    """
+
+    def __init__(self, table_name: Optional[str] = None):
+        """Initialize repository with DynamoDB table."""
+        self.table_name = table_name or os.environ.get(
+            "DYNAMODB_APP_ROLES_TABLE_NAME", "app-roles"
+        )
+        self._dynamodb = boto3.resource("dynamodb")
+        self._table = self._dynamodb.Table(self.table_name)
+
+    # =========================================================================
+    # Skill CRUD Operations
+    # =========================================================================
+
+    async def get_skill(self, skill_id: str) -> Optional[SkillDefinition]:
+        """
+        Get a skill by ID.
+
+        Args:
+            skill_id: The skill identifier
+
+        Returns:
+            SkillDefinition if found, None otherwise
+        """
+        try:
+            response = self._table.get_item(
+                Key={"PK": f"SKILL#{skill_id}", "SK": "METADATA"}
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return SkillDefinition.from_dynamo_item(item)
+        except ClientError as e:
+            logger.error(f"Error getting skill {skill_id}: {e}")
+            raise
+
+    async def list_skills(
+        self, status: Optional[str] = None
+    ) -> List[SkillDefinition]:
+        """
+        List all skills, optionally filtered by status.
+
+        Args:
+            status: Optional status filter (active, draft, disabled)
+
+        Returns:
+            List of SkillDefinition objects
+        """
+        try:
+            filter_expr = "begins_with(PK, :pk_prefix) AND SK = :sk"
+            expr_values = {":pk_prefix": "SKILL#", ":sk": "METADATA"}
+
+            response = self._table.scan(
+                FilterExpression=filter_expr,
+                ExpressionAttributeValues=expr_values,
+            )
+            items = response.get("Items", [])
+
+            # Handle pagination
+            while "LastEvaluatedKey" in response:
+                response = self._table.scan(
+                    FilterExpression=filter_expr,
+                    ExpressionAttributeValues=expr_values,
+                    ExclusiveStartKey=response["LastEvaluatedKey"],
+                )
+                items.extend(response.get("Items", []))
+
+            skills = [SkillDefinition.from_dynamo_item(item) for item in items]
+
+            # Apply status filter if provided
+            if status:
+                skills = [s for s in skills if s.status == status]
+
+            # Sort by category then display_name
+            skills.sort(key=lambda s: (s.category or "", s.display_name))
+
+            return skills
+
+        except ClientError as e:
+            logger.error(f"Error listing skills: {e}")
+            raise
+
+    async def create_skill(self, skill: SkillDefinition) -> SkillDefinition:
+        """
+        Create a new skill catalog entry.
+
+        Args:
+            skill: The SkillDefinition to create
+
+        Returns:
+            The created SkillDefinition
+
+        Raises:
+            ValueError: If skill already exists
+        """
+        try:
+            # Check if skill already exists
+            existing = await self.get_skill(skill.skill_id)
+            if existing:
+                raise ValueError(f"Skill '{skill.skill_id}' already exists")
+
+            # Set timestamps
+            now = datetime.now(timezone.utc)
+            skill.created_at = now
+            skill.updated_at = now
+
+            # Create item
+            item = skill.to_dynamo_item()
+            self._table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(PK)",
+            )
+
+            logger.info(f"Created skill: {skill.skill_id}")
+            return skill
+
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise ValueError(f"Skill '{skill.skill_id}' already exists")
+            logger.error(f"Error creating skill {skill.skill_id}: {e}")
+            raise
+
+    async def update_skill(
+        self,
+        skill_id: str,
+        updates: Dict[str, Any],
+        admin_user_id: Optional[str] = None,
+    ) -> Optional[SkillDefinition]:
+        """
+        Update a skill's metadata.
+
+        Args:
+            skill_id: The skill identifier
+            updates: Dictionary of fields to update
+            admin_user_id: ID of admin performing the update
+
+        Returns:
+            Updated SkillDefinition or None if not found
+        """
+        try:
+            existing = await self.get_skill(skill_id)
+            if not existing:
+                return None
+
+            # Apply updates
+            for field, value in updates.items():
+                if hasattr(existing, field) and value is not None:
+                    setattr(existing, field, value)
+
+            # Update audit fields
+            existing.updated_at = datetime.now(timezone.utc)
+            if admin_user_id:
+                existing.updated_by = admin_user_id
+
+            # Save
+            item = existing.to_dynamo_item()
+            self._table.put_item(Item=item)
+
+            logger.info(f"Updated skill: {skill_id}")
+            return existing
+
+        except ClientError as e:
+            logger.error(f"Error updating skill {skill_id}: {e}")
+            raise
+
+    async def soft_delete_skill(
+        self, skill_id: str, admin_user_id: Optional[str] = None
+    ) -> Optional[SkillDefinition]:
+        """
+        Soft delete a skill by setting status to DISABLED.
+
+        Args:
+            skill_id: The skill identifier
+            admin_user_id: ID of admin performing the deletion
+
+        Returns:
+            Updated SkillDefinition or None if not found
+        """
+        return await self.update_skill(
+            skill_id,
+            {"status": SkillStatus.DISABLED},
+            admin_user_id=admin_user_id,
+        )
+
+    async def skill_exists(self, skill_id: str) -> bool:
+        """Check if a skill exists in the catalog."""
+        skill = await self.get_skill(skill_id)
+        return skill is not None
+
+    # =========================================================================
+    # Batch Operations
+    # =========================================================================
+
+    async def batch_get_skills(
+        self, skill_ids: List[str]
+    ) -> List[SkillDefinition]:
+        """
+        Get multiple skills by ID.
+
+        Args:
+            skill_ids: List of skill identifiers
+
+        Returns:
+            List of SkillDefinition objects (may be shorter if some not found)
+        """
+        if not skill_ids:
+            return []
+
+        try:
+            # DynamoDB batch_get_item limit is 100
+            skills: List[SkillDefinition] = []
+            for i in range(0, len(skill_ids), 100):
+                batch_ids = skill_ids[i : i + 100]
+                keys = [
+                    {"PK": f"SKILL#{sid}", "SK": "METADATA"} for sid in batch_ids
+                ]
+
+                response = self._dynamodb.meta.client.batch_get_item(
+                    RequestItems={self.table_name: {"Keys": keys}}
+                )
+
+                items = response.get("Responses", {}).get(self.table_name, [])
+                skills.extend(
+                    [SkillDefinition.from_dynamo_item(item) for item in items]
+                )
+
+            return skills
+
+        except ClientError as e:
+            logger.error(f"Error batch getting skills: {e}")
+            raise
+
+
+# Global repository instance
+_repository_instance: Optional[SkillCatalogRepository] = None
+
+
+def get_skill_catalog_repository() -> SkillCatalogRepository:
+    """Get or create the global SkillCatalogRepository instance."""
+    global _repository_instance
+    if _repository_instance is None:
+        _repository_instance = SkillCatalogRepository()
+    return _repository_instance

--- a/backend/tests/shared/conftest.py
+++ b/backend/tests/shared/conftest.py
@@ -184,11 +184,14 @@ def roles_table(aws, monkeypatch):
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI3PK", "AttributeType": "S"},
             {"AttributeName": "GSI3SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4SK", "AttributeType": "S"},
         ],
         gsis=[
             _gsi("JwtRoleMappingIndex", "GSI1PK", "GSI1SK"),
             _gsi("ToolRoleMappingIndex", "GSI2PK", "GSI2SK"),
             _gsi("ModelRoleMappingIndex", "GSI3PK", "GSI3SK"),
+            _gsi("SkillOwnerIndex", "GSI4PK", "GSI4SK"),
         ],
     )
 
@@ -341,3 +344,9 @@ def file_repository(files_table):
 def role_repository(roles_table):
     from apis.shared.rbac.repository import AppRoleRepository
     return AppRoleRepository(table_name="test-app-roles")
+
+
+@pytest.fixture()
+def skill_repository(roles_table):
+    from apis.shared.skills.repository import SkillCatalogRepository
+    return SkillCatalogRepository(table_name="test-app-roles")

--- a/backend/tests/shared/test_skills_freshness.py
+++ b/backend/tests/shared/test_skills_freshness.py
@@ -1,0 +1,178 @@
+"""Tests for the skill-catalog freshness TTL cache.
+
+Mirrors backend/tests/apis/app_api/tools/test_freshness.py.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apis.shared.skills import freshness
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    freshness._reset_for_tests()
+    yield
+    freshness._reset_for_tests()
+
+
+def _skill(updated_at: datetime):
+    return SimpleNamespace(updated_at=updated_at)
+
+
+@pytest.mark.asyncio
+async def test_empty_skill_list_returns_empty_hash():
+    assert await freshness.get_freshness_hash([]) == ""
+
+
+@pytest.mark.asyncio
+async def test_hash_reflects_updated_at_changes():
+    repo = SimpleNamespace(
+        get_skill=AsyncMock(
+            return_value=_skill(datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        h1 = await freshness.get_freshness_hash(["pdf_workflows"])
+
+    freshness.invalidate("pdf_workflows")
+
+    repo.get_skill = AsyncMock(
+        return_value=_skill(datetime(2026, 2, 1, tzinfo=timezone.utc))
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        h2 = await freshness.get_freshness_hash(["pdf_workflows"])
+
+    assert h1 != h2
+
+
+@pytest.mark.asyncio
+async def test_ttl_avoids_repeat_reads_within_window():
+    repo = SimpleNamespace(
+        get_skill=AsyncMock(
+            return_value=_skill(datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        await freshness.get_freshness_hash(["pdf_workflows"])
+        await freshness.get_freshness_hash(["pdf_workflows"])
+        await freshness.get_freshness_hash(["pdf_workflows"])
+
+    assert repo.get_skill.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidate_forces_refetch():
+    repo = SimpleNamespace(
+        get_skill=AsyncMock(
+            return_value=_skill(datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        await freshness.get_skill_updated_at("pdf_workflows")
+        freshness.invalidate("pdf_workflows")
+        await freshness.get_skill_updated_at("pdf_workflows")
+
+    assert repo.get_skill.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_all_clears_every_entry():
+    repo = SimpleNamespace(
+        get_skill=AsyncMock(
+            return_value=_skill(datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        await freshness.get_skill_updated_at("pdf_workflows")
+        await freshness.get_skill_updated_at("doc_basics")
+
+    freshness.invalidate()
+    assert freshness._cache == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_skill_is_cached_as_none():
+    repo = SimpleNamespace(get_skill=AsyncMock(return_value=None))
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        result1 = await freshness.get_skill_updated_at("ghost")
+        result2 = await freshness.get_skill_updated_at("ghost")
+
+    assert result1 is None
+    assert result2 is None
+    assert repo.get_skill.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_repository_error_does_not_raise():
+    repo = SimpleNamespace(get_skill=AsyncMock(side_effect=RuntimeError("boom")))
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        result = await freshness.get_skill_updated_at("pdf_workflows")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_hash_is_stable_regardless_of_input_order():
+    repo = SimpleNamespace(
+        get_skill=AsyncMock(
+            return_value=_skill(datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        h1 = await freshness.get_freshness_hash(["pdf_workflows", "doc_basics"])
+        h2 = await freshness.get_freshness_hash(["doc_basics", "pdf_workflows"])
+
+    assert h1 == h2
+
+
+@pytest.mark.asyncio
+async def test_get_all_skill_ids_caches_and_invalidates():
+    repo = SimpleNamespace(
+        list_skills=AsyncMock(
+            return_value=[
+                SimpleNamespace(skill_id="pdf_workflows"),
+                SimpleNamespace(skill_id="doc_basics"),
+            ]
+        )
+    )
+    with patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    ):
+        ids1 = await freshness.get_all_skill_ids()
+        await freshness.get_all_skill_ids()  # served from TTL cache
+
+        assert ids1 == frozenset({"pdf_workflows", "doc_basics"})
+        assert repo.list_skills.await_count == 1
+
+        freshness.invalidate()
+        await freshness.get_all_skill_ids()  # forced refetch
+        assert repo.list_skills.await_count == 2

--- a/backend/tests/shared/test_skills_models.py
+++ b/backend/tests/shared/test_skills_models.py
@@ -1,0 +1,136 @@
+"""SkillDefinition model: round-trip (to/from dynamo) + skill_id regex.
+
+Pure-model tests — no AWS. Mirrors test_tools_gateway_config.py in spirit.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from apis.shared.skills.models import (
+    SkillDefinition,
+    SkillStatus,
+    SkillVisibility,
+)
+
+
+def _skill(**kw) -> SkillDefinition:
+    defaults = dict(
+        skill_id="pdf_workflows",
+        display_name="PDF Workflows",
+        description="Fill, merge and split PDFs.",
+        instructions="# PDF Workflows\nUse the bound tools to manipulate PDFs.",
+    )
+    defaults.update(kw)
+    return SkillDefinition(**defaults)
+
+
+class TestSkillRoundTrip:
+    def test_to_dynamo_item_keys_and_camel_case(self):
+        skill = _skill(
+            bound_tool_ids=["fill_pdf_form", "gateway_weather"],
+            compose=["doc_basics"],
+            category="document",
+            status=SkillStatus.ACTIVE,
+            created_by="admin-1",
+            updated_by="admin-1",
+        )
+        item = skill.to_dynamo_item()
+
+        # Primary key pattern mirrors tools (TOOL# -> SKILL#).
+        assert item["PK"] == "SKILL#pdf_workflows"
+        assert item["SK"] == "METADATA"
+
+        # SkillOwnerIndex (GSI4) keys are populated for the Phase-2 owner query.
+        assert item["GSI4PK"] == "OWNER#system"
+        assert item["GSI4SK"] == "SKILL#pdf_workflows"
+
+        # snake_case -> camelCase, same convention as ToolDefinition.
+        assert item["skillId"] == "pdf_workflows"
+        assert item["displayName"] == "PDF Workflows"
+        assert item["boundToolIds"] == ["fill_pdf_form", "gateway_weather"]
+        assert item["compose"] == ["doc_basics"]
+        assert item["status"] == "active"
+        assert item["category"] == "document"
+        assert item["ownerId"] == "system"
+        assert item["visibility"] == "admin"
+        assert item["createdBy"] == "admin-1"
+
+        # Computed display-only field is NOT persisted (mirrors tools).
+        assert "allowedAppRoles" not in item
+
+    def test_round_trip_preserves_fields(self):
+        skill = _skill(
+            bound_tool_ids=["fill_pdf_form"],
+            compose=["doc_basics"],
+            category="document",
+            owner_id="user-42",
+            visibility=SkillVisibility.PRIVATE,
+            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+        restored = SkillDefinition.from_dynamo_item(skill.to_dynamo_item())
+
+        assert restored.skill_id == "pdf_workflows"
+        assert restored.display_name == "PDF Workflows"
+        assert restored.description == skill.description
+        assert restored.instructions == skill.instructions
+        assert restored.bound_tool_ids == ["fill_pdf_form"]
+        assert restored.compose == ["doc_basics"]
+        assert restored.status == "active"
+        assert restored.category == "document"
+        assert restored.owner_id == "user-42"
+        assert restored.visibility == "private"
+        assert restored.created_at == skill.created_at
+        assert restored.updated_at == skill.updated_at
+
+    def test_defaults(self):
+        skill = _skill()
+        assert skill.bound_tool_ids == []
+        assert skill.compose == []
+        assert skill.status == "active"
+        assert skill.category is None
+        assert skill.owner_id == "system"
+        assert skill.visibility == "admin"
+        assert skill.allowed_app_roles == []
+
+    def test_from_dynamo_item_tolerates_missing_optional_fields(self):
+        # An older/minimal row with only the required identity fields.
+        item = {
+            "skillId": "minimal_skill",
+            "displayName": "Minimal",
+            "description": "desc",
+            "instructions": "body",
+        }
+        restored = SkillDefinition.from_dynamo_item(item)
+        assert restored.skill_id == "minimal_skill"
+        assert restored.bound_tool_ids == []
+        assert restored.owner_id == "system"
+        assert restored.visibility == "admin"
+        assert isinstance(restored.created_at, datetime)
+
+
+class TestSkillIdRegex:
+    @pytest.mark.parametrize(
+        "skill_id",
+        ["abc", "pdf_workflows", "a12", "skill_1_2_3", "a" * 50],
+    )
+    def test_valid_skill_ids(self, skill_id):
+        assert _skill(skill_id=skill_id).skill_id == skill_id
+
+    @pytest.mark.parametrize(
+        "skill_id",
+        [
+            "ab",  # too short (<3)
+            "1skill",  # must start with a letter
+            "Skill",  # no uppercase
+            "skill-1",  # no hyphen
+            "skill 1",  # no space
+            "a" * 51,  # too long (>50)
+            "",  # empty
+        ],
+    )
+    def test_invalid_skill_ids(self, skill_id):
+        with pytest.raises(ValidationError):
+            _skill(skill_id=skill_id)

--- a/backend/tests/shared/test_skills_repository.py
+++ b/backend/tests/shared/test_skills_repository.py
@@ -1,0 +1,128 @@
+"""SkillCatalogRepository CRUD tests (moto DynamoDB).
+
+Reuses the shared `roles_table` fixture (the app-roles table) via the
+`skill_repository` fixture, mirroring test_rbac_repository.py.
+"""
+
+import pytest
+
+from apis.shared.skills.models import SkillDefinition, SkillStatus
+
+
+def _make_skill(skill_id="pdf_workflows", **kw) -> SkillDefinition:
+    defaults = dict(
+        skill_id=skill_id,
+        display_name="PDF Workflows",
+        description="Fill, merge and split PDFs.",
+        instructions="# PDF Workflows\nUse the bound tools.",
+        bound_tool_ids=["fill_pdf_form"],
+    )
+    defaults.update(kw)
+    return SkillDefinition(**defaults)
+
+
+class TestSkillCatalogRepository:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, skill_repository):
+        created = await skill_repository.create_skill(_make_skill())
+        assert created.skill_id == "pdf_workflows"
+
+        result = await skill_repository.get_skill("pdf_workflows")
+        assert result is not None
+        assert result.display_name == "PDF Workflows"
+        assert result.bound_tool_ids == ["fill_pdf_form"]
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self, skill_repository):
+        assert await skill_repository.get_skill("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_raises(self, skill_repository):
+        await skill_repository.create_skill(_make_skill())
+        with pytest.raises(ValueError):
+            await skill_repository.create_skill(_make_skill())
+
+    @pytest.mark.asyncio
+    async def test_list_skills(self, skill_repository):
+        await skill_repository.create_skill(_make_skill("skill_one"))
+        await skill_repository.create_skill(_make_skill("skill_two"))
+        skills = await skill_repository.list_skills()
+        assert {s.skill_id for s in skills} == {"skill_one", "skill_two"}
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_pick_up_other_pk_items(
+        self, skill_repository, role_repository
+    ):
+        # A non-skill item in the same table must not appear in list_skills.
+        from apis.shared.rbac.models import AppRole
+
+        await role_repository.create_role(
+            AppRole(role_id="r1", display_name="R1", description="x")
+        )
+        await skill_repository.create_skill(_make_skill("skill_one"))
+
+        skills = await skill_repository.list_skills()
+        assert [s.skill_id for s in skills] == ["skill_one"]
+
+    @pytest.mark.asyncio
+    async def test_list_status_filter(self, skill_repository):
+        await skill_repository.create_skill(_make_skill("skill_one", status=SkillStatus.ACTIVE))
+        await skill_repository.create_skill(_make_skill("skill_two", status=SkillStatus.DRAFT))
+
+        active = await skill_repository.list_skills(status="active")
+        assert [s.skill_id for s in active] == ["skill_one"]
+
+        draft = await skill_repository.list_skills(status="draft")
+        assert [s.skill_id for s in draft] == ["skill_two"]
+
+    @pytest.mark.asyncio
+    async def test_update_skill(self, skill_repository):
+        await skill_repository.create_skill(_make_skill())
+        updated = await skill_repository.update_skill(
+            "pdf_workflows",
+            {"display_name": "PDF Tools", "bound_tool_ids": ["fill_pdf_form", "merge_pdf"]},
+            admin_user_id="admin-2",
+        )
+        assert updated is not None
+        assert updated.display_name == "PDF Tools"
+        assert updated.bound_tool_ids == ["fill_pdf_form", "merge_pdf"]
+        assert updated.updated_by == "admin-2"
+
+        # Persisted.
+        reloaded = await skill_repository.get_skill("pdf_workflows")
+        assert reloaded.display_name == "PDF Tools"
+        assert reloaded.bound_tool_ids == ["fill_pdf_form", "merge_pdf"]
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_returns_none(self, skill_repository):
+        assert await skill_repository.update_skill("nope", {"display_name": "x"}) is None
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_sets_disabled(self, skill_repository):
+        await skill_repository.create_skill(_make_skill())
+        result = await skill_repository.soft_delete_skill(
+            "pdf_workflows", admin_user_id="admin-3"
+        )
+        assert result is not None
+        assert result.status == "disabled"
+
+        reloaded = await skill_repository.get_skill("pdf_workflows")
+        assert reloaded.status == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_skill_exists(self, skill_repository):
+        await skill_repository.create_skill(_make_skill())
+        assert await skill_repository.skill_exists("pdf_workflows") is True
+        assert await skill_repository.skill_exists("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_batch_get_skills(self, skill_repository):
+        await skill_repository.create_skill(_make_skill("skill_one"))
+        await skill_repository.create_skill(_make_skill("skill_two"))
+
+        skills = await skill_repository.batch_get_skills(["skill_one", "skill_two", "ghost"])
+        assert {s.skill_id for s in skills} == {"skill_one", "skill_two"}
+
+    @pytest.mark.asyncio
+    async def test_batch_get_empty(self, skill_repository):
+        assert await skill_repository.batch_get_skills([]) == []

--- a/infrastructure/lib/constructs/data/auth-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/auth-tables-construct.ts
@@ -131,6 +131,17 @@ export class AuthTablesConstruct extends Construct {
       nonKeyAttributes: ['roleId', 'displayName', 'enabled'],
     });
 
+    // SkillOwnerIndex — reverse lookup of skills by owner (GSI4PK=OWNER#{ownerId},
+    // GSI4SK=SKILL#{skillId}). Unused in v1 (admin lists scan SKILL# items), but
+    // provisioned now so the Phase-2 "list my skills" query needs no table
+    // migration. See docs/specs/admin-skills-rbac-tool-binding.md (§5).
+    this.appRolesTable.addGlobalSecondaryIndex({
+      indexName: 'SkillOwnerIndex',
+      partitionKey: { name: 'GSI4PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI4SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     new ssm.StringParameter(this, 'AppRolesTableNameParameter', {
       parameterName: `/${config.projectPrefix}/rbac/app-roles-table-name`,
       stringValue: this.appRolesTable.tableName,

--- a/infrastructure/test/tables-detailed.test.ts
+++ b/infrastructure/test/tables-detailed.test.ts
@@ -67,13 +67,30 @@ describe('AuthTablesConstruct — detailed', () => {
     });
   });
 
-  it('AppRoles table has 3 GSIs', () => {
+  it('AppRoles table has 4 GSIs incl. SkillOwnerIndex', () => {
     t.hasResourceProperties('AWS::DynamoDB::Table', {
       TableName: 'test-project-app-roles',
       GlobalSecondaryIndexes: Match.arrayWith([
         Match.objectLike({ IndexName: 'JwtRoleMappingIndex' }),
         Match.objectLike({ IndexName: 'ToolRoleMappingIndex' }),
         Match.objectLike({ IndexName: 'ModelRoleMappingIndex' }),
+        Match.objectLike({ IndexName: 'SkillOwnerIndex' }),
+      ]),
+    });
+  });
+
+  it('SkillOwnerIndex is keyed on GSI4PK/GSI4SK with full projection', () => {
+    t.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: 'test-project-app-roles',
+      GlobalSecondaryIndexes: Match.arrayWith([
+        Match.objectLike({
+          IndexName: 'SkillOwnerIndex',
+          KeySchema: [
+            { AttributeName: 'GSI4PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI4SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+        }),
       ]),
     });
   });


### PR DESCRIPTION
## Scope — PR-1 of admin-managed Skills (shared data layer only)

First, foundational PR of the admin-managed Skills feature. It adds new shared modules and a CDK GSI, but **nothing consumes them yet** — **zero runtime behavior change**. RBAC, admin API, frontend, and runtime wiring are PR-2 through PR-6.

Design spec (on `develop`): [`docs/specs/admin-skills-rbac-tool-binding.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/admin-skills-rbac-tool-binding.md) — this PR implements §11 PR-1 (data model §4, persistence §5).

The whole point is **parallelism with the Tools catalog** — every module mirrors its `apis/shared/tools/` counterpart closely.

## Changes

**`backend/src/apis/shared/skills/`** (new)
- `models.py` — `SkillDefinition` (mirrors `ToolDefinition`): `skill_id` (regex `^[a-z][a-z0-9_]{2,49}$`), `display_name`, `description` (L1 catalog line), `instructions` (L2 SKILL.md body), `bound_tool_ids` (bare catalog ids, span all protocols), `compose`, `status` (`active`/`draft`/`disabled`), `category`; forward-compat `owner_id`/`visibility` (default ADMIN-scope in v1); computed-only `allowed_app_roles`; audit fields. snake_case→camelCase `to_dynamo_item()`/`from_dynamo_item()`.
- `repository.py` — `SkillCatalogRepository` (mirrors `ToolCatalogRepository`): reuses the `app-roles` table (`DYNAMODB_APP_ROLES_TABLE_NAME`), keys `PK=SKILL#{id}` / `SK=METADATA`, list via `begins_with(PK, "SKILL#")`. Methods: `get_skill`, `list_skills(status?)`, `create_skill`, `update_skill`, `soft_delete_skill`, `skill_exists`, `batch_get_skills`.
- `freshness.py` — 10s-TTL per-skill freshness hash + all-skill-ids snapshot + `invalidate(skill_id)` (mirrors tools).
- `__init__.py` — public exports.

**Infra**
- `auth-tables-construct.ts` — add `SkillOwnerIndex` GSI to the `app-roles` table (`GSI4PK=OWNER#{owner_id}`, `GSI4SK=SKILL#{skill_id}`, `PAY_PER_REQUEST`). Unused in v1; provisioned now to avoid a Phase-2 migration when users own skills.

**Tests**
- `test_skills_models.py` — to/from-dynamo round-trip + `skill_id` regex validation.
- `test_skills_repository.py` — CRUD via moto (reuses the shared `roles_table` fixture).
- `test_skills_freshness.py` — TTL cache + invalidation.
- `tables-detailed.test.ts` — asserts the new GSI (name + GSI4PK/GSI4SK key schema + full projection).
- `conftest.py` — `roles_table` gains GSI4; new `skill_repository` fixture.

## Verification
- ✅ `uv run python -m pytest tests/ -v` — **3544 passed, 3 skipped** (new skills tests: 37 passed). Import-boundary test green (`apis.shared` imports neither `app_api` nor `inference_api`).
- ✅ `npx tsc --noEmit` — clean.
- ✅ `npx jest` — `tables-detailed` 32/32 (incl. 2 new `SkillOwnerIndex` assertions). The only red suite is `config.test.ts` (9 `loadConfig` validation tests), which fails **identically on clean `develop`** — pre-existing/environmental, untouched here.
- ⚠️ `npx cdk synth` — the full app synth requires live deploy context (cert ARNs, `CDK_DOMAIN_NAME`, and a live Route53 `HostedZone.fromLookup`); it can't complete in a local sandbox without AWS creds and fails identically on clean `develop`. With cert/domain context supplied it instantiates the **entire** `PlatformStack` (incl. the modified `AuthTablesConstruct`), failing only on the live Route53 lookups. The GSI change is independently proven to synthesize by the passing `tables-detailed` jest spec (`Template.fromStack`).

## Acceptance
New `apis/shared/skills/` modules + `SkillOwnerIndex` GSI exist, fully tested, import-boundary-clean, and nothing else references them yet (zero behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)