### PR TITLE
fix(agents): gate skill-folded external MCP tools behind the approval prompt

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -298,7 +298,24 @@ class BaseAgent(ABC):
                 return set()
             return integration.approval_names_for_client(selected_tool.mcp_client)
 
-        return MCPExternalApprovalHook(approval_names_lookup=approval_names_lookup)
+        # Tools dispatched indirectly (SkillAgent's skill_executor meta-tool)
+        # never present as MCPAgentTool, so approval_names_lookup can't gate
+        # them. Subclasses that fold tools provide a tool_use-based second
+        # chance — mirrors the OAuth consent hook's fold-aware lookup.
+        return MCPExternalApprovalHook(
+            approval_names_lookup=approval_names_lookup,
+            tool_use_approval_lookup=self._build_tool_use_approval_lookup(),
+        )
+
+    def _build_tool_use_approval_lookup(
+        self,
+    ) -> Optional[Callable[[dict], Optional[Any]]]:
+        """Approval-target resolution from a raw `tool_use` dict, for agents
+        that dispatch tools indirectly (SkillAgent's meta-tools). The base
+        agent has no such indirection, so the approval hook gets None and
+        relies on `approval_names_lookup` alone.
+        """
+        return None
 
     def _build_oauth_consent_hook(self) -> OAuthConsentHook:
         """Construct the OAuth consent hook with closures over the MCP

--- a/backend/src/agents/main_agent/session/hooks/tool_approval.py
+++ b/backend/src/agents/main_agent/session/hooks/tool_approval.py
@@ -15,12 +15,19 @@ Design notes:
 - The interrupt name is scoped by `toolUseId` so two parallel calls of the
   same tool in one turn produce distinct interrupts (and distinct SSE events
   the frontend can correlate per-prompt).
+- Tools can be approval-gated through indirection too: in skills mode a
+  bound external MCP tool runs behind the `skill_executor` meta-tool, so
+  neither `selected_tool` nor `tool_use["name"]` identifies the flagged
+  tool. The optional `tool_use_approval_lookup` resolves the folded target
+  from the raw tool_use (name + input) in that case — same interrupt, same
+  resume; the prompt describes the inner tool, not the executor.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, Set
 
 from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
@@ -54,6 +61,28 @@ def _encode_tool_input(value: Any) -> Optional[str]:
 ApprovalNamesLookup = Callable[[Any], Set[str]]
 
 
+@dataclass(frozen=True)
+class FoldedToolApproval:
+    """An approval-flagged tool resolved from an indirect (folded) tool_use.
+
+    `tool_name` / `tool_input` describe the inner tool the user is being
+    asked to approve (e.g. `gmail_search` and its args), not the meta-tool
+    that carries it — the frontend dialog renders them verbatim.
+    """
+
+    tool_name: str
+    tool_input: Any = None
+
+
+# Second-chance resolution from the raw `tool_use` dict (name + input) for
+# tools that dispatch indirectly — SkillAgent's `skill_executor` meta-tool
+# runs folded external MCP tools, so `selected_tool` is the executor and
+# `ApprovalNamesLookup` can't gate it. Returns the folded target only when
+# that target is approval-flagged; None for everything else. Consulted only
+# when the direct path didn't fire.
+ToolUseApprovalLookup = Callable[[dict], Optional[FoldedToolApproval]]
+
+
 # Default user-facing message; admins can extend this later by wiring a
 # per-tool message field through the catalog if needed.
 _DEFAULT_APPROVAL_MESSAGE = (
@@ -65,23 +94,57 @@ _DEFAULT_APPROVAL_MESSAGE = (
 class MCPExternalApprovalHook(HookProvider):
     """Pause the agent for user approval before a flagged MCP tool runs."""
 
-    def __init__(self, approval_names_lookup: ApprovalNamesLookup):
+    def __init__(
+        self,
+        approval_names_lookup: ApprovalNamesLookup,
+        tool_use_approval_lookup: Optional[ToolUseApprovalLookup] = None,
+    ):
+        """Initialize.
+
+        Args:
+            approval_names_lookup: See `ApprovalNamesLookup`.
+            tool_use_approval_lookup: See `ToolUseApprovalLookup`. Optional.
+                When omitted, only directly-selected MCP tools are gated and
+                indirectly-dispatched tools (skill meta-tools) bypass the
+                approval prompt.
+        """
         self._approval_names_lookup = approval_names_lookup
+        self._tool_use_approval_lookup = tool_use_approval_lookup
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         registry.add_callback(BeforeToolCallEvent, self._gate)
 
     def _gate(self, event: BeforeToolCallEvent) -> None:
         approval_names = self._approval_names_lookup(event.selected_tool)
-        if not approval_names:
-            return
-
         tool_name = event.tool_use.get("name", "")
-        if tool_name not in approval_names:
+        if approval_names and tool_name in approval_names:
+            self._require_approval(event, tool_name, event.tool_use.get("input"))
             return
 
+        # Second chance: the call may be a flagged tool hiding behind an
+        # indirect dispatcher (skill_executor). The lookup applies the
+        # approval check itself, so a non-None result means "gate this".
+        folded = self._resolve_folded_target(event.tool_use)
+        if folded is not None:
+            self._require_approval(event, folded.tool_name, folded.tool_input)
+
+    def _resolve_folded_target(self, tool_use: Any) -> Optional[FoldedToolApproval]:
+        if self._tool_use_approval_lookup is None or not isinstance(tool_use, dict):
+            return None
+        return self._tool_use_approval_lookup(tool_use)
+
+    def _require_approval(
+        self, event: BeforeToolCallEvent, tool_name: str, tool_input: Any
+    ) -> None:
+        """Interrupt for user approval; cancel the call unless approved.
+
+        `tool_name` / `tool_input` describe the tool the user is approving —
+        for folded dispatch that's the inner tool, while the interrupt's
+        `toolUseId` stays the executor's so the frontend correlates it with
+        the actual streamed tool_use block.
+        """
         tool_use_id = event.tool_use.get("toolUseId", "")
-        tool_input = _encode_tool_input(event.tool_use.get("input"))
+        encoded_input = _encode_tool_input(tool_input)
 
         logger.info(
             "Pausing for user approval: tool=%s tool_use_id=%s",
@@ -98,7 +161,7 @@ class MCPExternalApprovalHook(HookProvider):
                 "type": "tool_approval_required",
                 "toolUseId": tool_use_id,
                 "toolName": tool_name,
-                "toolInput": tool_input,
+                "toolInput": encoded_input,
                 "message": _DEFAULT_APPROVAL_MESSAGE,
             },
         )

--- a/backend/src/agents/main_agent/skill_agent.py
+++ b/backend/src/agents/main_agent/skill_agent.py
@@ -309,6 +309,29 @@ class SkillAgent(ChatAgent):
             self._registry, integration.provider_for_client
         )
 
+    def _build_tool_use_approval_lookup(self):
+        """See through the skill fold for the per-tool approval gate.
+
+        Skill-bound external MCP tools execute via ``skill_executor``, so the
+        approval hook's ``approval_names_lookup`` (keyed on ``MCPAgentTool``)
+        can't gate them — an admin's ``needs_approval`` flag was silently
+        bypassed in skills mode. This resolver reads the executor's tool_use
+        input and checks the folded tool against its owning client's flagged
+        set, so the user sees the same approval prompt (describing the inner
+        tool, not the executor) as a directly-enabled tool would raise.
+        """
+        from agents.main_agent.integrations.external_mcp_client import (
+            get_external_mcp_integration,
+        )
+        from agents.main_agent.skills.mcp_binding import (
+            make_folded_tool_approval_lookup,
+        )
+
+        integration = get_external_mcp_integration()
+        return make_folded_tool_approval_lookup(
+            self._registry, integration.approval_names_for_client
+        )
+
     @property
     def registry(self) -> Optional[SkillRegistry]:
         """Access the skill registry for inspection."""

--- a/backend/src/agents/main_agent/skills/mcp_binding.py
+++ b/backend/src/agents/main_agent/skills/mcp_binding.py
@@ -185,6 +185,39 @@ def _stringify_mcp_result(result: Any) -> str:
         return str(result)
 
 
+def _resolve_folded_tool(registry: Any, tool_use: dict) -> Optional[FoldedMCPTool]:
+    """Resolve a ``skill_executor`` tool_use to the bound :class:`FoldedMCPTool`.
+
+    Shared by the OAuth-consent and tool-approval second-chance lookups:
+    reads ``skill_name`` / ``tool_name`` from the executor's tool_use input
+    and finds the matching folded tool in the registry. Returns None for
+    anything that isn't an executor call over a known skill's folded MCP
+    tool (local callables, unknown skills, malformed input).
+    """
+    from agents.main_agent.skills.skill_tools import SKILL_EXECUTOR_TOOL_NAME
+
+    if (tool_use or {}).get("name") != SKILL_EXECUTOR_TOOL_NAME:
+        return None
+    tool_input = tool_use.get("input") or {}
+    if not isinstance(tool_input, dict):
+        return None
+    skill_name = tool_input.get("skill_name")
+    tool_name = tool_input.get("tool_name")
+    if not skill_name or not tool_name:
+        return None
+    try:
+        tools = registry.get_tools(skill_name)
+    except Exception:  # noqa: BLE001 - unknown skill → nothing to gate
+        return None
+    for t in tools or []:
+        if not getattr(t, "is_mcp_folded", False):
+            continue
+        if getattr(t, "tool_name", None) != tool_name:
+            continue
+        return t
+    return None
+
+
 def make_folded_tool_provider_lookup(
     registry: Any, provider_for_client: Callable[[Any], Optional[str]]
 ) -> Callable[[dict], Optional[str]]:
@@ -195,38 +228,56 @@ def make_folded_tool_provider_lookup(
     selected tool being an ``MCPAgentTool``) can't see it — the OAuth gate
     silently never fired for skills mode, and an unauthorized tool ran
     tokenless instead of pausing the turn with ``oauth_required``. This
-    resolver gives the hook a second chance: it reads ``skill_name`` /
-    ``tool_name`` from the executor's tool_use input, finds the bound
-    :class:`FoldedMCPTool` in the registry, and maps its owning client to a
-    provider via ``provider_for_client`` (gateway clients aren't in that map,
-    so they resolve to None — correct, they auth with SigV4, not user OAuth).
+    resolver gives the hook a second chance: it finds the bound
+    :class:`FoldedMCPTool` and maps its owning client to a provider via
+    ``provider_for_client`` (gateway clients aren't in that map, so they
+    resolve to None — correct, they auth with SigV4, not user OAuth).
 
     Resolution is lazy (registry consulted per call), so building the lookup
     before bindings exist is safe.
     """
