### PR TITLE
feat(settings): platform chat-mode settings foundation (skills-mode PR-1)

### DIFF
--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -746,6 +746,11 @@ from .system_prompts.routes import router as system_prompts_admin_router
 
 router.include_router(system_prompts_admin_router)
 
+# ========== Include Platform Settings Admin Subrouter ==========
+from .settings.routes import router as settings_admin_router
+
+router.include_router(settings_admin_router)
+
 # ========== Include Fine-Tuning Admin Subrouter (conditional) ==========
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":
     from .fine_tuning.routes import router as fine_tuning_admin_router

--- a/backend/src/apis/app_api/admin/settings/__init__.py
+++ b/backend/src/apis/app_api/admin/settings/__init__.py
@@ -1,0 +1,5 @@
+"""Admin platform-settings routes."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/src/apis/app_api/admin/settings/routes.py
+++ b/backend/src/apis/app_api/admin/settings/routes.py
@@ -1,0 +1,62 @@
+"""Admin API routes for platform-wide settings.
+
+Currently hosts the chat-mode policy: which agent mode (skills vs. tools)
+new conversations get by default, and whether users may switch between
+modes. The user-facing read of the same policy lives at
+``GET /system/chat-settings``.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.shared.auth import User, require_admin
+from apis.shared.platform_settings.models import (
+    ChatModeSettingsResponse,
+    ChatModeSettingsUpdate,
+)
+from apis.shared.platform_settings.service import get_chat_mode_settings_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/settings", tags=["admin-settings"])
+
+
+@router.get(
+    "/chat",
+    response_model=ChatModeSettingsResponse,
+    summary="Get the chat-mode policy",
+)
+async def get_chat_mode_settings(
+    admin_user: User = Depends(require_admin),
+) -> ChatModeSettingsResponse:
+    """Get the current chat-mode policy (defaults if never configured)."""
+    service = get_chat_mode_settings_service()
+    settings = await service.get_settings()
+    return ChatModeSettingsResponse.from_settings(settings)
+
+
+@router.put(
+    "/chat",
+    response_model=ChatModeSettingsResponse,
+    summary="Update the chat-mode policy",
+)
+async def update_chat_mode_settings(
+    update: ChatModeSettingsUpdate,
+    admin_user: User = Depends(require_admin),
+) -> ChatModeSettingsResponse:
+    """Set the default agent mode and whether users may toggle between modes."""
+    service = get_chat_mode_settings_service()
+    try:
+        settings = await service.update_settings(update, updated_by=admin_user.email)
+    except Exception:
+        logger.exception("Failed to update chat-mode settings")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update chat-mode settings",
+        )
+    logger.info(
+        f"Admin {admin_user.email} updated chat-mode settings: "
+        f"default_mode={settings.default_mode}, allow_mode_toggle={settings.allow_mode_toggle}"
+    )
+    return ChatModeSettingsResponse.from_settings(settings)

--- a/backend/src/apis/app_api/system/routes.py
+++ b/backend/src/apis/app_api/system/routes.py
@@ -4,8 +4,12 @@ import logging
 from datetime import datetime, timezone
 
 from botocore.exceptions import ClientError
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.platform_settings.models import ChatSettingsPublicResponse
+from apis.shared.platform_settings.service import get_chat_mode_settings_service
 from apis.shared.users.models import UserProfile, UserStatus
 from apis.shared.users.repository import UserRepository
 
@@ -30,6 +34,16 @@ async def get_system_status() -> SystemStatusResponse:
     except Exception:
         logger.exception("Failed to read first-boot status from DynamoDB")
         return SystemStatusResponse(first_boot_completed=False)
+
+
+@router.get("/chat-settings", response_model=ChatSettingsPublicResponse)
+async def get_chat_settings(
+    current_user: User = Depends(get_current_user_from_session),
+) -> ChatSettingsPublicResponse:
+    """Chat-mode policy for the SPA: default agent mode + whether the user may toggle."""
+    service = get_chat_mode_settings_service()
+    settings = await service.get_settings()
+    return ChatSettingsPublicResponse.from_settings(settings)
 
 
 @router.post("/first-boot", status_code=200)

--- a/backend/src/apis/shared/platform_settings/__init__.py
+++ b/backend/src/apis/shared/platform_settings/__init__.py
@@ -1,0 +1,21 @@
+"""Platform-wide admin-managed settings shared by app-api and inference-api."""
+
+from .models import (
+    DEFAULT_CHAT_MODE,
+    ChatMode,
+    ChatModeSettings,
+    ChatModeSettingsUpdate,
+)
+from .repository import PlatformSettingsRepository, get_platform_settings_repository
+from .service import ChatModeSettingsService, get_chat_mode_settings_service
+
+__all__ = [
+    "DEFAULT_CHAT_MODE",
+    "ChatMode",
+    "ChatModeSettings",
+    "ChatModeSettingsUpdate",
+    "PlatformSettingsRepository",
+    "get_platform_settings_repository",
+    "ChatModeSettingsService",
+    "get_chat_mode_settings_service",
+]

