### PR TITLE
fix(agents): raise OAuth consent interrupt for skill-folded external MCP tools

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -8,7 +8,7 @@ stream_async() for their specific agent type.
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
 
 from agents.main_agent.core import ModelConfig, SystemPromptBuilder, AgentFactory
 from agents.main_agent.session import SessionFactory
@@ -316,6 +316,11 @@ class BaseAgent(ABC):
                 return None
             return integration.provider_for_client(selected_tool.mcp_client)
 
+        # Tools dispatched indirectly (SkillAgent's skill_executor meta-tool)
+        # never present as MCPAgentTool, so provider_lookup can't gate them.
+        # Subclasses that fold tools provide a tool_use-based second chance.
+        tool_use_provider_lookup = self._build_tool_use_provider_lookup()
+
         async def scopes_lookup(provider_id: str) -> List[str]:
             from apis.shared.oauth.provider_repository import get_provider_repository
 
@@ -363,7 +368,16 @@ class BaseAgent(ABC):
             provider_type_lookup=provider_type_lookup,
             custom_parameters_lookup=custom_parameters_lookup,
             disconnected_lookup=disconnected_lookup,
+            tool_use_provider_lookup=tool_use_provider_lookup,
         )
+
+    def _build_tool_use_provider_lookup(self) -> Optional[Callable[[dict], Optional[str]]]:
+        """OAuth provider resolution from a raw `tool_use` dict, for agents
+        that dispatch tools indirectly (SkillAgent's meta-tools). The base
+        agent has no such indirection, so the consent hook gets None and
+        relies on `provider_lookup` alone.
+        """
+        return None
 
     def _expand_gateway_tool_ids(self, gateway_tool_ids: List[str]) -> List[str]:
         """Expand #419 catalog gateway tools into the gateway's runtime per-tool

--- a/backend/src/agents/main_agent/session/hooks/oauth_consent.py
+++ b/backend/src/agents/main_agent/session/hooks/oauth_consent.py
@@ -6,6 +6,12 @@ the hook ensures we have an access token in the in-process cache. If we
 don't, it calls `event.interrupt(...)` to pause the agent mid-turn and
 hand the authorization URL back to the caller.
 
+Tools can be OAuth-gated through indirection too: in skills mode a bound
+external MCP tool runs behind the `skill_executor` meta-tool, so the
+selected tool alone doesn't identify the MCP server. The optional
+`tool_use_provider_lookup` resolves the provider from the raw tool_use
+(name + input) in that case — same gate, same interrupt, same resume.
+
 When the user completes consent in the popup and the frontend resumes the
 turn, the hook fires a second time and `event.interrupt(...)` returns the
 user's response (instead of raising). At that point AgentCore Identity has
@@ -105,6 +111,14 @@ def _looks_like_auth_failure(tool_result: Any) -> bool:
 # isn't OAuth-gated. Encapsulates the MCPClient -> provider mapping.
 ProviderLookup = Callable[[Any], Optional[str]]
 
+# Second-chance provider resolution from the raw `tool_use` dict (name +
+# input) for tools that dispatch indirectly — SkillAgent's `skill_executor`
+# meta-tool runs folded external MCP tools, so `selected_tool` is the
+# executor itself and `ProviderLookup` can't map it. Consulted only when
+# `ProviderLookup` returns None; return None for anything that isn't an
+# indirect OAuth-gated dispatch.
+ToolUseProviderLookup = Callable[[dict], Optional[str]]
+
 # Returns OAuth scopes for a provider_id. May be sync or async; the hook
 # awaits the result either way so we can read from an async repository
 # without forcing a sync wrapper.
@@ -142,6 +156,7 @@ class OAuthConsentHook(HookProvider):
         provider_type_lookup: Optional[ProviderTypeLookup] = None,
         custom_parameters_lookup: Optional[CustomParametersLookup] = None,
         disconnected_lookup: Optional[DisconnectedLookup] = None,
+        tool_use_provider_lookup: Optional[ToolUseProviderLookup] = None,
     ):
         """Initialize.
 
