### PR TITLE
feat(skills): runtime MCP-tool folding + reference-file disclosure + example seed (PR-6b)

### DIFF
--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -21,6 +21,7 @@ Environment variables:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import sys
@@ -28,7 +29,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -760,6 +761,263 @@ def seed_default_tools(
 
 
 
+# =============================================================================
+# Example bundled skill (PR-6b)
+# =============================================================================
+#
+# Seeds one demonstrable admin-managed Skill so the feature can be exercised
+# end-to-end: SKILL.md-style instructions + a bound LOCAL catalog tool
+# (fetch_url_content, seeded above) + a supporting reference file (uploaded to
+# the skill-resources S3 bucket and referenced by the row's `resources`
+# manifest). Mirrors the real `pdf`/`docx` bundle shape, where the instructions
+# body names a reference file the agent reads on demand via skill_dispatcher.
+#
+# The skill is granted to the `default` role so any user can reach it once an
+# assistant opts into agent_type="skill". It is otherwise inert: the default
+# agent_type stays "chat", so this changes nothing for existing chats.
+
+EXAMPLE_SKILL_ID = "web_research"
+
+EXAMPLE_SKILL_REFERENCE_FILENAME = "extraction_tips.md"
+
+EXAMPLE_SKILL_REFERENCE_BODY = b"""# Extraction Tips
+
+Guidance for turning a fetched web page into citable, well-structured notes.
+
+## Prefer primary sources
+- Quote the page's own words for any claim you will cite; paraphrase only
+  after you have the exact wording recorded.
+- Capture the page title and URL alongside every excerpt so a citation can be
+  reconstructed later.
+
+## Tables and lists
+- Re-render HTML tables as Markdown tables; keep the original column order.
+- Preserve list nesting - it usually encodes hierarchy that matters.
+
+## Noise to drop
+- Navigation chrome, cookie banners, "related articles", and ad copy are not
+  content. Exclude them before summarizing.
+
+## When a page is thin or blocked
+- If the fetched text is a paywall stub or a JS placeholder, say so explicitly
+  rather than summarizing the stub as if it were the article.
+"""
+
+EXAMPLE_SKILL_INSTRUCTIONS = (
+    "# Web Research Assistant\n"
+    "\n"
+    "Help the user research a topic by fetching web pages and turning them into\n"
+    "accurate, citable notes.\n"
+    "\n"
+    "## Workflow\n"
+    "1. Use the bound `fetch_url_content` tool (via `skill_executor`) to pull\n"
+    "   the page text for each URL the user provides.\n"
+    "2. Extract the relevant facts. For handling tables, paywalls, and noisy\n"
+    "   pages, read `extraction_tips.md` — call `skill_dispatcher` again with\n"
+    "   `reference=\"extraction_tips.md\"`.\n"
+    "3. Summarize with inline source attributions (page title + URL).\n"
+    "\n"
+    "Never invent details that are not present in the fetched content.\n"
+)
+
+
+def _upload_skill_reference(
+    skill_id: str, filename: str, content: bytes, content_type: str, region: str
+) -> Optional[dict[str, Any]]:
+    """Upload a reference file's bytes to the skill-resources bucket.
+
+    Content-addressed (``skills/{skill_id}/{sha256}``), mirroring
+    ``apis/shared/skills/resource_store.py``. Best-effort: returns the manifest
+    entry on success, or ``None`` (with a warning) when the bucket is not
+    configured or the put fails, so the skill still seeds without the bytes.
+    """
+    bucket = os.environ.get("S3_SKILL_RESOURCES_BUCKET_NAME", "")
+    if not bucket:
+        logger.warning(
+            "S3_SKILL_RESOURCES_BUCKET_NAME unset — seeding '%s' without its "
+            "reference file '%s'",
+            skill_id,
+            filename,
+        )
+        return None
+
+    digest = hashlib.sha256(content).hexdigest()
+    key = f"skills/{skill_id}/{digest}"
+    try:
+        s3 = boto3.Session(region_name=region).client("s3")
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=content,
+            ContentType=content_type,
+            ServerSideEncryption="AES256",
+        )
+    except ClientError as e:
+        logger.warning(
+            "Could not upload reference '%s' for skill '%s' to %s — seeding "
+            "without it: %s",
+            filename,
+            skill_id,
+            bucket,
+            e,
+        )
+        return None
+
+    logger.info("Uploaded reference '%s' for skill '%s' to s3://%s/%s", filename, skill_id, bucket, key)
+    return {
+        "filename": filename,
+        "contentHash": digest,
+        "size": len(content),
+        "contentType": content_type,
+        "s3Key": key,
+    }
+
+
+def _grant_skill_to_default_role(table, skill_id: str) -> None:
+    """Grant ``skill_id`` to the ``default`` role (idempotent).
+
+    RBAC resolution reads the precomputed ``effectivePermissions.skills`` on the
+    role DEFINITION (see ``apis/shared/rbac/service.py::_merge_permissions``), so
+    granting requires patching that array — the reverse-lookup ``SKILL_GRANT#``
+    item alone is not enough. Writes both. No-op if the default role is absent.
+    """
+    pk = "ROLE#default"
+    try:
+        existing = table.get_item(Key={"PK": pk, "SK": "DEFINITION"})
+    except ClientError as e:
+        logger.warning("Could not read default role for skill grant: %s", e)
+        return
+
+    item = existing.get("Item")
+    if not item:
+        logger.warning(
+            "default role not found — skipping grant of example skill '%s' "
+            "(system_admin's skills=['*'] still covers it)",
+            skill_id,
+        )
+        return
+
+    granted = list(item.get("grantedSkills", []) or [])
+    eff = dict(item.get("effectivePermissions", {}) or {})
+    eff_skills = list(eff.get("skills", []) or [])
+
+    changed = False
+    if skill_id not in granted:
+        granted.append(skill_id)
+        changed = True
+    if "*" not in eff_skills and skill_id not in eff_skills:
+        eff_skills.append(skill_id)
+        changed = True
+
+    if changed:
+        eff["skills"] = eff_skills
+        table.update_item(
+            Key={"PK": pk, "SK": "DEFINITION"},
+            UpdateExpression="SET grantedSkills = :g, effectivePermissions = :e",
+            ExpressionAttributeValues={":g": granted, ":e": eff},
+        )
+        logger.info("Granted example skill '%s' to default role", skill_id)
+
+    # Reverse-lookup grant item (so /admin/skills/{id}/roles lists 'default').
+    table.put_item(
+        Item={
+            "PK": pk,
+            "SK": f"SKILL_GRANT#{skill_id}",
+            "GSI2PK": f"SKILL#{skill_id}",
+            "GSI2SK": pk,
+            "roleId": "default",
+            "displayName": "Default",
+            "enabled": True,
+        }
+    )
+
+
+def seed_example_skills(
+    table_name: str,
+    region: str,
+) -> SeedResult:
+    """Seed one example bundled skill (instructions + bound tool + reference file)."""
+    result = SeedResult(category="skill")
+    session = boto3.Session(region_name=region)
+    dynamodb = session.resource("dynamodb")
+    table = dynamodb.Table(table_name)
+
+    skill_id = EXAMPLE_SKILL_ID
+    pk = f"SKILL#{skill_id}"
+    sk = "METADATA"
+
+    try:
+        existing = table.get_item(Key={"PK": pk, "SK": sk})
+        if "Item" in existing:
+            msg = f"Example skill '{skill_id}' already exists — skipped"
+            logger.info(msg)
+            result.skipped += 1
+            result.details.append(msg)
+            # Still (idempotently) ensure the default-role grant is present.
+            _grant_skill_to_default_role(table, skill_id)
+            return result
+    except ClientError as e:
+        msg = f"Failed to check existing skill '{skill_id}': {e}"
+        logger.error(msg)
+        result.failed += 1
+        result.details.append(msg)
+        return result
+
+    # Upload the supporting reference file (best-effort — see helper).
+    resources: list[dict[str, Any]] = []
+    ref = _upload_skill_reference(
+        skill_id,
+        EXAMPLE_SKILL_REFERENCE_FILENAME,
+        EXAMPLE_SKILL_REFERENCE_BODY,
+        "text/markdown",
+        region,
+    )
+    if ref:
+        resources.append(ref)
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    item: dict[str, Any] = {
+        "PK": pk,
+        "SK": sk,
+        # SkillOwnerIndex (GSI4) — mirrors SkillDefinition.to_dynamo_item.
+        "GSI4PK": "OWNER#system",
+        "GSI4SK": f"SKILL#{skill_id}",
+        "skillId": skill_id,
+        "displayName": "Web Research Assistant",
+        "description": "Fetch web pages and turn them into accurate, citable notes.",
+        "instructions": EXAMPLE_SKILL_INSTRUCTIONS,
+        "boundToolIds": ["fetch_url_content"],
+        "compose": [],
+        "resources": resources,
+        "status": "active",
+        "ownerId": "system",
+        "visibility": "admin",
+        "createdAt": now,
+        "updatedAt": now,
+        "createdBy": "bootstrap-seed",
+    }
+
+    try:
+        table.put_item(Item=item)
+        msg = (
+            f"Example skill '{skill_id}' created "
+            f"({len(resources)} reference file(s))"
+        )
+        logger.info(msg)
+        result.created += 1
+        result.details.append(msg)
+    except ClientError as e:
+        msg = f"Failed to write example skill '{skill_id}': {e}"
+        logger.error(msg)
+        result.failed += 1
+        result.details.append(msg)
+        return result
+
+    _grant_skill_to_default_role(table, skill_id)
+    return result
+
+
 def _serialize(item: dict[str, Any]) -> dict[str, Any]:
     """Convert a high-level DynamoDB item dict to low-level client format."""
     from boto3.dynamodb.types import TypeSerializer
