### PR TITLE
feat(skills): user skills surface + chat-mode policy enforcement (skills-mode PR-2)

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -1010,6 +1010,7 @@ class StreamCoordinator:
                 caching_enabled=snapshot_source.get("caching_enabled"),
                 max_tokens=inference_params.get("max_tokens"),
                 agent_type=snapshot_source.get("agent_type"),
+                enabled_skills=snapshot_source.get("enabled_skills"),
                 inference_params=dict(inference_params) if inference_params else None,
                 captured_at=now.isoformat(),
                 expires_at=(now + timedelta(hours=1)).isoformat(),

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -180,6 +180,7 @@ from apis.app_api.chat.proxy_routes import router as bff_chat_proxy_router
 from apis.app_api.mcp_apps.routes import router as mcp_apps_router
 from apis.app_api.memory.routes import router as memory_router
 from apis.app_api.tools.routes import router as tools_router
+from apis.app_api.skills.routes import router as user_skills_router
 from apis.app_api.files.routes import router as files_router
 from apis.app_api.assistants.routes import router as assistants_router
 from apis.app_api.documents.routes import router as documents_router
@@ -213,6 +214,7 @@ app.include_router(bff_chat_proxy_router)  # Cookie-authenticated SSE proxy (Pha
 app.include_router(mcp_apps_router)  # MCP Apps app-initiated tools/call proxy (PR #5; inert until host flag on)
 app.include_router(memory_router)  # AgentCore Memory access endpoints
 app.include_router(tools_router)  # Tool discovery and permissions
+app.include_router(user_skills_router)  # User-facing skill list + per-skill preferences
 app.include_router(files_router)  # File upload via pre-signed URLs
 app.include_router(connectors_router)  # User-facing connector catalog + consent flows
 app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors

--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -1,0 +1,118 @@
+"""User-facing skills API: list accessible skills + per-skill preferences.
+
+The skills parallel of ``apis/app_api/tools/routes.py``. Returns only the
+ACTIVE skills the user's RBAC roles grant — the same resolution
+(``apis.shared.skills.access``) and the same ACTIVE filter the SkillAgent
+applies at runtime, so what the user sees in the picker is exactly what the
+agent can activate. Preferences are a global per-user map (skill_id ->
+enabled); a skill absent from the map is enabled by default.
+
+Admin skill management routes are in ``apis.app_api.admin.skills.routes``.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.skills.access import resolve_accessible_skill_ids
+from apis.shared.skills.models import SkillStatus
+from apis.shared.skills.repository import get_skill_catalog_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/skills", tags=["skills"])
+
+
+class UserSkillResponse(BaseModel):
+    """A single skill as shown in the user's skills picker."""
+
+    skill_id: str = Field(..., alias="skillId")
+    display_name: str = Field(..., alias="displayName")
+    description: str
+    category: Optional[str] = None
+    bound_tool_count: int = Field(..., alias="boundToolCount")
+    user_enabled: Optional[bool] = Field(None, alias="userEnabled")
+    is_enabled: bool = Field(..., alias="isEnabled")
+
+    model_config = {"populate_by_name": True}
+
+
+class UserSkillsResponse(BaseModel):
+    """Response model for GET /skills/."""
+
+    skills: List[UserSkillResponse]
+    total_count: int = Field(..., alias="totalCount")
+
+    model_config = {"populate_by_name": True}
+
+
+class SkillPreferencesRequest(BaseModel):
+    """Request body for PUT /skills/preferences."""
+
+    preferences: Dict[str, bool] = Field(
+        ..., description="Map of skill_id -> enabled state"
+    )
+
+
+@router.get("/", response_model=UserSkillsResponse)
+async def get_user_skills(
+    user: User = Depends(get_current_user_from_session),
+) -> UserSkillsResponse:
+    """
+    Get the ACTIVE skills the current user's roles grant, with the user's
+    enabled/disabled preferences merged.
+    """
+    logger.info(f"User {user.name} getting skills with preferences")
+
+    accessible_ids = await resolve_accessible_skill_ids(user)
+    if not accessible_ids:
+        return UserSkillsResponse(skills=[], total_count=0)
+
+    repo = get_skill_catalog_repository()
+    records = await repo.batch_get_skills(accessible_ids)
+    preferences = (await repo.get_user_preferences(user.user_id)).skill_preferences
+
+    skills = [
+        UserSkillResponse(
+            skill_id=record.skill_id,
+            display_name=record.display_name,
+            description=record.description,
+            category=record.category,
+            bound_tool_count=len(record.bound_tool_ids),
+            user_enabled=preferences.get(record.skill_id),
+            is_enabled=preferences.get(record.skill_id, True),
+        )
+        for record in records
+        if record.status == SkillStatus.ACTIVE
+    ]
+    skills.sort(key=lambda s: s.display_name.lower())
+
+    return UserSkillsResponse(skills=skills, total_count=len(skills))
+
+
+@router.put("/preferences")
+async def update_skill_preferences(
+    request: SkillPreferencesRequest,
+    user: User = Depends(get_current_user_from_session),
+):
+    """
+    Save the user's per-skill enabled/disabled preferences.
+
+    Only accepts preferences for skills the user has access to.
+    """
+    logger.info(f"User {user.name} updating skill preferences")
+
+    accessible = set(await resolve_accessible_skill_ids(user))
+    unknown = sorted(sid for sid in request.preferences if sid not in accessible)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Preferences include skills you don't have access to: {unknown}",
+        )
+
+    repo = get_skill_catalog_repository()
+    await repo.save_user_preferences(user.user_id, request.preferences)
+    return {"message": "Preferences saved successfully"}

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -107,11 +107,19 @@ class InvocationRequest(BaseModel):
     # (assistant-prefill). Bypasses quota / RAG / file resolution like resume.
     continue_truncated: Optional[bool] = None
     # Selects which agent factory variant builds the turn. When omitted, the