@@ -162,6 +177,10 @@ class OAuthConsentHook(HookProvider):
                 effectively assumes the user has not disconnected. Wire
                 this to the durable disconnect repository in production so
                 a /disconnect on one replica is visible from any other.
+            tool_use_provider_lookup: See `ToolUseProviderLookup`. Optional.
+                When omitted, only `provider_lookup` is consulted and
+                indirectly-dispatched tools (skill meta-tools) are not
+                OAuth-gated.
         """
         self._user_id = user_id
         self._provider_lookup = provider_lookup
@@ -169,6 +188,7 @@ class OAuthConsentHook(HookProvider):
         self._provider_type_lookup = provider_type_lookup
         self._custom_parameters_lookup = custom_parameters_lookup
         self._disconnected_lookup = disconnected_lookup
+        self._tool_use_provider_lookup = tool_use_provider_lookup
         # Cache scopes per provider for the lifetime of this hook (one agent
         # invocation). Avoids repeated DB hits if the same provider is used
         # across multiple tool calls in a single turn.
@@ -203,8 +223,26 @@ class OAuthConsentHook(HookProvider):
         """
         self._reauth_attempted_providers.clear()
 
+    def _resolve_provider_id(
+        self, selected_tool: Any, tool_use: Any
+    ) -> Optional[str]:
+        """Map a tool call to its OAuth provider, seeing through indirection.
+
+        `provider_lookup` handles directly-selected MCP tools. When it can't
+        map the tool (e.g. SkillAgent's `skill_executor` meta-tool, whose
+        folded target only appears in the tool_use input), the optional
+        `tool_use_provider_lookup` gets a second chance with the raw
+        tool_use dict.
+        """
+        provider_id = self._provider_lookup(selected_tool)
+        if provider_id:
+            return provider_id
+        if self._tool_use_provider_lookup is None or not isinstance(tool_use, dict):
+            return None
+        return self._tool_use_provider_lookup(tool_use)
+
     async def _gate(self, event: BeforeToolCallEvent) -> None:
-        provider_id = self._provider_lookup(event.selected_tool)
+        provider_id = self._resolve_provider_id(event.selected_tool, event.tool_use)
         if not provider_id:
             return  # Not an OAuth-gated tool
 
@@ -341,7 +379,7 @@ class OAuthConsentHook(HookProvider):
         explicit user intent (the "Disconnect" button in the settings
         page).
         """
-        provider_id = self._provider_lookup(event.selected_tool)
+        provider_id = self._resolve_provider_id(event.selected_tool, event.tool_use)
         if not provider_id:
             return
 

--- a/backend/src/agents/main_agent/skill_agent.py
+++ b/backend/src/agents/main_agent/skill_agent.py
@@ -287,6 +287,28 @@ class SkillAgent(ChatAgent):
             len(bindings.unresolved),
         )
 
+    def _build_tool_use_provider_lookup(self):
+        """See through the skill fold for the OAuth consent gate.
+
+        Skill-bound external MCP tools execute via ``skill_executor``, so the
+        consent hook's ``provider_lookup`` (keyed on ``MCPAgentTool``) can't
+        map them. This resolver reads the executor's tool_use input and maps
+        the folded tool's owning client back to its OAuth provider, so an
+        unauthorized call pauses the turn with ``oauth_required`` exactly
+        like a directly-enabled tool would.
+        """
+        from agents.main_agent.integrations.external_mcp_client import (
+            get_external_mcp_integration,
+        )
+        from agents.main_agent.skills.mcp_binding import (
+            make_folded_tool_provider_lookup,
+        )
+
+        integration = get_external_mcp_integration()
+        return make_folded_tool_provider_lookup(
+            self._registry, integration.provider_for_client
+        )
+
     @property
     def registry(self) -> Optional[SkillRegistry]:
         """Access the skill registry for inspection."""

--- a/backend/src/agents/main_agent/skills/mcp_binding.py
+++ b/backend/src/agents/main_agent/skills/mcp_binding.py
@@ -76,6 +76,12 @@ class FoldedMCPTool:
         return self._agent_tool_name
 
     @property
+    def client(self) -> Any:
+        """The owning ``MCPClient`` — lets the OAuth consent gate map this
+        folded tool back to its provider via ``provider_for_client``."""
+        return self._client
+
+    @property
     def tool_spec(self) -> Dict[str, Any]:
         """The tool's parameter spec, resolved lazily for gateway tools.
 
