### PR TITLE
feat: add Amazon Bedrock Mantle as a model provider

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -59,6 +59,7 @@ class BaseAgent(ABC):
         provider: Optional[str] = None,
         max_tokens: Optional[int] = None,
         inference_params: Optional[Dict[str, Any]] = None,
+        mantle_endpoint_path: Optional[str] = None,
         skip_persistence: bool = False,
         extra_tools: Optional[List[Any]] = None,
     ):
@@ -103,6 +104,7 @@ class BaseAgent(ABC):
             caching_enabled=caching_enabled,
             provider=provider,
             inference_params=resolved_params,
+            mantle_endpoint_path=mantle_endpoint_path,
         )
 
         # Frozen snapshot of agent-construction params, used when the turn
@@ -115,6 +117,7 @@ class BaseAgent(ABC):
             "provider": provider,
             "caching_enabled": caching_enabled,
             "inference_params": dict(resolved_params),
+            "mantle_endpoint_path": mantle_endpoint_path,
         }
 
         # Load retry configuration from environment variables

--- a/backend/src/agents/main_agent/core/agent_factory.py
+++ b/backend/src/agents/main_agent/core/agent_factory.py
@@ -62,6 +62,46 @@ class AgentFactory:
         return OpenAIModel(client_args=client_args, **openai_config)
 
     @staticmethod
+    def _create_mantle_model(model_config: ModelConfig) -> OpenAIModel:
+        """
+        Create an OpenAIModel pointed at Bedrock Mantle
+
+        Mantle is AWS's OpenAI-compatible inference surface for Bedrock-hosted
+        models, so the Strands OpenAIModel does the protocol work — only the
+        client differs: the regional Mantle base URL plus a short-term bearer
+        token minted from the runtime role's credentials (requires
+        `bedrock:CallWithBearerToken`). The token is minted per agent build;
+        it lives 12h and an agent is built per turn, so expiry is a non-issue.
+
+        Args:
+            model_config: Model configuration
+
+        Returns:
+            OpenAIModel: Configured model targeting Bedrock Mantle
+
+        Raises:
+            ValueError: If no AWS credentials are available to mint the token
+        """
+        from apis.shared.bedrock import (
+            generate_bedrock_bearer_token,
+            get_mantle_base_url,
+        )
+
+        region = os.getenv(EnvVars.AWS_REGION)
+        base_url = get_mantle_base_url(region, model_config.mantle_endpoint_path)
+        client_args = {
+            "api_key": generate_bedrock_bearer_token(region),
+            "base_url": base_url,
+        }
+
+        mantle_config = model_config.to_mantle_config()
+        logger.info(
+            f"Creating Bedrock Mantle model with model_id={model_config.model_id} "
+            f"base_url={base_url}"
+        )
+        return OpenAIModel(client_args=client_args, **mantle_config)
+
+    @staticmethod
     def _create_gemini_model(model_config: ModelConfig) -> GeminiModel:
         """
         Create a GeminiModel instance
@@ -121,6 +161,8 @@ class AgentFactory:
             model = AgentFactory._create_bedrock_model(model_config)
         elif provider == ModelProvider.OPENAI:
             model = AgentFactory._create_openai_model(model_config)
+        elif provider == ModelProvider.MANTLE:
+            model = AgentFactory._create_mantle_model(model_config)
         elif provider == ModelProvider.GEMINI:
             model = AgentFactory._create_gemini_model(model_config)
         else:

--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -24,6 +24,12 @@ class ModelProvider(str, Enum):
     BEDROCK = "bedrock"
     OPENAI = "openai"
     GEMINI = "gemini"
+    # Bedrock Mantle — AWS's OpenAI-compatible inference surface for
+    # Bedrock-hosted open-weight models (`bedrock-mantle.<region>.api.aws`).
+    # Distinct from BEDROCK because it rides the OpenAI wire protocol with a
+    # bearer token, not the Converse API with SigV4. Never auto-detected from
+    # model_id — admins set it explicitly on the managed model.
+    MANTLE = "mantle"
 
 
 # Canonical param name -> provider-native key path (dot-separated for nested SDK fields).
@@ -45,6 +51,16 @@ _BEDROCK_PARAM_MAP: Dict[str, str] = {
 }
 
 _OPENAI_PARAM_MAP: Dict[str, str] = {
+    "temperature": "temperature",
+    "top_p": "top_p",
+    "max_tokens": "max_tokens",
+    "reasoning_effort": "reasoning_effort",
+}
+
+# Mantle speaks the OpenAI chat-completions protocol, so the canonical->native
+# mapping mirrors OpenAI's. Kept separate so Mantle-specific divergence (e.g.
+# params some open-weight models reject) has a home without touching OpenAI.
+_MANTLE_PARAM_MAP: Dict[str, str] = {
     "temperature": "temperature",
     "top_p": "top_p",
     "max_tokens": "max_tokens",
@@ -77,7 +93,10 @@ _INTEGER_CANONICAL_PARAMS: frozenset[str] = frozenset({"max_tokens", "top_k"})
 # to bypass that by inventing keys the admin hasn't seen yet (or that the
 # provider mapping starts forwarding in a future release).
 KNOWN_CANONICAL_PARAMS: frozenset[str] = frozenset(
-    set(_BEDROCK_PARAM_MAP) | set(_OPENAI_PARAM_MAP) | set(_GEMINI_PARAM_MAP)
+    set(_BEDROCK_PARAM_MAP)
+    | set(_OPENAI_PARAM_MAP)
+    | set(_GEMINI_PARAM_MAP)
+    | set(_MANTLE_PARAM_MAP)
 )
 
 
@@ -253,6 +272,10 @@ class ModelConfig:
     provider: ModelProvider = ModelProvider.BEDROCK
     inference_params: Dict[str, Any] = field(default_factory=dict)
     retry_config: Optional[RetryConfig] = None
+    # Bedrock Mantle endpoint path (``/v1`` or ``/openai/v1``). Only consulted
+    # on the MANTLE provider path, where it selects the base URL the OpenAI
+    # client targets. ``None`` falls back to ``/v1`` in the agent factory.
+    mantle_endpoint_path: Optional[str] = None
 
     def get_provider(self) -> ModelProvider:
         """
@@ -364,6 +387,22 @@ class ModelConfig:
             config["params"] = params
         return config
 
+    def to_mantle_config(self) -> Dict[str, Any]:
+        """Convert to OpenAIModel kwargs for Bedrock Mantle.
+
+        Mantle is OpenAI-wire-compatible, so the output feeds the same
+        Strands ``OpenAIModel`` — only the client (base_url + bearer token)
+        differs, and that's the factory's job.
+        """
+        params: Dict[str, Any] = {}
+        _apply_canonical_params(
+            params, self.inference_params, _MANTLE_PARAM_MAP, "mantle", self.model_id
+        )
+        config: Dict[str, Any] = {"model_id": self.model_id}
+        if params:
+            config["params"] = params
+        return config
+
     def to_gemini_config(self) -> Dict[str, Any]:
         """Convert to GeminiModel kwargs, translating canonical inference params."""
         params: Dict[str, Any] = {}
@@ -382,6 +421,7 @@ class ModelConfig:
             "caching_enabled": self.caching_enabled,
             "provider": self.get_provider().value,
             "inference_params": dict(self.inference_params),
+            "mantle_endpoint_path": self.mantle_endpoint_path,
         }
 
     @classmethod
@@ -391,16 +431,19 @@ class ModelConfig:
         caching_enabled: Optional[bool] = None,
         provider: Optional[str] = None,
         inference_params: Optional[Dict[str, Any]] = None,
+        mantle_endpoint_path: Optional[str] = None,
     ) -> "ModelConfig":
         """Create ModelConfig from optional parameters.
 
         Args:
             model_id: Model ID (provider-specific format)
             caching_enabled: Whether to enable prompt caching (Bedrock only)
-            provider: Provider name ("bedrock", "openai", or "gemini")
+            provider: Provider name ("bedrock", "openai", "gemini", or "mantle")
             inference_params: Canonical-name -> value map (temperature, top_p,
                 max_tokens, thinking, ...). Each provider's translation table
                 drops unsupported keys silently.
+            mantle_endpoint_path: Bedrock Mantle endpoint path ("/v1" or
+                "/openai/v1"). Only consulted on the MANTLE provider path.
         """
         provider_enum = ModelProvider.BEDROCK
         if provider:
@@ -414,4 +457,5 @@ class ModelConfig:
             caching_enabled=caching_enabled if caching_enabled is not None else cls.caching_enabled,
             provider=provider_enum,
             inference_params=dict(inference_params) if inference_params else {},
+            mantle_endpoint_path=mantle_endpoint_path,
         )

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -1012,6 +1012,7 @@ class StreamCoordinator:
                 agent_type=snapshot_source.get("agent_type"),
                 enabled_skills=snapshot_source.get("enabled_skills"),
                 inference_params=dict(inference_params) if inference_params else None,
+                mantle_endpoint_path=snapshot_source.get("mantle_endpoint_path"),
                 captured_at=now.isoformat(),
                 expires_at=(now + timedelta(hours=1)).isoformat(),
             )

