### PR TITLE
feat(skills): admin API for skill authoring + role grants (PR-3)

### DIFF
--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -716,6 +716,11 @@ from .tools.routes import router as tools_router
 
 router.include_router(tools_router)
 
+# ========== Include Skills Admin Subrouter ==========
+from .skills.routes import router as skills_router
+
+router.include_router(skills_router)
+
 # ========== Include OAuth Admin Subrouter ==========
 from .oauth.routes import router as oauth_admin_router
 

--- a/backend/src/apis/app_api/admin/skills/__init__.py
+++ b/backend/src/apis/app_api/admin/skills/__init__.py
@@ -1,0 +1,5 @@
+"""Admin skill management routes."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/src/apis/app_api/admin/skills/routes.py
+++ b/backend/src/apis/app_api/admin/skills/routes.py
@@ -1,0 +1,230 @@
+"""Admin API routes for skill catalog management.
+
+Mirrors apis/app_api/admin/tools/routes.py. All routes require admin access.
+There is no /discover endpoint — skills are authored, not discovered; the
+create/edit form populates its tool picker from GET /admin/tools.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from apis.shared.auth import User, require_admin
+from apis.shared.skills.models import (
+    AddRemoveSkillRolesRequest,
+    AdminSkillListResponse,
+    AdminSkillResponse,
+    SetSkillRolesRequest,
+    SkillCreateRequest,
+    SkillDefinition,
+    SkillRolesResponse,
+    SkillUpdateRequest,
+)
+from apis.app_api.skills.service import get_skill_catalog_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/skills", tags=["admin-skills"])
+
+
+@router.get("/", response_model=AdminSkillListResponse)
+async def admin_list_all_skills(
+    status: Optional[str] = Query(
+        None, description="Filter by status (active, draft, disabled)"
+    ),
+    admin: User = Depends(require_admin),
+):
+    """List all skills in the catalog with their role assignments."""
+    logger.info("Admin listing full skill catalog")
+
+    service = get_skill_catalog_service()
+    skills = await service.get_all_skills(status=status, include_roles=True)
+
+    return AdminSkillListResponse(
+        skills=[AdminSkillResponse.from_skill_definition(s) for s in skills],
+        total=len(skills),
+    )
+
+
+@router.get("/{skill_id}", response_model=AdminSkillResponse)
+async def admin_get_skill(
+    skill_id: str,
+    admin: User = Depends(require_admin),
+):
+    """Get a specific skill by ID, with its directly-granting roles."""
+    logger.info("Admin getting skill")
+
+    service = get_skill_catalog_service()
+    skill = await service.get_skill(skill_id)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    roles = await service.get_roles_for_skill(skill_id)
+    allowed_roles = [r.role_id for r in roles if r.grant_type == "direct"]
+
+    return AdminSkillResponse.from_skill_definition(skill, allowed_roles)
+
+
+@router.post("/", response_model=AdminSkillResponse)
+async def admin_create_skill(
+    request: SkillCreateRequest,
+    admin: User = Depends(require_admin),
+):
+    """Create a new skill catalog entry.
+
+    Every bound_tool_id is validated against the tool catalog (must exist and
+    be ACTIVE). This only creates the catalog entry; use the role endpoints to
+    grant it to AppRoles.
+    """
+    logger.info("Admin creating skill")
+
+    service = get_skill_catalog_service()
+
+    try:
+        skill = SkillDefinition(
+            skill_id=request.skill_id,
+            display_name=request.display_name,
+            description=request.description,
+            instructions=request.instructions,
+            bound_tool_ids=request.bound_tool_ids,
+            compose=request.compose,
+            status=request.status,
+            category=request.category,
+        )
+        created = await service.create_skill(skill, admin)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Drop the all-skill-ids snapshot so the new skill is recognized by
+    # SkillAccessService on the very next chat turn in this process.
+    from apis.shared.skills.freshness import invalidate as invalidate_freshness
+
+    invalidate_freshness(created.skill_id)
+
+    return AdminSkillResponse.from_skill_definition(created)
+
+
+@router.put("/{skill_id}", response_model=AdminSkillResponse)
+async def admin_update_skill(
+    skill_id: str,
+    request: SkillUpdateRequest,
+    admin: User = Depends(require_admin),
+):
+    """Update skill metadata. Re-validates bound tools when they change."""
+    logger.info("Admin updating skill")
+
+    service = get_skill_catalog_service()
+    updates = request.model_dump(exclude_unset=True, by_alias=False)
+
+    try:
+        updated = await service.update_skill(skill_id, updates, admin)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not updated:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    from apis.shared.skills.freshness import invalidate as invalidate_freshness
+
+    invalidate_freshness(skill_id)
+
+    return AdminSkillResponse.from_skill_definition(updated)
+
+
+@router.delete("/{skill_id}")
+async def admin_delete_skill(
+    skill_id: str,
+    hard: bool = Query(
+        False, description="If true, permanently delete instead of soft delete"
+    ),
+    admin: User = Depends(require_admin),
+):
+    """Delete a skill. Soft (disable) by default; hard=true permanently deletes."""
+    logger.info("Admin deleting skill")
+
+    service = get_skill_catalog_service()
+    deleted = await service.delete_skill(skill_id, admin, soft=not hard)
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    from apis.shared.skills.freshness import invalidate as invalidate_freshness
+
+    invalidate_freshness(skill_id)
+
+    action = "deleted" if hard else "disabled"
+    return {"message": f"Skill '{skill_id}' {action} successfully"}
+
+
+# =============================================================================
+# Role Assignment Endpoints
+# =============================================================================
+
+
+@router.get("/{skill_id}/roles", response_model=SkillRolesResponse)
+async def get_skill_roles(
+    skill_id: str,
+    admin: User = Depends(require_admin),
+):
+    """Get AppRoles that grant access to this skill (direct/inherited)."""
+    logger.info("Admin getting roles for skill")
+
+    service = get_skill_catalog_service()
+    skill = await service.get_skill(skill_id)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    roles = await service.get_roles_for_skill(skill_id)
+    return SkillRolesResponse(skill_id=skill_id, roles=roles)
+
+
+@router.put("/{skill_id}/roles")
+async def set_skill_roles(
+    skill_id: str,
+    request: SetSkillRolesRequest,
+    admin: User = Depends(require_admin),
+):
+    """Replace which AppRoles grant access to this skill (bidirectional sync)."""
+    logger.info("Admin setting roles for skill")
+
+    service = get_skill_catalog_service()
+    try:
+        await service.set_roles_for_skill(skill_id, request.app_role_ids, admin)
+        return {"message": f"Roles updated for skill '{skill_id}'"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/{skill_id}/roles/add")
+async def add_roles_to_skill(
+    skill_id: str,
+    request: AddRemoveSkillRolesRequest,
+    admin: User = Depends(require_admin),
+):
+    """Add AppRoles to skill access (preserves existing)."""
+    logger.info("Admin adding roles to skill")
+
+    service = get_skill_catalog_service()
+    try:
+        await service.add_roles_to_skill(skill_id, request.app_role_ids, admin)
+        return {"message": f"Roles added to skill '{skill_id}'"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/{skill_id}/roles/remove")
+async def remove_roles_from_skill(
+    skill_id: str,
+    request: AddRemoveSkillRolesRequest,
+    admin: User = Depends(require_admin),
+):
+    """Remove AppRoles from skill access."""
+    logger.info("Admin removing roles from skill")
+
+    service = get_skill_catalog_service()
+    try:
+        await service.remove_roles_from_skill(skill_id, request.app_role_ids, admin)
+        return {"message": f"Roles removed from skill '{skill_id}'"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/src/apis/app_api/skills/__init__.py
+++ b/backend/src/apis/app_api/skills/__init__.py
@@ -1,0 +1,43 @@
+"""Skills API module (app_api-specific service).
+
+Models and repository live in apis.shared.skills. The service lives here as it
+is app_api-specific (admin authoring + RBAC sync), mirroring apis.app_api.tools.
+"""
+
+from apis.shared.skills.models import (
+    AddRemoveSkillRolesRequest,
+    AdminSkillListResponse,
+    AdminSkillResponse,
+    SetSkillRolesRequest,
+    SkillCreateRequest,
+    SkillDefinition,
+    SkillRoleAssignment,
+    SkillRolesResponse,
+    SkillStatus,
+    SkillUpdateRequest,
+    SkillVisibility,
+)
+from apis.shared.skills.repository import (
+    SkillCatalogRepository,
+    get_skill_catalog_repository,
+)
+
+from .service import SkillCatalogService, get_skill_catalog_service
+
+__all__ = [
+    "SkillDefinition",
+    "SkillStatus",
+    "SkillVisibility",
+    "SkillCreateRequest",
+    "SkillUpdateRequest",
+    "SkillRoleAssignment",
+    "SkillRolesResponse",
+    "SetSkillRolesRequest",
+    "AddRemoveSkillRolesRequest",
+    "AdminSkillResponse",
+    "AdminSkillListResponse",
+    "SkillCatalogRepository",
+    "get_skill_catalog_repository",
+    "SkillCatalogService",
+    "get_skill_catalog_service",
+]

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -1,0 +1,395 @@
+"""
+Skill Catalog Service
+
+Service for skill catalog operations with AppRole integration. Mirrors
+``ToolCatalogService``: CRUD over skill metadata, bidirectional role sync
+(updating ``granted_skills`` on AppRoles), and ``allowedAppRoles`` hydration.
+
+Skill-specific: ``create_skill``/``update_skill`` validate that every
+``bound_tool_id`` exists in the tool catalog and is ACTIVE (spec §6), since a
+skill folds those catalog tools behind the meta-tools at runtime.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from apis.shared.auth.models import User
+from apis.shared.rbac.admin_service import (
+    AppRoleAdminService,
+    get_app_role_admin_service,
+)
+from apis.shared.rbac.service import AppRoleService, get_app_role_service
+from apis.shared.skills.models import (
+    SkillDefinition,
+    SkillRoleAssignment,
+)
+from apis.shared.skills.repository import (
+    SkillCatalogRepository,
+    get_skill_catalog_repository,
+)
+from apis.shared.tools.models import ToolStatus
+from apis.shared.tools.repository import (
+    ToolCatalogRepository,
+    get_tool_catalog_repository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SkillCatalogService:
+    """
+    Service for skill catalog operations.
+
+    Skill access is determined by AppRoles (granted_skills). This service
+    provides catalog CRUD, bound-tool validation against the tool catalog, and
+    bidirectional sync between skills and AppRoles.
+    """
+
+    def __init__(
+        self,
+        repository: Optional[SkillCatalogRepository] = None,
+        tool_repository: Optional[ToolCatalogRepository] = None,
+        app_role_service: Optional[AppRoleService] = None,
+        app_role_admin_service: Optional[AppRoleAdminService] = None,
+    ):
+        """Initialize with dependencies."""
+        self.repository = repository or get_skill_catalog_repository()
+        self.tool_repository = tool_repository or get_tool_catalog_repository()
+        self.app_role_service = app_role_service or get_app_role_service()
+        self.app_role_admin_service = (
+            app_role_admin_service or get_app_role_admin_service()
+        )
+
+    # =========================================================================
+    # Admin Methods - Skill CRUD
+    # =========================================================================
+
+    async def get_all_skills(
+        self, status: Optional[str] = None, include_roles: bool = True
+    ) -> List[SkillDefinition]:
+        """
+        Get all skills in the catalog.
+
+        Args:
+            status: Optional status filter
+            include_roles: If True, populate allowed_app_roles field
+
+        Returns:
+            List of SkillDefinition objects
+        """
+        skills = await self.repository.list_skills(status=status)
+
+        if include_roles:
+            for skill in skills:
+                roles = await self.get_roles_for_skill(skill.skill_id)
+                skill.allowed_app_roles = [
+                    r.role_id for r in roles if r.grant_type == "direct"
+                ]
+
+        return skills
+
+    async def get_skill(self, skill_id: str) -> Optional[SkillDefinition]:
+        """Get a specific skill by ID."""
+        return await self.repository.get_skill(skill_id)
+
+    async def _validate_bound_tools(self, bound_tool_ids: List[str]) -> None:
+        """
+        Validate that every bound tool exists in the catalog and is ACTIVE.
+
+        A skill folds its bound catalog tools behind the meta-tools at runtime,
+        so binding an unknown or disabled tool would silently drop it. Reject
+        such bindings up front (spec §6).
+
+        Raises:
+            ValueError: If any bound tool is unknown or not ACTIVE.
+        """
+        if not bound_tool_ids:
+            return
+
+        # Dedupe while preserving the admin's set for clear error messages.
+        requested = list(dict.fromkeys(bound_tool_ids))
+        found = await self.tool_repository.batch_get_tools(requested)
+        by_id = {t.tool_id: t for t in found}
+
+        unknown = [tid for tid in requested if tid not in by_id]
+        disabled = [
+            tid
+            for tid in requested
+            if tid in by_id and by_id[tid].status != ToolStatus.ACTIVE.value
+        ]
+
+        problems = []
+        if unknown:
+            problems.append(f"unknown tool(s): {', '.join(sorted(unknown))}")
+        if disabled:
+            problems.append(f"non-active tool(s): {', '.join(sorted(disabled))}")
+        if problems:
+            raise ValueError(
+                "Cannot bind " + "; ".join(problems) + ". "
+                "Bound tools must exist in the catalog and be active."
+            )
+
+    async def create_skill(
+        self, skill: SkillDefinition, admin: User
+    ) -> SkillDefinition:
+        """
+        Create a new skill catalog entry.
+
+        Args:
+            skill: Skill definition to create
+            admin: Admin user performing the action
+
+        Returns:
+            Created SkillDefinition
+
+        Raises:
+            ValueError: If a bound tool is unknown/disabled, or the skill exists
+        """
+        await self._validate_bound_tools(skill.bound_tool_ids)
+
+        skill.created_by = admin.user_id
+        skill.updated_by = admin.user_id
+
+        created = await self.repository.create_skill(skill)
+
+        logger.info(
+            f"Admin {admin.email} created skill: {skill.skill_id}",
+            extra={
+                "event": "skill_created",
+                "skill_id": skill.skill_id,
+                "admin_user_id": admin.user_id,
+                "admin_email": admin.email,
+            },
+        )
+
+        return created
+
+    async def update_skill(
+        self, skill_id: str, updates: Dict, admin: User
+    ) -> Optional[SkillDefinition]:
+        """
+        Update a skill's metadata.
+
+        Args:
+            skill_id: Skill identifier
+            updates: Fields to update (snake_case attribute names)
+            admin: Admin user performing the action
+
+        Returns:
+            Updated SkillDefinition or None if not found
+
+        Raises:
+            ValueError: If the new bound tools are unknown/disabled
+        """
+        if "bound_tool_ids" in updates and updates["bound_tool_ids"] is not None:
+            await self._validate_bound_tools(updates["bound_tool_ids"])
+
+        updated = await self.repository.update_skill(
+            skill_id, updates, admin_user_id=admin.user_id
+        )
+
+        if updated:
+            logger.info(
+                f"Admin {admin.email} updated skill: {skill_id}",
+                extra={
+                    "event": "skill_updated",
+                    "skill_id": skill_id,
+                    "admin_user_id": admin.user_id,
+                    "admin_email": admin.email,
+                    "changes": list(updates.keys()),
+                },
+            )
+
+        return updated
+
+    async def delete_skill(
+        self, skill_id: str, admin: User, soft: bool = True
+    ) -> bool:
+        """
+        Delete a skill from the catalog.
+
+        By default performs a soft delete (status -> DISABLED). A hard delete
+        removes the catalog row.
+
+        Args:
+            skill_id: Skill identifier
+            admin: Admin user performing the action
+            soft: If True, disable instead of deleting
+
+        Returns:
+            True if deleted/disabled, False if not found
+        """
+        existing = await self.repository.get_skill(skill_id)
+        if existing is None:
+            return False
+
+        if soft:
+            result = await self.repository.soft_delete_skill(skill_id, admin.user_id)
+            deleted = result is not None
+        else:
+            deleted = await self.repository.delete_skill(skill_id)
+
+        if deleted:
+            logger.info(
+                f"Admin {admin.email} deleted skill: {skill_id}",
+                extra={
+                    "event": "skill_deleted",
+                    "skill_id": skill_id,
+                    "admin_user_id": admin.user_id,
+                    "admin_email": admin.email,
+                    "soft_delete": soft,
+                },
+            )
+
+        return deleted
+
+    # =========================================================================
+    # Admin Methods - Role Sync
+    # =========================================================================
+
+    async def get_roles_for_skill(self, skill_id: str) -> List[SkillRoleAssignment]:
+        """
+        Get all AppRoles that grant access to a skill.
+
+        Reuses the ToolRoleMappingIndex GSI on the AppRoles table with a
+        ``SKILL#`` partition value.
+
+        Args:
+            skill_id: Skill identifier
+
+        Returns:
+            List of SkillRoleAssignment objects
+        """
+        role_infos = await self.app_role_admin_service.repository.get_roles_for_skill(
+            skill_id
+        )
+
+        assignments = []
+        for info in role_infos:
+            role_id = info.get("roleId")
+            if not role_id:
+                continue
+
+            role = await self.app_role_admin_service.get_role(role_id)
+            if not role:
+                continue
+
+            grant_type = "direct" if skill_id in role.granted_skills else "inherited"
+            inherited_from = None
+
+            if grant_type == "inherited":
+                for parent_id in role.inherits_from:
+                    parent = await self.app_role_admin_service.get_role(parent_id)
+                    if parent and skill_id in parent.effective_permissions.skills:
+                        inherited_from = parent_id
+                        break
+
+            assignments.append(
+                SkillRoleAssignment(
+                    role_id=role_id,
+                    display_name=role.display_name,
+                    grant_type=grant_type,
+                    inherited_from=inherited_from,
+                    enabled=role.enabled,
+                )
+            )
+
+        return assignments
+
+    async def set_roles_for_skill(
+        self, skill_id: str, app_role_ids: List[str], admin: User
+    ) -> None:
+        """
+        Set which AppRoles grant access to a skill (bidirectional sync).
+
+        Updates the grantedSkills field on each affected AppRole. Roles not in
+        the list have this skill removed from their grantedSkills.
+
+        Args:
+            skill_id: Skill identifier
+            app_role_ids: AppRole IDs that should grant this skill
+            admin: Admin user performing the action
+        """
+        skill = await self.get_skill(skill_id)
+        if not skill:
+            raise ValueError(f"Skill '{skill_id}' not found")
+
+        current_roles = await self.get_roles_for_skill(skill_id)
+        current_role_ids = {
+            r.role_id for r in current_roles if r.grant_type == "direct"
+        }
+        new_role_ids = set(app_role_ids)
+
+        to_add = new_role_ids - current_role_ids
+        to_remove = current_role_ids - new_role_ids
+
+        for role_id in to_add:
+            await self._add_skill_to_role(role_id, skill_id, admin)
+        for role_id in to_remove:
+            await self._remove_skill_from_role(role_id, skill_id, admin)
+
+        logger.info(
+            f"Admin {admin.email} set roles for skill {skill_id}",
+            extra={
+                "event": "skill_roles_updated",
+                "skill_id": skill_id,
+                "admin_user_id": admin.user_id,
+                "roles_added": list(to_add),
+                "roles_removed": list(to_remove),
+            },
+        )
+
+    async def add_roles_to_skill(
+        self, skill_id: str, app_role_ids: List[str], admin: User
+    ) -> None:
+        """Add AppRoles to skill access (preserves existing)."""
+        for role_id in app_role_ids:
+            await self._add_skill_to_role(role_id, skill_id, admin)
+
+    async def remove_roles_from_skill(
+        self, skill_id: str, app_role_ids: List[str], admin: User
+    ) -> None:
+        """Remove AppRoles from skill access."""
+        for role_id in app_role_ids:
+            await self._remove_skill_from_role(role_id, skill_id, admin)
+
+    async def _add_skill_to_role(
+        self, role_id: str, skill_id: str, admin: User
+    ) -> None:
+        """Add a skill to a role's grantedSkills."""
+        role = await self.app_role_admin_service.get_role(role_id)
+        if not role:
+            raise ValueError(f"Role '{role_id}' not found")
+
+        if skill_id not in role.granted_skills:
+            from apis.shared.rbac.models import AppRoleUpdate
+
+            updates = AppRoleUpdate(granted_skills=role.granted_skills + [skill_id])
+            await self.app_role_admin_service.update_role(role_id, updates, admin)
+
+    async def _remove_skill_from_role(
+        self, role_id: str, skill_id: str, admin: User
+    ) -> None:
+        """Remove a skill from a role's grantedSkills."""
+        role = await self.app_role_admin_service.get_role(role_id)
+        if not role:
+            raise ValueError(f"Role '{role_id}' not found")
+
+        if skill_id in role.granted_skills:
+            from apis.shared.rbac.models import AppRoleUpdate
+
+            new_skills = [s for s in role.granted_skills if s != skill_id]
+            updates = AppRoleUpdate(granted_skills=new_skills)
+            await self.app_role_admin_service.update_role(role_id, updates, admin)
+
+
+# Global service instance
+_service_instance: Optional[SkillCatalogService] = None
+
+
+def get_skill_catalog_service() -> SkillCatalogService:
+    """Get or create the global SkillCatalogService instance."""
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = SkillCatalogService()
+    return _service_instance

--- a/backend/src/apis/shared/skills/__init__.py
+++ b/backend/src/apis/shared/skills/__init__.py
@@ -14,8 +14,16 @@ from .freshness import (
 )
 from .models import (
     SKILL_ID_PATTERN,
+    AddRemoveSkillRolesRequest,
+    AdminSkillListResponse,
+    AdminSkillResponse,
+    SetSkillRolesRequest,
+    SkillCreateRequest,
     SkillDefinition,
+    SkillRoleAssignment,
+    SkillRolesResponse,
     SkillStatus,
+    SkillUpdateRequest,
     SkillVisibility,
 )
 from .repository import SkillCatalogRepository, get_skill_catalog_repository
@@ -25,6 +33,14 @@ __all__ = [
     "SkillDefinition",
     "SkillStatus",
     "SkillVisibility",
+    "SkillCreateRequest",
+    "SkillUpdateRequest",
+    "SkillRoleAssignment",
+    "SkillRolesResponse",
+    "SetSkillRolesRequest",
+    "AddRemoveSkillRolesRequest",
+    "AdminSkillResponse",
+    "AdminSkillListResponse",
     "SkillCatalogRepository",
     "get_skill_catalog_repository",
     "get_all_skill_ids",

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -181,3 +181,141 @@ class SkillDefinition(BaseModel):
             created_by=item.get("createdBy"),
             updated_by=item.get("updatedBy"),
         )
+
+
+# =============================================================================
+# API Request Models (admin) — mirror apis/shared/tools/models.py
+# =============================================================================
+
+
+class SkillCreateRequest(BaseModel):
+    """Request body for POST /admin/skills."""
+
+    skill_id: str = Field(..., pattern=SKILL_ID_PATTERN, alias="skillId")
+    display_name: str = Field(
+        ..., min_length=1, max_length=100, alias="displayName"
+    )
+    description: str = Field(..., max_length=500)
+    # SKILL.md body — uncapped (instructions can be long); empty is allowed so
+    # an admin can save a draft and fill it in later.
+    instructions: str = Field(default="")
+    bound_tool_ids: List[str] = Field(default_factory=list, alias="boundToolIds")
+    compose: List[str] = Field(default_factory=list)
+    status: SkillStatus = Field(default=SkillStatus.ACTIVE)
+    category: Optional[str] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class SkillUpdateRequest(BaseModel):
+    """Request body for PUT /admin/skills/{skill_id}."""
+
+    display_name: Optional[str] = Field(
+        None, min_length=1, max_length=100, alias="displayName"
+    )
+    description: Optional[str] = Field(None, max_length=500)
+    instructions: Optional[str] = None
+    bound_tool_ids: Optional[List[str]] = Field(None, alias="boundToolIds")
+    compose: Optional[List[str]] = None
+    status: Optional[SkillStatus] = None
+    category: Optional[str] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class SkillRoleAssignment(BaseModel):
+    """Role assignment info for a skill (mirror ToolRoleAssignment)."""
+
+    role_id: str = Field(..., alias="roleId")
+    display_name: str = Field(..., alias="displayName")
+    grant_type: str = Field(
+        ..., alias="grantType", description="'direct' or 'inherited'"
+    )
+    inherited_from: Optional[str] = Field(None, alias="inheritedFrom")
+    enabled: bool
+
+    model_config = {"populate_by_name": True}
+
+
+class SkillRolesResponse(BaseModel):
+    """Response for GET /admin/skills/{skill_id}/roles."""
+
+    skill_id: str = Field(..., alias="skillId")
+    roles: List[SkillRoleAssignment]
+
+    model_config = {"populate_by_name": True}
+
+
+class SetSkillRolesRequest(BaseModel):
+    """Request body for PUT /admin/skills/{skill_id}/roles."""
+
+    app_role_ids: List[str] = Field(..., alias="appRoleIds")
+
+    model_config = {"populate_by_name": True}
+
+
+class AddRemoveSkillRolesRequest(BaseModel):
+    """Request body for POST /admin/skills/{skill_id}/roles/add or /remove."""
+
+    app_role_ids: List[str] = Field(..., alias="appRoleIds")
+
+    model_config = {"populate_by_name": True}
+
+
+# =============================================================================
+# API Response Models (admin)
+# =============================================================================
+
+
+class AdminSkillResponse(BaseModel):
+    """Response model for admin skill listing (mirror AdminToolResponse)."""
+
+    skill_id: str = Field(..., alias="skillId")
+    display_name: str = Field(..., alias="displayName")
+    description: str
+    instructions: str
+    bound_tool_ids: List[str] = Field(default_factory=list, alias="boundToolIds")
+    compose: List[str] = Field(default_factory=list)
+    status: SkillStatus
+    category: Optional[str] = None
+    owner_id: str = Field("system", alias="ownerId")
+    visibility: SkillVisibility = SkillVisibility.ADMIN
+    allowed_app_roles: List[str] = Field(
+        default_factory=list, alias="allowedAppRoles"
+    )
+    created_at: str = Field("", alias="createdAt")
+    updated_at: str = Field("", alias="updatedAt")
+    created_by: Optional[str] = Field(None, alias="createdBy")
+    updated_by: Optional[str] = Field(None, alias="updatedBy")
+
+    model_config = {"populate_by_name": True, "use_enum_values": True}
+
+    @classmethod
+    def from_skill_definition(
+        cls, skill: "SkillDefinition", allowed_roles: Optional[List[str]] = None
+    ) -> "AdminSkillResponse":
+        """Create response from a SkillDefinition."""
+        return cls(
+            skill_id=skill.skill_id,
+            display_name=skill.display_name,
+            description=skill.description,
+            instructions=skill.instructions,
+            bound_tool_ids=list(skill.bound_tool_ids),
+            compose=list(skill.compose),
+            status=skill.status,
+            category=skill.category,
+            owner_id=skill.owner_id,
+            visibility=skill.visibility,
+            allowed_app_roles=allowed_roles or skill.allowed_app_roles,
+            created_at=skill.created_at.isoformat() + "Z" if skill.created_at else "",
+            updated_at=skill.updated_at.isoformat() + "Z" if skill.updated_at else "",
+            created_by=skill.created_by,
+            updated_by=skill.updated_by,
+        )
+
+
+class AdminSkillListResponse(BaseModel):
+    """Response for GET /admin/skills."""
+
+    skills: List[AdminSkillResponse]
+    total: int

--- a/backend/src/apis/shared/skills/repository.py
+++ b/backend/src/apis/shared/skills/repository.py
@@ -197,6 +197,32 @@ class SkillCatalogRepository:
             logger.error(f"Error updating skill {skill_id}: {e}")
             raise
 
+    async def delete_skill(self, skill_id: str) -> bool:
+        """
+        Hard delete a skill from the catalog.
+
+        Args:
+            skill_id: The skill identifier
+
+        Returns:
+            True if deleted, False if not found
+        """
+        try:
+            existing = await self.get_skill(skill_id)
+            if not existing:
+                return False
+
+            self._table.delete_item(
+                Key={"PK": f"SKILL#{skill_id}", "SK": "METADATA"}
+            )
+
+            logger.info(f"Deleted skill: {skill_id}")
+            return True
+
+        except ClientError as e:
+            logger.error(f"Error deleting skill {skill_id}: {e}")
+            raise
+
     async def soft_delete_skill(
         self, skill_id: str, admin_user_id: Optional[str] = None
     ) -> Optional[SkillDefinition]:

--- a/backend/tests/apis/app_api/skills/conftest.py
+++ b/backend/tests/apis/app_api/skills/conftest.py
@@ -1,0 +1,119 @@
+"""Moto fixtures for the skills admin service + routes tests.
+
+One app-roles table holds SKILL#, TOOL#, and ROLE# items (the skill catalog,
+tool catalog, and RBAC roles all share it), so a single moto table backs the
+whole SkillCatalogService.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.auth.models import User
+
+AWS_REGION = "us-east-1"
+TABLE = "test-app-roles"
+
+
+def _gsi(name, hash_key, range_key):
+    return {
+        "IndexName": name,
+        "KeySchema": [
+            {"AttributeName": hash_key, "KeyType": "HASH"},
+            {"AttributeName": range_key, "KeyType": "RANGE"},
+        ],
+        "Projection": {"ProjectionType": "ALL"},
+    }
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_skill_freshness():
+    from apis.shared.skills import freshness
+
+    freshness._reset_for_tests()
+    yield
+    freshness._reset_for_tests()
+
+
+@pytest.fixture()
+def app_roles_table(aws, monkeypatch):
+    monkeypatch.setenv("DYNAMODB_APP_ROLES_TABLE_NAME", TABLE)
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI3PK", "AttributeType": "S"},
+            {"AttributeName": "GSI3SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            _gsi("JwtRoleMappingIndex", "GSI1PK", "GSI1SK"),
+            _gsi("ToolRoleMappingIndex", "GSI2PK", "GSI2SK"),
+            _gsi("ModelRoleMappingIndex", "GSI3PK", "GSI3SK"),
+            _gsi("SkillOwnerIndex", "GSI4PK", "GSI4SK"),
+        ],
+    )
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE)
+
+
+@pytest.fixture()
+def tool_repo(app_roles_table):
+    """ToolCatalogRepository bound to the moto table (for seeding bound tools)."""
+    from apis.shared.tools.repository import ToolCatalogRepository
+
+    return ToolCatalogRepository(table_name=TABLE)
+
+
+@pytest.fixture()
+def skill_service(app_roles_table):
+    """SkillCatalogService wired to the moto table with isolated RBAC caches."""
+    from apis.app_api.skills.service import SkillCatalogService
+    from apis.shared.rbac.admin_service import AppRoleAdminService
+    from apis.shared.rbac.cache import AppRoleCache
+    from apis.shared.rbac.repository import AppRoleRepository
+    from apis.shared.rbac.service import AppRoleService
+    from apis.shared.skills.repository import SkillCatalogRepository
+    from apis.shared.tools.repository import ToolCatalogRepository
+
+    cache = AppRoleCache()
+    role_repo = AppRoleRepository(table_name=TABLE)
+    return SkillCatalogService(
+        repository=SkillCatalogRepository(table_name=TABLE),
+        tool_repository=ToolCatalogRepository(table_name=TABLE),
+        app_role_service=AppRoleService(repository=role_repo, cache=cache),
+        app_role_admin_service=AppRoleAdminService(repository=role_repo, cache=cache),
+    )
+
+
+@pytest.fixture()
+def admin_user() -> User:
+    return User(
+        user_id="admin-1",
+        email="admin@example.com",
+        name="Admin",
+        roles=["system_admin"],
+        raw_token="test-token",
+    )

--- a/backend/tests/apis/app_api/skills/test_admin_skill_routes.py
+++ b/backend/tests/apis/app_api/skills/test_admin_skill_routes.py
@@ -1,0 +1,154 @@
+"""Admin /skills route tests (TestClient + moto-backed service).
+
+Verifies endpoint wiring, status codes, response shape (camelCase aliases),
+bound-tool validation surfacing as 400, and role-grant round-trips.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import require_admin
+from apis.shared.rbac.models import AppRoleCreate
+from apis.shared.tools.models import ToolDefinition, ToolProtocol, ToolStatus
+from apis.app_api.admin.skills import routes as skill_routes
+
+
+@pytest.fixture()
+def client(skill_service, admin_user, monkeypatch):
+    monkeypatch.setattr(skill_routes, "get_skill_catalog_service", lambda: skill_service)
+    app = FastAPI()
+    app.include_router(skill_routes.router)
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    return TestClient(app)
+
+
+def _create_body(skill_id="pdf_workflows", **kw):
+    body = {
+        "skillId": skill_id,
+        "displayName": "PDF Workflows",
+        "description": "Fill, merge and split PDFs.",
+        "instructions": "# PDF Workflows",
+        "boundToolIds": [],
+    }
+    body.update(kw)
+    return body
+
+
+async def _seed_tool(tool_repo, tool_id, status=ToolStatus.ACTIVE):
+    await tool_repo.create_tool(
+        ToolDefinition(
+            tool_id=tool_id,
+            display_name=tool_id,
+            description="x",
+            protocol=ToolProtocol.LOCAL,
+            status=status,
+        )
+    )
+
+
+def test_create_and_get(client):
+    resp = client.post("/skills/", json=_create_body())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["skillId"] == "pdf_workflows"
+    assert body["displayName"] == "PDF Workflows"
+    assert body["status"] == "active"
+
+    got = client.get("/skills/pdf_workflows")
+    assert got.status_code == 200
+    assert got.json()["skillId"] == "pdf_workflows"
+
+
+def test_get_missing_404(client):
+    assert client.get("/skills/nope").status_code == 404
+
+
+def test_list(client):
+    client.post("/skills/", json=_create_body("skill_one"))
+    client.post("/skills/", json=_create_body("skill_two"))
+    resp = client.get("/skills/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert {s["skillId"] for s in body["skills"]} == {"skill_one", "skill_two"}
+
+
+def test_create_rejects_unknown_bound_tool(client):
+    resp = client.post(
+        "/skills/", json=_create_body(boundToolIds=["ghost_tool"])
+    )
+    assert resp.status_code == 400
+    assert "unknown tool" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_with_active_bound_tool(client, tool_repo):
+    await _seed_tool(tool_repo, "fill_pdf_form")
+    resp = client.post(
+        "/skills/", json=_create_body(boundToolIds=["fill_pdf_form"])
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["boundToolIds"] == ["fill_pdf_form"]
+
+
+def test_update(client):
+    client.post("/skills/", json=_create_body())
+    resp = client.put("/skills/pdf_workflows", json={"displayName": "PDF Tools"})
+    assert resp.status_code == 200
+    assert resp.json()["displayName"] == "PDF Tools"
+
+
+def test_update_missing_404(client):
+    assert client.put("/skills/nope", json={"displayName": "x"}).status_code == 404
+
+
+def test_soft_then_hard_delete(client):
+    client.post("/skills/", json=_create_body())
+
+    soft = client.delete("/skills/pdf_workflows")
+    assert soft.status_code == 200
+    assert "disabled" in soft.json()["message"]
+    # Soft delete keeps the row (status disabled).
+    assert client.get("/skills/pdf_workflows").json()["status"] == "disabled"
+
+    hard = client.delete("/skills/pdf_workflows?hard=true")
+    assert hard.status_code == 200
+    assert "deleted" in hard.json()["message"]
+    assert client.get("/skills/pdf_workflows").status_code == 404
+
+
+def test_delete_missing_404(client):
+    assert client.delete("/skills/nope").status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_role_grant_endpoints(client, skill_service, admin_user):
+    client.post("/skills/", json=_create_body())
+    await skill_service.app_role_admin_service.create_role(
+        AppRoleCreate(role_id="editor", display_name="Editor"), admin_user
+    )
+
+    # PUT replaces grants.
+    put = client.put("/skills/pdf_workflows/roles", json={"appRoleIds": ["editor"]})
+    assert put.status_code == 200
+
+    roles = client.get("/skills/pdf_workflows/roles")
+    assert roles.status_code == 200
+    body = roles.json()
+    assert body["skillId"] == "pdf_workflows"
+    assert [r["roleId"] for r in body["roles"]] == ["editor"]
+    assert body["roles"][0]["grantType"] == "direct"
+
+    # The grant landed on the role's granted_skills.
+    editor = await skill_service.app_role_admin_service.get_role("editor")
+    assert "pdf_workflows" in editor.granted_skills
+
+    # Remove via delta endpoint.
+    rm = client.post("/skills/pdf_workflows/roles/remove", json={"appRoleIds": ["editor"]})
+    assert rm.status_code == 200
+    assert client.get("/skills/pdf_workflows/roles").json()["roles"] == []
+
+
+def test_roles_for_missing_skill_404(client):
+    assert client.get("/skills/nope/roles").status_code == 404

--- a/backend/tests/apis/app_api/skills/test_skill_catalog_service.py
+++ b/backend/tests/apis/app_api/skills/test_skill_catalog_service.py
@@ -1,0 +1,214 @@
+"""SkillCatalogService tests (moto-backed).
+
+Covers CRUD, bound-tool validation against the tool catalog, allowedAppRoles
+hydration, and bidirectional role sync (writing granted_skills onto AppRoles).
+"""
+
+import pytest
+
+from apis.shared.rbac.models import AppRoleCreate
+from apis.shared.skills.models import SkillDefinition, SkillStatus
+from apis.shared.tools.models import ToolDefinition, ToolProtocol, ToolStatus
+
+
+def _skill(skill_id="pdf_workflows", bound_tool_ids=None, **kw) -> SkillDefinition:
+    defaults = dict(
+        skill_id=skill_id,
+        display_name="PDF Workflows",
+        description="Fill, merge and split PDFs.",
+        instructions="# PDF Workflows",
+        bound_tool_ids=bound_tool_ids if bound_tool_ids is not None else [],
+    )
+    defaults.update(kw)
+    return SkillDefinition(**defaults)
+
+
+async def _seed_tool(tool_repo, tool_id, status=ToolStatus.ACTIVE):
+    await tool_repo.create_tool(
+        ToolDefinition(
+            tool_id=tool_id,
+            display_name=tool_id,
+            description="x",
+            protocol=ToolProtocol.LOCAL,
+            status=status,
+        )
+    )
+
+
+async def _seed_role(skill_service, role_id, admin_user, **kw):
+    return await skill_service.app_role_admin_service.create_role(
+        AppRoleCreate(role_id=role_id, display_name=role_id, **kw), admin_user
+    )
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_and_get(skill_service, admin_user):
+    created = await skill_service.create_skill(_skill(), admin_user)
+    assert created.created_by == "admin-1"
+
+    fetched = await skill_service.get_skill("pdf_workflows")
+    assert fetched is not None
+    assert fetched.display_name == "PDF Workflows"
+
+
+@pytest.mark.asyncio
+async def test_get_all_skills_status_filter(skill_service, admin_user):
+    await skill_service.create_skill(_skill("skill_one", status=SkillStatus.ACTIVE), admin_user)
+    await skill_service.create_skill(_skill("skill_two", status=SkillStatus.DRAFT), admin_user)
+
+    active = await skill_service.get_all_skills(status="active")
+    assert [s.skill_id for s in active] == ["skill_one"]
+
+
+@pytest.mark.asyncio
+async def test_update_skill(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    updated = await skill_service.update_skill(
+        "pdf_workflows", {"display_name": "PDF Tools"}, admin_user
+    )
+    assert updated.display_name == "PDF Tools"
+    assert updated.updated_by == "admin-1"
+
+
+@pytest.mark.asyncio
+async def test_update_missing_returns_none(skill_service, admin_user):
+    assert await skill_service.update_skill("nope", {"display_name": "x"}, admin_user) is None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_disables(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    assert await skill_service.delete_skill("pdf_workflows", admin_user, soft=True) is True
+
+    reloaded = await skill_service.get_skill("pdf_workflows")
+    assert reloaded.status == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_removes_row(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    assert await skill_service.delete_skill("pdf_workflows", admin_user, soft=False) is True
+    assert await skill_service.get_skill("pdf_workflows") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_returns_false(skill_service, admin_user):
+    assert await skill_service.delete_skill("nope", admin_user) is False
+
+
+# ── bound-tool validation ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_with_active_bound_tool(skill_service, tool_repo, admin_user):
+    await _seed_tool(tool_repo, "fill_pdf_form")
+    created = await skill_service.create_skill(
+        _skill(bound_tool_ids=["fill_pdf_form"]), admin_user
+    )
+    assert created.bound_tool_ids == ["fill_pdf_form"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_bound_tool(skill_service, admin_user):
+    with pytest.raises(ValueError, match="unknown tool"):
+        await skill_service.create_skill(
+            _skill(bound_tool_ids=["does_not_exist"]), admin_user
+        )
+    # Nothing persisted.
+    assert await skill_service.get_skill("pdf_workflows") is None
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_disabled_bound_tool(skill_service, tool_repo, admin_user):
+    await _seed_tool(tool_repo, "old_tool", status=ToolStatus.DISABLED)
+    with pytest.raises(ValueError, match="non-active tool"):
+        await skill_service.create_skill(
+            _skill(bound_tool_ids=["old_tool"]), admin_user
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_revalidates_bound_tools(skill_service, tool_repo, admin_user):
+    await _seed_tool(tool_repo, "fill_pdf_form")
+    await skill_service.create_skill(_skill(bound_tool_ids=["fill_pdf_form"]), admin_user)
+
+    with pytest.raises(ValueError, match="unknown tool"):
+        await skill_service.update_skill(
+            "pdf_workflows", {"bound_tool_ids": ["ghost"]}, admin_user
+        )
+
+
+# ── role sync + hydration ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_roles_for_skill_bidirectional(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    await _seed_role(skill_service, "editor", admin_user)
+    await _seed_role(skill_service, "viewer", admin_user)
+
+    # Grant to editor + viewer.
+    await skill_service.set_roles_for_skill(
+        "pdf_workflows", ["editor", "viewer"], admin_user
+    )
+    roles = {r.role_id for r in await skill_service.get_roles_for_skill("pdf_workflows")}
+    assert roles == {"editor", "viewer"}
+
+    editor = await skill_service.app_role_admin_service.get_role("editor")
+    assert "pdf_workflows" in editor.granted_skills
+    assert "pdf_workflows" in editor.effective_permissions.skills
+
+    # Replace with just editor → viewer loses the grant.
+    await skill_service.set_roles_for_skill("pdf_workflows", ["editor"], admin_user)
+    roles = {r.role_id for r in await skill_service.get_roles_for_skill("pdf_workflows")}
+    assert roles == {"editor"}
+    viewer = await skill_service.app_role_admin_service.get_role("viewer")
+    assert "pdf_workflows" not in viewer.granted_skills
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_roles(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    await _seed_role(skill_service, "editor", admin_user)
+
+    await skill_service.add_roles_to_skill("pdf_workflows", ["editor"], admin_user)
+    assert {r.role_id for r in await skill_service.get_roles_for_skill("pdf_workflows")} == {"editor"}
+
+    await skill_service.remove_roles_from_skill("pdf_workflows", ["editor"], admin_user)
+    assert await skill_service.get_roles_for_skill("pdf_workflows") == []
+
+
+@pytest.mark.asyncio
+async def test_get_all_skills_hydrates_allowed_roles(skill_service, admin_user):
+    await skill_service.create_skill(_skill(), admin_user)
+    await _seed_role(skill_service, "editor", admin_user)
+    await skill_service.set_roles_for_skill("pdf_workflows", ["editor"], admin_user)
+
+    skills = await skill_service.get_all_skills(include_roles=True)
+    target = next(s for s in skills if s.skill_id == "pdf_workflows")
+    assert target.allowed_app_roles == ["editor"]
+
+
+@pytest.mark.asyncio
+async def test_reverse_lookup_returns_direct_granter_only(skill_service, admin_user):
+    """The skill→roles reverse lookup indexes only *direct* grants (it reuses
+    the tool GSI, which writes an item per granted skill). A child that merely
+    inherits the skill resolves it in its effective permissions but does not
+    appear as a granting role — same behavior as tools."""
+    await skill_service.create_skill(_skill(), admin_user)
+    await _seed_role(skill_service, "parent", admin_user, grantedSkills=["pdf_workflows"])
+    await _seed_role(skill_service, "child", admin_user, inheritsFrom=["parent"])
+
+    roles = {
+        r.role_id: r for r in await skill_service.get_roles_for_skill("pdf_workflows")
+    }
+    assert set(roles) == {"parent"}
+    assert roles["parent"].grant_type == "direct"
+
+    # The child still resolves the skill via inheritance, even though it isn't
+    # surfaced by the reverse lookup.
+    child = await skill_service.app_role_admin_service.get_role("child")
+    assert "pdf_workflows" in child.effective_permissions.skills


### PR DESCRIPTION
## Scope — PR-3 of admin-managed Skills (Admin API)

Third PR of the admin-managed Skills feature. Adds the admin REST surface for authoring skills and granting them to roles, plus a `SkillCatalogService` mirroring `ToolCatalogService`. The endpoints exist but have **no frontend consumer yet** (PR-4) and nothing in the runtime reads skills yet (PR-5), so there is **no user-visible behavior change** — these are net-new admin-only routes over an empty catalog.

Design spec (on `develop`): [`docs/specs/admin-skills-rbac-tool-binding.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/admin-skills-rbac-tool-binding.md) — implements §6 (Admin API); §11 PR-3. Consumes PR-1's `SkillCatalogRepository` and PR-2's RBAC reverse-lookup.

Everything mirrors `app_api/admin/tools/routes.py` + `app_api/tools/service.py`.

## Endpoints (`/admin/skills`, all `Depends(require_admin)`)

| Method | Path | Notes |
|---|---|---|
| GET | `/admin/skills` | list (optional `status` filter); hydrates `allowedAppRoles` |
| GET | `/admin/skills/{id}` | one skill + its direct-granting roles |
| POST | `/admin/skills` | create; **validates every `boundToolId` exists in the tool catalog and is ACTIVE** → 400 on unknown/disabled |
| PUT | `/admin/skills/{id}` | update; re-validates bound tools when they change |
| DELETE | `/admin/skills/{id}?hard={bool}` | soft (disable) default / hard |
| GET | `/admin/skills/{id}/roles` | roles granting this skill (`direct`/`inherited`) |
| PUT | `/admin/skills/{id}/roles` | replace grants (bidirectional sync onto `granted_skills`) |
| POST | `/admin/skills/{id}/roles/add` · `/remove` | delta grants |

No `/discover` — skills are authored; the form's tool picker is populated from `GET /admin/tools` (PR-4).

## Changes

- **`apis/shared/skills/models.py`** — admin request/response DTOs mirroring the tool equivalents: `SkillCreateRequest`, `SkillUpdateRequest`, `SkillRoleAssignment`, `SkillRolesResponse`, `SetSkillRolesRequest`, `AddRemoveSkillRolesRequest`, `AdminSkillResponse` (+`from_skill_definition`), `AdminSkillListResponse`.
- **`apis/shared/skills/repository.py`** — adds the hard `delete_skill` (PR-1 had only `soft_delete_skill`; the `?hard=` flag needs it).
- **`apis/app_api/skills/service.py`** (new) — `SkillCatalogService`: CRUD, `_validate_bound_tools` (batch-get against the tool catalog, reject unknown/non-active), `allowedAppRoles` hydration, and role sync (`set`/`add`/`remove` → writes `granted_skills` on AppRoles via `AppRoleAdminService`).
- **`apis/app_api/admin/skills/routes.py`** (new) — the router; `ValueError → 400`, missing → `404`, freshness invalidation on writes.
- **`apis/app_api/admin/routes.py`** — register the subrouter under `/admin` (one block, mirroring tools).

## Tests (`tests/apis/app_api/skills/`, moto-backed)
- `test_skill_catalog_service.py` — CRUD, **bound-tool validation** (unknown → "unknown tool", disabled → "non-active tool", nothing persisted on reject), soft/hard delete, role sync (bidirectional add/remove onto `granted_skills` + effective perms), `allowedAppRoles` hydration, and a note-test that the reverse lookup returns only *direct* granters (inherited grants resolve in effective perms but aren't surfaced — same as tools).
- `test_admin_skill_routes.py` — TestClient + `require_admin` override: status codes (200/400/404), camelCase response shape, bound-tool 400, and a full role-grant round-trip through the `/roles` endpoints.
- `conftest.py` — one moto app-roles table (holds `SKILL#`/`TOOL#`/`ROLE#`) + a `SkillCatalogService` with isolated RBAC caches.

## Verification
- ✅ `uv run python -m pytest tests/` — full suite green (see below); ruff clean; import-boundary test passes (`apis.shared.skills` adds only DTOs; the service lives in `app_api`).
- No infra change, so no `cdk`/`jest` run.

## Acceptance
An admin can create/list/get/update/delete skills and grant them to roles over REST; bound tools are validated against the tool catalog. No frontend wiring yet (PR-4) and the runtime still ignores skills (PR-5) — net-new routes, zero behavior change to existing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
