### PR TITLE
feat(skills): runtime — DB-backed load + RBAC + skills_hash + local binding (PR-6a)

### DIFF
--- a/backend/src/agents/main_agent/skill_agent.py
+++ b/backend/src/agents/main_agent/skill_agent.py
@@ -4,21 +4,72 @@ Skill Agent — ChatAgent with progressive skill disclosure.
 Replaces individual skill tools with skill_dispatcher + skill_executor,
 injecting a lightweight skill catalog into the system prompt instead of
 loading all tool schemas upfront.
+
+Two skill sources:
+
+- **DB / admin-managed** (PR-6): when ``accessible_skill_ids`` is provided
+  (the caller resolved them from the user's RBAC roles), the registry loads
+  those ACTIVE skills from the catalog repository. A granted skill's bound
+  catalog tools are added to the agent's tool universe so they materialize
+  (skill-as-grant), and locally-resolved bound tools are folded behind the
+  two meta-tools. Gateway / external MCP bound tools are surfaced as live
+  clients but not yet folded (PR-6b).
+- **File / dev** (legacy): when ``accessible_skill_ids`` is None, the registry
+  scans ``definitions/*/SKILL.md`` and binds local ``@skill``-decorated tools
+  by their ``_skill_name`` stamp, exactly as before — unchanged behavior.
+
+When zero skills are available the agent degrades to plain ``ChatAgent``.
 """
 
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from agents.main_agent.chat_agent import ChatAgent
 from agents.main_agent.core import AgentFactory
-from agents.main_agent.skills import (
-    SkillRegistry,
-    skill_dispatcher,
-    skill_executor,
-    set_dispatcher_registry,
-)
+from agents.main_agent.skills import SkillRegistry, make_skill_tools
 
 logger = logging.getLogger(__name__)
+
+
+def _is_active_status(status: Any) -> bool:
+    """True if a skill record's status is ACTIVE (handles enum or str)."""
+    return str(status).split(".")[-1].lower() == "active"
+
+
+def _fetch_skill_records(skill_ids: List[str]) -> List[Any]:
+    """Fetch ACTIVE skill records for the given ids from the catalog repo.
+
+    Bridges the async repository call into this sync agent-build path the same
+    way ``_register_external_mcp_tools`` / ``_expand_gateway_tool_ids`` do.
+    Returns an empty list on any failure (the agent then degrades to chat).
+    """
+    if not skill_ids:
+        return []
+
+    import asyncio
+
+    from apis.shared.skills.repository import get_skill_catalog_repository
+
+    repo = get_skill_catalog_repository()
+
+    async def _go() -> List[Any]:
+        records = await repo.batch_get_skills(list(skill_ids))
+        return [r for r in records if _is_active_status(getattr(r, "status", "active"))]
+
+    try:
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    return executor.submit(asyncio.run, _go()).result()
+            return loop.run_until_complete(_go())
+        except RuntimeError:
+            return asyncio.run(_go())
+    except Exception as e:  # noqa: BLE001 - degrade to chat on any error
+        logger.warning("Could not load skill records: %s", e)
+        return []
 
 
 class SkillAgent(ChatAgent):
@@ -26,41 +77,76 @@ class SkillAgent(ChatAgent):
     Chat agent with progressive skill disclosure.
 
     Overrides _create_agent() to:
-    1. Discover skills from SKILL.md definitions
-    2. Bind tools to skills via _skill_name metadata
-    3. Replace skill tools with skill_dispatcher + skill_executor
-    4. Inject skill catalog into system prompt
+    1. Discover skills (DB-backed when RBAC ids are supplied, else file scan)
+    2. Bind tools to skills (by catalog id for DB skills, by _skill_name for file)
+    3. Replace skill-bound tools with skill_dispatcher + skill_executor
+    4. Inject the skill catalog into the system prompt
 
-    The LLM sees a lightweight catalog and two meta-tools instead of
-    all individual tool schemas, dramatically reducing token usage.
+    The LLM sees a lightweight catalog and two meta-tools instead of all
+    individual tool schemas, reducing upfront token usage.
     """
 
-    def __init__(self, skills_dir: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        skills_dir: Optional[str] = None,
+        accessible_skill_ids: Optional[List[str]] = None,
+        **kwargs,
+    ):
         """
         Initialize skill agent.
 
         Args:
-            skills_dir: Optional path to skills definitions directory.
-                        Defaults to skills/definitions/ relative to the skills module.
-            **kwargs: All BaseAgent constructor args (session_id, user_id, etc.)
+            skills_dir: Optional path to file-based skill definitions (dev path).
+            accessible_skill_ids: When provided, load these admin/DB skills
+                (already RBAC-resolved for the user). When None, fall back to
+                the file scan.
+            **kwargs: All BaseAgent constructor args (session_id, user_id, ...).
         """
         self._skills_dir = skills_dir
-        self._registry: Optional[SkillRegistry] = None
+        self._accessible_skill_ids = accessible_skill_ids
+        self._db_mode = accessible_skill_ids is not None
+        self._registry: SkillRegistry = SkillRegistry(skills_dir)
+
+        # Discover skills BEFORE super().__init__ so we can augment the enabled
+        # tool set below — the materialization pipeline runs inside
+        # super().__init__ (which calls _create_agent at its tail).
+        if self._db_mode:
+            records = _fetch_skill_records(accessible_skill_ids or [])
+            self._registry.load_records(records)
+        else:
+            self._registry.discover_skills()
+
+        # Skill-as-grant: a granted skill's bound catalog tools become available
+        # whenever this agent runs, independent of the user's per-tool
+        # enabled_tools. Fold them into the enabled set so they materialize.
+        original_enabled_tools = kwargs.get("enabled_tools")
+        bound_ids = self._registry.all_bound_tool_ids()
+        if bound_ids:
+            existing = list(original_enabled_tools or [])
+            kwargs["enabled_tools"] = list(dict.fromkeys(existing + bound_ids))
+
         super().__init__(**kwargs)
 
+        # Resume hashes the construction snapshot's enabled_tools into the
+        # cache key. The augmentation above is recomputed deterministically by
+        # this same constructor, so the snapshot must store the ORIGINAL
+        # (route-supplied) enabled_tools — not the augmented set — or a resume
+        # would land on a different cache slot and orphan the paused agent
+        # (same hazard the system_prompt snapshot avoids). The cache key on the
+        # live turn already uses the original enabled_tools + skills_hash.
+        self._construction_snapshot["enabled_tools"] = original_enabled_tools
+
     def _create_agent(self) -> None:
-        """Create Strands Agent with skill disclosure instead of raw tool schemas."""
+        """Create the Strands Agent with skill disclosure instead of raw tool schemas."""
         try:
-            # Step 1: Get all filtered tools (local + gateway + external MCP)
+            # Step 1: Materialize the (possibly augmented) tool universe.
             all_tools = self._build_filtered_tools()
 
-            # Step 2: Initialize skill registry
-            self._registry = SkillRegistry(self._skills_dir)
-            discovered = self._registry.discover_skills()
-
-            if discovered == 0:
-                logger.warning("No skills discovered — falling back to standard ChatAgent behavior")
-                # Fall back to standard ChatAgent behavior
+            # Step 2: Degrade to plain ChatAgent when there are no skills.
+            if self._registry.get_skill_count() == 0:
+                logger.info(
+                    "No skills available — falling back to standard ChatAgent behavior"
+                )
                 hooks = self._create_hooks()
                 self.agent = AgentFactory.create_agent(
                     model_config=self.model_config,
@@ -71,39 +157,43 @@ class SkillAgent(ChatAgent):
                 )
                 return
 
-            # Step 3: Bind tools to skills
-            self._registry.bind_tools(all_tools)
+            # Step 3: Bind tools to skills.
+            if self._db_mode:
+                self._bind_catalog_tools()
+            else:
+                self._registry.bind_tools(all_tools)
 
-            # Step 4: Separate skill tools from non-skill tools
-            skill_tool_set = set()
+            # Step 4: Fold skill-bound tools out of the top-level list (matched
+            # by object identity — the bound objects are the same instances the
+            # tool filter materialized).
+            skill_tool_ids = set()
             for skill_name in self._registry.get_skill_names():
                 for tool_obj in self._registry.get_tools(skill_name):
-                    skill_tool_set.add(id(tool_obj))
+                    skill_tool_ids.add(id(tool_obj))
+            non_skill_tools = [t for t in all_tools if id(t) not in skill_tool_ids]
 
-            non_skill_tools = [t for t in all_tools if id(t) not in skill_tool_set]
+            # Step 5: Build per-agent meta-tools bound to THIS registry (no
+            # process-global — safe for concurrent per-user skills).
+            dispatcher, executor = make_skill_tools(self._registry)
+            final_tools = non_skill_tools + [dispatcher, executor]
 
-            # Step 5: Wire up the dispatcher registry
-            set_dispatcher_registry(self._registry)
-
-            # Step 6: Build final tool list: non-skill tools + dispatcher + executor
-            final_tools = non_skill_tools + [skill_dispatcher, skill_executor]
-
-            # Step 7: Inject skill catalog into system prompt
+            # Step 6: Inject the skill catalog into the system prompt.
             catalog = self._registry.get_catalog()
             if catalog:
                 if isinstance(self.system_prompt, str):
                     self.system_prompt = self.system_prompt + "\n\n" + catalog
                 elif isinstance(self.system_prompt, list):
-                    # System prompt is a list of content blocks
                     self.system_prompt.append({"text": "\n\n" + catalog})
 
             logger.info(
-                f"SkillAgent created: {discovered} skills, "
-                f"{len(non_skill_tools)} non-skill tools, "
-                f"2 meta-tools (dispatcher + executor)"
+                "SkillAgent created: %d skills (%s), %d non-skill tools, "
+                "2 meta-tools (dispatcher + executor)",
+                self._registry.get_skill_count(),
+                "db" if self._db_mode else "file",
+                len(non_skill_tools),
             )
 
-            # Step 8: Create agent
+            # Step 7: Create the agent.
             hooks = self._create_hooks()
             self.agent = AgentFactory.create_agent(
                 model_config=self.model_config,
@@ -116,6 +206,32 @@ class SkillAgent(ChatAgent):
         except Exception as e:
             logger.error(f"Error creating skill agent: {e}")
             raise
+
+    def _bind_catalog_tools(self) -> None:
+        """Resolve each DB skill's bound catalog tool ids to live objects.
+
+        Local tools resolve via the agent's tool registry (the same instances
+        the tool filter materialized), so they fold cleanly behind the meta-
+        tools. Gateway / external MCP bound ids don't resolve to individual
+        objects here (they're live client objects) — they remain available to
+        the model but are not folded yet (PR-6b).
+        """
+        catalog_map: dict = {}
+        non_local: List[str] = []
+        for tid in self._registry.all_bound_tool_ids():
+            if self.tool_registry.has_tool(tid):
+                catalog_map[tid] = self.tool_registry.get_tool(tid)
+            else:
+                non_local.append(tid)
+
+        self._registry.bind_catalog_tools(catalog_map)
+
+        if non_local:
+            logger.info(
+                "Skill-bound non-local tools are available to the model but not "
+                "folded behind the meta-tools yet (PR-6b): %s",
+                non_local,
+            )
 
     @property
     def registry(self) -> Optional[SkillRegistry]:

--- a/backend/src/agents/main_agent/skills/__init__.py
+++ b/backend/src/agents/main_agent/skills/__init__.py
@@ -12,12 +12,18 @@ upfront, especially as the number of tools grows.
 
 from .decorators import skill, register_skill
 from .skill_registry import SkillRegistry
-from .skill_tools import skill_dispatcher, skill_executor, set_dispatcher_registry
+from .skill_tools import (
+    make_skill_tools,
+    skill_dispatcher,
+    skill_executor,
+    set_dispatcher_registry,
+)
 
 __all__ = [
     "skill",
     "register_skill",
     "SkillRegistry",
+    "make_skill_tools",
     "skill_dispatcher",
     "skill_executor",
     "set_dispatcher_registry",

--- a/backend/src/agents/main_agent/skills/skill_registry.py
+++ b/backend/src/agents/main_agent/skills/skill_registry.py
@@ -91,6 +91,12 @@ class SkillRegistry:
                     "type": meta.get("type", "tool"),
                     "compose": meta.get("compose", []),
                     "tools": [],
+                    "bound_tool_ids": [],
+                    "resources": [],
+                    # File mode: instructions live in the SKILL.md body, read
+                    # on demand from md_path (kept None-instructions so
+                    # load_instructions takes the file path).
+                    "instructions": None,
                     "path": skill_dir,
                     "md_path": skill_md,
                 }
@@ -102,6 +108,77 @@ class SkillRegistry:
 
         logger.info(f"Discovered {count} skills from {self._skills_dir}")
         return count
+
+    def load_records(self, records: List[Any]) -> int:
+        """Populate the registry from DynamoDB-backed skill records.
+
+        The admin-managed (DB) source of skills (PR-6). Each record is a
+        ``SkillDefinition``-shaped object (duck-typed via ``getattr`` so tests
+        can pass simple stand-ins): ``skill_id``, ``description``,
+        ``instructions``, ``compose``, ``bound_tool_ids``, ``resources``.
+
+        Unlike ``discover_skills`` (file scan), instructions are carried inline
+        on the record (no file), and the skill keys on ``skill_id`` — the
+        stable id the model references in the catalog. Returns the number of
+        records loaded.
+        """
+        count = 0
+        for rec in records:
+            name = getattr(rec, "skill_id", None)
+            if not name:
+                continue
+            self._skills[name] = {
+                "description": getattr(rec, "description", "") or "",
+                "type": "tool",
+                "compose": list(getattr(rec, "compose", []) or []),
+                "tools": [],
+                "bound_tool_ids": list(getattr(rec, "bound_tool_ids", []) or []),
+                # Reference-file manifest — served on demand in PR-6b.
+                "resources": list(getattr(rec, "resources", []) or []),
+                # DB mode: instructions are inline (no md_path file).
+                "instructions": getattr(rec, "instructions", "") or "",
+                "path": None,
+                "md_path": None,
+            }
+            count += 1
+            logger.info(f"Loaded skill record: {name}")
+
+        logger.info(f"Loaded {count} skill records from repository")
+        return count
+
+    def all_bound_tool_ids(self) -> List[str]:
+        """Return the de-duplicated union of every skill's bound catalog
+        tool ids (admin/DB skills). Used to augment the agent's tool universe
+        so a granted skill's bound tools materialize (skill-as-grant)."""
+        seen: Dict[str, None] = {}
+        for info in self._skills.values():
+            for tid in info.get("bound_tool_ids", []) or []:
+                seen.setdefault(tid, None)
+        return list(seen.keys())
+
+    def bind_catalog_tools(self, catalog_map: Dict[str, Any]) -> int:
+        """Bind tools to skills by catalog ``tool_id`` (admin/DB skills).
+
+        ``catalog_map`` maps a catalog ``tool_id`` to the live tool object the
+        agent materialized for it. For each skill, every ``bound_tool_id`` that
+        resolves in the map is attached. This is the cross-source-aware analog
+        of ``bind_tools`` (which matches the local-only ``_skill_name`` stamp);
+        in PR-6a only locally-materialized tools resolve here — gateway /
+        external MCP tools are surfaced as live clients but not yet folded.
+
+        Returns the number of (skill, tool) bindings made.
+        """
+        bound = 0
+        for info in self._skills.values():
+            existing_ids = {id(t) for t in info["tools"]}
+            for tid in info.get("bound_tool_ids", []) or []:
+                tool_obj = catalog_map.get(tid)
+                if tool_obj is not None and id(tool_obj) not in existing_ids:
+                    info["tools"].append(tool_obj)
+                    existing_ids.add(id(tool_obj))
+                    bound += 1
+        logger.info(f"Bound {bound} catalog tools across {len(self._skills)} skills")
+        return bound
 
     def bind_tools(self, tools: List[Any]) -> int:
         """
@@ -173,6 +250,10 @@ class SkillRegistry:
         skill = self._skills.get(skill_name)
         if not skill:
             return None
+
+        # DB mode: instructions are carried inline on the record (no file).
+        if not skill.get("md_path"):
+            return skill.get("instructions") or ""
 
         try:
             with open(skill["md_path"], "r", encoding="utf-8") as f:

--- a/backend/src/agents/main_agent/skills/skill_tools.py
+++ b/backend/src/agents/main_agent/skills/skill_tools.py
@@ -7,6 +7,19 @@ Two tools exposed to the agent:
 
 These tools are registered with the Strands Agent in place of the individual
 skill tools, dramatically reducing the upfront token cost.
+
+Two ways to obtain the tools:
+
+- ``make_skill_tools(registry)`` returns a fresh ``(dispatcher, executor)``
+  pair bound to one specific registry via closure. This is what ``SkillAgent``
+  uses, so each agent's meta-tools resolve against **its own** registry. That
+  matters once skills are per-user (admin/DB-backed, RBAC-filtered): a process
+  serves many users concurrently, and a shared module-level registry would let
+  one user's invocation read another user's skills.
+- The module-level ``skill_dispatcher`` / ``skill_executor`` + a process-global
+  registry set by ``set_dispatcher_registry`` remain for the file-based dev
+  path and existing callers. Safe there because every file registry is
+  identical; do NOT use this path for per-user skills.
 """
 
 import asyncio
@@ -18,15 +31,19 @@ from strands import tool
 
 logger = logging.getLogger(__name__)
 
-# Module-level registry reference, set by set_dispatcher_registry()
+# Module-level registry reference, set by set_dispatcher_registry(). Used only
+# by the module-level skill_dispatcher/skill_executor (file/dev path).
 _registry = None
 
 
 def set_dispatcher_registry(registry: Any) -> None:
     """
-    Wire up the SkillRegistry for the dispatcher and executor.
+    Wire up the SkillRegistry for the module-level dispatcher and executor.
 
-    Must be called before the agent invokes skill_dispatcher or skill_executor.
+    Must be called before invoking the module-level skill_dispatcher or
+    skill_executor. NOTE: this is process-global; for per-user (admin/DB)
+    skills use ``make_skill_tools(registry)`` instead, which binds a registry
+    per agent and avoids cross-user bleed under concurrency.
 
     Args:
         registry: SkillRegistry instance
@@ -35,28 +52,10 @@ def set_dispatcher_registry(registry: Any) -> None:
     _registry = registry
 
 
-@tool
-def skill_dispatcher(skill_name: str, reference: str = "", source: str = "") -> str:
-    """
-    Load a skill's instructions, tool schemas, and optional reference or source code.
-
-    Call this tool when you want to activate a skill and learn how to use it.
-    The response includes the skill's detailed instructions (SKILL.md) and
-    the parameter schemas for its tools.
-
-    Args:
-        skill_name: Name of the skill to activate (from the Available Skills catalog)
-        reference: Optional — name of a reference file to read
-        source: Optional — name of a tool function to view source code for
-
-    Returns:
-        JSON string with skill instructions, tool schemas, and optional reference/source
-    """
-    if _registry is None:
-        return json.dumps({"error": "Skill registry not initialized"})
-
-    if not _registry.has_skill(skill_name):
-        available = ", ".join(_registry.get_skill_names())
+def _dispatch(registry: Any, skill_name: str, reference: str = "", source: str = "") -> str:
+    """Core skill_dispatcher logic against an explicit registry."""
+    if not registry.has_skill(skill_name):
+        available = ", ".join(registry.get_skill_names())
         return json.dumps({
             "error": f"Unknown skill '{skill_name}'",
             "available_skills": available,
@@ -65,12 +64,12 @@ def skill_dispatcher(skill_name: str, reference: str = "", source: str = "") -> 
     result = {}
 
     # Load Level 2 instructions
-    instructions = _registry.load_instructions(skill_name)
+    instructions = registry.load_instructions(skill_name)
     if instructions:
         result["instructions"] = instructions
 
     # Load tool schemas so the LLM knows what parameters to pass
-    schemas = _registry.get_tool_schemas(skill_name)
+    schemas = registry.get_tool_schemas(skill_name)
     if schemas:
         result["tool_schemas"] = schemas
 
@@ -80,29 +79,12 @@ def skill_dispatcher(skill_name: str, reference: str = "", source: str = "") -> 
     return json.dumps(result, default=str)
 
 
-@tool
-def skill_executor(skill_name: str, tool_name: str, tool_input: Any = None) -> Any:
-    """
-    Execute a tool within an activated skill.
-
-    Call this tool after using skill_dispatcher to learn which tools are available
-    and what parameters they accept.
-
-    Args:
-        skill_name: Name of the skill containing the tool
-        tool_name: Name of the specific tool to execute
-        tool_input: Input parameters for the tool (dict or JSON string)
-
-    Returns:
-        The tool's execution result
-    """
-    if _registry is None:
-        return json.dumps({"error": "Skill registry not initialized"})
-
-    if not _registry.has_skill(skill_name):
+def _execute(registry: Any, skill_name: str, tool_name: str, tool_input: Any = None) -> Any:
+    """Core skill_executor logic against an explicit registry."""
+    if not registry.has_skill(skill_name):
         return json.dumps({"error": f"Unknown skill '{skill_name}'"})
 
-    tools = _registry.get_tools(skill_name)
+    tools = registry.get_tools(skill_name)
     if not tools:
         return json.dumps({"error": f"No tools found for skill '{skill_name}'"})
 
@@ -133,11 +115,100 @@ def skill_executor(skill_name: str, tool_name: str, tool_input: Any = None) -> A
 
     # Execute the tool
     try:
-        result = _execute_tool(target_tool, tool_input)
-        return result
+        return _execute_tool(target_tool, tool_input)
     except Exception as e:
         logger.error(f"Error executing {skill_name}/{tool_name}: {e}", exc_info=True)
         return json.dumps({"error": str(e)})
+
+
+def make_skill_tools(registry: Any):
+    """Return a ``(skill_dispatcher, skill_executor)`` pair bound to ``registry``.
+
+    Each pair closes over its own registry, so concurrent agents (different
+    users / different accessible skills) never share skill state. This is the
+    per-agent replacement for the module-global ``set_dispatcher_registry``.
+    """
+
+    @tool
+    def skill_dispatcher(skill_name: str, reference: str = "", source: str = "") -> str:
+        """
+        Load a skill's instructions and tool schemas.
+
+        Call this to activate a skill from the Available Skills catalog and
+        learn how to use it. The response includes the skill's detailed
+        instructions and the parameter schemas for its tools.
+
+        Args:
+            skill_name: Name of the skill to activate (from the catalog)
+            reference: Optional — name of a reference file to read
+            source: Optional — name of a tool function to view source for
+
+        Returns:
+            JSON string with the skill's instructions and tool schemas
+        """
+        return _dispatch(registry, skill_name, reference, source)
+
+    @tool
+    def skill_executor(skill_name: str, tool_name: str, tool_input: Any = None) -> Any:
+        """
+        Execute a tool within an activated skill.
+
+        Call this after skill_dispatcher to run one of the skill's tools.
+
+        Args:
+            skill_name: Name of the skill containing the tool
+            tool_name: Name of the specific tool to execute
+            tool_input: Input parameters for the tool (dict or JSON string)
+
+        Returns:
+            The tool's execution result
+        """
+        return _execute(registry, skill_name, tool_name, tool_input)
+
+    return skill_dispatcher, skill_executor
+
+
+@tool
+def skill_dispatcher(skill_name: str, reference: str = "", source: str = "") -> str:
+    """
+    Load a skill's instructions, tool schemas, and optional reference or source code.
+
+    Call this tool when you want to activate a skill and learn how to use it.
+    The response includes the skill's detailed instructions (SKILL.md) and
+    the parameter schemas for its tools.
+
+    Args:
+        skill_name: Name of the skill to activate (from the Available Skills catalog)
+        reference: Optional — name of a reference file to read
+        source: Optional — name of a tool function to view source code for
+
+    Returns:
+        JSON string with skill instructions, tool schemas, and optional reference/source
+    """
+    if _registry is None:
+        return json.dumps({"error": "Skill registry not initialized"})
+    return _dispatch(_registry, skill_name, reference, source)
+
+
+@tool
+def skill_executor(skill_name: str, tool_name: str, tool_input: Any = None) -> Any:
+    """
+    Execute a tool within an activated skill.
+
+    Call this tool after using skill_dispatcher to learn which tools are available
+    and what parameters they accept.
+
+    Args:
+        skill_name: Name of the skill containing the tool
+        tool_name: Name of the specific tool to execute
+        tool_input: Input parameters for the tool (dict or JSON string)
+
+    Returns:
+        The tool's execution result
+    """
+    if _registry is None:
+        return json.dumps({"error": "Skill registry not initialized"})
+    return _execute(_registry, skill_name, tool_name, tool_input)
 
 
 def _execute_tool(tool_obj: Any, tool_input: dict) -> Any:

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -656,6 +656,27 @@ async def ping():
     }
 
 
+async def _resolve_accessible_skill_ids(current_user: User) -> list[str]:
+    """Resolve the skills a user's RBAC roles grant (admin/DB-backed).
+
+    Uses the shared ``AppRoleService`` (the same import-boundary-safe path the
+    model-access check uses) so the runtime never imports ``app_api``. A ``"*"``
+    wildcard grant expands to every known skill id. Never raises — on any
+    failure the user simply gets no skills (the SkillAgent degrades to chat).
+    """
+    try:
+        from apis.shared.rbac.service import get_app_role_service
+        from apis.shared.skills.freshness import get_all_skill_ids
+
+        skills = await get_app_role_service().get_accessible_skills(current_user)
+        if "*" in skills:
+            return sorted(await get_all_skill_ids())
+        return list(skills)
+    except Exception:
+        logger.warning("Failed to resolve accessible skills", exc_info=True)
+        return []
+
+
 @router.post("/invocations")
 async def invocations(request: InvocationRequest, current_user: User = Depends(get_current_user_trusted)):
     """
@@ -677,6 +698,16 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # they bypass quota, file resolution, and RAG augmentation because those
     # already ran on the original turn that got paused.
     is_resume = bool(input_data.interrupt_responses)
+    # Resolve the user's accessible skills (admin/DB-backed, RBAC-gated) once
+    # for the whole request — only for the skill agent path. Threaded into
+    # every get_agent call below so they share one skills_hash cache key
+    # (otherwise the app-tool-call / resume paths would miss the main turn's
+    # cached SkillAgent). The default chat path stays free of the extra reads.
+    accessible_skill_ids = (
+        await _resolve_accessible_skill_ids(current_user)
+        if input_data.agent_type == "skill"
+        else None
+    )
     # A "Continue" after a max_tokens truncation. Like resume, it bypasses
     # quota / RAG / file resolution and does NOT clear the turn state; unlike
     # resume there is no interrupt to validate — the agent is rebuilt from the
@@ -717,6 +748,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=inference_params,
                 agent_type=input_data.agent_type,
                 is_resume=False,
+                accessible_skill_ids=accessible_skill_ids,
             )
             payload = await dispatch_app_tool_call(
                 agent,
@@ -762,6 +794,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=inference_params,
                 agent_type=input_data.agent_type,
                 is_resume=False,
+                accessible_skill_ids=accessible_skill_ids,
             )
             payload = dispatch_app_context_update(
                 agent,
@@ -1277,6 +1310,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=resume_inference_params,
                 agent_type=snapshot.agent_type,
                 is_resume=True,
+                accessible_skill_ids=accessible_skill_ids,
             )
         else:
             # Build the canonical request inference-params dict. The frontend
@@ -1358,6 +1392,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 agent_type=input_data.agent_type,
                 extra_tools=extra_tools,
                 is_resume=False,
+                accessible_skill_ids=accessible_skill_ids,
             )
 
         # Resume requests must target interrupts that the cached agent

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -57,6 +57,7 @@ def _create_cache_key(
     provider: Optional[str],
     freshness_hash: str,
     agent_type: Optional[str],
+    skills_hash: str = "",
 ) -> Tuple:
     """
     Create a cache key for agent instances.
@@ -65,6 +66,13 @@ def _create_cache_key(
     `updated_at` values (see `freshness.get_freshness_hash`). When an
     admin edits a tool's config, the hash changes and the cache misses,
     so the next turn builds a fresh agent with the new config.
+
+    `skills_hash` is the skills analog: a digest of the user's resolved
+    accessible skill ids AND their `updated_at` values (skills/freshness).
+    A SkillAgent's tool universe is derived from the user's granted skills,
+    which `enabled_tools` does not capture — so without this an edit to a
+    granted skill (or a role grant change) would serve a stale agent. Empty
+    for chat agents (no skills), so the default path is unaffected.
     """
     tools_hash = _hash_tools(enabled_tools)
 
@@ -84,6 +92,7 @@ def _create_cache_key(
         provider or "bedrock",
         freshness_hash,
         agent_type or "chat",
+        skills_hash,
     )
 
 
@@ -121,6 +130,7 @@ async def get_agent(
     extra_tools: Optional[list] = None,
     inference_params: Optional[Dict[str, Any]] = None,
     is_resume: bool = False,
+    accessible_skill_ids: Optional[List[str]] = None,
 ) -> BaseAgent:
     """
     Get or create agent instance with current configuration for session
@@ -160,6 +170,18 @@ async def get_agent(
 
     freshness_hash = await get_freshness_hash(enabled_tools or [])
 
+    # Skills dimension of the cache key (skill agents only). Digest of the
+    # user's accessible skill ids + their updated_at, so an edit to a granted
+    # skill or a role-grant change invalidates the cached SkillAgent. Empty
+    # string for the chat path (no accessible_skill_ids) — key unchanged.
+    skills_hash = ""
+    if accessible_skill_ids:
+        from apis.shared.skills.freshness import (
+            get_freshness_hash as get_skills_freshness_hash,
+        )
+
+        skills_hash = await get_skills_freshness_hash(accessible_skill_ids)
+
     cache_key = _create_cache_key(
         session_id=session_id,
         user_id=user_id,
@@ -171,6 +193,7 @@ async def get_agent(
         provider=provider,
         freshness_hash=freshness_hash,
         agent_type=agent_type,
+        skills_hash=skills_hash,
     )
 
     if not extra_tools and cache_key in _agent_cache:
@@ -200,7 +223,7 @@ async def get_agent(
     # existing MainAgent (= ChatAgent) behavior; "skill" routes through
     # SkillAgent's progressive skill disclosure.
     resolved_agent_type = agent_type or "chat"
-    agent = create_agent(
+    create_kwargs: Dict[str, Any] = dict(
         agent_type=resolved_agent_type,
         session_id=session_id,
         user_id=user_id,
@@ -214,6 +237,11 @@ async def get_agent(
         extra_tools=extra_tools,
         inference_params=merged_params,
     )
+    # Only the SkillAgent accepts accessible_skill_ids; ChatAgent's constructor
+    # would reject the unknown kwarg, so gate it on the skill type.
+    if resolved_agent_type == "skill":
+        create_kwargs["accessible_skill_ids"] = accessible_skill_ids
+    agent = create_agent(**create_kwargs)
 
     # Stamp the type onto the construction snapshot so a paused turn can
     # resume on the same factory variant after cache eviction.

--- a/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
@@ -1,0 +1,73 @@
+"""Tests for SkillAgent's DB-source helpers (PR-6).
+
+Covers the repository fetch + ACTIVE filtering that feeds the registry, plus
+the status check — without constructing a full agent (which needs a live model
++ session manager).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agents.main_agent import skill_agent
+
+
+def _rec(skill_id, status="active"):
+    return SimpleNamespace(
+        skill_id=skill_id,
+        description="",
+        instructions="body",
+        compose=[],
+        bound_tool_ids=[],
+        resources=[],
+        status=status,
+    )
+
+
+class TestIsActiveStatus:
+    def test_accepts_string_active(self):
+        assert skill_agent._is_active_status("active") is True
+
+    def test_accepts_enum_repr_active(self):
+        # use_enum_values is on in the model, but be robust to "SkillStatus.ACTIVE".
+        assert skill_agent._is_active_status("SkillStatus.ACTIVE") is True
+
+    def test_rejects_non_active(self):
+        assert skill_agent._is_active_status("draft") is False
+        assert skill_agent._is_active_status("disabled") is False
+
+
+class TestFetchSkillRecords:
+    def test_empty_ids_short_circuit(self):
+        assert skill_agent._fetch_skill_records([]) == []
+
+    def test_filters_to_active_records(self):
+        repo = MagicMock()
+        repo.batch_get_skills = AsyncMock(
+            return_value=[
+                _rec("active_one", status="active"),
+                _rec("draft_one", status="draft"),
+                _rec("disabled_one", status="disabled"),
+            ]
+        )
+        # get_skill_catalog_repository is imported inside the function, so
+        # patch it at the source module.
+        with patch(
+            "apis.shared.skills.repository.get_skill_catalog_repository",
+            return_value=repo,
+        ):
+            records = skill_agent._fetch_skill_records(
+                ["active_one", "draft_one", "disabled_one"]
+            )
+
+        assert [r.skill_id for r in records] == ["active_one"]
+
+    def test_degrades_to_empty_on_repo_error(self):
+        repo = MagicMock()
+        repo.batch_get_skills = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch(
+            "apis.shared.skills.repository.get_skill_catalog_repository",
+            return_value=repo,
+        ):
+            # Never raises into agent construction — returns [] so the agent
+            # degrades to chat.
+            assert skill_agent._fetch_skill_records(["x"]) == []

--- a/backend/tests/agents/main_agent/skills/test_skill_registry.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_registry.py
@@ -139,3 +139,90 @@ class TestTools:
         schemas = registry.get_tool_schemas("web-search")
         assert len(schemas) == 1
         assert schemas[0]["name"] == "web_search"
+
+
+class _Rec:
+    """Minimal SkillDefinition stand-in (duck-typed by load_records)."""
+
+    def __init__(self, skill_id, description="", instructions="", compose=None,
+                 bound_tool_ids=None, resources=None, status="active"):
+        self.skill_id = skill_id
+        self.description = description
+        self.instructions = instructions
+        self.compose = compose or []
+        self.bound_tool_ids = bound_tool_ids or []
+        self.resources = resources or []
+        self.status = status
+
+
+class TestDbSource:
+    """Req SK-6 (PR-6): DynamoDB-backed skill records (admin-managed)."""
+
+    def test_load_records_populates_registry(self):
+        reg = SkillRegistry()
+        n = reg.load_records([
+            _Rec("pdf_workflows", description="PDFs", instructions="# PDF body",
+                 bound_tool_ids=["fill_pdf_form"]),
+            _Rec("doc_basics", description="Docs"),
+        ])
+        assert n == 2
+        assert reg.get_skill_count() == 2
+        assert reg.has_skill("pdf_workflows")
+        # Catalog lists the DB skills by skill_id + description.
+        catalog = reg.get_catalog()
+        assert "pdf_workflows" in catalog and "PDFs" in catalog
+
+    def test_load_instructions_returns_inline_body(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("pdf_workflows", instructions="# Inline body")])
+        # DB mode: instructions come from the record, not a file.
+        assert reg.load_instructions("pdf_workflows") == "# Inline body"
+
+    def test_all_bound_tool_ids_unions_and_dedupes(self):
+        reg = SkillRegistry()
+        reg.load_records([
+            _Rec("a", bound_tool_ids=["t1", "t2"]),
+            _Rec("b", bound_tool_ids=["t2", "t3"]),
+        ])
+        assert sorted(reg.all_bound_tool_ids()) == ["t1", "t2", "t3"]
+
+    def test_bind_catalog_tools_binds_matching_ids_only(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", bound_tool_ids=["local_tool", "gateway_x"])])
+
+        def local_tool():
+            return "ok"
+        local_tool.tool_name = "local_tool"
+
+        # Only the resolvable (local) id is in the map; the gateway id is not.
+        reg.bind_catalog_tools({"local_tool": local_tool})
+        tools = reg.get_tools("a")
+        assert tools == [local_tool]
+        # Schema reflects the bound local tool.
+        assert reg.get_tool_schemas("a")[0]["name"] == "local_tool"
+
+    def test_bind_catalog_tools_is_idempotent(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", bound_tool_ids=["t"])])
+
+        def t():
+            return 1
+        t.tool_name = "t"
+
+        reg.bind_catalog_tools({"t": t})
+        reg.bind_catalog_tools({"t": t})
+        assert reg.get_tools("a") == [t]  # not double-bound
+
+    def test_db_composite_aggregates_child_tools(self):
+        reg = SkillRegistry()
+        reg.load_records([
+            _Rec("child", bound_tool_ids=["t"]),
+            _Rec("parent", compose=["child"]),
+        ])
+
+        def t():
+            return 1
+        t.tool_name = "t"
+
+        reg.bind_catalog_tools({"t": t})
+        assert reg.get_tools("parent") == [t]

--- a/backend/tests/agents/main_agent/skills/test_skill_tools.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_tools.py
@@ -114,3 +114,67 @@ class TestDecorators:
         register_skill("batch-skill", tools=[tool_a, tool_b])
         assert tool_a._skill_name == "batch-skill"
         assert tool_b._skill_name == "batch-skill"
+
+
+class TestMakeSkillTools:
+    """Req SD-3 (PR-6): per-agent meta-tools bound to their own registry.
+
+    The concurrency fix: two agents serving different users must not share
+    skill state through a process-global registry.
+    """
+
+    def _registry_with(self, skill_id):
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        reg = SkillRegistry()
+
+        class _Rec:
+            def __init__(self, sid):
+                self.skill_id = sid
+                self.description = f"desc {sid}"
+                self.instructions = f"# {sid} body"
+                self.compose = []
+                self.bound_tool_ids = []
+                self.resources = []
+                self.status = "active"
+
+        reg.load_records([_Rec(skill_id)])
+        return reg
+
+    def test_each_pair_resolves_against_its_own_registry(self):
+        from agents.main_agent.skills.skill_tools import (
+            make_skill_tools,
+            set_dispatcher_registry,
+        )
+
+        # A stray global registry must NOT leak into the closures.
+        set_dispatcher_registry(None)
+
+        reg_a = self._registry_with("skill_a")
+        reg_b = self._registry_with("skill_b")
+        dispatch_a, _ = make_skill_tools(reg_a)
+        dispatch_b, _ = make_skill_tools(reg_b)
+
+        a = json.loads(dispatch_a(skill_name="skill_a"))
+        assert "# skill_a body" in a["instructions"]
+
+        # reg_b doesn't know skill_a → its dispatcher reports it unknown,
+        # proving the pairs are isolated (no shared global).
+        cross = json.loads(dispatch_b(skill_name="skill_a"))
+        assert "error" in cross and "Unknown skill" in cross["error"]
+
+        b = json.loads(dispatch_b(skill_name="skill_b"))
+        assert "# skill_b body" in b["instructions"]
+
+    def test_factory_pair_ignores_module_global(self):
+        from agents.main_agent.skills.skill_tools import (
+            make_skill_tools,
+            set_dispatcher_registry,
+        )
+
+        reg = self._registry_with("only_skill")
+        dispatch, _ = make_skill_tools(reg)
+        # Even with the global cleared, the closure works.
+        set_dispatcher_registry(None)
+        result = json.loads(dispatch(skill_name="only_skill"))
+        assert "# only_skill body" in result["instructions"]

--- a/backend/tests/apis/inference_api/test_chat_service.py
+++ b/backend/tests/apis/inference_api/test_chat_service.py
@@ -183,3 +183,69 @@ async def test_non_resume_keeps_non_paused_cached_agent(
 
     assert second is first
     assert mock_create_agent.call_count == 1
+
+
+def test_create_cache_key_includes_skills_hash():
+    """Two skill sets must not collide in the agent cache (skills_hash)."""
+    base = dict(
+        session_id="s",
+        user_id="u",
+        enabled_tools=["t"],
+        model_id="m",
+        inference_params={},
+        system_prompt=None,
+        caching_enabled=False,
+        provider="bedrock",
+        freshness_hash="f",
+        agent_type="skill",
+    )
+    k1 = service._create_cache_key(**base, skills_hash="aaa")
+    k2 = service._create_cache_key(**base, skills_hash="bbb")
+    assert k1 != k2
+    assert k1[-1] == "aaa"
+    # Default (chat) callers omit it → stable empty trailing element.
+    assert service._create_cache_key(**base)[-1] == ""
+
+
+@pytest.mark.asyncio
+async def test_skills_hash_separates_skill_agent_cache_slots(
+    mock_create_agent, mock_freshness_hash
+):
+    """Same session+user but different accessible skills → different agents;
+    identical skills → cache hit. Verifies skills_hash is threaded into the key.
+    """
+    with patch(
+        "apis.shared.skills.freshness.get_freshness_hash",
+        new=AsyncMock(side_effect=lambda ids: "|".join(sorted(ids))),
+    ):
+        a1 = await service.get_agent(
+            session_id="s", user_id="u", agent_type="skill",
+            accessible_skill_ids=["pdf"],
+        )
+        a1_again = await service.get_agent(
+            session_id="s", user_id="u", agent_type="skill",
+            accessible_skill_ids=["pdf"],
+        )
+        a2 = await service.get_agent(
+            session_id="s", user_id="u", agent_type="skill",
+            accessible_skill_ids=["pdf", "docx"],
+        )
+
+    assert a1 is a1_again            # same skills → cache hit
+    assert a1 is not a2             # different skills → distinct slot
+    assert mock_create_agent.call_count == 2
+    # The skill path forwards the resolved ids to the factory.
+    forwarded = [c.kwargs.get("accessible_skill_ids") for c in mock_create_agent.call_args_list]
+    assert ["pdf"] in forwarded and ["pdf", "docx"] in forwarded
+
+
+@pytest.mark.asyncio
+async def test_chat_path_unaffected_by_skills_hash(mock_create_agent, mock_freshness_hash):
+    """The default chat path passes no accessible skills → skills_hash empty,
+    cache behaves exactly as before, and accessible_skill_ids isn't forwarded.
+    """
+    a = await service.get_agent(session_id="s", user_id="u")
+    a_again = await service.get_agent(session_id="s", user_id="u")
+    assert a is a_again
+    assert mock_create_agent.call_count == 1
+    assert "accessible_skill_ids" not in mock_create_agent.call_args.kwargs


### PR DESCRIPTION
## PR-6a — Skills runtime: DB-backed load + RBAC + cache key + binding (opt-in)

First slice of the runtime wiring (spec §0.5 PR-6). Makes admin-authored skills actually load for the right users, fold their local tools behind the meta-tools, and cache correctly — **opt-in via `agent_type="skill"`, so the default `"chat"` path is unchanged (zero behavior change)**.

PR-6 was too big for one PR; this is the foundation. Deferred to follow-ups: **PR-6b** = folding gateway/external MCP tools behind the meta-tools (genuinely hard — they materialize as client objects, not individual callables) + the read-reference-file disclosure level + an example-skill seed; **PR-7** = flip the default.

### What's included
- **DB-backed `SkillRegistry` source** (`skill_registry.py`): `load_records()` populates the registry from `SkillCatalogRepository` records (instructions inline, `bound_tool_ids`, `compose`, `resources` manifest). `load_instructions()` is DB-aware (inline body, no file). Adds `all_bound_tool_ids()` and `bind_catalog_tools(catalog_id → live object)` — the cross-source-aware analog of the local-only `_skill_name` binding. The file scan stays as the dev/legacy path, unchanged.
- **Per-agent meta-tools** (`skill_tools.py`): new `make_skill_tools(registry)` returns a `(dispatcher, executor)` pair bound to one registry by closure. **Fixes a latent concurrency bug**: the module-global `_registry` was safe only because every file registry was identical; with per-user (RBAC-filtered) skills, concurrent invocations would read whichever registry was built last. The module-level functions + `set_dispatcher_registry` remain for the dev path.
- **`SkillAgent` rework** (`skill_agent.py`): DB discovery + **`enabled_tools` augmentation** before `super().__init__` (your call: a granted skill carries authorization — its bound tools become available, all sources) → materialize → bind/fold **local** tools behind the meta-tools; gateway/external bound tools are available to the model but not folded yet (logged, PR-6b). Degrades to plain `ChatAgent` at zero skills. Restores the original `enabled_tools` in the construction snapshot so a paused-then-resumed skill turn hashes back to the same cache slot.
- **RBAC threading + `skills_hash`** (`chat/service.py`, `chat/routes.py`): the route resolves the user's accessible skills via the shared `AppRoleService.get_accessible_skills` (`"*"` → `get_all_skill_ids()`) — import-boundary-safe, the same path the model-access check uses — and threads them into every `get_agent` call (so the app-tool-call / resume paths share one cache key). `get_agent` adds a `skills_hash` (digest of accessible ids + their `updated_at`, via `skills/freshness`) to `_create_cache_key`, so an edit to a granted skill or a role-grant change invalidates the cached SkillAgent. Empty for the chat path → key unchanged.

### Verification
- `cd backend && uv run python -m pytest tests/ -v` — full suite green (the only correctness gate).
- New/updated tests: registry DB source + `bind_catalog_tools` + composite aggregation; `make_skill_tools` per-agent isolation (no global bleed); `skills_hash` separates cache slots + chat path unaffected; `_fetch_skill_records` ACTIVE-filtering + error degradation. Existing file-based skill tests unchanged and passing.
- Import boundaries clean (`agents`/`inference_api` reach skills/RBAC only via `apis.shared`).

### Notes
- Opt-in and dark: nothing flips `agent_type` to `"skill"` yet, so production behavior is unchanged. A live end-to-end walk (spec §0.6, against a real seeded skill) lands with the PR-6b seed.
- Gateway/external **availability** works now (augmentation); their **folding** behind the meta-tools is the PR-6b design.

Spec: docs/specs/admin-skills-rbac-tool-binding.md §0.5 (PR-6), §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