--- a/backend/src/apis/app_api/admin/models.py
+++ b/backend/src/apis/app_api/admin/models.py
@@ -100,6 +100,29 @@ class OpenAIModelsResponse(BaseModel):
     total_count: int = Field(..., alias="totalCount")
 
 
+class MantleModelSummary(BaseModel):
+    """Summary information for a Bedrock Mantle model.
+
+    Mantle's `GET /v1/models` is OpenAI-wire-compatible, so the per-model
+    fields mirror the OpenAI list shape. `ownedBy` carries the upstream
+    model provider when Mantle populates it; otherwise the model id prefix
+    (e.g. `qwen.`, `openai.`) is the provider hint.
+    """
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    created: Optional[int] = None
+    owned_by: str = Field(..., alias="ownedBy")
+    object: Optional[str] = None
+
+
+class MantleModelsResponse(BaseModel):
+    """Response model for listing Bedrock Mantle models."""
+    models: List[MantleModelSummary]
+    region: str
+    total_count: int = Field(..., alias="totalCount")
+
+
 # =============================================================================
 # Managed Models (Model Management)
 # =============================================================================

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -18,6 +18,8 @@ from .models import (
     GeminiModelSummary,
     OpenAIModelsResponse,
     OpenAIModelSummary,
+    MantleModelsResponse,
+    MantleModelSummary,
     ManagedModelsListResponse,
 )
 from apis.shared.models.models import (
@@ -365,6 +367,107 @@ async def list_openai_models(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error fetching OpenAI models: {str(e)}"
+        )
+
+
+@router.get("/mantle/models", response_model=MantleModelsResponse)
+async def list_mantle_models(
+    region: Optional[str] = Query(None, description="AWS region to query (defaults to the service region)"),
+    max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return"),
+    admin_user: User = Depends(require_admin),
+):
+    """
+    List available Amazon Bedrock Mantle models (admin only).
+
+    Bedrock Mantle is AWS's OpenAI-compatible inference surface for
+    Bedrock-hosted models. Discovery is the standard OpenAI `GET /v1/models`
+    against `https://bedrock-mantle.<region>.api.aws/v1`, authenticated with
+    a short-term bearer token minted from this service's IAM credentials
+    (requires `bedrock:CallWithBearerToken`). The roster is regional, so the
+    optional `region` filter lets admins browse other regions.
+
+    Args:
+        region: Optional AWS region override (defaults to AWS_REGION)
+        max_results: Optional limit on number of models to return
+        admin_user: Authenticated admin user (injected by dependency)
+
+    Returns:
+        MantleModelsResponse with the models available in the region
+
+    Raises:
+        HTTPException:
+            - 401 if not authenticated
+            - 403 if user lacks admin role
+            - 500 if token minting or the Mantle API call fails
+    """
+    logger.info("Admin listing Bedrock Mantle models")
+
+    try:
+        from apis.shared.bedrock import (
+            generate_bedrock_bearer_token,
+            get_mantle_base_url,
+        )
+
+        # Import OpenAI SDK (Mantle speaks the OpenAI wire protocol)
+        try:
+            from openai import OpenAI
+        except ImportError:
+            logger.error("OpenAI SDK not installed")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="OpenAI SDK not installed. Please install openai package."
+            )
+
+        resolved_region = region or os.environ.get('AWS_REGION', 'us-east-1')
+        base_url = get_mantle_base_url(resolved_region)
+        bearer_token = generate_bedrock_bearer_token(resolved_region)
+
+        client = OpenAI(base_url=base_url, api_key=bearer_token)
+
+        logger.debug("Fetching Mantle models")
+        all_models = []
+        response = client.models.list()
+        for model in response.data:
+            all_models.append(
+                MantleModelSummary(
+                    id=model.id,
+                    created=getattr(model, 'created', None),
+                    ownedBy=getattr(model, 'owned_by', '') or '',
+                    object=getattr(model, 'object', None),
+                )
+            )
+
+        # Sort by id for a stable roster (Mantle ids are provider-prefixed,
+        # so this groups models by upstream provider).
+        all_models.sort(key=lambda m: m.id)
+
+        if max_results and len(all_models) > max_results:
+            all_models = all_models[:max_results]
+            logger.debug("Limited results to max_results models")
+
+        logger.info("✅ Retrieved Bedrock Mantle models")
+
+        return MantleModelsResponse(
+            models=all_models,
+            region=resolved_region,
+            totalCount=len(all_models),
+        )
+
+    except HTTPException:
+        # Re-raise HTTP exceptions
+        raise
+    except ValueError as e:
+        # Credential resolution failure from the token generator
+        logger.error("Failed to mint Bedrock bearer token", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error minting Bedrock bearer token: {str(e)}"
+        )
+    except Exception as e:
+        logger.error("Unexpected error listing Mantle models", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error fetching Bedrock Mantle models: {str(e)}"
         )
 
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -290,16 +290,19 @@ async def _resolve_model_settings(
     model_id: str | None,
     explicit_caching_enabled: bool | None,
     request_inference_params: dict | None,
-) -> tuple[bool | None, dict]:
+) -> tuple[bool | None, dict, str | None]:
     """Resolve runtime model knobs from the managed-model registry.
 
-    Returns ``(caching_enabled, inference_params)``. A single registry lookup
-    drives both, replacing the prior per-concern lookups.
+    Returns ``(caching_enabled, inference_params, mantle_endpoint_path)``. A
+    single registry lookup drives all three. ``mantle_endpoint_path`` is the
+    server-authoritative Bedrock Mantle path recorded on the model (``/v1`` or
+    ``/openai/v1``); ``None`` for non-Mantle models. Resolving it here keeps
+    the path off the client request — the SPA can't override it.
     """
     request_params = dict(request_inference_params or {})
 
     if not model_id:
-        return explicit_caching_enabled, request_params
+        return explicit_caching_enabled, request_params, None
 
     managed_model = await _find_managed_model(model_id)
 
