### PR TITLE
feat(agent): re-enable Strands Bedrock auto prompt caching

### DIFF
--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -299,16 +299,19 @@ class ModelConfig:
         # unconditionally on the Bedrock path.
         config["use_native_token_count"] = True
 
-        # Bedrock prompt caching is intentionally deferred. The previous SDK
-        # blocker — strands PR #1438, which fixed `cachePoint` blocks landing
-        # alongside non-PDF document attachments — is resolved in
-        # strands-agents 1.39.0, so the technical barrier is gone. Re-enabling
-        # is being held for a separate, scoped rollout (cost/badge impact is
-        # user-visible the moment caching turns on).
+        # Bedrock prompt caching. CacheConfig(strategy="auto") lets Strands
+        # place cache points per-model: for a model that supports automatic
+        # caching it injects a cachePoint on the system/tools/last-user blocks;
+        # for one that doesn't it logs a warning and no-ops, so this is safe to
+        # set whenever caching is enabled. The earlier SDK blocker — strands PR
+        # #1438, where `cachePoint` blocks collided with non-PDF document
+        # attachments — was fixed in strands-agents 1.39.0 (we pin 1.40.0).
+        # Cache hits are user-visible in the cost/context badge the moment this
+        # is on.
         # See: https://github.com/strands-agents/sdk-python/pull/1438
-        # if self.caching_enabled:
-        #     from strands.models import CacheConfig
-        #     config["cache_config"] = CacheConfig(strategy="auto")
+        if self.caching_enabled:
+            from strands.models import CacheConfig
+            config["cache_config"] = CacheConfig(strategy="auto")
 
         if self.retry_config:
             from botocore.config import Config as BotocoreConfig

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -98,16 +98,19 @@ class TestExplicitProviderOverride:
 class TestToBedrockConfig:
     """Validates: Requirements 1.6, 1.7"""
 
-    def test_bedrock_config_with_caching_enabled_currently_omits_cache_config(self):
-        """Req 1.6 — caching_enabled=True but cache_config omitted while
-        Bedrock prompt caching rollout is deferred. The SDK-side blocker is
-        resolved in strands 1.39.0; see model_config.py for the deferral note."""
+    def test_bedrock_config_with_caching_enabled_sets_auto_cache_config(self):
+        """Req 1.6 — caching_enabled=True emits a CacheConfig(strategy="auto").
+        Strands places cache points per-model and no-ops with a warning for
+        models that don't support automatic caching."""
+        from strands.models import CacheConfig
+
         cfg = ModelConfig(caching_enabled=True)
         result = cfg.to_bedrock_config()
 
         assert result["model_id"] == cfg.model_id
         assert "temperature" not in result  # No default temperature emitted
-        assert "cache_config" not in result
+        assert isinstance(result["cache_config"], CacheConfig)
+        assert result["cache_config"].strategy == "auto"
 
     def test_bedrock_config_without_caching(self):
         """Req 1.6 (negative) — caching disabled → no cache_config key."""


### PR DESCRIPTION
## What

Re-enables Strands Bedrock auto prompt caching by uncommenting the `cache_config` block in `ModelConfig.to_bedrock_config()`. When `caching_enabled=True` (the default), the Bedrock config now emits `CacheConfig(strategy="auto")`.

```python
if self.caching_enabled:
    from strands.models import CacheConfig
    config["cache_config"] = CacheConfig(strategy="auto")
```

## Why

Caching was previously commented out and held for "a separate, scoped rollout." The original deferral was a technical blocker — strands PR #1438, where `cachePoint` blocks collided with non-PDF document attachments — which was **fixed in strands-agents 1.39.0**. We pin **1.40.0**, so the barrier is gone.

## Why it's safe

- **API verified against the installed SDK (1.40.0):** `CacheConfig(strategy="auto")` matches the signature, and `BedrockModel.format_request` resolves `"auto"` per-model — injecting cache points on models that support automatic caching and logging a warning + no-op for those that don't. Safe to set unconditionally on the Bedrock path (gated only on `caching_enabled`).
- `CountTokensBedrockModel` only overrides `count_tokens`; it inherits `__init__`/config handling, so the kwarg flows through untouched.
- End-to-end check confirms the default catalog model (`us.anthropic.claude-haiku-4-5-...`) now emits `CacheConfig(strategy='auto')`.

## Tests

- Updated the test that asserted `cache_config` was *omitted* (`test_bedrock_config_with_caching_enabled_currently_omits_cache_config` → `..._sets_auto_cache_config`) to assert `CacheConfig(strategy="auto")` is present. The caching-disabled negative test is unchanged.
- `test_model_config.py`, `test_agent_factory.py`, `test_fixtures_smoke.py`, `test_chat_service.py` — **96 passed**.

## Reviewer note

The deferral wasn't technical at the end — it was that **cache hits become user-visible in the cost/context badge the moment caching is on**. This flips it on by default for every Bedrock chat turn. If a staged rollout behind an env flag is preferred over on-by-default, that's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)