@@ -819,6 +1077,9 @@ def main() -> None:
 
     # --- Tool seeding ---
     results.append(seed_default_tools(table_name=app_roles_table, region=region))
+
+    # --- Example bundled skill (PR-6b) ---
+    results.append(seed_example_skills(table_name=app_roles_table, region=region))
 
     # --- Summary ---
     print_summary(results)

--- a/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/gateway_mcp_client.py
@@ -16,6 +16,7 @@ from agents.main_agent.integrations.mcp_apps import (
     ensure_ui_extension_session_patch,
     record_and_filter_ui_tools,
 )
+from agents.main_agent.integrations.mcp_tool_folding import drop_folded_tools
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,11 @@ class FilteredMCPClient(MCPClient):
         # `self` is the client hosting these tools — recorded so PR #3 can
         # issue `resources/read` against it.
         filtered_tools = record_and_filter_ui_tools(filtered_tools, client=self)
+
+        # Drop tools folded behind a skill's meta-tools (PR-6b). No-op unless a
+        # SkillAgent registered a fold set for this client. The tools stay
+        # executable via skill_executor → this client's call_tool_sync.
+        filtered_tools = drop_folded_tools(self, filtered_tools)
 
         return PaginatedList(filtered_tools, token=paginated_result.pagination_token)
 

--- a/backend/src/agents/main_agent/integrations/mcp_apps.py
+++ b/backend/src/agents/main_agent/integrations/mcp_apps.py
@@ -726,4 +726,12 @@ class UICapableMCPClient(MCPClient):
     def list_tools_sync(self, *args: Any, **kwargs: Any) -> PaginatedList:
         result = super().list_tools_sync(*args, **kwargs)
         filtered = record_and_filter_ui_tools(list(result), client=self)
+        # Drop tools folded behind a skill's meta-tools (PR-6b). No-op unless a
+        # SkillAgent registered a fold set for this client; imported lazily to
+        # avoid a module import cycle (mcp_tool_folding is integration-neutral).
+        from agents.main_agent.integrations.mcp_tool_folding import (
+            drop_folded_tools,
+        )
+
+        filtered = drop_folded_tools(self, filtered)
         return PaginatedList(filtered, token=result.pagination_token)

--- a/backend/src/agents/main_agent/integrations/mcp_tool_folding.py
+++ b/backend/src/agents/main_agent/integrations/mcp_tool_folding.py
@@ -1,0 +1,82 @@
+"""Hide specific MCP tools from a client's model-facing tool list (PR-6b).
+
+Gateway and external MCP servers are handed to the Strands ``Agent`` as
+*client objects*, not as individual callables: Strands enumerates each
+client's tools through its ``list_tools_sync`` and adds one ``MCPAgentTool``
+per server tool. That is exactly why PR-6a could fold only LOCAL tools — there
+was no per-tool object to pull out of the top-level list.
+
+This module supplies the missing seam. A skill that binds a gateway/external
+tool registers that tool's *agent-facing name* as **folded** on the owning
+client; the client's ``list_tools_sync`` then drops it, so its schema never
+rides in the model's context. The tool stays fully executable: the client
+object remains in the agent's tool list (Strands keeps its session alive), and
+``skill_executor`` invokes the folded tool through the client's
+``call_tool_sync`` (see ``agents/main_agent/skills/mcp_binding.py``).
+
+Free functions (rather than a base class) so any ``MCPClient`` subclass opts in
+with two lines in its ``list_tools_sync`` and no change to its hierarchy — and
+so the mechanism works for clients constructed before a fold set is known.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, List
+
+logger = logging.getLogger(__name__)
+
+#: Attribute the fold set is stashed under on a client. Private/namespaced so
+#: it never collides with Strands' own attributes.
+_FOLD_ATTR = "_skill_folded_tool_names"
+
+
+def set_folded_tool_names(client: Any, names: Iterable[str]) -> None:
+    """Mark ``names`` as folded on ``client`` (hidden from its model tool list).
+
+    Idempotently *adds* to any existing fold set so binding two skills to the
+    same client accumulates rather than overwrites. Also invalidates the
+    client's cached ``_loaded_tools`` (set by a prior ``load_tools`` pre-flight)
+    so Strands re-lists through ``list_tools_sync`` with the fold applied — the
+    external pre-flight in ``BaseAgent._build_filtered_tools`` primes that cache
+    *before* folds are known, and without this reset the model would still see
+    the folded schemas.
+    """
+    existing = getattr(client, _FOLD_ATTR, None)
+    folded = set(existing) if existing else set()
+    folded.update(names)
+    setattr(client, _FOLD_ATTR, folded)
+
+    # Drop any cached tool list so the next load_tools() re-lists with the fold.
+    if getattr(client, "_loaded_tools", None) is not None:
+        try:
+            client._loaded_tools = None
+        except Exception:  # pragma: no cover - defensive; attr is a plain field
+            logger.debug("could not reset _loaded_tools on %r", client, exc_info=True)
+
+
+def folded_tool_names(client: Any) -> set:
+    """Return the (copy of the) fold set on ``client``, or an empty set."""
+    existing = getattr(client, _FOLD_ATTR, None)
+    return set(existing) if existing else set()
+
+
+def drop_folded_tools(client: Any, tools: List[Any]) -> List[Any]:
+    """Filter folded tools out of a ``list_tools_sync`` result.
+
+    Matches on the agent-facing ``tool_name`` (the name the model and
+    ``skill_executor`` use). A no-op when nothing is folded, so it is safe to
+    call unconditionally from any client's ``list_tools_sync``.
+    """
+    folded = getattr(client, _FOLD_ATTR, None)
+    if not folded:
+        return tools
+    kept = [t for t in tools if getattr(t, "tool_name", None) not in folded]
+    if len(kept) != len(tools):
+        logger.info(
+            "Folded %d MCP tool(s) out of the model tool list (behind skill "
+            "meta-tools): %s",
+            len(tools) - len(kept),
+            sorted(folded),
+        )
+    return kept

--- a/backend/src/agents/main_agent/skill_agent.py
+++ b/backend/src/agents/main_agent/skill_agent.py
@@ -11,9 +11,10 @@ Two skill sources:
   (the caller resolved them from the user's RBAC roles), the registry loads
   those ACTIVE skills from the catalog repository. A granted skill's bound
   catalog tools are added to the agent's tool universe so they materialize
-  (skill-as-grant), and locally-resolved bound tools are folded behind the
-  two meta-tools. Gateway / external MCP bound tools are surfaced as live
-  clients but not yet folded (PR-6b).
+  (skill-as-grant). Local tools fold behind the two meta-tools by object
+  identity; gateway / external MCP bound tools fold via the MCP client (their
+  schemas are dropped from the model tool list and they execute through
+  ``call_tool_sync`` — see ``skills/mcp_binding.py``, PR-6b).
 - **File / dev** (legacy): when ``accessible_skill_ids`` is None, the registry
   scans ``definitions/*/SKILL.md`` and binds local ``@skill``-decorated tools
   by their ``_skill_name`` stamp, exactly as before — unchanged behavior.
@@ -159,7 +160,8 @@ class SkillAgent(ChatAgent):
 
             # Step 3: Bind tools to skills.
             if self._db_mode:
-                self._bind_catalog_tools()
+                self._bind_catalog_tools()  # local tools (by catalog id)
+                self._bind_mcp_tools()      # gateway / external MCP tools (folded)
             else:
                 self._registry.bind_tools(all_tools)
 
@@ -208,30 +210,82 @@ class SkillAgent(ChatAgent):
             raise
 
     def _bind_catalog_tools(self) -> None:
-        """Resolve each DB skill's bound catalog tool ids to live objects.
+        """Resolve each DB skill's bound LOCAL catalog tool ids to live objects.
 
         Local tools resolve via the agent's tool registry (the same instances
         the tool filter materialized), so they fold cleanly behind the meta-
-        tools. Gateway / external MCP bound ids don't resolve to individual
-        objects here (they're live client objects) — they remain available to
-        the model but are not folded yet (PR-6b).
+        tools by object identity. Gateway / external MCP bound ids don't resolve
+        to individual objects here (they're live client objects) and are handled
+        by :meth:`_bind_mcp_tools`.
         """
         catalog_map: dict = {}
