### PR TITLE
feat(skills): admin frontend for authoring skills + reference files (PR-5)

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -150,6 +150,7 @@ export class AdminLayout {
       items: [
         { label: 'Models', icon: 'heroPencilSquare', route: '/admin/manage-models' },
         { label: 'Tools', icon: 'heroWrenchScrewdriver', route: '/admin/tools' },
+        { label: 'Skills', icon: 'heroSparkles', route: '/admin/skills' },
         { label: 'Connectors', icon: 'heroLink', route: '/admin/connectors' },
       ],
     },

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -70,6 +70,18 @@ export const adminRoutes: Routes = [
     loadComponent: () => import('./tools/pages/tool-form.page').then(m => m.ToolFormPage),
   },
   {
+    path: 'skills',
+    loadComponent: () => import('./skills/pages/skill-list.page').then(m => m.SkillListPage),
+  },
+  {
+    path: 'skills/new',
+    loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
+  },
+  {
+    path: 'skills/edit/:skillId',
+    loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
+  },
+  {
     path: 'connectors',
     loadComponent: () => import('./connectors/pages/connector-list.page').then(m => m.ConnectorListPage),
   },

--- a/frontend/ai.client/src/app/admin/skills/components/skill-role-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/skills/components/skill-role-dialog.component.ts
@@ -1,0 +1,246 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  OnInit,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroUserGroup } from '@ng-icons/heroicons/outline';
+import { AdminSkillService } from '../services/admin-skill.service';
+import { AdminSkill, SkillRoleAssignment } from '../models/admin-skill.model';
+import { AppRolesService } from '../../roles/services/app-roles.service';
+import { AppRole } from '../../roles/models/app-role.model';
+
+/**
+ * Data passed to the skill role dialog.
+ */
+export interface SkillRoleDialogData {
+  skill: AdminSkill;
+}
+
+/**
+ * Result returned when the dialog is closed: the selected role IDs if saved,
+ * or undefined if cancelled.
+ */
+export type SkillRoleDialogResult = string[] | undefined;
+
+@Component({
+  selector: 'app-skill-role-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark, heroUserGroup })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <!-- Backdrop -->
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <!-- Dialog Panel -->
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="skill-role-title"
+        aria-describedby="skill-role-description"
+      >
+        <!-- Header -->
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="skill-role-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Manage Role Access
+            </h2>
+            <p id="skill-role-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Select which roles can use <span class="font-medium">{{ data.skill.displayName }}</span>.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <!-- Content -->
+        <div class="max-h-72 overflow-y-auto px-6 py-4">
+          @if (loading()) {
+            <div class="flex items-center justify-center py-8">
+              <div class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
+            </div>
+          } @else {
+            <div class="space-y-2">
+              @for (role of allRoles(); track role.roleId) {
+                <label
+                  class="flex cursor-pointer items-center gap-3 rounded-2xl border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50"
+                  [class.border-blue-500]="selectedRoleIds().has(role.roleId)"
+                  [class.bg-blue-50]="selectedRoleIds().has(role.roleId)"
+                  [class.dark:border-blue-400]="selectedRoleIds().has(role.roleId)"
+                  [class.dark:bg-blue-900/20]="selectedRoleIds().has(role.roleId)"
+                >
+                  <input
+                    type="checkbox"
+                    [checked]="selectedRoleIds().has(role.roleId)"
+                    (change)="toggleRole(role.roleId)"
+                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ role.displayName }}</div>
+                    <div class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">{{ role.roleId }}</div>
+                  </div>
+                  @if (currentAssignments().has(role.roleId)) {
+                    <span class="shrink-0 text-xs/5 text-gray-400 dark:text-gray-500">
+                      {{ getGrantType(role.roleId) }}
+                    </span>
+                  }
+                </label>
+              }
+            </div>
+
+            @if (allRoles().length === 0) {
+              <p class="py-8 text-center text-sm/6 text-gray-500 dark:text-gray-400">
+                No roles available. Create roles first.
+              </p>
+            }
+
+            <p class="mt-4 text-xs/5 text-amber-600 dark:text-amber-400">
+              Changes take effect within 5-10 minutes.
+            </p>
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-end gap-2 border-t border-gray-200 px-6 py-3 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="save()"
+            [disabled]="saving() || loading()"
+            class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ saving() ? 'Saving…' : 'Save Changes' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+
+    @keyframes dialog-fade-in-up {
+      from {
+        opacity: 0;
+        transform: translateY(1rem) scale(0.97);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+  `,
+})
+export class SkillRoleDialogComponent implements OnInit {
+  protected readonly dialogRef = inject(DialogRef<SkillRoleDialogResult>);
+  protected readonly data = inject<SkillRoleDialogData>(DIALOG_DATA);
+
+  private adminSkillService = inject(AdminSkillService);
+  private appRolesService = inject(AppRolesService);
+
+  loading = signal(true);
+  saving = signal(false);
+  allRoles = signal<AppRole[]>([]);
+  currentAssignments = signal<Map<string, SkillRoleAssignment>>(new Map());
+  selectedRoleIds = signal<Set<string>>(new Set());
+
+  async ngOnInit(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const [rolesResponse, assignments] = await Promise.all([
+        this.appRolesService.fetchRoles(),
+        this.adminSkillService.getSkillRoles(this.data.skill.skillId),
+      ]);
+
+      this.allRoles.set(rolesResponse.roles.filter((r) => r.roleId !== 'system_admin'));
+
+      const assignmentMap = new Map<string, SkillRoleAssignment>();
+      for (const a of assignments) {
+        assignmentMap.set(a.roleId, a);
+      }
+      this.currentAssignments.set(assignmentMap);
+
+      const directGrants = assignments
+        .filter((a) => a.grantType === 'direct')
+        .map((a) => a.roleId);
+      this.selectedRoleIds.set(new Set(directGrants));
+    } catch (error) {
+      console.error('Error loading data:', error);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  toggleRole(roleId: string): void {
+    this.selectedRoleIds.update((set) => {
+      const next = new Set(set);
+      if (next.has(roleId)) {
+        next.delete(roleId);
+      } else {
+        next.add(roleId);
+      }
+      return next;
+    });
+  }
+
+  getGrantType(roleId: string): string {
+    const assignment = this.currentAssignments().get(roleId);
+    if (!assignment) return '';
+    if (assignment.grantType === 'inherited') {
+      return `inherited from ${assignment.inheritedFrom}`;
+    }
+    return 'direct';
+  }
+
+  save(): void {
+    this.saving.set(true);
+    try {
+      this.dialogRef.close(Array.from(this.selectedRoleIds()));
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/skills/components/tool-picker-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/skills/components/tool-picker-dialog.component.ts
@@ -1,0 +1,258 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
+import { AdminToolService } from '../../tools/services/admin-tool.service';
+import { TOOL_CATEGORIES } from '../../tools/models/admin-tool.model';
+
+/**
+ * Data passed to the tool picker dialog: the currently-bound tool IDs.
+ */
+export interface ToolPickerDialogData {
+  selectedToolIds: string[];
+}
+
+/**
+ * Result: the chosen tool IDs if confirmed, or undefined if cancelled.
+ */
+export type ToolPickerDialogResult = string[] | undefined;
+
+@Component({
+  selector: 'app-tool-picker-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [provideIcons({ heroXMark, heroMagnifyingGlass })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <!-- Backdrop -->
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <!-- Dialog Panel -->
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative flex max-h-[80vh] w-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="tool-picker-title"
+        aria-describedby="tool-picker-description"
+      >
+        <!-- Header -->
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="tool-picker-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Bind Tools
+            </h2>
+            <p id="tool-picker-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Select the catalog tools this skill carries. The agent loads only these tools when the skill is active.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <!-- Search -->
+        <div class="px-6 pt-4">
+          <div class="relative">
+            <ng-icon
+              name="heroMagnifyingGlass"
+              class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <label for="tool-search" class="sr-only">Search tools</label>
+            <input
+              id="tool-search"
+              type="text"
+              [ngModel]="searchQuery()"
+              (ngModelChange)="searchQuery.set($event)"
+              placeholder="Search by name, ID, category or protocol…"
+              class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+            />
+          </div>
+          <div class="mt-2 flex items-center justify-between text-xs/5">
+            <span class="text-gray-500 dark:text-gray-400">
+              {{ selectedToolIds().size }} selected
+            </span>
+            @if (selectedToolIds().size > 0) {
+              <button
+                type="button"
+                (click)="clearAll()"
+                class="font-medium text-gray-500 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:text-white"
+              >
+                Clear
+              </button>
+            }
+          </div>
+        </div>
+
+        <!-- Content -->
+        <div class="mt-2 flex-1 overflow-y-auto px-6 py-2">
+          @if (toolsResource.isLoading()) {
+            <p class="py-8 text-center text-sm/6 text-gray-500 dark:text-gray-400">Loading tools…</p>
+          } @else if (filteredTools().length === 0) {
+            <p class="py-8 text-center text-sm/6 text-gray-500 dark:text-gray-400">
+              No active tools match the search.
+            </p>
+          } @else {
+            <div class="space-y-2">
+              @for (tool of filteredTools(); track tool.toolId) {
+                <label
+                  class="flex cursor-pointer items-center gap-3 rounded-2xl border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50"
+                  [class.border-blue-500]="selectedToolIds().has(tool.toolId)"
+                  [class.bg-blue-50]="selectedToolIds().has(tool.toolId)"
+                  [class.dark:border-blue-400]="selectedToolIds().has(tool.toolId)"
+                  [class.dark:bg-blue-900/20]="selectedToolIds().has(tool.toolId)"
+                >
+                  <input
+                    type="checkbox"
+                    [checked]="selectedToolIds().has(tool.toolId)"
+                    (change)="toggleTool(tool.toolId)"
+                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                      {{ tool.displayName }}
+                    </div>
+                    <div class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
+                      {{ tool.toolId }}
+                    </div>
+                  </div>
+                  <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium capitalize text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
+                    {{ categoryLabel(tool.category) }}
+                  </span>
+                </label>
+              }
+            </div>
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-end gap-2 border-t border-gray-200 px-6 py-3 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="confirm()"
+            class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+
+    @keyframes dialog-fade-in-up {
+      from {
+        opacity: 0;
+        transform: translateY(1rem) scale(0.97);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+  `,
+})
+export class ToolPickerDialogComponent {
+  protected readonly dialogRef = inject(DialogRef<ToolPickerDialogResult>);
+  protected readonly data = inject<ToolPickerDialogData>(DIALOG_DATA);
+
+  private adminToolService = inject(AdminToolService);
+
+  readonly toolsResource = this.adminToolService.toolsResource;
+  readonly searchQuery = signal('');
+  readonly selectedToolIds = signal<Set<string>>(new Set(this.data.selectedToolIds));
+
+  /**
+   * Only ACTIVE tools are bindable — the backend rejects binding an unknown or
+   * non-active tool (see SkillCatalogService._validate_bound_tools).
+   */
+  readonly activeTools = computed(() =>
+    this.adminToolService.getTools().filter((t) => t.status === 'active')
+  );
+
+  readonly filteredTools = computed(() => {
+    const query = this.searchQuery().toLowerCase().trim();
+    const tools = this.activeTools();
+    const filtered = query
+      ? tools.filter(
+          (t) =>
+            t.displayName.toLowerCase().includes(query) ||
+            t.toolId.toLowerCase().includes(query) ||
+            t.category.toLowerCase().includes(query) ||
+            t.protocol.toLowerCase().includes(query)
+        )
+      : tools;
+    return [...filtered].sort((a, b) => a.displayName.localeCompare(b.displayName));
+  });
+
+  categoryLabel(category: string): string {
+    return TOOL_CATEGORIES.find((c) => c.value === category)?.label ?? category;
+  }
+
+  toggleTool(toolId: string): void {
+    this.selectedToolIds.update((set) => {
+      const next = new Set(set);
+      if (next.has(toolId)) {
+        next.delete(toolId);
+      } else {
+        next.add(toolId);
+      }
+      return next;
+    });
+  }
+
+  clearAll(): void {
+    this.selectedToolIds.set(new Set());
+  }
+
+  confirm(): void {
+    this.dialogRef.close(Array.from(this.selectedToolIds()));
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/skills/index.ts
+++ b/frontend/ai.client/src/app/admin/skills/index.ts
@@ -1,0 +1,7 @@
+export * from './models/admin-skill.model';
+export * from './models/skill-import.util';
+export * from './services/admin-skill.service';
+export * from './pages/skill-list.page';
+export * from './pages/skill-form.page';
+export * from './components/skill-role-dialog.component';
+export * from './components/tool-picker-dialog.component';

--- a/frontend/ai.client/src/app/admin/skills/models/admin-skill.model.ts
+++ b/frontend/ai.client/src/app/admin/skills/models/admin-skill.model.ts
@@ -1,0 +1,148 @@
+/**
+ * Admin Skill catalog models — the TypeScript mirror of the backend
+ * `apis/shared/skills/models.py` (`AdminSkillResponse`, `SkillResourceRef`,
+ * the create/update/role DTOs). Shapes must stay in sync with that module
+ * (CLAUDE.md cross-package contract).
+ */
+
+/**
+ * Availability status of a skill (mirrors backend SkillStatus).
+ */
+export type SkillStatus = 'active' | 'draft' | 'disabled';
+
+/**
+ * Ownership visibility — reserved for Phase 2; v1 is always 'admin'.
+ */
+export type SkillVisibility = 'admin' | 'private' | 'shared';
+
+/**
+ * Manifest entry for one of a skill's supporting reference files. The bytes
+ * live in S3 (the skill-resources bucket); this is the lightweight pointer
+ * carried on the catalog row and returned by the /resources endpoints.
+ */
+export interface SkillResourceRef {
+  filename: string;
+  contentHash: string;
+  size: number;
+  contentType: string;
+  s3Key: string;
+}
+
+/**
+ * Admin skill definition with role assignments + reference-file manifest.
+ */
+export interface AdminSkill {
+  skillId: string;
+  displayName: string;
+  description: string;
+  instructions: string;
+  boundToolIds: string[];
+  compose: string[];
+  resources: SkillResourceRef[];
+  status: SkillStatus;
+  category: string | null;
+  ownerId: string;
+  visibility: SkillVisibility;
+  allowedAppRoles: string[];
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string | null;
+  updatedBy: string | null;
+}
+
+/**
+ * Response for listing admin skills.
+ */
+export interface AdminSkillListResponse {
+  skills: AdminSkill[];
+  total: number;
+}
+
+/**
+ * Role assignment for a skill.
+ */
+export interface SkillRoleAssignment {
+  roleId: string;
+  displayName: string;
+  grantType: 'direct' | 'inherited';
+  inheritedFrom: string | null;
+  enabled: boolean;
+}
+
+/**
+ * Response for getting skill roles.
+ */
+export interface SkillRolesResponse {
+  skillId: string;
+  roles: SkillRoleAssignment[];
+}
+
+/**
+ * Response for the /admin/skills/{id}/resources manifest endpoints.
+ */
+export interface SkillResourcesResponse {
+  skillId: string;
+  resources: SkillResourceRef[];
+}
+
+/**
+ * Request body for POST /admin/skills.
+ */
+export interface SkillCreateRequest {
+  skillId: string;
+  displayName: string;
+  description: string;
+  instructions?: string;
+  boundToolIds?: string[];
+  compose?: string[];
+  status?: SkillStatus;
+  category?: string | null;
+}
+
+/**
+ * Request body for PUT /admin/skills/{id}. All fields optional (partial update).
+ */
+export interface SkillUpdateRequest {
+  displayName?: string;
+  description?: string;
+  instructions?: string;
+  boundToolIds?: string[];
+  compose?: string[];
+  status?: SkillStatus;
+  category?: string | null;
+}
+
+/**
+ * Request body for setting/adding/removing skill role grants.
+ */
+export interface SetSkillRolesRequest {
+  appRoleIds: string[];
+}
+
+/**
+ * skill_id regex — identical to the backend SKILL_ID_PATTERN.
+ */
+export const SKILL_ID_PATTERN = /^[a-z][a-z0-9_]{2,49}$/;
+
+/**
+ * Available skill statuses for dropdowns.
+ */
+export const SKILL_STATUSES: { value: SkillStatus; label: string }[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'disabled', label: 'Disabled' },
+];
+
+/**
+ * Suggested skill categories for the optional grouping dropdown. The backend
+ * stores `category` as a free-form string, so this list is advisory.
+ */
+export const SKILL_CATEGORIES: { value: string; label: string }[] = [
+  { value: 'document', label: 'Document' },
+  { value: 'data', label: 'Data' },
+  { value: 'research', label: 'Research' },
+  { value: 'code', label: 'Code' },
+  { value: 'productivity', label: 'Productivity' },
+  { value: 'utility', label: 'Utility' },
+  { value: 'custom', label: 'Custom' },
+];

--- a/frontend/ai.client/src/app/admin/skills/models/skill-import.util.spec.ts
+++ b/frontend/ai.client/src/app/admin/skills/models/skill-import.util.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSkillMarkdown,
+  slugifySkillId,
+  isValidSkillId,
+} from './skill-import.util';
+
+describe('parseSkillMarkdown', () => {
+  it('extracts name, description and body from frontmatter', () => {
+    const md = [
+      '---',
+      'name: pdf',
+      'description: Use this skill whenever a PDF is involved.',
+      '---',
+      '',
+      '# PDF Workflows',
+      '',
+      'Use the bound tools to manipulate PDFs.',
+    ].join('\n');
+
+    const parsed = parseSkillMarkdown(md);
+    expect(parsed.name).toBe('pdf');
+    expect(parsed.description).toBe('Use this skill whenever a PDF is involved.');
+    expect(parsed.instructions).toBe(
+      '# PDF Workflows\n\nUse the bound tools to manipulate PDFs.'
+    );
+  });
+
+  it('strips surrounding quotes from frontmatter values', () => {
+    const md = '---\nname: "docx"\ndescription: \'Word docs\'\n---\nBody';
+    const parsed = parseSkillMarkdown(md);
+    expect(parsed.name).toBe('docx');
+    expect(parsed.description).toBe('Word docs');
+  });
+
+  it('treats the whole text as instructions when there is no frontmatter', () => {
+    const md = '# Just a body\n\nNo frontmatter here.';
+    const parsed = parseSkillMarkdown(md);
+    expect(parsed.name).toBe('');
+    expect(parsed.description).toBe('');
+    expect(parsed.instructions).toBe('# Just a body\n\nNo frontmatter here.');
+  });
+
+  it('normalizes CRLF line endings', () => {
+    const md = '---\r\nname: x\r\n---\r\n\r\nbody line';
+    const parsed = parseSkillMarkdown(md);
+    expect(parsed.name).toBe('x');
+    expect(parsed.instructions).toBe('body line');
+  });
+
+  it('ignores unknown frontmatter keys (tools/scripts not imported)', () => {
+    const md =
+      '---\nname: pdf\nallowed-tools: Bash, Read\nlicense: MIT\n---\nbody';
+    const parsed = parseSkillMarkdown(md);
+    expect(parsed.name).toBe('pdf');
+    // Only name/description are mapped; the rest are dropped.
+    expect(parsed.description).toBe('');
+    expect(parsed.instructions).toBe('body');
+  });
+});
+
+describe('slugifySkillId', () => {
+  it('keeps a valid id unchanged', () => {
+    expect(slugifySkillId('pdf_workflows')).toBe('pdf_workflows');
+  });
+
+  it('converts hyphens to underscores', () => {
+    expect(slugifySkillId('pdf-tools')).toBe('pdf_tools');
+  });
+
+  it('lowercases and collapses non-word runs', () => {
+    expect(slugifySkillId('PDF  Tools!!')).toBe('pdf_tools');
+  });
+
+  it('prefixes when it would not start with a letter', () => {
+    expect(slugifySkillId('123-skill')).toBe('s_123_skill');
+  });
+
+  it('trims surrounding underscores', () => {
+    expect(slugifySkillId('--edge--')).toBe('edge');
+  });
+
+  it('clamps to 50 characters without a trailing underscore', () => {
+    const slug = slugifySkillId('a'.repeat(60));
+    expect(slug.length).toBeLessThanOrEqual(50);
+    expect(slug.endsWith('_')).toBe(false);
+  });
+});
+
+describe('isValidSkillId', () => {
+  it.each(['abc', 'pdf_workflows', 'a12', 'a'.repeat(50)])(
+    'accepts %s',
+    (id) => expect(isValidSkillId(id)).toBe(true)
+  );
+
+  it.each(['ab', '1skill', 'Skill', 'skill-1', '', 'a'.repeat(51)])(
+    'rejects %s',
+    (id) => expect(isValidSkillId(id)).toBe(false)
+  );
+});

--- a/frontend/ai.client/src/app/admin/skills/models/skill-import.util.ts
+++ b/frontend/ai.client/src/app/admin/skills/models/skill-import.util.ts
@@ -1,0 +1,117 @@
+/**
+ * SKILL.md import helpers (PR-5, §0.4).
+ *
+ * Import is a *writing shortcut*: it prefills the create form from an existing
+ * skill bundle's `SKILL.md`. Tool bindings are NOT imported (off-the-shelf
+ * skills carry no reference to our catalog) and scripts are out of scope —
+ * only the authored knowledge (frontmatter + instructions body) is mapped.
+ *
+ * These are pure functions so the parsing/slugifying rules are unit-tested
+ * without a DOM (the file-reading wrapper lives in the form page).
+ */
+
+import { SKILL_ID_PATTERN } from './admin-skill.model';
+
+/**
+ * The prefill fields extracted from a SKILL.md.
+ */
+export interface ParsedSkillMarkdown {
+  /** Frontmatter `name` (raw), or '' if absent. */
+  name: string;
+  /** Frontmatter `description`, or '' if absent. */
+  description: string;
+  /** The markdown body after the frontmatter (→ instructions). */
+  instructions: string;
+}
+
+/**
+ * Parse a SKILL.md into prefill fields.
+ *
+ * Recognises a leading YAML frontmatter block delimited by `---` lines and
+ * extracts the `name` / `description` keys (a deliberately small subset — the
+ * ecosystem SKILL.md frontmatter only uses simple `key: value` scalars).
+ * Everything after the closing `---` is the instructions body. With no
+ * frontmatter, the whole text becomes the instructions.
+ */
+export function parseSkillMarkdown(text: string): ParsedSkillMarkdown {
+  const normalized = text.replace(/\r\n/g, '\n');
+  const fm = extractFrontmatter(normalized);
+  if (!fm) {
+    return { name: '', description: '', instructions: normalized.trim() };
+  }
+  return {
+    name: fm.fields['name'] ?? '',
+    description: fm.fields['description'] ?? '',
+    instructions: fm.body.trim(),
+  };
+}
+
+interface Frontmatter {
+  fields: Record<string, string>;
+  body: string;
+}
+
+function extractFrontmatter(text: string): Frontmatter | null {
+  if (!text.startsWith('---\n')) {
+    return null;
+  }
+  // Closing delimiter: a line that is exactly `---`.
+  const closeMatch = text.match(/\n---[ \t]*(\n|$)/);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return null;
+  }
+  const block = text.slice(4, closeMatch.index);
+  const body = text.slice(closeMatch.index + closeMatch[0].length);
+
+  const fields: Record<string, string> = {};
+  for (const line of block.split('\n')) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s?(.*)$/);
+    if (m) {
+      fields[m[1].toLowerCase()] = stripQuotes(m[2].trim());
+    }
+  }
+  return { fields, body };
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+/**
+ * Best-effort conversion of a SKILL.md `name` (often hyphenated, e.g.
+ * `pdf-tools`) into a valid skill_id (`^[a-z][a-z0-9_]{2,49}$`): lowercase,
+ * non-`[a-z0-9_]` → `_`, collapse repeats, trim underscores, ensure it starts
+ * with a letter, and clamp the length. The result may still be invalid (e.g.
+ * too short) — the form validates and lets the admin correct it.
+ */
+export function slugifySkillId(name: string): string {
+  let slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  // Must start with a letter.
+  if (slug && !/^[a-z]/.test(slug)) {
+    slug = `s_${slug}`;
+  }
+  // Clamp to the 50-char ceiling, then re-trim a trailing underscore the cut
+  // may have left.
+  if (slug.length > 50) {
+    slug = slug.slice(0, 50).replace(/_+$/g, '');
+  }
+  return slug;
+}
+
+/**
+ * Whether a candidate skill_id satisfies the backend pattern.
+ */
+export function isValidSkillId(skillId: string): boolean {
+  return SKILL_ID_PATTERN.test(skillId);
+}