--- a/backend/src/apis/shared/platform_settings/models.py
+++ b/backend/src/apis/shared/platform_settings/models.py
@@ -1,0 +1,95 @@
+"""Models for platform-wide chat-mode settings.
+
+Chat-mode settings control which agent mode new conversations get by
+default (``skill`` routes through the SkillAgent, ``chat`` through the
+plain ChatAgent) and whether users may switch between the two modes.
+
+The defaults here must reproduce the server behavior that existed before
+these settings were introduced (``DEFAULT_AGENT_TYPE = "skill"``, client
+``agent_type`` overrides honored), so an environment without a stored
+settings item sees no behavior change.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ChatMode = Literal["skill", "chat"]
+
+DEFAULT_CHAT_MODE: ChatMode = "skill"
+
+
+class ChatModeSettings(BaseModel):
+    """The stored chat-mode policy."""
+
+    default_mode: ChatMode = DEFAULT_CHAT_MODE
+    allow_mode_toggle: bool = True
+    updated_at: Optional[datetime] = None
+    updated_by: Optional[str] = None
+
+    def to_dynamo_item(self) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "defaultMode": self.default_mode,
+            "allowModeToggle": self.allow_mode_toggle,
+        }
+        if self.updated_at is not None:
+            item["updatedAt"] = self.updated_at.isoformat()
+        if self.updated_by is not None:
+            item["updatedBy"] = self.updated_by
+        return item
+
+    @classmethod
+    def from_dynamo_item(cls, item: Dict[str, Any]) -> "ChatModeSettings":
+        updated_at = item.get("updatedAt")
+        return cls(
+            default_mode=item.get("defaultMode", DEFAULT_CHAT_MODE),
+            allow_mode_toggle=item.get("allowModeToggle", True),
+            updated_at=datetime.fromisoformat(updated_at) if updated_at else None,
+            updated_by=item.get("updatedBy"),
+        )
+
+
+class ChatModeSettingsUpdate(BaseModel):
+    """Admin PUT body. Accepts camelCase from the SPA."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    default_mode: ChatMode = Field(alias="defaultMode")
+    allow_mode_toggle: bool = Field(alias="allowModeToggle")
+
+
+class ChatModeSettingsResponse(BaseModel):
+    """Admin-facing view, including audit fields."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    default_mode: ChatMode = Field(alias="defaultMode")
+    allow_mode_toggle: bool = Field(alias="allowModeToggle")
+    updated_at: Optional[datetime] = Field(None, alias="updatedAt")
+    updated_by: Optional[str] = Field(None, alias="updatedBy")
+
+    @classmethod
+    def from_settings(cls, settings: ChatModeSettings) -> "ChatModeSettingsResponse":
+        return cls(
+            default_mode=settings.default_mode,
+            allow_mode_toggle=settings.allow_mode_toggle,
+            updated_at=settings.updated_at,
+            updated_by=settings.updated_by,
+        )
+
+
+class ChatSettingsPublicResponse(BaseModel):
+    """User-facing view for the SPA — just the policy flags."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    default_mode: ChatMode = Field(alias="defaultMode")
+    allow_mode_toggle: bool = Field(alias="allowModeToggle")
+
+    @classmethod
+    def from_settings(cls, settings: ChatModeSettings) -> "ChatSettingsPublicResponse":
+        return cls(
+            default_mode=settings.default_mode,
+            allow_mode_toggle=settings.allow_mode_toggle,
+        )

--- a/backend/src/apis/shared/platform_settings/repository.py
+++ b/backend/src/apis/shared/platform_settings/repository.py
@@ -1,0 +1,101 @@
+"""DynamoDB repository for platform-wide chat-mode settings.
+
+Stores a single sentinel item in the auth-providers table, following the
+``SYSTEM_SETTINGS#first-boot`` convention (`app_api/system/repository.py`).
+Both app-api and the inference-api runtime already have this table's name
+in their environment (``DYNAMODB_AUTH_PROVIDERS_TABLE_NAME``) and IAM read
+access, so no new infrastructure is required.
+"""
+
+import logging
+import os
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .models import ChatModeSettings
+
+logger = logging.getLogger(__name__)
+
+CHAT_MODE_PK = "SYSTEM_SETTINGS#chat-mode"
+CHAT_MODE_SK = "SYSTEM_SETTINGS#chat-mode"
+
+
+class PlatformSettingsRepository:
+    """Repository for platform-settings sentinel items."""
+
+    def __init__(
+        self,
+        table_name: Optional[str] = None,
+        region: Optional[str] = None,
+    ):
+        self._table_name = table_name or os.getenv("DYNAMODB_AUTH_PROVIDERS_TABLE_NAME")
+        self._region = region or os.getenv("AWS_REGION", "us-west-2")
+        self._enabled = bool(self._table_name)
+
+        if not self._enabled:
+            logger.warning(
+                "DYNAMODB_AUTH_PROVIDERS_TABLE_NAME not set. "
+                "Platform settings repository is disabled."
+            )
+            return
+
+        profile = os.getenv("AWS_PROFILE")
+        if profile:
+            session = boto3.Session(profile_name=profile)
+            self._dynamodb = session.resource("dynamodb", region_name=self._region)
+        else:
+            self._dynamodb = boto3.resource("dynamodb", region_name=self._region)
+
+        self._table = self._dynamodb.Table(self._table_name)
+        logger.info(f"Initialized platform settings repository: table={self._table_name}")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def get_chat_mode_settings(self) -> Optional[ChatModeSettings]:
+        """Read the stored chat-mode settings, or None if never written."""
+        if not self._enabled:
+            return None
+
+        try:
+            response = self._table.get_item(
+                Key={"PK": CHAT_MODE_PK, "SK": CHAT_MODE_SK}
+            )
+            item = response.get("Item")
+            if item is None:
+                return None
+            return ChatModeSettings.from_dynamo_item(item)
+        except ClientError as e:
+            logger.error(f"Error reading chat-mode settings: {e}")
+            raise
+
+    async def put_chat_mode_settings(self, settings: ChatModeSettings) -> None:
+        """Write the chat-mode settings item (full replace)."""
+        if not self._enabled:
+            raise RuntimeError("Platform settings repository is not enabled")
+
+        item = {
+            "PK": CHAT_MODE_PK,
+            "SK": CHAT_MODE_SK,
+            **settings.to_dynamo_item(),
+        }
+        self._table.put_item(Item=item)
+        logger.info(
+            f"Chat-mode settings updated: default_mode={settings.default_mode}, "
+            f"allow_mode_toggle={settings.allow_mode_toggle}"
+        )
+
+
+# Singleton instance
+_repository: Optional[PlatformSettingsRepository] = None
+
+
+def get_platform_settings_repository() -> PlatformSettingsRepository:
+    """Get the platform settings repository singleton."""
+    global _repository
+    if _repository is None:
+        _repository = PlatformSettingsRepository()
+    return _repository

