### PR TITLE
fix(backup/restore): include S3 Vectors index in the snapshot loop

### DIFF
--- a/scripts/backup-data/backup.py
+++ b/scripts/backup-data/backup.py
@@ -103,6 +103,25 @@ S3_BUCKETS: list[dict[str, Any]] = [
     {"logical": "fine-tuning-data",     "ssm": "/fine-tuning/data-bucket-name",         "optional": True},
 ]
 
+# S3 Vectors indexes. Distinct from S3_BUCKETS because S3 Vectors is a
+# separate AWS service (`AWS::S3Vectors::*` / boto3 `s3vectors` client) —
+# `aws s3 sync` cannot reach the vectors and `list_objects_v2` won't see
+# them. Each entry is backed up via `s3vectors.list_vectors` paginated
+# enumeration and replayed on restore via `s3vectors.put_vectors`.
+#
+# The vector index backs the assistants RAG knowledge base:
+# `bedrock_embeddings.search_assistant_knowledgebase` issues
+# `query_vectors(filter={"assistant_id": ...})` against this index, so an
+# empty index post-restore = silently broken RAG even though the DDB
+# document metadata and S3 originals are intact. See
+# `tests/supply_chain/test_backup_coverage.py::TestBackupCoversVectorIndexes`
+# for the canary that enforces this list stays in sync with CDK.
+VECTOR_INDEXES: list[dict[str, Any]] = [
+    {"logical": "rag-vectors",
+     "bucket_ssm": "/rag/vector-bucket-name",
+     "index_ssm":  "/rag/vector-index-name"},
+]
+
 SSM_USER_POOL_ID = "/auth/cognito/user-pool-id"
 SSM_MEMORY_ID = "/inference-api/memory-id"
 
@@ -432,6 +451,98 @@ def backup_s3_bucket(ctx: BackupContext, logical: str, source_bucket: str) -> Co
             error=f"Destination count {dest_count} < source count {obj_count}",
         )
     return ComponentResult("s3", logical, "ok", detail=detail)
+
+
+# --------------------------------------------------------------------------- #
+# S3 Vectors                                                                  #
+# --------------------------------------------------------------------------- #
+def backup_vector_index(
+    ctx: BackupContext,
+    logical: str,
+    vector_bucket: str,
+    index_name: str,
+) -> ComponentResult:
+    """Snapshot every vector in an S3 Vectors index to a gzipped JSONL.
+
+    Calls `s3vectors.list_vectors(returnData=True, returnMetadata=True)` in
+    a paginated loop, streaming each `(key, data, metadata)` triple to
+    `vectors/{logical}.jsonl.gz` in the backup bucket. The output format
+    is byte-for-byte compatible with `s3vectors.put_vectors` on restore —
+    each line is a JSON object that can be passed straight to the
+    `vectors=[...]` argument.
+
+    The API surface used here is documented at:
+      https://docs.aws.amazon.com/cli/latest/reference/s3vectors/list-vectors.html
+
+    Permissions required (granted by the backup workflow's IAM role):
+      - s3vectors:ListVectors
+      - s3vectors:GetVectors  (needed when returnData/returnMetadata=true)
+    """
+    s3vectors = ctx.session.client("s3vectors", config=BOTO_CONFIG)
+
+    detail: dict[str, Any] = {
+        "vector_bucket": vector_bucket,
+        "index_name": index_name,
+        "destination_key": f"s3://{ctx.bucket}/{ctx.root_prefix}/vectors/{logical}.jsonl.gz",
+    }
+
+    if ctx.dry_run:
+        try:
+            # Cheap probe to confirm the index exists / is reachable.
+            probe = s3vectors.list_vectors(
+                vectorBucketName=vector_bucket,
+                indexName=index_name,
+                maxResults=1,
+            )
+            detail["probe_vector_count"] = len(probe.get("vectors", []))
+        except ClientError as exc:
+            return ComponentResult(
+                "vectors", logical, "failed",
+                detail=detail,
+                error=f"ListVectors probe: {exc.response.get('Error', {}).get('Code')}",
+            )
+        return ComponentResult("vectors", logical, "skipped",
+                               detail={**detail, "reason": "dry-run"})
+
+    rel_key = f"vectors/{logical}.jsonl.gz"
+    vector_count = 0
+    next_token: str | None = None
+
+    try:
+        with _GzS3Writer(ctx, rel_key) as writer:
+            while True:
+                kwargs: dict[str, Any] = {
+                    "vectorBucketName": vector_bucket,
+                    "indexName": index_name,
+                    "returnData": True,
+                    "returnMetadata": True,
+                }
+                if next_token is not None:
+                    kwargs["nextToken"] = next_token
+                resp = s3vectors.list_vectors(**kwargs)
+                for v in resp.get("vectors", []):
+                    # The list_vectors response shape:
+                    #   {"key": str, "data": {"float32": [floats]},
+                    #    "metadata": <document>}
+                    # — exactly the shape put_vectors accepts on restore.
+                    writer.write(
+                        (json.dumps(_scrub_datetimes(v), separators=(",", ":")) + "\n").encode("utf-8")
+                    )
+                    vector_count += 1
+                next_token = resp.get("nextToken")
+                if not next_token:
+                    break
+    except ClientError as exc:
+        return ComponentResult(
+            "vectors", logical, "failed",
+            detail=detail,
+            error=f"ListVectors: {exc.response.get('Error', {}).get('Code')}",
+        )
+
+    detail["vector_count"] = vector_count
+    LOG.info("Backed up %d vectors from %s/%s → %s",
+             vector_count, vector_bucket, index_name, rel_key)
+    return ComponentResult("vectors", logical, "ok", detail=detail)
 
 
 # --------------------------------------------------------------------------- #