--- a/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
@@ -1,0 +1,725 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+  OnInit,
+} from '@angular/core';
+import { RouterLink, Router, ActivatedRoute } from '@angular/router';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroPlus,
+  heroTrash,
+  heroEye,
+  heroArrowUpTray,
+  heroWrenchScrewdriver,
+  heroDocumentText,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import { AdminSkillService } from '../services/admin-skill.service';
+import { AdminToolService } from '../../tools/services/admin-tool.service';
+import {
+  SkillResourceRef,
+  SkillStatus,
+  SKILL_STATUSES,
+  SKILL_CATEGORIES,
+  SKILL_ID_PATTERN,
+} from '../models/admin-skill.model';
+import {
+  parseSkillMarkdown,
+  slugifySkillId,
+} from '../models/skill-import.util';
+import {
+  ToolPickerDialogComponent,
+  ToolPickerDialogData,
+  ToolPickerDialogResult,
+} from '../components/tool-picker-dialog.component';
+
+@Component({
+  selector: 'app-skill-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, ReactiveFormsModule, NgIcon],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPlus,
+      heroTrash,
+      heroEye,
+      heroArrowUpTray,
+      heroWrenchScrewdriver,
+      heroDocumentText,
+      heroXMark,
+    }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+        <!-- Back link -->
+        <a
+          routerLink="/admin/skills"
+          class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Back to Skills
+        </a>
+
+        <!-- Page Header -->
+        <div class="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">
+              {{ isEditMode() ? 'Edit Skill' : 'Create Skill' }}
+            </h1>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              {{ isEditMode() ? 'Update skill instructions, reference files and bound tools.' : 'Author a new skill, or import a SKILL.md to prefill it.' }}
+            </p>
+          </div>
+
+          @if (!isEditMode()) {
+            <div>
+              <label
+                for="skillImport"
+                class="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                <ng-icon name="heroArrowUpTray" class="size-4" aria-hidden="true" />
+                Import SKILL.md
+              </label>
+              <input
+                id="skillImport"
+                type="file"
+                accept=".md,.markdown,text/markdown,text/plain"
+                class="sr-only"
+                (change)="onImportSelected($event)"
+              />
+            </div>
+          }
+        </div>
+
+        @if (loading()) {
+          <div class="flex h-64 items-center justify-center">
+            <div class="size-10 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-700 dark:border-t-blue-500"></div>
+          </div>
+        } @else {
+          @if (importNotice()) {
+            <div class="mb-6 rounded-2xl border border-blue-200 bg-blue-50 p-3 text-sm/6 text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+              {{ importNotice() }}
+            </div>
+          }
+          @if (error()) {
+            <div class="mb-6 rounded-2xl border border-red-200 bg-red-50 p-3 text-sm/6 text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+              {{ error() }}
+            </div>
+          }
+
+          <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-8">
+            <!-- Basic Information -->
+            <section class="space-y-4">
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Basic information</h2>
+
+              @if (!isEditMode()) {
+                <div>
+                  <label for="skillId" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Skill ID <span class="text-red-600">*</span>
+                  </label>
+                  <input
+                    id="skillId"
+                    type="text"
+                    formControlName="skillId"
+                    placeholder="e.g., pdf_workflows"
+                    class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                    [class.border-red-500]="form.get('skillId')?.invalid && form.get('skillId')?.touched"
+                  />
+                  @if (form.get('skillId')?.invalid && form.get('skillId')?.touched) {
+                    <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">
+                      Skill ID must be 3-50 characters: lowercase letters, numbers and underscores, starting with a letter.
+                    </p>
+                  }
+                </div>
+              }
+
+              <div>
+                <label for="displayName" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                  Display Name <span class="text-red-600">*</span>
+                </label>
+                <input
+                  id="displayName"
+                  type="text"
+                  formControlName="displayName"
+                  placeholder="e.g., PDF Workflows"
+                  class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                  [class.border-red-500]="form.get('displayName')?.invalid && form.get('displayName')?.touched"
+                />
+                @if (form.get('displayName')?.invalid && form.get('displayName')?.touched) {
+                  <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Display name is required (1-100 characters).</p>
+                }
+              </div>
+
+              <div>
+                <label for="description" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                  Description <span class="text-red-600">*</span>
+                </label>
+                <textarea
+                  id="description"
+                  formControlName="description"
+                  rows="2"
+                  placeholder="One-line catalog summary the agent sees (token-cheap)…"
+                  class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                  [class.border-red-500]="form.get('description')?.invalid && form.get('description')?.touched"
+                ></textarea>
+                @if (form.get('description')?.invalid && form.get('description')?.touched) {
+                  <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Description is required (max 500 characters).</p>
+                }
+              </div>
+
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <label for="status" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Status</label>
+                  <select
+                    id="status"
+                    formControlName="status"
+                    class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  >
+                    @for (status of statuses; track status.value) {
+                      <option [value]="status.value">{{ status.label }}</option>
+                    }
+                  </select>
+                </div>
+                <div>
+                  <label for="category" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Category</label>
+                  <select
+                    id="category"
+                    formControlName="category"
+                    class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  >
+                    <option value="">— None —</option>
+                    @for (cat of categories; track cat.value) {
+                      <option [value]="cat.value">{{ cat.label }}</option>
+                    }
+                  </select>
+                </div>
+              </div>
+            </section>
+
+            <!-- Instructions -->
+            <section class="space-y-4">
+              <div>
+                <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Instructions</h2>
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                  The SKILL.md body, loaded when the agent activates this skill. Markdown.
+                </p>
+              </div>
+              <textarea
+                id="instructions"
+                formControlName="instructions"
+                rows="12"
+                placeholder="# How to use these tools&#10;&#10;Describe the procedure the agent should follow…"
+                class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              ></textarea>
+            </section>
+
+            <!-- Bound Tools -->
+            <section class="space-y-4">
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Bound tools</h2>
+                  <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                    Catalog tools this skill carries. The agent loads only these when the skill is active.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  (click)="openToolPicker()"
+                  class="inline-flex shrink-0 items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <ng-icon name="heroWrenchScrewdriver" class="size-4" aria-hidden="true" />
+                  Bind tools
+                </button>
+              </div>
+              @if (boundToolIds().length > 0) {
+                <div class="flex flex-wrap gap-1.5">
+                  @for (toolId of boundToolIds(); track toolId) {
+                    <span class="inline-flex items-center gap-1 rounded-2xl bg-blue-100 py-0.5 pl-2.5 pr-1 text-xs/5 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                      <span class="font-mono" [title]="toolId">{{ toolDisplayName(toolId) }}</span>
+                      <button
+                        type="button"
+                        (click)="removeTool(toolId)"
+                        [attr.aria-label]="'Remove ' + toolId"
+                        class="flex size-4 items-center justify-center rounded-full hover:bg-blue-200 dark:hover:bg-blue-800"
+                      >
+                        <ng-icon name="heroXMark" class="size-3" aria-hidden="true" />
+                      </button>
+                    </span>
+                  }
+                </div>
+              } @else {
+                <p class="text-sm/6 italic text-gray-500 dark:text-gray-400">No tools bound yet.</p>
+              }
+            </section>
+
+            <!-- Reference Files -->
+            <section class="space-y-4">
+              <div>
+                <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Reference files</h2>
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                  Supporting docs the agent can read on demand (markdown/text, up to 1&nbsp;MB each, 50 per skill).
+                </p>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <label
+                  for="refUpload"
+                  class="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  [class.opacity-50]="resourceBusy()"
+                >
+                  <ng-icon name="heroArrowUpTray" class="size-4" aria-hidden="true" />
+                  {{ isEditMode() ? 'Upload files' : 'Add files' }}
+                </label>
+                <input
+                  id="refUpload"
+                  type="file"
+                  multiple
+                  accept=".md,.markdown,.txt,text/markdown,text/plain"
+                  class="sr-only"
+                  [disabled]="resourceBusy()"
+                  (change)="onRefFilesSelected($event)"
+                />
+                <button
+                  type="button"
+                  (click)="toggleNewFile()"
+                  class="inline-flex items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+                  New file
+                </button>
+              </div>
+
+              <!-- Inline new-file authoring -->
+              @if (showNewFile()) {
+                <div class="space-y-2 rounded-2xl border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/40">
+                  <input
+                    type="text"
+                    [value]="newFileName()"
+                    (input)="newFileName.set(asValue($event))"
+                    placeholder="filename.md"
+                    class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  />
+                  <textarea
+                    [value]="newFileContent()"
+                    (input)="newFileContent.set(asValue($event))"
+                    rows="6"
+                    placeholder="# Reference content…"
+                    class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  ></textarea>
+                  <div class="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      (click)="toggleNewFile()"
+                      class="rounded-2xl px-3 py-1.5 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      (click)="addNewFile()"
+                      [disabled]="resourceBusy() || !newFileName().trim() || !newFileContent()"
+                      class="rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    >
+                      Add file
+                    </button>
+                  </div>
+                </div>
+              }
+
+              <!-- Live manifest (edit mode) -->
+              @if (isEditMode()) {
+                @if (resources().length > 0) {
+                  <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+                    @for (res of resources(); track res.filename) {
+                      <li class="flex items-center gap-3 px-3 py-2">
+                        <ng-icon name="heroDocumentText" class="size-4 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        <div class="min-w-0 flex-1">
+                          <span class="block truncate font-mono text-sm/6 text-gray-900 dark:text-white">{{ res.filename }}</span>
+                          <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ formatSize(res.size) }} · {{ res.contentType }}</span>
+                        </div>
+                        <button
+                          type="button"
+                          (click)="viewResource(res)"
+                          [attr.aria-label]="'View ' + res.filename"
+                          class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                        >
+                          <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          (click)="deleteResource(res)"
+                          [disabled]="resourceBusy()"
+                          [attr.aria-label]="'Delete ' + res.filename"
+                          class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                        >
+                          <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                        </button>
+                      </li>
+                    }
+                  </ul>
+                } @else {
+                  <p class="text-sm/6 italic text-gray-500 dark:text-gray-400">No reference files yet.</p>
+                }
+
+                @if (viewing(); as v) {
+                  <div class="rounded-2xl border border-gray-200 dark:border-gray-700">
+                    <div class="flex items-center justify-between border-b border-gray-200 px-3 py-2 dark:border-gray-700">
+                      <span class="font-mono text-sm/6 text-gray-900 dark:text-white">{{ v.filename }}</span>
+                      <button
+                        type="button"
+                        (click)="viewing.set(null)"
+                        aria-label="Close preview"
+                        class="flex size-7 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                      >
+                        <ng-icon name="heroXMark" class="size-4" aria-hidden="true" />
+                      </button>
+                    </div>
+                    <pre class="max-h-72 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs/5 text-gray-700 dark:text-gray-300">{{ v.content }}</pre>
+                  </div>
+                }
+              } @else {
+                <!-- Staged files (create mode) -->
+                @if (pendingFiles().length > 0) {
+                  <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+                    @for (file of pendingFiles(); track file.name) {
+                      <li class="flex items-center gap-3 px-3 py-2">
+                        <ng-icon name="heroDocumentText" class="size-4 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        <div class="min-w-0 flex-1">
+                          <span class="block truncate font-mono text-sm/6 text-gray-900 dark:text-white">{{ file.name }}</span>
+                          <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ formatSize(file.size) }} · uploads after the skill is created</span>
+                        </div>
+                        <button
+                          type="button"
+                          (click)="removePendingFile(file.name)"
+                          [attr.aria-label]="'Remove ' + file.name"
+                          class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                        >
+                          <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                        </button>
+                      </li>
+                    }
+                  </ul>
+                } @else {
+                  <p class="text-sm/6 italic text-gray-500 dark:text-gray-400">No reference files staged.</p>
+                }
+              }
+            </section>
+
+            <!-- Actions -->
+            <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-6 dark:border-gray-700">
+              <a
+                routerLink="/admin/skills"
+                class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </a>
+              <button
+                type="submit"
+                [disabled]="saving() || form.invalid"
+                class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-600"
+              >
+                {{ saving() ? 'Saving…' : (isEditMode() ? 'Update Skill' : 'Create Skill') }}
+              </button>
+            </div>
+          </form>
+        }
+      </div>
+    </div>
+  `,
+})
+export class SkillFormPage implements OnInit {
+  private fb = inject(FormBuilder);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+  private dialog = inject(Dialog);
+  private adminSkillService = inject(AdminSkillService);
+  private adminToolService = inject(AdminToolService);
+
+  readonly statuses = SKILL_STATUSES;
+  readonly categories = SKILL_CATEGORIES;
+
+  loading = signal(false);
+  saving = signal(false);
+  error = signal<string | null>(null);
+  importNotice = signal<string | null>(null);
+  skillId = signal<string | null>(null);
+
+  readonly isEditMode = computed(() => !!this.skillId());
+
+  // Bound tools (managed via the picker dialog).
+  readonly boundToolIds = signal<string[]>([]);
+
+  // Reference files: live manifest in edit mode, staged Files in create mode.
+  readonly resources = signal<SkillResourceRef[]>([]);
+  readonly pendingFiles = signal<File[]>([]);
+  readonly resourceBusy = signal(false);
+  readonly viewing = signal<{ filename: string; content: string } | null>(null);
+
+  // Inline new-file authoring.
+  readonly showNewFile = signal(false);
+  readonly newFileName = signal('');
+  readonly newFileContent = signal('');
+
+  form: FormGroup = this.fb.group({
+    skillId: ['', [Validators.required, Validators.pattern(SKILL_ID_PATTERN)]],
+    displayName: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(100)]],
+    description: ['', [Validators.required, Validators.maxLength(500)]],
+    instructions: [''],
+    status: ['active' as SkillStatus],
+    category: [''],
+  });
+
+  async ngOnInit(): Promise<void> {
+    const id = this.route.snapshot.paramMap.get('skillId');
+    if (id) {
+      this.skillId.set(id);
+      // In edit mode the skillId control is irrelevant (hidden); clear its
+      // validators so the form is valid.
+      this.form.get('skillId')?.clearValidators();
+      this.form.get('skillId')?.updateValueAndValidity();
+      await this.loadSkill(id);
+    }
+  }
+
+  async loadSkill(skillId: string): Promise<void> {
+    this.loading.set(true);
+    try {
+      const skill = await this.adminSkillService.fetchSkill(skillId);
+      this.form.patchValue({
+        skillId: skill.skillId,
+        displayName: skill.displayName,
+        description: skill.description,
+        instructions: skill.instructions,
+        status: skill.status,
+        category: skill.category ?? '',
+      });
+      this.boundToolIds.set([...skill.boundToolIds]);
+      this.resources.set([...skill.resources]);
+    } catch (err: unknown) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to load skill.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  // --- Helpers ---------------------------------------------------------------
+
+  asValue(event: Event): string {
+    return (event.target as HTMLInputElement | HTMLTextAreaElement).value;
+  }
+
+  toolDisplayName(toolId: string): string {
+    return this.adminToolService.getToolById(toolId)?.displayName ?? toolId;
+  }
+
+  formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  // --- Import ----------------------------------------------------------------
+
+  async onImportSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = ''; // allow re-importing the same file
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const parsed = parseSkillMarkdown(text);
+      const patch: Record<string, string> = {
+        displayName: parsed.name || this.form.get('displayName')?.value || '',
+        description: parsed.description || this.form.get('description')?.value || '',
+        instructions: parsed.instructions || this.form.get('instructions')?.value || '',
+      };
+      if (parsed.name) {
+        patch['skillId'] = slugifySkillId(parsed.name);
+      }
+      this.form.patchValue(patch);
+      this.importNotice.set(
+        'Imported from SKILL.md. Tool bindings are not imported — pick them below. Review the Skill ID, then add reference files.'
+      );
+    } catch {
+      this.error.set('Could not read the selected SKILL.md file.');
+    }
+  }
+
+  // --- Bound tools -----------------------------------------------------------
+
+  async openToolPicker(): Promise<void> {
+    const dialogRef = this.dialog.open<ToolPickerDialogResult>(ToolPickerDialogComponent, {
+      data: { selectedToolIds: this.boundToolIds() } as ToolPickerDialogData,
+    });
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result !== undefined) {
+      this.boundToolIds.set(result);
+    }
+  }
+
+  removeTool(toolId: string): void {
+    this.boundToolIds.update((ids) => ids.filter((id) => id !== toolId));
+  }
+
+  // --- Reference files -------------------------------------------------------
+
+  toggleNewFile(): void {
+    this.showNewFile.update((v) => !v);
+    if (!this.showNewFile()) {
+      this.newFileName.set('');
+      this.newFileContent.set('');
+    }
+  }
+
+  async addNewFile(): Promise<void> {
+    const name = this.newFileName().trim();
+    const content = this.newFileContent();
+    if (!name || !content) return;
+    const file = new File([content], name, { type: 'text/markdown' });
+    await this.acceptFiles([file]);
+    this.newFileName.set('');
+    this.newFileContent.set('');
+    this.showNewFile.set(false);
+  }
+
+  async onRefFilesSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    input.value = '';
+    if (files.length > 0) {
+      await this.acceptFiles(files);
+    }
+  }
+
+  /**
+   * Edit mode → upload each file immediately; create mode → stage it (uploaded
+   * after the skill is created, since uploads need a skill_id).
+   */
+  private async acceptFiles(files: File[]): Promise<void> {
+    if (this.isEditMode()) {
+      const id = this.skillId()!;
+      this.resourceBusy.set(true);
+      this.error.set(null);
+      try {
+        let manifest = this.resources();
+        for (const file of files) {
+          manifest = await this.adminSkillService.uploadResource(id, file);
+        }
+        this.resources.set(manifest);
+      } catch (err: unknown) {
+        this.error.set(err instanceof Error ? err.message : 'Failed to upload reference file.');
+      } finally {
+        this.resourceBusy.set(false);
+      }
+    } else {
+      this.pendingFiles.update((current) => {
+        const byName = new Map(current.map((f) => [f.name, f]));
+        for (const file of files) {
+          byName.set(file.name, file); // replace same-named staged file
+        }
+        return Array.from(byName.values());
+      });
+    }
+  }
+
+  removePendingFile(name: string): void {
+    this.pendingFiles.update((files) => files.filter((f) => f.name !== name));
+  }
+
+  async viewResource(res: SkillResourceRef): Promise<void> {
+    const id = this.skillId();
+    if (!id) return;
+    this.resourceBusy.set(true);
+    try {
+      const content = await this.adminSkillService.readResource(id, res.filename);
+      this.viewing.set({ filename: res.filename, content });
+    } catch (err: unknown) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to read reference file.');
+    } finally {
+      this.resourceBusy.set(false);
+    }
+  }
+
+  async deleteResource(res: SkillResourceRef): Promise<void> {
+    const id = this.skillId();
+    if (!id) return;
+    if (!confirm(`Delete reference file "${res.filename}"?`)) return;
+    this.resourceBusy.set(true);
+    this.error.set(null);
+    try {
+      const manifest = await this.adminSkillService.deleteResource(id, res.filename);
+      this.resources.set(manifest);
+      if (this.viewing()?.filename === res.filename) {
+        this.viewing.set(null);
+      }
+    } catch (err: unknown) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to delete reference file.');
+    } finally {
+      this.resourceBusy.set(false);
+    }
+  }
+
+  // --- Submit ----------------------------------------------------------------
+
+  async onSubmit(): Promise<void> {
+    if (this.form.invalid) return;
+    this.saving.set(true);
+    this.error.set(null);
+    try {
+      const v = this.form.getRawValue();
+      const category = v.category ? v.category : null;
+
+      if (this.isEditMode()) {
+        await this.adminSkillService.updateSkill(this.skillId()!, {
+          displayName: v.displayName,
+          description: v.description,
+          instructions: v.instructions,
+          status: v.status,
+          category,
+          boundToolIds: this.boundToolIds(),
+        });
+      } else {
+        const created = await this.adminSkillService.createSkill({
+          skillId: v.skillId,
+          displayName: v.displayName,
+          description: v.description,
+          instructions: v.instructions,
+          status: v.status,
+          category,
+          boundToolIds: this.boundToolIds(),
+        });
+        // Upload any staged reference files now that the skill exists.
+        for (const file of this.pendingFiles()) {
+          await this.adminSkillService.uploadResource(created.skillId, file);
+        }
+      }
+
+      await this.router.navigate(['/admin/skills']);
+    } catch (err: unknown) {
+      console.error('Error saving skill:', err);
+      this.error.set(this.describeSaveError(err));
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  private describeSaveError(err: unknown): string {
+    if (err && typeof err === 'object' && 'error' in err) {
+      const body = (err as { error?: unknown }).error;
+      if (body && typeof body === 'object' && 'detail' in body) {
+        const detail = (body as { detail?: unknown }).detail;
+        if (typeof detail === 'string') return detail;
+      }
+    }
+    return err instanceof Error ? err.message : 'Failed to save skill.';
+  }
+}

--- a/frontend/ai.client/src/app/admin/skills/pages/skill-list.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-list.page.ts
@@ -1,0 +1,426 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroPlus,
+  heroMagnifyingGlass,
+  heroChevronDown,
+  heroPencilSquare,
+  heroTrash,
+  heroUserGroup,
+  heroWrenchScrewdriver,
+  heroDocumentText,
+} from '@ng-icons/heroicons/outline';
+import { AdminSkillService } from '../services/admin-skill.service';
+import { AdminSkill, SKILL_STATUSES } from '../models/admin-skill.model';
+import { AppRolesService } from '../../roles/services/app-roles.service';
+import { AdminToolService } from '../../tools/services/admin-tool.service';
+import {
+  SkillRoleDialogComponent,
+  SkillRoleDialogData,
+  SkillRoleDialogResult,
+} from '../components/skill-role-dialog.component';
+
+@Component({
+  selector: 'app-skill-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, FormsModule, NgIcon],
+  providers: [
+    provideIcons({
+      heroPlus,
+      heroMagnifyingGlass,
+      heroChevronDown,
+      heroPencilSquare,
+      heroTrash,
+      heroUserGroup,
+      heroWrenchScrewdriver,
+      heroDocumentText,
+    }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <!-- Page Header -->
+        <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Skill Catalog</h1>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Author skills that bundle instructions, reference files and bound tools, then grant them to roles.
+            </p>
+          </div>
+          <a
+            routerLink="/admin/skills/new"
+            class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+            Add Skill
+          </a>
+        </div>
+
+        <!-- Toolbar: search + status filter -->
+        <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div class="relative flex-1">
+            <ng-icon
+              name="heroMagnifyingGlass"
+              class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <label for="search" class="sr-only">Search skills</label>
+            <input
+              type="text"
+              id="search"
+              [ngModel]="searchQuery()"
+              (ngModelChange)="searchQuery.set($event)"
+              placeholder="Search by name, ID, or description…"
+              class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+            />
+          </div>
+
+          <label for="status" class="sr-only">Filter by status</label>
+          <select
+            id="status"
+            [ngModel]="statusFilter()"
+            (ngModelChange)="statusFilter.set($event)"
+            class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          >
+            <option value="">All statuses</option>
+            @for (status of statuses; track status.value) {
+              <option [value]="status.value">{{ status.label }}</option>
+            }
+          </select>
+
+          @if (hasActiveFilters()) {
+            <button
+              (click)="resetFilters()"
+              class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+            >
+              Reset
+            </button>
+          }
+        </div>
+
+        <!-- Count -->
+        <div class="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+          {{ filteredSkills().length }} skill{{ filteredSkills().length !== 1 ? 's' : '' }}
+        </div>
+
+        <!-- Loading State -->
+        @if (skillsResource.isLoading() && skills().length === 0) {
+          <div class="flex h-64 items-center justify-center">
+            <div class="flex flex-col items-center gap-4">
+              <div class="size-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading skills…</p>
+            </div>
+          </div>
+        }
+
+        <!-- Error State -->
+        @if (skillsResource.error()) {
+          <div class="mb-6 rounded-2xl border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+            <p class="text-sm/6">Failed to load skills. Please try again.</p>
+            <button
+              (click)="adminSkillService.reload()"
+              class="mt-2 text-sm/6 font-medium underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        }
+
+        <!-- Skills List -->
+        @if (!skillsResource.isLoading() || skills().length > 0) {
+          @if (filteredSkills().length === 0) {
+            <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+              @if (hasActiveFilters()) {
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">No skills match the current filters.</p>
+              } @else {
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">No skills in catalog yet.</p>
+                <a
+                  routerLink="/admin/skills/new"
+                  class="mt-4 inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+                  Add Skill
+                </a>
+              }
+            </div>
+          } @else {
+            <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+              @for (skill of filteredSkills(); track skill.skillId) {
+                <li>
+                  <!-- Row -->
+                  <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                    <button
+                      type="button"
+                      (click)="toggleExpand(skill.skillId)"
+                      [attr.aria-expanded]="isExpanded(skill.skillId)"
+                      [attr.aria-controls]="'skill-detail-' + skill.skillId"
+                      [attr.aria-label]="(isExpanded(skill.skillId) ? 'Hide' : 'Show') + ' details for ' + skill.displayName"
+                      class="flex size-7 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                    >
+                      <ng-icon
+                        name="heroChevronDown"
+                        class="size-4 transition-transform duration-150"
+                        [class.rotate-180]="isExpanded(skill.skillId)"
+                        aria-hidden="true"
+                      />
+                    </button>
+
+                    <!-- Name + skill id -->
+                    <div class="min-w-0 flex-1">
+                      <span class="block truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                        {{ skill.displayName }}
+                      </span>
+                      <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
+                        {{ skill.skillId }}
+                      </p>
+                    </div>
+
+                    <!-- Bound tools count -->
+                    <span class="hidden shrink-0 items-center gap-1 text-xs/5 text-gray-500 sm:inline-flex dark:text-gray-400" [title]="skill.boundToolIds.length + ' bound tool(s)'">
+                      <ng-icon name="heroWrenchScrewdriver" class="size-4" aria-hidden="true" />
+                      {{ skill.boundToolIds.length }}
+                    </span>
+
+                    <!-- Reference files count -->
+                    <span class="hidden shrink-0 items-center gap-1 text-xs/5 text-gray-500 sm:inline-flex dark:text-gray-400" [title]="skill.resources.length + ' reference file(s)'">
+                      <ng-icon name="heroDocumentText" class="size-4" aria-hidden="true" />
+                      {{ skill.resources.length }}
+                    </span>
+
+                    <!-- Roles count -->
+                    <span class="hidden w-16 shrink-0 justify-end text-right text-xs/5 text-gray-500 sm:flex dark:text-gray-400">
+                      {{ skill.allowedAppRoles.length }} role{{ skill.allowedAppRoles.length !== 1 ? 's' : '' }}
+                    </span>
+
+                    <!-- Status -->
+                    <span [class]="getStatusClass(skill.status)">{{ skill.status }}</span>
+
+                    <!-- Actions -->
+                    <div class="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        (click)="openRoleDialog(skill)"
+                        [attr.aria-label]="'Manage role access for ' + skill.displayName"
+                        [title]="'Manage role access for ' + skill.displayName"
+                        class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                      >
+                        <ng-icon name="heroUserGroup" class="size-4" aria-hidden="true" />
+                      </button>
+                      <a
+                        [routerLink]="['/admin/skills/edit', skill.skillId]"
+                        [attr.aria-label]="'Edit ' + skill.displayName"
+                        [title]="'Edit ' + skill.displayName"
+                        class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                      >
+                        <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                      </a>
+                      <button
+                        type="button"
+                        (click)="deleteSkill(skill)"
+                        [attr.aria-label]="'Delete ' + skill.displayName"
+                        [title]="'Delete ' + skill.displayName"
+                        class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                      >
+                        <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+
+                  <!-- Expanded detail -->
+                  @if (isExpanded(skill.skillId)) {
+                    <div
+                      [id]="'skill-detail-' + skill.skillId"
+                      class="border-t border-gray-100 bg-gray-50 px-4 py-3 sm:pl-14 dark:border-gray-700/60 dark:bg-gray-900/40"
+                    >
+                      <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+                        <div class="sm:col-span-2">
+                          <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Description</dt>
+                          <dd class="mt-0.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                            {{ skill.description || 'No description provided.' }}
+                          </dd>
+                        </div>
+
+                        <div>
+                          <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Bound tools</dt>
+                          <dd class="mt-1 flex flex-wrap gap-1.5">
+                            @if (skill.boundToolIds.length > 0) {
+                              @for (toolId of skill.boundToolIds; track toolId) {
+                                <span class="inline-flex items-center rounded-2xl bg-blue-100 px-2 py-0.5 font-mono text-xs/5 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" [title]="toolId">
+                                  {{ getToolDisplayName(toolId) }}
+                                </span>
+                              }
+                            } @else {
+                              <span class="text-xs/5 italic text-gray-500 dark:text-gray-400">No tools bound</span>
+                            }
+                          </dd>
+                        </div>
+
+                        <div>
+                          <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Reference files</dt>
+                          <dd class="mt-1 flex flex-wrap gap-1.5">
+                            @if (skill.resources.length > 0) {
+                              @for (res of skill.resources; track res.filename) {
+                                <span class="inline-flex items-center rounded-2xl bg-gray-100 px-2 py-0.5 font-mono text-xs/5 text-gray-700 dark:bg-gray-700 dark:text-gray-300" [title]="res.size + ' bytes'">
+                                  {{ res.filename }}
+                                </span>
+                              }
+                            } @else {
+                              <span class="text-xs/5 italic text-gray-500 dark:text-gray-400">No reference files</span>
+                            }
+                          </dd>
+                        </div>
+
+                        <div class="sm:col-span-2">
+                          <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Access</dt>
+                          <dd class="mt-1 flex flex-wrap gap-1.5">
+                            @if (skill.allowedAppRoles.length > 0) {
+                              @for (roleId of skill.allowedAppRoles; track roleId) {
+                                <span class="inline-flex items-center rounded-2xl bg-purple-100 px-2 py-0.5 text-xs/5 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300" [title]="roleId">
+                                  {{ getRoleDisplayName(roleId) }}
+                                </span>
+                              }
+                            } @else {
+                              <span class="text-xs/5 italic text-gray-500 dark:text-gray-400">No roles assigned</span>
+                            }
+                          </dd>
+                        </div>
+                      </dl>
+                    </div>
+                  }
+                </li>
+              }
+            </ul>
+          }
+        }
+      </div>
+    </div>
+  `,
+})
+export class SkillListPage {
+  adminSkillService = inject(AdminSkillService);
+  private dialog = inject(Dialog);
+  private appRolesService = inject(AppRolesService);
+  private adminToolService = inject(AdminToolService);
+
+  readonly skillsResource = this.adminSkillService.skillsResource;
+  readonly statuses = SKILL_STATUSES;
+
+  searchQuery = signal('');
+  statusFilter = signal('');
+
+  private expandedIds = signal<ReadonlySet<string>>(new Set());
+
+  readonly skills = computed(() => this.adminSkillService.getSkills());
+
+  readonly filteredSkills = computed(() => {
+    let skills = this.skills();
+    const query = this.searchQuery().toLowerCase();
+    const status = this.statusFilter();
+
+    if (query) {
+      skills = skills.filter(
+        (s) =>
+          s.displayName.toLowerCase().includes(query) ||
+          s.skillId.toLowerCase().includes(query) ||
+          s.description.toLowerCase().includes(query)
+      );
+    }
+
+    if (status) {
+      skills = skills.filter((s) => s.status === status);
+    }
+
+    return [...skills].sort((a, b) => {
+      const catCompare = (a.category ?? '').localeCompare(b.category ?? '');
+      if (catCompare !== 0) return catCompare;
+      return a.displayName.localeCompare(b.displayName);
+    });
+  });
+
+  readonly hasActiveFilters = computed(() => !!(this.searchQuery() || this.statusFilter()));
+
+  resetFilters(): void {
+    this.searchQuery.set('');
+    this.statusFilter.set('');
+  }
+
+  isExpanded(skillId: string): boolean {
+    return this.expandedIds().has(skillId);
+  }
+
+  toggleExpand(skillId: string): void {
+    this.expandedIds.update((current) => {
+      const next = new Set(current);
+      if (next.has(skillId)) {
+        next.delete(skillId);
+      } else {
+        next.add(skillId);
+      }
+      return next;
+    });
+  }
+
+  getRoleDisplayName(roleId: string): string {
+    return this.appRolesService.getRoleById(roleId)?.displayName ?? roleId;
+  }
+
+  getToolDisplayName(toolId: string): string {
+    return this.adminToolService.getToolById(toolId)?.displayName ?? toolId;
+  }
+
+  getStatusClass(status: string): string {
+    const base = 'shrink-0 rounded-2xl px-2.5 py-0.5 text-xs/5 font-medium';
+    switch (status) {
+      case 'active':
+        return `${base} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300`;
+      case 'draft':
+        return `${base} bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300`;
+      case 'disabled':
+        return `${base} bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300`;
+      default:
+        return `${base} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300`;
+    }
+  }
+
+  async openRoleDialog(skill: AdminSkill): Promise<void> {
+    const dialogRef = this.dialog.open<SkillRoleDialogResult>(SkillRoleDialogComponent, {
+      data: { skill } as SkillRoleDialogData,
+    });
+
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result !== undefined) {
+      try {
+        await this.adminSkillService.setSkillRoles(skill.skillId, result);
+      } catch (error: unknown) {
+        console.error('Error saving roles:', error);
+        alert(error instanceof Error ? error.message : 'Failed to save roles.');
+      }
+    }
+  }
+
+  async deleteSkill(skill: AdminSkill): Promise<void> {
+    const confirmed = confirm(
+      `Delete skill "${skill.displayName}"? This disables it; you can re-enable it later from the edit page.`
+    );
+    if (!confirmed) {
+      return;
+    }
+    try {
+      // Soft delete (status → disabled) keeps the row + reference-file manifest.
+      await this.adminSkillService.deleteSkill(skill.skillId, false);
+    } catch (error: unknown) {
+      console.error('Error deleting skill:', error);
+      alert(error instanceof Error ? error.message : 'Failed to delete skill.');
+    }
+  }
+}