@@ -310,13 +313,19 @@ async def _resolve_model_settings(
     else:
         caching = None
 
+    mantle_endpoint_path = (
+        getattr(managed_model, "mantle_endpoint_path", None)
+        if managed_model is not None
+        else None
+    )
+
     inference_params = _merge_inference_params(managed_model, request_params)
-    return caching, inference_params
+    return caching, inference_params, mantle_endpoint_path
 
 
 async def _resolve_caching_enabled(model_id: str | None, explicit_caching_enabled: bool | None) -> bool | None:
     """Backward-compat wrapper around :func:`_resolve_model_settings`."""
-    caching, _ = await _resolve_model_settings(model_id, explicit_caching_enabled, None)
+    caching, _, _ = await _resolve_model_settings(model_id, explicit_caching_enabled, None)
     return caching
 
 
@@ -798,7 +807,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         atc = input_data.app_tool_call
         try:
             request_inference_params = dict(input_data.inference_params or {})
-            caching_enabled, inference_params = await _resolve_model_settings(
+            caching_enabled, inference_params, mantle_endpoint_path = await _resolve_model_settings(
                 model_id=input_data.model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
@@ -813,6 +822,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=input_data.provider,
                 inference_params=inference_params,
+                mantle_endpoint_path=mantle_endpoint_path,
                 agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=effective_skill_ids,
@@ -844,7 +854,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         acu = input_data.app_context_update
         try:
             request_inference_params = dict(input_data.inference_params or {})
-            caching_enabled, inference_params = await _resolve_model_settings(
+            caching_enabled, inference_params, mantle_endpoint_path = await _resolve_model_settings(
                 model_id=input_data.model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
@@ -859,6 +869,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=input_data.provider,
                 inference_params=inference_params,
+                mantle_endpoint_path=mantle_endpoint_path,
                 agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=effective_skill_ids,
@@ -1375,6 +1386,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=snapshot.caching_enabled,
                 provider=snapshot.provider,
                 inference_params=resume_inference_params,
+                mantle_endpoint_path=snapshot.mantle_endpoint_path,
                 agent_type=snapshot.agent_type,
                 is_resume=True,
                 # Resume must rebuild the SAME cache key the original turn used,
@@ -1431,9 +1443,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                             "User default model exists but RBAC denies access; falling back to system default"
                         )
 
-            # Single registry lookup resolves caching + inference params,
-            # merging admin defaults with request overrides.
-            caching_enabled, inference_params = await _resolve_model_settings(
+            # Single registry lookup resolves caching + inference params +
+            # the Mantle endpoint path, merging admin defaults with request
+            # overrides.
+            caching_enabled, inference_params, mantle_endpoint_path = await _resolve_model_settings(
                 model_id=effective_model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
@@ -1473,6 +1486,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 caching_enabled=caching_enabled,
                 provider=effective_provider,
                 inference_params=inference_params,
+                mantle_endpoint_path=mantle_endpoint_path,
                 agent_type=effective_agent_type,
                 extra_tools=extra_tools,
                 is_resume=False,

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -129,6 +129,7 @@ async def get_agent(
     agent_type: Optional[str] = None,
     extra_tools: Optional[list] = None,
     inference_params: Optional[Dict[str, Any]] = None,
+    mantle_endpoint_path: Optional[str] = None,
     is_resume: bool = False,
     accessible_skill_ids: Optional[List[str]] = None,
 ) -> BaseAgent:
@@ -236,6 +237,7 @@ async def get_agent(
         max_tokens=max_tokens,
         extra_tools=extra_tools,
         inference_params=merged_params,
+        mantle_endpoint_path=mantle_endpoint_path,
     )
     # Only the SkillAgent accepts accessible_skill_ids; ChatAgent's constructor
     # would reject the unknown kwarg, so gate it on the skill type.

--- a/backend/src/apis/shared/bedrock/__init__.py
+++ b/backend/src/apis/shared/bedrock/__init__.py
@@ -1,0 +1,5 @@
+"""Shared Bedrock helpers (bearer tokens for OpenAI-compatible Bedrock surfaces)."""
+
+from .bearer_token import generate_bedrock_bearer_token, get_mantle_base_url
+
+__all__ = ["generate_bedrock_bearer_token", "get_mantle_base_url"]

--- a/backend/src/apis/shared/bedrock/bearer_token.py
+++ b/backend/src/apis/shared/bedrock/bearer_token.py
@@ -1,0 +1,93 @@
+"""Short-term Bedrock bearer tokens for OpenAI-compatible Bedrock surfaces.
+
+Bedrock Mantle (`https://bedrock-mantle.<region>.api.aws/v1`) speaks the
+OpenAI wire protocol and authenticates with a bearer token instead of SigV4.
+The short-term token is a SigV4 *presigned* `CallWithBearerToken` request,
+base64-encoded and prefixed — the same construction as AWS's
+`aws-bedrock-token-generator` package, inlined here so we don't carry a
+dependency for ~20 lines of botocore. The token authorizes as whatever
+principal signed it (task role locally on ECS, runtime role in AgentCore).
+The presign signs the standard `bedrock` service (matching AWS's official
+generator), but the Mantle service authorizes the signer against its own
+namespace — `bedrock-mantle:CallWithBearerToken` (and
+`bedrock-mantle:CreateInference` for chat completions). Mantle must also be
+enabled for the account in the target region; IAM alone can't grant a
+disabled service (the API returns a "not enabled for this account" 401).
+
+Tokens expire with the signing credentials, capped at 12 hours. We generate
+one per client construction (per admin browse call / per agent turn) rather
+than caching, so credential rotation on the task role is a non-issue.
+"""
+
+import base64
+import logging
+import os
+from typing import Optional
+
+import boto3
+from botocore.auth import SigV4QueryAuth
+from botocore.awsrequest import AWSRequest
+
+logger = logging.getLogger(__name__)
+
+_BEDROCK_HOST = "bedrock.amazonaws.com"
+_SERVICE_NAME = "bedrock"
+_AUTH_PREFIX = "bedrock-api-key-"
+_TOKEN_VERSION = "&Version=1"
+_TOKEN_DURATION_SECONDS = 43200  # 12 hours — the service-side maximum
+
+# Mantle is a regional endpoint on the api.aws TLD (not amazonaws.com).
+_MANTLE_HOST_TEMPLATE = "https://bedrock-mantle.{region}.api.aws"
+# Default OpenAI-compatible path. Some models (e.g. Gemma 4) are served on
+# `/openai/v1` instead — see `ManagedModel.mantle_endpoint_path`.
+_MANTLE_DEFAULT_PATH = "/v1"
+
+
+def get_mantle_base_url(
+    region: Optional[str] = None, endpoint_path: Optional[str] = None
+) -> str:
+    """OpenAI-compatible base URL for Bedrock Mantle in ``region``.
+
+    ``region`` falls back to AWS_REGION, then us-east-1 (Mantle's broadest
+    region). ``endpoint_path`` is the per-model path segment — ``/v1`` (the
+    default, OpenAI Chat Completions) or ``/openai/v1`` (e.g. Gemma 4). Mantle
+    exposes no API to discover a model's path, so the caller supplies the
+    value recorded on the managed model.
+    """
+    resolved_region = region or os.environ.get("AWS_REGION") or "us-east-1"
+    path = endpoint_path or _MANTLE_DEFAULT_PATH
+    if not path.startswith("/"):
+        path = "/" + path
+    return _MANTLE_HOST_TEMPLATE.format(region=resolved_region) + path
+
+
+def generate_bedrock_bearer_token(region: Optional[str] = None) -> str:
+    """Mint a short-term Bedrock bearer token from the ambient AWS credentials.
+
+    Raises:
+        ValueError: when no AWS credentials are resolvable in this environment.
+    """
+    resolved_region = region or os.environ.get("AWS_REGION") or "us-east-1"
+    credentials = boto3.Session().get_credentials()
+    if credentials is None:
+        raise ValueError(
+            "No AWS credentials available to mint a Bedrock bearer token. "
+            "Ensure the task/runtime role (or local AWS profile) is configured."
+        )
+
+    request = AWSRequest(
+        method="POST",
+        url=f"https://{_BEDROCK_HOST}/",
+        headers={"host": _BEDROCK_HOST},
+        params={"Action": "CallWithBearerToken"},
+    )
+    auth = SigV4QueryAuth(
+        credentials.get_frozen_credentials(),
+        _SERVICE_NAME,
+        resolved_region,
+        expires=_TOKEN_DURATION_SECONDS,
+    )
+    auth.add_auth(request)
+
+    presigned = request.url.replace("https://", "") + _TOKEN_VERSION
+    return _AUTH_PREFIX + base64.b64encode(presigned.encode("utf-8")).decode("utf-8")

--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -37,6 +37,21 @@ def _resolve_supports_caching(supports_caching: Optional[bool], provider: str) -
     # Admins can explicitly set this to False for Bedrock models that don't support it
     return provider.lower() == 'bedrock'
 
+
+def _resolve_mantle_endpoint_path(endpoint_path: Optional[str], provider: str) -> Optional[str]:
+    """Resolve the Bedrock Mantle endpoint path for a model.
+
+    Only meaningful for ``provider == 'mantle'`` — Mantle serves different
+    models on different OpenAI-compatible paths (``/v1`` vs ``/openai/v1``)
+    and exposes no API to discover which, so the value is recorded per model
+    (from the model card / curated catalog). Defaults to ``/v1`` for Mantle
+    models when unset; ``None`` for every other provider (the field is inert
+    there).
+    """
+    if provider.lower() != 'mantle':
+        return None
+    return endpoint_path or '/v1'
+
 # Initialize DynamoDB client
 dynamodb = boto3.resource('dynamodb')
 
@@ -218,6 +233,7 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         knowledge_cutoff_date=model_data.knowledge_cutoff_date,
         supports_caching=_resolve_supports_caching(model_data.supports_caching, model_data.provider),
         is_default=model_data.is_default,
+        mantle_endpoint_path=_resolve_mantle_endpoint_path(model_data.mantle_endpoint_path, model_data.provider),
         supported_params=model_data.supported_params,
         created_at=now,
         updated_at=now,
@@ -256,6 +272,9 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         item['cacheReadPricePerMillionTokens'] = model_data.cache_read_price_per_million_tokens
     if model_data.knowledge_cutoff_date is not None:
         item['knowledgeCutoffDate'] = model_data.knowledge_cutoff_date
+    resolved_mantle_path = _resolve_mantle_endpoint_path(model_data.mantle_endpoint_path, model_data.provider)
+    if resolved_mantle_path is not None:
+        item['mantleEndpointPath'] = resolved_mantle_path
     if model_data.supported_params is not None:
         item['supportedParams'] = model_data.supported_params.model_dump(by_alias=True, exclude_none=True)
 

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -195,6 +195,14 @@ class ManagedModelCreate(BaseModel):
         alias="isDefault",
         description="Whether this is the default model for new sessions. Only one model can be default."
     )
+    mantle_endpoint_path: Optional[str] = Field(
+        None,
+        alias="mantleEndpointPath",
+        description="Bedrock Mantle endpoint path segment (provider='mantle' only): "
+                    "'/v1' (OpenAI Chat Completions, the default) or '/openai/v1' "
+                    "(e.g. Gemma 4). The per-model value comes from the model card; "
+                    "there is no API that exposes it. Ignored for other providers."
+    )
     supported_params: Optional[SupportedParams] = Field(
         None,
         alias="supportedParams",
@@ -257,6 +265,12 @@ class ManagedModelUpdate(BaseModel):
         alias="isDefault",
         description="Whether this is the default model for new sessions."
     )
+    mantle_endpoint_path: Optional[str] = Field(
+        None,
+        alias="mantleEndpointPath",
+        description="Bedrock Mantle endpoint path segment (provider='mantle' only): "
+                    "'/v1' or '/openai/v1'. Ignored for other providers."
+    )
     supported_params: Optional[SupportedParams] = Field(
         None,
         alias="supportedParams",
@@ -316,6 +330,12 @@ class ManagedModel(BaseModel):
         False,
         alias="isDefault",
         description="Whether this is the default model for new sessions. Only one model can be default."
+    )
+    mantle_endpoint_path: Optional[str] = Field(
+        None,
+        alias="mantleEndpointPath",
+        description="Bedrock Mantle endpoint path segment (provider='mantle' only): "
+                    "'/v1' or '/openai/v1'. Ignored for other providers."
     )
     supported_params: Optional[SupportedParams] = Field(
         None,

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -122,6 +122,13 @@ class PausedTurnSnapshot(BaseModel):
         description="Canonical inference param dict captured at pause. When present, "
                     "supersedes the legacy temperature/max_tokens fields on resume."
     )
+    mantle_endpoint_path: Optional[str] = Field(
+        default=None,
+        alias="mantleEndpointPath",
+        description="Bedrock Mantle endpoint path ('/v1' or '/openai/v1') captured at "
+                    "pause so a resumed Mantle turn rebuilds the same base URL. None for "
+                    "non-Mantle turns and snapshots written before the field existed.",
+    )
     captured_at: str = Field(..., alias="capturedAt", description="ISO 8601 timestamp when the turn paused")
     expires_at: str = Field(..., alias="expiresAt", description="ISO 8601 timestamp after which the snapshot is no longer valid for resume")
 

--- a/backend/tests/agents/main_agent/core/test_agent_factory.py
+++ b/backend/tests/agents/main_agent/core/test_agent_factory.py
@@ -85,6 +85,88 @@ class TestCreateAgentOpenAI:
 
 
 # ---------------------------------------------------------------------------
+# Bedrock Mantle provider creates Agent with OpenAIModel against the
+# regional Mantle endpoint, authenticated with a minted bearer token.
+# ---------------------------------------------------------------------------
+class TestCreateAgentMantle:
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.OpenAIModel")
+    def test_mantle_provider_creates_openai_model_with_mantle_client(
+        self, mock_openai_cls, mock_agent_cls, monkeypatch
+    ):
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        mock_model_instance = MagicMock()
+        mock_openai_cls.return_value = mock_model_instance
+
+        mantle_config = ModelConfig(
+            model_id="openai.gpt-oss-120b", provider=ModelProvider.MANTLE
+        )
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            return_value="bedrock-api-key-token",
+        ) as mock_token:
+            AgentFactory.create_agent(model_config=mantle_config, **_COMMON_KWARGS)
+
+        mock_token.assert_called_once_with("us-west-2")
+        mock_openai_cls.assert_called_once()
+        call_kwargs = mock_openai_cls.call_args.kwargs
+        assert call_kwargs["client_args"]["api_key"] == "bedrock-api-key-token"
+        assert (
+            call_kwargs["client_args"]["base_url"]
+            == "https://bedrock-mantle.us-west-2.api.aws/v1"
+        )
+        assert call_kwargs["model_id"] == "openai.gpt-oss-120b"
+        mock_agent_cls.assert_called_once()
+        assert mock_agent_cls.call_args.kwargs["model"] is mock_model_instance
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.OpenAIModel")
+    def test_mantle_endpoint_path_selects_base_url(
+        self, mock_openai_cls, mock_agent_cls, monkeypatch
+    ):
+        """A model carrying mantle_endpoint_path='/openai/v1' (e.g. Gemma 4)
+        must build the base URL on that path, not the default /v1."""
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        mantle_config = ModelConfig(
+            model_id="google.gemma-4-31b",
+            provider=ModelProvider.MANTLE,
+            mantle_endpoint_path="/openai/v1",
+        )
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            return_value="bedrock-api-key-token",
+        ):
+            AgentFactory.create_agent(model_config=mantle_config, **_COMMON_KWARGS)
+
+        call_kwargs = mock_openai_cls.call_args.kwargs
+        assert (
+            call_kwargs["client_args"]["base_url"]
+            == "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+        )
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.OpenAIModel")
+    def test_mantle_without_credentials_raises(
+        self, mock_openai_cls, mock_agent_cls, monkeypatch
+    ):
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        mantle_config = ModelConfig(
+            model_id="openai.gpt-oss-120b", provider=ModelProvider.MANTLE
+        )
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            side_effect=ValueError("No AWS credentials available"),
+        ):
+            with pytest.raises(ValueError, match="No AWS credentials"):
+                AgentFactory.create_agent(model_config=mantle_config, **_COMMON_KWARGS)
+
+
+# ---------------------------------------------------------------------------
 # Req 4.3 — Gemini provider with API key creates Agent with GeminiModel
 # ---------------------------------------------------------------------------
 class TestCreateAgentGemini:

--- a/backend/tests/agents/main_agent/core/test_model_config.py
+++ b/backend/tests/agents/main_agent/core/test_model_config.py
@@ -410,6 +410,55 @@ class TestToOpenAIConfig:
         assert "params" not in result
 
 
+class TestToMantleConfig:
+    """Bedrock Mantle — OpenAI-wire-compatible config translation."""
+
+    def test_mantle_config_basic(self):
+        cfg = ModelConfig(
+            model_id="openai.gpt-oss-120b",
+            provider=ModelProvider.MANTLE,
+            inference_params={"temperature": 0.5},
+        )
+        result = cfg.to_mantle_config()
+
+        assert result["model_id"] == "openai.gpt-oss-120b"
+        assert result["params"]["temperature"] == 0.5
+
+    def test_mantle_config_without_inference_params_omits_params_block(self):
+        cfg = ModelConfig(
+            model_id="qwen.qwen3-coder-30b-a3b-instruct",
+            provider=ModelProvider.MANTLE,
+        )
+        result = cfg.to_mantle_config()
+
+        assert "params" not in result
+
+    def test_mantle_config_drops_top_k(self):
+        """OpenAI wire protocol has no top_k — translation drops it silently."""
+        cfg = ModelConfig(
+            model_id="openai.gpt-oss-120b",
+            provider=ModelProvider.MANTLE,
+            inference_params={"top_k": 40},
+        )
+        result = cfg.to_mantle_config()
+
+        assert "params" not in result
+
+    def test_explicit_mantle_provider_wins_over_auto_detect(self):
+        """Mantle is never auto-detected; explicit provider must stick even
+        for ids that look like other providers' (e.g. `openai.` prefix)."""
+        cfg = ModelConfig(model_id="openai.gpt-oss-120b", provider=ModelProvider.MANTLE)
+
+        assert cfg.get_provider() == ModelProvider.MANTLE
+
+    def test_from_params_accepts_mantle(self):
+        cfg = ModelConfig.from_params(
+            model_id="qwen.qwen3-coder-30b-a3b-instruct", provider="mantle"
+        )
+
+        assert cfg.get_provider() == ModelProvider.MANTLE
+
+
 class TestToGeminiConfig:
     """Validates: Requirement 1.9"""
 
@@ -454,6 +503,7 @@ class TestToDict:
             "caching_enabled",
             "provider",
             "inference_params",
+            "mantle_endpoint_path",
         }
 
 

--- a/backend/tests/apis/app_api/admin/test_mantle_models_route.py
+++ b/backend/tests/apis/app_api/admin/test_mantle_models_route.py
@@ -1,0 +1,117 @@
+"""Route tests for ``GET /admin/mantle/models`` (Bedrock Mantle browse)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.auth import require_admin
+from apis.shared.auth.models import User
+
+from apis.app_api.admin import routes as admin_routes
+
+
+def _admin() -> User:
+    return User(
+        user_id="admin-1",
+        email="admin@example.com",
+        name="Admin",
+        roles=["admin"],
+        raw_token="test-token",
+    )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_routes.router)
+    app.dependency_overrides[require_admin] = _admin
+    return TestClient(app)
+
+
+def _mantle_model(model_id: str, owned_by: str = "bedrock") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=model_id, created=1750000000, owned_by=owned_by, object="model"
+    )
+
+
+def _mock_openai_client(models):
+    client = MagicMock()
+    client.models.list.return_value = SimpleNamespace(data=models)
+    return client
+
+
+class TestListMantleModels:
+    def test_lists_models_sorted_by_id(self, client, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        mock_client = _mock_openai_client(
+            [
+                _mantle_model("qwen.qwen3-coder-30b-a3b-instruct"),
+                _mantle_model("openai.gpt-oss-120b"),
+            ]
+        )
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            return_value="bedrock-api-key-abc",
+        ) as mock_token, patch("openai.OpenAI", return_value=mock_client) as mock_ctor:
+            response = client.get("/admin/mantle/models")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["region"] == "us-west-2"
+        assert body["totalCount"] == 2
+        assert [m["id"] for m in body["models"]] == [
+            "openai.gpt-oss-120b",
+            "qwen.qwen3-coder-30b-a3b-instruct",
+        ]
+        mock_token.assert_called_once_with("us-west-2")
+        # OpenAI-compatible client pointed at the regional Mantle endpoint,
+        # authenticated with the minted bearer token.
+        _, kwargs = mock_ctor.call_args
+        assert kwargs["base_url"] == "https://bedrock-mantle.us-west-2.api.aws/v1"
+        assert kwargs["api_key"] == "bedrock-api-key-abc"
+
+    def test_region_override_and_max_results(self, client, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        mock_client = _mock_openai_client(
+            [_mantle_model("a.model"), _mantle_model("b.model")]
+        )
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            return_value="bedrock-api-key-abc",
+        ) as mock_token, patch("openai.OpenAI", return_value=mock_client):
+            response = client.get(
+                "/admin/mantle/models", params={"region": "eu-west-1", "max_results": 1}
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["region"] == "eu-west-1"
+        assert body["totalCount"] == 1
+        mock_token.assert_called_once_with("eu-west-1")
+
+    def test_credential_failure_is_500_with_detail(self, client):
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            side_effect=ValueError("No AWS credentials available"),
+        ):
+            response = client.get("/admin/mantle/models")
+
+        assert response.status_code == 500
+        assert "bearer token" in response.json()["detail"]
+
+    def test_mantle_api_failure_is_500(self, client):
+        failing_client = MagicMock()
+        failing_client.models.list.side_effect = RuntimeError("connection refused")
+        with patch(
+            "apis.shared.bedrock.generate_bedrock_bearer_token",
+            return_value="bedrock-api-key-abc",
+        ), patch("openai.OpenAI", return_value=failing_client):
+            response = client.get("/admin/mantle/models")
+
+        assert response.status_code == 500
+        assert "Mantle" in response.json()["detail"]

--- a/backend/tests/shared/test_bedrock_bearer_token.py
+++ b/backend/tests/shared/test_bedrock_bearer_token.py
@@ -1,0 +1,81 @@
+"""Tests for the shared Bedrock bearer-token generator (Mantle auth)."""
+
+import base64
+from unittest.mock import patch, MagicMock
+
+import pytest
+from botocore.credentials import Credentials
+
+from apis.shared.bedrock.bearer_token import (
+    generate_bedrock_bearer_token,
+    get_mantle_base_url,
+)
+
+
+def _fake_session_with(credentials):
+    session = MagicMock()
+    session.get_credentials.return_value = credentials
+    return session
+
+
+class TestGetMantleBaseUrl:
+    def test_explicit_region(self):
+        assert (
+            get_mantle_base_url("us-west-2")
+            == "https://bedrock-mantle.us-west-2.api.aws/v1"
+        )
+
+    def test_falls_back_to_aws_region_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        assert (
+            get_mantle_base_url()
+            == "https://bedrock-mantle.eu-west-1.api.aws/v1"
+        )
+
+    def test_defaults_to_us_east_1(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        assert (
+            get_mantle_base_url()
+            == "https://bedrock-mantle.us-east-1.api.aws/v1"
+        )
+
+
+class TestGenerateBedrockBearerToken:
+    def test_token_shape_matches_aws_generator(self):
+        creds = Credentials(access_key="AKIATEST", secret_key="secret")
+        with patch(
+            "apis.shared.bedrock.bearer_token.boto3.Session",
+            return_value=_fake_session_with(creds),
+        ):
+            token = generate_bedrock_bearer_token("us-west-2")
+
+        assert token.startswith("bedrock-api-key-")
+        decoded = base64.b64decode(token[len("bedrock-api-key-"):]).decode("utf-8")
+        # Presigned CallWithBearerToken request against the global bedrock host,
+        # with the trailing token version marker.
+        assert decoded.startswith("bedrock.amazonaws.com/")
+        assert "Action=CallWithBearerToken" in decoded
+        assert "X-Amz-Signature=" in decoded
+        assert "X-Amz-Expires=43200" in decoded
+        assert decoded.endswith("&Version=1")
+
+    def test_session_token_included_for_temporary_credentials(self):
+        creds = Credentials(
+            access_key="ASIATEST", secret_key="secret", token="session-token"
+        )
+        with patch(
+            "apis.shared.bedrock.bearer_token.boto3.Session",
+            return_value=_fake_session_with(creds),
+        ):
+            token = generate_bedrock_bearer_token("us-west-2")
+
+        decoded = base64.b64decode(token[len("bedrock-api-key-"):]).decode("utf-8")
+        assert "X-Amz-Security-Token=" in decoded
+
+    def test_raises_without_credentials(self):
+        with patch(
+            "apis.shared.bedrock.bearer_token.boto3.Session",
+            return_value=_fake_session_with(None),
+        ):
+            with pytest.raises(ValueError, match="No AWS credentials"):
+                generate_bedrock_bearer_token("us-west-2")

--- a/backend/tests/shared/test_managed_models.py
+++ b/backend/tests/shared/test_managed_models.py
@@ -93,6 +93,41 @@ class TestManagedModels:
         model = await create_managed_model(_make_model_data("gpt4", provider="openai"))
         assert model.supports_caching is False
 
+    @pytest.mark.asyncio
+    async def test_mantle_endpoint_path_defaults_to_v1(self):
+        from apis.shared.models.managed_models import create_managed_model, get_managed_model
+        model = await create_managed_model(
+            _make_model_data("qwen.qwen3-32b", provider="mantle", providerName="Qwen")
+        )
+        assert model.mantle_endpoint_path == "/v1"
+        # Persists and reloads.
+        reloaded = await get_managed_model(model.id)
+        assert reloaded.mantle_endpoint_path == "/v1"
+
+    @pytest.mark.asyncio
+    async def test_mantle_endpoint_path_explicit_openai_v1(self):
+        from apis.shared.models.managed_models import create_managed_model, get_managed_model
+        model = await create_managed_model(
+            _make_model_data(
+                "google.gemma-4-31b",
+                provider="mantle",
+                providerName="Google",
+                mantleEndpointPath="/openai/v1",
+            )
+        )
+        assert model.mantle_endpoint_path == "/openai/v1"
+        reloaded = await get_managed_model(model.id)
+        assert reloaded.mantle_endpoint_path == "/openai/v1"
+
+    @pytest.mark.asyncio
+    async def test_mantle_endpoint_path_none_for_non_mantle(self):
+        from apis.shared.models.managed_models import create_managed_model
+        # Even if a path is supplied, it's inert for non-Mantle providers.
+        model = await create_managed_model(
+            _make_model_data("claude-3", provider="bedrock", mantleEndpointPath="/openai/v1")
+        )
+        assert model.mantle_endpoint_path is None
+
 
 class TestMaxTokensCeiling:
     """max_tokens spec must not exceed the model's declared output ceiling."""

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
@@ -7,7 +7,7 @@ import { ModelCatalogPage } from './model-catalog.page';
 import { ManagedModelsService } from './services/managed-models.service';
 import { CuratedModelPrefillService } from './services/curated-model-prefill.service';
 import { AddCuratedModelDialogComponent } from './components/add-curated-model-dialog.component';
-import { CURATED_BEDROCK_MODELS } from './models/curated-models';
+import { CURATED_BEDROCK_MODELS, CURATED_MANTLE_MODELS } from './models/curated-models';
 
 function createMockManagedModelsService(overrides: Partial<{
   isModelAdded: (modelId: string) => boolean;
@@ -193,6 +193,22 @@ describe('ModelCatalogPage', () => {
     expect(page.errorFor(target.key)).toBe('Model ID already in use');
     expect(routerNavigate).not.toHaveBeenCalled();
     expect(page.addingKey()).toBeNull();
+  });
+
+  it('renders curated Mantle cards (with vetted endpoint paths) on the Mantle tab', () => {
+    const page = createComponent();
+    page.selectTab('mantle');
+
+    const keys = page.visibleModels().map(m => m.key);
+    expect(keys).toEqual(CURATED_MANTLE_MODELS.map(m => m.key));
+
+    // Gemma 4 must carry the /openai/v1 path; the Qwen coder the default /v1.
+    const gemma = page.visibleModels().find(m => m.key === 'gemma-4-31b');
+    const qwen = page.visibleModels().find(m => m.key === 'qwen3-coder-30b');
+    expect(gemma?.template.mantleEndpointPath).toBe('/openai/v1');
+    expect(qwen?.template.mantleEndpointPath).toBe('/v1');
+    // Mantle models never cache (model-bound to Claude/Nova).
+    expect(gemma?.template.supportsCaching).toBe(false);
   });
 
   it('ignores a second addCuratedModel while a create is in flight', async () => {

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.ts
@@ -32,6 +32,7 @@ const PROVIDER_TABS: ProviderTab[] = [
   { id: 'bedrock', label: 'Bedrock' },
   { id: 'openai', label: 'OpenAI' },
   { id: 'gemini', label: 'Gemini' },
+  { id: 'mantle', label: 'Bedrock Mantle' },
 ];
 
 const PROVIDER_LOGO_DIR: Record<string, string> = {

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -47,10 +47,22 @@
               type="text"
               id="modelId"
               formControlName="modelId"
+              [attr.list]="isMantle() ? 'mantle-model-ids' : null"
               placeholder="e.g., anthropic.claude-3-5-sonnet-20241022-v2:0"
               class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
               [class.border-red-500]="modelForm.controls.modelId.invalid && modelForm.controls.modelId.touched"
             />
+            @if (isMantle() && mantleModelIdOptions().length > 0) {
+              <datalist id="mantle-model-ids">
+                @for (id of mantleModelIdOptions(); track id) {
+                  <option [value]="id"></option>
+                }
+              </datalist>
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                Suggestions are the live Bedrock Mantle roster for this region. Check the model card
+                for the correct endpoint path below.
+              </p>
+            }
             @if (modelForm.controls.modelId.invalid && modelForm.controls.modelId.touched) {
               <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Model ID is required</p>
             }
@@ -112,6 +124,30 @@
               }
             </div>
           </div>
+
+          <!-- Bedrock Mantle endpoint path (Mantle provider only) -->
+          @if (isMantle()) {
+            <div>
+              <label for="mantleEndpointPath" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Mantle endpoint path <span class="text-red-600">*</span>
+              </label>
+              <select
+                id="mantleEndpointPath"
+                formControlName="mantleEndpointPath"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:max-w-xs dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              >
+                @for (path of mantleEndpointPaths; track path) {
+                  <option [value]="path">{{ path }}</option>
+                }
+              </select>
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                Bedrock Mantle serves different models on different OpenAI-compatible paths and
+                exposes no API to discover which. Use <code>/v1</code> for most models;
+                <code>/openai/v1</code> for models whose card specifies it (e.g. Gemma 4). The wrong
+                path returns a misleading "not enabled" error at chat time.
+              </p>
+            </div>
+          }
 
           <!-- Knowledge Cutoff Date -->
           <div>

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -16,7 +16,9 @@ import {
   AVAILABLE_PROVIDERS,
   KNOWN_PARAMS,
   KnownParamMeta,
+  MANTLE_ENDPOINT_PATHS,
   ManagedModelFormData,
+  MantleEndpointPath,
   ModelParamSpec,
   ModelProvider,
   SupportedParams,
@@ -229,6 +231,7 @@ interface ModelFormGroup {
   cacheReadPricePerMillionTokens: FormControl<number | null>;
   knowledgeCutoffDate: FormControl<string | null>;
   supportsCaching: FormControl<boolean>;
+  mantleEndpointPath: FormControl<MantleEndpointPath>;
   inferenceParams: FormArray<FormGroup<ParamRowGroup>>;
   customInferenceParams: FormArray<FormGroup<CustomParamRowGroup>>;
 }
@@ -252,6 +255,25 @@ export class ModelFormPage implements OnInit {
   // Available options for multi-select fields
   readonly availableProviders = AVAILABLE_PROVIDERS;
   readonly availableModalities = ['TEXT', 'IMAGE', 'VIDEO', 'AUDIO', 'SPEECH', 'EMBEDDING'];
+  readonly mantleEndpointPaths = MANTLE_ENDPOINT_PATHS;
+
+  /**
+   * Tracks the selected provider as a signal so the template can show/hide
+   * the Mantle-only endpoint-path field and suppress the caching controls
+   * (Mantle open-weight models never cache). Kept in sync with the form
+   * control in ngOnInit + its valueChanges subscription.
+   */
+  readonly selectedProvider = signal<ModelProvider>('bedrock');
+  readonly isMantle = computed(() => this.selectedProvider() === 'mantle');
+
+  /**
+   * Model-id suggestions for the Mantle escape-hatch form, sourced from the
+   * live `GET /admin/mantle/models` roster. The curated cards are the primary
+   * path; this just spares an admin adding an off-catalog model from typing
+   * an exact id. Fetched once, lazily, the first time the form is on Mantle.
+   */
+  readonly mantleModelIdOptions = signal<string[]>([]);
+  private mantleModelIdsLoaded = false;
 
   // AppRoles from the API (reactive resource)
   readonly rolesResource = this.appRolesService.rolesResource;
@@ -288,6 +310,7 @@ export class ModelFormPage implements OnInit {
     cacheReadPricePerMillionTokens: this.fb.control<number | null>(null, { validators: [Validators.min(0)] }),
     knowledgeCutoffDate: this.fb.control<string | null>(null),
     supportsCaching: this.fb.control(false, { nonNullable: true }),
+    mantleEndpointPath: this.fb.control<MantleEndpointPath>('/v1', { nonNullable: true }),
     inferenceParams: this.fb.array<FormGroup<ParamRowGroup>>([], {
       validators: [thinkingInvariantsValidator, maxTokensCeilingValidator],
     }),
@@ -383,10 +406,23 @@ export class ModelFormPage implements OnInit {
       }
     });
 
+    // Mirror the initial provider into the signal so Mantle-only UI is
+    // correct on first paint (edit mode / curated prefill set it before this).
+    this.selectedProvider.set(this.modelForm.controls.provider.value);
+    if (this.isMantle()) {
+      this.loadMantleModelIdOptions();
+    }
+
     // Rebuild the inference-param rows whenever the provider changes so the
-    // visible knobs match what the selected SDK actually understands.
+    // visible knobs match what the selected SDK actually understands. Also
+    // keep the provider signal in sync and lazily pull the Mantle model-id
+    // suggestions the first time the form lands on Mantle.
     this.modelForm.controls.provider.valueChanges.subscribe(provider => {
       this.rebuildInferenceParamRows(provider);
+      this.selectedProvider.set(provider);
+      if (provider === 'mantle') {
+        this.loadMantleModelIdOptions();
+      }
     });
 
     // Keep the max_tokens row pinned to the model's output ceiling: pre-fill
@@ -783,6 +819,7 @@ export class ModelFormPage implements OnInit {
         cacheReadPricePerMillionTokens: model.cacheReadPricePerMillionTokens ?? null,
         knowledgeCutoffDate: model.knowledgeCutoffDate,
         supportsCaching: model.supportsCaching ?? true,
+        mantleEndpointPath: this.coerceMantlePath(model.mantleEndpointPath),
       });
 
       // Repopulate the inference-params rows with any persisted spec.
@@ -824,6 +861,7 @@ export class ModelFormPage implements OnInit {
       cacheReadPricePerMillionTokens: template.cacheReadPricePerMillionTokens ?? null,
       knowledgeCutoffDate: template.knowledgeCutoffDate ?? null,
       supportsCaching: template.supportsCaching ?? true,
+      mantleEndpointPath: this.coerceMantlePath(template.mantleEndpointPath),
     });
 
     this.rebuildInferenceParamRows(template.provider, template.supportedParams ?? null);
@@ -845,6 +883,23 @@ export class ModelFormPage implements OnInit {
         maxOutputTokens: params['maxOutputTokens'] ? parseInt(params['maxOutputTokens'], 10) : 0,
         knowledgeCutoffDate: params['knowledgeCutoffDate'] || null,
       });
+    }
+  }
+
+  /**
+   * Fetch the live Bedrock Mantle roster once to seed the model-id datalist
+   * for the escape-hatch form. Best-effort: failures leave the datalist empty
+   * (the admin can still type any id), so we swallow errors quietly.
+   */
+  private async loadMantleModelIdOptions(): Promise<void> {
+    if (this.mantleModelIdsLoaded) return;
+    this.mantleModelIdsLoaded = true;
+    try {
+      const response = await this.managedModelsService.fetchMantleModels();
+      this.mantleModelIdOptions.set(response.models.map(m => m.id));
+    } catch {
+      // Non-fatal — the datalist is a convenience, not a requirement.
+      this.mantleModelIdsLoaded = false;
     }
   }
 
@@ -906,6 +961,9 @@ export class ModelFormPage implements OnInit {
         cacheReadPricePerMillionTokens: v.cacheReadPricePerMillionTokens,
         knowledgeCutoffDate: v.knowledgeCutoffDate,
         supportsCaching: v.supportsCaching,
+        // Only meaningful for Mantle; null elsewhere so the backend stores
+        // nothing for other providers.
+        mantleEndpointPath: v.provider === 'mantle' ? v.mantleEndpointPath : null,
         supportedParams: this.collectSupportedParams(),
       };
 
@@ -928,6 +986,17 @@ export class ModelFormPage implements OnInit {
     } finally {
       this.isSubmitting.set(false);
     }
+  }
+
+  /**
+   * Normalize a stored/templated Mantle path onto the known options, falling
+   * back to the default `/v1` for null/legacy/unknown values so the select
+   * always has a valid selection.
+   */
+  private coerceMantlePath(value: string | null | undefined): MantleEndpointPath {
+    return MANTLE_ENDPOINT_PATHS.includes(value as MantleEndpointPath)
+      ? (value as MantleEndpointPath)
+      : '/v1';
   }
 
   /**

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -127,7 +127,96 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
 ];
 
 /**
- * Provider-keyed lookup for the catalog tabs. Bedrock is populated;
+ * Shared defaults for Bedrock Mantle (OpenAI-compatible open-weight) models.
+ *
+ * Caching is intentionally absent: prompt caching on Bedrock is model-bound
+ * to Anthropic Claude + a small set of Amazon Nova models, none of which run
+ * through the Mantle provider, so these never cache and carry no cache
+ * pricing. `mantleEndpointPath` is the one Mantle-specific field — sourced
+ * from each model card (there is no API that exposes it).
+ */
+const mantleDefaults = (): Pick<
+  ManagedModelFormData,
+  | 'provider'
+  | 'outputModalities'
+  | 'responseStreamingSupported'
+  | 'allowedAppRoles'
+  | 'availableToRoles'
+  | 'enabled'
+  | 'isDefault'
+  | 'supportsCaching'
+> => ({
+  provider: 'mantle',
+  outputModalities: ['TEXT'],
+  responseStreamingSupported: true,
+  allowedAppRoles: [],
+  availableToRoles: [],
+  enabled: true,
+  isDefault: false,
+  supportsCaching: false,
+});
+
+// Pricing verified against the AWS Bedrock pricing page (2026-06); modalities,
+// capabilities, context, and endpoint path verified against each model card.
+// Mantle per-token pricing equals the bedrock-runtime price for the same model.
+// Re-verify when AWS revises pricing or a newer model version ships.
+export const CURATED_MANTLE_MODELS: CuratedModel[] = [
+  {
+    key: 'qwen3-coder-30b',
+    tagline: 'Qwen3 Coder 30B — long-context coding model on Bedrock Mantle.',
+    capabilities: ['Coding', 'Long context'],
+    template: {
+      ...mantleDefaults(),
+      modelId: 'qwen.qwen3-coder-30b-a3b-instruct',
+      modelName: 'Qwen3 Coder 30B',
+      providerName: 'Qwen',
+      inputModalities: ['TEXT'],
+      maxInputTokens: 256_000,
+      maxOutputTokens: 8_192,
+      mantleEndpointPath: '/v1',
+      inputPricePerMillionTokens: 0.15,
+      outputPricePerMillionTokens: 0.6,
+      supportedParams: {
+        params: {
+          temperature: { supported: true, min: 0, max: 2, default: 0.7 },
+          top_p: { supported: true, min: 0, max: 1, default: null },
+          max_tokens: { supported: true, min: 1, max: 8_192, default: 4_096 },
+        },
+      },
+    },
+  },
+  {
+    key: 'gemma-4-31b',
+    tagline:
+      "Google Gemma 4 31B — reasoning, vision + tool use, served on Mantle's /openai/v1 path.",
+    capabilities: ['Reasoning', 'Tool use', 'Vision', '256K context'],
+    template: {
+      ...mantleDefaults(),
+      modelId: 'google.gemma-4-31b',
+      modelName: 'Gemma 4 31B',
+      providerName: 'Google',
+      // Per the AWS model card: text + image + video in, text out. (The
+      // request payload note explicitly covers images and video.)
+      inputModalities: ['TEXT', 'IMAGE', 'VIDEO'],
+      maxInputTokens: 256_000,
+      maxOutputTokens: 8_192,
+      // Gemma 4 is served on the /openai/v1 path, NOT the default /v1.
+      mantleEndpointPath: '/openai/v1',
+      inputPricePerMillionTokens: 0.14,
+      outputPricePerMillionTokens: 0.4,
+      supportedParams: {
+        params: {
+          temperature: { supported: true, min: 0, max: 2, default: 0.7 },
+          top_p: { supported: true, min: 0, max: 1, default: null },
+          max_tokens: { supported: true, min: 1, max: 8_192, default: 4_096 },
+        },
+      },
+    },
+  },
+];
+
+/**
+ * Provider-keyed lookup for the catalog tabs. Bedrock + Mantle are populated;
  * OpenAI/Gemini are intentional empty arrays — the page renders a
  * 'Coming soon' empty state when the active tab has no entries.
  */
@@ -135,4 +224,5 @@ export const CURATED_MODELS_BY_PROVIDER: Record<ModelProvider, CuratedModel[]> =
   bedrock: CURATED_BEDROCK_MODELS,
   openai: [],
   gemini: [],
+  mantle: CURATED_MANTLE_MODELS,
 };

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -1,12 +1,17 @@
 /**
  * Available model providers.
+ *
+ * `mantle` is Amazon Bedrock Mantle — AWS's OpenAI-compatible inference
+ * surface for Bedrock-hosted open-weight models. It is a distinct provider
+ * from `bedrock` because the backend reaches it over the OpenAI wire
+ * protocol with a bearer token rather than the Converse API.
  */