-    from agents.main_agent.skills.skill_tools import SKILL_EXECUTOR_TOOL_NAME
 
     def lookup(tool_use: dict) -> Optional[str]:
-        if (tool_use or {}).get("name") != SKILL_EXECUTOR_TOOL_NAME:
+        folded = _resolve_folded_tool(registry, tool_use)
+        if folded is None:
             return None
-        tool_input = tool_use.get("input") or {}
-        if not isinstance(tool_input, dict):
+        return provider_for_client(folded.client)
+
+    return lookup
+
+
+def make_folded_tool_approval_lookup(
+    registry: Any, approval_names_for_client: Callable[[Any], set]
+) -> Callable[[dict], Optional[Any]]:
+    """Build the approval gate's tool_use → flagged-target resolver for skills.
+
+    Mirrors :func:`make_folded_tool_provider_lookup` for the per-tool
+    approval hook: a skill-bound external MCP tool runs behind
+    ``skill_executor``, so the hook's ``approval_names_lookup`` (keyed on the
+    selected tool being an ``MCPAgentTool``) can't see the admin's
+    ``needs_approval`` flag and the call ran without the user prompt. This
+    resolver finds the bound :class:`FoldedMCPTool`, checks its agent-facing
+    name against the owning client's flagged set (same name the direct path
+    matches when the tool is enabled outside a skill), and returns the inner
+    tool's name + args so the approval dialog describes the real tool, not
+    the executor. Returns None when the folded target isn't flagged.
+
+    Resolution is lazy (registry consulted per call), so building the lookup
+    before bindings exist is safe.
+    """
+
+    def lookup(tool_use: dict) -> Optional[Any]:
+        from agents.main_agent.session.hooks.tool_approval import FoldedToolApproval
+
+        folded = _resolve_folded_tool(registry, tool_use)
+        if folded is None:
             return None