--- a/frontend/ai.client/src/app/admin/skills/services/admin-skill.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/skills/services/admin-skill.service.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { AdminSkillService } from './admin-skill.service';
+import { ConfigService } from '../../../services/config.service';
+
+describe('AdminSkillService', () => {
+  let service: AdminSkillService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        AdminSkillService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(AdminSkillService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('should fetch skills', async () => {
+    const mockResponse = { skills: [], total: 0 };
+    const promise = service.fetchSkills();
+    await vi.waitFor(() => {
+      httpMock.expectOne('http://localhost:8000/admin/skills/').flush(mockResponse);
+    });
+    expect(await promise).toEqual(mockResponse);
+  });
+
+  it('should fetch skill by id', async () => {
+    const mockSkill = { skillId: 'pdf_workflows', displayName: 'PDF' };
+    const promise = service.fetchSkill('pdf_workflows');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows')
+        .flush(mockSkill);
+    });
+    expect(await promise).toEqual(mockSkill);
+  });
+
+  it('should create skill', async () => {
+    const skillData = { skillId: 'pdf_workflows', displayName: 'PDF', description: 'x' } as any;
+    const mockSkill = { skillId: 'pdf_workflows', displayName: 'PDF' };
+    const promise = service.createSkill(skillData);
+    await vi.waitFor(() => {
+      httpMock.expectOne('http://localhost:8000/admin/skills/').flush(mockSkill);
+    });
+    expect(await promise).toEqual(mockSkill);
+  });
+
+  it('should update skill', async () => {
+    const updates = { displayName: 'Updated' } as any;
+    const mockSkill = { skillId: 'pdf_workflows', displayName: 'Updated' };
+    const promise = service.updateSkill('pdf_workflows', updates);
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows')
+        .flush(mockSkill);
+    });
+    expect(await promise).toEqual(mockSkill);
+  });
+
+  it('should delete skill', async () => {
+    const promise = service.deleteSkill('pdf_workflows');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows?hard=false')
+        .flush(null);
+    });
+    await promise;
+  });
+
+  it('should get skill roles', async () => {
+    const promise = service.getSkillRoles('pdf_workflows');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows/roles')
+        .flush({ skillId: 'pdf_workflows', roles: [{ roleId: 'editor' }] });
+    });
+    expect(await promise).toEqual([{ roleId: 'editor' }]);
+  });
+
+  it('should list resources', async () => {
+    const promise = service.listResources('pdf_workflows');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows/resources')
+        .flush({ skillId: 'pdf_workflows', resources: [{ filename: 'forms.md' }] });
+    });
+    expect(await promise).toEqual([{ filename: 'forms.md' }]);
+  });
+
+  it('should upload a resource as multipart and return the manifest', async () => {
+    const file = new File(['# Forms'], 'forms.md', { type: 'text/markdown' });
+    const promise = service.uploadResource('pdf_workflows', file);
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(
+        'http://localhost:8000/admin/skills/pdf_workflows/resources'
+      );
+      expect(req.request.body instanceof FormData).toBe(true);
+      req.flush({ skillId: 'pdf_workflows', resources: [{ filename: 'forms.md' }] });
+    });
+    expect(await promise).toEqual([{ filename: 'forms.md' }]);
+  });
+
+  it('should read a resource as text', async () => {
+    const promise = service.readResource('pdf_workflows', 'forms.md');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows/resources/forms.md')
+        .flush('# Forms body');
+    });
+    expect(await promise).toBe('# Forms body');
+  });
+
+  it('should delete a resource and return the manifest', async () => {
+    const promise = service.deleteResource('pdf_workflows', 'forms.md');
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne('http://localhost:8000/admin/skills/pdf_workflows/resources/forms.md')
+        .flush({ skillId: 'pdf_workflows', resources: [] });
+    });
+    expect(await promise).toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/admin/skills/services/admin-skill.service.ts
+++ b/frontend/ai.client/src/app/admin/skills/services/admin-skill.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, inject, resource, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import {
+  AdminSkill,
+  AdminSkillListResponse,
+  SkillCreateRequest,
+  SkillUpdateRequest,
+  SkillRolesResponse,
+  SkillRoleAssignment,
+  SkillResourceRef,
+  SkillResourcesResponse,
+} from '../models/admin-skill.model';
+
+/**
+ * Service for admin skill management.
+ *
+ * Mirrors `AdminToolService`: `resource()`-backed catalog + signal state,
+ * CRUD, role-grant sync, plus the reference-file (S3-backed) endpoints
+ * introduced in PR-4.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminSkillService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/admin/skills`);
+
+  private _loading = signal(false);
+  private _error = signal<string | null>(null);
+
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  /**
+   * Reactive resource for fetching admin skills.
+   */
+  readonly skillsResource = resource({
+    loader: async () => {
+      await Promise.resolve();
+      return this.fetchSkills();
+    },
+  });
+
+  /**
+   * Get all skills from the cached resource.
+   */
+  getSkills(): AdminSkill[] {
+    return this.skillsResource.value()?.skills ?? [];
+  }
+
+  /**
+   * Get a skill by ID from the cached resource.
+   */
+  getSkillById(skillId: string): AdminSkill | undefined {
+    return this.getSkills().find((s) => s.skillId === skillId);
+  }
+
+  /**
+   * Fetch all skills from the API.
+   */
+  async fetchSkills(status?: string): Promise<AdminSkillListResponse> {
+    let url = `${this.baseUrl()}/`;
+    if (status) {
+      url += `?status=${status}`;
+    }
+    return firstValueFrom(this.http.get<AdminSkillListResponse>(url));
+  }
+
+  /**
+   * Fetch a single skill by ID.
+   */
+  async fetchSkill(skillId: string): Promise<AdminSkill> {
+    return firstValueFrom(this.http.get<AdminSkill>(`${this.baseUrl()}/${skillId}`));
+  }
+
+  /**
+   * Create a new skill.
+   */
+  async createSkill(skillData: SkillCreateRequest): Promise<AdminSkill> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const response = await firstValueFrom(
+        this.http.post<AdminSkill>(`${this.baseUrl()}/`, skillData)
+      );
+      this.skillsResource.reload();
+      return response;
+    } catch (err: unknown) {
+      this._error.set(err instanceof Error ? err.message : 'Failed to create skill');
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Update an existing skill.
+   */
+  async updateSkill(skillId: string, updates: SkillUpdateRequest): Promise<AdminSkill> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const response = await firstValueFrom(
+        this.http.put<AdminSkill>(`${this.baseUrl()}/${skillId}`, updates)
+      );
+      this.skillsResource.reload();
+      return response;
+    } catch (err: unknown) {
+      this._error.set(err instanceof Error ? err.message : 'Failed to update skill');
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Delete a skill (soft delete by default).
+   */
+  async deleteSkill(skillId: string, hard: boolean = false): Promise<void> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      await firstValueFrom(
+        this.http.delete<void>(`${this.baseUrl()}/${skillId}?hard=${hard}`)
+      );
+      this.skillsResource.reload();
+    } catch (err: unknown) {
+      this._error.set(err instanceof Error ? err.message : 'Failed to delete skill');
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Get roles that grant access to a skill.
+   */
+  async getSkillRoles(skillId: string): Promise<SkillRoleAssignment[]> {
+    const response = await firstValueFrom(
+      this.http.get<SkillRolesResponse>(`${this.baseUrl()}/${skillId}/roles`)
+    );
+    return response.roles;
+  }
+
+  /**
+   * Set which roles grant access to a skill (bidirectional sync).
+   */
+  async setSkillRoles(skillId: string, roleIds: string[]): Promise<void> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      await firstValueFrom(
+        this.http.put(`${this.baseUrl()}/${skillId}/roles`, { appRoleIds: roleIds })
+      );
+      this.skillsResource.reload();
+    } catch (err: unknown) {
+      this._error.set(err instanceof Error ? err.message : 'Failed to set skill roles');
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  // ===========================================================================
+  // Reference files (S3-backed supporting reference files — PR-4)
+  // ===========================================================================
+
+  /**
+   * List a skill's reference-file manifest.
+   */
+  async listResources(skillId: string): Promise<SkillResourceRef[]> {
+    const response = await firstValueFrom(
+      this.http.get<SkillResourcesResponse>(`${this.baseUrl()}/${skillId}/resources`)
+    );
+    return response.resources;
+  }
+
+  /**
+   * Upload (or replace) one reference file; returns the updated manifest.
+   */
+  async uploadResource(skillId: string, file: File): Promise<SkillResourceRef[]> {
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+    const response = await firstValueFrom(
+      this.http.post<SkillResourcesResponse>(
+        `${this.baseUrl()}/${skillId}/resources`,
+        formData
+      )
+    );
+    this.skillsResource.reload();
+    return response.resources;
+  }
+
+  /**
+   * Read one reference file's raw text content.
+   */
+  async readResource(skillId: string, filename: string): Promise<string> {
+    return firstValueFrom(
+      this.http.get(
+        `${this.baseUrl()}/${skillId}/resources/${encodeURIComponent(filename)}`,
+        { responseType: 'text' }
+      )
+    );
+  }
+
+  /**
+   * Delete one reference file; returns the updated manifest.
+   */
+  async deleteResource(skillId: string, filename: string): Promise<SkillResourceRef[]> {
+    const response = await firstValueFrom(
+      this.http.delete<SkillResourcesResponse>(
+        `${this.baseUrl()}/${skillId}/resources/${encodeURIComponent(filename)}`
+      )
+    );
+    this.skillsResource.reload();
+    return response.resources;
+  }
+
+  /**
+   * Reload the skills resource.
+   */
+  reload(): void {
+    this.skillsResource.reload();
+  }
+}