-export type ModelProvider = 'bedrock' | 'openai' | 'gemini';
+export type ModelProvider = 'bedrock' | 'openai' | 'gemini' | 'mantle';
 
 /**
  * Available model providers as a constant array.
  */
-export const AVAILABLE_PROVIDERS: ModelProvider[] = ['bedrock', 'openai', 'gemini'];
+export const AVAILABLE_PROVIDERS: ModelProvider[] = ['bedrock', 'openai', 'gemini', 'mantle'];
 
 /**
  * Capability + bounds for a single inference parameter.
@@ -93,6 +98,13 @@ export interface ManagedModel {
   supportsCaching: boolean;
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
+  /**
+   * Bedrock Mantle endpoint path (`provider === 'mantle'` only): `/v1`
+   * (OpenAI Chat Completions, the default) or `/openai/v1` (e.g. Gemma 4).
+   * Sourced from the model card — there is no API that exposes it. Null/absent
+   * for every other provider.
+   */
+  mantleEndpointPath?: string | null;
   /** Per-model inference parameter capabilities (temperature, top_p, etc.) */
   supportedParams?: SupportedParams | null;
   /** Date the model was added to the system (ISO string from API) */
@@ -145,9 +157,18 @@ export interface ManagedModelFormData {
   supportsCaching?: boolean;
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
+  /**
+   * Bedrock Mantle endpoint path (`provider === 'mantle'` only): `/v1` or
+   * `/openai/v1`. Inert for other providers.
+   */
+  mantleEndpointPath?: string | null;
   /** Per-model inference parameter capabilities */
   supportedParams?: SupportedParams | null;
 }
