### PR TITLE
feat(skills): S3-backed reference-file data layer for admin Skills (PR-4)

### DIFF
--- a/backend/src/apis/app_api/admin/skills/routes.py
+++ b/backend/src/apis/app_api/admin/skills/routes.py
@@ -8,7 +8,8 @@ create/edit form populates its tool picker from GET /admin/tools.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi.responses import Response
 
 from apis.shared.auth import User, require_admin
 from apis.shared.skills.models import (
@@ -18,6 +19,7 @@ from apis.shared.skills.models import (
     SetSkillRolesRequest,
     SkillCreateRequest,
     SkillDefinition,
+    SkillResourcesResponse,
     SkillRolesResponse,
     SkillUpdateRequest,
 )
@@ -228,3 +230,111 @@ async def remove_roles_from_skill(
         return {"message": f"Roles removed from skill '{skill_id}'"}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+# =============================================================================
+# Reference-File Endpoints (S3-backed supporting reference files — PR-4)
+# =============================================================================
+
+
+def _resource_value_error(e: ValueError) -> HTTPException:
+    """Map a service ValueError to 404 (missing) or 400 (validation)."""
+    status = 404 if "not found" in str(e).lower() else 400
+    return HTTPException(status_code=status, detail=str(e))
+
+
+@router.get("/{skill_id}/resources", response_model=SkillResourcesResponse)
+async def list_skill_resources(
+    skill_id: str,
+    admin: User = Depends(require_admin),
+):
+    """List a skill's reference-file manifest (no bytes)."""
+    logger.info("Admin listing skill reference files")
+
+    service = get_skill_catalog_service()
+    try:
+        resources = await service.list_resources(skill_id)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)
+
+
+@router.post("/{skill_id}/resources", response_model=SkillResourcesResponse)
+async def upload_skill_resource(
+    skill_id: str,
+    file: UploadFile = File(...),
+    admin: User = Depends(require_admin),
+):
+    """Upload (or replace) one supporting reference file for a skill.
+
+    Bytes are stored content-addressed in S3; the catalog row's manifest is
+    updated atomically. Re-uploading the same filename replaces it. Returns
+    the skill's updated manifest.
+    """
+    logger.info("Admin uploading skill reference file")
+
+    service = get_skill_catalog_service()
+    content = await file.read()
+    try:
+        resources = await service.add_resource(
+            skill_id,
+            filename=file.filename or "",
+            content=content,
+            content_type=file.content_type or "",
+            admin=admin,
+        )
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    from apis.shared.skills.freshness import invalidate as invalidate_freshness
+
+    invalidate_freshness(skill_id)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)
+
+
+@router.get("/{skill_id}/resources/{filename}")
+async def read_skill_resource(
+    skill_id: str,
+    filename: str,
+    admin: User = Depends(require_admin),
+):
+    """Return the raw bytes of one reference file with its content type."""
+    logger.info("Admin reading skill reference file")
+
+    service = get_skill_catalog_service()
+    try:
+        ref, content = await service.read_resource(skill_id, filename)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return Response(
+        content=content,
+        media_type=ref.content_type or "application/octet-stream",
+        headers={
+            "Content-Disposition": f'inline; filename="{ref.filename}"',
+        },
+    )
+
+
+@router.delete("/{skill_id}/resources/{filename}", response_model=SkillResourcesResponse)
+async def delete_skill_resource(
+    skill_id: str,
+    filename: str,
+    admin: User = Depends(require_admin),
+):
+    """Delete one reference file from a skill. Returns the updated manifest."""
+    logger.info("Admin deleting skill reference file")
+
+    service = get_skill_catalog_service()
+    try:
+        resources = await service.delete_resource(skill_id, filename, admin)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    from apis.shared.skills.freshness import invalidate as invalidate_freshness
+
+    invalidate_freshness(skill_id)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -11,7 +11,8 @@ skill folds those catalog tools behind the meta-tools at runtime.
 """
 
 import logging
-from typing import Dict, List, Optional
+import re
+from typing import Dict, List, Optional, Tuple
 
 from apis.shared.auth.models import User
 from apis.shared.rbac.admin_service import (
@@ -21,11 +22,17 @@ from apis.shared.rbac.admin_service import (
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
 from apis.shared.skills.models import (
     SkillDefinition,
+    SkillResourceRef,
     SkillRoleAssignment,
 )
 from apis.shared.skills.repository import (
     SkillCatalogRepository,
     get_skill_catalog_repository,
+)
+from apis.shared.skills.resource_store import (
+    SkillResourceStore,
+    compute_content_hash,
+    get_skill_resource_store,
 )
 from apis.shared.tools.models import ToolStatus
 from apis.shared.tools.repository import (
@@ -34,6 +41,16 @@ from apis.shared.tools.repository import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Reference-file guardrails. Reference files are small read-only docs
+# (markdown/text), not bulk assets — keep both axes modest so a skill's
+# manifest stays well inside the DynamoDB item limit and the agent's
+# progressive-disclosure budget (PR-6) stays bounded.
+MAX_RESOURCE_BYTES = 1_048_576  # 1 MiB per file
+MAX_RESOURCES_PER_SKILL = 50
+# Safe, flat filenames only — no path separators, no traversal. Mirrors the
+# skill_id discipline: visible, predictable object keys.
+_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 class SkillCatalogService:
@@ -51,6 +68,7 @@ class SkillCatalogService:
         tool_repository: Optional[ToolCatalogRepository] = None,
         app_role_service: Optional[AppRoleService] = None,
         app_role_admin_service: Optional[AppRoleAdminService] = None,
+        resource_store: Optional[SkillResourceStore] = None,
     ):
         """Initialize with dependencies."""
         self.repository = repository or get_skill_catalog_repository()
@@ -59,6 +77,7 @@ class SkillCatalogService:
         self.app_role_admin_service = (
             app_role_admin_service or get_app_role_admin_service()
         )
+        self.resource_store = resource_store or get_skill_resource_store()
 
     # =========================================================================
     # Admin Methods - Skill CRUD
@@ -242,6 +261,195 @@ class SkillCatalogService:
             )
 
         return deleted
+
+    # =========================================================================
+    # Admin Methods - Reference Files (S3-backed)
+    # =========================================================================
+
+    async def list_resources(self, skill_id: str) -> List[SkillResourceRef]:
+        """Return a skill's reference-file manifest.
+
+        Raises:
+            ValueError: If the skill does not exist (mapped to 404 by route).
+        """
+        skill = await self.repository.get_skill(skill_id)
+        if skill is None:
+            raise ValueError(f"Skill '{skill_id}' not found")
+        return list(skill.resources)
+
+    async def add_resource(
+        self,
+        skill_id: str,
+        filename: str,
+        content: bytes,
+        content_type: str,
+        admin: User,
+    ) -> List[SkillResourceRef]:
+        """Upload (or replace) one reference file and update the manifest.
+
+        Bytes are stored content-addressed in S3 (dedupe); the manifest on
+        the catalog row is updated atomically (single row write). Re-uploading
+        the same filename replaces its manifest entry; any S3 object that is
+        no longer referenced afterward is garbage-collected.
+
+        Returns the skill's updated manifest.
+
+        Raises:
+            ValueError: If the skill is missing, the filename is invalid, the
+                file is too large, or the per-skill file cap is exceeded.
+        """
+        skill = await self.repository.get_skill(skill_id)
+        if skill is None:
+            raise ValueError(f"Skill '{skill_id}' not found")
+
+        self._validate_filename(filename)
+        if len(content) > MAX_RESOURCE_BYTES:
+            raise ValueError(
+                f"Reference file '{filename}' is {len(content)} bytes; "
+                f"the limit is {MAX_RESOURCE_BYTES} bytes."
+            )
+        if not content:
+            raise ValueError(f"Reference file '{filename}' is empty.")
+
+        existing = list(skill.resources)
+        # Adding a NEW filename must respect the per-skill cap; replacing an
+        # existing filename is always allowed.
+        is_new = all(r.filename != filename for r in existing)
+        if is_new and len(existing) >= MAX_RESOURCES_PER_SKILL:
+            raise ValueError(
+                f"Skill '{skill_id}' already has the maximum of "
+                f"{MAX_RESOURCES_PER_SKILL} reference files."
+            )
+
+        resolved_type = content_type or "application/octet-stream"
+        digest = compute_content_hash(content)
+        s3_key = self.resource_store.put(
+            skill_id=skill_id, content=content, content_type=resolved_type
+        )
+        new_ref = SkillResourceRef(
+            filename=filename,
+            content_hash=digest,
+            size=len(content),
+            content_type=resolved_type,
+            s3_key=s3_key,
+        )
+
+        new_resources = [r for r in existing if r.filename != filename]
+        new_resources.append(new_ref)
+        new_resources.sort(key=lambda r: r.filename)
+
+        await self._persist_resources(skill_id, new_resources, admin)
+        self._gc_orphaned(existing, new_resources)
+
+        logger.info(
+            f"Admin {admin.email} uploaded reference file to skill {skill_id}",
+            extra={
+                "event": "skill_resource_added",
+                "skill_id": skill_id,
+                # NB: not "filename" — that key is reserved on LogRecord and
+                # raises KeyError when the record is actually emitted.
+                "resource_filename": filename,
+                "size": len(content),
+                "admin_user_id": admin.user_id,
+            },
+        )
+        return new_resources
+
+    async def read_resource(
+        self, skill_id: str, filename: str
+    ) -> Tuple[SkillResourceRef, bytes]:
+        """Return one reference file's manifest entry and its bytes.
+
+        Raises:
+            ValueError: If the skill or the named file does not exist.
+        """
+        skill = await self.repository.get_skill(skill_id)
+        if skill is None:
+            raise ValueError(f"Skill '{skill_id}' not found")
+
+        ref = next((r for r in skill.resources if r.filename == filename), None)
+        if ref is None:
+            raise ValueError(
+                f"Reference file '{filename}' not found on skill '{skill_id}'"
+            )
+
+        content = self.resource_store.get(ref.s3_key)
+        return ref, content
+
+    async def delete_resource(
+        self, skill_id: str, filename: str, admin: User
+    ) -> List[SkillResourceRef]:
+        """Remove one reference file from the manifest (and GC its object).
+
+        Returns the skill's updated manifest.
+
+        Raises:
+            ValueError: If the skill or the named file does not exist.
+        """
+        skill = await self.repository.get_skill(skill_id)
+        if skill is None:
+            raise ValueError(f"Skill '{skill_id}' not found")
+
+        existing = list(skill.resources)
+        if all(r.filename != filename for r in existing):
+            raise ValueError(
+                f"Reference file '{filename}' not found on skill '{skill_id}'"
+            )
+
+        new_resources = [r for r in existing if r.filename != filename]
+        await self._persist_resources(skill_id, new_resources, admin)
+        self._gc_orphaned(existing, new_resources)
+
+        logger.info(
+            f"Admin {admin.email} deleted reference file from skill {skill_id}",
+            extra={
+                "event": "skill_resource_deleted",
+                "skill_id": skill_id,
+                # NB: not "filename" — reserved on LogRecord (see add_resource).
+                "resource_filename": filename,
+                "admin_user_id": admin.user_id,
+            },
+        )
+        return new_resources
+
+    @staticmethod
+    def _validate_filename(filename: str) -> None:
+        """Reject path traversal / unsafe filenames up front."""
+        if not _FILENAME_PATTERN.match(filename or ""):
+            raise ValueError(
+                f"Invalid reference filename '{filename}'. Use letters, "
+                "digits, '.', '_' and '-' only (no path separators), "
+                "1-128 characters."
+            )
+
+    async def _persist_resources(
+        self,
+        skill_id: str,
+        resources: List[SkillResourceRef],
+        admin: User,
+    ) -> None:
+        """Write the manifest to the catalog row (single atomic item write)."""
+        await self.repository.update_skill(
+            skill_id, {"resources": resources}, admin_user_id=admin.user_id
+        )
+
+    def _gc_orphaned(
+        self,
+        old_resources: List[SkillResourceRef],
+        new_resources: List[SkillResourceRef],
+    ) -> None:
+        """Delete S3 objects no longer referenced by the new manifest.
+
+        Objects are content-addressed, so a key still referenced by another
+        manifest entry (identical content under a different filename) is
+        retained. Best-effort: a failed cleanup never fails the write — the
+        manifest is already consistent; an orphaned object is only wasted
+        storage.
+        """
+        old_keys = {r.s3_key for r in old_resources}
+        new_keys = {r.s3_key for r in new_resources}
+        for key in old_keys - new_keys:
+            self.resource_store.delete(key)
 
     # =========================================================================
     # Admin Methods - Role Sync

--- a/backend/src/apis/shared/skills/__init__.py
+++ b/backend/src/apis/shared/skills/__init__.py
@@ -20,6 +20,8 @@ from .models import (
     SetSkillRolesRequest,
     SkillCreateRequest,
     SkillDefinition,
+    SkillResourceRef,
+    SkillResourcesResponse,
     SkillRoleAssignment,
     SkillRolesResponse,
     SkillStatus,
@@ -27,10 +29,17 @@ from .models import (
     SkillVisibility,
 )
 from .repository import SkillCatalogRepository, get_skill_catalog_repository
+from .resource_store import (
+    SkillResourceStore,
+    SkillResourceStoreError,
+    get_skill_resource_store,
+)
 
 __all__ = [
     "SKILL_ID_PATTERN",
     "SkillDefinition",
+    "SkillResourceRef",
+    "SkillResourcesResponse",
     "SkillStatus",
     "SkillVisibility",
     "SkillCreateRequest",
@@ -43,6 +52,9 @@ __all__ = [
     "AdminSkillListResponse",
     "SkillCatalogRepository",
     "get_skill_catalog_repository",
+    "SkillResourceStore",
+    "SkillResourceStoreError",
+    "get_skill_resource_store",
     "get_all_skill_ids",
     "get_freshness_hash",
     "get_skill_updated_at",

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -51,6 +51,43 @@ class SkillVisibility(str, Enum):
 # =============================================================================
 
 
+class SkillResourceRef(BaseModel):
+    """Manifest entry for one of a skill's supporting reference files.
+
+    A skill's reference files (read-only markdown/resources for deep
+    progressive disclosure) live as bytes in the ``skill-resources`` S3
+    bucket — never inline in the DynamoDB item (400 KB limit). The
+    ``SkillDefinition`` row carries only this lightweight manifest; the
+    bytes are addressed by ``s3_key`` (content-hash keyed, so identical
+    content within a skill dedupes to one object). See
+    ``docs/specs/admin-skills-rbac-tool-binding.md`` (§0.2, §5, PR-4) and
+    ``apis/shared/skills/resource_store.py``.
+
+    camelCase aliases are declared so the same model round-trips both the
+    admin API response (FastAPI serializes by alias) and is constructible
+    from snake_case kwargs (``populate_by_name``). DynamoDB (de)serialization
+    is handled explicitly in ``SkillDefinition.to_dynamo_item`` /
+    ``from_dynamo_item``.
+    """
+
+    filename: str = Field(..., description="Display filename, e.g. 'forms.md'")
+    content_hash: str = Field(
+        ..., alias="contentHash", description="sha256 hex of the file bytes"
+    )
+    size: int = Field(..., description="Size of the file in bytes")
+    content_type: str = Field(
+        ..., alias="contentType", description="MIME type, e.g. 'text/markdown'"
+    )
+    s3_key: str = Field(
+        ...,
+        alias="s3Key",
+        description="Object key in the skill-resources bucket "
+        "(skills/{skill_id}/{content_hash})",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
 class SkillDefinition(BaseModel):
     """
     Catalog entry for a skill stored in DynamoDB.
