### PR TITLE
feat: per-tool MCP enablement (skills binding + model settings)

### DIFF
--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -15,7 +15,7 @@ OAuth Support:
 
 import logging
 import re
-from typing import Any, Callable, Optional, List
+from typing import Any, Callable, Optional, List, Set
 
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
@@ -26,6 +26,7 @@ from apis.shared.tools.models import (
     MCPTransport,
     ToolDefinition,
 )
+from apis.shared.tools.scoped_ids import collect_tool_name_filters
 from agents.main_agent.integrations import oauth_token_cache
 from agents.main_agent.integrations.mcp_apps import UICapableMCPClient
 from agents.main_agent.integrations.gateway_auth import get_sigv4_auth
@@ -97,6 +98,7 @@ def create_external_mcp_client(
     tool_definition: Optional[ToolDefinition] = None,
     oauth_token: Optional[str] = None,
     token_provider: Optional[Callable[[], Optional[str]]] = None,
+    allowed_tool_names: Optional[Set[str]] = None,
 ) -> Optional[MCPClient]:
     """
     Create an MCP client for an externally deployed MCP server.
@@ -109,6 +111,10 @@ def create_external_mcp_client(
         tool_definition: Optional tool definition for logging
         oauth_token: Optional static token (used for OIDC forwarding)
         token_provider: Optional callable returning the current token
+        allowed_tool_names: If provided, only these MCP-server tool names are
+            exposed to the model (per-tool enablement). ``None`` exposes the
+            whole server. Matched against the raw MCP tool name by the SDK's
+            ``ToolFilters`` (no prefix is applied to external clients).
 
     Returns:
         MCPClient instance or None if configuration is invalid
@@ -183,6 +189,15 @@ def create_external_mcp_client(
             transport = MCPTransport(transport)
 
         if transport == MCPTransport.STREAMABLE_HTTP:
+            # Per-tool enablement: restrict the model's view of this server to
+            # the selected tools. The base MCPClient applies this in
+            # list_tools_sync (matched against the raw MCP tool name); the UI
+            # filter then layers on top. Sorted for a stable client identity.
+            tool_filters = (
+                {"allowed": sorted(allowed_tool_names)}
+                if allowed_tool_names is not None
+                else None
+            )
             # UICapableMCPClient advertises the MCP Apps UI extension on
             # initialize and filters app-only tools out of the model's tool
             # list (both inert unless AGENTCORE_MCP_APPS_HOST_ENABLED=true).
@@ -191,11 +206,19 @@ def create_external_mcp_client(
                     url,
                     auth=auth
                 ),
+                tool_filters=tool_filters,
                 # Retained so the MCP Apps header can resolve the server's
                 # served-manifest icon from this origin (best-effort).
                 server_url=config.server_url,
             )
-            logger.info(f"✅ External MCP client created for {tool_id}: {config.server_url}")
+            scope_label = (
+                f" (tools: {', '.join(sorted(allowed_tool_names))})"
+                if allowed_tool_names is not None
+                else ""
+            )
+            logger.info(
+                f"✅ External MCP client created for {tool_id}: {config.server_url}{scope_label}"
+            )
             return mcp_client
         else:
             logger.warning(f"Unsupported transport type: {transport}")
@@ -282,7 +305,12 @@ class ExternalMCPIntegration:
         clients = []
         repository = get_tool_catalog_repository()
 
-        for tool_id in enabled_tool_ids:
+        # Scoped ids (`base::tool`) collapse to their base catalog id plus a
+        # per-server set of selected tool names; a bare id means the whole
+        # server (filter is None).
+        name_filters = collect_tool_name_filters(enabled_tool_ids)
+
+        for tool_id, allowed_tool_names in name_filters.items():
             try:
                 tool = await repository.get_tool(tool_id)
                 if not tool:
@@ -300,6 +328,11 @@ class ExternalMCPIntegration:
                 requires_user_auth = forward_auth or requires_oauth
 
                 cache_key = self._get_cache_key(tool_id, user_id, requires_user_auth)
+                # A different selected-tool subset is a different client, so fold
+                # the filter into the cache key (the integration is shared across
+                # agents — two users may select different subsets of one server).
+                if allowed_tool_names is not None:
+                    cache_key += "|allow:" + ",".join(sorted(allowed_tool_names))
                 tool_version = (
                     tool.updated_at.isoformat() + "Z" if tool.updated_at else ""
                 )
@@ -353,6 +386,7 @@ class ExternalMCPIntegration:
                     tool_definition=tool,
                     oauth_token=static_token,
                     token_provider=token_provider,
+                    allowed_tool_names=allowed_tool_names,
                 )
 
                 if client:

--- a/backend/src/agents/main_agent/tools/gateway_integration.py
+++ b/backend/src/agents/main_agent/tools/gateway_integration.py
@@ -4,6 +4,7 @@ Gateway MCP client integration for managed tool execution
 import logging
 from typing import List, Optional, Any
 from agents.main_agent.integrations.gateway_mcp_client import get_gateway_client_if_enabled
+from apis.shared.tools.scoped_ids import parse_scoped_tool_id
 
 logger = logging.getLogger(__name__)
 
@@ -20,27 +21,51 @@ async def expand_gateway_tool_ids(
     matches on. Expand each catalog tool from the ``target_name`` + ``tools``
     list on its ``mcp_gateway_config``.
 
+    A *scoped* catalog id (``gateway_class_search::search``) selects one tool of
+    the target and expands to just ``gateway_<target>___search`` — this is how a
+    skill or a user enables a subset of a gateway target's tools.
+
     Ids that already contain ``___`` are runtime gateway ids enabled directly
-    via RBAC (no catalog row) and pass through unchanged, as do catalog tools
-    with no curated tool list (e.g. DYNAMIC listing). Order-preserving and
+    via RBAC (no catalog row) and pass through unchanged, as do bare catalog
+    tools with no curated tool list (e.g. DYNAMIC listing). Order-preserving and
     de-duplicated.
 
     Args:
-        gateway_tool_ids: enabled ids that the filter classified as gateway.
+        gateway_tool_ids: enabled ids that the filter classified as gateway
+            (bare catalog ids, scoped ``base::tool`` ids, or runtime ids).
         repository: tool-catalog repository exposing ``async get_tool(id)``.
     """
     expanded: List[str] = []
     for tool_id in gateway_tool_ids:
         if "___" in tool_id:
+            # Already a runtime gateway id (RBAC-enabled, no catalog row).
             expanded.append(tool_id)
             continue
-        tool = await repository.get_tool(tool_id)
+        base, tool_name = parse_scoped_tool_id(tool_id)
+        tool = await repository.get_tool(base)
         cfg = getattr(tool, "mcp_gateway_config", None) if tool else None
         target = getattr(cfg, "target_name", None) if cfg else None
         entries = getattr(cfg, "tools", None) if cfg else None
-        if tool and tool.protocol == "mcp" and target and entries:
+        is_gateway = bool(tool and tool.protocol == "mcp")
+
+        if tool_name is not None:
+            # Scoped: a single tool of this target. The target name is required
+            # to build the runtime id the FilteredMCPClient matches on.
+            if is_gateway and target:
+                expanded.append(f"gateway_{target}___{tool_name}")
+            else:
+                logger.warning(
+                    "Cannot resolve scoped gateway tool '%s' (no target_name); skipping",
+                    tool_id,
+                )
+            continue
+
+        # Bare catalog id = the whole target.
+        if is_gateway and target and entries:
             expanded.extend(f"gateway_{target}___{entry.name}" for entry in entries)
         else:
+            # No curated list (DYNAMIC listing) or not a gateway tool — pass
+            # the id through unchanged.
             expanded.append(tool_id)
 
     seen: set = set()

--- a/backend/src/agents/main_agent/tools/tool_filter.py
+++ b/backend/src/agents/main_agent/tools/tool_filter.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Optional, Any, Tuple
 from agents.main_agent.config.constants import Prefixes
 from agents.main_agent.tools.tool_registry import ToolRegistry
+from apis.shared.tools.scoped_ids import base_tool_id
 
 logger = logging.getLogger(__name__)
 
@@ -74,15 +75,23 @@ class ToolFilter:
 
         filtered_tools = []
         gateway_tool_ids = []
+        seen_local: set[int] = set()
 
         for tool_id in enabled_tool_ids:
-            if self.registry.has_tool(tool_id):
-                # Local tool from registry
-                filtered_tools.append(self.registry.get_tool(tool_id))
-            elif tool_id.startswith(Prefixes.GATEWAY_TOOL):
+            # A scoped id (``base::tool``) selects one tool within an MCP server;
+            # classify by its base catalog id and let the per-source resolver
+            # apply the tool-name filter.
+            base = base_tool_id(tool_id)
+            if self.registry.has_tool(base):
+                # Local tool from registry — a single tool, so scoping is moot.
+                tool_obj = self.registry.get_tool(base)
+                if id(tool_obj) not in seen_local:
+                    seen_local.add(id(tool_obj))
+                    filtered_tools.append(tool_obj)
+            elif base.startswith(Prefixes.GATEWAY_TOOL):
                 # Gateway MCP tool - collect for separate handling
                 gateway_tool_ids.append(tool_id)
-            elif tool_id in self._external_mcp_tools:
+            elif base in self._external_mcp_tools:
                 # External MCP tool - handled separately
                 pass
             else:
@@ -113,15 +122,24 @@ class ToolFilter:
         filtered_tools = []
         gateway_tool_ids = []
         external_mcp_tool_ids = []
+        seen_local: set[int] = set()
 
         for tool_id in enabled_tool_ids:
-            if self.registry.has_tool(tool_id):
-                # Local tool from registry
-                filtered_tools.append(self.registry.get_tool(tool_id))
-            elif tool_id.startswith(Prefixes.GATEWAY_TOOL):
+            # A scoped id (``base::tool``) selects one tool within an MCP server;
+            # classify by its base catalog id. Scoped gateway/external ids ride
+            # through to their resolver (expand_gateway_tool_ids /
+            # load_external_tools), which applies the per-server tool filter.
+            base = base_tool_id(tool_id)
+            if self.registry.has_tool(base):
+                # Local tool from registry — a single tool, so scoping is moot.
+                tool_obj = self.registry.get_tool(base)
+                if id(tool_obj) not in seen_local:
+                    seen_local.add(id(tool_obj))
+                    filtered_tools.append(tool_obj)
+            elif base.startswith(Prefixes.GATEWAY_TOOL):
                 # Gateway MCP tool (AgentCore Gateway)
                 gateway_tool_ids.append(tool_id)
-            elif tool_id in self._external_mcp_tools:
+            elif base in self._external_mcp_tools:
                 # External MCP tool (deployed separately)
                 external_mcp_tool_ids.append(tool_id)
             else:
@@ -158,11 +176,12 @@ class ToolFilter:
         unknown_count = 0
 
         for tool_id in enabled_tool_ids:
-            if self.registry.has_tool(tool_id):
+            base = base_tool_id(tool_id)
+            if self.registry.has_tool(base):
                 local_count += 1
-            elif tool_id.startswith(Prefixes.GATEWAY_TOOL):
+            elif base.startswith(Prefixes.GATEWAY_TOOL):
                 gateway_count += 1
-            elif tool_id in self._external_mcp_tools:
+            elif base in self._external_mcp_tools:
                 external_mcp_count += 1
             else:
                 unknown_count += 1

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from apis.shared.auth import User, require_admin
 from apis.app_api.tools.service import get_tool_catalog_service