-        non_local: List[str] = []
         for tid in self._registry.all_bound_tool_ids():
             if self.tool_registry.has_tool(tid):
                 catalog_map[tid] = self.tool_registry.get_tool(tid)
-            else:
-                non_local.append(tid)
 
         self._registry.bind_catalog_tools(catalog_map)
 
-        if non_local:
-            logger.info(
-                "Skill-bound non-local tools are available to the model but not "
-                "folded behind the meta-tools yet (PR-6b): %s",
-                non_local,
-            )
+    def _bind_mcp_tools(self) -> None:
+        """Fold a granted skill's gateway / external MCP bound tools (PR-6b).
+
+        These materialize as *client objects* (one ``MCPClient`` per server,
+        exposing many tools), not individual callables — which is why PR-6a left
+        them visible. Here each bound non-local id is classified (gateway vs
+        external), resolved to its concrete MCP tool(s) + owning client, wrapped
+        as a ``FoldedMCPTool`` bound into the registry (so the meta-tools can
+        show its schema and run it), and its agent-facing name is folded off the
+        client's model tool list. The client object stays in the agent's tool
+        list, so Strands keeps its session alive for ``call_tool_sync``.
+        """
+        non_local = [
+            tid
+            for tid in self._registry.all_bound_tool_ids()
+            if not self.tool_registry.has_tool(tid)
+        ]
+        if not non_local:
+            return
+
+        # Classify the non-local bound ids with the same filter that
+        # materialized the clients (its external set was populated from the
+        # augmented enabled_tools in __init__).
+        classified = self.tool_filter.filter_tools_extended(non_local)
+        gateway_ids = classified.gateway_tool_ids
+        external_ids = classified.external_mcp_tool_ids
+        if not gateway_ids and not external_ids:
+            return
+
+        from agents.main_agent.integrations.external_mcp_client import (
+            get_external_mcp_integration,
+        )
+        from agents.main_agent.integrations.mcp_tool_folding import (
+            set_folded_tool_names,
+        )
+        from agents.main_agent.skills.mcp_binding import resolve_mcp_bindings
+
+        external_integration = get_external_mcp_integration()
+
+        bindings = resolve_mcp_bindings(
+            gateway_ids=gateway_ids,
+            external_ids=external_ids,
+            gateway_client=self.gateway_integration.client,
+            expand_gateway=self._expand_gateway_tool_ids,
+            external_client_lookup=lambda tid: external_integration.get_client(
+                tid, self.user_id
+            ),
+        )
+
+        if bindings.catalog_map:
+            self._registry.bind_catalog_tools(bindings.catalog_map)
+        for client, names in bindings.fold_by_client.items():
+            set_folded_tool_names(client, names)
+
+        folded_count = sum(len(v) for v in bindings.catalog_map.values())
+        logger.info(
+            "SkillAgent folded %d gateway/external MCP tool(s) behind the meta-"
+            "tools (%d unresolved)",
+            folded_count,
+            len(bindings.unresolved),
+        )
 
     @property
     def registry(self) -> Optional[SkillRegistry]:

