### PR TITLE
feat(skills): RBAC extension — grant skills to roles (PR-2)

### DIFF
--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -517,9 +517,11 @@ def seed_system_admin_role(
         "inheritsFrom": [],
         "grantedTools": ["*"],
         "grantedModels": ["*"],
+        "grantedSkills": ["*"],
         "effectivePermissions": {
             "tools": ["*"],
             "models": ["*"],
+            "skills": ["*"],
             "quotaTier": None,
         },
         "priority": 1000,
@@ -550,6 +552,18 @@ def seed_system_admin_role(
         "enabled": True,
     }
 
+    # Skill grants reuse the GSI2 keyspace with a SKILL# partition value
+    # (mirror of tool grants; the TOOL#/SKILL# partitions are disjoint).
+    skill_grant_item = {
+        "PK": pk,
+        "SK": "SKILL_GRANT#*",
+        "GSI2PK": "SKILL#*",
+        "GSI2SK": pk,
+        "roleId": role_id,
+        "displayName": "System Administrator",
+        "enabled": True,
+    }
+
     jwt_mapping_item = {
         "PK": pk,
         "SK": "JWT_MAPPING#system_admin",
@@ -566,11 +580,12 @@ def seed_system_admin_role(
                 {"Put": {"TableName": table_name, "Item": _serialize(definition_item)}},
                 {"Put": {"TableName": table_name, "Item": _serialize(tool_grant_item)}},
                 {"Put": {"TableName": table_name, "Item": _serialize(model_grant_item)}},
+                {"Put": {"TableName": table_name, "Item": _serialize(skill_grant_item)}},
                 {"Put": {"TableName": table_name, "Item": _serialize(jwt_mapping_item)}},
             ]
         )
         result.created = 1
-        result.details.append("system_admin role created with TOOL_GRANT#*, MODEL_GRANT#*, and JWT_MAPPING#system_admin")
+        result.details.append("system_admin role created with TOOL_GRANT#*, MODEL_GRANT#*, SKILL_GRANT#*, and JWT_MAPPING#system_admin")
     except ClientError as e:
         msg = f"Failed to create system_admin role: {e}"
         logger.error(msg)

--- a/backend/src/apis/app_api/admin/services/skill_access.py
+++ b/backend/src/apis/app_api/admin/services/skill_access.py
@@ -1,0 +1,160 @@
+"""
+Skill Access Service
+
+Handles skill authorization based on AppRoles. Mirrors ToolAccessService:
+a user's accessible skills come from ``resolve_user_permissions(user).skills``
+(with ``"*"`` wildcard), and ``filter_allowed_skills`` intersects requested
+skills against the DynamoDB-backed skill catalog.
+
+Unlike tools, skills have no dynamically-loaded ("gateway_*") runtime form —
+every skill is an authored catalog entry — so there is no prefix passthrough
+in the wildcard branch.
+"""
+import logging
+from typing import List, Optional, Set
+
+from apis.shared.auth.models import User
+from apis.shared.rbac.service import AppRoleService, get_app_role_service
+from apis.shared.skills.freshness import get_all_skill_ids
+
+logger = logging.getLogger(__name__)
+
+
+class SkillAccessService:
+    """Service for checking skill access based on AppRoles."""
+
+    def __init__(self, app_role_service: Optional[AppRoleService] = None):
+        """Initialize with optional AppRoleService."""
+        self._app_role_service = app_role_service
+
+    @property
+    def app_role_service(self) -> AppRoleService:
+        """Lazy-load AppRoleService."""
+        if self._app_role_service is None:
+            self._app_role_service = get_app_role_service()
+        return self._app_role_service
+
+    async def get_user_allowed_skills(self, user: User) -> Set[str]:
+        """
+        Get the set of skill IDs the user is allowed to use.
+
+        Returns:
+            Set of skill IDs. Contains "*" if user has wildcard access.
+        """
+        permissions = await self.app_role_service.resolve_user_permissions(user)
+        return set(permissions.skills)
+
+    async def can_access_skill(self, user: User, skill_id: str) -> bool:
+        """
+        Check if a user can access a specific skill.
+
+        Args:
+            user: The user to check
+            skill_id: Skill identifier
+
+        Returns:
+            True if user has access to the skill
+        """
+        allowed_skills = await self.get_user_allowed_skills(user)
+
+        # Wildcard grants access to all skills
+        if "*" in allowed_skills:
+            return True
+
+        # Check if specific skill is in allowed set
+        return skill_id in allowed_skills
+
+    async def filter_allowed_skills(
+        self,
+        user: User,
+        requested_skills: Optional[List[str]] = None,
+    ) -> List[str]:
+        """
+        Filter a list of requested skills to only those the user can access.
+
+        If no skills are requested, returns all skills the user can access.
+
+        The "universe of known skills" is sourced from the DynamoDB-backed
+        skill catalog (TTL-cached via ``freshness.get_all_skill_ids``).
+
+        Args:
+            user: The user to check
+            requested_skills: Optional list of skill IDs the user wants to use.
+                              If None, returns all allowed skills.
+
+        Returns:
+            List of skill IDs the user is allowed to use from the requested set.
+        """
+        allowed_skills = await self.get_user_allowed_skills(user)
+        has_wildcard = "*" in allowed_skills
+
+        # Get all available skill IDs from the DynamoDB catalog
+        all_skill_ids = await get_all_skill_ids()
+
+        if requested_skills is None:
+            # No specific skills requested - return all allowed
+            if has_wildcard:
+                return list(all_skill_ids)
+            else:
+                # Only return allowed skills that exist in the catalog
+                return list(allowed_skills & all_skill_ids)
+
+        # Filter requested skills to only allowed ones
+        if has_wildcard:
+            # Wildcard: allow all requested skills that exist in the catalog
+            return [s for s in requested_skills if s in all_skill_ids]
+        else:
+            # Only return intersection of requested and allowed
+            return [s for s in requested_skills if s in allowed_skills]
+
+    async def check_access_and_filter(
+        self,
+        user: User,
+        requested_skills: Optional[List[str]] = None,
+        strict: bool = False,
+    ) -> tuple[List[str], List[str]]:
+        """
+        Check skill access and return both allowed and denied skills.
+
+        Args:
+            user: The user to check
+            requested_skills: Optional list of skill IDs the user wants to use
+            strict: If True, raise ValueError if any requested skill is denied
+
+        Returns:
+            Tuple of (allowed_skills, denied_skills)
+
+        Raises:
+            ValueError: If strict=True and any skills are denied
+        """
+        if requested_skills is None:
+            allowed = await self.filter_allowed_skills(user, None)
+            return allowed, []
+
+        allowed = await self.filter_allowed_skills(user, requested_skills)
+        allowed_set = set(allowed)
+        denied = [s for s in requested_skills if s not in allowed_set]
+
+        if strict and denied:
+            raise ValueError(
+                f"User {user.email} is not authorized to use skills: {', '.join(denied)}"
+            )
+
+        if denied:
+            logger.warning(
+                f"User {user.email} requested unauthorized skills: {denied}"
+            )
+
+        return allowed, denied
+
+
+# Singleton instance
+_skill_access_service: Optional[SkillAccessService] = None
+
+
+def get_skill_access_service() -> SkillAccessService:
+    """Get the singleton SkillAccessService instance."""
+    global _skill_access_service
+    if _skill_access_service is None:
+        _skill_access_service = SkillAccessService()
+    return _skill_access_service

--- a/backend/src/apis/shared/rbac/admin_service.py
+++ b/backend/src/apis/shared/rbac/admin_service.py
@@ -75,6 +75,7 @@ class AppRoleAdminService:
             inherits_from=role_data.inherits_from,
             granted_tools=role_data.granted_tools,
             granted_models=role_data.granted_models,
+            granted_skills=role_data.granted_skills,
             priority=role_data.priority,
             enabled=role_data.enabled,
             is_system_role=False,
@@ -282,6 +283,7 @@ class AppRoleAdminService:
         """
         all_tools: Set[str] = set(role.granted_tools)
         all_models: Set[str] = set(role.granted_models)
+        all_skills: Set[str] = set(role.granted_skills)
 
         # Process inherited roles (single level only)
         for parent_role_id in role.inherits_from:
@@ -289,10 +291,12 @@ class AppRoleAdminService:
             if parent and parent.enabled:
                 all_tools.update(parent.granted_tools)
                 all_models.update(parent.granted_models)
+                all_skills.update(parent.granted_skills)
 
         return EffectivePermissions(
             tools=list(all_tools),
             models=list(all_models),
+            skills=list(all_skills),
             quota_tier=None,  # Quota tier comes from direct configuration
         )
 
@@ -438,6 +442,135 @@ class AppRoleAdminService:
                         "event": "tool_removed_from_role",
                         "role_id": role_id,
                         "tool_id": tool_id,
+                        "admin_user_id": admin.user_id,
+                    },
+                )
+                return updated
+
+        return role
+
+    # =========================================================================
+    # Skill Management Extensions (mirror of the tool management methods)
+    # =========================================================================
+
+    async def get_roles_granting_skill(self, skill_id: str) -> List[dict]:
+        """
+        Query which AppRoles grant access to a specific skill.
+        Reuses GSI2 (ToolRoleMappingIndex) with a `SKILL#` partition value.
+
+        Args:
+            skill_id: The skill identifier
+
+        Returns:
+            List of role info dicts with roleId, displayName, grantType, etc.
+        """
+        results = await self.repository.get_roles_for_skill(skill_id)
+
+        roles = []
+        for item in results:
+            role_id = item.get("roleId")
+            if not role_id:
+                continue
+
+            role = await self.get_role(role_id)
+            if not role:
+                continue
+
+            # Determine if grant is direct or inherited
+            grant_type = "direct" if skill_id in role.granted_skills else "inherited"
+            inherited_from = None
+
+            if grant_type == "inherited":
+                # Find which parent role provides this skill
+                for parent_id in role.inherits_from:
+                    parent = await self.get_role(parent_id)
+                    if parent and skill_id in parent.effective_permissions.skills:
+                        inherited_from = parent_id
+                        break
+
+            roles.append({
+                "roleId": role.role_id,
+                "displayName": role.display_name,
+                "grantType": grant_type,
+                "inheritedFrom": inherited_from,
+                "enabled": role.enabled,
+            })
+
+        return roles
+
+    async def add_skill_to_role(
+        self, role_id: str, skill_id: str, admin: User
+    ) -> AppRole:
+        """
+        Add a skill to a role's grantedSkills.
+        Triggers permission recomputation.
+
+        Args:
+            role_id: Role identifier
+            skill_id: Skill identifier
+            admin: Admin user performing the action
+
+        Returns:
+            Updated AppRole
+
+        Raises:
+            ValueError: If role not found
+        """
+        role = await self.get_role(role_id)
+        if not role:
+            raise ValueError(f"Role '{role_id}' not found")
+
+        if skill_id not in role.granted_skills:
+            new_skills = role.granted_skills + [skill_id]
+            updates = AppRoleUpdate(granted_skills=new_skills)
+            updated = await self.update_role(role_id, updates, admin)
+            if updated:
+                logger.info(
+                    f"Admin {admin.email} added skill {skill_id} to role {role_id}",
+                    extra={
+                        "event": "skill_added_to_role",
+                        "role_id": role_id,
+                        "skill_id": skill_id,
+                        "admin_user_id": admin.user_id,
+                    },
+                )
+                return updated
+
+        return role
+
+    async def remove_skill_from_role(
+        self, role_id: str, skill_id: str, admin: User
+    ) -> AppRole:
+        """
+        Remove a skill from a role's grantedSkills.
+        Triggers permission recomputation.
+
+        Args:
+            role_id: Role identifier
+            skill_id: Skill identifier
+            admin: Admin user performing the action
+
+        Returns:
+            Updated AppRole
+
+        Raises:
+            ValueError: If role not found
+        """
+        role = await self.get_role(role_id)
+        if not role:
+            raise ValueError(f"Role '{role_id}' not found")
+
+        if skill_id in role.granted_skills:
+            new_skills = [s for s in role.granted_skills if s != skill_id]
+            updates = AppRoleUpdate(granted_skills=new_skills)
+            updated = await self.update_role(role_id, updates, admin)
+            if updated:
+                logger.info(
+                    f"Admin {admin.email} removed skill {skill_id} from role {role_id}",
+                    extra={
+                        "event": "skill_removed_from_role",
+                        "role_id": role_id,
+                        "skill_id": skill_id,
                         "admin_user_id": admin.user_id,
                     },
                 )

--- a/backend/src/apis/shared/rbac/models.py
+++ b/backend/src/apis/shared/rbac/models.py
@@ -11,6 +11,7 @@ class EffectivePermissions:
 
     tools: List[str] = field(default_factory=list)
     models: List[str] = field(default_factory=list)
+    skills: List[str] = field(default_factory=list)
     quota_tier: Optional[str] = None
 
     def to_dict(self) -> dict:
@@ -18,15 +19,22 @@ class EffectivePermissions:
         return {
             "tools": self.tools,
             "models": self.models,
+            "skills": self.skills,
             "quotaTier": self.quota_tier,
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "EffectivePermissions":
-        """Create from dictionary (DynamoDB item)."""
+        """Create from dictionary (DynamoDB item).
+
+        `skills` defaults to [] for roles persisted before skills existed —
+        they pick up skill grants on their next save/sync (mirror of how a new
+        permission type rolls out for tools/models).
+        """
         return cls(
             tools=data.get("tools", []),
             models=data.get("models", []),
+            skills=data.get("skills", []),
             quota_tier=data.get("quotaTier"),
         )
 
@@ -58,6 +66,7 @@ class AppRole:
     # Direct permission grants (before inheritance resolution)
     granted_tools: List[str] = field(default_factory=list)
     granted_models: List[str] = field(default_factory=list)
+    granted_skills: List[str] = field(default_factory=list)
 
     # Metadata
     priority: int = 0
@@ -80,6 +89,7 @@ class AppRole:
             "effectivePermissions": self.effective_permissions.to_dict(),
             "grantedTools": self.granted_tools,
             "grantedModels": self.granted_models,
+            "grantedSkills": self.granted_skills,
             "priority": self.priority,
             "isSystemRole": self.is_system_role,
             "enabled": self.enabled,
@@ -101,6 +111,7 @@ class AppRole:
             effective_permissions=EffectivePermissions.from_dict(effective_perms_data),
             granted_tools=data.get("grantedTools", []),
             granted_models=data.get("grantedModels", []),
+            granted_skills=data.get("grantedSkills", []),
             priority=data.get("priority", 0),
             is_system_role=data.get("isSystemRole", False),
             enabled=data.get("enabled", True),
@@ -124,6 +135,9 @@ class UserEffectivePermissions:
     models: List[str]
     quota_tier: Optional[str]
     resolved_at: str
+    # Trailing default so existing positional/kwargs construction sites that
+    # predate skills keep working (they resolve to no skills).
+    skills: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -132,6 +146,7 @@ class UserEffectivePermissions:
             "appRoles": self.app_roles,
             "tools": self.tools,
             "models": self.models,
+            "skills": self.skills,
             "quotaTier": self.quota_tier,
             "resolvedAt": self.resolved_at,
         }
@@ -154,6 +169,7 @@ class AppRoleCreate(BaseModel):
     inherits_from: List[str] = Field(default_factory=list, alias="inheritsFrom")
     granted_tools: List[str] = Field(default_factory=list, alias="grantedTools")
     granted_models: List[str] = Field(default_factory=list, alias="grantedModels")
+    granted_skills: List[str] = Field(default_factory=list, alias="grantedSkills")
     priority: int = Field(0, ge=0, le=999)
     enabled: bool = True
 
@@ -171,6 +187,7 @@ class AppRoleUpdate(BaseModel):
     inherits_from: Optional[List[str]] = Field(None, alias="inheritsFrom")
     granted_tools: Optional[List[str]] = Field(None, alias="grantedTools")
     granted_models: Optional[List[str]] = Field(None, alias="grantedModels")
+    granted_skills: Optional[List[str]] = Field(None, alias="grantedSkills")
     priority: Optional[int] = Field(None, ge=0, le=999)
     enabled: Optional[bool] = None
 
@@ -182,6 +199,7 @@ class EffectivePermissionsResponse(BaseModel):
 
     tools: List[str]
     models: List[str]
+    skills: List[str] = Field(default_factory=list)
     quota_tier: Optional[str] = Field(None, alias="quotaTier")
 
     model_config = {"populate_by_name": True}
@@ -197,6 +215,7 @@ class AppRoleResponse(BaseModel):
     inherits_from: List[str] = Field(..., alias="inheritsFrom")
     granted_tools: List[str] = Field(..., alias="grantedTools")
     granted_models: List[str] = Field(..., alias="grantedModels")
+    granted_skills: List[str] = Field(default_factory=list, alias="grantedSkills")
     effective_permissions: EffectivePermissionsResponse = Field(
         ..., alias="effectivePermissions"
     )
@@ -220,9 +239,11 @@ class AppRoleResponse(BaseModel):
             inherits_from=role.inherits_from,
             granted_tools=role.granted_tools,
             granted_models=role.granted_models,
+            granted_skills=role.granted_skills,
             effective_permissions=EffectivePermissionsResponse(
                 tools=role.effective_permissions.tools,
                 models=role.effective_permissions.models,
+                skills=role.effective_permissions.skills,
                 quota_tier=role.effective_permissions.quota_tier,
             ),
             priority=role.priority,

--- a/backend/src/apis/shared/rbac/repository.py
+++ b/backend/src/apis/shared/rbac/repository.py
@@ -303,6 +303,40 @@ class AppRoleRepository:
             logger.error(f"Error querying model role mappings for {model_id}: {e}")
             raise
 
+    async def get_roles_for_skill(self, skill_id: str) -> List[Dict[str, Any]]:
+        """
+        Get AppRoles that grant access to a skill.
+
+        Reuses GSI2 (ToolRoleMappingIndex) with a `SKILL#` partition value, so
+        skill grants share the tool reverse-lookup index without a new GSI
+        (the `TOOL#` and `SKILL#` partitions are disjoint). See spec §5.
+
+        Args:
+            skill_id: The skill identifier
+
+        Returns:
+            List of role info dicts with roleId, displayName, enabled
+        """
+        try:
+            response = self._table.query(
+                IndexName="ToolRoleMappingIndex",
+                KeyConditionExpression="GSI2PK = :pk",
+                ExpressionAttributeValues={":pk": f"SKILL#{skill_id}"},
+            )
+
+            return [
+                {
+                    "roleId": item.get("roleId"),
+                    "displayName": item.get("displayName"),
+                    "enabled": item.get("enabled", True),
+                }
+                for item in response.get("Items", [])
+            ]
+
+        except ClientError as e:
+            logger.error(f"Error querying skill role mappings for {skill_id}: {e}")
+            raise
+
     # =========================================================================
     # Helper Methods
     # =========================================================================
@@ -361,6 +395,22 @@ class AppRoleRepository:
                 "SK": f"MODEL_GRANT#{model_id}",
                 "GSI3PK": f"MODEL#{model_id}",
                 "GSI3SK": f"ROLE#{role.role_id}",
+                "roleId": role.role_id,
+                "displayName": role.display_name,
+                "enabled": role.enabled,
+            }
+            items.append(
+                {"Put": {"TableName": self.table_name, "Item": mapping_item}}
+            )
+
+        # 5. Skill permission mapping items — reuse the GSI2 keyspace
+        # (ToolRoleMappingIndex) with a `SKILL#` partition value (spec §5).
+        for skill_id in role.granted_skills:
+            mapping_item = {
+                "PK": f"ROLE#{role.role_id}",
+                "SK": f"SKILL_GRANT#{skill_id}",
+                "GSI2PK": f"SKILL#{skill_id}",
+                "GSI2SK": f"ROLE#{role.role_id}",
                 "roleId": role.role_id,
                 "displayName": role.display_name,
                 "enabled": role.enabled,

--- a/backend/src/apis/shared/rbac/seeder.py
+++ b/backend/src/apis/shared/rbac/seeder.py
@@ -18,9 +18,11 @@ SYSTEM_ADMIN_ROLE = AppRole(
     inherits_from=[],
     granted_tools=["*"],
     granted_models=["*"],
+    granted_skills=["*"],
     effective_permissions=EffectivePermissions(
         tools=["*"],
         models=["*"],
+        skills=["*"],
         quota_tier=None,  # No quota limits
     ),
     priority=1000,
@@ -38,9 +40,11 @@ DEFAULT_ROLE = AppRole(
     inherits_from=[],
     granted_tools=[],
     granted_models=[],
+    granted_skills=[],
     effective_permissions=EffectivePermissions(
         tools=[],
         models=[],
+        skills=[],
         quota_tier="tier_basic",
     ),
     priority=0,

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -129,13 +129,15 @@ class AppRoleService:
                 app_roles=[],
                 tools=[],
                 models=[],
+                skills=[],
                 quota_tier=None,
                 resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
             )
 
-        # Collect all tools and models (union)
+        # Collect all tools, models and skills (union)
         all_tools: Set[str] = set()
         all_models: Set[str] = set()
+        all_skills: Set[str] = set()
 
         for role in roles:
             if role.effective_permissions:
@@ -149,6 +151,11 @@ class AppRoleService:
                     all_models.add("*")
                 else:
                     all_models.update(role.effective_permissions.models)
+
+                if "*" in role.effective_permissions.skills:
+                    all_skills.add("*")
+                else:
+                    all_skills.update(role.effective_permissions.skills)
 
         # Determine quota tier (highest priority wins)
         sorted_roles = sorted(roles, key=lambda r: r.priority, reverse=True)
@@ -166,6 +173,7 @@ class AppRoleService:
             app_roles=[r.role_id for r in roles],
             tools=list(all_tools),
             models=list(all_models),
+            skills=list(all_skills),
             quota_tier=quota_tier,
             resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
         )
@@ -190,6 +198,16 @@ class AppRoleService:
 
         return model_id in permissions.models
 
+    async def can_access_skill(self, user: User, skill_id: str) -> bool:
+        """Check if user can access a specific skill."""
+        permissions = await self.resolve_user_permissions(user)
+
+        # Wildcard grants access to all
+        if "*" in permissions.skills:
+            return True
+
+        return skill_id in permissions.skills
+
     async def get_accessible_tools(self, user: User) -> List[str]:
         """Get list of tool IDs user can access."""
         permissions = await self.resolve_user_permissions(user)
@@ -199,6 +217,11 @@ class AppRoleService:
         """Get list of model IDs user can access."""
         permissions = await self.resolve_user_permissions(user)
         return permissions.models
+
+    async def get_accessible_skills(self, user: User) -> List[str]:
+        """Get list of skill IDs user can access."""
+        permissions = await self.resolve_user_permissions(user)
+        return permissions.skills
 
     async def get_user_quota_tier(self, user: User) -> Optional[str]:
         """Get the quota tier for a user based on their roles."""

--- a/backend/tests/apis/app_api/admin/services/test_skill_access.py
+++ b/backend/tests/apis/app_api/admin/services/test_skill_access.py
@@ -1,0 +1,158 @@
+"""Tests for SkillAccessService.
+
+Mirrors test_tool_access.py: filter_allowed_skills sources its "universe of
+known skills" from the DynamoDB-backed catalog (via the freshness snapshot).
+Unlike tools, skills have no dynamically-loaded ("gateway_*") form, so there
+is no prefix-passthrough case.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apis.app_api.admin.services.skill_access import SkillAccessService
+from apis.shared.auth.models import User
+from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.skills import freshness
+
+
+@pytest.fixture(autouse=True)
+def _reset_freshness():
+    freshness._reset_for_tests()
+    yield
+    freshness._reset_for_tests()
+
+
+def _user(roles=None) -> User:
+    return User(
+        email="admin@example.com",
+        user_id="admin-1",
+        name="Admin",
+        roles=roles or [],
+    )
+
+
+def _permissions(skills, app_roles=("admin",)) -> UserEffectivePermissions:
+    return UserEffectivePermissions(
+        user_id="admin-1",
+        app_roles=list(app_roles),
+        tools=[],
+        models=[],
+        skills=list(skills),
+        quota_tier=None,
+        resolved_at="2026-06-09T00:00:00Z",
+    )
+
+
+def _service(permissions: UserEffectivePermissions) -> SkillAccessService:
+    role_service = AsyncMock()
+    role_service.resolve_user_permissions = AsyncMock(return_value=permissions)
+    return SkillAccessService(app_role_service=role_service)
+
+
+def _patch_catalog(skill_ids):
+    """Patch the repository.list_skills call that backs the freshness snapshot."""
+    repo = SimpleNamespace(
+        list_skills=AsyncMock(
+            return_value=[SimpleNamespace(skill_id=sid) for sid in skill_ids]
+        )
+    )
+    return patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_access_skill_wildcard():
+    service = _service(_permissions(["*"]))
+    assert await service.can_access_skill(_user(), "pdf_workflows") is True
+
+
+@pytest.mark.asyncio
+async def test_can_access_skill_specific():
+    service = _service(_permissions(["pdf_workflows"]))
+    assert await service.can_access_skill(_user(), "pdf_workflows") is True
+    assert await service.can_access_skill(_user(), "doc_basics") is False
+
+
+@pytest.mark.asyncio
+async def test_wildcard_user_expands_to_all_catalog_skills():
+    service = _service(_permissions(["*"]))
+
+    with _patch_catalog(["pdf_workflows", "doc_basics"]):
+        result = await service.filter_allowed_skills(_user(), None)
+
+    assert set(result) == {"pdf_workflows", "doc_basics"}
+
+
+@pytest.mark.asyncio
+async def test_wildcard_user_filters_out_unknown_skill():
+    """Wildcard means 'every known skill', not every id a client claims."""
+    service = _service(_permissions(["*"]))
+
+    with _patch_catalog(["pdf_workflows"]):
+        result = await service.filter_allowed_skills(
+            _user(),
+            requested_skills=["pdf_workflows", "made_up_skill"],
+        )
+
+    assert result == ["pdf_workflows"]
+
+
+@pytest.mark.asyncio
+async def test_non_wildcard_user_sees_intersection_of_granted_and_catalog():
+    service = _service(_permissions(["pdf_workflows", "ghost_skill"]))
+
+    with _patch_catalog(["pdf_workflows", "doc_basics"]):
+        result = await service.filter_allowed_skills(_user(), None)
+
+    # ghost_skill is granted but not in the catalog → excluded.
+    assert set(result) == {"pdf_workflows"}
+
+
+@pytest.mark.asyncio
+async def test_non_wildcard_user_denies_unauthorized_request():
+    service = _service(_permissions(["pdf_workflows"]))
+
+    with _patch_catalog(["pdf_workflows", "doc_basics"]):
+        result = await service.filter_allowed_skills(
+            _user(),
+            requested_skills=["pdf_workflows", "doc_basics"],
+        )
+
+    assert result == ["pdf_workflows"]
+
+
+@pytest.mark.asyncio
+async def test_check_access_and_filter_reports_denied():
+    service = _service(_permissions(["pdf_workflows"]))
+
+    with _patch_catalog(["pdf_workflows", "doc_basics"]):
+        allowed, denied = await service.check_access_and_filter(
+            _user(),
+            requested_skills=["pdf_workflows", "doc_basics"],
+        )
+
+    assert allowed == ["pdf_workflows"]
+    assert denied == ["doc_basics"]
+
+
+@pytest.mark.asyncio
+async def test_check_access_and_filter_strict_raises():
+    service = _service(_permissions(["pdf_workflows"]))
+
+    with _patch_catalog(["pdf_workflows", "doc_basics"]):
+        with pytest.raises(ValueError, match="not authorized"):
+            await service.check_access_and_filter(
+                _user(),
+                requested_skills=["doc_basics"],
+                strict=True,
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_user_allowed_skills():
+    service = _service(_permissions(["pdf_workflows", "doc_basics"]))
+    assert await service.get_user_allowed_skills(_user()) == {"pdf_workflows", "doc_basics"}

--- a/backend/tests/rbac/conftest.py
+++ b/backend/tests/rbac/conftest.py
@@ -31,8 +31,10 @@ def make_app_role():
         inherits_from: Optional[List[str]] = None,
         granted_tools: Optional[List[str]] = None,
         granted_models: Optional[List[str]] = None,
+        granted_skills: Optional[List[str]] = None,
         tools: Optional[List[str]] = None,
         models: Optional[List[str]] = None,
+        skills: Optional[List[str]] = None,
         quota_tier: Optional[str] = None,
         priority: int = 0,
         is_system_role: bool = False,
@@ -41,6 +43,7 @@ def make_app_role():
     ) -> AppRole:
         effective_tools = tools if tools is not None else (granted_tools or [])
         effective_models = models if models is not None else (granted_models or [])
+        effective_skills = skills if skills is not None else (granted_skills or [])
 
         return AppRole(
             role_id=role_id,
@@ -51,10 +54,12 @@ def make_app_role():
             effective_permissions=EffectivePermissions(
                 tools=effective_tools,
                 models=effective_models,
+                skills=effective_skills,
                 quota_tier=quota_tier,
             ),
             granted_tools=granted_tools if granted_tools is not None else [],
             granted_models=granted_models if granted_models is not None else [],
+            granted_skills=granted_skills if granted_skills is not None else [],
             priority=priority,
             is_system_role=is_system_role,
             enabled=enabled,

--- a/backend/tests/rbac/test_app_role_skills.py
+++ b/backend/tests/rbac/test_app_role_skills.py
@@ -1,0 +1,299 @@
+"""Unit tests for skill RBAC (PR-2): granted_skills + EffectivePermissions.skills.
+
+Mirrors the tool/model coverage in test_app_role_service.py and
+test_app_role_admin_service.py:
+- skills union merge across roles (service)
+- wildcard skills (service)
+- can_access_skill: wildcard / match / no-match (service)
+- only enabled roles contribute skills (service)
+- inheritance merge of granted_skills (admin _compute_effective_permissions)
+- add_skill_to_role / remove_skill_from_role (admin)
+- get_roles_granting_skill: direct + inherited (admin reverse lookup)
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from apis.shared.auth.models import User
+from apis.shared.rbac.admin_service import AppRoleAdminService
+from apis.shared.rbac.models import AppRoleCreate
+from apis.shared.rbac.service import AppRoleService
+
+
+@pytest.fixture
+def user():
+    return User(
+        email="test@example.com",
+        user_id="user-1",
+        name="Test User",
+        roles=["Editor", "Viewer"],
+    )
+
+
+@pytest.fixture
+def admin():
+    return User(
+        email="admin@example.com",
+        user_id="admin-1",
+        name="Admin User",
+        roles=["Admin"],
+    )
+
+
+@pytest.fixture
+def service(mock_app_role_repo, mock_app_role_cache):
+    return AppRoleService(repository=mock_app_role_repo, cache=mock_app_role_cache)
+
+
+@pytest.fixture
+def admin_service(mock_app_role_repo, mock_app_role_cache):
+    return AppRoleAdminService(repository=mock_app_role_repo, cache=mock_app_role_cache)
+
+
+def _wire_two_roles(mock_app_role_repo, role_a, role_b):
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
+        "Editor": ["editor"],
+        "Viewer": ["viewer"],
+    }.get(r, [])
+    mock_app_role_repo.get_role.side_effect = lambda rid: {
+        "editor": role_a,
+        "viewer": role_b,
+    }.get(rid)
+
+
+# ── service: resolution ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skills_union_merge(service, mock_app_role_repo, make_app_role, user):
+    """Merging multiple AppRoles produces the union of all skills."""
+    role_a = make_app_role(role_id="editor", skills=["skill_a", "skill_b"], priority=1)
+    role_b = make_app_role(role_id="viewer", skills=["skill_b", "skill_c"], priority=0)
+    _wire_two_roles(mock_app_role_repo, role_a, role_b)
+
+    perms = await service.resolve_user_permissions(user)
+
+    assert set(perms.skills) == {"skill_a", "skill_b", "skill_c"}
+
+
+@pytest.mark.asyncio
+async def test_wildcard_in_skills(service, mock_app_role_repo, make_app_role, user):
+    """When any role has '*' in skills, the merged skills contain '*'."""
+    role_a = make_app_role(role_id="editor", skills=["*"], priority=1)
+    role_b = make_app_role(role_id="viewer", skills=["skill_c"], priority=0)
+    _wire_two_roles(mock_app_role_repo, role_a, role_b)
+
+    perms = await service.resolve_user_permissions(user)
+
+    assert "*" in perms.skills
+
+
+@pytest.mark.asyncio
+async def test_can_access_skill_with_wildcard(service, mock_app_role_repo, make_app_role, user):
+    role_a = make_app_role(role_id="editor", skills=["*"], priority=1)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
+        "Editor": ["editor"],
+        "Viewer": [],
+    }.get(r, [])
+    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
+
+    assert await service.can_access_skill(user, "any_skill") is True
+
+
+@pytest.mark.asyncio
+async def test_can_access_skill_with_match(service, mock_app_role_repo, make_app_role, user):
+    role_a = make_app_role(role_id="editor", skills=["pdf_workflows"], priority=1)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
+        "Editor": ["editor"],
+        "Viewer": [],
+    }.get(r, [])
+    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
+
+    assert await service.can_access_skill(user, "pdf_workflows") is True
+
+
+@pytest.mark.asyncio
+async def test_can_access_skill_with_no_match(service, mock_app_role_repo, make_app_role, user):
+    role_a = make_app_role(role_id="editor", skills=["pdf_workflows"], priority=1)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
+        "Editor": ["editor"],
+        "Viewer": [],
+    }.get(r, [])
+    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
+
+    assert await service.can_access_skill(user, "other_skill") is False
+
+
+@pytest.mark.asyncio
+async def test_only_enabled_roles_contribute_skills(service, mock_app_role_repo, make_app_role, user):
+    role_enabled = make_app_role(role_id="editor", skills=["skill_a"], enabled=True)
+    role_disabled = make_app_role(role_id="viewer", skills=["skill_secret"], enabled=False)
+    _wire_two_roles(mock_app_role_repo, role_enabled, role_disabled)
+
+    perms = await service.resolve_user_permissions(user)
+
+    assert "skill_a" in perms.skills
+    assert "skill_secret" not in perms.skills
+
+
+@pytest.mark.asyncio
+async def test_get_accessible_skills(service, mock_app_role_repo, make_app_role, user):
+    role_a = make_app_role(role_id="editor", skills=["skill_a", "skill_b"], priority=1)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
+        "Editor": ["editor"],
+        "Viewer": [],
+    }.get(r, [])
+    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
+
+    assert set(await service.get_accessible_skills(user)) == {"skill_a", "skill_b"}
+
+
+# ── admin: effective-permission computation + inheritance ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_role_computes_skills(admin_service, mock_app_role_repo, admin):
+    role_data = AppRoleCreate(
+        role_id="editor",
+        display_name="Editor",
+        granted_skills=["skill_a", "skill_b"],
+    )
+    mock_app_role_repo.get_role.return_value = None
+
+    async def capture_create(role):
+        return role
+    mock_app_role_repo.create_role.side_effect = capture_create
+
+    result = await admin_service.create_role(role_data, admin)
+
+    assert set(result.granted_skills) == {"skill_a", "skill_b"}
+    assert set(result.effective_permissions.skills) == {"skill_a", "skill_b"}
+
+
+@pytest.mark.asyncio
+async def test_inheritance_merges_granted_skills(admin_service, mock_app_role_repo, make_app_role, admin):
+    parent_role = make_app_role(
+        role_id="parent_role",
+        granted_skills=["parent_skill_a", "parent_skill_b"],
+        enabled=True,
+    )
+    role_data = AppRoleCreate(
+        role_id="child_role",
+        display_name="Child",
+        inherits_from=["parent_role"],
+        granted_skills=["child_skill"],
+    )
+    mock_app_role_repo.get_role.return_value = parent_role
+
+    async def capture_create(role):
+        return role
+    mock_app_role_repo.create_role.side_effect = capture_create
+
+    result = await admin_service.create_role(role_data, admin)
+
+    assert set(result.effective_permissions.skills) == {
+        "child_skill", "parent_skill_a", "parent_skill_b"
+    }
+
+
+# ── admin: add / remove skill ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_skill_to_role(admin_service, mock_app_role_repo, make_app_role, admin):
+    role = make_app_role(role_id="editor", granted_skills=["skill_a"], skills=["skill_a"])
+    mock_app_role_repo.get_role.return_value = role
+
+    async def capture_update(r):
+        return r
+    mock_app_role_repo.update_role.side_effect = capture_update
+
+    result = await admin_service.add_skill_to_role("editor", "skill_b", admin)
+
+    assert "skill_a" in result.granted_skills
+    assert "skill_b" in result.granted_skills
+
+
+@pytest.mark.asyncio
+async def test_add_skill_idempotent(admin_service, mock_app_role_repo, make_app_role, admin):
+    role = make_app_role(role_id="editor", granted_skills=["skill_a"], skills=["skill_a"])
+    mock_app_role_repo.get_role.return_value = role
+
+    result = await admin_service.add_skill_to_role("editor", "skill_a", admin)
+
+    assert result.granted_skills == ["skill_a"]
+    mock_app_role_repo.update_role.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_skill_from_role(admin_service, mock_app_role_repo, make_app_role, admin):
+    role = make_app_role(
+        role_id="editor",
+        granted_skills=["skill_a", "skill_b"],
+        skills=["skill_a", "skill_b"],
+    )
+    mock_app_role_repo.get_role.return_value = role
+
+    async def capture_update(r):
+        return r
+    mock_app_role_repo.update_role.side_effect = capture_update
+
+    result = await admin_service.remove_skill_from_role("editor", "skill_a", admin)
+
+    assert "skill_a" not in result.granted_skills
+    assert "skill_b" in result.granted_skills
+
+
+# ── admin: reverse lookup ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_roles_granting_skill_direct(admin_service, mock_app_role_repo, make_app_role):
+    role = make_app_role(role_id="editor", granted_skills=["pdf_workflows"])
+    mock_app_role_repo.get_roles_for_skill = AsyncMock(
+        side_effect=lambda sid: (
+            [{"roleId": "editor", "displayName": "Editor", "enabled": True}]
+            if sid == "pdf_workflows" else []
+        )
+    )
+    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role}.get(rid)
+
+    roles = await admin_service.get_roles_granting_skill("pdf_workflows")
+
+    assert len(roles) == 1
+    assert roles[0]["roleId"] == "editor"
+    assert roles[0]["grantType"] == "direct"
+
+
+@pytest.mark.asyncio
+async def test_get_roles_granting_skill_inherited(admin_service, mock_app_role_repo, make_app_role):
+    parent = make_app_role(
+        role_id="parent",
+        granted_skills=["pdf_workflows"],
+        skills=["pdf_workflows"],
+    )
+    # Child inherits the skill (it's in effective_permissions but not granted directly).
+    child = make_app_role(
+        role_id="child",
+        inherits_from=["parent"],
+        granted_skills=[],
+        skills=["pdf_workflows"],
+    )
+    mock_app_role_repo.get_roles_for_skill = AsyncMock(
+        side_effect=lambda sid: (
+            [{"roleId": "child", "displayName": "Child", "enabled": True}]
+            if sid == "pdf_workflows" else []
+        )
+    )
+    mock_app_role_repo.get_role.side_effect = lambda rid: {
+        "child": child,
+        "parent": parent,
+    }.get(rid)
+
+    roles = await admin_service.get_roles_granting_skill("pdf_workflows")
+
+    assert len(roles) == 1
+    assert roles[0]["roleId"] == "child"
+    assert roles[0]["grantType"] == "inherited"
+    assert roles[0]["inheritedFrom"] == "parent"

--- a/backend/tests/shared/test_rbac_repository.py
+++ b/backend/tests/shared/test_rbac_repository.py
@@ -87,6 +87,48 @@ class TestAppRoleRepository:
         roles = await role_repository.get_roles_for_model("gpt4")
         assert len(roles) >= 1
 
+    @pytest.mark.asyncio
+    async def test_granted_skills_round_trip(self, role_repository):
+        await role_repository.create_role(
+            _make_role("r1", granted_skills=["pdf_workflows", "doc_basics"])
+        )
+        role = await role_repository.get_role("r1")
+        assert set(role.granted_skills) == {"pdf_workflows", "doc_basics"}
+
+    @pytest.mark.asyncio
+    async def test_get_roles_for_skill(self, role_repository):
+        await role_repository.create_role(
+            _make_role("r1", granted_skills=["pdf_workflows"])
+        )
+        roles = await role_repository.get_roles_for_skill("pdf_workflows")
+        assert [r["roleId"] for r in roles] == ["r1"]
+
+    @pytest.mark.asyncio
+    async def test_skill_grant_does_not_collide_with_tool_grant(self, role_repository):
+        """Skill grants share GSI2 with tool grants but use a disjoint SKILL#
+        partition, so a tool query must not return skill-granting roles."""
+        await role_repository.create_role(
+            _make_role("r1", granted_tools=["calc"], granted_skills=["calc"])
+        )
+        # Same id 'calc' as both a tool and a skill — partitions stay disjoint.
+        tool_roles = await role_repository.get_roles_for_tool("calc")
+        skill_roles = await role_repository.get_roles_for_skill("calc")
+        assert [r["roleId"] for r in tool_roles] == ["r1"]
+        assert [r["roleId"] for r in skill_roles] == ["r1"]
+
+    @pytest.mark.asyncio
+    async def test_update_role_replaces_skill_grants(self, role_repository):
+        await role_repository.create_role(
+            _make_role("r1", granted_skills=["old_skill"])
+        )
+        role = await role_repository.get_role("r1")
+        role.granted_skills = ["new_skill"]
+        await role_repository.update_role(role)
+
+        assert [r["roleId"] for r in await role_repository.get_roles_for_skill("new_skill")] == ["r1"]
+        # The stale grant's reverse-lookup item must be gone.
+        assert await role_repository.get_roles_for_skill("old_skill") == []
+
 
 class TestRBACSeeder:
     @pytest.mark.asyncio

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -71,6 +71,8 @@ class TestSeedSystemAdminRole:
         assert item["jwtRoleMappings"] == ["system_admin"]
         assert item["grantedTools"] == ["*"]
         assert item["grantedModels"] == ["*"]
+        assert item["grantedSkills"] == ["*"]
+        assert item["effectivePermissions"]["skills"] == ["*"]
         assert item["isSystemRole"] is True
         assert item["priority"] == 1000
 
@@ -90,6 +92,15 @@ class TestSeedSystemAdminRole:
         grant = resp["Item"]
         assert grant["GSI3PK"] == "MODEL#*"
         assert grant["GSI3SK"] == "ROLE#system_admin"
+        assert grant["enabled"] is True
+
+        # Verify SKILL_GRANT#* — reuses the GSI2 keyspace with a SKILL# partition
+        resp = dynamodb_table.get_item(
+            Key={"PK": "ROLE#system_admin", "SK": "SKILL_GRANT#*"}
+        )
+        grant = resp["Item"]
+        assert grant["GSI2PK"] == "SKILL#*"
+        assert grant["GSI2SK"] == "ROLE#system_admin"
         assert grant["enabled"] is True
 
         # Verify JWT_MAPPING#system_admin (maps Cognito group → AppRole)


### PR DESCRIPTION
## Scope — PR-2 of admin-managed Skills (RBAC extension)

Second PR of the admin-managed Skills feature. Extends the RBAC engine so skills are granted to AppRoles exactly like tools/models, and adds the server-side access service that resolves a user's accessible skills. **No route, frontend, or runtime wiring yet** (PR-3 = admin API, PR-4 = frontend, PR-5 = runtime) — so there is **no user-visible behavior change**: nothing grants or reads skills at runtime until a later PR, and the skill catalog is still empty.

Design spec (on `develop`): [`docs/specs/admin-skills-rbac-tool-binding.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/admin-skills-rbac-tool-binding.md) — implements §4.2 (RBAC model), §5 (reverse lookup), §7 (access service); §11 PR-2.

Everything mirrors the existing **tool** RBAC path so the engine stays uniform.

## Changes (`apis/shared/rbac/`)

- **`models.py`**
  - `EffectivePermissions` gains `skills` (+ `to_dict`/`from_dict`); `from_dict` defaults `skills=[]` so roles persisted before skills resolve to none.
  - `AppRole` gains `granted_skills` (+ `to_dict`/`from_dict`).
  - `UserEffectivePermissions` gains `skills` (trailing defaulted field, so existing construction sites are non-breaking).
  - `AppRoleCreate`/`AppRoleUpdate` gain `grantedSkills`; `AppRoleResponse`/`EffectivePermissionsResponse` gain `grantedSkills`/`skills` (defaulted → additive, non-breaking for the existing roles admin).
- **`admin_service.py`** — `_compute_effective_permissions` unions `granted_skills` across single-level inheritance; `create_role` threads `granted_skills`. New mirror methods: `get_roles_granting_skill`, `add_skill_to_role`, `remove_skill_from_role`.
- **`service.py`** — `_merge_permissions` unions skills (with `"*"` wildcard); new `can_access_skill` / `get_accessible_skills`.
- **`repository.py`** — `_build_role_items` writes `SKILL_GRANT#{skill_id}` reverse-lookup items, **reusing the GSI2 keyspace** (`ToolRoleMappingIndex`) with a disjoint `SKILL#` partition value (spec §5 — no new GSI). New `get_roles_for_skill`. (`_delete_mapping_items` already clears these on update/delete.)
- **`seeder.py`** — `system_admin` gets `granted_skills=["*"]` + `effective_permissions.skills=["*"]` (mirror of its tools/models wildcard); `default` explicitly `[]` (skills are gated, not open-by-default).

## Access service (`app_api/admin/services/skill_access.py`)

New `SkillAccessService` mirroring `ToolAccessService`: `get_user_allowed_skills`, `can_access_skill` (wildcard), `filter_allowed_skills` (intersect against the DynamoDB-backed catalog via `skills.freshness.get_all_skill_ids`), `check_access_and_filter`. Drops the tool service's `gateway_*` prefix passthrough — skills have no dynamically-loaded form.

## Bootstrap (`scripts/seed_bootstrap_data.py`)

`seed_system_admin_role` (the fresh-creation path that actually runs in real deploys; the in-app `seeder.py` only fires when the role is absent) now also writes `grantedSkills=["*"]`, `effectivePermissions.skills=["*"]`, and a `SKILL_GRANT#*` reverse-lookup item — so the full-access role has the skill wildcard end-to-end. Seeding the example **skill catalog entries** remains PR-5; this only concerns the system_admin role's grants.

## Tests
- `tests/rbac/test_app_role_skills.py` — skills union merge, wildcard, `can_access_skill`, only-enabled-roles, inheritance merge, add/remove, reverse-lookup (direct + inherited classification).
- `tests/shared/test_rbac_repository.py` — `granted_skills` round-trip, `get_roles_for_skill`, **tool↔skill partition non-collision** (same id as both a tool and a skill), and stale-grant cleanup on update.
- `tests/apis/app_api/admin/services/test_skill_access.py` — wildcard expansion, unknown-skill filtering, intersection, deny, strict raise.
- `tests/test_seed_system_admin_jwt.py` — asserts the new `grantedSkills`/`SKILL_GRANT#*`.
- `tests/rbac/conftest.py` — `make_app_role` factory gains `granted_skills`/`skills`.

## Verification
- ✅ `uv run python -m pytest tests/ -v` — full suite green (see below); ruff clean; import-boundary test passes.
- No infra change (reverse lookup reuses the existing GSI2), so no `cdk`/`jest` run needed.

## Acceptance
A role can carry `granted_skills`; effective permissions union them (incl. inheritance + `"*"`); the reverse lookup answers "which roles grant this skill"; `SkillAccessService` resolves/filters a user's accessible skills. Wired into no route yet — zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