### PR DESCRIPTION
## PR-5 — Admin frontend for skills (admin-managed Skills)

Adds the `admin/skills/` Angular feature, mirroring `admin/tools/`. Admins can author a skill (instructions + bound catalog tools + S3-backed reference files from PR-4) and grant it to roles. **No backend changes** — this consumes the PR-3 admin API and the PR-4 reference-file endpoints.

Spec: [`docs/specs/admin-skills-rbac-tool-binding.md`](docs/specs/admin-skills-rbac-tool-binding.md) §0.5 (PR-5).

### What's included
- **Models** — `admin-skill.model.ts` (`AdminSkill`, `SkillResourceRef`, create/update/role DTOs, `SKILL_STATUSES`/`SKILL_CATEGORIES`, the shared `skill_id` regex). TS shapes mirror `apis/shared/skills/models.py` (cross-package contract).
- **Service** — `AdminSkillService` (`resource()`+signals): CRUD, role-grant sync, and the reference-file methods (`listResources`/`uploadResource` multipart/`readResource` text/`deleteResource`).
- **List page** — `skill-list.page.ts`: OnPush, search + status filters, expandable rows with bound-tool / reference-file / role badges, row actions (role dialog, edit, soft-delete). Soft delete (disable) keeps the row + reference-file manifest (no orphaned S3 objects).
- **Form page** — `skill-form.page.ts`: reactive form (`skillId` create-only, `displayName`, `description`, `instructions`, `status`, `category`) + **bound-tool picker** + **reference-file management** (multi-file upload, view content, delete, plus inline "new .md" authoring) + **SKILL.md import-prefill**.
- **Dialogs** — `skill-role-dialog` (copy of `tool-role-dialog`) and `tool-picker-dialog` (multi-select **active** catalog tools — the backend rejects binding non-active tools). Both use the redesigned dialog tokens (`rounded-2xl`, `text-sm/6`, `bg-blue-600`) per the frontend CLAUDE.md.
- **Routes + nav** — `skills` / `skills/new` / `skills/edit/:skillId`, and a "Skills" link under **AI Configuration** in the admin nav.