@@ -835,6 +946,30 @@ def run(ctx: BackupContext) -> int:
                    for lg, nm in s3_targets}
         for fut in as_completed(futures):
             ctx.results.append(fut.result())
+
+    # ---- S3 Vectors indexes (sequential — usually 1 index, paginated API) ----
+    for cfg in VECTOR_INDEXES:
+        logical = cfg["logical"]
+        bucket_path = f"/{ctx.project_prefix}{cfg['bucket_ssm']}"
+        index_path = f"/{ctx.project_prefix}{cfg['index_ssm']}"
+        vector_bucket = get_ssm_param(ctx.session, bucket_path)
+        index_name = get_ssm_param(ctx.session, index_path)
+        if not vector_bucket or not index_name:
+            if cfg.get("optional"):
+                ctx.results.append(ComponentResult(
+                    "vectors", logical, "skipped",
+                    detail={"bucket_ssm": bucket_path, "index_ssm": index_path,
+                            "reason": "optional, not present"},
+                ))
+            else:
+                ctx.results.append(ComponentResult(
+                    "vectors", logical, "failed",
+                    detail={"bucket_ssm": bucket_path, "index_ssm": index_path},
+                    error="Required SSM parameters not found "
+                          "(both bucket-name and index-name must be published)",
+                ))
+            continue
+        ctx.results.append(backup_vector_index(ctx, logical, vector_bucket, index_name))
 
     # ---- Cognito ----
     user_pool_id = get_ssm_param(ctx.session, f"/{ctx.project_prefix}{SSM_USER_POOL_ID}")

--- a/scripts/restore-data/restore.py
+++ b/scripts/restore-data/restore.py
@@ -117,6 +117,17 @@ BUCKET_SSM_MAP: dict[str, str] = {
     "fine-tuning-data":  "/fine-tuning/data-bucket-name",
 }
 
+# S3 Vectors indexes. Mirrors `VECTOR_INDEXES` in scripts/backup-data/backup.py.
+# Each entry maps a logical name to the SSM paths that hold the target
+# bucket name and index name on the destination platform. The backup
+# component layout is `vectors/{logical}.jsonl.gz` and the restore step
+# replays those vectors via `s3vectors.put_vectors`.
+VECTOR_INDEXES: list[dict[str, str]] = [
+    {"logical": "rag-vectors",
+     "bucket_ssm": "/rag/vector-bucket-name",
+     "index_ssm":  "/rag/vector-index-name"},
+]
+
 SSM_USER_POOL_ID = "/auth/cognito/user-pool-id"
 SSM_MEMORY_ID = "/inference-api/memory-id"
 
