### PR TITLE
feat(skills): flip default agent_type to "skill" (PR-7)

### DIFF
--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -106,9 +106,11 @@ class InvocationRequest(BaseModel):
     # continues the truncated assistant message already in restored history
     # (assistant-prefill). Bypasses quota / RAG / file resolution like resume.
     continue_truncated: Optional[bool] = None
-    # Selects which agent factory variant builds the turn. Defaults to "chat"
-    # (MainAgent / ChatAgent) when omitted, so existing clients are unaffected.
-    # Pass "skill" to route through SkillAgent's progressive skill disclosure.
+    # Selects which agent factory variant builds the turn. When omitted, the
+    # server applies its default (PR-7: "skill" — see routes.DEFAULT_AGENT_TYPE),
+    # routing through SkillAgent's progressive disclosure; a user with no granted
+    # skills degrades to plain ChatAgent behavior. Pass "chat" to opt out of the
+    # skill path for a turn.
     agent_type: Optional[str] = None
     # User-selected custom system prompt ("conversation mode") for this
     # turn. The frontend forwards the active selection on every submit so

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -67,6 +67,17 @@ router = APIRouter(tags=["agentcore-runtime"])
 # Preview session prefix - sessions with this prefix skip persistence
 PREVIEW_SESSION_PREFIX = "preview-"
 