-        skill_name = tool_input.get("skill_name")
-        tool_name = tool_input.get("tool_name")
-        if not skill_name or not tool_name:
+        if folded.tool_name not in approval_names_for_client(folded.client):
             return None
-        try:
-            tools = registry.get_tools(skill_name)
-        except Exception:  # noqa: BLE001 - unknown skill → not OAuth-gated
-            return None
-        for t in tools or []:
-            if not getattr(t, "is_mcp_folded", False):
-                continue
-            if getattr(t, "tool_name", None) != tool_name:
-                continue
-            return provider_for_client(t.client)
-        return None
+        return FoldedToolApproval(
+            tool_name=folded.tool_name,
+            tool_input=(tool_use.get("input") or {}).get("tool_input"),
+        )
 
     return lookup
 

--- a/backend/tests/agents/main_agent/session/test_tool_approval.py
+++ b/backend/tests/agents/main_agent/session/test_tool_approval.py
@@ -9,7 +9,10 @@ cancels it ("declined" — anything not "approved" fails closed).
 from typing import Any
 from unittest.mock import MagicMock
 
-from agents.main_agent.session.hooks.tool_approval import MCPExternalApprovalHook
+from agents.main_agent.session.hooks.tool_approval import (
+    FoldedToolApproval,
+    MCPExternalApprovalHook,
+)
 
 
 def _make_event(tool_name: str, tool_use_id: str = "tu-1", interrupt_response: Any = None):