@@ -512,6 +523,120 @@ def _compute_created_username(
     seed = f"{first.get('providerName', '')}/{first.get('userId', '')}".encode("utf-8")
     digest = hashlib.sha256(seed).hexdigest()[:16]
     return f"migrated-{digest}"
+
+
+# --------------------------------------------------------------------------- #
+# S3 Vectors restore                                                          #
+# --------------------------------------------------------------------------- #
+def restore_vector_index(ctx: RestoreContext, logical_name: str) -> dict:
+    """Replay backed-up vectors into the target S3 Vectors index.
+
+    Reads `vectors/{logical}.jsonl.gz` from the backup bucket — written by
+    `scripts/backup-data/backup.py::backup_vector_index` — and pushes each
+    record back into the destination index via `s3vectors.put_vectors`.
+    Each line of the file is a JSON object with the exact shape
+    put_vectors accepts:
+        {"key": str, "data": {"float32": [floats]}, "metadata": {...}}
+
+    `put_vectors` is an upsert keyed on `key`, so this function is
+    idempotent on re-run: a partially-completed previous restore can be
+    resumed by re-invoking the script. We also tolerate the backup file
+    being missing (older backups predate the vectors backup feature):
+    in that case we return a `skipped` status with a clear reason rather
+    than failing the whole restore.
+
+    Batch size matches `bedrock_embeddings.store_embeddings_in_s3`'s
+    BATCH_SIZE=50, which is the safe upper bound for the S3 Vectors
+    PutVectors request body limit.
+    """
+    # Find the matching backup-side config to know which SSM paths to look up.
+    cfg = next((c for c in VECTOR_INDEXES if c["logical"] == logical_name), None)
+    if cfg is None:
+        return {"logical": logical_name, "status": "skipped",
+                "reason": "no matching VECTOR_INDEXES entry"}
+
+    target_bucket = get_ssm_param(ctx.session, ctx.target_prefix, cfg["bucket_ssm"])
+    target_index = get_ssm_param(ctx.session, ctx.target_prefix, cfg["index_ssm"])
+    if not target_bucket or not target_index:
+        return {"logical": logical_name, "status": "skipped",
+                "reason": "target vector bucket/index not found via SSM"}
+
+    root_prefix = ctx.manifest.get("root_prefix", "")
+    if root_prefix and not root_prefix.endswith("/"):
+        root_prefix = root_prefix + "/"
+    backup_key = f"{root_prefix}vectors/{logical_name}.jsonl.gz"
+
+    s3 = ctx.session.client("s3", config=BOTO_CONFIG)
+    try:
+        obj = s3.get_object(Bucket=ctx.backup_bucket, Key=backup_key)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            return {"logical": logical_name, "status": "skipped",
+                    "reason": f"no vectors backup file at {backup_key} "
+                              "(backup may pre-date vectors support)"}
+        return {"logical": logical_name, "status": "failed",
+                "error": f"GetObject {backup_key}: {e}"}
+
+    body = gzip.decompress(obj["Body"].read())
+    if not body.strip():
+        return {"logical": logical_name, "status": "ok",
+                "vectors_written": 0, "target_bucket": target_bucket,
+                "target_index": target_index,
+                "reason": "backup file empty"}
+
+    if ctx.dry_run:
+        line_count = sum(1 for line in body.decode("utf-8").splitlines() if line.strip())
+        return {"logical": logical_name, "status": "skipped",
+                "reason": "dry-run", "vectors_in_backup": line_count}
+
+    s3vectors = ctx.session.client("s3vectors", config=BOTO_CONFIG)
+    BATCH_SIZE = 50
+    batch: list[dict[str, Any]] = []
+    vectors_written = 0
+    batches_sent = 0
+
+    def _flush() -> None:
+        nonlocal batch, vectors_written, batches_sent
+        if not batch:
+            return
+        s3vectors.put_vectors(
+            vectorBucketName=target_bucket,
+            indexName=target_index,
+            vectors=batch,
+        )
+        vectors_written += len(batch)
+        batches_sent += 1
+        batch = []
+
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError as parse_err:
+            LOG.warning(f"[Vectors] {logical_name}: skipping malformed line: {parse_err}")
+            continue
+        # Defensive shape validation — the line must have key + data + metadata
+        # in the put_vectors-compatible form. metadata is permitted to be
+        # absent/None on the live API but we backed up returnMetadata=True
+        # so it should always be present.
+        if "key" not in record or "data" not in record:
+            LOG.warning(f"[Vectors] {logical_name}: skipping record missing 'key' or 'data'")
+            continue
+        batch.append(record)
+        if len(batch) >= BATCH_SIZE:
+            _flush()
+
+    _flush()
+
+    LOG.info(f"[Vectors] {logical_name}: wrote {vectors_written} vectors "
+             f"to {target_bucket}/{target_index} ({batches_sent} batches)")
+    return {"logical": logical_name, "status": "ok",
+            "vectors_written": vectors_written,
+            "batches_sent": batches_sent,
+            "target_bucket": target_bucket,
+            "target_index": target_index}
 
 
 # --------------------------------------------------------------------------- #
@@ -1330,6 +1455,31 @@ def run_restore(ctx: RestoreContext) -> dict:
             continue
         result = restore_s3_bucket(ctx, comp["logical_name"], comp)
         ctx.results.append(result)
+
+    # --- S3 Vectors ---
+    # Runs after the S3 documents bucket so the on-disk originals exist
+    # before the assistants RAG knowledge base goes live. Vectors are an
+    # entirely separate AWS service from regular S3, hence its own step.
+    # The backup may pre-date vectors support (older snapshots before
+    # PR #N), in which case each entry skips cleanly with a clear reason.
+    vector_components = components.get("vectors", [])
+    if vector_components:
+        LOG.info(f"Restoring {len(vector_components)} S3 Vectors index(es)...")
+        for comp in vector_components:
+            if comp.get("status") != "ok":
+                ctx.results.append({"logical": comp["logical_name"], "status": "skipped",
+                                    "reason": "backup status was not ok"})
+                continue
+            result = restore_vector_index(ctx, comp["logical_name"])
+            ctx.results.append(result)
+    else:
+        # Older backup with no vectors component at all. Try the
+        # configured indexes anyway — restore_vector_index() will skip
+        # cleanly if the corresponding backup file isn't present.
+        LOG.info("No vectors component in manifest; probing configured indexes "
+                 "(harmless skip if backup pre-dates vectors support)")
+        for cfg in VECTOR_INDEXES:
+            ctx.results.append(restore_vector_index(ctx, cfg["logical"]))
 
     # --- AgentCore Memory ---
     # Runs after Cognito (so sub_map is populated for actorId remap) AND

--- a/scripts/restore-data/test_restore.py
+++ b/scripts/restore-data/test_restore.py
@@ -1470,3 +1470,231 @@ def test_cognito_federated_user_idempotent_rerun_uses_migrated_username():
 
     # Sub map records old → existing-on-rerun.
     assert ctx.sub_map == {"OLD-SUB-UUID": "EXISTING-SUB"}
+
+
+# --------------------------------------------------------------------------- #
+# S3 Vectors restore                                                          #
+# --------------------------------------------------------------------------- #
+def _vectors_jsonl_gz(records: list[dict]) -> bytes:
+    """Helper: build a gzipped JSONL body from a list of put_vectors records."""
+    body = "\n".join(json.dumps(r) for r in records).encode("utf-8")
+    return gzip.compress(body)
+
+
+def test_restore_vector_index_replays_via_put_vectors():
+    """Backed-up vectors must be re-pushed to the target index in batches
+    of 50 (matching bedrock_embeddings.store_embeddings_in_s3.BATCH_SIZE).
+    Each record's key/data/metadata must round-trip 1:1."""
+    records = [
+        {
+            "key": f"doc-1#{i}",
+            "data": {"float32": [0.1 * i, 0.2 * i, 0.3 * i]},
+            "metadata": {"text": f"chunk {i}", "assistant_id": "ast-abc",
+                         "document_id": "doc-1", "source": "report.pdf"},
+        }
+        for i in range(125)  # > 2 batches of 50 to confirm flushing logic
+    ]
+    body = _vectors_jsonl_gz(records)
+
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": io.BytesIO(body)}
+    s3vectors = MagicMock()
+    s3vectors.put_vectors.return_value = {}
+
+    def client_factory(name, *_a, **_kw):
+        if name == "s3":
+            return s3
+        if name == "s3vectors":
+            return s3vectors
+        return MagicMock()
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    def fake_get(_session, _prefix, ssm_path):
+        if ssm_path.endswith("/vector-bucket-name"):
+            return "target-vector-bucket"
+        if ssm_path.endswith("/vector-index-name"):
+            return "target-vector-index"
+        return None
+
+    with patch.object(restore, "get_ssm_param", side_effect=fake_get):
+        result = restore.restore_vector_index(ctx, "rag-vectors")
+
+    assert result["status"] == "ok"
+    assert result["vectors_written"] == 125
+    # 125 records / 50 batch = 3 batches (50 + 50 + 25)
+    assert result["batches_sent"] == 3
+    assert result["target_bucket"] == "target-vector-bucket"
+    assert result["target_index"] == "target-vector-index"
+
+    # Verify put_vectors was called 3 times with the right batch sizes
+    assert s3vectors.put_vectors.call_count == 3
+    sizes = [len(c.kwargs["vectors"]) for c in s3vectors.put_vectors.call_args_list]
+    assert sizes == [50, 50, 25]
+    # Bucket + index args constant across calls
+    for c in s3vectors.put_vectors.call_args_list:
+        assert c.kwargs["vectorBucketName"] == "target-vector-bucket"
+        assert c.kwargs["indexName"] == "target-vector-index"
+    # First record matches the input shape exactly (1:1 round-trip)
+    first_pushed = s3vectors.put_vectors.call_args_list[0].kwargs["vectors"][0]
+    assert first_pushed == records[0]
+
+
+def test_restore_vector_index_skips_when_backup_file_missing():
+    """Older backups (pre-vectors-support) won't have vectors/*.jsonl.gz.
+    Restore must skip cleanly with a clear reason rather than failing."""
+    from botocore.exceptions import ClientError as _CE
+    s3 = MagicMock()
+    s3.get_object.side_effect = _CE(
+        {"Error": {"Code": "NoSuchKey"}}, "GetObject",
+    )
+    s3vectors = MagicMock()
+
+    def client_factory(name, *_a, **_kw):
+        if name == "s3":
+            return s3
+        if name == "s3vectors":
+            return s3vectors
+        return MagicMock()
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    def fake_get(_session, _prefix, ssm_path):
+        if ssm_path.endswith("/vector-bucket-name"):
+            return "target-vector-bucket"
+        if ssm_path.endswith("/vector-index-name"):
+            return "target-vector-index"
+        return None
+
+    with patch.object(restore, "get_ssm_param", side_effect=fake_get):
+        result = restore.restore_vector_index(ctx, "rag-vectors")
+
+    assert result["status"] == "skipped"
+    assert "no vectors backup file" in result["reason"]
+    s3vectors.put_vectors.assert_not_called()
+
+
+def test_restore_vector_index_skips_when_target_bucket_missing():
+    """If the target platform doesn't publish the vector-bucket-name SSM
+    (e.g. RAG disabled in this prefix), skip gracefully without making
+    any AWS calls beyond the SSM lookup."""
+    s3 = MagicMock()
+    s3vectors = MagicMock()
+
+    def client_factory(name, *_a, **_kw):
+        if name == "s3":
+            return s3
+        if name == "s3vectors":
+            return s3vectors
+        return MagicMock()
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    with patch.object(restore, "get_ssm_param", return_value=None):
+        result = restore.restore_vector_index(ctx, "rag-vectors")
+
+    assert result["status"] == "skipped"
+    assert "vector bucket/index not found" in result["reason"]
+    s3.get_object.assert_not_called()
+    s3vectors.put_vectors.assert_not_called()
+
+
+def test_restore_vector_index_dry_run_does_not_call_put_vectors():
+    """Dry run must report what *would* be restored without making any
+    s3vectors API calls."""
+    records = [
+        {"key": f"k{i}", "data": {"float32": [0.0]}, "metadata": {}}
+        for i in range(7)
+    ]
+    body = _vectors_jsonl_gz(records)
+
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": io.BytesIO(body)}
+    s3vectors = MagicMock()
+
+    def client_factory(name, *_a, **_kw):
+        if name == "s3":
+            return s3
+        if name == "s3vectors":
+            return s3vectors
+        return MagicMock()
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=True)
+    ctx.session.client.side_effect = client_factory
+
+    def fake_get(_session, _prefix, ssm_path):
+        if ssm_path.endswith("/vector-bucket-name"):
+            return "target-bucket"
+        if ssm_path.endswith("/vector-index-name"):
+            return "target-index"
+        return None
+
+    with patch.object(restore, "get_ssm_param", side_effect=fake_get):
+        result = restore.restore_vector_index(ctx, "rag-vectors")
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "dry-run"
+    assert result["vectors_in_backup"] == 7
+    s3vectors.put_vectors.assert_not_called()
+
+
+def test_restore_vector_index_idempotent_on_rerun_via_put_vectors_upsert():
+    """put_vectors keyed on `key` is an upsert in S3 Vectors — re-running
+    the restore should call put_vectors with the SAME records again
+    without raising. The test exercises that path."""
+    records = [
+        {"key": "doc-1#0", "data": {"float32": [0.1]}, "metadata": {"a": 1}},
+    ]
+    body = _vectors_jsonl_gz(records)
+
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": io.BytesIO(body)}
+    s3vectors = MagicMock()
+    s3vectors.put_vectors.return_value = {}
+
+    def client_factory(name, *_a, **_kw):
+        if name == "s3":
+            return s3
+        if name == "s3vectors":
+            return s3vectors
+        return MagicMock()
+
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    ctx.session.client.side_effect = client_factory
+
+    with patch.object(restore, "get_ssm_param", return_value="target"):
+        # Need to return a non-None for both bucket and index lookups —
+        # the side-effect form would be cleaner but a plain return value
+        # is enough here since both lookups expect a string.
+        r1 = restore.restore_vector_index(ctx, "rag-vectors")
+
+    # Re-run — same input, fresh body (S3 Body is a one-shot stream)
+    s3.get_object.return_value = {"Body": io.BytesIO(body)}
+    with patch.object(restore, "get_ssm_param", return_value="target"):
+        r2 = restore.restore_vector_index(ctx, "rag-vectors")
+
+    assert r1["status"] == "ok" and r2["status"] == "ok"
+    assert s3vectors.put_vectors.call_count == 2
+    # Both calls had the same vectors payload
+    assert (
+        s3vectors.put_vectors.call_args_list[0].kwargs["vectors"]
+        == s3vectors.put_vectors.call_args_list[1].kwargs["vectors"]
+    )
+
+
+def test_restore_vector_index_skips_unknown_logical_name():
+    """Defensive: if a manifest references a logical name that's not in
+    VECTOR_INDEXES, skip cleanly without crashing."""
+    ctx = _make_ctx({"root_prefix": "root"}, dry_run=False)
+    result = restore.restore_vector_index(ctx, "nonexistent-vector-store")
+    assert result["status"] == "skipped"
+    assert "no matching VECTOR_INDEXES entry" in result["reason"]
+
+
+def test_restore_vector_index_in_vector_indexes_constant():
+    """The known live deployment uses the `rag-vectors` logical name."""
+    logicals = {c["logical"] for c in restore.VECTOR_INDEXES}
+    assert "rag-vectors" in logicals