@@ -104,10 +110,18 @@ class FoldedMCPTool:
         return spec
 
     def invoke(self, tool_input: Optional[dict]) -> Any:
-        """Execute the tool through the MCP client and return a string result.
+        """Execute the tool through the MCP client.
 
         Synthesizes a ``tool_use_id`` (the executor path has none) and reduces
         the structured ``MCPToolResult`` to text/JSON the model can read.
+
+        Failures return a ToolResult-shaped dict (``status: error``) rather
+        than a plain string: ``skill_executor`` returns it verbatim and
+        Strands' ``@tool`` decorator passes status+content dicts through
+        unchanged, so the error status survives the fold. Without it every
+        folded failure surfaced as a *success*-status result and the OAuth
+        consent hook's 401-retry heuristic (gated on ``status == "error"``)
+        could never fire for skill-bound tools.
         """
         try:
             result = self._client.call_tool_sync(
@@ -120,8 +134,22 @@ class FoldedMCPTool:
                 "Folded MCP tool %s failed: %s", self._agent_tool_name, e,
                 exc_info=True,
             )
-            return json.dumps({"error": str(e)})
-        return _stringify_mcp_result(result)
+            return _error_tool_result(json.dumps({"error": str(e)}))
+
+        status = (
+            result.get("status")
+            if isinstance(result, dict)
+            else getattr(result, "status", None)
+        )
+        text = _stringify_mcp_result(result)
+        if status == "error":
+            return _error_tool_result(text)
+        return text
+
+
+def _error_tool_result(text: str) -> dict:
+    """ToolResult-shaped error for the executor to return as-is."""
+    return {"status": "error", "content": [{"text": text}]}
 
 
 def _stringify_mcp_result(result: Any) -> str:
@@ -155,6 +183,52 @@ def _stringify_mcp_result(result: Any) -> str:
         return json.dumps(result, default=str)
     except (TypeError, ValueError):
         return str(result)
+
+
+def make_folded_tool_provider_lookup(
+    registry: Any, provider_for_client: Callable[[Any], Optional[str]]
+) -> Callable[[dict], Optional[str]]:
+    """Build the OAuth consent gate's tool_use → provider resolver for skills.
+
+    A skill-bound external MCP tool executes through the ``skill_executor``
+    meta-tool, so the consent hook's ``provider_lookup`` (which keys off the
+    selected tool being an ``MCPAgentTool``) can't see it — the OAuth gate
+    silently never fired for skills mode, and an unauthorized tool ran
+    tokenless instead of pausing the turn with ``oauth_required``. This
+    resolver gives the hook a second chance: it reads ``skill_name`` /
+    ``tool_name`` from the executor's tool_use input, finds the bound
+    :class:`FoldedMCPTool` in the registry, and maps its owning client to a
+    provider via ``provider_for_client`` (gateway clients aren't in that map,
+    so they resolve to None — correct, they auth with SigV4, not user OAuth).
+
+    Resolution is lazy (registry consulted per call), so building the lookup
+    before bindings exist is safe.
+    """
+    from agents.main_agent.skills.skill_tools import SKILL_EXECUTOR_TOOL_NAME
+
+    def lookup(tool_use: dict) -> Optional[str]:
+        if (tool_use or {}).get("name") != SKILL_EXECUTOR_TOOL_NAME:
+            return None
+        tool_input = tool_use.get("input") or {}
+        if not isinstance(tool_input, dict):
+            return None
+        skill_name = tool_input.get("skill_name")
+        tool_name = tool_input.get("tool_name")
+        if not skill_name or not tool_name:
+            return None
+        try:
+            tools = registry.get_tools(skill_name)
+        except Exception:  # noqa: BLE001 - unknown skill → not OAuth-gated
+            return None
+        for t in tools or []:
+            if not getattr(t, "is_mcp_folded", False):
+                continue
+            if getattr(t, "tool_name", None) != tool_name:
+                continue
+            return provider_for_client(t.client)
+        return None
+
+    return lookup
 
 
 class MCPBindingResult:

--- a/backend/src/agents/main_agent/skills/skill_tools.py
+++ b/backend/src/agents/main_agent/skills/skill_tools.py
@@ -31,6 +31,12 @@ from strands import tool
 
 logger = logging.getLogger(__name__)
 
+# Agent-facing name of the executor meta-tool (both the module-level tool and
+# the per-registry pairs from make_skill_tools use this function name). The
+# OAuth consent gate matches tool_use dicts against it to see through the
+# fold (see skills/mcp_binding.make_folded_tool_provider_lookup).
+SKILL_EXECUTOR_TOOL_NAME = "skill_executor"
+
 # Module-level registry reference, set by set_dispatcher_registry(). Used only
 # by the module-level skill_dispatcher/skill_executor (file/dev path).
 _registry = None

--- a/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
+++ b/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
@@ -338,6 +338,126 @@ class TestOAuthConsentHookConsentRequired:
         assert "google" in event.cancel_tool
 
 
+class TestOAuthConsentHookSkillFoldedTools:
+    """Regression guard for the skills-mode consent gap.
+
+    A skill-bound external MCP tool executes through the `skill_executor`
+    meta-tool, so `selected_tool` is the executor (not an MCPAgentTool) and
+    `provider_lookup` returns None. Before the `tool_use_provider_lookup`
+    fallback existed, the gate silently skipped these calls: the tool ran
+    tokenless, returned an auth error, and the model apologized in text
+    instead of the turn pausing with an `oauth_required` interrupt.
+    """
+
+    @staticmethod
+    def _tool_use_lookup(tool_use: dict) -> str | None:
+        # Stands in for skills/mcp_binding.make_folded_tool_provider_lookup
+        # (covered by its own tests); resolves the executor's folded target.
+        if tool_use.get("name") != "skill_executor":
+            return None
+        if (tool_use.get("input") or {}).get("tool_name") == "gmail_search":
+            return "google"
+        return None
+
+    def _executor_event(self):
+        event = _make_event(provider_id=None)
+        event.tool_use = {
+            "toolUseId": "tu_skill",
+            "name": "skill_executor",
+            "input": {
+                "skill_name": "gmail-for-employees",
+                "tool_name": "gmail_search",
+                "tool_input": {"query": "from:hr"},
+            },
+        }
+        return event
+
+    @pytest.mark.asyncio
+    async def test_skill_bound_tool_without_token_pauses_with_oauth_required(self):
+        identity = MagicMock()
+        identity.get_token_for_user = AsyncMock(
+            return_value=TokenResult(authorization_url="https://accounts/consent")
+        )
+
+        hook = OAuthConsentHook(
+            user_id="alice",
+            provider_lookup=lambda _tool: None,  # executor isn't an MCPAgentTool
+            scopes_lookup=lambda _: ["gmail.readonly"],
+            tool_use_provider_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event()
+
+        with patch(
+            "agents.main_agent.session.hooks.oauth_consent.get_agentcore_identity_client",
+            return_value=identity,
+        ):
+            with pytest.raises(InterruptException) as excinfo:
+                await hook._gate(event)
+
+        interrupt = excinfo.value.interrupt
+        assert interrupt.name == "oauth:google"
+        assert interrupt.reason == {
+            "type": "oauth_required",
+            "providerId": "google",
+            "authorizationUrl": "https://accounts/consent",
+        }
+
+    @pytest.mark.asyncio
+    async def test_skill_bound_tool_with_cached_token_proceeds(self):
+        oauth_token_cache.set("alice", "google", "warm-token")
+        hook = OAuthConsentHook(
+            user_id="alice",
+            provider_lookup=lambda _tool: None,
+            scopes_lookup=lambda _: [],
+            tool_use_provider_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event()
+
+        await hook._gate(event)
+
+        assert event.cancel_tool is None
+
+    @pytest.mark.asyncio
+    async def test_401_from_folded_tool_clears_cache_and_retries(self):
+        """The fold preserves error status (FoldedMCPTool returns a
+        ToolResult-shaped dict), so the AfterToolCallEvent retry path must
+        work through the executor too."""
+        oauth_token_cache.set("alice", "google", "stale-token")
+        hook = OAuthConsentHook(
+            user_id="alice",
+            provider_lookup=lambda _tool: None,
+            scopes_lookup=lambda _: [],
+            tool_use_provider_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event()
+        event.invocation_state = {}
+        event.result = {
+            "toolUseId": "tu_skill",
+            "status": "error",
+            "content": [{"text": "Error calling tool (HTTP 401): Unauthorized"}],
+        }
+        event.retry = False
+
+        await hook._handle_auth_failure(event)
+
+        assert event.retry is True
+        assert oauth_token_cache.get("alice", "google") is None
+
+    @pytest.mark.asyncio
+    async def test_without_tool_use_lookup_executor_is_not_gated(self):
+        """Plain ChatAgent wiring (no lookup) keeps the old behavior."""
+        hook = OAuthConsentHook(
+            user_id="alice",
+            provider_lookup=lambda _tool: None,
+            scopes_lookup=lambda _: [],
+        )
+        event = self._executor_event()
+
+        await hook._gate(event)
+
+        assert event.cancel_tool is None
+
+
 class TestParallelToolCallsSameProvider:
     """Regression guard for the OAuth interrupt collision concern.
 