--- a/backend/src/apis/shared/platform_settings/service.py
+++ b/backend/src/apis/shared/platform_settings/service.py
@@ -1,0 +1,82 @@
+"""Chat-mode settings service with a short in-process TTL cache.
+
+The inference path reads the policy on every turn; the TTL cache keeps
+that to one DynamoDB read per container per minute. Admin updates bust
+the local cache immediately — other containers converge within the TTL.
+Reads degrade to compiled-in defaults (current server behavior) when the
+table is unconfigured, the item is absent, or the read fails.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from .models import ChatModeSettings, ChatModeSettingsUpdate
+from .repository import PlatformSettingsRepository, get_platform_settings_repository
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 60.0
+
+
+class ChatModeSettingsService:
+    """Cached read / write-through update of the chat-mode policy."""
+
+    def __init__(
+        self,
+        repository: Optional[PlatformSettingsRepository] = None,
+        cache_ttl_seconds: float = CACHE_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._repository = repository or get_platform_settings_repository()
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._clock = clock
+        self._cached: Optional[ChatModeSettings] = None
+        self._cached_at: float = 0.0
+
+    async def get_settings(self) -> ChatModeSettings:
+        """Get the chat-mode policy, falling back to defaults on any failure."""
+        now = self._clock()
+        if self._cached is not None and (now - self._cached_at) < self._cache_ttl_seconds:
+            return self._cached
+
+        try:
+            settings = await self._repository.get_chat_mode_settings()
+        except Exception:
+            logger.exception("Failed to read chat-mode settings — using defaults")
+            settings = None
+
+        resolved = settings or ChatModeSettings()
+        self._cached = resolved
+        self._cached_at = now
+        return resolved
+
+    async def update_settings(
+        self,
+        update: ChatModeSettingsUpdate,
+        updated_by: str,
+    ) -> ChatModeSettings:
+        """Persist a new chat-mode policy and bust the local cache."""
+        settings = ChatModeSettings(
+            default_mode=update.default_mode,
+            allow_mode_toggle=update.allow_mode_toggle,
+            updated_at=datetime.now(timezone.utc),
+            updated_by=updated_by,
+        )
+        await self._repository.put_chat_mode_settings(settings)
+        self._cached = settings
+        self._cached_at = self._clock()
+        return settings
+
+
+# Singleton instance
+_service: Optional[ChatModeSettingsService] = None
+
+
+def get_chat_mode_settings_service() -> ChatModeSettingsService:
+    """Get the chat-mode settings service singleton."""
+    global _service
+    if _service is None:
+        _service = ChatModeSettingsService()
+    return _service

--- a/backend/tests/apis/app_api/test_chat_settings_routes.py
+++ b/backend/tests/apis/app_api/test_chat_settings_routes.py
@@ -1,0 +1,136 @@
+"""Route tests for the chat-mode policy endpoints.
+
+Covers the admin surface (``GET/PUT /admin/settings/chat``) and the
+user-facing SPA read (``GET /system/chat-settings``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import require_admin
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.platform_settings.models import ChatModeSettings
+from apis.shared.platform_settings.service import ChatModeSettingsService
+
+from apis.app_api.admin.settings import routes as admin_settings_routes
+from apis.app_api.system import routes as system_routes
+
+
+def _admin() -> User:
+    return User(
+        user_id="admin-1",
+        email="admin@example.com",
+        name="Admin",
+        roles=["admin"],
+        raw_token="test-token",
+    )
+
+
+def _user() -> User:
+    return User(
+        user_id="user-1",
+        email="user@example.com",
+        name="User",
+        roles=["default"],
+        raw_token="test-token",
+    )
+
+
+class _InMemoryRepo:
+    """Duck-typed stand-in for PlatformSettingsRepository."""
+
+    def __init__(self, stored: ChatModeSettings | None = None):
+        self.stored = stored
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def get_chat_mode_settings(self):
+        return self.stored
+
+    async def put_chat_mode_settings(self, settings) -> None:
+        self.stored = settings
+
+
+@pytest.fixture
+def repo() -> _InMemoryRepo:
+    return _InMemoryRepo()
+
+
+@pytest.fixture
+def client(repo: _InMemoryRepo, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    service = ChatModeSettingsService(repository=repo, cache_ttl_seconds=0.0)
+    monkeypatch.setattr(
+        admin_settings_routes, "get_chat_mode_settings_service", lambda: service
+    )
+    monkeypatch.setattr(
+        system_routes, "get_chat_mode_settings_service", lambda: service
+    )
+
+    app = FastAPI()
+    app.include_router(admin_settings_routes.router, prefix="/admin")
+    app.include_router(system_routes.router)
+    app.dependency_overrides[require_admin] = _admin
+    app.dependency_overrides[get_current_user_from_session] = _user
+    return TestClient(app)
+
+
+class TestAdminChatSettings:
+    def test_get_returns_defaults_when_unconfigured(self, client: TestClient):
+        response = client.get("/admin/settings/chat")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["defaultMode"] == "skill"
+        assert body["allowModeToggle"] is True
+        assert body["updatedBy"] is None
+
+    def test_put_persists_and_stamps_audit_fields(
+        self, client: TestClient, repo: _InMemoryRepo
+    ):
+        response = client.put(
+            "/admin/settings/chat",
+            json={"defaultMode": "chat", "allowModeToggle": False},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["defaultMode"] == "chat"
+        assert body["allowModeToggle"] is False
+        assert body["updatedBy"] == "admin@example.com"
+        assert body["updatedAt"] is not None
+
+        assert repo.stored is not None
+        assert repo.stored.default_mode == "chat"
+
+        # Subsequent GET reflects the stored policy
+        follow_up = client.get("/admin/settings/chat")
+        assert follow_up.json()["defaultMode"] == "chat"
+
+    def test_put_rejects_invalid_mode(self, client: TestClient):
+        response = client.put(
+            "/admin/settings/chat",
+            json={"defaultMode": "voice", "allowModeToggle": True},
+        )
+        assert response.status_code == 422
+
+
+class TestSystemChatSettings:
+    def test_returns_policy_flags_only(self, client: TestClient):
+        client.put(
+            "/admin/settings/chat",
+            json={"defaultMode": "chat", "allowModeToggle": False},
+        )
+
+        response = client.get("/system/chat-settings")
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"defaultMode": "chat", "allowModeToggle": False}
+
+    def test_defaults_when_unconfigured(self, client: TestClient):
+        response = client.get("/system/chat-settings")
+        assert response.status_code == 200
+        assert response.json() == {"defaultMode": "skill", "allowModeToggle": True}

--- a/backend/tests/shared/test_platform_settings.py
+++ b/backend/tests/shared/test_platform_settings.py
@@ -1,0 +1,259 @@
+"""Unit tests for platform-wide chat-mode settings (models, repository, service)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+from pydantic import ValidationError
+
+from apis.shared.platform_settings.models import (
+    DEFAULT_CHAT_MODE,
+    ChatModeSettings,
+    ChatModeSettingsUpdate,
+)
+from apis.shared.platform_settings.repository import (
+    CHAT_MODE_PK,
+    CHAT_MODE_SK,
+    PlatformSettingsRepository,
+)
+from apis.shared.platform_settings.service import ChatModeSettingsService
+
+pytestmark = pytest.mark.asyncio
+
+
+# =========================================================================
+# Model tests
+# =========================================================================
+
+
+class TestChatModeSettings:
+    def test_defaults_reproduce_pre_settings_behavior(self):
+        """Defaults must match the hardcoded server behavior (skill default, toggling allowed)."""
+        settings = ChatModeSettings()
+        assert settings.default_mode == DEFAULT_CHAT_MODE == "skill"
+        assert settings.allow_mode_toggle is True
+        assert settings.updated_at is None
+        assert settings.updated_by is None
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            ChatModeSettings(default_mode="voice")
+
+    def test_dynamo_round_trip(self):
+        from datetime import datetime, timezone
+
+        original = ChatModeSettings(
+            default_mode="chat",
+            allow_mode_toggle=False,
+            updated_at=datetime(2026, 6, 11, 12, 0, tzinfo=timezone.utc),
+            updated_by="admin@example.com",
+        )
+        restored = ChatModeSettings.from_dynamo_item(original.to_dynamo_item())
+        assert restored == original
+
+    def test_from_dynamo_item_tolerates_missing_fields(self):
+        restored = ChatModeSettings.from_dynamo_item({})
+        assert restored.default_mode == "skill"
+        assert restored.allow_mode_toggle is True
+
+
+class TestChatModeSettingsUpdate:
+    def test_accepts_camel_case_aliases(self):
+        update = ChatModeSettingsUpdate.model_validate(
+            {"defaultMode": "chat", "allowModeToggle": False}
+        )
+        assert update.default_mode == "chat"
+        assert update.allow_mode_toggle is False
+
+    def test_accepts_snake_case_field_names(self):
+        update = ChatModeSettingsUpdate(default_mode="skill", allow_mode_toggle=True)
+        assert update.default_mode == "skill"
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            ChatModeSettingsUpdate.model_validate(
+                {"defaultMode": "agent", "allowModeToggle": True}
+            )
+
+
+# =========================================================================
+# Repository tests
+# =========================================================================
+
+
+class TestPlatformSettingsRepository:
+    def _make_repo(self) -> PlatformSettingsRepository:
+        """Create a repository with a mocked DynamoDB table."""
+        with patch("apis.shared.platform_settings.repository.boto3") as mock_boto:
+            mock_table = MagicMock()
+            mock_resource = MagicMock()
+            mock_resource.Table.return_value = mock_table
+            mock_boto.Session.return_value.resource.return_value = mock_resource
+            mock_boto.resource.return_value = mock_resource
+
+            repo = PlatformSettingsRepository(table_name="test-table")
+            repo._table = mock_table
+            return repo
+
+    async def test_get_returns_none_when_item_missing(self):
+        repo = self._make_repo()
+        repo._table.get_item.return_value = {}
+
+        result = await repo.get_chat_mode_settings()
+        assert result is None
+
+        repo._table.get_item.assert_called_once_with(
+            Key={"PK": CHAT_MODE_PK, "SK": CHAT_MODE_SK}
+        )
+
+    async def test_get_parses_stored_item(self):
+        repo = self._make_repo()
+        repo._table.get_item.return_value = {
+            "Item": {
+                "PK": CHAT_MODE_PK,
+                "SK": CHAT_MODE_SK,
+                "defaultMode": "chat",
+                "allowModeToggle": False,
+                "updatedBy": "admin@example.com",
+            }
+        }
+
+        result = await repo.get_chat_mode_settings()
+        assert result is not None
+        assert result.default_mode == "chat"
+        assert result.allow_mode_toggle is False
+        assert result.updated_by == "admin@example.com"
+
+    async def test_get_raises_on_client_error(self):
+        repo = self._make_repo()
+        repo._table.get_item.side_effect = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "boom"}}, "GetItem"
+        )
+        with pytest.raises(ClientError):
+            await repo.get_chat_mode_settings()
+
+    async def test_put_writes_sentinel_item(self):
+        repo = self._make_repo()
+        await repo.put_chat_mode_settings(
+            ChatModeSettings(default_mode="chat", allow_mode_toggle=False)
+        )
+
+        item = repo._table.put_item.call_args.kwargs["Item"]
+        assert item["PK"] == CHAT_MODE_PK
+        assert item["SK"] == CHAT_MODE_SK
+        assert item["defaultMode"] == "chat"
+        assert item["allowModeToggle"] is False
+
+    async def test_disabled_without_table_name(self):
+        with patch.dict("os.environ", {}, clear=False):
+            with patch("os.getenv", side_effect=lambda k, d=None: d):
+                repo = PlatformSettingsRepository()
+        assert repo.enabled is False
+        assert await repo.get_chat_mode_settings() is None
+        with pytest.raises(RuntimeError):
+            await repo.put_chat_mode_settings(ChatModeSettings())
+
+
+# =========================================================================
+# Service tests (TTL cache + degradation)
+# =========================================================================
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class TestChatModeSettingsService:
+    async def test_returns_defaults_when_nothing_stored(self):
+        service = ChatModeSettingsService(
+            repository=_AsyncRepo(None), clock=_FakeClock()
+        )
+
+        settings = await service.get_settings()
+        assert settings.default_mode == "skill"
+        assert settings.allow_mode_toggle is True
+
+    async def test_caches_within_ttl(self):
+        repo = _AsyncRepo(ChatModeSettings(default_mode="chat"))
+        clock = _FakeClock()
+        service = ChatModeSettingsService(
+            repository=repo, cache_ttl_seconds=60.0, clock=clock
+        )
+
+        first = await service.get_settings()
+        clock.now += 30.0
+        second = await service.get_settings()
+
+        assert first.default_mode == second.default_mode == "chat"
+        assert repo.get_calls == 1
+
+    async def test_refetches_after_ttl_expiry(self):
+        repo = _AsyncRepo(ChatModeSettings(default_mode="chat"))
+        clock = _FakeClock()
+        service = ChatModeSettingsService(
+            repository=repo, cache_ttl_seconds=60.0, clock=clock
+        )
+
+        await service.get_settings()
+        repo.stored = ChatModeSettings(default_mode="skill")
+        clock.now += 61.0
+
+        refreshed = await service.get_settings()
+        assert refreshed.default_mode == "skill"
+        assert repo.get_calls == 2
+
+    async def test_returns_defaults_on_read_error(self):
+        repo = _AsyncRepo(None, raise_on_get=True)
+        service = ChatModeSettingsService(repository=repo, clock=_FakeClock())
+
+        settings = await service.get_settings()
+        assert settings.default_mode == "skill"
+        assert settings.allow_mode_toggle is True
+
+    async def test_update_writes_through_and_busts_cache(self):
+        repo = _AsyncRepo(ChatModeSettings(default_mode="skill"))
+        clock = _FakeClock()
+        service = ChatModeSettingsService(
+            repository=repo, cache_ttl_seconds=60.0, clock=clock
+        )
+
+        await service.get_settings()  # prime the cache
+        updated = await service.update_settings(
+            ChatModeSettingsUpdate(default_mode="chat", allow_mode_toggle=False),
+            updated_by="admin@example.com",
+        )
+
+        assert repo.stored.default_mode == "chat"
+        assert updated.updated_by == "admin@example.com"
+        assert updated.updated_at is not None
+
+        # Cached value reflects the update without another read
+        current = await service.get_settings()
+        assert current.default_mode == "chat"
+        assert repo.get_calls == 1
+
+
+class _AsyncRepo:
+    """Duck-typed in-memory stand-in for PlatformSettingsRepository."""
+
+    def __init__(self, stored, raise_on_get: bool = False):
+        self.stored = stored
+        self.raise_on_get = raise_on_get
+        self.get_calls = 0
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def get_chat_mode_settings(self):
+        self.get_calls += 1
+        if self.raise_on_get:
+            raise RuntimeError("read failed")
+        return self.stored
+
+    async def put_chat_mode_settings(self, settings) -> None:
+        self.stored = settings

--- a/docs/specs/skills-mode.md
+++ b/docs/specs/skills-mode.md
@@ -1,0 +1,329 @@
+# Skills Mode — user-visible mode toggle + admin policy
+
+> Status: DRAFT (spec only, nothing built). Follows on from
+> `admin-skills-rbac-tool-binding.md` Phase 1 (PR-1..7, all merged — default
+> `agent_type` is already `"skill"` server-side as of #470). This spec makes the
+> mode a **first-class, user-visible concept** with per-skill toggles and
+> admin-controlled policy.
+
+## 1. Summary
+
+Two user-facing modes, surfaced in the existing model-settings slide-over:
+
+- **Skills mode** (`agent_type="skill"`) — routes through `SkillAgent`. The panel
+  shows the user's RBAC-accessible skills as a toggle list (mirroring today's tool
+  toggles). Capabilities come from the enabled skills' bound tools; the raw tool
+  picker is hidden. This is the tool-hiding UX that motivated skills.
+- **Tools mode** (`agent_type="chat"`) — routes through plain `ChatAgent`. The
+  existing fine-grained tool picker (whole-server + per-MCP-tool toggles) applies,
+  unchanged.
+
+Two admin-controlled global policies:
+
+- **Default mode** — which mode new conversations (and clients that don't specify)
+  get. Replaces the hardcoded `DEFAULT_AGENT_TYPE` constant as the source of truth.
+- **Allow mode toggle** — whether users may switch modes at all. When off, the
+  toggle UI is hidden *and* the server ignores a client-supplied `agent_type`
+  (UI gating alone is not enforcement).
+
+## 2. Current state (verified 2026-06-11)
+
+What already exists and is load-bearing for this feature:
+
+| Piece | Where | State |
+|---|---|---|
+| Server default agent type | `inference_api/chat/routes.py:79` (`DEFAULT_AGENT_TYPE = "skill"`) | Hardcoded constant; flipped in #470 |
+| Per-turn override | `inference_api/chat/models.py:109` (`InvocationRequest.agent_type`) | Exists; SPA never sends it today |
+| Effective-type resolution | `inference_api/chat/routes.py:715` (`input_data.agent_type or DEFAULT_AGENT_TYPE`) | Skills resolved only when effective type is `"skill"` (lines 722–726) |
+| Resume | `PausedTurnSnapshot.agent_type` (`apis/shared/sessions/models.py:109`), restored at `routes.py:1327` | Resume already gates skill resolution on `snapshot.agent_type == "skill"` |
+| Accessible skills | `_resolve_accessible_skill_ids` (`inference_api/chat/routes.py:670–689`) → `AppRoleService.get_accessible_skills` + `"*"` expansion | All-or-nothing: user always gets every RBAC-granted skill; **no per-skill user toggle exists** |
+| SkillAgent | `agents/main_agent/skill_agent.py:76+` | Takes `accessible_skill_ids`; degrades to ChatAgent behavior at 0 skills |
+| Agent cache key | `inference_api/chat/service.py:176–183` (`skills_hash` over ids + `updated_at`) | Hashes the *accessible* set — must hash the *effective* set once toggles exist |
+| User-facing skills API | — | **None.** `app_api/skills/service.py` is the admin-backing `SkillCatalogService`; no user routes, no "list my skills" endpoint |
+| Tool toggles (user) | `app_api/tools/routes.py` (`GET /tools/`, `PUT /tools/preferences`), prefs in `apis/shared/tools/repository.py`; SPA `ToolService` + Tools section of `components/model-settings/` | The exact pattern to mirror for skills |
+| SPA chat request | `session/services/chat/chat-request.service.ts:194–257` | Sends `enabled_tools`, `model_id`, `inference_params`, `selected_prompt_id`; **no `agent_type`** |
+| BFF chat proxy | `app_api/chat/proxy_routes.py` | Relays the body verbatim — request-shape changes touch only inference-api + SPA |
+| Session preferences | `SessionPreferences` (backend `apis/shared/sessions/models.py:125`; FE `session-metadata.model.ts:14–22`) | Has `lastModel`/`selectedPromptId` hydration precedent in `session.page.ts:183–211`; no mode field |
+| User settings | `apis/shared/user_settings/repository.py` (`USER#{id}` / `SETTINGS`) | Only `defaultModelId` today; natural home for `preferredAgentMode` + skill prefs |
+| Global admin settings store | — | **None.** No platform-settings table, no feature-flag/bootstrap endpoint for the SPA |
+
+## 3. Key design decisions
+
+1. **Skills are the only capability unit in skills mode.** The SPA sends
+   `enabled_tools: []` when in skills mode; active tools are exactly the bound
+   tools of the enabled skills (skill-as-grant folding, unchanged from PR-6).
+   *Alternative (rejected for v1): send both and union them — blurs the mental
+   model and resurrects the tool-bloat the feature exists to kill. A standalone
+   tool a user needs in skills mode is a signal the admin should wrap it in a
+   skill.*
+2. **Per-skill toggles are a global user preference**, not per-session — exactly
+   mirroring tool preferences (`PUT /tools/preferences`). Mode itself is
+   per-session (`SessionPreferences.agent_type`) with a user-level
+   `preferredAgentMode` for new conversations — exactly mirroring model selection
+   (`lastModel` + `defaultModelId`).
+3. **Server-side enforcement of the toggle policy.** When `allow_mode_toggle` is
+   false, inference-api overrides any client `agent_type` with the admin default.
+   Enforcement applies only when the requested type is `"chat"` or `"skill"` —
+   `"voice"` and any future internal types are untouched.
+4. **Admin policy lives in a new `platform_settings` shared domain** stored as a
+   **sentinel item in the auth-providers table** (`PK=SK=SYSTEM_SETTINGS#chat-mode`),
+   following the existing `SYSTEM_SETTINGS#first-boot` convention
+   (`app_api/system/repository.py`). *(Revised 2026-06-11 from the original
+   dedicated-table recommendation: the first-boot precedent is the established
+   house pattern for global state, and the auth-providers table's name + IAM
+   read access are **already wired into both app-api and the inference runtime**
+   — so this needs zero CDK changes.)* Both app-api (admin CRUD + SPA read) and
+   inference-api (policy enforcement) consume it via `apis.shared` — respecting
+   the import-boundary rule. Inference-api reads through a short in-process TTL
+   cache (~60 s) so policy flips don't require a redeploy but also don't add a
+   Dynamo read per turn.
+5. **`enabled_skills` request semantics:** `None`/absent → all accessible skills
+   (today's behavior, so existing clients are unaffected); a list → intersected
+   server-side with the RBAC-accessible set (client input is never trusted to
+   grant). Empty list → zero skills → SkillAgent's existing degrade-to-chat path.
+6. **Missing-table / local-dev fallback:** when the platform-settings table or
+   item is absent, policy defaults to `{default_mode: DEFAULT_AGENT_TYPE,
+   allow_mode_toggle: true}` — current behavior, zero-config local dev.
+
+## 4. Data model
+
+### 4.1 Platform settings — `apis/shared/platform_settings/` (new)
+
+```python
+class ChatModeSettings(BaseModel):
+    default_mode: Literal["skill", "chat"] = "skill"
+    allow_mode_toggle: bool = True
+    updated_at: datetime
+    updated_by: str  # admin user id, audit trail
+```
+
+`models.py` + `repository.py` (table `{prefix}-platform-settings`, env
+`DYNAMODB_PLATFORM_SETTINGS_TABLE_NAME`) + `service.py` with a TTL-cached
+`get_chat_mode_settings()` read used by inference-api.
+
+### 4.2 Request contract — `inference_api/chat/models.py`
+
+```python
+enabled_skills: Optional[List[str]] = None  # None = all accessible (back-compat)
+```
+
+### 4.3 Snapshot — `apis/shared/sessions/models.py`
+
+Add `enabled_skills: Optional[List[str]]` to `PausedTurnSnapshot` so a paused turn
+(OAuth consent) resumes with the same effective skill set. The existing
+`agent_type` gate on resume stays.
+
+### 4.4 Session preferences (backend + FE interface)
+
+Add `agent_type: Optional[str]` to `SessionPreferences` (backend
+`apis/shared/sessions/models.py:125`, FE `session-metadata.model.ts`). Per-session
+`enabled_skills` is **not** stored — skill toggles are global user prefs (§3.2).
+
+### 4.5 User settings — `apis/shared/user_settings/repository.py`
+
+Add `preferredAgentMode: Optional[str]` alongside `defaultModelId`. Skill
+preferences (`Record<skill_id, bool>`) persist via a skills-preferences store
+mirroring `apis/shared/tools/repository.py`'s user-preference rows.
+
+## 5. Backend API
+
+### 5.1 User-facing — `app_api/skills/routes.py` (new, next to the existing service)
+
+Auth: `Depends(get_current_user_from_session)` (house rule — no Bearer-only deps).
+
+- `GET /skills/` — the user's RBAC-accessible **ACTIVE** skills with prefs merged:
+  `{skills: [{skillId, displayName, description, category, boundToolCount,
+  userEnabled, isEnabled}], appRolesApplied}`. Resolution reuses the same
+  RBAC path as inference (`get_accessible_skills` + `"*"` expansion). The
+  wildcard-expansion helper currently lives in `inference_api/chat/routes.py:670`
+  — lift the reusable core into `apis/shared/skills/` so app-api and
+  inference-api don't drift (import-boundary rule: shared by two consumers →
+  `apis.shared`).
+- `PUT /skills/preferences` — `{preferences: Record<skillId, boolean>}`, rejecting
+  ids outside the user's accessible set (mirror `update_tool_preferences`).
+
+### 5.2 Policy read for the SPA — `app_api/system/routes.py` (existing router)
+
+- `GET /system/chat-settings` — `{defaultMode, allowModeToggle}` (session auth).
+  Loaded once at SPA auth alongside tools/models. The `system` domain already
+  hosts app-level metadata (`/system/status`, `/system/first-boot`).
+
+### 5.3 Admin — `app_api/admin/settings/routes.py` (new domain folder)
+
+- `GET /admin/settings/chat` / `PUT /admin/settings/chat` — `Depends(require_admin)`.
+  PUT validates `default_mode ∈ {"skill","chat"}` and stamps `updated_by`.
+
+## 6. Inference path changes — `inference_api/chat/routes.py`
+
+1. **Policy resolution** (replaces direct `DEFAULT_AGENT_TYPE` use at line 715):
+
+   ```python
+   settings = await get_chat_mode_settings()        # TTL-cached, falls back to constant
+   requested = input_data.agent_type
+   if requested in ("skill", "chat") and not settings.allow_mode_toggle:
+       requested = None                              # policy override, log it
+   effective_agent_type = requested or settings.default_mode
+   ```
+
+   `DEFAULT_AGENT_TYPE` stays as the code-level fallback when the table is absent.
+
+2. **Effective skill set** (extends lines 722–726): when effective type is
+   `"skill"`, compute `accessible ∩ enabled_skills` (None → accessible). Pass the
+   *effective* list into `service.get_agent` → `SkillAgent`.
+
+3. **Cache key** (`service.py:176–183`): `skills_hash` now hashes the effective
+   set, not the accessible set — two sessions of the same user with different
+   skill toggles must not share an agent. (Known fold gotcha carries over
+   unchanged: `set_folded_tool_names` must keep nulling external clients'
+   pre-cached `_loaded_tools`.)
+
+4. **Snapshot persist/restore**: `stream_coordinator.py` persists
+   `enabled_skills` next to `agent_type` (lines ~1004–1016); resume threads it
+   back through, still gated on `snapshot.agent_type == "skill"`.
+
+## 7. Frontend
+
+### 7.1 New services
+
+- **`SkillService`** (`app/services/skill/skill.service.ts`) — mirror
+  `ToolService`: `_skills` signal from `GET /skills/`, `enabledSkillIds`
+  computed, `toggleSkill()` → optimistic update + `PUT /skills/preferences`.
+- **`ChatModeService`** (`app/session/services/chat-mode/`) — signals:
+  `policy` (from `GET /system/chat-settings`, loaded at auth), `mode`
+  (`'skill' | 'chat'`), `canToggle` computed. New-session initial mode:
+  `preferredAgentMode ?? policy.defaultMode`; toggling persists
+  `preferredAgentMode` (user settings) and `agent_type` (session preferences).
+
+### 7.2 Model-settings panel (`components/model-settings/`)
+
+- **Mode control**: a two-option segmented control ("Skills" / "Tools") above the
+  capabilities sections, rendered only when `canToggle()`. When toggling is
+  disallowed, no control — the panel simply shows whichever section matches the
+  admin default.
+- **Skills section** (new, shown in skills mode): toggle list of accessible
+  skills — name, description, category chip, enabled count badge in the header
+  (visual twin of the Tools section). Empty state for zero accessible skills:
+  "No skills are available for your role" (+ a "switch to Tools" hint when
+  `canToggle()`).
+- **Tools section** (existing, shown in tools mode only).
+
+### 7.3 Chat request (`chat-request.service.ts`)
+
+- Always send `agent_type: mode()`.
+- Skills mode: `enabled_skills: skillService.getEnabledSkillIds()`,
+  `enabled_tools: []`.
+- Tools mode: `enabled_tools` as today; omit `enabled_skills`.
+
+### 7.4 Session hydration (`session.page.ts`)
+
+New effect mirroring the `lastModel` pattern: on session load, if
+`preferences.agentType` is set, `chatModeService.setMode(...)` — a conversation
+reopens in the mode it was created with (subject to `canToggle`; if policy now
+forbids the stored mode's opposite, the policy wins).
+
+### 7.5 Admin page
+
+`admin/settings/` (new): a "Chat settings" page — default-mode radio
+(Skills / Tools) + "Allow users to switch modes" toggle, save via
+`PUT /admin/settings/chat`. Follow the list-page redesign tokens
+(rounded-2xl / text-sm/6 / text-2xl/8, flat form — no heavy section cards).
+
+## 8. Infrastructure (CDK)
+
+**None required.** *(Revised 2026-06-11 — see §3.4.)* The chat-mode settings
+item lives in the auth-providers table, whose env var
+(`DYNAMODB_AUTH_PROVIDERS_TABLE_NAME`) and IAM grants already reach both the
+app-api task definition (`app-api-environment.ts:254`) and the inference
+runtime (`inference-agentcore-construct.ts:316`,
+`inference-api-iam-roles.ts:149`). Deploy order for the rollout is just
+`backend.yml` → `frontend-deploy.yml`. Backward-safe at every step: backend
+tolerates a missing item (§3.6); old SPA omits the new fields (back-compat
+semantics §3.5).
+
+## 9. Edge cases
+
+- **Zero accessible skills, skills mode** — existing SkillAgent degrade path;
+  panel shows the empty state. No behavior change from today.
+- **All skills toggled off** — effective set empty → degrade path; with
+  `enabled_tools: []` the turn is model-only. The Skills section header's count
+  badge makes this visible; acceptable v1 (matches a user disabling every tool
+  in tools mode today).
+- **Voice** — `agent_type="voice"` bypasses the policy override (§3.3).
+- **Assistants (`rag_assistant_id`)** — out of scope; assistant turns keep their
+  current behavior (they already replace `enabled_tools` with `[]`). Interaction
+  between assistants and skills mode is a follow-up decision.
+- **API-key / external clients** — policy enforcement is uniform (they hit the
+  same `/invocations` resolution). If a service integration must pin a mode, that
+  becomes an explicit carve-out later, not a silent bypass now.
+- **Stale SPA policy** — SPA loads policy at auth; if an admin flips it mid-session
+  the server still enforces (§3.3), so the worst case is a hidden-but-ignored
+  toggle until refresh.
+- **Mid-conversation mode switch** — allowed (it's per-turn server-side already);
+  the per-session preference just tracks the latest choice. Resume of a paused
+  turn uses the snapshot, so an in-flight turn can't change modes midway.
+
+## 10. Testing
+
+- **Backend (pytest — full local suite; not in CI):**
+  - `platform_settings` repo/service: missing table fallback, TTL cache, PUT validation.
+  - Enforcement matrix: {toggle allowed, denied} × {requested skill, chat, voice, absent}.
+  - Effective-skill intersection: None → all; subset; ids outside accessible set dropped; empty → degrade.
+  - Snapshot round-trip with `enabled_skills`; resume gating unchanged.
+  - Cache-key differentiation on differing effective sets.
+  - `GET /skills/` RBAC filtering + ACTIVE-only; preferences PUT rejects inaccessible ids.
+  - Import-boundary test picks up the new shared domain automatically.
+- **Frontend (`ng test`, not raw vitest; DI tokens over `vi.mock`):**
+  - `SkillService` load/toggle/persist; `ChatModeService` init precedence
+    (session pref > user pref > admin default) and `canToggle` gating.
+  - Model-settings: section visibility per mode × policy; empty state.
+  - `buildChatRequestObject` field matrix per mode.
+- **Infra:** construct unit test for the table + env threading (`npx jest`).
+
+## 11. Phasing / PR breakdown
+
+All PRs branch from `develop`; conventional commits.
+
+1. **PR-1 — Platform settings foundation (backend only, no CDK).**
+   `apis/shared/platform_settings/` (sentinel item in the auth-providers table,
+   §3.4) + `/admin/settings/chat` + `GET /system/chat-settings`. No behavior
+   change (nothing consumes the policy yet).
+2. **PR-2 — User skills surface + inference enforcement (backend).**
+   `GET /skills/` + `PUT /skills/preferences` (incl. lifting the shared
+   resolution helper into `apis/shared/skills/`), `enabled_skills` on
+   `InvocationRequest`, effective-set intersection, cache-key + snapshot changes,
+   policy enforcement in the effective-type resolution. Back-compat: absent
+   fields reproduce today's behavior exactly.
+3. **PR-3 — SPA: skills mode UX.** `SkillService`, `ChatModeService`,
+   model-settings mode control + Skills section, chat-request wiring, session
+   hydration, user-settings `preferredAgentMode`.
+4. **PR-4 — SPA: admin chat-settings page** (+ any polish: empty states, count
+   badges). Small; can fold into PR-3 if it stays lean.
+
+## 12. Risks / open questions
+
+- **`enabled_tools: []` in skills mode** (§3.1) — needs product sign-off: users
+  who relied on ad-hoc standalone tools lose them while in skills mode until an
+  admin binds them into a skill. The toggle back to tools mode (where allowed) is
+  the escape hatch.
+- **Policy cache window** — a ~60 s TTL means an admin lockdown takes up to a
+  minute to bite on in-flight containers. Acceptable; document it on the admin page.
+- **Effective-set cache-key churn** — per-user toggle changes now create more
+  distinct agent cache entries; bounded by (users × toggle combinations actually
+  used), same order as `enabled_tools` churn today.
+- **Assistants × skills mode** deferred (§9) — revisit when assistants get a
+  skills story.
+- **Default-mode flip vs. existing constant** — after PR-2, `DEFAULT_AGENT_TYPE`
+  is only the no-table fallback; the admin setting is authoritative. Make sure
+  nightly/env bootstrap seeds the settings item so environments don't silently
+  diverge from what admins see in the UI.
+
+## 13. Definition of done
+
+An admin can set the platform default mode and disallow switching; a user in
+skills mode sees exactly their RBAC-granted active skills in the model-settings
+panel, toggles a subset, and the agent's capabilities are precisely the bound
+tools of the enabled skills (verified via the `contextBreakdown` tools
+partition); switching to tools mode (where allowed) restores today's
+fine-grained tool picker behavior; resume, paused-turn OAuth flows, voice, and
+assistants behave exactly as before; old clients (no new fields) see zero
+behavior change.


### PR DESCRIPTION
## Summary

PR-1 of the **skills mode** feature ([spec](https://github.com/Boise-State-Development/agentcore-public-stack/blob/feature/platform-settings-foundation/docs/specs/skills-mode.md), included in this PR). Adds the admin-managed **chat-mode policy** — which agent mode (`skill`/`chat`) new conversations default to, and whether users may toggle between modes — that PR-2 (inference enforcement + user skills surface) and PR-3/4 (SPA UX) build on.

**No behavior change**: nothing consumes the policy yet, and the defaults (`skill` default, toggling allowed) reproduce today's hardcoded `DEFAULT_AGENT_TYPE` behavior exactly.

## Changes

- **`apis/shared/platform_settings/`** (new shared domain) — `ChatModeSettings` model + repository + 60s-TTL-cached service. Stored as a `SYSTEM_SETTINGS#chat-mode` sentinel item in the **auth-providers table**, following the existing `SYSTEM_SETTINGS#first-boot` convention — **zero CDK changes**, since both app-api and the inference runtime already have that table's env var and IAM grants.
- **`GET/PUT /admin/settings/chat`** (`require_admin`) — read/update the policy, with `updatedBy`/`updatedAt` audit stamping.
- **`GET /system/chat-settings`** (`get_current_user_from_session`) — SPA-facing read of the two policy flags, loaded at auth alongside tools/models.

## Spec revision

The spec originally proposed a dedicated platform-settings table; while building this I found the established first-boot sentinel-item convention with both services already wired to the table, so the spec's §3.4/§8 were revised to match (noted inline with the date).

## Testing

- 22 new tests: model validation + Dynamo round-trip, repository (missing item / disabled / errors), service TTL-cache semantics (injected clock), and route tests for all three endpoints incl. camelCase body handling and 422 on invalid mode.
- Full backend suite: **3777 passed, 3 skipped** (pytest is not in CI — local suite is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)