--- a/backend/src/agents/main_agent/skills/mcp_binding.py
+++ b/backend/src/agents/main_agent/skills/mcp_binding.py
@@ -1,0 +1,301 @@
+"""Resolve a skill's gateway / external MCP bound tools into foldable adapters.
+
+PR-6a folded only LOCAL callable tools behind ``skill_dispatcher`` /
+``skill_executor``. Gateway and external MCP tools materialize as *client
+objects* (one ``MCPClient`` exposing many tools), not individual callables, so
+they could be made available but not hidden. This module closes that gap.
+
+For each non-local ``bound_tool_id`` a skill carries, ``resolve_mcp_bindings``:
+
+1. classifies it (gateway vs external) — reusing the agent's tool filter;
+2. resolves it to the concrete MCP tool name(s) and the owning client —
+   gateway ids expand via ``expand_gateway_tool_ids`` (catalog ``gateway_<id>``
+   → runtime ``gateway_<target>___<tool>``; the gateway tool name is that with
+   the ``gateway_`` prefix stripped); external ids map to the per-server client
+   the external integration already built, whose tools are enumerated live
+   (its session is active after the build-time ``load_tools`` pre-flight);
+3. wraps each as a :class:`FoldedMCPTool` — a lightweight adapter the registry
+   stores so ``skill_dispatcher`` can show its schema and ``skill_executor`` can
+   run it through the client — and records its agent-facing name to fold off
+   the client's model tool list.
+
+The adapter executes via ``MCPClient.call_tool_sync`` rather than the local
+``tool_obj(**input)`` path, because an ``MCPAgentTool`` is not a plain callable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY_PREFIX = "gateway_"
+
+
+class FoldedMCPTool:
+    """Adapter exposing one folded gateway/external MCP tool to the registry.
+
+    Duck-types the slice of the tool interface the skill registry + meta-tools
+    use: ``tool_name`` (matched by ``skill_executor`` and used in catalog/schema
+    output) and ``tool_spec`` (returned by ``skill_dispatcher`` so the model
+    learns the parameters). Execution is routed through the MCP client, marked
+    by ``is_mcp_folded`` so ``skill_executor`` calls :meth:`invoke` instead of
+    treating it as a plain callable.
+    """
+
+    is_mcp_folded = True
+
+    def __init__(
+        self,
+        client: Any,
+        mcp_tool_name: str,
+        agent_tool_name: Optional[str] = None,
+        tool_spec: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Args:
+            client: The ``MCPClient`` (gateway or external) that hosts the tool.
+            mcp_tool_name: Server-side tool name, passed to ``call_tool_sync``.
+            agent_tool_name: Agent-facing name (what the model calls). Defaults
+                to ``mcp_tool_name`` (true for gateway; external tools may
+                disambiguate, so it is captured explicitly there).
+            tool_spec: Captured tool spec, when known at build time (external).
+                When None (gateway, resolved without a live session), the spec
+                is fetched lazily from the client on first access.
+        """
+        self._client = client
+        self._mcp_tool_name = mcp_tool_name
+        self._agent_tool_name = agent_tool_name or mcp_tool_name
+        self._tool_spec = tool_spec
+
+    @property
+    def tool_name(self) -> str:
+        return self._agent_tool_name
+
+    @property
+    def tool_spec(self) -> Dict[str, Any]:
+        """The tool's parameter spec, resolved lazily for gateway tools.
+
+        Lazy resolution lists the client (its session is live during the agent
+        loop, when ``skill_dispatcher`` runs) and caches the match. Falls back
+        to a name-only spec so the dispatcher always returns something usable.
+        """
+        if self._tool_spec is not None:
+            return self._tool_spec
+
+        spec: Dict[str, Any] = {"name": self._agent_tool_name}
+        try:
+            for t in self._client.list_tools_sync():
+                if getattr(t, "tool_name", None) == self._agent_tool_name:
+                    resolved = getattr(t, "tool_spec", None)
+                    if resolved:
+                        spec = resolved
+                    break
+        except Exception:  # noqa: BLE001 - never break dispatch on a list failure
+            logger.debug(
+                "Could not resolve tool_spec for folded MCP tool %s",
+                self._agent_tool_name,
+                exc_info=True,
+            )
+        self._tool_spec = spec
+        return spec
+
+    def invoke(self, tool_input: Optional[dict]) -> Any:
+        """Execute the tool through the MCP client and return a string result.
+
+        Synthesizes a ``tool_use_id`` (the executor path has none) and reduces
+        the structured ``MCPToolResult`` to text/JSON the model can read.
+        """
+        try:
+            result = self._client.call_tool_sync(
+                tool_use_id=f"skill-{uuid.uuid4().hex}",
+                name=self._mcp_tool_name,
+                arguments=tool_input or {},
+            )
+        except Exception as e:  # noqa: BLE001 - surface as a tool error, not a crash
+            logger.error(
+                "Folded MCP tool %s failed: %s", self._agent_tool_name, e,
+                exc_info=True,
+            )
+            return json.dumps({"error": str(e)})
+        return _stringify_mcp_result(result)
+
+
+def _stringify_mcp_result(result: Any) -> str:
+    """Reduce an ``MCPToolResult`` to a string for the model.
+
+    Joins text content blocks; falls back to a JSON dump of the content (or the
+    whole result) so non-text results still surface something. ``MCPToolResult``
+    is a TypedDict (``{"content": [...], "status": ...}``); handle dict-shaped
+    and attribute-shaped results defensively.
+    """
+    content = None
+    if isinstance(result, dict):
+        content = result.get("content")
+    else:
+        content = getattr(result, "content", None)
+
+    if isinstance(content, list):
+        texts: List[str] = []
+        for block in content:
+            text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+            if isinstance(text, str):
+                texts.append(text)
+        if texts:
+            return "\n".join(texts)
+        try:
+            return json.dumps(content, default=str)
+        except (TypeError, ValueError):
+            return str(content)
+
+    try:
+        return json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+class MCPBindingResult:
+    """Outcome of :func:`resolve_mcp_bindings`.
+
+    Attributes:
+        catalog_map: ``{catalog_tool_id -> [FoldedMCPTool, ...]}`` to hand to
+            ``SkillRegistry.bind_catalog_tools`` (a catalog id can expand to
+            several tools — a gateway target or external server with many).
+        fold_by_client: ``{client -> {agent_tool_name, ...}}`` to apply with
+            ``set_folded_tool_names`` so the bound tools drop off the model
+            tool list.
+        unresolved: catalog ids that could not be resolved (gateway disabled,
+            external client absent, …) — left visible/unfolded and logged.
+    """
+
+    def __init__(self) -> None:
+        self.catalog_map: Dict[str, List[FoldedMCPTool]] = {}
+        self.fold_by_client: Dict[Any, set] = {}
+        self.unresolved: List[str] = []
+
+    def _add(self, catalog_id: str, client: Any, tool: FoldedMCPTool) -> None:
+        self.catalog_map.setdefault(catalog_id, []).append(tool)
+        self.fold_by_client.setdefault(client, set()).add(tool.tool_name)
+
+
+def resolve_mcp_bindings(
+    *,
+    gateway_ids: List[str],
+    external_ids: List[str],
+    gateway_client: Any,
+    expand_gateway: Callable[[List[str]], List[str]],
+    external_client_lookup: Callable[[str], Any],
+) -> MCPBindingResult:
+    """Resolve gateway/external bound catalog ids to foldable MCP tools.
+
+    Args:
+        gateway_ids: bound catalog ids classified as gateway.
+        external_ids: bound catalog ids classified as external MCP.
+        gateway_client: the single live gateway ``MCPClient`` (or None when
+            gateway is disabled / no gateway tools were materialized).
+        expand_gateway: maps catalog ``gateway_<id>`` → runtime
+            ``gateway_<target>___<tool>`` ids (``BaseAgent._expand_gateway_tool_ids``).
+        external_client_lookup: maps an external catalog ``tool_id`` to its live
+            ``MCPClient`` (or None) — typically
+            ``lambda tid: integration.get_client(tid, user_id)``.
+    """
+    result = MCPBindingResult()
+
+    _resolve_gateway(result, gateway_ids, gateway_client, expand_gateway)
+    _resolve_external(result, external_ids, external_client_lookup)
+
+    if result.unresolved:
+        logger.info(
+            "Skill-bound MCP tools could not be folded (kept visible): %s",
+            result.unresolved,
+        )
+    return result
+
+
+def _resolve_gateway(
+    result: MCPBindingResult,
+    gateway_ids: List[str],
+    gateway_client: Any,
+    expand_gateway: Callable[[List[str]], List[str]],
+) -> None:
+    if not gateway_ids:
+        return
+    if gateway_client is None:
+        result.unresolved.extend(gateway_ids)
+        return
+
+    for catalog_id in gateway_ids:
+        # A catalog gateway id can expand to several runtime per-tool ids; an
+        # already-expanded RBAC-direct id (`gateway_<target>___<tool>`) maps to
+        # itself. The gateway tool name is the runtime id minus the prefix.
+        try:
+            runtime_ids = expand_gateway([catalog_id])
+        except Exception:  # noqa: BLE001 - degrade to unresolved on lookup failure
+            logger.warning(
+                "Could not expand gateway id %s for skill binding",
+                catalog_id,
+                exc_info=True,
+            )
+            result.unresolved.append(catalog_id)
+            continue
+
+        resolved_any = False
+        for rid in runtime_ids:
+            tool_name = rid[len(_GATEWAY_PREFIX):] if rid.startswith(_GATEWAY_PREFIX) else rid
+            result._add(
+                catalog_id,
+                gateway_client,
+                FoldedMCPTool(gateway_client, mcp_tool_name=tool_name),
+            )
+            resolved_any = True
+        if not resolved_any:
+            result.unresolved.append(catalog_id)
+
+
+def _resolve_external(
+    result: MCPBindingResult,
+    external_ids: List[str],
+    external_client_lookup: Callable[[str], Any],
+) -> None:
+    for catalog_id in external_ids:
+        client = external_client_lookup(catalog_id)
+        if client is None:
+            result.unresolved.append(catalog_id)
+            continue
+
+        # Binding an external catalog id binds its whole MCP server; enumerate
+        # the server's tools (session is live post-load_tools) so each folds
+        # individually and carries its captured spec.
+        try:
+            tools = list(client.list_tools_sync())
+        except Exception:  # noqa: BLE001 - degrade to unresolved on list failure
+            logger.warning(
+                "Could not list external MCP tools for skill binding (%s)",
+                catalog_id,
+                exc_info=True,
+            )
+            result.unresolved.append(catalog_id)
+            continue
+
+        if not tools:
+            result.unresolved.append(catalog_id)
+            continue
+
+        for t in tools:
+            agent_name = getattr(t, "tool_name", None)
+            if not agent_name:
+                continue
+            mcp_name = getattr(getattr(t, "mcp_tool", None), "name", None) or agent_name
+            result._add(
+                catalog_id,
+                client,
+                FoldedMCPTool(
+                    client,
+                    mcp_tool_name=mcp_name,
+                    agent_tool_name=agent_name,
+                    tool_spec=getattr(t, "tool_spec", None),
+                ),
+            )

--- a/backend/src/agents/main_agent/skills/skill_registry.py
+++ b/backend/src/agents/main_agent/skills/skill_registry.py
@@ -26,6 +26,18 @@ _YAML_LINE_RE = re.compile(r"^(\w+):\s*(.*)$")
 _YAML_LIST_ITEM_RE = re.compile(r"^\s*-\s+(.+)$")
 
 
+def _ref_attr(ref: Any, name: str) -> Any:
+    """Read a reference-manifest field, tolerating pydantic objects or dicts.
+
+    Records loaded from the repository carry ``SkillResourceRef`` objects;
+    duck-typed test stand-ins may pass dicts (snake_case or camelCase).
+    """
+    value = getattr(ref, name, None)
+    if value is None and isinstance(ref, dict):
+        value = ref.get(name)
+    return value
+
+
 class SkillRegistry:
     """
     Registry for discovering and managing agent skills.
@@ -160,11 +172,13 @@ class SkillRegistry:
         """Bind tools to skills by catalog ``tool_id`` (admin/DB skills).
 
         ``catalog_map`` maps a catalog ``tool_id`` to the live tool object the