+from apis.app_api.tools.discovery import discover_tools_for_saved_tool
 from apis.shared.tools.gateway_target_service import (
     GatewayTargetConflictError,
     GatewayTargetNotFoundError,
@@ -434,6 +435,32 @@ async def admin_discover_mcp_tools(
         discovered.append(DiscoveredMCPTool(name=name, description=description))
 
     return MCPDiscoverResponse(tools=discovered)
+
+
+@router.post("/{tool_id}/discover", response_model=MCPDiscoverResponse)
+async def admin_discover_saved_tool_tools(
+    tool_id: str,
+    admin: User = Depends(require_admin),
+):
+    """List the individual tools a *saved* catalog tool exposes.
+
+    Used by the admin skills picker to drive per-tool binding for an MCP server
+    whose tools aren't enumerated in the catalog. For a gateway target this
+    returns the tools the gateway recorded at registration; for an external MCP
+    server it connects live (OAuth-gated servers fall back to the curated list,
+    since the admin session has no end-user token).
+    """
+    service = get_tool_catalog_service()
+    tool = await service.get_tool(tool_id)
+    if tool is None:
+        raise HTTPException(status_code=404, detail="Tool not found")
+
+    try:
+        tools = await discover_tools_for_saved_tool(tool)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    return MCPDiscoverResponse(tools=tools)
 
 
 @router.get("/{tool_id}/gateway-status", response_model=GatewayTargetStatusResponse)

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -35,6 +35,11 @@ from apis.shared.skills.resource_store import (
     get_skill_resource_store,
 )
 from apis.shared.tools.models import ToolStatus
+from apis.shared.tools.scoped_ids import (
+    base_tool_id,
+    base_tool_ids,
+    parse_scoped_tool_id,
+)
 from apis.shared.tools.repository import (
     ToolCatalogRepository,
     get_tool_catalog_repository,
@@ -119,29 +124,62 @@ class SkillCatalogService:
         so binding an unknown or disabled tool would silently drop it. Reject
         such bindings up front (spec §6).
 
+        A scoped id (``tool_id::mcp_tool_name``) binds a single tool of an MCP
+        server. Its base catalog tool must exist + be active, and — when the
+        server has a curated tool list — the named tool must be one it exposes.
+        Servers whose tools are discovered live have no curated list, so the
+        name can't be validated statically and is accepted.
+
         Raises:
-            ValueError: If any bound tool is unknown or not ACTIVE.
+            ValueError: If any bound tool is unknown, non-active, scoped onto a
+                tool the server doesn't expose, or scoped onto a non-MCP tool.
         """
         if not bound_tool_ids:
             return
 
         # Dedupe while preserving the admin's set for clear error messages.
         requested = list(dict.fromkeys(bound_tool_ids))
-        found = await self.tool_repository.batch_get_tools(requested)
+        base_ids = base_tool_ids(requested)
+        found = await self.tool_repository.batch_get_tools(base_ids)
         by_id = {t.tool_id: t for t in found}
 
-        unknown = [tid for tid in requested if tid not in by_id]
+        unknown = [tid for tid in requested if base_tool_id(tid) not in by_id]
         disabled = [
             tid
             for tid in requested
-            if tid in by_id and by_id[tid].status != ToolStatus.ACTIVE.value
+            if base_tool_id(tid) in by_id
+            and by_id[base_tool_id(tid)].status != ToolStatus.ACTIVE.value
         ]
+
+        # Per-tool bindings: the named tool must belong to the server (when the
+        # server exposes a curated list) and the base must be an MCP server.
+        unexposed: List[str] = []
+        not_mcp: List[str] = []
+        for tid in requested:
+            base, tool_name = parse_scoped_tool_id(tid)
+            if tool_name is None or base not in by_id or tid in disabled:
+                continue
+            tool = by_id[base]
+            if tool.protocol not in ("mcp", "mcp_external"):
+                not_mcp.append(tid)
+                continue
+            names = tool.curated_tool_names()
+            if names is not None and tool_name not in names:
+                unexposed.append(tid)
 
         problems = []
         if unknown:
             problems.append(f"unknown tool(s): {', '.join(sorted(unknown))}")
         if disabled:
             problems.append(f"non-active tool(s): {', '.join(sorted(disabled))}")
+        if not_mcp:
+            problems.append(
+                f"per-tool binding on non-MCP tool(s): {', '.join(sorted(not_mcp))}"
+            )
+        if unexposed:
+            problems.append(
+                f"tool(s) not exposed by their server: {', '.join(sorted(unexposed))}"
+            )
         if problems:
             raise ValueError(
                 "Cannot bind " + "; ".join(problems) + ". "

--- a/backend/src/apis/app_api/tools/discovery.py
+++ b/backend/src/apis/app_api/tools/discovery.py
@@ -1,0 +1,102 @@
+"""Live MCP tool discovery for a *saved* catalog tool.
+
+Drives per-tool selection in the admin skills picker and the user-facing model
+settings: given a saved MCP/gateway catalog tool, return the individual tools it
+exposes so a caller can enable a subset.
+
+- external MCP (``mcp_external``): connect to the server and list its tools. For
+  ``forward_auth_token`` servers, pass the caller's OIDC token so the live
+  session authenticates as them. OAuth-provider (3LO) servers can't be
+  discovered without an end-user consent token, so we fall back to any curated
+  ``tools[]`` the admin recorded.
+- gateway (``mcp``): the AgentCore Gateway enumerates a target's tools at
+  registration, so return the curated ``tools[]`` (live gateway listing is not
+  performed here).
+
+NOTE: importing MCP-client construction from ``agents`` mirrors the existing
+``/admin/tools/discover`` route. The import-boundary test permits
+``app_api -> agents`` (it only forbids ``agents -> app_api``).
+"""
+
+import asyncio
+import logging
+from typing import List, Optional
+
+from apis.shared.tools.models import DiscoveredMCPTool, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def _curated(tool: ToolDefinition) -> List[DiscoveredMCPTool]:
+    """The tools an admin recorded on the catalog entry (may be empty)."""
+    names = tool.curated_tool_names()
+    if not names:
+        return []
+    cfg = tool.mcp_config or tool.mcp_gateway_config
+    return [
+        DiscoveredMCPTool(name=e.name, description=e.description)
+        for e in (getattr(cfg, "tools", None) or [])
+    ]
+
+
+async def discover_tools_for_saved_tool(
+    tool: ToolDefinition,
+    oauth_token: Optional[str] = None,
+) -> List[DiscoveredMCPTool]:
+    """Return the individual tools a saved MCP/gateway catalog tool exposes.
+
+    Args:
+        tool: the saved catalog tool (must be protocol ``mcp`` or ``mcp_external``).
+        oauth_token: the caller's OIDC token, forwarded to ``forward_auth_token``
+            servers so discovery authenticates as the caller.
+
+    Raises:
+        RuntimeError: if a live external MCP server can't be reached. Routes
+            translate this into a 502.
+    """
+    if tool.protocol == "mcp":
+        # Gateway target — tools are enumerated by the gateway at registration.
+        return _curated(tool)
+
+    if tool.protocol != "mcp_external" or not tool.mcp_config:
+        return []
+
+    # OAuth (3LO) servers need an end-user consent token we don't hold here.
+    if tool.requires_oauth_provider:
+        return _curated(tool)
+
+    from agents.main_agent.integrations.external_mcp_client import (
+        create_external_mcp_client,
+    )
+
+    forward = bool(getattr(tool, "forward_auth_token", False))
+    client = create_external_mcp_client(
+        config=tool.mcp_config,
+        tool_definition=tool,
+        oauth_token=oauth_token if forward else None,
+    )
+    if client is None:
+        return []
+
+    def _list_tools():
+        # MCPClient opens its session on context enter; list_tools_sync runs the
+        # MCP tools/list call. Pushed to a thread so the event loop stays free.
+        with client:
+            return list(client.list_tools_sync())
+
+    try:
+        tools = await asyncio.to_thread(_list_tools)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a 502 by the route
+        logger.warning("Live MCP discovery failed for %s: %s", tool.tool_id, exc)
+        raise RuntimeError(f"MCP server did not respond to tools/list: {exc}") from exc
+
+    discovered: List[DiscoveredMCPTool] = []
+    for t in tools:
+        spec = getattr(t, "mcp_tool", None)
+        name = getattr(spec, "name", None) or getattr(t, "tool_name", None)
+        if not name:
+            continue
+        discovered.append(
+            DiscoveredMCPTool(name=name, description=getattr(spec, "description", None))
+        )
+    return discovered

--- a/backend/src/apis/app_api/tools/routes.py
+++ b/backend/src/apis/app_api/tools/routes.py
@@ -20,9 +20,11 @@ from agents.main_agent.tools import (
 
 # Import new service and models
 from .service import get_tool_catalog_service
+from .discovery import discover_tools_for_saved_tool
 from apis.shared.tools.models import (
     UserToolsResponse,
     ToolPreferencesRequest,
+    MCPDiscoverResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -130,6 +132,37 @@ async def update_tool_preferences(
         return {"message": "Preferences saved successfully"}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/{tool_id}/discover", response_model=MCPDiscoverResponse)
+async def discover_my_tool_tools(
+    tool_id: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """List the individual tools a saved MCP server exposes (per-tool enablement).
+
+    Lets the model-settings UI offer per-tool toggles for an MCP server whose
+    tools aren't enumerated in the catalog (discovered live). Gated by the
+    user's RBAC access to the tool; ``forward_auth_token`` servers are
+    discovered with the user's own token.
+    """
+    service = get_tool_catalog_service()
+
+    # RBAC: the user must already have access to this catalog tool.
+    accessible = await service.get_user_accessible_tools(user)
+    if not any(t.tool_id == tool_id for t in accessible):
+        raise HTTPException(status_code=404, detail="Tool not found or not accessible")
+
+    tool = await service.repository.get_tool(tool_id)
+    if tool is None:
+        raise HTTPException(status_code=404, detail="Tool not found")
+
+    try:
+        tools = await discover_tools_for_saved_tool(tool, oauth_token=user.raw_token)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    return MCPDiscoverResponse(tools=tools)
 
 
 # =============================================================================

--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -17,11 +17,13 @@ from apis.shared.tools.models import (
     ToolDefinition,
     ToolProtocol,
     UserToolAccess,
+    UserToolServerTool,
     UserToolPreference,
     ToolCategory,
     ToolRoleAssignment,
 )
 from apis.shared.tools.repository import ToolCatalogRepository, get_tool_catalog_repository
+from apis.shared.tools.scoped_ids import SCOPE_DELIMITER, parse_scoped_tool_id
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +97,35 @@ class ToolCatalogService:
                 continue
 
             user_enabled = prefs.tool_preferences.get(tool.tool_id)
-            is_enabled = user_enabled if user_enabled is not None else tool.enabled_by_default
+            default_enabled = (
+                user_enabled if user_enabled is not None else tool.enabled_by_default
+            )
+
+            # Surface an MCP server's individual tools so the UI can enable a
+            # subset. Empty for non-MCP tools or servers with no curated list.
+            # Each sub-tool's effective state: its own scoped preference, else
+            # the server-level preference, else the catalog default.
+            cfg = tool.mcp_config or tool.mcp_gateway_config
+            server_tools = []
+            for entry in getattr(cfg, "tools", None) or []:
+                scoped_key = f"{tool.tool_id}{SCOPE_DELIMITER}{entry.name}"
+                scoped_pref = prefs.tool_preferences.get(scoped_key)
+                server_tools.append(
+                    UserToolServerTool(
+                        name=entry.name,
+                        description=entry.description,
+                        needs_approval=entry.needs_approval,
+                        enabled=scoped_pref if scoped_pref is not None else default_enabled,
+                    )
+                )
+
+            # The server row is "on" when any of its tools are on (or, for a
+            # server with no curated list, the server-level preference applies).
+            is_enabled = (
+                any(st.enabled for st in server_tools)
+                if server_tools
+                else default_enabled
+            )
 
             accessible.append(
                 UserToolAccess(
@@ -109,6 +139,7 @@ class ToolCatalogService:
                     enabled_by_default=tool.enabled_by_default,
                     user_enabled=user_enabled,
                     is_enabled=is_enabled,
+                    server_tools=server_tools,
                 )
             )
 
@@ -161,15 +192,32 @@ class ToolCatalogService:
         Raises:
             ValueError: If user tries to configure tools they don't have access to
         """
-        # Get accessible tools
+        # Get accessible tools. A preference key may be scoped
+        # (`tool_id::mcp_tool_name`) to enable a single tool of an MCP server;
+        # validate the base catalog id for access (RBAC) and the tool name
+        # against the server's curated list when it has one.
         accessible = await self.get_user_accessible_tools(user)
-        accessible_ids = {t.tool_id for t in accessible}
+        accessible_by_id = {t.tool_id: t for t in accessible}
 
-        # Validate preferences
-        invalid_tools = set(preferences.keys()) - accessible_ids
+        invalid_tools = set()
+        unexposed_tools = set()
+        for key in preferences:
+            base, tool_name = parse_scoped_tool_id(key)
+            if base not in accessible_by_id:
+                invalid_tools.add(key)
+                continue
+            if tool_name is not None:
+                server_names = {st.name for st in accessible_by_id[base].server_tools}
+                if server_names and tool_name not in server_names:
+                    unexposed_tools.add(key)
+
         if invalid_tools:
             raise ValueError(
                 f"Cannot configure tools user doesn't have access to: {invalid_tools}"
+            )
+        if unexposed_tools:
+            raise ValueError(
+                f"Cannot configure tools not exposed by their server: {unexposed_tools}"
             )
 
         # Save preferences

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -7,7 +7,7 @@ Integrates with the existing AppRole RBAC system.
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -689,6 +689,23 @@ class ToolDefinition(BaseModel):
 
     model_config = {"use_enum_values": True}
 
+    def curated_tool_names(self) -> Optional[Set[str]]:
+        """The MCP tool names this catalog tool exposes, when known.
+
+        For an external-MCP (``mcp_external``) or Gateway (``mcp``) tool the
+        admin may curate the server's tool list; return those names so callers
+        can validate a per-tool selection (``tool_id::name``) against them.
+        Returns ``None`` when the tool is not an MCP server or has no curated
+        list (e.g. a DYNAMIC gateway target, or a server whose tools are
+        discovered live) — in which case per-tool names can't be validated
+        statically.
+        """
+        cfg = self.mcp_config or self.mcp_gateway_config
+        entries = getattr(cfg, "tools", None) if cfg else None
+        if not entries:
+            return None
+        return {entry.name for entry in entries}
+
     def to_dynamo_item(self) -> dict:
         """Convert to DynamoDB item format."""
         item = {
@@ -818,6 +835,24 @@ class UserToolPreference(BaseModel):
 # =============================================================================
 
 
+class UserToolServerTool(BaseModel):
+    """One tool exposed by an MCP-server catalog tool.
+
+    Surfaced on ``UserToolAccess`` so the user-facing tools UI can enable a
+    subset of a server's tools (per-tool enablement). ``name`` is the raw MCP
+    tool name; a preference for it is keyed ``<tool_id>::<name>``. ``enabled``
+    is the user's effective state for this individual tool (scoped preference,
+    falling back to the server-level preference, then the catalog default).
+    """
+
+    name: str
+    description: Optional[str] = None
+    needs_approval: bool = Field(default=False, alias="needsApproval")
+    enabled: bool = True
+
+    model_config = {"populate_by_name": True}
+
+
 class UserToolAccess(BaseModel):
     """
     Computed tool access for a specific user.
@@ -831,6 +866,13 @@ class UserToolAccess(BaseModel):
     protocol: ToolProtocol
     status: ToolStatus
     requires_oauth_provider: Optional[str] = Field(None, alias="requiresOauthProvider")
+
+    # For MCP-server tools (protocol 'mcp'/'mcp_external'): the individual tools
+    # the server exposes, so the UI can offer per-tool enablement. Empty for
+    # non-MCP tools or servers whose tools are discovered live.
+    server_tools: List[UserToolServerTool] = Field(
+        default_factory=list, alias="serverTools"
+    )
 
     # Access info
     granted_by: List[str] = Field(

--- a/backend/src/apis/shared/tools/scoped_ids.py
+++ b/backend/src/apis/shared/tools/scoped_ids.py
@@ -1,0 +1,87 @@
+"""Scoped tool identifiers — referencing an individual tool within an MCP server.
+
+A bare catalog tool id (e.g. ``fetch_url_content`` or ``gateway_class_search``)
+means "the whole server / all of its tools" — the historical behaviour. A
+*scoped* id ``<catalog_tool_id>::<mcp_tool_name>`` references a single tool the
+server exposes, so a skill binding or a user preference can carry a subset of a
+server's tools instead of all of them.
+
+This module is the one place that knows the on-the-wire scoping format. It is
+shared by the app_api validation layer and the agents runtime (import-boundary
+safe — depends on nothing else in the package).
+"""
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+# Delimiter between a catalog tool id and an individual MCP tool name. Chosen so
+# it cannot collide with catalog ids (which use single underscores) or with the
+# gateway runtime convention ``gateway_<target>___<tool>`` (triple underscore).
+SCOPE_DELIMITER = "::"
+
+
+def is_scoped_tool_id(tool_id: str) -> bool:
+    """True if ``tool_id`` references a single tool within a server."""
+    return SCOPE_DELIMITER in tool_id
+
+
+def make_scoped_tool_id(catalog_tool_id: str, mcp_tool_name: str) -> str:
+    """Build the scoped id for one tool of an MCP-server catalog tool."""
+    return f"{catalog_tool_id}{SCOPE_DELIMITER}{mcp_tool_name}"
+
+
+def parse_scoped_tool_id(tool_id: str) -> Tuple[str, Optional[str]]:
+    """Split a possibly-scoped id into ``(catalog_tool_id, mcp_tool_name)``.
+
+    A bare id returns ``(tool_id, None)``. A scoped id returns the base catalog
+    id and the individual tool name. Only the first delimiter splits, so an
+    (unlikely) tool name containing the delimiter is preserved verbatim.
+    """
+    if SCOPE_DELIMITER not in tool_id:
+        return tool_id, None
+    base, _, name = tool_id.partition(SCOPE_DELIMITER)
+    name = name.strip()
+    return base, (name or None)
+
+
+def base_tool_id(tool_id: str) -> str:
+    """The catalog tool id that a (possibly-scoped) id refers to."""
+    return parse_scoped_tool_id(tool_id)[0]
+
+
+def base_tool_ids(tool_ids: Iterable[str]) -> List[str]:
+    """De-duplicated catalog ids referenced by an id list, order-preserving."""
+    seen: Dict[str, None] = {}
+    for tid in tool_ids:
+        seen.setdefault(base_tool_id(tid), None)
+    return list(seen.keys())
+
+
+def collect_tool_name_filters(
+    tool_ids: Iterable[str],
+) -> Dict[str, Optional[Set[str]]]:
+    """Map each referenced catalog id to its selected tool-name filter.
+
+    The value is ``None`` when the whole server is selected — a bare id is
+    present for that catalog id, which wins over any scoped ids for the same
+    server — or a set of individual tool names when only a subset is selected.
+    Catalog ids keep their first-seen order (callers downstream rely on a
+    deterministic order, e.g. when one server's client fails to start).
+
+    Example::
+
+        collect_tool_name_filters(["a", "b::x", "b::y", "c", "c::z"])
+        # -> {"a": None, "b": {"x", "y"}, "c": None}
+        #    'c' is whole-server because the bare 'c' is present alongside 'c::z'.
+    """
+    order: List[str] = []
+    whole: Set[str] = set()
+    scoped: Dict[str, Set[str]] = {}
+    for tid in tool_ids:
+        base, name = parse_scoped_tool_id(tid)
+        if base not in whole and base not in scoped:
+            order.append(base)
+        if name is None:
+            whole.add(base)
+        else:
+            scoped.setdefault(base, set()).add(name)
+
+    return {base: (None if base in whole else scoped[base]) for base in order}

--- a/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
+++ b/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
@@ -306,3 +306,70 @@ class TestLoadExternalToolsPreflight:
 
         assert result == [good_client]
         assert integration.clients == {"gmail": good_client}
+
+
+class TestLoadExternalToolsScoped:
+    """Per-tool enablement: a scoped id (`base::tool`) restricts the client to
+    the selected tool names; a bare id exposes the whole server."""
+
+    @pytest.mark.asyncio
+    async def test_scoped_ids_collapse_to_one_filtered_client(self):
+        integration = ExternalMCPIntegration()
+        tool = _fake_tool(datetime(2025, 1, 1, tzinfo=timezone.utc))
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+        client = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+            return_value=client,
+        ) as create_mock:
+            await integration.load_external_tools(["gmail::send", "gmail::search"])
+
+        # Two scoped ids for one server build a single client, restricted to
+        # the selected tool names.
+        assert create_mock.call_count == 1
+        assert create_mock.call_args.kwargs["allowed_tool_names"] == {"send", "search"}
+
+    @pytest.mark.asyncio
+    async def test_bare_id_exposes_whole_server(self):
+        integration = ExternalMCPIntegration()
+        tool = _fake_tool(datetime(2025, 1, 1, tzinfo=timezone.utc))
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+        client = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+            return_value=client,
+        ) as create_mock:
+            await integration.load_external_tools(["gmail"])
+
+        assert create_mock.call_args.kwargs["allowed_tool_names"] is None
+
+    @pytest.mark.asyncio
+    async def test_different_subsets_are_distinct_cached_clients(self):
+        integration = ExternalMCPIntegration()
+        tool = _fake_tool(datetime(2025, 1, 1, tzinfo=timezone.utc))
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+        client_a = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+        client_b = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+            side_effect=[client_a, client_b],
+        ):
+            first = await integration.load_external_tools(["gmail::send"])
+            second = await integration.load_external_tools(["gmail::search"])
+
+        # A different selected-tool subset must not reuse the other's client.
+        assert first == [client_a]
+        assert second == [client_b]
+        assert len(integration.clients) == 2

--- a/backend/tests/agents/main_agent/tools/test_gateway_integration.py
+++ b/backend/tests/agents/main_agent/tools/test_gateway_integration.py
@@ -71,6 +71,34 @@ async def test_unknown_and_empty_tool_list_pass_through():
 
 
 @pytest.mark.asyncio
+async def test_scoped_id_expands_to_single_runtime_id():
+    # A scoped catalog id selects ONE tool of the target.
+    repo = _FakeRepo(
+        {"gateway_class_search": _gateway_tool("gateway-class-search", ["search_classes", "get_class_details"])}
+    )
+    out = await expand_gateway_tool_ids(["gateway_class_search::search_classes"], repo)
+    assert out == ["gateway_gateway-class-search___search_classes"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_id_works_for_tool_not_in_curated_list():
+    # Discover-path: a scoped tool need not be in the curated tools[] (e.g. a
+    # DYNAMIC target discovered live). The target name still resolves it.
+    repo = _FakeRepo({"gateway_dyn": _gateway_tool("dyn-target", [])})
+    out = await expand_gateway_tool_ids(["gateway_dyn::live_tool"], repo)
+    assert out == ["gateway_dyn-target___live_tool"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_id_without_target_is_skipped():
+    # Cannot build a runtime id without a target_name — skip rather than emit a
+    # malformed id.
+    repo = _FakeRepo({"gateway_x": SimpleNamespace(protocol="mcp", mcp_gateway_config=None)})
+    out = await expand_gateway_tool_ids(["gateway_x::foo"], repo)
+    assert out == []
+
+
+@pytest.mark.asyncio
 async def test_dedupes_preserving_order():
     repo = _FakeRepo(
         {

--- a/backend/tests/agents/main_agent/tools/test_tool_filter.py
+++ b/backend/tests/agents/main_agent/tools/test_tool_filter.py
@@ -127,6 +127,39 @@ class TestFilterToolsExtended:
 
 
 # ---------------------------------------------------------------------------
+# Scoped ids (`base::tool`) — classify by the base catalog id, carry through
+# ---------------------------------------------------------------------------
+class TestFilterToolsScoped:
+    """A scoped id selecting one tool of an MCP server is classified by its base
+    catalog id; the scoped id rides through to the per-source resolver."""
+
+    def test_scoped_gateway_id_carried_through(self, tool_filter: ToolFilter):
+        result = tool_filter.filter_tools_extended(["gateway_wiki::search"])
+        assert result.gateway_tool_ids == ["gateway_wiki::search"]
+        assert result.external_mcp_tool_ids == []
+
+    def test_scoped_external_id_carried_through(self, tool_filter: ToolFilter):
+        tool_filter.set_external_mcp_tools(["ext_tool_a"])
+        result = tool_filter.filter_tools_extended(["ext_tool_a::do_thing"])
+        assert result.external_mcp_tool_ids == ["ext_tool_a::do_thing"]
+        assert result.local_tools == []
+
+    def test_bare_and_scoped_local_not_double_added(self, tool_filter: ToolFilter):
+        # A local tool is a single tool — bare + scoped must not add it twice.
+        result = tool_filter.filter_tools_extended(["calculator", "calculator::x"])
+        assert len(result.local_tools) == 1
+
+    def test_scoped_counts_as_its_base_category_in_stats(self, tool_filter: ToolFilter):
+        tool_filter.set_external_mcp_tools(["ext_tool_a"])
+        stats = tool_filter.get_statistics(
+            ["gateway_wiki::search", "ext_tool_a::do_thing"]
+        )
+        assert stats["gateway_tools"] == 1
+        assert stats["external_mcp_tools"] == 1
+        assert stats["unknown_tools"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Req 6.6 — get_statistics returns correct counts
 # ---------------------------------------------------------------------------
 class TestGetStatistics:

--- a/backend/tests/apis/app_api/skills/test_skill_catalog_service.py
+++ b/backend/tests/apis/app_api/skills/test_skill_catalog_service.py
@@ -141,6 +141,75 @@ async def test_update_revalidates_bound_tools(skill_service, tool_repo, admin_us
         )
 
 
+# ── scoped (per-tool) bindings ───────────────────────────────────────────────
+
+
+async def _seed_mcp_tool(tool_repo, tool_id, tool_names, status=ToolStatus.ACTIVE):
+    """Seed an external-MCP catalog tool with a curated tools[] list."""
+    from apis.shared.tools.models import MCPServerConfig, MCPToolEntry
+
+    await tool_repo.create_tool(
+        ToolDefinition(
+            tool_id=tool_id,
+            display_name=tool_id,
+            description="x",
+            protocol=ToolProtocol.MCP_EXTERNAL,
+            status=status,
+            mcp_config=MCPServerConfig(
+                server_url="https://example.com/mcp",
+                tools=[MCPToolEntry(name=n) for n in tool_names],
+            ),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_bind_scoped_tool_exposed_by_server(skill_service, tool_repo, admin_user):
+    await _seed_mcp_tool(tool_repo, "gmail", ["send", "search", "draft"])
+    created = await skill_service.create_skill(
+        _skill(bound_tool_ids=["gmail::send", "gmail::search"]), admin_user
+    )
+    assert created.bound_tool_ids == ["gmail::send", "gmail::search"]
+
+
+@pytest.mark.asyncio
+async def test_bind_scoped_tool_not_exposed_is_rejected(skill_service, tool_repo, admin_user):
+    await _seed_mcp_tool(tool_repo, "gmail", ["send", "search"])
+    with pytest.raises(ValueError, match="not exposed by their server"):
+        await skill_service.create_skill(
+            _skill(bound_tool_ids=["gmail::delete_everything"]), admin_user
+        )
+
+
+@pytest.mark.asyncio
+async def test_bind_scoped_tool_on_server_with_no_curated_list(skill_service, tool_repo, admin_user):
+    # No curated tools[] (discovered live) → the name can't be validated
+    # statically and is accepted.
+    await _seed_mcp_tool(tool_repo, "dyn", [])
+    created = await skill_service.create_skill(
+        _skill(bound_tool_ids=["dyn::live_tool"]), admin_user
+    )
+    assert created.bound_tool_ids == ["dyn::live_tool"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_binding_on_local_tool_is_rejected(skill_service, tool_repo, admin_user):
+    # A local tool is a single tool — per-tool scoping is meaningless.
+    await _seed_tool(tool_repo, "fill_pdf_form")
+    with pytest.raises(ValueError, match="non-MCP tool"):
+        await skill_service.create_skill(
+            _skill(bound_tool_ids=["fill_pdf_form::x"]), admin_user
+        )
+
+
+@pytest.mark.asyncio
+async def test_scoped_binding_on_unknown_base_is_rejected(skill_service, admin_user):
+    with pytest.raises(ValueError, match="unknown tool"):
+        await skill_service.create_skill(
+            _skill(bound_tool_ids=["ghost::tool"]), admin_user
+        )
+
+
 # ── role sync + hydration ────────────────────────────────────────────────────
 
 

--- a/backend/tests/apis/app_api/tools/test_discovery.py
+++ b/backend/tests/apis/app_api/tools/test_discovery.py
@@ -1,0 +1,106 @@
+"""Live MCP tool discovery for a saved catalog tool (per-tool enablement).
+
+The helper connects to a saved external MCP server (or returns a gateway
+target's recorded tools) so the admin skills picker and model-settings UI can
+offer per-tool selection. The MCP client is patched — no network here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apis.app_api.tools.discovery import discover_tools_for_saved_tool
+from apis.shared.tools.models import (
+    MCPGatewayConfig,
+    MCPServerConfig,
+    MCPToolEntry,
+    ToolDefinition,
+    ToolProtocol,
+    ToolStatus,
+)
+
+CREATE_CLIENT = (
+    "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client"
+)
+
+
+def _ext(tool_id="gmail", names=(), requires_oauth=None, forward=False):
+    return ToolDefinition(
+        tool_id=tool_id,
+        display_name=tool_id,
+        description="x",
+        protocol=ToolProtocol.MCP_EXTERNAL,
+        status=ToolStatus.ACTIVE,
+        requires_oauth_provider=requires_oauth,
+        forward_auth_token=forward,
+        mcp_config=MCPServerConfig(
+            server_url="https://example.com/mcp",
+            tools=[MCPToolEntry(name=n) for n in names],
+        ),
+    )
+
+
+class _FakeMCPTool:
+    def __init__(self, name, desc=None):
+        self.mcp_tool = SimpleNamespace(name=name, description=desc)
+        self.tool_name = name
+
+
+class _FakeClient:
+    def __init__(self, tools):
+        self._tools = tools
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def list_tools_sync(self):
+        return self._tools
+
+
+@pytest.mark.asyncio
+async def test_gateway_returns_curated_tools():
+    tool = ToolDefinition(
+        tool_id="gw",
+        display_name="gw",
+        description="x",
+        protocol=ToolProtocol.MCP_GATEWAY,
+        status=ToolStatus.ACTIVE,
+        mcp_gateway_config=MCPGatewayConfig(
+            target_name="t",
+            endpoint_url="https://example.com/mcp",
+            tools=[MCPToolEntry(name="a"), MCPToolEntry(name="b")],
+        ),
+    )
+    out = await discover_tools_for_saved_tool(tool)
+    assert {t.name for t in out} == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_external_lists_live_tools():
+    client = _FakeClient([_FakeMCPTool("send", "Send mail"), _FakeMCPTool("search")])
+    with patch(CREATE_CLIENT, return_value=client):
+        out = await discover_tools_for_saved_tool(_ext(names=()))
+    assert {t.name for t in out} == {"send", "search"}
+
+
+@pytest.mark.asyncio
+async def test_oauth_server_falls_back_to_curated_without_connecting():
+    tool = _ext(names=("a",), requires_oauth="google")
+    with patch(CREATE_CLIENT, side_effect=AssertionError("should not connect")):
+        out = await discover_tools_for_saved_tool(tool)
+    assert {t.name for t in out} == {"a"}
+
+
+@pytest.mark.asyncio
+async def test_unreachable_server_raises_runtimeerror():
+    class _BoomClient(_FakeClient):
+        def list_tools_sync(self):
+            raise RuntimeError("connection refused")
+
+    with patch(CREATE_CLIENT, return_value=_BoomClient([])):
+        with pytest.raises(RuntimeError, match="tools/list"):
+            await discover_tools_for_saved_tool(_ext())

--- a/backend/tests/apis/app_api/tools/test_user_preferences_scoped.py
+++ b/backend/tests/apis/app_api/tools/test_user_preferences_scoped.py
@@ -1,0 +1,137 @@
+"""Per-tool (scoped) user preferences + server-tool surfacing in ToolCatalogService.
+
+A user can enable a subset of an MCP server's tools. The preference key is
+``<tool_id>::<mcp_tool_name>``; the base tool_id is still the RBAC unit, and
+``UserToolAccess.server_tools`` carries the server's tools so the UI can render
+sub-toggles. Dependencies are mocked — the logic under test is pure.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.app_api.tools.service import ToolCatalogService
+from apis.shared.auth.models import User
+from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.tools.models import (
+    MCPServerConfig,
+    MCPToolEntry,
+    ToolDefinition,
+    ToolProtocol,
+    ToolStatus,
+    UserToolPreference,
+)
+
+
+def _user():
+    return User(user_id="u1", email="u@x.com", name="U", roles=["User"], raw_token="t")
+
+
+def _perms(tools):
+    return UserEffectivePermissions(
+        user_id="u1",
+        app_roles=["User"],
+        tools=tools,
+        models=["*"],
+        quota_tier=None,
+        resolved_at="2024-01-01T00:00:00Z",
+    )
+
+
+def _mcp_tool(tool_id="gmail", names=("send", "search")):
+    return ToolDefinition(
+        tool_id=tool_id,
+        display_name=tool_id,
+        description="x",
+        protocol=ToolProtocol.MCP_EXTERNAL,
+        status=ToolStatus.ACTIVE,
+        mcp_config=MCPServerConfig(
+            server_url="https://example.com/mcp",
+            tools=[MCPToolEntry(name=n) for n in names],
+        ),
+    )
+
+
+def _service(tools, prefs=None):
+    repo = MagicMock()
+    repo.list_tools = AsyncMock(return_value=tools)
+    repo.get_user_preferences = AsyncMock(
+        return_value=UserToolPreference(user_id="u1", tool_preferences=prefs or {})
+    )
+    repo.save_user_preferences = AsyncMock(
+        side_effect=lambda uid, p: UserToolPreference(user_id=uid, tool_preferences=p)
+    )
+    role_service = MagicMock()
+    role_service.resolve_user_permissions = AsyncMock(return_value=_perms(["*"]))
+    return ToolCatalogService(repository=repo, app_role_service=role_service)
+
+
+@pytest.mark.asyncio
+async def test_accessible_tools_surface_server_tools():
+    service = _service([_mcp_tool(names=("send", "search", "draft"))])
+    tools = await service.get_user_accessible_tools(_user())
+    assert len(tools) == 1
+    assert {st.name for st in tools[0].server_tools} == {"send", "search", "draft"}
+
+
+@pytest.mark.asyncio
+async def test_scoped_pref_drives_per_tool_enabled_state():
+    # send explicitly off, search explicitly on; draft falls back to the
+    # server default (enabled_by_default=False here).
+    service = _service(
+        [_mcp_tool(names=("send", "search", "draft"))],
+        prefs={"gmail::send": False, "gmail::search": True},
+    )
+    tools = await service.get_user_accessible_tools(_user())
+    by_name = {st.name: st.enabled for st in tools[0].server_tools}
+    assert by_name == {"send": False, "search": True, "draft": False}
+    # The server row is "on" because at least one tool (search) is enabled.
+    assert tools[0].is_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_server_level_pref_applies_to_all_subtools():
+    # A bare (server-level) preference applies to every sub-tool absent a
+    # more-specific scoped preference.
+    service = _service(
+        [_mcp_tool(names=("send", "search"))],
+        prefs={"gmail": True},
+    )
+    tools = await service.get_user_accessible_tools(_user())
+    assert all(st.enabled for st in tools[0].server_tools)
+    assert tools[0].is_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_save_scoped_preference_for_exposed_tool():
+    service = _service([_mcp_tool(names=("send", "search"))])
+    saved = await service.save_user_preferences(
+        _user(), {"gmail::send": True, "gmail::search": False}
+    )
+    assert saved.tool_preferences == {"gmail::send": True, "gmail::search": False}
+
+
+@pytest.mark.asyncio
+async def test_save_scoped_preference_for_unexposed_tool_rejected():
+    service = _service([_mcp_tool(names=("send",))])
+    with pytest.raises(ValueError, match="not exposed by their server"):
+        await service.save_user_preferences(_user(), {"gmail::delete_all": True})
+
+
+@pytest.mark.asyncio
+async def test_save_preference_for_inaccessible_base_rejected():
+    # RBAC is still enforced on the base id — no role grants 'secret_server'.
+    service = _service([_mcp_tool(tool_id="gmail", names=("send",))])
+    service.app_role_service.resolve_user_permissions = AsyncMock(
+        return_value=_perms(["gmail"])
+    )
+    with pytest.raises(ValueError, match="have access to"):
+        await service.save_user_preferences(_user(), {"secret_server::x": True})
+
+
+@pytest.mark.asyncio
+async def test_scoped_preference_on_dynamic_server_accepted():
+    # No curated list (discovered live) → name can't be validated, so accept.
+    service = _service([_mcp_tool(names=())])
+    saved = await service.save_user_preferences(_user(), {"gmail::live_tool": True})
+    assert saved.tool_preferences == {"gmail::live_tool": True}

--- a/backend/tests/shared/test_scoped_tool_ids.py
+++ b/backend/tests/shared/test_scoped_tool_ids.py
@@ -1,0 +1,72 @@
+"""Tests for scoped tool identifiers (apis.shared.tools.scoped_ids).
+
+A bare catalog id means "the whole MCP server"; a ``cat::tool`` id means one
+tool of that server. These helpers are the single source of truth for that
+format, shared by app_api validation and the agents runtime.
+"""
+
+from apis.shared.tools.scoped_ids import (
+    SCOPE_DELIMITER,
+    base_tool_id,
+    base_tool_ids,
+    collect_tool_name_filters,
+    is_scoped_tool_id,
+    make_scoped_tool_id,
+    parse_scoped_tool_id,
+)
+
+
+def test_is_scoped_tool_id():
+    assert is_scoped_tool_id("fetch_url_content::fetch") is True
+    assert is_scoped_tool_id("fetch_url_content") is False
+    assert is_scoped_tool_id("gateway_class_search") is False
+
+
+def test_make_scoped_tool_id_roundtrips():
+    scoped = make_scoped_tool_id("gateway_class_search", "search")
+    assert scoped == f"gateway_class_search{SCOPE_DELIMITER}search"
+    assert parse_scoped_tool_id(scoped) == ("gateway_class_search", "search")
+
+
+def test_parse_bare_id():
+    assert parse_scoped_tool_id("fetch_url_content") == ("fetch_url_content", None)
+
+
+def test_parse_scoped_id():
+    assert parse_scoped_tool_id("server::do_thing") == ("server", "do_thing")
+
+
+def test_parse_strips_whitespace_and_treats_empty_name_as_whole_server():
+    assert parse_scoped_tool_id("server::  ") == ("server", None)
+    assert parse_scoped_tool_id("server:: do_thing ") == ("server", "do_thing")
+
+
+def test_parse_only_splits_on_first_delimiter():
+    # Defensive: an (unlikely) tool name containing the delimiter is preserved.
+    assert parse_scoped_tool_id("server::a::b") == ("server", "a::b")
+
+
+def test_base_tool_id():
+    assert base_tool_id("server::tool") == "server"
+    assert base_tool_id("server") == "server"
+
+
+def test_base_tool_ids_dedupes_order_preserving():
+    ids = ["server::a", "server::b", "other", "server", "other::x"]
+    assert base_tool_ids(ids) == ["server", "other"]
+
+
+def test_collect_filters_subset_and_whole():
+    filters = collect_tool_name_filters(["a", "b::x", "b::y", "local_tool"])
+    assert filters == {"b": {"x", "y"}, "a": None, "local_tool": None}
+
+
+def test_collect_filters_whole_server_wins_over_subset():
+    # A bare id alongside scoped ids for the same server means the whole server
+    # is selected — the subset is subsumed, not intersected.
+    filters = collect_tool_name_filters(["c::z", "c"])
+    assert filters == {"c": None}
+
+
+def test_collect_filters_empty():
+    assert collect_tool_name_filters([]) == {}

--- a/frontend/ai.client/src/app/admin/skills/components/tool-picker-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/skills/components/tool-picker-dialog.component.ts
@@ -8,12 +8,20 @@ import {
 import { FormsModule } from '@angular/forms';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
+import {
+  heroXMark,
+  heroMagnifyingGlass,
+  heroChevronRight,
+  heroChevronDown,
+  heroArrowPath,
+} from '@ng-icons/heroicons/outline';
 import { AdminToolService } from '../../tools/services/admin-tool.service';
-import { TOOL_CATEGORIES } from '../../tools/models/admin-tool.model';
+import { TOOL_CATEGORIES, AdminTool } from '../../tools/models/admin-tool.model';
+import { makeScopedToolId, parseScopedToolId } from '../../../shared/utils/scoped-tool-id';
 
 /**
- * Data passed to the tool picker dialog: the currently-bound tool IDs.
+ * Data passed to the tool picker dialog: the currently-bound tool IDs (may be
+ * bare catalog ids or scoped `toolId::mcpToolName` ids).
  */
 export interface ToolPickerDialogData {
   selectedToolIds: string[];
@@ -24,11 +32,25 @@ export interface ToolPickerDialogData {
  */
 export type ToolPickerDialogResult = string[] | undefined;
 
+/** A single tool exposed by an MCP server (curated or discovered live). */
+interface ServerTool {
+  name: string;
+  description?: string | null;
+}
+
 @Component({
   selector: 'app-tool-picker-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, NgIcon],
-  providers: [provideIcons({ heroXMark, heroMagnifyingGlass })],
+  providers: [
+    provideIcons({
+      heroXMark,
+      heroMagnifyingGlass,
+      heroChevronRight,
+      heroChevronDown,
+      heroArrowPath,
+    }),
+  ],
   host: {
     class: 'block',
     '(keydown.escape)': 'onCancel()',
@@ -57,7 +79,8 @@ export type ToolPickerDialogResult = string[] | undefined;
               Bind Tools
             </h2>
             <p id="tool-picker-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-              Select the catalog tools this skill carries. The agent loads only these tools when the skill is active.
+              Select the catalog tools this skill carries. For an MCP server, expand it to bind only
+              the tools you need.
             </p>
           </div>
           <button
@@ -90,7 +113,7 @@ export type ToolPickerDialogResult = string[] | undefined;
           </div>
           <div class="mt-2 flex items-center justify-between text-xs/5">
             <span class="text-gray-500 dark:text-gray-400">
-              {{ selectedToolIds().size }} selected
+              {{ selectedCountLabel() }}
             </span>
             @if (selectedToolIds().size > 0) {
               <button
@@ -115,31 +138,112 @@ export type ToolPickerDialogResult = string[] | undefined;
           } @else {
             <div class="space-y-2">
               @for (tool of filteredTools(); track tool.toolId) {
-                <label
-                  class="flex cursor-pointer items-center gap-3 rounded-2xl border border-gray-200 p-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50"
-                  [class.border-blue-500]="selectedToolIds().has(tool.toolId)"
-                  [class.bg-blue-50]="selectedToolIds().has(tool.toolId)"
-                  [class.dark:border-blue-400]="selectedToolIds().has(tool.toolId)"
-                  [class.dark:bg-blue-900/20]="selectedToolIds().has(tool.toolId)"
+                <div
+                  class="rounded-2xl border border-gray-200 dark:border-gray-700"
+                  [class.border-blue-500]="serverState(tool) !== 'none'"
+                  [class.bg-blue-50]="serverState(tool) !== 'none'"
+                  [class.dark:border-blue-400]="serverState(tool) !== 'none'"
+                  [class.dark:bg-blue-900/20]="serverState(tool) !== 'none'"
                 >
-                  <input
-                    type="checkbox"
-                    [checked]="selectedToolIds().has(tool.toolId)"
-                    (change)="toggleTool(tool.toolId)"
-                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
-                  />
-                  <div class="min-w-0 flex-1">
-                    <div class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
-                      {{ tool.displayName }}
+                  <!-- Server / tool row -->
+                  <div class="flex items-center gap-2 p-3">
+                    @if (isMcpServer(tool)) {
+                      <button
+                        type="button"
+                        (click)="toggleExpanded(tool.toolId)"
+                        [attr.aria-label]="expanded().has(tool.toolId) ? 'Collapse' : 'Expand'"
+                        [attr.aria-expanded]="expanded().has(tool.toolId)"
+                        class="flex size-6 shrink-0 items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                      >
+                        <ng-icon
+                          [name]="expanded().has(tool.toolId) ? 'heroChevronDown' : 'heroChevronRight'"
+                          class="size-4"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    } @else {
+                      <span class="size-6 shrink-0"></span>
+                    }
+
+                    <input
+                      type="checkbox"
+                      [checked]="serverState(tool) === 'all'"
+                      [indeterminate]="serverState(tool) === 'partial'"
+                      (change)="toggleServer(tool)"
+                      [attr.aria-label]="'Bind ' + tool.displayName"
+                      class="size-4 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                    />
+
+                    <div class="min-w-0 flex-1">
+                      <div class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                        {{ tool.displayName }}
+                      </div>
+                      <div class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
+                        {{ tool.toolId }}
+                        @if (isMcpServer(tool) && serverState(tool) === 'partial') {
+                          · {{ selectedScopedNames(tool.toolId).length }} of
+                          {{ serverToolsFor(tool).length || '?' }} tools
+                        }
+                      </div>
                     </div>
-                    <div class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
-                      {{ tool.toolId }}
-                    </div>
+
+                    <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium capitalize text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
+                      {{ categoryLabel(tool.category) }}
+                    </span>
                   </div>
-                  <span class="hidden shrink-0 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium capitalize text-gray-600 sm:inline-block dark:bg-gray-700 dark:text-gray-300">
-                    {{ categoryLabel(tool.category) }}
-                  </span>
-                </label>
+
+                  <!-- Expanded sub-tools -->
+                  @if (isMcpServer(tool) && expanded().has(tool.toolId)) {
+                    <div class="border-t border-gray-200 px-3 py-2 pl-11 dark:border-gray-700">
+                      @if (serverToolsFor(tool).length > 0) {
+                        <div class="space-y-1.5">
+                          @for (sub of serverToolsFor(tool); track sub.name) {
+                            <label class="flex cursor-pointer items-start gap-2.5 rounded-lg px-1 py-1 hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                              <input
+                                type="checkbox"
+                                [checked]="isSubToolSelected(tool, sub.name)"
+                                (change)="toggleSubTool(tool, sub.name)"
+                                class="mt-0.5 size-4 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                              />
+                              <span class="min-w-0">
+                                <span class="block truncate font-mono text-xs/5 text-gray-700 dark:text-gray-200">{{ sub.name }}</span>
+                                @if (sub.description) {
+                                  <span class="block truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ sub.description }}</span>
+                                }
+                              </span>
+                            </label>
+                          }
+                        </div>
+                      } @else {
+                        <!-- No curated list — offer live discovery -->
+                        <div class="flex flex-col gap-1.5 py-1">
+                          <button
+                            type="button"
+                            (click)="discover(tool)"
+                            [disabled]="discovering().has(tool.toolId)"
+                            class="inline-flex w-fit items-center gap-1.5 rounded-lg px-2 py-1 text-xs/5 font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50 dark:text-blue-300 dark:hover:bg-blue-900/30"
+                          >
+                            <ng-icon
+                              name="heroArrowPath"
+                              class="size-3.5"
+                              [class.animate-spin]="discovering().has(tool.toolId)"
+                              aria-hidden="true"
+                            />
+                            {{ discovering().has(tool.toolId) ? 'Discovering…' : 'Discover tools' }}
+                          </button>
+                          @if (discoverError()[tool.toolId]) {
+                            <span class="text-xs/5 text-red-600 dark:text-red-400">{{ discoverError()[tool.toolId] }}</span>
+                          } @else {
+                            <span class="text-xs/5 text-gray-500 dark:text-gray-400">
+                              This server's tools aren't listed in the catalog. Discover them to bind a subset,
+                              or bind the whole server with the checkbox above.
+                            </span>
+                          }
+                        </div>
+                      }
+                    </div>
+                  }
+                </div>
               }
             </div>
           }
@@ -204,6 +308,10 @@ export class ToolPickerDialogComponent {
   readonly toolsResource = this.adminToolService.toolsResource;
   readonly searchQuery = signal('');
   readonly selectedToolIds = signal<Set<string>>(new Set(this.data.selectedToolIds));
+  readonly expanded = signal<Set<string>>(new Set());
+  readonly discovering = signal<Set<string>>(new Set());
+  readonly discovered = signal<Record<string, ServerTool[]>>({});
+  readonly discoverError = signal<Record<string, string>>({});
 
   /**
    * Only ACTIVE tools are bindable — the backend rejects binding an unknown or
@@ -228,10 +336,98 @@ export class ToolPickerDialogComponent {
     return [...filtered].sort((a, b) => a.displayName.localeCompare(b.displayName));
   });
 
+  readonly selectedCountLabel = computed(() => `${this.selectedToolIds().size} selected`);
+
   categoryLabel(category: string): string {
     return TOOL_CATEGORIES.find((c) => c.value === category)?.label ?? category;
   }
 
+  isMcpServer(tool: AdminTool): boolean {
+    return tool.protocol === 'mcp' || tool.protocol === 'mcp_external';
+  }
+
+  /** The tools a server exposes — its curated list, else any discovered live. */
+  serverToolsFor(tool: AdminTool): ServerTool[] {
+    const curated = tool.mcpConfig?.tools ?? tool.mcpGatewayConfig?.tools ?? [];
+    if (curated.length > 0) {
+      return curated.map((t) => ({ name: t.name, description: t.description }));
+    }
+    return this.discovered()[tool.toolId] ?? [];
+  }
+
+  /** Names of the individual tools currently selected for a given server. */
+  selectedScopedNames(toolId: string): string[] {
+    const names: string[] = [];
+    for (const id of this.selectedToolIds()) {
+      const { base, name } = parseScopedToolId(id);
+      if (base === toolId && name) {
+        names.push(name);
+      }
+    }
+    return names;
+  }
+
+  /** Whole server ('all'), a subset ('partial'), or nothing ('none'). */
+  serverState(tool: AdminTool): 'all' | 'partial' | 'none' {
+    const set = this.selectedToolIds();
+    if (set.has(tool.toolId)) {
+      return 'all';
+    }
+    return this.selectedScopedNames(tool.toolId).length > 0 ? 'partial' : 'none';
+  }
+
+  isSubToolSelected(tool: AdminTool, name: string): boolean {
+    const set = this.selectedToolIds();
+    return set.has(tool.toolId) || set.has(makeScopedToolId(tool.toolId, name));
+  }
+
+  toggleExpanded(toolId: string): void {
+    this.expanded.update((set) => {
+      const next = new Set(set);
+      if (next.has(toolId)) {
+        next.delete(toolId);
+      } else {
+        next.add(toolId);
+      }
+      return next;
+    });
+  }
+
+  /** Toggle binding the whole server (clears any per-tool subset). */
+  toggleServer(tool: AdminTool): void {
+    const wasOff = this.serverState(tool) === 'none';
+    this.selectedToolIds.update((set) => {
+      const next = this.withoutBase(set, tool.toolId);
+      if (wasOff) {
+        next.add(tool.toolId);
+      }
+      return next;
+    });
+  }
+
+  /** Toggle a single tool of a server (switches the server to a subset). */
+  toggleSubTool(tool: AdminTool, name: string): void {
+    const scoped = makeScopedToolId(tool.toolId, name);
+    this.selectedToolIds.update((set) => {
+      const next = new Set(set);
+      // Customizing a whole-server binding expands it into explicit per-tool
+      // ids for everything currently known, then toggles the chosen one.
+      if (next.has(tool.toolId)) {
+        next.delete(tool.toolId);
+        for (const sub of this.serverToolsFor(tool)) {
+          next.add(makeScopedToolId(tool.toolId, sub.name));
+        }
+      }
+      if (next.has(scoped)) {
+        next.delete(scoped);
+      } else {
+        next.add(scoped);
+      }
+      return next;
+    });
+  }
+
+  /** Toggle a non-MCP (single) tool. */
   toggleTool(toolId: string): void {
     this.selectedToolIds.update((set) => {
       const next = new Set(set);
@@ -244,6 +440,39 @@ export class ToolPickerDialogComponent {
     });
   }
 
+  async discover(tool: AdminTool): Promise<void> {
+    this.discovering.update((s) => new Set(s).add(tool.toolId));
+    this.discoverError.update((m) => {
+      const next = { ...m };
+      delete next[tool.toolId];
+      return next;
+    });
+    try {
+      const res = await this.adminToolService.discoverSavedToolTools(tool.toolId);
+      this.discovered.update((d) => ({
+        ...d,
+        [tool.toolId]: res.tools.map((t) => ({ name: t.name, description: t.description })),
+      }));
+      if (res.tools.length === 0) {
+        this.discoverError.update((m) => ({
+          ...m,
+          [tool.toolId]: 'The server returned no tools.',
+        }));
+      }
+    } catch {
+      this.discoverError.update((m) => ({
+        ...m,
+        [tool.toolId]: 'Could not list this server’s tools. Bind the whole server instead.',
+      }));
+    } finally {
+      this.discovering.update((s) => {
+        const next = new Set(s);
+        next.delete(tool.toolId);
+        return next;
+      });
+    }
+  }
+
   clearAll(): void {
     this.selectedToolIds.set(new Set());
   }
@@ -254,5 +483,16 @@ export class ToolPickerDialogComponent {
 
   onCancel(): void {
     this.dialogRef.close(undefined);
+  }
+
+  /** A copy of `set` with the bare id and every scoped id for `base` removed. */
+  private withoutBase(set: Set<string>, base: string): Set<string> {
+    const next = new Set<string>();
+    for (const id of set) {
+      if (parseScopedToolId(id).base !== base) {
+        next.add(id);
+      }
+    }
+    return next;
   }
 }

--- a/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
@@ -39,6 +39,7 @@ import {
   ToolPickerDialogData,
   ToolPickerDialogResult,
 } from '../components/tool-picker-dialog.component';
+import { parseScopedToolId } from '../../../shared/utils/scoped-tool-id';
 
 @Component({
   selector: 'app-skill-form',
@@ -517,7 +518,11 @@ export class SkillFormPage implements OnInit {
   }
 
   toolDisplayName(toolId: string): string {
-    return this.adminToolService.getToolById(toolId)?.displayName ?? toolId;
+    // A scoped id (`base::mcpToolName`) binds one tool of a server — show
+    // "Server · tool" so the chip reads cleanly.
+    const { base, name } = parseScopedToolId(toolId);
+    const serverName = this.adminToolService.getToolById(base)?.displayName ?? base;
+    return name ? `${serverName} · ${name}` : serverName;
   }
 
   formatSize(bytes: number): string {

--- a/frontend/ai.client/src/app/admin/skills/pages/skill-list.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-list.page.ts
@@ -23,6 +23,7 @@ import {
 import { AdminSkillService } from '../services/admin-skill.service';
 import { AdminSkill, SKILL_STATUSES } from '../models/admin-skill.model';
 import { AppRolesService } from '../../roles/services/app-roles.service';
+import { parseScopedToolId } from '../../../shared/utils/scoped-tool-id';
 import { AdminToolService } from '../../tools/services/admin-tool.service';
 import {
   SkillRoleDialogComponent,
@@ -375,7 +376,10 @@ export class SkillListPage {
   }
 
   getToolDisplayName(toolId: string): string {
-    return this.adminToolService.getToolById(toolId)?.displayName ?? toolId;
+    // A scoped id (`base::mcpToolName`) binds one tool of a server.
+    const { base, name } = parseScopedToolId(toolId);
+    const serverName = this.adminToolService.getToolById(base)?.displayName ?? base;
+    return name ? `${serverName} · ${name}` : serverName;
   }
 
   getStatusClass(status: string): string {

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
@@ -216,6 +216,17 @@ export class AdminToolService {
   }
 
   /**
+   * List the individual tools a *saved* catalog tool exposes. Used by the
+   * skills picker to drive per-tool binding for an MCP server whose tools
+   * aren't enumerated in the catalog (discovered live).
+   */
+  async discoverSavedToolTools(toolId: string): Promise<MCPDiscoverResponse> {
+    return firstValueFrom(
+      this.http.post<MCPDiscoverResponse>(`${this.baseUrl()}/${toolId}/discover`, {})
+    );
+  }
+
+  /**
    * Fetch the live AgentCore Gateway health for a protocol='mcp' tool. The
    * gateway syncs a target asynchronously after registration, so this is how
    * the UI learns a target FAILED (e.g. the gateway role can't invoke the

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -326,40 +326,108 @@
             } @else {
               <div class="space-y-3" role="group" aria-labelledby="tools-heading">
                 @for (tool of toolService.tools(); track tool.toolId) {
-                  <div class="flex items-start justify-between gap-3">
-                    <div class="min-w-0 flex-1">
-                      <label
-                        [id]="'tool-label-' + tool.toolId"
-                        [for]="'tool-toggle-' + tool.toolId"
-                        class="text-sm/6 font-medium text-gray-900 dark:text-white">
-                        {{ tool.displayName }}
-                      </label>
-                      <p
-                        [id]="'tool-desc-' + tool.toolId"
-                        class="text-xs/5 text-gray-500 dark:text-gray-400">
-                        {{ tool.description }}
-                      </p>
+                  <div>
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="flex min-w-0 flex-1 items-start gap-1.5">
+                        @if (isMcpServer(tool)) {
+                          <button
+                            type="button"
+                            (click)="toggleServerExpanded(tool.toolId)"
+                            [attr.aria-expanded]="isServerExpanded(tool.toolId)"
+                            [attr.aria-label]="(isServerExpanded(tool.toolId) ? 'Collapse ' : 'Expand ') + tool.displayName"
+                            class="-ml-1 mt-0.5 flex size-5 shrink-0 items-center justify-center rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+                            <ng-icon [name]="isServerExpanded(tool.toolId) ? 'heroChevronDown' : 'heroChevronRight'" class="size-4" aria-hidden="true" />
+                          </button>
+                        }
+                        <div class="min-w-0 flex-1">
+                          <label
+                            [id]="'tool-label-' + tool.toolId"
+                            [for]="'tool-toggle-' + tool.toolId"
+                            class="text-sm/6 font-medium text-gray-900 dark:text-white">
+                            {{ tool.displayName }}
+                          </label>
+                          <p
+                            [id]="'tool-desc-' + tool.toolId"
+                            class="text-xs/5 text-gray-500 dark:text-gray-400">
+                            {{ tool.description }}
+                          </p>
+                          @if (isMcpServer(tool) && partialServerLabel(tool); as label) {
+                            <p class="text-xs/5 font-medium text-primary-600 dark:text-primary-400">{{ label }}</p>
+                          }
+                        </div>
+                      </div>
+                      <!-- Toggle Switch (whole server) -->
+                      <button
+                        type="button"
+                        role="switch"
+                        [id]="'tool-toggle-' + tool.toolId"
+                        [attr.aria-checked]="tool.isEnabled"
+                        [attr.aria-labelledby]="'tool-label-' + tool.toolId"
+                        [attr.aria-describedby]="'tool-desc-' + tool.toolId"
+                        (click)="toggleTool(tool.toolId)"
+                        (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
+                        (keydown.enter)="toggleTool(tool.toolId)"
+                        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                        [class]="tool.isEnabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                        <span
+                          aria-hidden="true"
+                          class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                          [class.translate-x-5]="tool.isEnabled"
+                          [class.translate-x-0]="!tool.isEnabled">
+                        </span>
+                      </button>
                     </div>
-                    <!-- Toggle Switch -->
-                    <button
-                      type="button"
-                      role="switch"
-                      [id]="'tool-toggle-' + tool.toolId"
-                      [attr.aria-checked]="tool.isEnabled"
-                      [attr.aria-labelledby]="'tool-label-' + tool.toolId"
-                      [attr.aria-describedby]="'tool-desc-' + tool.toolId"
-                      (click)="toggleTool(tool.toolId)"
-                      (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
-                      (keydown.enter)="toggleTool(tool.toolId)"
-                      class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                      [class]="tool.isEnabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
-                      <span
-                        aria-hidden="true"
-                        class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                        [class.translate-x-5]="tool.isEnabled"
-                        [class.translate-x-0]="!tool.isEnabled">
-                      </span>
-                    </button>
+
+                    <!-- Per-tool sub-toggles -->
+                    @if (isMcpServer(tool) && isServerExpanded(tool.toolId)) {
+                      <div class="mt-2 space-y-2 border-l border-gray-200 pl-4 dark:border-white/10">
+                        @if (tool.serverTools && tool.serverTools.length > 0) {
+                          @for (sub of tool.serverTools; track sub.name) {
+                            <div class="flex items-start justify-between gap-3">
+                              <div class="min-w-0 flex-1">
+                                <span [id]="'subtool-label-' + tool.toolId + '-' + sub.name" class="block truncate font-mono text-xs/5 text-gray-700 dark:text-gray-200">{{ sub.name }}</span>
+                                @if (sub.description) {
+                                  <span class="block truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ sub.description }}</span>
+                                }
+                              </div>
+                              <button
+                                type="button"
+                                role="switch"
+                                [attr.aria-checked]="sub.enabled"
+                                [attr.aria-labelledby]="'subtool-label-' + tool.toolId + '-' + sub.name"
+                                (click)="toggleServerTool(tool.toolId, sub.name)"
+                                (keydown.space)="$event.preventDefault(); toggleServerTool(tool.toolId, sub.name)"
+                                (keydown.enter)="toggleServerTool(tool.toolId, sub.name)"
+                                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                                [class]="sub.enabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                                <span
+                                  aria-hidden="true"
+                                  class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                                  [class.translate-x-4]="sub.enabled"
+                                  [class.translate-x-0]="!sub.enabled">
+                                </span>
+                              </button>
+                            </div>
+                          }
+                        } @else {
+                          <div class="flex flex-col gap-1">
+                            <button
+                              type="button"
+                              (click)="discoverServerTools(tool)"
+                              [disabled]="discoveringServers().has(tool.toolId)"
+                              class="inline-flex w-fit items-center gap-1.5 rounded px-1.5 py-1 text-xs/5 font-medium text-primary-600 hover:bg-primary-50 disabled:opacity-50 dark:text-primary-400 dark:hover:bg-primary-900/30">
+                              <ng-icon name="heroArrowPath" class="size-3.5" [class.animate-spin]="discoveringServers().has(tool.toolId)" aria-hidden="true" />
+                              {{ discoveringServers().has(tool.toolId) ? 'Discovering…' : 'Discover tools' }}
+                            </button>
+                            @if (discoverError()[tool.toolId]) {
+                              <span class="text-xs/5 text-red-600 dark:text-red-400">{{ discoverError()[tool.toolId] }}</span>
+                            } @else {
+                              <span class="text-xs/5 text-gray-500 dark:text-gray-400">Discover this server’s tools to enable only the ones you need.</span>
+                            }
+                          </div>
+                        }
+                      </div>
+                    }
                   </div>
                 }
               </div>

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -1,8 +1,8 @@
 import { Component, ChangeDetectionStrategy, inject, input, output, signal, computed, effect, ElementRef } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroCheck, heroChevronDown, heroChevronRight } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath } from '@ng-icons/heroicons/outline';
 import { ModelService } from '../../session/services/model/model.service';
-import { ToolService } from '../../services/tool/tool.service';
+import { ToolService, Tool } from '../../services/tool/tool.service';
 import { SystemPromptsService } from '../../services/system-prompts/system-prompts.service';
 import {
   KNOWN_PARAMS,
@@ -40,7 +40,7 @@ interface AdvancedParamRow {
   selector: 'app-model-settings',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
-  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight })],
+  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath })],
   host: {
     '(document:click)': 'onDocumentClick($event)',
   },
@@ -266,8 +266,72 @@ export class ModelSettings {
     }
   }
 
+  /** Which MCP server rows are expanded to show their per-tool toggles. */
+  protected expandedServers = signal<Set<string>>(new Set());
+  /** Servers with a live discovery request in flight. */
+  protected discoveringServers = signal<Set<string>>(new Set());
+  /** Per-server discovery error messages. */
+  protected discoverError = signal<Record<string, string>>({});
+
   toggleTool(toolId: string): void {
     this.toolService.toggleTool(toolId);
+  }
+
+  /** True when a tool is an MCP server that supports per-tool enablement. */
+  isMcpServer(tool: Tool): boolean {
+    return tool.protocol === 'mcp' || tool.protocol === 'mcp_external';
+  }
+
+  isServerExpanded(toolId: string): boolean {
+    return this.expandedServers().has(toolId);
+  }
+
+  /** "3 of 8 tools enabled" when a server is partially enabled, else null. */
+  partialServerLabel(tool: Tool): string | null {
+    const subs = tool.serverTools ?? [];
+    if (subs.length === 0) return null;
+    const on = subs.filter((s) => s.enabled).length;
+    if (on === 0 || on === subs.length) return null;
+    return `${on} of ${subs.length} tools enabled`;
+  }
+
+  toggleServerExpanded(toolId: string): void {
+    this.expandedServers.update((set) => {
+      const next = new Set(set);
+      if (next.has(toolId)) {
+        next.delete(toolId);
+      } else {
+        next.add(toolId);
+      }
+      return next;
+    });
+  }
+
+  toggleServerTool(toolId: string, name: string): void {
+    this.toolService.toggleServerTool(toolId, name);
+  }
+
+  async discoverServerTools(tool: Tool): Promise<void> {
+    this.discoveringServers.update((s) => new Set(s).add(tool.toolId));
+    this.discoverError.update((m) => {
+      const next = { ...m };
+      delete next[tool.toolId];
+      return next;
+    });
+    try {
+      await this.toolService.discoverServerTools(tool.toolId);
+    } catch {
+      this.discoverError.update((m) => ({
+        ...m,
+        [tool.toolId]: 'Could not list this server’s tools.',
+      }));
+    } finally {
+      this.discoveringServers.update((s) => {
+        const next = new Set(s);
+        next.delete(tool.toolId);
+        return next;
+      });
+    }
   }
 
   selectPrompt(promptId: string | null): void {

--- a/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
@@ -124,6 +124,96 @@ describe('ToolService', () => {
     });
   });
 
+  describe('per-tool enablement', () => {
+    const baseServer: Tool = {
+      toolId: 'gmail', displayName: 'Gmail', description: 'Email', category: 'utility',
+      icon: null, protocol: 'mcp_external', status: 'active', grantedBy: ['user'],
+      enabledByDefault: false, userEnabled: null, isEnabled: true,
+    };
+
+    async function setupServer(server: Tool) {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          ToolService,
+          { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+        ],
+      });
+      service = TestBed.inject(ToolService);
+      httpMock = TestBed.inject(HttpTestingController);
+      await vi.waitFor(() => {
+        httpMock.expectOne('http://localhost:8000/tools/').flush({
+          tools: [server], categories: ['utility'], appRolesApplied: ['user'],
+        });
+      });
+    }
+
+    it('emits scoped ids for a partially-enabled server', async () => {
+      await setupServer({
+        ...baseServer,
+        serverTools: [
+          { name: 'send', enabled: true },
+          { name: 'search', enabled: true },
+          { name: 'draft', enabled: false },
+        ],
+      });
+      expect(service.enabledToolIds()).toEqual(['gmail::send', 'gmail::search']);
+    });
+
+    it('emits the bare id when every tool is enabled', async () => {
+      await setupServer({
+        ...baseServer,
+        serverTools: [
+          { name: 'send', enabled: true },
+          { name: 'search', enabled: true },
+        ],
+      });
+      expect(service.enabledToolIds()).toEqual(['gmail']);
+    });
+
+    it('toggleServerTool saves a scoped preference and recomputes ids', async () => {
+      await setupServer({
+        ...baseServer,
+        serverTools: [
+          { name: 'send', enabled: true },
+          { name: 'draft', enabled: false },
+        ],
+      });
+      const promise = service.toggleServerTool('gmail', 'draft');
+      expect(service.getTool('gmail')?.serverTools?.find(s => s.name === 'draft')?.enabled).toBe(true);
+      await vi.waitFor(() => {
+        const req = httpMock.expectOne('http://localhost:8000/tools/preferences');
+        expect(req.request.body).toEqual({ preferences: { 'gmail::draft': true } });
+        req.flush({});
+      });
+      await promise;
+      // Both tools now enabled → collapses to the bare server id.
+      expect(service.enabledToolIds()).toEqual(['gmail']);
+    });
+
+    it('whole-server toggle disables the server and every tool', async () => {
+      await setupServer({
+        ...baseServer,
+        serverTools: [
+          { name: 'send', enabled: true },
+          { name: 'search', enabled: true },
+        ],
+      });
+      const promise = service.toggleTool('gmail');
+      await vi.waitFor(() => {
+        const req = httpMock.expectOne('http://localhost:8000/tools/preferences');
+        expect(req.request.body).toEqual({
+          preferences: { 'gmail': false, 'gmail::send': false, 'gmail::search': false },
+        });
+        req.flush({});
+      });
+      await promise;
+      expect(service.getTool('gmail')?.isEnabled).toBe(false);
+      expect(service.enabledToolIds()).toEqual([]);
+    });
+  });
+
   describe('reload', () => {
     beforeEach(setup);
 

--- a/frontend/ai.client/src/app/services/tool/tool.service.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../config.service';
+import { makeScopedToolId } from '../../shared/utils/scoped-tool-id';
 /**
  * Tool category enum
  */
@@ -21,12 +22,23 @@ export type ToolCategory =
 /**
  * Tool protocol enum
  */
-export type ToolProtocol = 'local' | 'aws_sdk' | 'mcp' | 'a2a';
+export type ToolProtocol = 'local' | 'aws_sdk' | 'mcp' | 'mcp_external' | 'a2a';
 
 /**
  * Tool status enum
  */
 export type ToolStatus = 'active' | 'deprecated' | 'disabled' | 'coming_soon';
+
+/**
+ * One tool exposed by an MCP server, for per-tool enablement. `enabled` is the
+ * user's effective state for this individual tool.
+ */
+export interface ServerTool {
+  name: string;
+  description?: string | null;
+  needsApproval?: boolean;
+  enabled: boolean;
+}
 
 /**
  * Tool with user access and preference info
@@ -43,6 +55,11 @@ export interface Tool {
   enabledByDefault: boolean;
   userEnabled: boolean | null;
   isEnabled: boolean;
+  /**
+   * For MCP-server tools, the individual tools the server exposes. Empty for
+   * non-MCP tools or servers whose tools are discovered live.
+   */
+  serverTools?: ServerTool[];
 }
 
 /**
@@ -101,9 +118,32 @@ export class ToolService {
     this._tools().filter(t => t.isEnabled)
   );
 
-  readonly enabledToolIds = computed(() =>
-    this.enabledTools().map(t => t.toolId)
-  );
+  /**
+   * Tool ids to send to the agent. A server with a per-tool selection emits
+   * scoped ids (`toolId::name`) for its enabled tools; a fully-enabled server
+   * (or a tool with no sub-tools) emits its bare id.
+   */
+  readonly enabledToolIds = computed(() => {
+    const ids: string[] = [];
+    for (const tool of this._tools()) {
+      const subs = tool.serverTools ?? [];
+      if (subs.length === 0) {
+        if (tool.isEnabled) {
+          ids.push(tool.toolId);
+        }
+        continue;
+      }
+      const enabled = subs.filter(s => s.enabled);
+      if (enabled.length === subs.length) {
+        ids.push(tool.toolId);
+      } else {
+        for (const s of enabled) {
+          ids.push(makeScopedToolId(tool.toolId, s.name));
+        }
+      }
+    }
+    return ids;
+  });
 
   readonly enabledCount = computed(() =>
     this.enabledTools().length
@@ -151,15 +191,46 @@ export class ToolService {
   }
 
   /**
-   * Toggle a tool's enabled state.
+   * Toggle a tool's enabled state. For an MCP server with per-tool entries this
+   * toggles the whole server (every tool), authoritatively overriding any prior
+   * per-tool selection.
    */
   async toggleTool(toolId: string): Promise<void> {
     const tool = this._tools().find(t => t.toolId === toolId);
     if (!tool) return;
 
+    const subs = tool.serverTools ?? [];
     const newState = !tool.isEnabled;
 
-    // Optimistic update
+    if (subs.length > 0) {
+      // Whole-server toggle: set the server-level default AND every known tool
+      // so the new state wins over any lingering per-tool preference.
+      const prefs: Record<string, boolean> = { [toolId]: newState };
+      for (const s of subs) {
+        prefs[makeScopedToolId(toolId, s.name)] = newState;
+      }
+      this._tools.update(tools =>
+        tools.map(t =>
+          t.toolId === toolId
+            ? {
+                ...t,
+                isEnabled: newState,
+                userEnabled: newState,
+                serverTools: (t.serverTools ?? []).map(s => ({ ...s, enabled: newState })),
+              }
+            : t
+        )
+      );
+      try {
+        await this.savePreferences(prefs);
+      } catch (err) {
+        this._tools.update(tools => tools.map(t => (t.toolId === toolId ? tool : t)));
+        throw err;
+      }
+      return;
+    }
+
+    // Optimistic update (tool with no sub-tools)
     this._tools.update(tools =>
       tools.map(t =>
         t.toolId === toolId
@@ -181,6 +252,63 @@ export class ToolService {
       );
       throw err;
     }
+  }
+
+  /**
+   * Toggle a single tool of an MCP server (per-tool enablement). The server's
+   * `isEnabled` becomes "any tool enabled".
+   */
+  async toggleServerTool(toolId: string, name: string): Promise<void> {
+    const tool = this._tools().find(t => t.toolId === toolId);
+    const sub = tool?.serverTools?.find(s => s.name === name);
+    if (!tool || !sub) return;
+
+    const newState = !sub.enabled;
+
+    this._tools.update(tools =>
+      tools.map(t => {
+        if (t.toolId !== toolId) return t;
+        const serverTools = (t.serverTools ?? []).map(s =>
+          s.name === name ? { ...s, enabled: newState } : s
+        );
+        return { ...t, serverTools, isEnabled: serverTools.some(s => s.enabled) };
+      })
+    );
+
+    try {
+      await this.savePreferences({ [makeScopedToolId(toolId, name)]: newState });
+    } catch (err) {
+      // Revert on error
+      this._tools.update(tools => tools.map(t => (t.toolId === toolId ? tool : t)));
+      throw err;
+    }
+  }
+
+  /**
+   * Discover an MCP server's tools live and attach them as per-tool entries.
+   * New entries default to the server's current enabled state.
+   */
+  async discoverServerTools(toolId: string): Promise<void> {
+    const res = await firstValueFrom(
+      this.http.post<{ tools: { name: string; description?: string | null }[] }>(
+        `${this.baseUrl()}/${toolId}/discover`,
+        {}
+      )
+    );
+    this._tools.update(tools =>
+      tools.map(t =>
+        t.toolId === toolId
+          ? {
+              ...t,
+              serverTools: res.tools.map(d => ({
+                name: d.name,
+                description: d.description,
+                enabled: t.isEnabled,
+              })),
+            }
+          : t
+      )
+    );
   }
 
   /**

--- a/frontend/ai.client/src/app/shared/utils/scoped-tool-id.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/scoped-tool-id.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SCOPE_DELIMITER,
+  baseToolId,
+  isScopedToolId,
+  makeScopedToolId,
+  parseScopedToolId,
+} from './scoped-tool-id';
+
+describe('scoped-tool-id', () => {
+  it('detects scoped ids', () => {
+    expect(isScopedToolId('gmail::send')).toBe(true);
+    expect(isScopedToolId('gmail')).toBe(false);
+  });
+
+  it('round-trips make/parse', () => {
+    const id = makeScopedToolId('gateway_class_search', 'search');
+    expect(id).toBe(`gateway_class_search${SCOPE_DELIMITER}search`);
+    expect(parseScopedToolId(id)).toEqual({ base: 'gateway_class_search', name: 'search' });
+  });
+
+  it('parses a bare id', () => {
+    expect(parseScopedToolId('fetch_url_content')).toEqual({
+      base: 'fetch_url_content',
+      name: null,
+    });
+  });
+
+  it('treats an empty name as a bare id', () => {
+    expect(parseScopedToolId('server::  ')).toEqual({ base: 'server', name: null });
+  });
+
+  it('only splits on the first delimiter', () => {
+    expect(parseScopedToolId('server::a::b')).toEqual({ base: 'server', name: 'a::b' });
+  });
+
+  it('returns the base id', () => {
+    expect(baseToolId('server::tool')).toBe('server');
+    expect(baseToolId('server')).toBe('server');
+  });
+});

--- a/frontend/ai.client/src/app/shared/utils/scoped-tool-id.ts
+++ b/frontend/ai.client/src/app/shared/utils/scoped-tool-id.ts
@@ -1,0 +1,41 @@
+/**
+ * Scoped tool identifiers — referencing an individual tool within an MCP server.
+ *
+ * Mirrors the backend `apis.shared.tools.scoped_ids`. A bare catalog tool id
+ * (e.g. `fetch_url_content`) means the whole server / all of its tools; a
+ * scoped id `<toolId>::<mcpToolName>` references a single tool the server
+ * exposes. Used by the admin skills picker (bound tool ids) and model settings
+ * (user preferences) so both can carry a subset of a server's tools.
+ */
+
+/** Delimiter between a catalog tool id and an individual MCP tool name. */
+export const SCOPE_DELIMITER = '::';
+
+/** True if `toolId` references a single tool within a server. */
+export function isScopedToolId(toolId: string): boolean {
+  return toolId.includes(SCOPE_DELIMITER);
+}
+
+/** Build the scoped id for one tool of an MCP-server catalog tool. */
+export function makeScopedToolId(catalogToolId: string, mcpToolName: string): string {
+  return `${catalogToolId}${SCOPE_DELIMITER}${mcpToolName}`;
+}
+
+/**
+ * Split a possibly-scoped id into its base catalog id and individual tool name.
+ * A bare id returns `{ base, name: null }`. Only the first delimiter splits.
+ */
+export function parseScopedToolId(toolId: string): { base: string; name: string | null } {
+  const idx = toolId.indexOf(SCOPE_DELIMITER);
+  if (idx === -1) {
+    return { base: toolId, name: null };
+  }
+  const base = toolId.slice(0, idx);
+  const name = toolId.slice(idx + SCOPE_DELIMITER.length).trim();
+  return { base, name: name || null };
+}
+
+/** The catalog tool id a (possibly-scoped) id refers to. */
+export function baseToolId(toolId: string): string {
+  return parseScopedToolId(toolId).base;
+}


### PR DESCRIPTION
## Summary

Lets a skill binding **and** a user's model settings enable a **subset** of an MCP server's tools instead of the whole server. Today a "tool" in the catalog is a whole MCP server (one `toolId` carrying many tools); this adds a per-tool granularity across the stack while staying fully backward-compatible.

## The primitive

A bare catalog id (`fetch_url_content`) still means "the whole server." A **scoped** id `toolId::mcpToolName` references a single tool. Single source of truth in `apis/shared/tools/scoped_ids.py` with a frontend mirror in `shared/utils/scoped-tool-id.ts`. Existing bare-id lists are untouched.

## What changed

**Runtime** — filtering happens at the one seam where Strands expands an MCP client (a `ToolProvider`) into individually-named tools (`list_tools_sync`):
- Gateway: `expand_gateway_tool_ids` emits only the chosen `gateway_<target>___<name>`; `FilteredMCPClient` already matches them.
- External: `create_external_mcp_client` passes the SDK-native `tool_filters={'allowed': [...]}` (matched on the raw MCP tool name).
- The tool-filter classifier routes a scoped id by its base id.

**Validation & persistence** — scoped ids accepted in skill `bound_tool_ids` (`_validate_bound_tools`) and user preferences (`save_user_preferences`): the base must exist + be active, and the named tool must belong to the server when it has a curated list. `GET /tools/` now returns each server's tools via `UserToolAccess.serverTools` with their effective enabled state.

**Discovery** — new `POST /admin/tools/{id}/discover` and `POST /tools/{id}/discover` list a saved server's tools live, so per-tool selection works for servers whose tools aren't enumerated in the catalog (the chosen behavior for dynamic / discover-at-runtime servers).

**UIs**
- Admin skills **Bind Tools** dialog: expandable servers with per-tool checkboxes (all / partial / none) + a Discover action.
- **Model settings**: expandable servers with per-tool switches + a Discover action; "N of M tools enabled" indicator.

## Verification

- Backend: **full `pytest` suite — 3677 passed, 3 skipped, 0 failures** (the only correctness gate). New coverage for scoped ids, gateway/external filtering, skill + prefs validation, and discovery.
- Frontend: AOT `ng build` clean; ng-test specs green (scoped-id util, model-settings, tool-service incl. new per-tool cases).
- No browser clickthrough (app needs AWS auth; preview is `SKIP_AUTH`-only) — verified via build + unit tests.

## Notes

- Scoped gateway/external tools are made available and correctly filtered, but **not yet folded** behind the skill meta-tools — that folding is the in-flight PR-6b (#468) work and shares the same resolver. This change is finer-grained and complementary.
- `app_api → agents` imports (for MCP-client construction in `discovery.py`) follow the existing `/admin/tools/discover` pattern; the import-boundary test only forbids the reverse and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