--- a/tests/supply_chain/test_backup_coverage.py
+++ b/tests/supply_chain/test_backup_coverage.py
@@ -74,14 +74,33 @@ def extract_bucket_names_from_constructs() -> set[str]:
 
 
 def extract_backup_tables() -> set[str]:
-    """Parse the backup script to find which tables it backs up."""
+    """Parse the backup script to find which tables it backs up.
+
+    Section-aware: only reads logical names from DYNAMODB_TABLES,
+    DYNAMODB_TABLES_BY_CONVENTION, and DYNAMODB_TABLES_EPHEMERAL —
+    not from S3_BUCKETS or VECTOR_INDEXES (which also use the
+    "logical": key).
+    """
     content = BACKUP_SCRIPT.read_text()
     tables = set()
-
-    # Match "logical": "xxx" entries in DYNAMODB_TABLES and DYNAMODB_TABLES_BY_CONVENTION
-    for match in re.finditer(r'"logical":\s*"([^"]+)"', content):
-        tables.add(match.group(1))
-
+    section_starts = ("DYNAMODB_TABLES", "DYNAMODB_TABLES_BY_CONVENTION",
+                      "DYNAMODB_TABLES_EPHEMERAL")
+    in_table_section = False
+    for line in content.split("\n"):
+        if any(s in line for s in section_starts) and "list[" in line:
+            in_table_section = True
+            continue
+        if in_table_section:
+            if line.strip() == "]" or (
+                line.strip()
+                and not line.startswith(" ")
+                and not line.startswith("{")
+            ):
+                in_table_section = False
+                continue
+            match = re.search(r'"logical":\s*"([^"]+)"', line)
+            if match:
+                tables.add(match.group(1))
     return tables
 
 