--- a/backend/tests/agents/main_agent/skills/test_mcp_binding.py
+++ b/backend/tests/agents/main_agent/skills/test_mcp_binding.py
@@ -12,6 +12,7 @@ import pytest
 from agents.main_agent.skills.mcp_binding import (
     FoldedMCPTool,
     _stringify_mcp_result,
+    make_folded_tool_provider_lookup,
     resolve_mcp_bindings,
 )
 
@@ -178,13 +179,27 @@ class TestFoldedMCPToolExecution:
         FoldedMCPTool(client, mcp_tool_name="t").invoke(None)
         assert client.calls[0][2] == {}
 
-    def test_invoke_surfaces_errors_as_tool_result(self):
+    def test_invoke_surfaces_exceptions_as_error_status_result(self):
+        """A client exception must keep its error status through the fold —
+        Strands' @tool decorator passes status+content dicts through, and the
+        OAuth consent hook's 401-retry heuristic only fires on error-status
+        results."""
+
         class _Boom(_FakeClient):
             def call_tool_sync(self, *a, **k):
                 raise RuntimeError("mcp down")
 
         out = FoldedMCPTool(_Boom(), mcp_tool_name="t").invoke({})
-        assert "mcp down" in out
+        assert out["status"] == "error"
+        assert "mcp down" in out["content"][0]["text"]
+
+    def test_invoke_preserves_error_status_from_mcp_result(self):
+        client = _FakeClient(
+            result={"status": "error", "content": [{"text": "HTTP 401 Unauthorized"}]}
+        )
+        out = FoldedMCPTool(client, mcp_tool_name="t").invoke({})
+        assert out["status"] == "error"
+        assert "401" in out["content"][0]["text"]
 
     def test_is_mcp_folded_marker(self):
         assert FoldedMCPTool(_FakeClient(), mcp_tool_name="t").is_mcp_folded is True