@@ -89,6 +126,16 @@ class SkillDefinition(BaseModel):
     compose: List[str] = Field(
         default_factory=list,
         description="skill_ids composed into this skill (composite skills)",
+    )
+
+    # Supporting reference files (rev 2026-06-09 §0.2; PR-4). Lightweight
+    # manifest only — the file BYTES live in the skill-resources S3 bucket
+    # (the 400 KB DynamoDB item limit rules out inlining reference docs).
+    # Managed via the /admin/skills/{id}/resources endpoints, NOT the
+    # create/update body. Old rows without this attribute deserialize to [].
+    resources: List[SkillResourceRef] = Field(
+        default_factory=list,
+        description="Manifest of S3-backed supporting reference files",
     )
 
     # Lifecycle / grouping
@@ -142,6 +189,18 @@ class SkillDefinition(BaseModel):
             "instructions": self.instructions,
             "boundToolIds": list(self.bound_tool_ids),
             "compose": list(self.compose),
+            # Reference-file manifest (camelCase maps, mirroring the row's
+            # convention). The bytes live in S3; this is just pointers.
+            "resources": [
+                {
+                    "filename": r.filename,
+                    "contentHash": r.content_hash,
+                    "size": r.size,
+                    "contentType": r.content_type,
+                    "s3Key": r.s3_key,
+                }
+                for r in self.resources
+            ],
             "status": self.status
             if isinstance(self.status, str)
             else self.status.value,