-    # server applies its default (PR-7: "skill" — see routes.DEFAULT_AGENT_TYPE),
-    # routing through SkillAgent's progressive disclosure; a user with no granted
-    # skills degrades to plain ChatAgent behavior. Pass "chat" to opt out of the
-    # skill path for a turn.
+    # server applies its default (PR-7: "skill" — admin-configurable via the
+    # chat-mode policy, see routes.py), routing through SkillAgent's progressive
+    # disclosure; a user with no granted skills degrades to plain ChatAgent
+    # behavior. Pass "chat" to opt out of the skill path for a turn — honored
+    # only while the admin policy allows mode toggling.
     agent_type: Optional[str] = None
+    # Per-turn selection of which accessible skills are active (skill agent
+    # path only). None/absent = all RBAC-accessible skills (back-compat with
+    # clients that predate the skills picker). A list is intersected
+    # server-side with the accessible set — client input can narrow the set,
+    # never grant. An empty (or fully inaccessible) list yields zero skills,
+    # so the SkillAgent degrades to plain chat behavior for the turn.
+    enabled_skills: Optional[List[str]] = None
     # User-selected custom system prompt ("conversation mode") for this
     # turn. The frontend forwards the active selection on every submit so
     # the inference path doesn't have to round-trip session metadata to

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import time
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -28,6 +28,8 @@ from apis.shared.errors import (
 )
 from apis.shared.files.file_resolver import get_file_resolver
 from apis.shared.models.managed_models import list_managed_models