@@ -123,6 +142,66 @@ def extract_restore_tables() -> set[str]:
                 tables.add(match.group(1))
 
     return tables
+
+
+def extract_vector_indexes_from_constructs() -> set[str]:
+    """Scan all construct .ts files for AWS::S3Vectors::Index resources.
+
+    Vector indexes are declared as:
+        new CfnResource(this, '<id>', {
+          type: 'AWS::S3Vectors::Index',
+          properties: { VectorBucketName: ..., IndexName: ..., ... },
+        });
+
+    The "logical name" we care about for backup coverage is the
+    `IndexName` value, which goes through `getResourceName(config, 'X-...')`.
+    For coverage purposes we care that *every* CDK-defined index is
+    represented in `VECTOR_INDEXES` of backup.py. Returns the set of
+    construct id substrings (e.g. "rag-vector") so the assertion is
+    robust against `getResourceName` versioning suffixes.
+    """
+    indexes = set()
+    for ts_file in CONSTRUCTS_DIR.rglob("*.ts"):
+        if ".d.ts" in ts_file.name:
+            continue
+        content = ts_file.read_text()
+        # Find every "AWS::S3Vectors::Index" type declaration
+        for match in re.finditer(
+            r"type:\s*'AWS::S3Vectors::Index'", content
+        ):
+            # Walk backward to find the construct id from `new CfnResource(this, '<id>'`
+            preceding = content[: match.start()]
+            id_match = re.search(
+                r"new CfnResource\([^,]+,\s*'([^']+)'\s*,\s*\{[^}]*$",
+                preceding,
+                re.DOTALL,
+            )
+            if id_match:
+                # Construct id like 'RagVectorIndex' → normalize for matching
+                indexes.add(id_match.group(1).lower())
+    return indexes
+
+
+def extract_backup_vector_indexes() -> set[str]:
+    """Parse backup.py's VECTOR_INDEXES list for logical names."""
+    content = BACKUP_SCRIPT.read_text()
+    indexes = set()
+    in_section = False
+    for line in content.split("\n"):
+        if "VECTOR_INDEXES" in line and "list[" in line:
+            in_section = True
+            continue
+        if in_section:
+            if line.strip() == "]" or (
+                line.strip()
+                and not line.startswith(" ")
+                and not line.startswith("{")
+            ):
+                break
+            match = re.search(r'"logical":\s*"([^"]+)"', line)
+            if match:
+                indexes.add(match.group(1))
+    return indexes
 
 
 # ============================================================