### Import-prefill (§0.4)
Per the chosen scope (**no new dependency**): the importer reads a single `SKILL.md`, parses the YAML frontmatter (`name`→`skillId` slugified, `description`) and body (→`instructions`); reference files are added separately via multi-file upload. **Tool bindings are not imported** (off-the-shelf skills carry no reference to our catalog — picked manually) and **scripts are out of scope**. Validation-walk (§0.6) confirmed this maps a real bundle faithfully. Folder/zip import is a clean follow-up if wanted (would add `jszip`).

### Verification
- `ng test` (the `@angular/build:unit-test` builder) — **31 passing**: `skill-import.util.spec` (frontmatter parse, CRLF, quote-strip, tools-not-imported, slugify, id validation) + `admin-skill.service.spec` (every CRUD/role/reference-file endpoint, incl. multipart upload + text read).
- `ng build` — green; `skill-list-page` / `skill-form-page` chunks AOT-compile with full template type-checking.
- A live clickthrough needs the app-api backend + admin auth (AWS-backed), so it isn't exercisable in a local sandbox — a manual test script is in the PR thread.

### Acceptance
An admin can create/edit/delete a skill, pick bound tools, upload/view/delete reference files, import a `SKILL.md` to prefill, and grant the skill to roles — all from `/admin/skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