@@ -145,3 +148,115 @@ class TestMCPExternalApprovalHook:
         registry.add_callback.assert_called_once()
         args = registry.add_callback.call_args.args
         assert args[0] is BeforeToolCallEvent
+
+
+class TestApprovalHookSkillFoldedTools:
+    """Regression guard for the skills-mode approval bypass.
+
+    A skill-bound external MCP tool executes through the `skill_executor`
+    meta-tool, so `selected_tool` is the executor (not an MCPAgentTool) and
+    `approval_names_lookup` returns an empty set — and `tool_use["name"]`
+    is "skill_executor", so the direct name match could never fire either.
+    Before the `tool_use_approval_lookup` fallback existed, an admin's
+    needs_approval=True flag was silently bypassed whenever the tool was
+    bound to a skill: the call ran with no user prompt.
+    """
+
+    @staticmethod
+    def _tool_use_lookup(tool_use: dict) -> FoldedToolApproval | None:
+        # Stands in for skills/mcp_binding.make_folded_tool_approval_lookup
+        # (covered by its own tests); resolves the executor's folded target
+        # and applies the needs_approval check itself.
+        if tool_use.get("name") != "skill_executor":
+            return None
+        tool_input = tool_use.get("input") or {}
+        if tool_input.get("tool_name") != "gmail_send":
+            return None
+        return FoldedToolApproval(
+            tool_name="gmail_send", tool_input=tool_input.get("tool_input")
+        )
+
+    def _executor_event(self, tool_name="gmail_send", interrupt_response=None):
+        event = _make_event("skill_executor", tool_use_id="tu_skill")
+        event.tool_use["input"] = {
+            "skill_name": "gmail-for-employees",
+            "tool_name": tool_name,
+            "tool_input": {"to": "hr@example.com", "body": "resignation"},
+        }
+        event.interrupt = MagicMock(return_value=interrupt_response)
+        return event
+
+    def test_flagged_folded_tool_pauses_and_describes_inner_tool(self):
+        """The interrupt's toolName/toolInput must describe the folded tool
+        (gmail_send and its args) — not skill_executor — so the frontend
+        dialog is meaningful. toolUseId stays the executor's, since that is
+        the streamed tool_use block the frontend correlates with."""
+        import json
+
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: set(),  # executor isn't an MCPAgentTool
+            tool_use_approval_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event(interrupt_response="approved")
+        hook._gate(event)
+
+        event.interrupt.assert_called_once()
+        reason = event.interrupt.call_args.kwargs["reason"]
+        assert reason["type"] == "tool_approval_required"
+        assert reason["toolName"] == "gmail_send"
+        assert reason["toolUseId"] == "tu_skill"
+        assert json.loads(reason["toolInput"]) == {
+            "to": "hr@example.com",
+            "body": "resignation",
+        }
+        # Approved → executor proceeds.
+        assert event.cancel_tool is None
+
+    def test_declined_folded_tool_cancels_with_inner_tool_name(self):
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: set(),
+            tool_use_approval_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event(interrupt_response="declined")
+        hook._gate(event)
+
+        assert event.cancel_tool is not None
+        assert "gmail_send" in event.cancel_tool
+        assert "skill_executor" not in event.cancel_tool
+
+    def test_unflagged_folded_tool_runs_without_pause(self):
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: set(),
+            tool_use_approval_lookup=self._tool_use_lookup,
+        )
+        event = self._executor_event(tool_name="gmail_search")
+        hook._gate(event)
+
+        event.interrupt.assert_not_called()
+        assert event.cancel_tool is None
+
+    def test_without_tool_use_lookup_executor_is_not_gated(self):
+        """Plain ChatAgent wiring (no lookup) keeps the old behavior."""
+        hook = MCPExternalApprovalHook(approval_names_lookup=lambda _: set())
+        event = self._executor_event()
+        hook._gate(event)
+
+        event.interrupt.assert_not_called()
+        assert event.cancel_tool is None
+
+    def test_direct_path_takes_precedence_over_folded_lookup(self):
+        """A directly-selected flagged tool interrupts via the direct path;
+        the folded lookup must not be consulted for it."""
+
+        def exploding_lookup(_tool_use: dict):
+            raise AssertionError("folded lookup consulted on the direct path")
+
+        hook = MCPExternalApprovalHook(
+            approval_names_lookup=lambda _: {"send_email"},
+            tool_use_approval_lookup=exploding_lookup,
+        )
+        event = _make_event("send_email", interrupt_response="approved")
+        hook._gate(event)
+
+        event.interrupt.assert_called_once()
+        assert event.cancel_tool is None