@@ -207,6 +222,101 @@ class TestFoldedMCPToolSpec:
         client = _FakeClient(raise_on_list=True)
         tool = FoldedMCPTool(client, mcp_tool_name="t")
         assert tool.tool_spec == {"name": "t"}
+
+
+class TestFoldedToolProviderLookup:
+    """`make_folded_tool_provider_lookup` lets the OAuth consent gate see
+    through the skill fold: skill_executor tool_use input → bound
+    FoldedMCPTool → owning client → provider_id."""
+
+    def _registry_with_folded_gmail(self, client):
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="gmail-for-employees",
+                    description="Gmail",
+                    instructions="Use Gmail tools.",
+                    compose=[],
+                    bound_tool_ids=["gmail_mcp"],
+                    resources=[],
+                )
+            ]
+        )
+        folded = FoldedMCPTool(
+            client, mcp_tool_name="gmail_search", agent_tool_name="gmail_search"
+        )
+        registry.bind_catalog_tools({"gmail_mcp": [folded]})
+        return registry
+
+    def _executor_tool_use(self, skill_name="gmail-for-employees", tool_name="gmail_search"):
+        return {
+            "toolUseId": "tu_1",
+            "name": "skill_executor",
+            "input": {"skill_name": skill_name, "tool_name": tool_name},
+        }
+
+    def test_resolves_provider_for_folded_tool(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_provider_lookup(
+            registry, lambda c: "google" if c is client else None
+        )
+        assert lookup(self._executor_tool_use()) == "google"
+
+    def test_ignores_non_executor_tool_use(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_provider_lookup(registry, lambda c: "google")
+        assert lookup({"name": "gmail_search", "input": {}}) is None
+
+    def test_unknown_skill_or_tool_resolves_none(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_provider_lookup(registry, lambda c: "google")
+        assert lookup(self._executor_tool_use(skill_name="nope")) is None
+        assert lookup(self._executor_tool_use(tool_name="nope")) is None
+
+    def test_local_non_folded_tool_resolves_none(self):
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="local-skill",
+                    description="",
+                    instructions="",
+                    compose=[],
+                    bound_tool_ids=["local_tool"],
+                    resources=[],
+                )
+            ]
+        )
+        registry.bind_catalog_tools(
+            {"local_tool": SimpleNamespace(tool_name="local_tool")}
+        )
+        lookup = make_folded_tool_provider_lookup(registry, lambda c: "google")
+        assert (
+            lookup(self._executor_tool_use("local-skill", "local_tool")) is None
+        )
+
+    def test_unmapped_client_resolves_none(self):
+        # Gateway clients aren't in the provider map (SigV4, not user OAuth).
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_provider_lookup(registry, lambda c: None)
+        assert lookup(self._executor_tool_use()) is None
+
+    def test_malformed_input_resolves_none(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_provider_lookup(registry, lambda c: "google")
+        assert lookup({}) is None
+        assert lookup({"name": "skill_executor"}) is None
+        assert lookup({"name": "skill_executor", "input": "not-a-dict"}) is None
 
 
 class TestStringify:

--- a/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
@@ -71,3 +71,58 @@ class TestFetchSkillRecords:
             # Never raises into agent construction — returns [] so the agent
             # degrades to chat.
             assert skill_agent._fetch_skill_records(["x"]) == []
+
+
+class TestToolUseProviderLookupWiring:
+    """SkillAgent must hand the OAuth consent hook a tool_use-based provider
+    resolver over ITS registry — that's what lets the consent gate see a
+    skill-bound external MCP tool behind skill_executor (the skills-mode
+    `oauth_required` regression). Built without a full agent: the override
+    only reads `self._registry` and the global external MCP integration.
+    """
+
+    def test_lookup_resolves_folded_tool_via_integration(self):
+        from agents.main_agent.skills.mcp_binding import FoldedMCPTool
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        client = object()
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="gmail-for-employees",
+                    description="",
+                    instructions="",
+                    compose=[],
+                    bound_tool_ids=["gmail_mcp"],
+                    resources=[],
+                )
+            ]
+        )
+        registry.bind_catalog_tools(
+            {"gmail_mcp": [FoldedMCPTool(client, mcp_tool_name="gmail_search")]}
+        )
+
+        agent = object.__new__(skill_agent.SkillAgent)
+        agent._registry = registry
+
+        integration = MagicMock()
+        integration.provider_for_client = (
+            lambda c: "google" if c is client else None
+        )
+        with patch(
+            "agents.main_agent.integrations.external_mcp_client.get_external_mcp_integration",
+            return_value=integration,
+        ):
+            lookup = agent._build_tool_use_provider_lookup()
+
+        assert lookup(
+            {
+                "name": "skill_executor",
+                "input": {
+                    "skill_name": "gmail-for-employees",
+                    "tool_name": "gmail_search",
+                },
+            }
+        ) == "google"
+        assert lookup({"name": "some_other_tool", "input": {}}) is None