-        agent materialized for it. For each skill, every ``bound_tool_id`` that
-        resolves in the map is attached. This is the cross-source-aware analog
-        of ``bind_tools`` (which matches the local-only ``_skill_name`` stamp);
-        in PR-6a only locally-materialized tools resolve here — gateway /
-        external MCP tools are surfaced as live clients but not yet folded.
+        agent materialized for it — or a *list* of objects, since one catalog
+        id can expand to several runtime tools (a gateway target or external
+        MCP server with many tools; see ``mcp_binding.resolve_mcp_bindings``).
+        For each skill, every ``bound_tool_id`` that resolves in the map is
+        attached. This is the cross-source-aware analog of ``bind_tools`` (which
+        matches the local-only ``_skill_name`` stamp): local tools and folded
+        gateway/external MCP tools both resolve here in PR-6b.
 
         Returns the number of (skill, tool) bindings made.
         """
@@ -172,11 +186,15 @@ class SkillRegistry:
         for info in self._skills.values():
             existing_ids = {id(t) for t in info["tools"]}
             for tid in info.get("bound_tool_ids", []) or []:
-                tool_obj = catalog_map.get(tid)
-                if tool_obj is not None and id(tool_obj) not in existing_ids:
-                    info["tools"].append(tool_obj)
-                    existing_ids.add(id(tool_obj))
-                    bound += 1
+                value = catalog_map.get(tid)
+                if value is None:
+                    continue
+                tool_objs = value if isinstance(value, list) else [value]
+                for tool_obj in tool_objs:
+                    if id(tool_obj) not in existing_ids:
+                        info["tools"].append(tool_obj)
+                        existing_ids.add(id(tool_obj))
+                        bound += 1
         logger.info(f"Bound {bound} catalog tools across {len(self._skills)} skills")
         return bound
 
@@ -262,6 +280,87 @@ class SkillRegistry:
         except Exception as e:
             logger.error(f"Error loading instructions for '{skill_name}': {e}")
             return None
+
+    def get_resource_names(self, skill_name: str) -> List[str]:
+        """List a skill's supporting reference filenames (Level-2.5).
+
+        These are the deep progressive-disclosure files (e.g. ``forms.md``)
+        that the SKILL.md body refers to. ``skill_dispatcher`` surfaces this
+        list so the model knows which files it may read; the bytes live in S3
+        (see :meth:`read_resource`). Empty for file/dev skills (no manifest).
+        """
+        skill = self._skills.get(skill_name)
+        if not skill:
+            return []
+        names: List[str] = []
+        for ref in skill.get("resources", []) or []:
+            filename = _ref_attr(ref, "filename")
+            if filename:
+                names.append(filename)
+        return names
+
+    def read_resource(
+        self, skill_name: str, filename: str, store: Optional[Any] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch one of a skill's reference files on demand (Level-3 disclosure).
+
+        Resolves ``filename`` against the skill's ``resources`` manifest and
+        reads the bytes from the S3-backed ``SkillResourceStore`` (the runtime
+        was granted read access to the skill-resources bucket in PR-6a). Returns
+        a dict the dispatcher serializes:
+
+          - ``{"filename", "content_type", "content"}`` for text;
+          - ``{"filename", "content_type", "size", "note"}`` for binary
+            (never dumps raw bytes into the model context);
+          - ``{"error": ...}`` if the file is missing or storage is unavailable.
+
+        ``None`` only when the skill itself is unknown. ``store`` is injectable
+        for tests; defaults to the process-global store.
+        """
+        skill = self._skills.get(skill_name)
+        if not skill:
+            return None
+
+        ref = None
+        for candidate in skill.get("resources", []) or []:
+            if _ref_attr(candidate, "filename") == filename:
+                ref = candidate
+                break
+        if ref is None:
+            return {"error": f"Reference file '{filename}' not found in skill '{skill_name}'"}
+
+        s3_key = _ref_attr(ref, "s3_key") or _ref_attr(ref, "s3Key")
+        content_type = _ref_attr(ref, "content_type") or _ref_attr(ref, "contentType") or ""
+        size = _ref_attr(ref, "size")
+        if not s3_key:
+            return {"error": f"Reference file '{filename}' has no storage key"}
+
+        from apis.shared.skills.resource_store import (
+            SkillResourceStoreError,
+            get_skill_resource_store,
+        )
+
+        store = store or get_skill_resource_store()
+        try:
+            data = store.get(s3_key)
+        except SkillResourceStoreError as e:
+            logger.warning("Could not read reference '%s' for skill '%s': %s", filename, skill_name, e)
+            return {"error": f"Could not read reference file '{filename}': {e}"}
+
+        try:
+            text = data.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return {
+                "filename": filename,
+                "content_type": content_type or "application/octet-stream",
+                "size": size if size is not None else len(data),
+                "note": "Binary reference file — not rendered as text.",
+            }
+        return {
+            "filename": filename,
+            "content_type": content_type or "text/markdown",
+            "content": text,
+        }
 
     def get_tools(self, skill_name: str) -> List[Any]:
         """

--- a/backend/src/agents/main_agent/skills/skill_tools.py
+++ b/backend/src/agents/main_agent/skills/skill_tools.py
@@ -61,6 +61,18 @@ def _dispatch(registry: Any, skill_name: str, reference: str = "", source: str =
             "available_skills": available,
         })
 
+    # Deep progressive disclosure: when a reference filename is given, serve
+    # that supporting file's bytes from S3 instead of the instructions block.
+    if reference:
+        ref_result = registry.read_resource(skill_name, reference)
+        if ref_result is None or "error" in (ref_result or {}):
+            return json.dumps({
+                "error": (ref_result or {}).get("error")
+                or f"Reference file '{reference}' not found in skill '{skill_name}'",
+                "available_references": registry.get_resource_names(skill_name),
+            })
+        return json.dumps(ref_result, default=str)
+
     result = {}
 
     # Load Level 2 instructions
@@ -72,6 +84,17 @@ def _dispatch(registry: Any, skill_name: str, reference: str = "", source: str =
     schemas = registry.get_tool_schemas(skill_name)
     if schemas:
         result["tool_schemas"] = schemas
+
+    # Surface the skill's supporting reference files so the model knows what it
+    # can read on demand (its instructions typically name them, e.g. "see
+    # forms.md"). Read one by calling skill_dispatcher again with `reference=`.
+    references = registry.get_resource_names(skill_name)
+    if references:
+        result["available_references"] = references
+        result["reference_hint"] = (
+            "Call skill_dispatcher again with reference=<filename> to read one "
+            "of these supporting files."
+        )
 
     if not result:
         result["error"] = f"No instructions or tools found for skill '{skill_name}'"
@@ -113,8 +136,11 @@ def _execute(registry: Any, skill_name: str, tool_name: str, tool_input: Any = N
     if tool_input is None:
         tool_input = {}
 
-    # Execute the tool
+    # Execute the tool. Folded gateway/external MCP tools (PR-6b) are not plain
+    # callables — they run through the MCP client via their own invoke().
     try:
+        if getattr(target_tool, "is_mcp_folded", False):
+            return target_tool.invoke(tool_input)
         return _execute_tool(target_tool, tool_input)
     except Exception as e:
         logger.error(f"Error executing {skill_name}/{tool_name}: {e}", exc_info=True)

--- a/backend/tests/agents/main_agent/integrations/test_mcp_tool_folding.py
+++ b/backend/tests/agents/main_agent/integrations/test_mcp_tool_folding.py
@@ -1,0 +1,69 @@
+"""Tests for the per-client MCP tool-fold mechanism (PR-6b)."""
+
+from types import SimpleNamespace
+
+from agents.main_agent.integrations.mcp_tool_folding import (
+    drop_folded_tools,
+    folded_tool_names,
+    set_folded_tool_names,
+)
+
+
+def _tool(name):
+    return SimpleNamespace(tool_name=name)
+
+
+class _Client:
+    """Minimal stand-in for an MCPClient (just the fields the helpers touch)."""
+
+    def __init__(self, loaded=None):
+        self._loaded_tools = loaded
+
+
+class TestSetFolded:
+    def test_records_names(self):
+        c = _Client()
+        set_folded_tool_names(c, ["a", "b"])
+        assert folded_tool_names(c) == {"a", "b"}
+
+    def test_accumulates_across_calls(self):
+        c = _Client()
+        set_folded_tool_names(c, ["a"])
+        set_folded_tool_names(c, ["b", "c"])
+        assert folded_tool_names(c) == {"a", "b", "c"}
+
+    def test_invalidates_loaded_tools_cache(self):
+        # The external pre-flight primes _loaded_tools before folds are known;
+        # setting a fold must reset it so Strands re-lists with the fold.
+        c = _Client(loaded=[_tool("x")])
+        set_folded_tool_names(c, ["x"])
+        assert c._loaded_tools is None
+
+    def test_no_cache_to_invalidate_is_fine(self):
+        c = _Client(loaded=None)
+        set_folded_tool_names(c, ["x"])
+        assert c._loaded_tools is None
+
+
+class TestDropFolded:
+    def test_drops_only_folded(self):
+        c = _Client()
+        set_folded_tool_names(c, ["hide_me"])
+        tools = [_tool("keep"), _tool("hide_me"), _tool("keep2")]
+        kept = drop_folded_tools(c, tools)
+        assert [t.tool_name for t in kept] == ["keep", "keep2"]
+
+    def test_no_fold_set_is_passthrough(self):
+        c = _Client()
+        tools = [_tool("a"), _tool("b")]
+        assert drop_folded_tools(c, tools) is tools
+
+    def test_empty_fold_set_is_passthrough(self):
+        c = _Client()
+        set_folded_tool_names(c, [])
+        tools = [_tool("a")]
+        # An empty set is falsy → treated as "nothing folded".
+        assert drop_folded_tools(c, tools) == tools
+
+    def test_folded_names_empty_default(self):
+        assert folded_tool_names(_Client()) == set()

--- a/backend/tests/agents/main_agent/skills/test_mcp_binding.py
+++ b/backend/tests/agents/main_agent/skills/test_mcp_binding.py
@@ -1,0 +1,224 @@
+"""Tests for cross-source MCP skill binding + folding (PR-6b).
+
+Covers the genuinely-hard piece: resolving a skill's gateway / external MCP
+bound tool ids to foldable adapters that execute through the MCP client, with
+no live MCP server (clients are faked).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agents.main_agent.skills.mcp_binding import (
+    FoldedMCPTool,
+    _stringify_mcp_result,
+    resolve_mcp_bindings,
+)
+
+
+def _mcp_agent_tool(agent_name, server_name=None, spec=None):
+    """Fake of a Strands MCPAgentTool (the slice the resolver reads)."""
+    return SimpleNamespace(
+        tool_name=agent_name,
+        tool_spec=spec or {"name": agent_name, "inputSchema": {"json": {}}},
+        mcp_tool=SimpleNamespace(name=server_name or agent_name),
+    )
+
+
+class _FakeClient:
+    """Records call_tool_sync; serves list_tools_sync from a fixed list."""
+
+    def __init__(self, tools=None, result=None, raise_on_list=False):
+        self._tools = tools or []
+        self._result = result
+        self._raise_on_list = raise_on_list
+        self.calls = []
+
+    def list_tools_sync(self, *a, **k):
+        if self._raise_on_list:
+            raise RuntimeError("session not active")
+        return list(self._tools)
+
+    def call_tool_sync(self, tool_use_id, name, arguments=None, **k):
+        self.calls.append((tool_use_id, name, arguments))
+        return self._result
+
+
+class TestResolveGateway:
+    def test_expands_and_folds(self):
+        client = _FakeClient()
+        res = resolve_mcp_bindings(
+            gateway_ids=["gateway_wiki"],
+            external_ids=[],
+            gateway_client=client,
+            expand_gateway=lambda ids: [
+                "gateway_wikipedia___search",
+                "gateway_wikipedia___get_article",
+            ],
+            external_client_lookup=lambda tid: None,
+        )
+        tools = res.catalog_map["gateway_wiki"]
+        assert [t._mcp_tool_name for t in tools] == [
+            "wikipedia___search",
+            "wikipedia___get_article",
+        ]
+        # Agent-facing name == gateway tool name (no `gateway_` prefix).
+        assert res.fold_by_client[client] == {
+            "wikipedia___search",
+            "wikipedia___get_article",
+        }
+        assert res.unresolved == []
+
+    def test_already_expanded_runtime_id_passes_through(self):
+        client = _FakeClient()
+        res = resolve_mcp_bindings(
+            gateway_ids=["gateway_target___tool"],
+            external_ids=[],
+            gateway_client=client,
+            expand_gateway=lambda ids: list(ids),  # already runtime form
+            external_client_lookup=lambda tid: None,
+        )
+        assert res.catalog_map["gateway_target___tool"][0]._mcp_tool_name == "target___tool"
+
+    def test_no_gateway_client_is_unresolved(self):
+        res = resolve_mcp_bindings(
+            gateway_ids=["gateway_wiki"],
+            external_ids=[],
+            gateway_client=None,
+            expand_gateway=lambda ids: ids,
+            external_client_lookup=lambda tid: None,
+        )
+        assert res.unresolved == ["gateway_wiki"]
+        assert res.catalog_map == {}
+
+    def test_expand_failure_is_unresolved(self):
+        def boom(ids):
+            raise RuntimeError("catalog down")
+
+        res = resolve_mcp_bindings(
+            gateway_ids=["gateway_wiki"],
+            external_ids=[],
+            gateway_client=_FakeClient(),
+            expand_gateway=boom,
+            external_client_lookup=lambda tid: None,
+        )
+        assert res.unresolved == ["gateway_wiki"]
+
+
+class TestResolveExternal:
+    def test_lists_server_and_folds_each_tool(self):
+        tools = [
+            _mcp_agent_tool("search", server_name="search"),
+            _mcp_agent_tool("fetch", server_name="fetch_raw"),
+        ]
+        client = _FakeClient(tools=tools)
+        res = resolve_mcp_bindings(
+            gateway_ids=[],
+            external_ids=["my_server"],
+            gateway_client=None,
+            expand_gateway=lambda ids: ids,
+            external_client_lookup=lambda tid: client,
+        )
+        bound = res.catalog_map["my_server"]
+        # Server-side name preserved for call_tool_sync; agent-facing for fold.
+        assert {(t.tool_name, t._mcp_tool_name) for t in bound} == {
+            ("search", "search"),
+            ("fetch", "fetch_raw"),
+        }
+        assert res.fold_by_client[client] == {"search", "fetch"}
+        # Spec captured eagerly from the listed tool.
+        assert bound[0].tool_spec["name"] == "search"
+
+    def test_missing_client_is_unresolved(self):
+        res = resolve_mcp_bindings(
+            gateway_ids=[],
+            external_ids=["gone"],
+            gateway_client=None,
+            expand_gateway=lambda ids: ids,
+            external_client_lookup=lambda tid: None,
+        )
+        assert res.unresolved == ["gone"]
+
+    def test_list_failure_is_unresolved(self):
+        res = resolve_mcp_bindings(
+            gateway_ids=[],
+            external_ids=["srv"],
+            gateway_client=None,
+            expand_gateway=lambda ids: ids,
+            external_client_lookup=lambda tid: _FakeClient(raise_on_list=True),
+        )
+        assert res.unresolved == ["srv"]
+
+    def test_empty_server_is_unresolved(self):
+        res = resolve_mcp_bindings(
+            gateway_ids=[],
+            external_ids=["srv"],
+            gateway_client=None,
+            expand_gateway=lambda ids: ids,
+            external_client_lookup=lambda tid: _FakeClient(tools=[]),
+        )
+        assert res.unresolved == ["srv"]
+
+
+class TestFoldedMCPToolExecution:
+    def test_invoke_routes_through_client(self):
+        client = _FakeClient(
+            result={"status": "success", "content": [{"text": "the answer"}]}
+        )
+        tool = FoldedMCPTool(client, mcp_tool_name="wikipedia___search")
+        out = tool.invoke({"query": "strands"})
+        assert out == "the answer"
+        # call_tool_sync got the server-side name + args.
+        (_, name, args) = client.calls[0]
+        assert name == "wikipedia___search"
+        assert args == {"query": "strands"}
+
+    def test_invoke_handles_none_input(self):
+        client = _FakeClient(result={"content": [{"text": "ok"}]})
+        FoldedMCPTool(client, mcp_tool_name="t").invoke(None)
+        assert client.calls[0][2] == {}
+
+    def test_invoke_surfaces_errors_as_tool_result(self):
+        class _Boom(_FakeClient):
+            def call_tool_sync(self, *a, **k):
+                raise RuntimeError("mcp down")
+
+        out = FoldedMCPTool(_Boom(), mcp_tool_name="t").invoke({})
+        assert "mcp down" in out
+
+    def test_is_mcp_folded_marker(self):
+        assert FoldedMCPTool(_FakeClient(), mcp_tool_name="t").is_mcp_folded is True
+
+
+class TestFoldedMCPToolSpec:
+    def test_eager_spec_returned(self):
+        spec = {"name": "x", "inputSchema": {"json": {"type": "object"}}}
+        tool = FoldedMCPTool(_FakeClient(), mcp_tool_name="x", tool_spec=spec)
+        assert tool.tool_spec is spec
+
+    def test_lazy_spec_resolves_from_client(self):
+        # Gateway path: no spec at build time; resolved by listing at dispatch.
+        listed = [_mcp_agent_tool("target___tool", spec={"name": "target___tool", "k": 1})]
+        client = _FakeClient(tools=listed)
+        tool = FoldedMCPTool(client, mcp_tool_name="target___tool")
+        assert tool.tool_spec["k"] == 1
+
+    def test_lazy_spec_falls_back_to_name(self):
+        client = _FakeClient(raise_on_list=True)
+        tool = FoldedMCPTool(client, mcp_tool_name="t")
+        assert tool.tool_spec == {"name": "t"}
+
+
+class TestStringify:
+    def test_joins_text_blocks(self):
+        result = {"content": [{"text": "a"}, {"text": "b"}]}
+        assert _stringify_mcp_result(result) == "a\nb"
+
+    def test_non_text_content_json_dumps(self):
+        result = {"content": [{"json": {"k": 1}}]}
+        out = _stringify_mcp_result(result)
+        assert "json" in out and "k" in out
+
+    def test_object_shaped_result(self):
+        result = SimpleNamespace(content=[SimpleNamespace(text="hi")])
+        assert _stringify_mcp_result(result) == "hi"