@@ -168,6 +227,17 @@ class SkillDefinition(BaseModel):
             instructions=item.get("instructions", ""),
             bound_tool_ids=list(item.get("boundToolIds") or []),
             compose=list(item.get("compose") or []),
+            resources=[
+                SkillResourceRef(
+                    filename=r.get("filename", ""),
+                    content_hash=r.get("contentHash", ""),
+                    # DynamoDB returns numbers as Decimal — coerce to int.
+                    size=int(r.get("size", 0)),
+                    content_type=r.get("contentType", ""),
+                    s3_key=r.get("s3Key", ""),
+                )
+                for r in (item.get("resources") or [])
+            ],
             status=item.get("status", SkillStatus.ACTIVE),
             category=item.get("category"),
             owner_id=item.get("ownerId", "system"),
@@ -276,6 +346,7 @@ class AdminSkillResponse(BaseModel):
     instructions: str
     bound_tool_ids: List[str] = Field(default_factory=list, alias="boundToolIds")
     compose: List[str] = Field(default_factory=list)
+    resources: List[SkillResourceRef] = Field(default_factory=list)
     status: SkillStatus
     category: Optional[str] = None
     owner_id: str = Field("system", alias="ownerId")
@@ -302,6 +373,7 @@ class AdminSkillResponse(BaseModel):
             instructions=skill.instructions,
             bound_tool_ids=list(skill.bound_tool_ids),
             compose=list(skill.compose),
+            resources=list(skill.resources),
             status=skill.status,
             category=skill.category,
             owner_id=skill.owner_id,
@@ -319,3 +391,17 @@ class AdminSkillListResponse(BaseModel):
 
     skills: List[AdminSkillResponse]
     total: int
+
+
+class SkillResourcesResponse(BaseModel):
+    """Response for the /admin/skills/{skill_id}/resources manifest endpoints.
+
+    Returned by list, upload, and delete so the caller always sees the
+    skill's current reference-file manifest after a write (the read-bytes
+    endpoint returns the raw file body instead).
+    """
+
+    skill_id: str = Field(..., alias="skillId")
+    resources: List[SkillResourceRef] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}