--- a/backend/tests/agents/main_agent/skills/test_mcp_binding.py
+++ b/backend/tests/agents/main_agent/skills/test_mcp_binding.py
@@ -12,6 +12,7 @@ import pytest
 from agents.main_agent.skills.mcp_binding import (
     FoldedMCPTool,
     _stringify_mcp_result,
+    make_folded_tool_approval_lookup,
     make_folded_tool_provider_lookup,
     resolve_mcp_bindings,
 )
@@ -317,6 +318,113 @@ class TestFoldedToolProviderLookup:
         assert lookup({}) is None
         assert lookup({"name": "skill_executor"}) is None
         assert lookup({"name": "skill_executor", "input": "not-a-dict"}) is None
+
+
+class TestFoldedToolApprovalLookup:
+    """`make_folded_tool_approval_lookup` lets the per-tool approval gate see
+    through the skill fold: skill_executor tool_use input → bound
+    FoldedMCPTool → owning client's needs_approval set → the inner tool's
+    name + args for the approval dialog."""
+
+    def _registry_with_folded_gmail(self, client):
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="gmail-for-employees",
+                    description="Gmail",
+                    instructions="Use Gmail tools.",
+                    compose=[],
+                    bound_tool_ids=["gmail_mcp"],
+                    resources=[],
+                )
+            ]
+        )
+        folded = FoldedMCPTool(
+            client, mcp_tool_name="gmail_send", agent_tool_name="gmail_send"
+        )
+        registry.bind_catalog_tools({"gmail_mcp": [folded]})
+        return registry
+
+    def _executor_tool_use(
+        self, skill_name="gmail-for-employees", tool_name="gmail_send"
+    ):
+        return {
+            "toolUseId": "tu_1",
+            "name": "skill_executor",
+            "input": {
+                "skill_name": skill_name,
+                "tool_name": tool_name,
+                "tool_input": {"to": "hr@example.com"},
+            },
+        }
+
+    def test_resolves_flagged_folded_tool_with_inner_args(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_approval_lookup(
+            registry, lambda c: {"gmail_send"} if c is client else set()
+        )
+        target = lookup(self._executor_tool_use())
+        assert target is not None
+        assert target.tool_name == "gmail_send"
+        assert target.tool_input == {"to": "hr@example.com"}
+
+    def test_unflagged_folded_tool_resolves_none(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_approval_lookup(
+            registry, lambda c: {"some_other_tool"}
+        )
+        assert lookup(self._executor_tool_use()) is None
+
+    def test_unflagged_client_resolves_none(self):
+        # Gateway clients have no needs_approval snapshot — empty set.
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_approval_lookup(registry, lambda c: set())
+        assert lookup(self._executor_tool_use()) is None
+
+    def test_ignores_non_executor_tool_use(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_approval_lookup(registry, lambda c: {"gmail_send"})
+        assert lookup({"name": "gmail_send", "input": {}}) is None
+
+    def test_unknown_skill_or_tool_resolves_none(self):
+        client = _FakeClient()
+        registry = self._registry_with_folded_gmail(client)
+        lookup = make_folded_tool_approval_lookup(registry, lambda c: {"gmail_send"})
+        assert lookup(self._executor_tool_use(skill_name="nope")) is None
+        assert lookup(self._executor_tool_use(tool_name="nope")) is None
+
+    def test_local_non_folded_tool_resolves_none(self):
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="local-skill",
+                    description="",
+                    instructions="",
+                    compose=[],
+                    bound_tool_ids=["local_tool"],
+                    resources=[],
+                )
+            ]
+        )
+        registry.bind_catalog_tools(
+            {"local_tool": SimpleNamespace(tool_name="local_tool")}
+        )
+        lookup = make_folded_tool_approval_lookup(
+            registry, lambda c: {"local_tool"}
+        )
+        assert (
+            lookup(self._executor_tool_use("local-skill", "local_tool")) is None
+        )
 
 
 class TestStringify:

--- a/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
@@ -126,3 +126,63 @@ class TestToolUseProviderLookupWiring:
             }
         ) == "google"
         assert lookup({"name": "some_other_tool", "input": {}}) is None
+
+
+class TestToolUseApprovalLookupWiring:
+    """SkillAgent must hand the per-tool approval hook a tool_use-based
+    resolver over ITS registry — that's what lets the hook see an admin's
+    needs_approval flag on a skill-bound external MCP tool behind
+    skill_executor (the skills-mode approval-bypass regression). Built
+    without a full agent: the override only reads `self._registry` and the
+    global external MCP integration.
+    """
+
+    def test_lookup_resolves_flagged_folded_tool_via_integration(self):
+        from agents.main_agent.skills.mcp_binding import FoldedMCPTool
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        client = object()
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="gmail-for-employees",
+                    description="",
+                    instructions="",
+                    compose=[],
+                    bound_tool_ids=["gmail_mcp"],
+                    resources=[],
+                )
+            ]
+        )
+        registry.bind_catalog_tools(
+            {"gmail_mcp": [FoldedMCPTool(client, mcp_tool_name="gmail_send")]}
+        )
+
+        agent = object.__new__(skill_agent.SkillAgent)
+        agent._registry = registry
+
+        integration = MagicMock()
+        integration.approval_names_for_client = (
+            lambda c: {"gmail_send"} if c is client else set()
+        )
+        with patch(
+            "agents.main_agent.integrations.external_mcp_client.get_external_mcp_integration",
+            return_value=integration,
+        ):
+            lookup = agent._build_tool_use_approval_lookup()
+
+        target = lookup(
+            {
+                "name": "skill_executor",
+                "input": {
+                    "skill_name": "gmail-for-employees",
+                    "tool_name": "gmail_send",
+                    "tool_input": {"to": "hr@example.com"},
+                },
+            }
+        )
+        assert target is not None
+        assert target.tool_name == "gmail_send"
+        assert target.tool_input == {"to": "hr@example.com"}
+        assert lookup({"name": "some_other_tool", "input": {}}) is None


### PR DESCRIPTION
## Summary

Closes the skills-mode counterpart of the approval gate the same way #477 closed the OAuth consent gap.

`MCPExternalApprovalHook` gates `needs_approval=True` external MCP tools via `approval_names_lookup(event.selected_tool)`, which only resolves when the selected tool is a Strands `MCPAgentTool`. In skills mode (the server default), a skill-bound external MCP tool executes through the `skill_executor` meta-tool — so the lookup returned an empty set, `tool_use["name"]` was `"skill_executor"` so the name match could never fire either, and an admin's `needs_approval=True` flag was **silently bypassed**: the tool ran with no user approval prompt.

## How

Mirrors the fold-aware second-chance lookup from #477:

- `tool_approval.py` — optional `tool_use_approval_lookup` on the hook; when the direct path doesn't fire, it resolves the folded target from the raw `tool_use` and raises the same `tool_approval_required` interrupt. The interrupt's `toolName`/`toolInput` describe the **inner** tool (e.g. `gmail_send` and its args from `tool_use.input.tool_input`), not the executor, so the frontend dialog is meaningful; `toolUseId` stays the executor's so the frontend correlates it with the streamed tool_use block. Decline cancels with the inner tool's name.
- `mcp_binding.py` — shared `_resolve_folded_tool` extracted from the provider lookup; new `make_folded_tool_approval_lookup` checks the folded tool's agent-facing name against `approval_names_for_client(client)` (same name the direct path matches when the tool is enabled outside a skill).
- `base_agent.py` / `skill_agent.py` — `_build_tool_use_approval_lookup` extension point (None in base, registry-backed in `SkillAgent`), mirroring `_build_tool_use_provider_lookup`.

## Stacked on #477

Base is `fix/skills-oauth-consent-fold` so the diff shows only this change (it reuses that PR's fold-resolution infrastructure). Retargets to `develop` when #477 merges.

## Test plan

- New regression tests: `TestApprovalHookSkillFoldedTools` (hook), `TestFoldedToolApprovalLookup` (resolver), `TestToolUseApprovalLookupWiring` (SkillAgent wiring) — modeled on #477's `TestOAuthConsentHookSkillFoldedTools`.
- Full backend suite (pytest is not run in CI): **3832 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)