### PR DESCRIPTION
## Problem

In skills mode (now the server default, `agent_type="skill"`), invoking a skill whose bound external MCP tool has no active OAuth authorization (e.g. "Gmail for employees" with no Gmail token in the vault) produced a text apology from the model instead of pausing the turn with the in-conversation consent prompt.

**Root cause:** `OAuthConsentHook`'s `provider_lookup` only resolves when `event.selected_tool` is an `MCPAgentTool`. In skills mode the model calls the `skill_executor` meta-tool (a decorated function tool) — the real target only appears in the tool-use *input* (`{skill_name, tool_name, ...}`) — so the gate concluded "not OAuth-gated", the `FoldedMCPTool` ran `call_tool_sync` tokenless, and the auth error surfaced as tool text. No Strands interrupt → no `pending_interrupt` → no `oauth_required` SSE event.

A compounding bug: `FoldedMCPTool.invoke` swallowed all failures into **success**-status strings, so the hook's 401-retry heuristic (gated on `status == "error"`) was also dead for folded tools — even the expired-token refresh path.

## Fix

- **`oauth_consent.py`** — optional `tool_use_provider_lookup`: a second-chance resolver receiving the raw `tool_use` dict, consulted by both the consent gate and the 401-retry handler when `provider_lookup` returns `None`. Plain chat wiring passes `None` → behavior unchanged.
- **`skills/mcp_binding.py`** — `make_folded_tool_provider_lookup(registry, provider_for_client)`: executor tool_use input → bound `FoldedMCPTool` → owning client → provider id. Gateway clients resolve to `None` (SigV4, not user OAuth). `FoldedMCPTool.invoke` now returns a ToolResult-shaped `{"status": "error", ...}` on failure (Strands' `@tool` decorator passes status+content dicts through), so error status survives the fold.
- **`base_agent.py` / `skill_agent.py`** — new `_build_tool_use_provider_lookup()` hook point (base returns `None`); `SkillAgent` overrides it with its registry + the external MCP integration.

Resume path is unchanged: the interrupt is raised on the `skill_executor` call itself, so consent → `interrupt_responses` → token-cache warm → the client's lazy token provider injects the bearer on the actual MCP request.

## Tests

- `TestOAuthConsentHookSkillFoldedTools` — skill-bound tool with no token → `InterruptException` with the exact `oauth_required` reason; cached token proceeds; 401-through-the-fold clears cache and retries; no-lookup preserves old behavior.
- `TestFoldedToolProviderLookup` — resolver against a real `SkillRegistry` (unknown skill/tool, local non-folded tools, unmapped clients, malformed input).
- `TestToolUseProviderLookupWiring` — `SkillAgent` hands the hook a working resolver.
- `FoldedMCPTool` error-status preservation (exception + error-status MCP result).

Full backend suite: **3820 passed, 3 skipped** (pytest is not run in CI; local suite is the gate).

## Out of scope (flagged separately)

`MCPExternalApprovalHook` has the identical hole — `needs_approval=True` tools bound to a skill bypass the approval prompt. Tracked as a follow-up task using the same `tool_use` fallback pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)