@@ -302,3 +381,76 @@ class TestRestoreIsIdempotent:
     def test_has_dry_run(self):
         content = RESTORE_SCRIPT.read_text()
         assert "--dry-run" in content
+
+
+class TestBackupCoversVectorIndexes:
+    """Every AWS::S3Vectors::Index in the CDK constructs must be backed up.
+
+    S3 Vectors is a *separate AWS service* from regular S3 — the
+    `s3vectors` boto3 client + `AWS::S3Vectors::*` CFN types — so
+    `aws s3 sync` cannot reach the embeddings stored in a vector index.
+    Without an explicit backup step that calls `s3vectors.list_vectors`,
+    the index is silently dropped through teardown→redeploy→restore: the
+    DDB document metadata and the originals in the rag-documents bucket
+    are restored, but the vector index ends up empty and assistant RAG
+    queries return zero hits.
+
+    See also:
+      scripts/backup-data/backup.py::VECTOR_INDEXES
+      scripts/backup-data/backup.py::backup_vector_index
+      scripts/restore-data/restore.py::restore_vector_index
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.cdk_indexes = extract_vector_indexes_from_constructs()
+        self.backup_indexes = extract_backup_vector_indexes()
+        self.restore_content = RESTORE_SCRIPT.read_text()
+        self.backup_content = BACKUP_SCRIPT.read_text()
+
+    def test_at_least_one_vector_index_in_cdk(self):
+        """Sanity: the rag-data construct should declare a vector index."""
+        assert len(self.cdk_indexes) >= 1, (
+            "Expected at least one AWS::S3Vectors::Index in CDK constructs; "
+            f"found {self.cdk_indexes}"
+        )
+
+    def test_backup_has_vector_indexes_inventory(self):
+        """backup.py must declare a VECTOR_INDEXES list with at least one entry
+        whenever the CDK declares vector indexes."""
+        assert len(self.backup_indexes) >= 1, (
+            "CDK declares an AWS::S3Vectors::Index but backup.py has no "
+            "VECTOR_INDEXES entries. Vectors will be lost on every "
+            "teardown→redeploy→restore cycle. Add an entry to "
+            "scripts/backup-data/backup.py::VECTOR_INDEXES."
+        )
+
+    def test_backup_calls_list_vectors(self):
+        """backup.py must invoke s3vectors.list_vectors paginated. Without
+        this call the VECTOR_INDEXES list above would be a dead config."""
+        assert "list_vectors" in self.backup_content, (
+            "backup.py declares VECTOR_INDEXES but never calls "
+            "s3vectors.list_vectors. The backup step is incomplete."
+        )
+        # Also assert it requests data + metadata (without these, the
+        # restore can't reconstruct the vectors).
+        assert "returnData" in self.backup_content
+        assert "returnMetadata" in self.backup_content
+
+    def test_restore_calls_put_vectors(self):
+        """restore.py must invoke s3vectors.put_vectors to repopulate the
+        index. Reading the backup file but not pushing it back is a no-op."""
+        assert "put_vectors" in self.restore_content, (
+            "restore.py never calls s3vectors.put_vectors. The vectors "
+            "backup file is read but never replayed into the target index."
+        )
+
+    def test_restore_has_vector_index_function(self):
+        """The restore-side function must exist and be wired into run_restore."""
+        assert "def restore_vector_index" in self.restore_content
+        assert "restore_vector_index(" in self.restore_content
+        # And it must be called from somewhere in the orchestrator
+        assert self.restore_content.count("restore_vector_index(") >= 2, (
+            "restore_vector_index is defined but appears to never be called. "
+            "Wire it into run_restore() after the S3 buckets pass."
+        )


### PR DESCRIPTION
## Symptom (reported by a forker)

After a teardown → redeploy → restore cycle, RAG assistants showed their documents in the UI (visual indicator from the DDB `rag-assistants` rows + S3 originals), but **the connection to the knowledge base didn't carry forward** — every retrieval came back empty.

## Root cause

The assistants RAG knowledge base is backed by an `AWS::S3Vectors::Index` (`rag-vector-index-v1`) that lives in a **separate AWS service** from regular S3 — the `s3vectors` boto3 client / `AWS::S3Vectors::*` CFN types. `aws s3 sync` cannot reach it, `list_objects_v2` doesn't see it, and nothing in `backup.py` or `restore.py` was touching it.

The result: after teardown→redeploy→restore the new vector index was empty. The DDB document metadata restored, the S3 originals restored, every assistant *appeared* connected — but every `s3vectors.query_vectors(filter={"assistant_id": ...})` call returned zero hits because no vectors existed for any `assistant_id` in the new index.

This wasn't caught by the existing supply-chain coverage test because that test only enforces DynamoDB-table and regular-S3-bucket coverage. Adding the vector store via untyped `CfnResource` slipped through the canary.

## Fix

Same "snapshot and replay" model the rest of the restore tool uses, applied to the S3 Vectors index.

### `backup.py`

| Change | Detail |
|---|---|
| New `VECTOR_INDEXES` list | Parallel to `S3_BUCKETS`. Each entry maps a logical name to two SSM paths (bucket-name + index-name). |
| New `backup_vector_index()` | Paginates `s3vectors.list_vectors(returnData=True, returnMetadata=True)` and streams every `{key, data, metadata}` record to `vectors/{logical}.jsonl.gz` in the backup bucket. The on-disk shape is **byte-compatible with `put_vectors`** on restore — round-trip with no transformation. |
| `run()` orchestrator | Iterates `VECTOR_INDEXES` after the regular S3 buckets pass. |

### `restore.py`

| Change | Detail |
|---|---|
| New `VECTOR_INDEXES` constant | Mirrors backup.py. |
| New `restore_vector_index()` | Reads the gzipped JSONL, batches records 50-at-a-time (matches `bedrock_embeddings.store_embeddings_in_s3.BATCH_SIZE`), and calls `s3vectors.put_vectors`. **Idempotent on re-run** (put_vectors with same key is an upsert). **Skips cleanly** on older backups that pre-date the vectors snapshot and on target prefixes where RAG is disabled. |
| `run_restore()` orchestrator | Runs the vector restore step after the S3 buckets pass and before the AgentCore Memory replay. |

### Test coverage

| Suite | Result |
|---|---|
| `tests/supply_chain/test_backup_coverage.py::TestBackupCoversVectorIndexes` (new) | 5 / 5 ✅ — scans CDK for `AWS::S3Vectors::Index` and verifies `backup.py` declares it, calls `list_vectors` with `returnData`/`returnMetadata`, and `restore.py` both defines AND wires in `restore_vector_index`. Same canary pattern that already covers DDB tables and S3 buckets. |
| `scripts/restore-data/test_restore.py` (7 new tests) | 48 / 48 ✅ — covers: 1:1 round-trip with batch-of-50 flushing, missing backup file skip, missing target SSM skip, dry-run, idempotent re-run via put_vectors upsert, unknown logical name skip, and the `rag-vectors` logical-name pin. |

Drive-by: `extract_backup_tables` in the supply-chain test is now section-scoped so its `"logical":` regex stops slurping entries from `S3_BUCKETS` or the new `VECTOR_INDEXES`.

The 3 pre-existing supply-chain failures (`system-prompts` table and `skill-resources` bucket from prior feature PRs) are untouched and unrelated to this PR.

## API verification

I verified the API surface against the AWS docs before relying on it:

- `s3vectors:ListVectors` supports paginated full enumeration via `nextToken` and exposes `returnData` + `returnMetadata` flags. With both true, the response includes the float32 vector and the metadata document — exactly the shape `put_vectors` accepts. Permissions required: `s3vectors:ListVectors` + `s3vectors:GetVectors` for the backup, `s3vectors:PutVectors` for the restore. (See https://docs.aws.amazon.com/cli/latest/reference/s3vectors/list-vectors.html.)
- `s3vectors.put_vectors` is keyed on `key` and is an upsert — so a partially-completed prior restore can be resumed by re-invoking the script.

The backup workflow runs under `secrets.AWS_ROLE_ARN`, which is the deployment role that already has `s3vectors:*` permissions for the platform. No IAM changes are needed for the typical fork.

## What this PR does NOT include

A one-off recovery script for the existing affected forker who's already in the empty-vector-index state. That was scoped as a separate task per the diagnosis discussion. The two viable options for them are:

1. **Reuse the original backup** (if the source environment's vector store is still reachable) — write a small one-off that does the new backup_vectors → restore_vectors loop directly between the two environments.
2. **Re-ingest from S3 originals** — trigger the rag-ingestion lambda for every document in the assistants table. Costs Bedrock Titan embedding calls, but it's a recovery scenario.

I'm happy to write whichever the forker prefers as a follow-up.

## Operator notes (for forks adopting this PR)

- After merging, run `backup-data.yml` to capture a fresh snapshot that **includes** the vectors. Existing backup buckets predating this PR will still be readable by the restore (it will skip the vectors restore with a clear "no vectors backup file" reason).
- The new manifest entry (`vectors`) is additive; older restore tooling reading newer manifests would simply ignore it.