+# Default agent factory variant for a user turn when the client doesn't pin one
+# (PR-7). Flipped from "chat" to "skill": every turn now routes through the
+# SkillAgent's progressive disclosure, which folds a granted skill's bound tools
+# behind the two meta-tools. Safe by construction — a user with zero accessible
+# skills gets a SkillAgent that degrades to plain ChatAgent behavior
+# (skill_agent.py), so this is a no-op for them. Clients can still opt out per
+# turn by sending agent_type="chat". (The lower-level service.get_agent keeps a
+# conservative "chat" fallback for direct/programmatic callers that don't
+# resolve skills; this request-policy default lives here.)
+DEFAULT_AGENT_TYPE = "skill"
+
 
 def is_preview_session(session_id: str) -> bool:
     """Check if a session ID is a preview session (should skip persistence).
@@ -698,14 +709,19 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # they bypass quota, file resolution, and RAG augmentation because those
     # already ran on the original turn that got paused.
     is_resume = bool(input_data.interrupt_responses)
+    # Resolve the effective agent type once: the client's explicit choice, else
+    # the server default (PR-7: "skill"). Used for the skill resolution below
+    # and the non-resume get_agent calls (resume reuses the snapshot's type).
+    effective_agent_type = input_data.agent_type or DEFAULT_AGENT_TYPE
     # Resolve the user's accessible skills (admin/DB-backed, RBAC-gated) once
     # for the whole request — only for the skill agent path. Threaded into
     # every get_agent call below so they share one skills_hash cache key
     # (otherwise the app-tool-call / resume paths would miss the main turn's
-    # cached SkillAgent). The default chat path stays free of the extra reads.
+    # cached SkillAgent). An explicit agent_type="chat" opts out and stays free
+    # of the extra reads.
     accessible_skill_ids = (
         await _resolve_accessible_skill_ids(current_user)
-        if input_data.agent_type == "skill"
+        if effective_agent_type == "skill"
         else None
     )
     # A "Continue" after a max_tokens truncation. Like resume, it bypasses
@@ -746,7 +762,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=input_data.provider,
                 inference_params=inference_params,
-                agent_type=input_data.agent_type,
+                agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=accessible_skill_ids,
             )
@@ -792,7 +808,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=input_data.provider,
                 inference_params=inference_params,
-                agent_type=input_data.agent_type,
+                agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=accessible_skill_ids,
             )
@@ -1310,7 +1326,15 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=resume_inference_params,
                 agent_type=snapshot.agent_type,
                 is_resume=True,
-                accessible_skill_ids=accessible_skill_ids,
+                # Resume must rebuild the SAME cache key the original turn used,
+                # or the paused agent is orphaned. The original turn's
+                # skills_hash was derived from accessible_skill_ids only when it
+                # was a skill turn; mirror that off the snapshot's type (the
+                # request default is "skill", but a turn explicitly built as
+                # "chat" carried no skills → empty skills_hash).
+                accessible_skill_ids=(
+                    accessible_skill_ids if snapshot.agent_type == "skill" else None
+                ),
             )
         else:
             # Build the canonical request inference-params dict. The frontend
@@ -1389,7 +1413,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=effective_provider,
                 inference_params=inference_params,
-                agent_type=input_data.agent_type,
+                agent_type=effective_agent_type,
                 extra_tools=extra_tools,
                 is_resume=False,
                 accessible_skill_ids=accessible_skill_ids,

--- a/backend/tests/routes/test_inference.py
+++ b/backend/tests/routes/test_inference.py
@@ -168,3 +168,76 @@ class TestInvocationsInvalid:
             json={"message": "Hello"},
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PR-7: default agent_type flips to "skill"
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultAgentTypeFlip:
+    """When the client omits agent_type, the turn routes through SkillAgent."""
+
+    def _mock_agent(self):
+        agent = MagicMock()
+
+        async def fake_stream(*args, **kwargs):
+            yield "event: done\ndata: {}\n\n"
+
+        agent.stream_async = fake_stream
+        return agent
+
+    def test_omitted_agent_type_defaults_to_skill(self, authed_app, authed_client):
+        get_agent_mock = MagicMock(return_value=self._mock_agent())
+        resolve_mock = AsyncMock(return_value=["web_research"])
+        with patch(
+            "apis.inference_api.chat.routes.get_agent", get_agent_mock
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.inference_api.chat.routes._resolve_accessible_skill_ids",
+            resolve_mock,
+        ):
+            resp = authed_client.post(
+                "/invocations",
+                json={"session_id": "sess-skill", "message": "hi"},
+            )
+            _ = resp.text  # force the streaming generator to run
+
+        assert resp.status_code == 200
+        # Skills were resolved even though the client sent no agent_type,
+        # and get_agent was built as a skill agent with them threaded in.
+        resolve_mock.assert_awaited()
+        kwargs = get_agent_mock.call_args.kwargs
+        assert kwargs["agent_type"] == "skill"
+        assert kwargs["accessible_skill_ids"] == ["web_research"]
+
+    def test_explicit_chat_opts_out(self, authed_app, authed_client):
+        get_agent_mock = MagicMock(return_value=self._mock_agent())
+        resolve_mock = AsyncMock(return_value=["web_research"])
+        with patch(
+            "apis.inference_api.chat.routes.get_agent", get_agent_mock
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.inference_api.chat.routes._resolve_accessible_skill_ids",
+            resolve_mock,
+        ):
+            resp = authed_client.post(
+                "/invocations",
+                json={
+                    "session_id": "sess-chat",
+                    "message": "hi",
+                    "agent_type": "chat",
+                },
+            )
+            _ = resp.text
+
+        assert resp.status_code == 200
+        # Explicit chat → no skill resolution, no skills forwarded.
+        resolve_mock.assert_not_awaited()
+        kwargs = get_agent_mock.call_args.kwargs
+        assert kwargs["agent_type"] == "chat"
+        assert kwargs["accessible_skill_ids"] is None

--- a/docs/specs/admin-skills-rbac-tool-binding.md
+++ b/docs/specs/admin-skills-rbac-tool-binding.md
@@ -4,7 +4,7 @@
 **Author:** (drafted with Claude)
 **Date:** 2026-06-08 (rev. 2026-06-09)
 **Targets branch:** `develop`
-**Built so far:** PR-1 (#461, data layer) · PR-2 (#462, RBAC) · PR-3 (#463, admin API) — all merged.
+**Built so far:** PR-1 (#461, data) · PR-2 (#462, RBAC) · PR-3 (#463, admin API) · PR-4 (#465, reference-file data layer) · PR-5 (#466, admin frontend) · PR-6a (#467, runtime DB-load/RBAC/local-fold) merged; PR-6b (#468, MCP-fold + reference-file disclosure + example seed) open; PR-7 (default `agent_type` flip) in progress.
 
 ---
 
@@ -71,8 +71,13 @@ PR-1..3 are merged unchanged. Remaining work is re-cut around the bundle model:
   a progressive-disclosure **read-reference-file** level so the agent loads a skill's
   reference docs on demand (a `read_skill_resource`-style mechanism; `SkillRegistry` learns
   to scan/serve non-`SKILL.md` files) + bootstrap seed of one example bundled skill.
-- **PR-7 — Default/rollout (optional).** Flip default `agent_type` to `"skill"`; measure
-  `toolTokens` before/after via the context-attribution partition.
+- **PR-7 — Default/rollout.** Flip the server default `agent_type` to `"skill"` (one
+  request-policy constant, `routes.DEFAULT_AGENT_TYPE`); every turn routes through the
+  SkillAgent, which degrades to plain ChatAgent for a user with no granted skills, so the
+  flip is a no-op for them. Clients can opt out per turn with `agent_type="chat"`.
+  `toolTokens` is measured post-deploy via the context-attribution `contextBreakdown`
+  partition (a granted-skill user's `tools` partition drops as the bound tools fold behind
+  the two meta-tools; the skill catalog moves into the `system` partition).
 
 ### 0.6 Validation note
 Before/while building PR-6, walk one real published skill (e.g. Anthropic's `pdf` or `docx`


### PR DESCRIPTION
## PR-7 — flip the default `agent_type` to `"skill"` (final Skills increment)

The last step of the admin-managed Skills feature. Follows PR-6a ([#467](https://github.com/Boise-State-Development/agentcore-public-stack/pull/467)) and PR-6b ([#468](https://github.com/Boise-State-Development/agentcore-public-stack/pull/468), merged). Spec: [`docs/specs/admin-skills-rbac-tool-binding.md`](docs/specs/admin-skills-rbac-tool-binding.md) §0.5 / §8.4.

The server now defaults a user turn to the **SkillAgent** instead of the ChatAgent. This activates the whole feature for end users: a granted skill's bound tools fold behind the two meta-tools, the skill catalog rides in the system prompt, and the model only sees the meta-tools + the user's non-folded tools.

### Safe by construction
- A user with **zero accessible skills** gets a SkillAgent that **degrades to plain ChatAgent behavior** (`skill_agent.py` — 0 skills → falls back), so the flip is a behavioral no-op for them.
- A user whose roles grant a skill (e.g. the `web_research` example seeded in PR-6b, granted to `default`) gets that skill's bound tools folded.
- Clients can **opt out per turn** by sending `agent_type="chat"`.

### Implementation (one request-policy constant)
- **`routes.py`** — `DEFAULT_AGENT_TYPE = "skill"`. `invocations()` computes `effective_agent_type = input_data.agent_type or DEFAULT_AGENT_TYPE` once, and uses it for skill resolution (`_resolve_accessible_skill_ids`) and the three non-resume `get_agent` calls. The SPA omits `agent_type`, so it gets the new default.
- **Resume safety** — the resume `get_agent` call gates `accessible_skill_ids` on `snapshot.agent_type == "skill"`. Without this, a turn explicitly built as `"chat"` that pauses on an interrupt would resolve skills on resume (non-empty `skills_hash`) and rebuild under a *different* cache key than the original chat agent — orphaning the paused agent and breaking the interrupt resume. Mirroring the snapshot's type keeps the key identical.
- **`service.get_agent` is unchanged** — it keeps a conservative `"chat"` fallback for direct/programmatic callers that don't resolve skills (existing service tests depend on this). The user-request default lives in the route, where skills are actually resolved.
- **`models.py`** — updated the `agent_type` field comment to document the server default.

### toolTokens measurement
Measured post-deploy via the existing context-attribution `contextBreakdown` partition (no new code): for a granted-skill user, the `tools` partition drops as bound tools fold behind the meta-tools, while the skill catalog moves into the `system` partition. Net context shrinks when a role's tool set is larger than the catalog + 2 meta-tools.

## Testing
- **Full backend suite: `3712 passed, 3 skipped`** (the one failure is the pre-existing flaky `test_pbt_auth_sweep`, a Hypothesis `DeadlineExceeded`/timing flake — confirmed passing in isolation; unrelated to this change).
- New route tests (`test_inference.py::TestDefaultAgentTypeFlip`): omitted `agent_type` → `get_agent` built as `"skill"` with resolved skills threaded in; explicit `agent_type="chat"` → no skill resolution, no skills forwarded.
- Rebased onto current `develop` (includes #469 per-tool MCP enablement) — no conflicts; affected tests green on the rebased tree.

## Acceptance
- ✅ default turn routes through SkillAgent; folds a granted skill's tools behind the meta-tools
- ✅ no-op for users with no granted skills (graceful ChatAgent degradation)
- ✅ per-turn opt-out via `agent_type="chat"`; resume cache-key parity preserved
- ✅ `toolTokens` observable via the context-attribution partition

🤖 Generated with [Claude Code](https://claude.com/claude-code)