--- a/backend/src/apis/shared/skills/resource_store.py
+++ b/backend/src/apis/shared/skills/resource_store.py
@@ -1,0 +1,215 @@
+"""S3-backed store for a skill's supporting reference files (PR-4).
+
+A skill's reference files (read-only markdown/resources for deep
+progressive disclosure) are too large to inline in the DynamoDB
+``SkillDefinition`` row (400 KB item limit), so the bytes live in the
+``skill-resources`` S3 bucket and the row carries only a lightweight
+``SkillResourceRef`` manifest.
+
+This store mirrors the content-hash + dedupe shape used by the MCP-Apps
+UI-resource persistence and the artifacts bucket:
+
+  - Objects are **content-addressed**: the key is
+    ``skills/{skill_id}/{content_hash}`` where ``content_hash`` is the
+    sha256 hex of the bytes. Two reference files with identical content
+    within a skill therefore resolve to the same object (dedupe) — a
+    re-upload of unchanged bytes is a no-op ``head_object`` instead of a
+    re-``put``.
+  - The manifest on the catalog row references objects by key; the bytes
+    never travel through DynamoDB.
+
+Boundary: this module lives under ``apis/shared/skills/`` and is import-
+clean (it never imports ``app_api``/``inference_api``). The admin write
+path (app-api) and the future runtime read path (inference-api, PR-6) both
+reach it through ``apis.shared``.
+
+Configuration: the bucket name comes from ``S3_SKILL_RESOURCES_BUCKET_NAME``
+(set on both compute roles by the CDK ``SkillResourcesConstruct`` wiring).
+When boto3 or the bucket name is absent (local dev without AWS), the store
+is ``enabled == False`` and every operation raises ``SkillResourceStoreError``
+so a misconfigured admin write surfaces loudly rather than silently
+"succeeding" with no bytes persisted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# AWS-managed (SSE-S3 / AES256) encryption, matching the bucket default and
+# the artifacts/file-upload buckets.
+_SSE_ALGORITHM = "AES256"
+
+
+class SkillResourceStoreError(RuntimeError):
+    """Raised when the store is asked to do work it cannot complete.
+
+    Covers both "storage not configured" (no bucket / no boto3) and an
+    unexpected S3 failure, so callers (the admin service) have one error
+    type to translate.
+    """
+
+
+def content_key(skill_id: str, content_hash: str) -> str:
+    """Return the content-addressed object key for a skill's file."""
+    return f"skills/{skill_id}/{content_hash}"
+
+
+def compute_content_hash(content: bytes) -> str:
+    """Return the sha256 hex digest used as the content address."""
+    return hashlib.sha256(content).hexdigest()
+
+
+class SkillResourceStore:
+    """Put / get / delete a skill's reference-file bytes in S3."""
+
+    def __init__(
+        self,
+        bucket_name: Optional[str] = None,
+        s3_client: Optional[object] = None,
+    ) -> None:
+        self.bucket_name = bucket_name or os.environ.get(
+            "S3_SKILL_RESOURCES_BUCKET_NAME"
+        )
+        # Allow an explicit client (tests inject a moto client); otherwise it
+        # is created lazily on first use so importing the module never needs
+        # AWS creds.
+        self._s3 = s3_client
+
+    @property
+    def enabled(self) -> bool:
+        """True when a bucket is configured and boto3 is importable."""
+        return bool(self.bucket_name) and boto3 is not None
+
+    def _client(self):
+        if self._s3 is None:
+            if boto3 is None:  # pragma: no cover - import-guarded above
+                raise SkillResourceStoreError(
+                    "skill resource storage unavailable: boto3 is not installed"
+                )
+            self._s3 = boto3.client("s3")
+        return self._s3
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise SkillResourceStoreError(
+                "skill resource storage is not configured "
+                "(S3_SKILL_RESOURCES_BUCKET_NAME is unset)"
+            )
+
+    def put(
+        self, *, skill_id: str, content: bytes, content_type: str
+    ) -> str:
+        """Persist file bytes content-addressed; return the object key.
+
+        Computes the sha256 of ``content``, derives the
+        ``skills/{skill_id}/{content_hash}`` key, and uploads. If an object
+        already exists at that key (same content), the upload is skipped
+        (dedupe) — the key is returned either way.
+        """
+        self._require_enabled()
+        digest = compute_content_hash(content)
+        key = content_key(skill_id, digest)
+        client = self._client()
+
+        if self._object_exists(key):
+            logger.info(
+                "skill-resources: dedupe hit for skill=%s key=%s (%d bytes)",
+                skill_id,
+                key,
+                len(content),
+            )
+            return key
+
+        try:
+            client.put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=content,
+                ContentType=content_type or "application/octet-stream",
+                ServerSideEncryption=_SSE_ALGORITHM,
+            )
+        except ClientError as e:  # pragma: no cover - network/permission path
+            logger.error(
+                "skill-resources: put failed for skill=%s key=%s: %s",
+                skill_id,
+                key,
+                e,
+            )
+            raise SkillResourceStoreError(
+                f"failed to store reference file for skill '{skill_id}'"
+            ) from e
+
+        logger.info(
+            "skill-resources: stored skill=%s key=%s (%d bytes)",
+            skill_id,
+            key,
+            len(content),
+        )
+        return key
+
+    def get(self, s3_key: str) -> bytes:
+        """Return the bytes for an object key. Raises if missing/unavailable."""
+        self._require_enabled()
+        client = self._client()
+        try:
+            response = client.get_object(Bucket=self.bucket_name, Key=s3_key)
+            return response["Body"].read()
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "404"):
+                raise SkillResourceStoreError(
+                    f"reference file not found at key '{s3_key}'"
+                ) from e
+            logger.error("skill-resources: get failed for key=%s: %s", s3_key, e)
+            raise SkillResourceStoreError(
+                f"failed to read reference file at key '{s3_key}'"
+            ) from e
+
+    def delete(self, s3_key: str) -> None:
+        """Delete an object key. Best-effort — never raises on the storage
+        miss path (deleting an already-absent object is a no-op in S3)."""
+        if not self.enabled:
+            return
+        client = self._client()
+        try:
+            client.delete_object(Bucket=self.bucket_name, Key=s3_key)
+        except ClientError:  # pragma: no cover - best-effort cleanup
+            logger.warning(
+                "skill-resources: delete failed for key=%s", s3_key, exc_info=True
+            )
+
+    def _object_exists(self, key: str) -> bool:
+        client = self._client()
+        try:
+            client.head_object(Bucket=self.bucket_name, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            # Any other error (permissions, throttling) is real — surface it
+            # rather than masquerading as "absent" and double-uploading.
+            raise
+
+
+_store: Optional[SkillResourceStore] = None
+
+
+def get_skill_resource_store() -> SkillResourceStore:
+    """Get or create the process-global skill-resource store."""
+    global _store
+    if _store is None:
+        _store = SkillResourceStore()
+    return _store

--- a/backend/tests/apis/app_api/skills/conftest.py
+++ b/backend/tests/apis/app_api/skills/conftest.py
@@ -13,6 +13,7 @@ from apis.shared.auth.models import User
 
 AWS_REGION = "us-east-1"
 TABLE = "test-app-roles"
+SKILL_RESOURCES_BUCKET = "test-skill-resources"
 
 
 def _gsi(name, hash_key, range_key):
@@ -88,7 +89,20 @@ def tool_repo(app_roles_table):
 
 
 @pytest.fixture()
-def skill_service(app_roles_table):
+def skill_resource_store(aws):
+    """SkillResourceStore bound to a moto S3 bucket (for reference files)."""
+    from apis.shared.skills.resource_store import SkillResourceStore
+
+    s3 = boto3.client("s3", region_name=AWS_REGION)
+    s3.create_bucket(Bucket=SKILL_RESOURCES_BUCKET)
+    return SkillResourceStore(
+        bucket_name=SKILL_RESOURCES_BUCKET,
+        s3_client=s3,
+    )
+
+
+@pytest.fixture()
+def skill_service(app_roles_table, skill_resource_store):
     """SkillCatalogService wired to the moto table with isolated RBAC caches."""
     from apis.app_api.skills.service import SkillCatalogService
     from apis.shared.rbac.admin_service import AppRoleAdminService
@@ -105,6 +119,7 @@ def skill_service(app_roles_table):
         tool_repository=ToolCatalogRepository(table_name=TABLE),
         app_role_service=AppRoleService(repository=role_repo, cache=cache),
         app_role_admin_service=AppRoleAdminService(repository=role_repo, cache=cache),
+        resource_store=skill_resource_store,
     )
 
 