+
+/** Selectable Bedrock Mantle endpoint paths for the model form. */
+export const MANTLE_ENDPOINT_PATHS = ['/v1', '/openai/v1'] as const;
+export type MantleEndpointPath = (typeof MANTLE_ENDPOINT_PATHS)[number];
 
 /**
  * Frontend catalog of well-known canonical inference params.
@@ -210,8 +231,9 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
       bedrock: { min: 0, max: 1 },   // Anthropic/Bedrock cap
       openai: { min: 0, max: 2 },    // OpenAI accepts 0–2
       gemini: { min: 0, max: 1 },
+      mantle: { min: 0, max: 2 },    // OpenAI wire protocol range
     },
-    providers: ['bedrock', 'openai', 'gemini'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
   },
   {
     key: 'top_p',
@@ -220,7 +242,7 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     kind: 'number',
     defaultMin: 0,
     defaultMax: 1,
-    providers: ['bedrock', 'openai', 'gemini'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
   },
   {
     key: 'top_k',
@@ -236,7 +258,7 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     description: 'Maximum tokens in the model response.',
     kind: 'integer',
     defaultMin: 1,
-    providers: ['bedrock', 'openai', 'gemini'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
   },
   {
     key: 'thinking',
@@ -263,9 +285,9 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
   {
     key: 'reasoning_effort',
     label: 'Reasoning Effort',
-    description: 'Reasoning depth (OpenAI o-series).',
+    description: 'Reasoning depth (OpenAI o-series and reasoning models on Bedrock Mantle).',
     kind: 'number',
-    providers: ['openai'],
+    providers: ['openai', 'mantle'],
   },
 ];
 

--- a/frontend/ai.client/src/app/admin/manage-models/services/managed-models.service.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/services/managed-models.service.ts
@@ -13,6 +13,26 @@ export interface ManagedModelsListResponse {
 }
 
 /**
+ * A model on Bedrock Mantle's live roster (`GET /admin/mantle/models`).
+ * Mirrors the OpenAI list-models shape the Mantle endpoint speaks.
+ */
+export interface MantleModelSummary {
+  id: string;
+  created?: number | null;
+  ownedBy: string;
+  object?: string | null;
+}
+
+/**
+ * Response model for the Bedrock Mantle browse endpoint.
+ */
+export interface MantleModelsResponse {
+  models: MantleModelSummary[];
+  region: string;
+  totalCount: number;
+}
+
+/**
  * Service to manage the list of models that have been added to the system.
  * This service maintains the state of managed models and provides utilities
  * to check if a model has already been added.
@@ -78,6 +98,24 @@ export class ManagedModelsService {
     } catch (error) {
       throw error;
     }
+  }
+
+  /**
+   * Fetch the live Bedrock Mantle roster for the deployment's region.
+   *
+   * Unlike the curated catalog, Mantle's available models are discovered
+   * server-side (the backend authenticates against the regional Mantle
+   * endpoint with an IAM-derived bearer token).
+   *
+   * @returns Promise resolving to MantleModelsResponse
+   * @throws Error if the API request fails or user lacks admin privileges
+   */
+  async fetchMantleModels(): Promise<MantleModelsResponse> {
+    return firstValueFrom(
+      this.http.get<MantleModelsResponse>(
+        `${this.config.appApiUrl()}/admin/mantle/models`
+      )
+    );
   }
 
   /**

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -405,6 +405,30 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Bedrock Mantle model browsing ──
+  // GET /admin/mantle/models authenticates against the OpenAI-compatible
+  // Bedrock Mantle endpoint with a short-term bearer token presigned by this
+  // role (apis/shared/bedrock/bearer_token.py). Mantle has its OWN IAM
+  // service namespace — `bedrock-mantle:*`, NOT `bedrock:*`. Listing models
+  // needs the Get/List actions on the project resource plus the bearer-token
+  // transport on `*` (read-only subset of AmazonBedrockMantleInferenceAccess).
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'BedrockMantleList',
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock-mantle:Get*', 'bedrock-mantle:List*'],
+      resources: [`arn:aws:bedrock-mantle:*:${cdk.Stack.of(scope).account}:project/*`],
+    }),
+  );
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'BedrockMantleCallWithBearerToken',
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock-mantle:CallWithBearerToken'],
+      resources: ['*'],
+    }),
+  );
+
   // ── SSM read for inference-api image tag (runtime endpoint resolution) ──
   taskRole.addToPrincipalPolicy(
     new iam.PolicyStatement({

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -82,6 +82,31 @@ export function createRuntimeExecutionRole(
     resources: [`arn:aws:bedrock:*::foundation-model/*`, `arn:aws:bedrock:${config.awsRegion}:${config.awsAccount}:*`],
   }));
 
+  // ── Bedrock Mantle inference ──
+  // Managed models with provider="mantle" run through Bedrock Mantle's
+  // OpenAI-compatible endpoint. The agent factory presigns a short-term
+  // bearer token with this role (apis/shared/bedrock/bearer_token.py).
+  //
+  // Mantle has its OWN IAM service namespace — `bedrock-mantle:*`, NOT
+  // `bedrock:*`. These statements mirror the AWS managed policy
+  // AmazonBedrockMantleInferenceAccess: chat completions need
+  // bedrock-mantle:CreateInference (plus Get/List) on the project resource,
+  // and the bearer-token transport is authorized separately on `*`.
+  // NOTE: this only takes effect once Bedrock Mantle is ENABLED for the
+  // account in the target region — IAM alone can't grant a disabled service.
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'BedrockMantleInference',
+    effect: iam.Effect.ALLOW,
+    actions: ['bedrock-mantle:CreateInference', 'bedrock-mantle:Get*', 'bedrock-mantle:List*'],
+    resources: [`arn:aws:bedrock-mantle:*:${config.awsAccount}:project/*`],
+  }));
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'BedrockMantleCallWithBearerToken',
+    effect: iam.Effect.ALLOW,
+    actions: ['bedrock-mantle:CallWithBearerToken'],
+    resources: ['*'],
+  }));
+
   // ── AWS Marketplace (model subscription validation) ──
   role.addToPolicy(new iam.PolicyStatement({
     sid: 'MarketplaceModelAccess',

--- a/infrastructure/test/integration.test.ts
+++ b/infrastructure/test/integration.test.ts
@@ -87,6 +87,42 @@ describe('Single-stack integration', () => {
       });
     });
 
+    it('grants bedrock-mantle:CallWithBearerToken for Bedrock Mantle (runtime + app-api)', () => {
+      // Bedrock Mantle (the OpenAI-compatible Bedrock surface) has its own
+      // IAM service namespace — `bedrock-mantle:*`, NOT `bedrock:*`. It
+      // authenticates with a presigned bearer token; the service authorizes
+      // the signer against bedrock-mantle:CallWithBearerToken. The runtime
+      // role needs it for mantle-provider inference, the app-api task role
+      // for the GET /admin/mantle/models browse endpoint. Both statements
+      // carry the same Sid, so assert the shape appears at least twice.
+      const statementsOf = (resources: Record<string, any>) =>
+        Object.values(resources).flatMap((res: any) => [
+          ...(res.Properties?.PolicyDocument?.Statement ?? []),
+          ...(res.Properties?.Policies ?? []).flatMap(
+            (p: any) => p.PolicyDocument?.Statement ?? [],
+          ),
+        ]);
+      const allStatements = [
+        ...statementsOf(template.findResources('AWS::IAM::Policy')),
+        ...statementsOf(template.findResources('AWS::IAM::ManagedPolicy')),
+        ...statementsOf(template.findResources('AWS::IAM::Role')),
+      ];
+      const bearerStatements = allStatements.filter(
+        (stmt: any) => stmt.Sid === 'BedrockMantleCallWithBearerToken',
+      );
+      expect(bearerStatements.length).toBeGreaterThanOrEqual(2);
+      for (const stmt of bearerStatements) {
+        expect(stmt.Action).toBe('bedrock-mantle:CallWithBearerToken');
+        expect(stmt.Resource).toBe('*');
+      }
+      // The runtime role must also be able to create inferences.
+      const inferenceStatement = allStatements.find(
+        (stmt: any) => stmt.Sid === 'BedrockMantleInference',
+      );
+      expect(inferenceStatement).toBeDefined();
+      expect(inferenceStatement.Action).toContain('bedrock-mantle:CreateInference');
+    });
+
     it('creates the AgentCore Memory + CI + Browser + Gateway', () => {
       template.resourceCountIs('AWS::BedrockAgentCore::Memory', 1);
       template.resourceCountIs('AWS::BedrockAgentCore::CodeInterpreterCustom', 1);


### PR DESCRIPTION
## Overview

Adds **Amazon Bedrock Mantle** as a first-class model provider. Mantle is AWS's OpenAI-compatible inference surface for Bedrock-hosted open-weight models (Qwen, GPT-OSS, Gemma, DeepSeek, …). It's distinct from the existing `bedrock` provider because it speaks the **OpenAI wire protocol with a short-term bearer token**, not the Converse API with SigV4.

Admins can now **browse** Mantle models and **add** them via curated quick-add cards (with a manual escape-hatch form), and users can chat with them like any other managed model.

## What's included

**Backend (`feat(models)`)**
- `apis/shared/bedrock/bearer_token.py` — SigV4-presigned `CallWithBearerToken` bearer token, ported inline from `aws-bedrock-token-generator` (**no new dependency**), plus a region+path base-URL helper.
- `GET /admin/mantle/models` — browse the live regional Mantle roster via the OpenAI SDK.
- `ModelProvider.MANTLE` threaded end to end: `model_config` translation → `agent_factory` builds a Strands `OpenAIModel` against the Mantle base URL → `BaseAgent` + inference chat pipeline.
- **`mantle_endpoint_path`** on the managed-model shape, persisted and resolved server-authoritatively in `_resolve_model_settings`, and carried through the paused-turn snapshot for resume correctness.

**Infra (`feat(infra)`)**
- Grants the **`bedrock-mantle:*`** IAM namespace (mirrors AWS-managed `AmazonBedrockMantleInferenceAccess`): `CreateInference` + `Get*`/`List*` + `CallWithBearerToken` on the runtime role; read-only + `CallWithBearerToken` on the app-API task role.

**Frontend (`feat(spa)`)**
- A **Bedrock Mantle** catalog tab with curated cards (Qwen3 Coder 30B on `/v1`, Gemma 4 31B on `/openai/v1`), a Mantle-aware model form (endpoint-path selector, caching hidden, model-id datalist seeded from the live roster).

## Key design decisions

- **The endpoint path is recorded, not discovered.** Mantle serves different models on different OpenAI-compatible paths (`/v1` vs `/openai/v1`) and exposes **no API** to tell you which — verified against both the data plane (`/v1/models` returns only `{id, created, object, owned_by}`) and the absence of a `bedrock-mantle` boto3 control-plane client. We rejected both a maintained code-level mapping and runtime probing in favor of storing the path per model (sourced from the AWS model card, baked into curated cards, admin-settable in the escape hatch). The wrong path returns a misleading `401 "not enabled for this account"` at chat time, so this matters.
- **Caching is intentionally off for Mantle.** Prompt caching on Bedrock is model-bound to Anthropic Claude + a few Amazon Nova models, none of which run through the Mantle provider. (Claude/Nova continue to use the `bedrock` provider where `CacheConfig` caching already works.)
- **Curated-card data is verified**: pricing against the AWS Bedrock pricing page (2026-06); modalities/capabilities/context/path against each model card.

## Reviewer notes / deploy

- **Two preconditions for cloud:** (1) Bedrock Mantle must be **enabled for the account** in the target region (an AWS-console action, not a deploy); (2) `platform.yml` must deploy the `bedrock-mantle:*` IAM before inference works in cloud. Verified end-to-end locally against `us-west-2` (token mint → `/v1/models` → chat completions on both `/v1` and `/openai/v1`).
- **Known Gemma-4 behavior** (Chat Completions path): reasoning happens but its trace isn't returned (Responses-API only), and parallel tool calls aren't supported (one per turn).
- **Follow-up (not in this PR):** expose `reasoning_effort` as a tunable for Gemma — needs a small shared-catalog fix (`number` → `select`).

## Testing

- Backend: **3861 passed**, 3 skipped
- Frontend: **1216 passed**
- Infra: `tsc` clean, integration **24 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