--- a/backend/tests/agents/main_agent/skills/test_skill_registry.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_registry.py
@@ -1,5 +1,7 @@
 """Tests for SkillRegistry — discovery, binding, and three-level access."""
 
+from types import SimpleNamespace
+
 import pytest
 from agents.main_agent.skills.skill_registry import SkillRegistry
 
@@ -226,3 +228,97 @@ class TestDbSource:
 
         reg.bind_catalog_tools({"t": t})
         assert reg.get_tools("parent") == [t]
+
+    def test_bind_catalog_tools_accepts_list_value(self):
+        # One catalog id can expand to several runtime tools (gateway target /
+        # external server with many) — bind_catalog_tools accepts a list.
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", bound_tool_ids=["server"])])
+
+        t1 = SimpleNamespace(tool_name="search")
+        t2 = SimpleNamespace(tool_name="fetch")
+        reg.bind_catalog_tools({"server": [t1, t2]})
+
+        tools = reg.get_tools("a")
+        assert tools == [t1, t2]
+
+    def test_bind_catalog_tools_list_is_idempotent(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", bound_tool_ids=["server"])])
+        t1 = SimpleNamespace(tool_name="search")
+        reg.bind_catalog_tools({"server": [t1]})
+        reg.bind_catalog_tools({"server": [t1]})
+        assert reg.get_tools("a") == [t1]
+
+
+def _ref(filename, s3_key="k", content_type="text/markdown", size=10):
+    return {
+        "filename": filename,
+        "s3_key": s3_key,
+        "content_type": content_type,
+        "size": size,
+    }
+
+
+class _FakeStore:
+    """Stand-in for SkillResourceStore keyed by s3_key."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, s3_key):
+        if s3_key not in self._data:
+            from apis.shared.skills.resource_store import SkillResourceStoreError
+
+            raise SkillResourceStoreError(f"missing {s3_key}")
+        return self._data[s3_key]
+
+
+class TestReferenceFiles:
+    """Req (PR-6b): reference-file progressive disclosure level."""
+
+    def test_get_resource_names(self):
+        reg = SkillRegistry()
+        reg.load_records([
+            _Rec("a", resources=[_ref("forms.md", "k1"), _ref("reference.md", "k2")])
+        ])
+        assert reg.get_resource_names("a") == ["forms.md", "reference.md"]
+
+    def test_get_resource_names_empty_when_none(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a")])
+        assert reg.get_resource_names("a") == []
+
+    def test_read_resource_returns_text(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", resources=[_ref("forms.md", "k1")])])
+        store = _FakeStore({"k1": b"# Forms\nfill them in"})
+        out = reg.read_resource("a", "forms.md", store=store)
+        assert out["content"] == "# Forms\nfill them in"
+        assert out["filename"] == "forms.md"
+
+    def test_read_resource_unknown_skill_returns_none(self):
+        reg = SkillRegistry()
+        assert reg.read_resource("nope", "x.md", store=_FakeStore({})) is None
+
+    def test_read_resource_missing_file_errors(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", resources=[_ref("forms.md", "k1")])])
+        out = reg.read_resource("a", "absent.md", store=_FakeStore({}))
+        assert "error" in out
+
+    def test_read_resource_storage_error_is_error_dict(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", resources=[_ref("forms.md", "k1")])])
+        # Store has no k1 → raises SkillResourceStoreError → error dict.
+        out = reg.read_resource("a", "forms.md", store=_FakeStore({}))
+        assert "error" in out
+
+    def test_read_resource_binary_is_noted_not_dumped(self):
+        reg = SkillRegistry()
+        reg.load_records([_Rec("a", resources=[_ref("logo.png", "k1", "image/png")])])
+        store = _FakeStore({"k1": b"\x89PNG\x00\xff"})
+        out = reg.read_resource("a", "logo.png", store=store)
+        assert "content" not in out
+        assert "note" in out
+        assert out["content_type"] == "image/png"

--- a/backend/tests/agents/main_agent/skills/test_skill_tools.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_tools.py
@@ -5,10 +5,33 @@ import pytest
 
 from agents.main_agent.skills.skill_registry import SkillRegistry
 from agents.main_agent.skills.skill_tools import (
+    make_skill_tools,
     skill_dispatcher,
     skill_executor,
     set_dispatcher_registry,
 )
+
+
+class _DbRec:
+    """Minimal SkillDefinition stand-in for DB-mode registries."""
+
+    def __init__(self, skill_id, instructions="# body", bound_tool_ids=None,
+                 resources=None):
+        self.skill_id = skill_id
+        self.description = f"desc {skill_id}"
+        self.instructions = instructions
+        self.compose = []
+        self.bound_tool_ids = bound_tool_ids or []
+        self.resources = resources or []
+        self.status = "active"
+
+
+class _FakeStore:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, s3_key):
+        return self._data[s3_key]
 
 
 @pytest.fixture(autouse=True)
@@ -91,6 +114,92 @@ class TestSkillExecutor:
             tool_name="web_search",
         ))
         assert "error" in result
+
+
+class TestReferenceDisclosure:
+    """Req (PR-6b): skill_dispatcher serves reference files on demand."""
+
+    def _registry(self):
+        reg = SkillRegistry()
+        reg.load_records([
+            _DbRec(
+                "research",
+                instructions="# Research\nSee forms.md",
+                resources=[{
+                    "filename": "forms.md",
+                    "s3_key": "k1",
+                    "content_type": "text/markdown",
+                    "size": 7,
+                }],
+            )
+        ])
+        return reg
+
+    def test_dispatch_lists_available_references(self):
+        dispatch, _ = make_skill_tools(self._registry())
+        result = json.loads(dispatch(skill_name="research"))
+        assert result["available_references"] == ["forms.md"]
+        assert "reference_hint" in result
+
+    def test_dispatch_reads_reference(self, monkeypatch):
+        import apis.shared.skills.resource_store as rs
+
+        monkeypatch.setattr(
+            rs, "get_skill_resource_store",
+            lambda: _FakeStore({"k1": b"# Forms\nfill"}),
+        )
+        dispatch, _ = make_skill_tools(self._registry())
+        result = json.loads(dispatch(skill_name="research", reference="forms.md"))
+        assert result["content"] == "# Forms\nfill"
+        assert result["filename"] == "forms.md"
+
+    def test_dispatch_unknown_reference_lists_available(self):
+        dispatch, _ = make_skill_tools(self._registry())
+        result = json.loads(dispatch(skill_name="research", reference="absent.md"))
+        assert "error" in result
+        assert result["available_references"] == ["forms.md"]
+
+
+class TestFoldedMCPExecutor:
+    """Req (PR-6b): skill_executor runs a folded gateway/external MCP tool
+    through the MCP client (covers the gateway + external execution path)."""
+
+    def test_executor_routes_through_client(self):
+        from agents.main_agent.skills.mcp_binding import FoldedMCPTool
+
+        class _Client:
+            def __init__(self):
+                self.calls = []
+
+            def call_tool_sync(self, tool_use_id, name, arguments=None, **k):
+                self.calls.append((name, arguments))
+                return {"content": [{"text": "folded result"}]}
+
+        client = _Client()
+        reg = SkillRegistry()
+        reg.load_records([_DbRec("g", bound_tool_ids=["gateway_x"])])
+        folded = FoldedMCPTool(client, mcp_tool_name="target___tool")
+        reg.bind_catalog_tools({"gateway_x": [folded]})
+
+        _, execute = make_skill_tools(reg)
+        out = execute(
+            skill_name="g", tool_name="target___tool", tool_input={"q": "hi"}
+        )
+        assert out == "folded result"
+        assert client.calls[0] == ("target___tool", {"q": "hi"})
+
+    def test_dispatch_shows_folded_tool_schema(self):
+        from agents.main_agent.skills.mcp_binding import FoldedMCPTool
+
+        reg = SkillRegistry()
+        reg.load_records([_DbRec("g", bound_tool_ids=["gateway_x"])])
+        spec = {"name": "target___tool", "inputSchema": {"json": {}}}
+        folded = FoldedMCPTool(None, mcp_tool_name="target___tool", tool_spec=spec)
+        reg.bind_catalog_tools({"gateway_x": [folded]})
+
+        dispatch, _ = make_skill_tools(reg)
+        result = json.loads(dispatch(skill_name="g"))
+        assert result["tool_schemas"][0]["name"] == "target___tool"
 
 
 class TestDecorators:

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -13,6 +13,9 @@ sys.path.insert(
 )
 
 from seed_bootstrap_data import (  # noqa: E402
+    EXAMPLE_SKILL_ID,
+    seed_default_role,
+    seed_example_skills,
     seed_system_admin_role,
     seed_default_tools,
 )
@@ -226,3 +229,83 @@ class TestSeedDefaultTools:
 
         assert result.created == 5
         assert result.skipped == 1
+
+
+class TestSeedExampleSkills:
+    """seed_example_skills — the PR-6b bundled-skill seed."""
+
+    def test_creates_skill_and_grants_to_default(self, dynamodb_table, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        seed_default_role(TABLE_NAME, REGION)
+
+        result = seed_example_skills(TABLE_NAME, REGION)
+        assert result.created == 1
+        assert result.failed == 0
+
+        # SKILL# record — instructions + bound LOCAL tool + active.
+        item = dynamodb_table.get_item(
+            Key={"PK": f"SKILL#{EXAMPLE_SKILL_ID}", "SK": "METADATA"}
+        )["Item"]
+        assert item["skillId"] == EXAMPLE_SKILL_ID
+        assert item["status"] == "active"
+        assert item["boundToolIds"] == ["fetch_url_content"]
+        assert item["instructions"]
+        assert item["GSI4PK"] == "OWNER#system"
+        # No bucket configured → seeded without reference bytes.
+        assert item["resources"] == []
+
+        # Default role granted (effectivePermissions is what RBAC reads).
+        role = dynamodb_table.get_item(
+            Key={"PK": "ROLE#default", "SK": "DEFINITION"}
+        )["Item"]
+        assert EXAMPLE_SKILL_ID in role["grantedSkills"]
+        assert EXAMPLE_SKILL_ID in role["effectivePermissions"]["skills"]
+
+        # Reverse-lookup grant item (GSI2 SKILL# keyspace).
+        grant = dynamodb_table.get_item(
+            Key={"PK": "ROLE#default", "SK": f"SKILL_GRANT#{EXAMPLE_SKILL_ID}"}
+        )["Item"]
+        assert grant["GSI2PK"] == f"SKILL#{EXAMPLE_SKILL_ID}"
+        assert grant["GSI2SK"] == "ROLE#default"
+        assert grant["enabled"] is True
+
+    def test_idempotent_skip(self, dynamodb_table, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        seed_default_role(TABLE_NAME, REGION)
+        seed_example_skills(TABLE_NAME, REGION)
+
+        result = seed_example_skills(TABLE_NAME, REGION)
+        assert result.skipped == 1
+        assert result.created == 0
+
+    def test_grant_skipped_when_no_default_role(self, dynamodb_table, monkeypatch):
+        monkeypatch.delenv("S3_SKILL_RESOURCES_BUCKET_NAME", raising=False)
+        # No default role seeded — skill still created, grant no-ops.
+        result = seed_example_skills(TABLE_NAME, REGION)
+        assert result.created == 1
+        resp = dynamodb_table.get_item(
+            Key={"PK": "ROLE#default", "SK": f"SKILL_GRANT#{EXAMPLE_SKILL_ID}"}
+        )
+        assert "Item" not in resp
+
+    def test_uploads_reference_file_to_s3_when_bucket_set(
+        self, dynamodb_table, monkeypatch
+    ):
+        bucket = "test-skill-resources"
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=bucket)
+        monkeypatch.setenv("S3_SKILL_RESOURCES_BUCKET_NAME", bucket)
+        seed_default_role(TABLE_NAME, REGION)
+
+        seed_example_skills(TABLE_NAME, REGION)
+
+        item = dynamodb_table.get_item(
+            Key={"PK": f"SKILL#{EXAMPLE_SKILL_ID}", "SK": "METADATA"}
+        )["Item"]
+        assert len(item["resources"]) == 1
+        ref = item["resources"][0]
+        assert ref["filename"] == "extraction_tips.md"
+        assert ref["s3Key"].startswith(f"skills/{EXAMPLE_SKILL_ID}/")
+        # Bytes really landed in S3 at the content-addressed key.
+        body = s3.get_object(Bucket=bucket, Key=ref["s3Key"])["Body"].read()
+        assert b"Extraction Tips" in body

--- a/scripts/stack-bootstrap/seed.sh
+++ b/scripts/stack-bootstrap/seed.sh
@@ -49,6 +49,14 @@ main() {
 
     export AWS_REGION="${region}"
 
+    # Skill-resources S3 bucket — deterministic name from the project prefix
+    # (CDK: getResourceName(config, 'skill-resources') in
+    # infrastructure/lib/constructs/skills/skill-resources-construct.ts). Used by
+    # the example-skill seed to upload its reference file; the seed degrades to
+    # no reference bytes if this is unset.
+    export S3_SKILL_RESOURCES_BUCKET_NAME="${prefix}-skill-resources"
+    log_info "Skill resources bucket: ${S3_SKILL_RESOURCES_BUCKET_NAME}"
+
     # Invoke the Python seed script
     log_info "Running seed script..."
     python3 "${PROJECT_ROOT}/backend/scripts/seed_bootstrap_data.py"


### PR DESCRIPTION
## PR-6b — runtime increment after PR-6a

Third piece of the admin-managed Skills runtime, following [#467](https://github.com/Boise-State-Development/agentcore-public-stack/pull/467) (PR-6a). Spec: [`docs/specs/admin-skills-rbac-tool-binding.md`](docs/specs/admin-skills-rbac-tool-binding.md) — **§0.5** (phasing), **§8** (runtime integration), **§12** (risks).

**Everything is opt-in via `agent_type="skill"`.** The default `"chat"` path is untouched, so this is a zero default-behavior-change increment. The default flip + `toolTokens` measurement remain PR-7.

### 1. Fold gateway/external MCP tools behind the meta-tools (the hard part)
PR-6a could only fold **local** callables. Gateway/external tools materialize as *client objects* (one `MCPClient` exposing many tools), not individual callables — so they were *available but not hidden*. This PR closes the gap without disturbing client lifecycle:

- **`integrations/mcp_tool_folding.py`** (new) — a per-client **fold set**. Both `FilteredMCPClient` (gateway) and `UICapableMCPClient` (external) drop folded tool names from `list_tools_sync()` — the exact seam Strands uses to build the model's tool list, so a folded tool's schema never rides in context. Setting a fold also invalidates the client's `_loaded_tools` cache so Strands re-lists with the fold applied (external clients are pre-flighted *before* folds are known).
- **`skills/mcp_binding.py`** (new) — `resolve_mcp_bindings` maps each non-local `bound_tool_id` → its concrete MCP tool(s) + owning client: **gateway** via `expand_gateway_tool_ids` (catalog `gateway_<id>` → runtime `gateway_<target>___<tool>`, prefix stripped — resolved from the catalog, *no session needed*); **external** by enumerating the live client (its session is active post-`load_tools`). Each becomes a `FoldedMCPTool` adapter the registry stores so `skill_dispatcher` shows its schema and `skill_executor` runs it through `MCPClient.call_tool_sync`. The client object **stays** in the agent's tool list (Strands keeps its session alive); only the bound tool's *schema* is folded out.
- **`SkillAgent._bind_mcp_tools`** wires it after the existing local binding; `bind_catalog_tools` now accepts a list per catalog id (one id can expand to several runtime tools).

### 2. Read-reference-file progressive-disclosure level
`skill_dispatcher`'s previously-unused `reference` arg is now wired: it serves a skill's supporting reference files from the PR-4 S3 `SkillResourceStore` on demand (the runtime already has bucket read access, granted in PR-6a). The no-arg dispatch response lists `available_references` so the model knows which files it can read — mirroring how a real `SKILL.md` body names its files (see validation walk below).

### 3. Bootstrap example-skill seed
`seed_example_skills` (mirrors `seed_default_tools`) seeds one demonstrable bundle — **`web_research`**: instructions + a bound local tool (`fetch_url_content`) + an S3-uploaded reference file (`extraction_tips.md`) — and grants it to the **`default`** role (RBAC reads precomputed `effectivePermissions.skills`, so both that array and the reverse `SKILL_GRANT#` item are written). The skill-resources bucket name is derived in `seed.sh` from the project prefix; reference upload is best-effort (skill still seeds without bytes if the bucket is absent).

> Note: granted to `default` (not just admin) purely so the bundle is demonstrable end-to-end for any user once an assistant opts into `agent_type="skill"`. It is inert under the default `"chat"` path. Easy to scope to `system_admin` only if reviewers prefer.

### §0.6 validation walk
Walked Anthropic's real `pdf` skill bundle end-to-end: `SKILL.md` (frontmatter + body) + `reference.md`/`forms.md` + `scripts/*.py` (deferred per §0.3) + `LICENSE.txt`. Key finding that shaped piece 2: the SKILL.md body *names* its reference files ("see reference.md", "read forms.md and follow its instructions"), so the dispatcher must surface available filenames **and** serve them on request. The seed example reproduces this shape.

## Testing
- **Full backend suite: `3711 passed, 3 skipped`** (the one pre-existing flaky PBT test `test_pbt_auth_sweep` passed this run).
- New runtime tests cover binding **one tool of each protocol** (local/gateway/external) — the §12 highest-risk item: `test_mcp_binding.py`, `test_mcp_tool_folding.py`, plus reference-file + folded-executor cases in `test_skill_registry.py` / `test_skill_tools.py`, and `seed_example_skills` cases (moto S3 + DynamoDB).
- Import boundary (`tests/architecture/test_import_boundaries.py`) green — the runtime reaches `SkillResourceStore` only through `apis.shared`.

## Acceptance
- ✅ a granted gateway/external skill's tools fold behind the two meta-tools and execute via the MCP client
- ✅ the agent loads a skill's reference files on demand from S3
- ✅ one seeded example skill demonstrates the full bundle (instructions + bound tool + reference file)
- ✅ all opt-in — zero default behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)