--- a/backend/tests/apis/app_api/skills/test_skill_resource_routes.py
+++ b/backend/tests/apis/app_api/skills/test_skill_resource_routes.py
@@ -1,0 +1,216 @@
+"""Admin /skills/{id}/resources route tests (TestClient + moto S3 + DDB).
+
+Covers the reference-file lifecycle: upload → list manifest → read bytes →
+re-upload (replace) → delete, plus validation (filename, size, empty, caps),
+content-hash dedupe / orphan GC, and 404s for missing skills/files.
+"""
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import require_admin
+from apis.app_api.admin.skills import routes as skill_routes
+from apis.app_api.skills import service as skill_service_module
+
+from .conftest import AWS_REGION, SKILL_RESOURCES_BUCKET
+
+
+@pytest.fixture()
+def client(skill_service, admin_user, monkeypatch):
+    monkeypatch.setattr(
+        skill_routes, "get_skill_catalog_service", lambda: skill_service
+    )
+    app = FastAPI()
+    app.include_router(skill_routes.router)
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    return TestClient(app)
+
+
+def _create_skill(client, skill_id="pdf_workflows"):
+    resp = client.post(
+        "/skills/",
+        json={
+            "skillId": skill_id,
+            "displayName": "PDF Workflows",
+            "description": "Fill, merge and split PDFs.",
+            "instructions": "# PDF Workflows",
+            "boundToolIds": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _bucket_keys():
+    s3 = boto3.client("s3", region_name=AWS_REGION)
+    return [
+        o["Key"]
+        for o in s3.list_objects_v2(Bucket=SKILL_RESOURCES_BUCKET).get("Contents", [])
+    ]
+
+
+def _upload(client, skill_id, filename, body, content_type="text/markdown"):
+    return client.post(
+        f"/skills/{skill_id}/resources",
+        files={"file": (filename, body, content_type)},
+    )
+
+
+class TestUploadAndList:
+    def test_upload_then_list_manifest(self, client):
+        _create_skill(client)
+        resp = _upload(client, "pdf_workflows", "forms.md", b"# Forms")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["skillId"] == "pdf_workflows"
+        assert len(body["resources"]) == 1
+        ref = body["resources"][0]
+        assert ref["filename"] == "forms.md"
+        assert ref["size"] == len(b"# Forms")
+        assert ref["contentType"] == "text/markdown"
+        assert ref["s3Key"] == f"skills/pdf_workflows/{ref['contentHash']}"
+
+        listed = client.get("/skills/pdf_workflows/resources")
+        assert listed.status_code == 200
+        assert [r["filename"] for r in listed.json()["resources"]] == ["forms.md"]
+
+    def test_manifest_reflected_on_skill_get(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "forms.md", b"# Forms")
+        skill = client.get("/skills/pdf_workflows").json()
+        assert [r["filename"] for r in skill["resources"]] == ["forms.md"]
+
+    def test_multiple_files_sorted(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "zebra.md", b"z")
+        _upload(client, "pdf_workflows", "alpha.md", b"a")
+        names = [
+            r["filename"]
+            for r in client.get("/skills/pdf_workflows/resources").json()["resources"]
+        ]
+        assert names == ["alpha.md", "zebra.md"]
+
+
+class TestReadBytes:
+    def test_read_returns_bytes_and_content_type(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "forms.md", b"# Forms body")
+        resp = client.get("/skills/pdf_workflows/resources/forms.md")
+        assert resp.status_code == 200
+        assert resp.content == b"# Forms body"
+        assert resp.headers["content-type"].startswith("text/markdown")
+
+    def test_read_missing_file_404(self, client):
+        _create_skill(client)
+        assert (
+            client.get("/skills/pdf_workflows/resources/nope.md").status_code == 404
+        )
+
+
+class TestReplaceAndDedupe:
+    def test_reupload_same_filename_replaces(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "forms.md", b"v1")
+        resp = _upload(client, "pdf_workflows", "forms.md", b"v2-longer")
+        assert resp.status_code == 200
+        manifest = resp.json()["resources"]
+        assert len(manifest) == 1  # replaced, not appended
+        assert manifest[0]["size"] == len(b"v2-longer")
+        # Reading back returns the new content.
+        assert (
+            client.get("/skills/pdf_workflows/resources/forms.md").content
+            == b"v2-longer"
+        )
+
+    def test_reupload_garbage_collects_orphaned_object(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "forms.md", b"v1")
+        _upload(client, "pdf_workflows", "forms.md", b"v2")
+        # Only the current object remains; the v1 object was GC'd.
+        keys = _bucket_keys()
+        assert len(keys) == 1
+
+    def test_identical_content_two_filenames_dedupes_object(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "a.md", b"identical")
+        _upload(client, "pdf_workflows", "b.md", b"identical")
+        # Manifest has both filenames...
+        names = [
+            r["filename"]
+            for r in client.get("/skills/pdf_workflows/resources").json()["resources"]
+        ]
+        assert names == ["a.md", "b.md"]
+        # ...but only one S3 object (content-addressed).
+        assert len(_bucket_keys()) == 1
+
+    def test_delete_one_keeps_shared_object(self, client):
+        # a.md and b.md share one content-addressed object; deleting a.md must
+        # NOT delete the object b.md still references.
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "a.md", b"identical")
+        _upload(client, "pdf_workflows", "b.md", b"identical")
+        client.delete("/skills/pdf_workflows/resources/a.md")
+        assert len(_bucket_keys()) == 1
+        assert client.get("/skills/pdf_workflows/resources/b.md").content == b"identical"
+
+
+class TestDelete:
+    def test_delete_removes_from_manifest_and_object(self, client):
+        _create_skill(client)
+        _upload(client, "pdf_workflows", "forms.md", b"x")
+        resp = client.delete("/skills/pdf_workflows/resources/forms.md")
+        assert resp.status_code == 200
+        assert resp.json()["resources"] == []
+        assert _bucket_keys() == []
+        assert (
+            client.get("/skills/pdf_workflows/resources/forms.md").status_code == 404
+        )
+
+    def test_delete_missing_file_404(self, client):
+        _create_skill(client)
+        assert (
+            client.delete("/skills/pdf_workflows/resources/nope.md").status_code
+            == 404
+        )
+
+
+class TestValidationAnd404s:
+    def test_upload_missing_skill_404(self, client):
+        resp = _upload(client, "ghost_skill", "forms.md", b"x")
+        assert resp.status_code == 404
+
+    def test_list_missing_skill_404(self, client):
+        assert client.get("/skills/ghost_skill/resources").status_code == 404
+
+    def test_invalid_filename_400(self, client):
+        _create_skill(client)
+        resp = _upload(client, "pdf_workflows", "../etc/passwd", b"x")
+        assert resp.status_code == 400
+        assert "Invalid reference filename" in resp.json()["detail"]
+
+    def test_empty_file_400(self, client):
+        _create_skill(client)
+        resp = _upload(client, "pdf_workflows", "forms.md", b"")
+        assert resp.status_code == 400
+
+    def test_too_large_400(self, client, monkeypatch):
+        _create_skill(client)
+        monkeypatch.setattr(skill_service_module, "MAX_RESOURCE_BYTES", 8)
+        resp = _upload(client, "pdf_workflows", "forms.md", b"way too many bytes")
+        assert resp.status_code == 400
+
+    def test_count_cap_400(self, client, monkeypatch):
+        _create_skill(client)
+        monkeypatch.setattr(skill_service_module, "MAX_RESOURCES_PER_SKILL", 1)
+        assert _upload(client, "pdf_workflows", "a.md", b"a").status_code == 200
+        resp = _upload(client, "pdf_workflows", "b.md", b"b")
+        assert resp.status_code == 400
+        assert "maximum" in resp.json()["detail"]
+
+    def test_count_cap_allows_replacing_existing(self, client, monkeypatch):
+        _create_skill(client)
+        monkeypatch.setattr(skill_service_module, "MAX_RESOURCES_PER_SKILL", 1)
+        assert _upload(client, "pdf_workflows", "a.md", b"a").status_code == 200
+        # Replacing the same filename is allowed even at the cap.
+        assert _upload(client, "pdf_workflows", "a.md", b"a2").status_code == 200

--- a/backend/tests/shared/test_skills_models.py
+++ b/backend/tests/shared/test_skills_models.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from apis.shared.skills.models import (
     SkillDefinition,
+    SkillResourceRef,
     SkillStatus,
     SkillVisibility,
 )
@@ -109,6 +110,88 @@ class TestSkillRoundTrip:
         assert restored.owner_id == "system"
         assert restored.visibility == "admin"
         assert isinstance(restored.created_at, datetime)
+
+
+class TestSkillResourcesRoundTrip:
+    def _ref(self, **kw) -> SkillResourceRef:
+        defaults = dict(
+            filename="forms.md",
+            content_hash="a" * 64,
+            size=1234,
+            content_type="text/markdown",
+            s3_key="skills/pdf_workflows/" + "a" * 64,
+        )
+        defaults.update(kw)
+        return SkillResourceRef(**defaults)
+
+    def test_resource_ref_camel_case_aliases(self):
+        # Constructible from snake_case (populate_by_name) and serializes
+        # camelCase by alias (the admin API response shape).
+        ref = self._ref()
+        dumped = ref.model_dump(by_alias=True)
+        assert dumped["filename"] == "forms.md"
+        assert dumped["contentHash"] == "a" * 64
+        assert dumped["contentType"] == "text/markdown"
+        assert dumped["s3Key"].startswith("skills/pdf_workflows/")
+
+    def test_resources_serialized_to_dynamo_item(self):
+        skill = _skill(resources=[self._ref(), self._ref(filename="merge.md")])
+        item = skill.to_dynamo_item()
+
+        assert isinstance(item["resources"], list)
+        assert len(item["resources"]) == 2
+        first = item["resources"][0]
+        # camelCase maps, mirroring the row convention.
+        assert set(first) == {
+            "filename",
+            "contentHash",
+            "size",
+            "contentType",
+            "s3Key",
+        }
+        assert first["filename"] == "forms.md"
+        assert first["contentHash"] == "a" * 64
+
+    def test_resources_round_trip_preserves_manifest(self):
+        skill = _skill(resources=[self._ref(filename="forms.md", size=10)])
+        restored = SkillDefinition.from_dynamo_item(skill.to_dynamo_item())
+
+        assert len(restored.resources) == 1
+        ref = restored.resources[0]
+        assert ref.filename == "forms.md"
+        assert ref.size == 10
+        assert ref.content_type == "text/markdown"
+        assert ref.s3_key.startswith("skills/pdf_workflows/")
+
+    def test_size_coerced_from_decimal(self):
+        # DynamoDB returns numbers as Decimal; from_dynamo_item coerces to int.
+        from decimal import Decimal
+
+        item = _skill().to_dynamo_item()
+        item["resources"] = [
+            {
+                "filename": "forms.md",
+                "contentHash": "b" * 64,
+                "size": Decimal("2048"),
+                "contentType": "text/markdown",
+                "s3Key": "skills/pdf_workflows/" + "b" * 64,
+            }
+        ]
+        restored = SkillDefinition.from_dynamo_item(item)
+        assert restored.resources[0].size == 2048
+        assert isinstance(restored.resources[0].size, int)
+
+    def test_defaults_empty_and_backward_compatible(self):
+        # New skills default to no resources.
+        assert _skill().resources == []
+        # An old row with no `resources` attribute deserializes to [].
+        item = {
+            "skillId": "legacy_skill",
+            "displayName": "Legacy",
+            "description": "desc",
+            "instructions": "body",
+        }
+        assert SkillDefinition.from_dynamo_item(item).resources == []
 
 
 class TestSkillIdRegex:

--- a/backend/tests/shared/test_skills_resource_store.py
+++ b/backend/tests/shared/test_skills_resource_store.py
@@ -1,0 +1,155 @@
+"""Tests for the S3-backed skill reference-file store (PR-4).
+
+moto-backed: exercises content-hash keying, dedupe (no second put for
+identical bytes), get/delete round-trip, and the not-configured guard.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.skills.resource_store import (
+    SkillResourceStore,
+    SkillResourceStoreError,
+    compute_content_hash,
+    content_key,
+    get_skill_resource_store,
+)
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-skill-resources"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def s3_client(aws):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+@pytest.fixture()
+def store(s3_client):
+    return SkillResourceStore(bucket_name=BUCKET, s3_client=s3_client)
+
+
+class TestContentKey:
+    def test_key_is_content_addressed(self):
+        digest = compute_content_hash(b"# Notes")
+        assert content_key("pdf_workflows", digest) == (
+            f"skills/pdf_workflows/{digest}"
+        )
+
+    def test_hash_is_sha256_hex(self):
+        import hashlib
+
+        assert compute_content_hash(b"abc") == hashlib.sha256(b"abc").hexdigest()
+
+
+class TestPutGetDelete:
+    def test_put_returns_content_addressed_key(self, store):
+        key = store.put(
+            skill_id="pdf_workflows",
+            content=b"# Notes",
+            content_type="text/markdown",
+        )
+        assert key == content_key("pdf_workflows", compute_content_hash(b"# Notes"))
+
+    def test_get_returns_bytes(self, store):
+        key = store.put(
+            skill_id="pdf_workflows", content=b"hello", content_type="text/plain"
+        )
+        assert store.get(key) == b"hello"
+
+    def test_put_is_idempotent_dedupe(self, store, s3_client):
+        # Two puts of identical content land on one object (content-addressed).
+        k1 = store.put(
+            skill_id="pdf_workflows", content=b"same", content_type="text/plain"
+        )
+        k2 = store.put(
+            skill_id="pdf_workflows", content=b"same", content_type="text/plain"
+        )
+        assert k1 == k2
+        listed = s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", [])
+        assert len(listed) == 1
+
+    def test_different_content_distinct_keys(self, store, s3_client):
+        store.put(skill_id="s", content=b"a", content_type="text/plain")
+        store.put(skill_id="s", content=b"b", content_type="text/plain")
+        listed = s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", [])
+        assert len(listed) == 2
+
+    def test_same_content_scoped_per_skill(self, store, s3_client):
+        # The key includes the skill_id, so identical content under two skills
+        # is two objects (dedupe is per-skill, matching the key layout).
+        store.put(skill_id="skill_a", content=b"shared", content_type="text/plain")
+        store.put(skill_id="skill_b", content=b"shared", content_type="text/plain")
+        listed = s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", [])
+        assert len(listed) == 2
+
+    def test_put_sets_content_type(self, store, s3_client):
+        key = store.put(
+            skill_id="s", content=b"# md", content_type="text/markdown"
+        )
+        head = s3_client.head_object(Bucket=BUCKET, Key=key)
+        assert head["ContentType"] == "text/markdown"
+
+    def test_delete_removes_object(self, store, s3_client):
+        key = store.put(skill_id="s", content=b"x", content_type="text/plain")
+        store.delete(key)
+        assert s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", []) == []
+
+    def test_get_missing_raises(self, store):
+        with pytest.raises(SkillResourceStoreError):
+            store.get("skills/s/deadbeef")
+
+    def test_delete_missing_is_noop(self, store):
+        # No object at the key — delete must not raise (S3 delete is idempotent).
+        store.delete("skills/s/deadbeef")
+
+
+class TestNotConfigured:
+    def test_disabled_when_no_bucket(self, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        s = SkillResourceStore()
+        assert s.enabled is False
+
+    def test_put_raises_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        s = SkillResourceStore()
+        with pytest.raises(SkillResourceStoreError):
+            s.put(skill_id="s", content=b"x", content_type="text/plain")
+
+    def test_get_raises_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        s = SkillResourceStore()
+        with pytest.raises(SkillResourceStoreError):
+            s.get("skills/s/abc")
+
+    def test_delete_silent_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        SkillResourceStore().delete("skills/s/abc")  # must not raise
+
+    def test_enabled_from_env(self, monkeypatch):
+        monkeypatch.setenv("S3_SKILL_RESOURCES_BUCKET_NAME", "some-bucket")
+        assert SkillResourceStore().enabled is True
+
+
+def test_global_store_is_singleton(monkeypatch):
+    monkeypatch.setenv("S3_SKILL_RESOURCES_BUCKET_NAME", "b")
+    import apis.shared.skills.resource_store as mod
+
+    mod._store = None
+    a = get_skill_resource_store()
+    b = get_skill_resource_store()
+    assert a is b
+    mod._store = None

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -287,6 +287,19 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Skill reference files (S3) ──
+  // app-api is the writer: admins upload/replace/delete a skill's reference
+  // files (apis/shared/skills/resource_store.py). Sourced from a typed ref.
+  const skillResourcesBucketArn = props.refs.skillResourcesBucket.bucketArn;
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'SkillResourcesBucketReadWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+      resources: [skillResourcesBucketArn, `${skillResourcesBucketArn}/*`],
+    }),
+  );
+
   // ── Fine-tuning ──
   // Sourced from typed PlatformStack refs.
   const ftJobsTableArn = props.refs.fineTuningJobsTable.tableArn;

--- a/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
@@ -180,6 +180,10 @@ export class AppApiServiceConstruct extends Construct {
     environment['ARTIFACTS_ORIGIN'] = props.artifactsOrigin;
     environment['ARTIFACTS_RENDER_TOKEN_SECRET_ARN'] = props.refs.artifactRenderTokenSecret.secretArn;
 
+    // Skill reference-file bucket (admin-managed Skills, PR-4). Read by
+    // apis/shared/skills/resource_store.py via S3_SKILL_RESOURCES_BUCKET_NAME.
+    environment['S3_SKILL_RESOURCES_BUCKET_NAME'] = props.refs.skillResourcesBucket.bucketName;
+
     // Fine-tuning env vars (always-on). Names verified against
     // backend/src/apis/app_api/fine_tuning/* to match the exact env
     // var names Python reads via os.environ.get(...).

--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -336,6 +336,11 @@ export class InferenceAgentCoreConstruct extends Construct {
         // with "S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME not configured".
         S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME: props.refs.ragDocumentsBucket.bucketName,
 
+        // Skill reference-file bucket (admin-managed Skills). Provisioned now
+        // (read grant below) so the PR-6 runtime can read a skill's reference
+        // files at dispatch time; no code consumes it yet.
+        S3_SKILL_RESOURCES_BUCKET_NAME: props.refs.skillResourcesBucket.bucketName,
+
         // Authentication
         ENABLE_QUOTA_ENFORCEMENT: 'true',
 

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -217,6 +217,18 @@ export function createRuntimeExecutionRole(
     resources: [artifactsTableArn, `${artifactsTableArn}/index/*`],
   }));
 
+  // ── Skill reference files (S3, read-only) ──
+  // The runtime is a READER of a skill's reference files (PR-6 progressive
+  // disclosure); app-api owns writes. Provisioned now so PR-6 needs no infra
+  // change. No code consumes it yet.
+  const skillResourcesBucketArn = refs.skillResourcesBucket.bucketArn;
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'SkillResourcesBucketRead',
+    effect: iam.Effect.ALLOW,
+    actions: ['s3:GetObject', 's3:ListBucket'],
+    resources: [skillResourcesBucketArn, `${skillResourcesBucketArn}/*`],
+  }));
+
   // ── S3 Vectors (RAG query) ──
   const vectorBucketName = refs.ragVectorBucketName;
   const vectorIndexName = refs.ragVectorIndexName;

--- a/infrastructure/lib/constructs/platform-compute-refs.ts
+++ b/infrastructure/lib/constructs/platform-compute-refs.ts
@@ -94,6 +94,9 @@ export interface PlatformComputeRefs {
   artifactRenderTokenSecret: secretsmanager.ISecret;
   artifactsOriginUrl: string;
 
+  // ── Skills (admin-managed) — S3-backed reference files (PR-4)
+  skillResourcesBucket: s3.IBucket;
+
   // ── Fine-tuning
   fineTuningJobsTable: dynamodb.ITable;
   fineTuningAccessTable: dynamodb.ITable;

--- a/infrastructure/lib/constructs/skills/skill-resources-construct.ts
+++ b/infrastructure/lib/constructs/skills/skill-resources-construct.ts
@@ -1,0 +1,69 @@
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+import {
+  AppConfig,
+  getAutoDeleteObjects,
+  getRemovalPolicy,
+  getResourceName,
+} from '../../config';
+
+export interface SkillResourcesConstructProps {
+  config: AppConfig;
+}
+
+/**
+ * SkillResourcesConstruct — S3 content bucket for admin-managed Skills'
+ * supporting reference files (PR-4 of admin-managed Skills).
+ *
+ * A skill's reference files (read-only markdown/resources for deep
+ * progressive disclosure) are too large to inline in the skill's DynamoDB
+ * row (400 KB item limit), so the bytes live here and the row carries only
+ * a lightweight `resources` manifest. Mirrors the artifacts content bucket.
+ *
+ * S3 layout (content-addressed, so identical content within a skill dedupes
+ * to one object — see `apis/shared/skills/resource_store.py`):
+ *   skills/{skill_id}/{content_hash}
+ *
+ * Private — bytes are only ever fetched server-side by app-api (admin
+ * authoring) and, in PR-6, the inference-api runtime at dispatch time. No
+ * CORS; never loaded cross-origin by a browser.
+ *
+ * Lifecycle:
+ *   - Failed multipart uploads aborted after 7 days.
+ *   (No expiration rule: reference files persist for the life of the skill
+ *   and are removed explicitly by the delete-resource path.)
+ *
+ * The bucket name is threaded to the compute roles via
+ * `PlatformComputeRefs.skillResourcesBucket` (typed ref, not SSM) — see
+ * the CLAUDE.md File Creation Rules.
+ */
+export class SkillResourcesConstruct extends Construct {
+  public readonly bucket: s3.Bucket;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: SkillResourcesConstructProps,
+  ) {
+    super(scope, id);
+
+    const { config } = props;
+
+    this.bucket = new s3.Bucket(this, 'SkillResourcesBucket', {
+      bucketName: getResourceName(config, 'skill-resources'),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      lifecycleRules: [
+        {
+          id: 'abort-stale-multipart',
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(7),
+        },
+      ],
+      removalPolicy: getRemovalPolicy(config),
+      autoDeleteObjects: getAutoDeleteObjects(config),
+    });
+  }
+}

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -50,6 +50,7 @@ import { RagIngestionLambdaConstruct } from './constructs/rag-ingestion/rag-inge
 import { ArtifactsDataConstruct } from './constructs/artifacts/artifacts-data-construct';
 import { ArtifactRenderLambdaConstruct } from './constructs/artifacts/artifact-render-lambda-construct';
 import { ArtifactsDistributionConstruct } from './constructs/artifacts/artifacts-distribution-construct';
+import { SkillResourcesConstruct } from './constructs/skills/skill-resources-construct';
 
 // AgentCore (Memory, Code Interpreter, Browser, Gateway).
 // Pure infrastructure — no code, no out-of-band updates needed.
@@ -197,6 +198,9 @@ export class PlatformStack extends cdk.Stack {
    * Platform, this typed ref isn't needed for cross-stack.
    */
   public readonly artifactsOriginUrl: string;
+
+  // ── Skills (admin-managed) — S3-backed reference files (PR-4)
+  public readonly skillResourcesBucket: s3.IBucket;
 
   // ── Fine-tuning
   public readonly fineTuningJobsTable: dynamodb.ITable;
@@ -405,6 +409,18 @@ export class PlatformStack extends cdk.Stack {
     );
     this.artifactsContentBucket = this._artifactsDataConstruct.bucket;
     this.artifactsTable = this._artifactsDataConstruct.table;
+
+    // ============================================================
+    // Skill reference-file storage (admin-managed Skills, PR-4).
+    // Bytes-only S3 bucket; the skill catalog row (app-roles table)
+    // carries the lightweight manifest. Threaded to the compute roles
+    // via PlatformComputeRefs.skillResourcesBucket below.
+    // ============================================================
+    this.skillResourcesBucket = new SkillResourcesConstruct(
+      this,
+      'SkillResources',
+      { config },
+    ).bucket;
 
     const artifactsDomainName = config.domainName!;
     this.artifactsFrameAncestors = [
@@ -631,6 +647,7 @@ export class PlatformStack extends cdk.Stack {
       artifactsTable: this.artifactsTable,
       artifactRenderTokenSecret: this.artifactRenderTokenSecret,
       artifactsOriginUrl: this.artifactsOriginUrl,
+      skillResourcesBucket: this.skillResourcesBucket,
       fineTuningJobsTable: this.fineTuningJobsTable,
       fineTuningAccessTable: this.fineTuningAccessTable,
       fineTuningDataBucket: this.fineTuningDataBucket,

--- a/infrastructure/test/constructs.test.ts
+++ b/infrastructure/test/constructs.test.ts
@@ -28,6 +28,7 @@ import { SharedConversationsConstruct } from '../lib/constructs/data/shared-conv
 import { RagDataConstruct } from '../lib/constructs/rag/rag-data-construct';
 import { FineTuningDataConstruct } from '../lib/constructs/fine-tuning/fine-tuning-data-construct';
 import { ArtifactsDataConstruct } from '../lib/constructs/artifacts/artifacts-data-construct';
+import { SkillResourcesConstruct } from '../lib/constructs/skills/skill-resources-construct';
 import { SpaBucketConstruct } from '../lib/constructs/spa/spa-bucket-construct';
 import { AgentCoreGatewayConstruct } from '../lib/constructs/gateway/agentcore-gateway-construct';
 
@@ -265,6 +266,28 @@ describe('ArtifactsDataConstruct', () => {
     const t = Template.fromStack(stack);
     t.resourceCountIs('AWS::DynamoDB::Table', 1);
     t.resourceCountIs('AWS::S3::Bucket', 1);
+  });
+});
+
+describe('SkillResourcesConstruct', () => {
+  it('creates a private, encrypted S3 bucket', () => {
+    const stack = testStack();
+    new SkillResourcesConstruct(stack, 'SkillRes', { config: createMockConfig() });
+    const t = Template.fromStack(stack);
+    t.resourceCountIs('AWS::S3::Bucket', 1);
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          { ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } },
+        ],
+      },
+    });
   });
 });
 

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -113,8 +113,9 @@ describe('PlatformStack', () => {
 
   describe('S3 buckets', () => {
     it('creates all data buckets', () => {
-      // file-uploads, SPA static, mcp-sandbox, rag-documents, fine-tuning-data, artifacts-content
-      template.resourceCountIs('AWS::S3::Bucket', 6);
+      // file-uploads, SPA static, mcp-sandbox, rag-documents, fine-tuning-data,
+      // artifacts-content, skill-resources (admin-managed Skills reference files)
+      template.resourceCountIs('AWS::S3::Bucket', 7);
     });
   });
 


### PR DESCRIPTION
## PR-4 — Reference-file data layer (admin-managed Skills)

Implements **PR-4** of the re-scoped admin-managed Skills plan: the pure **data + API layer** for a skill's supporting **reference files** (read-only markdown/resources for deep progressive disclosure). **No runtime wiring and no frontend** in this PR — those are PR-6 and PR-5. Nothing consumes the reference files yet, so this is **zero behavior change**.

Spec: [`docs/specs/admin-skills-rbac-tool-binding.md`](docs/specs/admin-skills-rbac-tool-binding.md) §0.5 (PR-4), §4, §5.

### Why this shape
A skill = `SKILL.md` instructions + **supporting reference files** + bound catalog tools. Reference-file **bytes live in S3** (content-addressed, dedupe), never inline in DynamoDB (400 KB item limit). The `SkillDefinition` row carries only a lightweight `resources` manifest. Mirrors the artifacts content bucket and the MCP-Apps UI-resource content-hash persistence.

### What's included
- **Model** (`apis/shared/skills/models.py`): new `SkillResourceRef` (`filename`, `content_hash`, `size`, `content_type`, `s3_key`) + `resources: List[SkillResourceRef]` on `SkillDefinition`, round-tripped through `to_dynamo_item`/`from_dynamo_item` (camelCase, backward-compatible — old rows → `[]`). Surfaced on `AdminSkillResponse`.
- **S3 store** (`apis/shared/skills/resource_store.py`): `SkillResourceStore` — content-hash keyed (`skills/{skill_id}/{content_hash}`), dedupe via `head_object`, put/get/delete, graceful degradation when the bucket/boto3 is absent. Import-clean (lives in `apis.shared`).
- **Service** (`app_api/skills/service.py`): upload / list / read / delete resource methods on `SkillCatalogService` — filename validation (no path traversal), per-file size cap (1 MiB) and per-skill count cap (50), **atomic manifest update** with the catalog row, and **orphaned-object GC** (a content-addressed object shared by two filenames is retained until the last reference is gone).
- **Admin API** (`app_api/admin/skills/routes.py`, all `Depends(require_admin)`): `POST` (upload), `GET` (list manifest), `GET /{filename}` (read bytes), `DELETE /{filename}`. `ValueError`→400 / missing→404 / freshness invalidation, mirroring the existing skills routes.
- **CDK** (`infrastructure/lib/constructs/skills/skill-resources-construct.ts`): new private, AES256-encrypted `skill-resources` bucket (block-public-access, enforce-SSL, abort-stale-multipart). Composed into `PlatformStack`, threaded via `PlatformComputeRefs` (not SSM). Grants **app-api read/write** and **inference-api read-only** + env var `S3_SKILL_RESOURCES_BUCKET_NAME` (forward-compat so PR-6 needs no infra change).
- **Tests**: model round-trip (incl. resources + Decimal coercion + backward-compat), moto-backed store (put/get/list/delete + dedupe + per-skill scoping + not-configured guard), TestClient endpoints (lifecycle + replace + dedupe/GC + validation + 404s), infra jest (`Template.fromStack` bucket assertions).

### Verification
- `cd backend && uv run python -m pytest tests/ -v` — full suite green (the only correctness gate; pytest is not in CI).
- `cd infrastructure && npx tsc --noEmit && npx jest` — green. (Full `cdk synth` needs cert/domain + a live Route53 lookup so it can't complete in a local sandbox; relied on `tsc` + the jest construct tests, per the spec note.)

### Acceptance
A skill can carry S3-backed reference files managed via `/admin/skills/{id}/resources`; the manifest round-trips on the catalog row; **nothing in the runtime or frontend consumes them yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