+from apis.shared.platform_settings.models import DEFAULT_CHAT_MODE, ChatModeSettings
+from apis.shared.platform_settings.service import get_chat_mode_settings_service
 from apis.shared.quota import (
     QuotaExceededEvent,
     build_no_quota_configured_event,
@@ -76,7 +78,13 @@ PREVIEW_SESSION_PREFIX = "preview-"
 # turn by sending agent_type="chat". (The lower-level service.get_agent keeps a
 # conservative "chat" fallback for direct/programmatic callers that don't
 # resolve skills; this request-policy default lives here.)
-DEFAULT_AGENT_TYPE = "skill"
+#
+# Since the skills-mode work (docs/specs/skills-mode.md) the *runtime* default
+# comes from the admin-managed chat-mode policy (apis.shared.platform_settings),
+# which also decides whether a client agent_type override is honored at all —
+# see _resolve_effective_agent_type. This constant is the compiled-in fallback
+# the policy model itself defaults to, kept aliased so they can never drift.
+DEFAULT_AGENT_TYPE = DEFAULT_CHAT_MODE
 
 
 def is_preview_session(session_id: str) -> bool:
@@ -670,22 +678,57 @@ async def ping():
 async def _resolve_accessible_skill_ids(current_user: User) -> list[str]:
     """Resolve the skills a user's RBAC roles grant (admin/DB-backed).
 
-    Uses the shared ``AppRoleService`` (the same import-boundary-safe path the
-    model-access check uses) so the runtime never imports ``app_api``. A ``"*"``
-    wildcard grant expands to every known skill id. Never raises — on any
-    failure the user simply gets no skills (the SkillAgent degrades to chat).
+    Thin delegate to the shared resolver (``apis.shared.skills.access``) used
+    by both this path and the user-facing skills API, so the picker and the
+    runtime can never drift. Kept as a module-level seam for tests. Never
+    raises — on any failure the user simply gets no skills (the SkillAgent
+    degrades to chat).
     """
-    try:
-        from apis.shared.rbac.service import get_app_role_service
-        from apis.shared.skills.freshness import get_all_skill_ids
+    from apis.shared.skills.access import resolve_accessible_skill_ids
 
-        skills = await get_app_role_service().get_accessible_skills(current_user)
-        if "*" in skills:
-            return sorted(await get_all_skill_ids())
-        return list(skills)
-    except Exception:
-        logger.warning("Failed to resolve accessible skills", exc_info=True)
-        return []
+    return await resolve_accessible_skill_ids(current_user)
+
+
+def _resolve_effective_agent_type(
+    requested: Optional[str], settings: ChatModeSettings
+) -> str:
+    """Apply the admin chat-mode policy to a client's requested agent type.
+
+    The client's choice between "skill" and "chat" is honored only while the
+    policy allows mode toggling; otherwise the admin default wins (UI gating
+    alone is not enforcement — the SPA hides the toggle, but any client can
+    craft a request). Other values ("voice", future internal types) pass
+    through untouched: the policy governs the user-facing mode pair only.
+    """
+    if (
+        requested in ("skill", "chat")
+        and requested != settings.default_mode
+        and not settings.allow_mode_toggle
+    ):
+        logger.info(
+            "Client agent_type=%s overridden to %s (mode toggling disabled by admin)",
+            requested,
+            settings.default_mode,
+        )
+        requested = None
+    return requested or settings.default_mode
+
+
+def _apply_enabled_skills_filter(
+    accessible_skill_ids: list[str], enabled_skills: Optional[list[str]]
+) -> list[str]:
+    """Narrow the RBAC-accessible skill set by the client's per-turn selection.
+
+    ``None`` means the client predates (or isn't using) the skills picker —
+    all accessible skills stay active, the pre-picker behavior. A list is an
+    intersection: client input can narrow the set, never grant. The result
+    stays a list (possibly empty) because SkillAgent distinguishes [] (DB
+    mode, zero skills → degrade to chat) from None (file-scan fallback).
+    """
+    if enabled_skills is None:
+        return accessible_skill_ids
+    requested = set(enabled_skills)
+    return [sid for sid in accessible_skill_ids if sid in requested]
 
 
 @router.post("/invocations")
@@ -709,21 +752,29 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # they bypass quota, file resolution, and RAG augmentation because those
     # already ran on the original turn that got paused.
     is_resume = bool(input_data.interrupt_responses)
-    # Resolve the effective agent type once: the client's explicit choice, else
-    # the server default (PR-7: "skill"). Used for the skill resolution below
-    # and the non-resume get_agent calls (resume reuses the snapshot's type).
-    effective_agent_type = input_data.agent_type or DEFAULT_AGENT_TYPE
-    # Resolve the user's accessible skills (admin/DB-backed, RBAC-gated) once
-    # for the whole request — only for the skill agent path. Threaded into
+    # Resolve the effective agent type once: the client's explicit choice
+    # (honored only while the admin chat-mode policy allows toggling), else
+    # the policy's default mode. Used for the skill resolution below and the
+    # non-resume get_agent calls (resume reuses the snapshot's type). The
+    # settings read is TTL-cached in-process (~60s) and degrades to compiled-in
+    # defaults, so this adds no per-turn Dynamo cost and can't fail the turn.
+    chat_mode_settings = await get_chat_mode_settings_service().get_settings()
+    effective_agent_type = _resolve_effective_agent_type(
+        input_data.agent_type, chat_mode_settings
+    )
+    # Resolve the user's *effective* skills once for the whole request — only
+    # for the skill agent path: the RBAC-accessible set (admin/DB-backed),
+    # narrowed by the client's per-turn enabled_skills selection. Threaded into
     # every get_agent call below so they share one skills_hash cache key
     # (otherwise the app-tool-call / resume paths would miss the main turn's
     # cached SkillAgent). An explicit agent_type="chat" opts out and stays free
     # of the extra reads.
-    accessible_skill_ids = (
-        await _resolve_accessible_skill_ids(current_user)
-        if effective_agent_type == "skill"
-        else None
-    )
+    effective_skill_ids = None
+    if effective_agent_type == "skill":
+        effective_skill_ids = _apply_enabled_skills_filter(
+            await _resolve_accessible_skill_ids(current_user),
+            input_data.enabled_skills,
+        )
     # A "Continue" after a max_tokens truncation. Like resume, it bypasses
     # quota / RAG / file resolution and does NOT clear the turn state; unlike
     # resume there is no interrupt to validate — the agent is rebuilt from the
@@ -764,7 +815,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=inference_params,
                 agent_type=effective_agent_type,
                 is_resume=False,
-                accessible_skill_ids=accessible_skill_ids,
+                accessible_skill_ids=effective_skill_ids,
             )
             payload = await dispatch_app_tool_call(
                 agent,
@@ -810,7 +861,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 inference_params=inference_params,
                 agent_type=effective_agent_type,
                 is_resume=False,
-                accessible_skill_ids=accessible_skill_ids,
+                accessible_skill_ids=effective_skill_ids,
             )
             payload = dispatch_app_context_update(
                 agent,
@@ -1328,12 +1379,21 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 is_resume=True,
                 # Resume must rebuild the SAME cache key the original turn used,
                 # or the paused agent is orphaned. The original turn's
-                # skills_hash was derived from accessible_skill_ids only when it
-                # was a skill turn; mirror that off the snapshot's type (the
-                # request default is "skill", but a turn explicitly built as
-                # "chat" carried no skills → empty skills_hash).
+                # skills_hash was derived from its *effective* skill set only
+                # when it was a skill turn; mirror that off the snapshot's type
+                # (a turn explicitly built as "chat" carried no skills → empty
+                # skills_hash). New snapshots carry that exact set in
+                # enabled_skills; legacy snapshots (written before the field
+                # existed) fall back to this request's resolution, the
+                # pre-skills-picker behavior.
                 accessible_skill_ids=(
-                    accessible_skill_ids if snapshot.agent_type == "skill" else None
+                    (
+                        snapshot.enabled_skills
+                        if snapshot.enabled_skills is not None
+                        else effective_skill_ids
+                    )
+                    if snapshot.agent_type == "skill"
+                    else None
                 ),
             )
         else:
@@ -1416,7 +1476,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 agent_type=effective_agent_type,
                 extra_tools=extra_tools,
                 is_resume=False,
-                accessible_skill_ids=accessible_skill_ids,
+                accessible_skill_ids=effective_skill_ids,
             )
 
         # Resume requests must target interrupts that the cached agent

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -244,9 +244,13 @@ async def get_agent(
     agent = create_agent(**create_kwargs)
 
     # Stamp the type onto the construction snapshot so a paused turn can
-    # resume on the same factory variant after cache eviction.
+    # resume on the same factory variant after cache eviction. Skill turns
+    # also stamp their effective skill set: resume must rebuild the same
+    # skills_hash cache key even if the user toggles skills mid-pause.
     if hasattr(agent, "_construction_snapshot"):
         agent._construction_snapshot["agent_type"] = resolved_agent_type
+        if resolved_agent_type == "skill" and accessible_skill_ids is not None:
+            agent._construction_snapshot["enabled_skills"] = list(accessible_skill_ids)
 
     # Don't cache agents with context-bound extra_tools
     if extra_tools:

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -107,6 +107,15 @@ class PausedTurnSnapshot(BaseModel):
     caching_enabled: Optional[bool] = Field(default=None, alias="cachingEnabled")
     max_tokens: Optional[int] = Field(default=None, alias="maxTokens")
     agent_type: Optional[str] = Field(default=None, alias="agentType")
+    enabled_skills: Optional[List[str]] = Field(
+        default=None,
+        alias="enabledSkills",
+        description="Effective skill ids the paused skill turn was built with. "
+                    "Resume rebuilds the same skills_hash cache key from these "
+                    "even if the user toggles skills mid-pause. None on chat "
+                    "turns and on snapshots written before the field existed "
+                    "(those fall back to request-time resolution).",
+    )
     inference_params: Optional[Dict[str, Any]] = Field(
         default=None,
         alias="inferenceParams",

--- a/backend/src/apis/shared/skills/__init__.py
+++ b/backend/src/apis/shared/skills/__init__.py
@@ -28,6 +28,8 @@ from .models import (
     SkillUpdateRequest,
     SkillVisibility,
 )
+from .access import resolve_accessible_skill_ids
+from .models import UserSkillPreference
 from .repository import SkillCatalogRepository, get_skill_catalog_repository
 from .resource_store import (
     SkillResourceStore,
@@ -59,4 +61,6 @@ __all__ = [
     "get_freshness_hash",
     "get_skill_updated_at",
     "invalidate",
+    "resolve_accessible_skill_ids",
+    "UserSkillPreference",
 ]

--- a/backend/src/apis/shared/skills/access.py
+++ b/backend/src/apis/shared/skills/access.py
@@ -1,0 +1,34 @@
+"""Per-user skill access resolution shared by app_api and the runtime.
+
+Single source of truth for "which skills do this user's RBAC roles grant",
+so the user-facing skills API (``app_api/skills``) and the inference path
+(``inference_api/chat``) can never drift. Lives in ``apis.shared`` per the
+import-boundary rule (both consume it; neither may import the other).
+"""
+
+import logging
+from typing import List
+
+from apis.shared.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_accessible_skill_ids(user: User) -> List[str]:
+    """Resolve the skills a user's RBAC roles grant (admin/DB-backed).
+
+    A ``"*"`` wildcard grant expands to every known skill id. Never raises —
+    on any failure the user simply gets no skills (the SkillAgent degrades
+    to chat, the skills list renders empty).
+    """
+    try:
+        from apis.shared.rbac.service import get_app_role_service
+        from apis.shared.skills.freshness import get_all_skill_ids
+
+        skills = await get_app_role_service().get_accessible_skills(user)
+        if "*" in skills:
+            return sorted(await get_all_skill_ids())
+        return list(skills)
+    except Exception:
+        logger.warning("Failed to resolve accessible skills", exc_info=True)
+        return []

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -17,7 +17,7 @@ Persistence).
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -405,3 +405,44 @@ class SkillResourcesResponse(BaseModel):
     resources: List[SkillResourceRef] = Field(default_factory=list)
 
     model_config = {"populate_by_name": True}
+
+
+class UserSkillPreference(BaseModel):
+    """
+    User's explicit per-skill enabled/disabled preferences (mirrors
+    ``UserToolPreference``). A skill absent from the map is enabled by
+    default — RBAC granted means on unless the user toggled it off.
+
+    Stored per-user in the skills/AppRoles table:
+    PK=USER#{user_id}, SK=SKILL_PREFERENCES.
+    """
+
+    user_id: str
+    skill_preferences: Dict[str, bool] = Field(
+        default_factory=dict, description="Map of skill_id -> enabled state"
+    )
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dynamo_item(self) -> dict:
+        """Convert to DynamoDB item format."""
+        return {
+            "PK": f"USER#{self.user_id}",
+            "SK": "SKILL_PREFERENCES",
+            "userId": self.user_id,
+            "skillPreferences": self.skill_preferences,
+            "updatedAt": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @classmethod
+    def from_dynamo_item(cls, item: dict) -> "UserSkillPreference":
+        """Create from a DynamoDB item."""
+        updated_at = item.get("updatedAt")
+        return cls(
+            user_id=item.get("userId", ""),
+            skill_preferences=dict(item.get("skillPreferences", {})),
+            updated_at=(
+                datetime.fromisoformat(updated_at.rstrip("Z"))
+                if updated_at
+                else datetime.now(timezone.utc)
+            ),
+        )

--- a/backend/src/apis/shared/skills/repository.py
+++ b/backend/src/apis/shared/skills/repository.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
-from .models import SkillDefinition, SkillStatus
+from .models import SkillDefinition, SkillStatus, UserSkillPreference
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +288,62 @@ class SkillCatalogRepository:
 
         except ClientError as e:
             logger.error(f"Error batch getting skills: {e}")
+            raise
+
+    # =========================================================================
+    # User Preferences (mirrors ToolCatalogRepository)
+    # =========================================================================
+
+    async def get_user_preferences(self, user_id: str) -> UserSkillPreference:
+        """
+        Get user's per-skill preferences.
+
+        Args:
+            user_id: The user identifier
+
+        Returns:
+            UserSkillPreference (empty if not found)
+        """
+        try:
+            response = self._table.get_item(
+                Key={"PK": f"USER#{user_id}", "SK": "SKILL_PREFERENCES"}
+            )
+            item = response.get("Item")
+            if not item:
+                return UserSkillPreference(user_id=user_id)
+            return UserSkillPreference.from_dynamo_item(item)
+        except ClientError as e:
+            logger.error(f"Error getting skill preferences for {user_id}: {e}")
+            raise
+
+    async def save_user_preferences(
+        self, user_id: str, preferences: Dict[str, bool]
+    ) -> UserSkillPreference:
+        """
+        Save user's per-skill preferences.
+
+        Merges with existing preferences (does not replace).
+
+        Args:
+            user_id: The user identifier
+            preferences: Map of skill_id -> enabled state
+
+        Returns:
+            Updated UserSkillPreference
+        """
+        try:
+            existing = await self.get_user_preferences(user_id)
+
+            existing.skill_preferences.update(preferences)
+            existing.updated_at = datetime.now(timezone.utc)
+
+            self._table.put_item(Item=existing.to_dynamo_item())
+
+            logger.info(f"Saved skill preferences for user: {user_id}")
+            return existing
+
+        except ClientError as e:
+            logger.error(f"Error saving skill preferences for {user_id}: {e}")
             raise
 
 

--- a/backend/tests/apis/app_api/test_user_skills_routes.py
+++ b/backend/tests/apis/app_api/test_user_skills_routes.py
@@ -1,0 +1,152 @@
+"""Route tests for the user-facing skills API (GET /skills/, PUT /skills/preferences)."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.skills.models import SkillDefinition, SkillStatus, UserSkillPreference
+
+from apis.app_api.skills import routes as skills_routes
+
+
+def _user() -> User:
+    return User(
+        user_id="user-1",
+        email="user@example.com",
+        name="User",
+        roles=["default"],
+        raw_token="tok",
+    )
+
+
+def _skill(skill_id: str, display_name: str, status=SkillStatus.ACTIVE, bound=None):
+    return SkillDefinition(
+        skill_id=skill_id,
+        display_name=display_name,
+        description=f"{display_name} description",
+        instructions="...",
+        bound_tool_ids=bound or [],
+        status=status,
+    )
+
+
+class _FakeRepo:
+    """Duck-typed stand-in for SkillCatalogRepository."""
+
+    def __init__(self, skills: List[SkillDefinition], prefs: Dict[str, bool]):
+        self._skills = {s.skill_id: s for s in skills}
+        self.prefs = dict(prefs)
+        self.saved: Optional[Dict[str, bool]] = None
+
+    async def batch_get_skills(self, skill_ids):
+        return [self._skills[sid] for sid in skill_ids if sid in self._skills]
+
+    async def get_user_preferences(self, user_id):
+        return UserSkillPreference(user_id=user_id, skill_preferences=self.prefs)
+
+    async def save_user_preferences(self, user_id, preferences):
+        self.saved = dict(preferences)
+        self.prefs.update(preferences)
+        return UserSkillPreference(user_id=user_id, skill_preferences=self.prefs)
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    accessible: List[str],
+    repo: _FakeRepo,
+) -> TestClient:
+    async def fake_resolve(user):
+        return list(accessible)
+
+    monkeypatch.setattr(skills_routes, "resolve_accessible_skill_ids", fake_resolve)
+    monkeypatch.setattr(skills_routes, "get_skill_catalog_repository", lambda: repo)
+
+    app = FastAPI()
+    app.include_router(skills_routes.router)
+    app.dependency_overrides[get_current_user_from_session] = _user
+    return TestClient(app)
+
+
+class TestGetUserSkills:
+    def test_lists_active_accessible_skills_with_prefs_merged(self, monkeypatch):
+        repo = _FakeRepo(
+            skills=[
+                _skill("web_research", "Web Research", bound=["t1", "t2"]),
+                _skill("pdf_workflows", "PDF Workflows"),
+            ],
+            prefs={"web_research": False},
+        )
+        client = _make_client(monkeypatch, ["web_research", "pdf_workflows"], repo)
+
+        body = client.get("/skills/").json()
+        assert body["totalCount"] == 2
+        by_id = {s["skillId"]: s for s in body["skills"]}
+
+        # Toggled-off skill: explicit preference surfaces, effective off
+        assert by_id["web_research"]["userEnabled"] is False
+        assert by_id["web_research"]["isEnabled"] is False
+        assert by_id["web_research"]["boundToolCount"] == 2
+
+        # Untouched skill: no preference, enabled by default
+        assert by_id["pdf_workflows"]["userEnabled"] is None
+        assert by_id["pdf_workflows"]["isEnabled"] is True
+
+        # Sorted by display name
+        assert [s["skillId"] for s in body["skills"]] == [
+            "pdf_workflows",
+            "web_research",
+        ]
+
+    def test_non_active_skills_are_hidden(self, monkeypatch):
+        repo = _FakeRepo(
+            skills=[
+                _skill("active_one", "Active One"),
+                _skill("draft_one", "Draft One", status=SkillStatus.DRAFT),
+                _skill("disabled_one", "Disabled One", status=SkillStatus.DISABLED),
+            ],
+            prefs={},
+        )
+        client = _make_client(
+            monkeypatch, ["active_one", "draft_one", "disabled_one"], repo
+        )
+
+        body = client.get("/skills/").json()
+        assert [s["skillId"] for s in body["skills"]] == ["active_one"]
+
+    def test_no_accessible_skills_returns_empty(self, monkeypatch):
+        repo = _FakeRepo(skills=[], prefs={})
+        client = _make_client(monkeypatch, [], repo)
+
+        body = client.get("/skills/").json()
+        assert body == {"skills": [], "totalCount": 0}
+
+
+class TestUpdateSkillPreferences:
+    def test_saves_preferences_for_accessible_skills(self, monkeypatch):
+        repo = _FakeRepo(skills=[_skill("web_research", "Web Research")], prefs={})
+        client = _make_client(monkeypatch, ["web_research"], repo)
+
+        resp = client.put(
+            "/skills/preferences",
+            json={"preferences": {"web_research": False}},
+        )
+        assert resp.status_code == 200
+        assert repo.saved == {"web_research": False}
+
+    def test_rejects_inaccessible_skill_ids(self, monkeypatch):
+        repo = _FakeRepo(skills=[_skill("web_research", "Web Research")], prefs={})
+        client = _make_client(monkeypatch, ["web_research"], repo)
+
+        resp = client.put(
+            "/skills/preferences",
+            json={"preferences": {"web_research": True, "forbidden_skill": True}},
+        )
+        assert resp.status_code == 400
+        assert "forbidden_skill" in resp.json()["detail"]
+        assert repo.saved is None

--- a/backend/tests/routes/test_agent_mode_policy.py
+++ b/backend/tests/routes/test_agent_mode_policy.py
@@ -1,0 +1,250 @@
+"""Tests for the chat-mode policy + per-turn skill selection on /invocations.
+
+Covers (skills-mode PR-2, docs/specs/skills-mode.md):
+- _resolve_effective_agent_type — admin policy vs. client agent_type
+- _apply_enabled_skills_filter — RBAC ∩ client enabled_skills
+- route-level threading of both into get_agent
+- PausedTurnSnapshot.enabled_skills round-trip
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.inference_api.chat.routes import (
+    _apply_enabled_skills_filter,
+    _resolve_effective_agent_type,
+    router,
+)
+from apis.shared.auth.dependencies import get_current_user_trusted
+from apis.shared.platform_settings.models import ChatModeSettings
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/routes/test_inference.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+@pytest.fixture
+def trusted_user(make_user):
+    return make_user(raw_token="fake-jwt-token")
+
+
+@pytest.fixture
+def authed_client(app, trusted_user):
+    app.dependency_overrides[get_current_user_trusted] = lambda: trusted_user
+    return TestClient(app)
+
+
+class _StubSettingsService:
+    def __init__(self, settings: ChatModeSettings):
+        self._settings = settings
+
+    async def get_settings(self) -> ChatModeSettings:
+        return self._settings
+
+
+def _mock_agent():
+    agent = MagicMock()
+
+    async def fake_stream(*args, **kwargs):
+        yield "event: done\ndata: {}\n\n"
+
+    agent.stream_async = fake_stream
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# _resolve_effective_agent_type
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffectiveAgentType:
+    def test_toggle_allowed_honors_client_choice(self):
+        settings = ChatModeSettings(default_mode="skill", allow_mode_toggle=True)
+        assert _resolve_effective_agent_type("chat", settings) == "chat"
+        assert _resolve_effective_agent_type("skill", settings) == "skill"
+
+    def test_omitted_falls_back_to_admin_default(self):
+        assert (
+            _resolve_effective_agent_type(
+                None, ChatModeSettings(default_mode="skill", allow_mode_toggle=True)
+            )
+            == "skill"
+        )
+        assert (
+            _resolve_effective_agent_type(
+                None, ChatModeSettings(default_mode="chat", allow_mode_toggle=False)
+            )
+            == "chat"
+        )
+
+    def test_toggle_disabled_overrides_client_choice(self):
+        settings = ChatModeSettings(default_mode="skill", allow_mode_toggle=False)
+        assert _resolve_effective_agent_type("chat", settings) == "skill"
+
+        settings = ChatModeSettings(default_mode="chat", allow_mode_toggle=False)
+        assert _resolve_effective_agent_type("skill", settings) == "chat"
+
+    def test_toggle_disabled_matching_choice_passes(self):
+        settings = ChatModeSettings(default_mode="skill", allow_mode_toggle=False)
+        assert _resolve_effective_agent_type("skill", settings) == "skill"
+
+    def test_non_mode_types_bypass_the_policy(self):
+        settings = ChatModeSettings(default_mode="skill", allow_mode_toggle=False)
+        assert _resolve_effective_agent_type("voice", settings) == "voice"
+
+
+# ---------------------------------------------------------------------------
+# _apply_enabled_skills_filter
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEnabledSkillsFilter:
+    def test_none_means_all_accessible(self):
+        assert _apply_enabled_skills_filter(["a", "b"], None) == ["a", "b"]
+
+    def test_intersection_preserves_accessible_order(self):
+        assert _apply_enabled_skills_filter(["a", "b", "c"], ["c", "a"]) == ["a", "c"]
+
+    def test_client_cannot_grant_inaccessible_skills(self):
+        assert _apply_enabled_skills_filter(["a"], ["a", "forbidden"]) == ["a"]
+
+    def test_empty_selection_yields_zero_skills(self):
+        assert _apply_enabled_skills_filter(["a", "b"], []) == []
+
+    def test_empty_accessible_stays_empty(self):
+        assert _apply_enabled_skills_filter([], ["a"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Route-level threading into get_agent
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationsModePolicy:
+    def _invoke(self, authed_client, payload, *, settings, accessible):
+        get_agent_mock = MagicMock(return_value=_mock_agent())
+        resolve_mock = AsyncMock(return_value=accessible)
+        with patch(
+            "apis.inference_api.chat.routes.get_agent", get_agent_mock
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.inference_api.chat.routes._resolve_accessible_skill_ids",
+            resolve_mock,
+        ), patch(
+            "apis.inference_api.chat.routes.get_chat_mode_settings_service",
+            return_value=_StubSettingsService(settings),
+        ):
+            resp = authed_client.post("/invocations", json=payload)
+            _ = resp.text  # force the streaming generator to run
+
+        assert resp.status_code == 200
+        return get_agent_mock.call_args.kwargs
+
+    def test_enabled_skills_narrows_the_skill_set(self, authed_client):
+        kwargs = self._invoke(
+            authed_client,
+            {
+                "session_id": "sess-1",
+                "message": "hi",
+                "enabled_skills": ["pdf_workflows", "forbidden_skill"],
+            },
+            settings=ChatModeSettings(default_mode="skill", allow_mode_toggle=True),
+            accessible=["web_research", "pdf_workflows"],
+        )
+        assert kwargs["agent_type"] == "skill"
+        assert kwargs["accessible_skill_ids"] == ["pdf_workflows"]
+
+    def test_omitted_enabled_skills_keeps_all_accessible(self, authed_client):
+        kwargs = self._invoke(
+            authed_client,
+            {"session_id": "sess-2", "message": "hi"},
+            settings=ChatModeSettings(default_mode="skill", allow_mode_toggle=True),
+            accessible=["web_research"],
+        )
+        assert kwargs["accessible_skill_ids"] == ["web_research"]
+
+    def test_toggle_disabled_forces_admin_default(self, authed_client):
+        kwargs = self._invoke(
+            authed_client,
+            {"session_id": "sess-3", "message": "hi", "agent_type": "chat"},
+            settings=ChatModeSettings(default_mode="skill", allow_mode_toggle=False),
+            accessible=["web_research"],
+        )
+        # Client asked for chat; policy forces the skill default through.
+        assert kwargs["agent_type"] == "skill"
+        assert kwargs["accessible_skill_ids"] == ["web_research"]
+
+    def test_admin_default_chat_skips_skill_resolution(self, authed_client):
+        get_agent_mock = MagicMock(return_value=_mock_agent())
+        resolve_mock = AsyncMock(return_value=["web_research"])
+        with patch(
+            "apis.inference_api.chat.routes.get_agent", get_agent_mock
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.inference_api.chat.routes._resolve_accessible_skill_ids",
+            resolve_mock,
+        ), patch(
+            "apis.inference_api.chat.routes.get_chat_mode_settings_service",
+            return_value=_StubSettingsService(
+                ChatModeSettings(default_mode="chat", allow_mode_toggle=True)
+            ),
+        ):
+            resp = authed_client.post(
+                "/invocations", json={"session_id": "sess-4", "message": "hi"}
+            )
+            _ = resp.text
+
+        assert resp.status_code == 200
+        resolve_mock.assert_not_awaited()
+        kwargs = get_agent_mock.call_args.kwargs
+        assert kwargs["agent_type"] == "chat"
+        assert kwargs["accessible_skill_ids"] is None
+
+
+# ---------------------------------------------------------------------------
+# PausedTurnSnapshot.enabled_skills
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotEnabledSkills:
+    def test_round_trips_through_alias(self):
+        from apis.shared.sessions.models import PausedTurnSnapshot
+
+        snap = PausedTurnSnapshot(
+            agent_type="skill",
+            enabled_skills=["web_research"],
+            captured_at="2026-06-11T12:00:00+00:00",
+            expires_at="2026-06-11T13:00:00+00:00",
+        )
+        dumped = snap.model_dump(by_alias=True)
+        assert dumped["enabledSkills"] == ["web_research"]
+
+        restored = PausedTurnSnapshot.model_validate(dumped)
+        assert restored.enabled_skills == ["web_research"]
+
+    def test_legacy_snapshot_defaults_to_none(self):
+        from apis.shared.sessions.models import PausedTurnSnapshot
+
+        snap = PausedTurnSnapshot.model_validate(
+            {
+                "agentType": "skill",
+                "capturedAt": "2026-06-11T12:00:00+00:00",
+                "expiresAt": "2026-06-11T13:00:00+00:00",
+            }
+        )
+        assert snap.enabled_skills is None

--- a/backend/tests/shared/test_skills_access.py
+++ b/backend/tests/shared/test_skills_access.py
@@ -1,0 +1,55 @@
+"""Unit tests for the shared per-user skill access resolver."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from apis.shared.auth.models import User
+from apis.shared.skills.access import resolve_accessible_skill_ids
+
+pytestmark = pytest.mark.asyncio
+
+
+def _user() -> User:
+    return User(
+        user_id="user-1",
+        email="user@example.com",
+        name="User",
+        roles=["default"],
+        raw_token="tok",
+    )
+
+
+class TestResolveAccessibleSkillIds:
+    async def test_plain_grants_pass_through(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(
+            return_value=["web_research", "pdf_workflows"]
+        )
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ):
+            result = await resolve_accessible_skill_ids(_user())
+        assert result == ["web_research", "pdf_workflows"]
+
+    async def test_wildcard_expands_to_all_known_skills_sorted(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(return_value=["*"])
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ), patch(
+            "apis.shared.skills.freshness.get_all_skill_ids",
+            AsyncMock(return_value=frozenset({"zeta", "alpha"})),
+        ):
+            result = await resolve_accessible_skill_ids(_user())
+        assert result == ["alpha", "zeta"]
+
+    async def test_failure_degrades_to_no_skills(self):
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            side_effect=RuntimeError("rbac unavailable"),
+        ):
+            result = await resolve_accessible_skill_ids(_user())
+        assert result == []

--- a/backend/tests/shared/test_skills_preferences.py
+++ b/backend/tests/shared/test_skills_preferences.py
@@ -1,0 +1,100 @@
+"""Unit tests for per-user skill preferences (model + repository)."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apis.shared.skills.models import UserSkillPreference
+from apis.shared.skills.repository import SkillCatalogRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestUserSkillPreferenceModel:
+    def test_dynamo_round_trip(self):
+        original = UserSkillPreference(
+            user_id="user-1",
+            skill_preferences={"web_research": False, "pdf_workflows": True},
+            updated_at=datetime(2026, 6, 11, 12, 0, tzinfo=timezone.utc),
+        )
+        item = original.to_dynamo_item()
+        assert item["PK"] == "USER#user-1"
+        assert item["SK"] == "SKILL_PREFERENCES"
+
+        restored = UserSkillPreference.from_dynamo_item(item)
+        assert restored.user_id == "user-1"
+        assert restored.skill_preferences == {
+            "web_research": False,
+            "pdf_workflows": True,
+        }
+
+    def test_defaults_to_empty_preferences(self):
+        pref = UserSkillPreference(user_id="user-1")
+        assert pref.skill_preferences == {}
+
+
+class TestSkillPreferencesRepository:
+    def _make_repo(self) -> SkillCatalogRepository:
+        with patch("apis.shared.skills.repository.boto3") as mock_boto:
+            mock_table = MagicMock()
+            mock_resource = MagicMock()
+            mock_resource.Table.return_value = mock_table
+            mock_boto.resource.return_value = mock_resource
+
+            repo = SkillCatalogRepository(table_name="test-table")
+            repo._table = mock_table
+            return repo
+
+    async def test_get_returns_empty_when_no_row(self):
+        repo = self._make_repo()
+        repo._table.get_item.return_value = {}
+
+        result = await repo.get_user_preferences("user-1")
+        assert result.user_id == "user-1"
+        assert result.skill_preferences == {}
+
+        repo._table.get_item.assert_called_once_with(
+            Key={"PK": "USER#user-1", "SK": "SKILL_PREFERENCES"}
+        )
+
+    async def test_get_parses_stored_row(self):
+        repo = self._make_repo()
+        repo._table.get_item.return_value = {
+            "Item": {
+                "PK": "USER#user-1",
+                "SK": "SKILL_PREFERENCES",
+                "userId": "user-1",
+                "skillPreferences": {"web_research": False},
+                "updatedAt": "2026-06-11T12:00:00+00:00",
+            }
+        }
+
+        result = await repo.get_user_preferences("user-1")
+        assert result.skill_preferences == {"web_research": False}
+
+    async def test_save_merges_with_existing(self):
+        repo = self._make_repo()
+        repo._table.get_item.return_value = {
+            "Item": {
+                "PK": "USER#user-1",
+                "SK": "SKILL_PREFERENCES",
+                "userId": "user-1",
+                "skillPreferences": {"web_research": False},
+                "updatedAt": "2026-06-11T12:00:00+00:00",
+            }
+        }
+
+        result = await repo.save_user_preferences(
+            "user-1", {"pdf_workflows": True}
+        )
+
+        assert result.skill_preferences == {
+            "web_research": False,
+            "pdf_workflows": True,
+        }
+        saved_item = repo._table.put_item.call_args.kwargs["Item"]
+        assert saved_item["skillPreferences"] == {
+            "web_research": False,
+            "pdf_workflows": True,
+        }


### PR DESCRIPTION
## Summary

PR-2 of **skills mode** ([spec](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/skills-mode.md), follows #473). The complete backend half: users can list and toggle their RBAC-granted skills, the chat request can carry a per-turn skill selection, and the admin chat-mode policy is now **enforced** on `/invocations`. PR-3/4 (SPA UX + admin settings page) build on these endpoints.

**Back-compat by construction**: clients that send none of the new fields get exactly today's behavior — `enabled_skills` absent means all accessible skills, an unconfigured policy means skill-default with toggling allowed, and legacy paused-turn snapshots fall back to request-time skill resolution.

## Changes

### User-facing skills API
- **`GET /skills/`** — the user's ACTIVE, RBAC-accessible skills with per-user preferences merged (`skillId`, `displayName`, `description`, `category`, `boundToolCount`, `userEnabled`, `isEnabled`). Same resolution + ACTIVE filter the SkillAgent applies at runtime, so the picker always matches what the agent can activate.
- **`PUT /skills/preferences`** — global per-user `skill_id -> enabled` map (merge semantics), rejecting ids outside the accessible set. Stored as a `USER#{id}` / `SKILL_PREFERENCES` row, mirroring tool preferences.
- **`apis/shared/skills/access.py`** — the shared "which skills does this user get" resolver (RBAC + `*` wildcard expansion, never raises), now used by both app-api and inference so they can't drift.

### Inference path
- **`InvocationRequest.enabled_skills`** — `None` = all accessible; a list is **intersected server-side** with the RBAC set (client input can narrow, never grant); empty = zero skills → SkillAgent's existing degrade-to-chat path. The *effective* set feeds both SkillAgent and the `skills_hash` cache key, so two sessions with different toggles never share a cached agent.
- **Policy enforcement** — effective `agent_type` resolves through the PR-1 admin settings (TTL-cached, default-degrading). With `allowModeToggle=false`, a client's `skill`/`chat` choice is overridden to the admin default (UI gating alone is not enforcement); `voice` and other internal types bypass the policy. `DEFAULT_AGENT_TYPE` is now aliased to the policy model's compiled-in default.
- **`PausedTurnSnapshot.enabled_skills`** — paused skill turns persist their effective skill set, so resume rebuilds the identical `skills_hash` cache key even if the user toggles skills mid-pause (the same snapshot-wins rule used for tools/params).

## Testing

- 29 new tests: shared resolver (wildcard / failure-degrade), preference model + repository (merge semantics), user routes (ACTIVE filter, prefs merge, inaccessible-id rejection), the policy matrix (`toggle × requested type` incl. voice bypass), intersection threading into `get_agent` at the route level, and snapshot round-trip/legacy-default.
- Pre-existing `test_inference.py` agent-type tests pass unchanged (the patched `_resolve_accessible_skill_ids` seam was kept as a thin delegate).
- Full backend suite: **3808 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)