### PR TITLE
Tighten admin-route input handling and data-layer ownership edges

### DIFF
--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -5,9 +5,10 @@ Requires admin role (Admin or SuperAdmin) via JWT token.
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Query, status
-from typing import Optional
+from typing import Literal, Optional
 import logging
 import os
+import re
 import boto3
 from botocore.exceptions import ClientError, BotoCoreError
 
@@ -46,12 +47,40 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 
 
+# AWS Bedrock's accepted shape for byProvider — alphanumerics, hyphens, and
+# spaces, 1-63 chars. Validating client-side keeps obviously-malformed input
+# (HTML, control chars, oversized strings) from reaching the AWS API at all.
+_BEDROCK_PROVIDER_RE = re.compile(r"^[A-Za-z0-9 -]{1,63}$")
+
+
 @router.get("/bedrock/models", response_model=BedrockModelsResponse)
 async def list_bedrock_models(
-    by_provider: Optional[str] = Query(None, description="Filter by provider name (e.g., 'Anthropic', 'Amazon')"),
-    by_output_modality: Optional[str] = Query(None, description="Filter by output modality (e.g., 'TEXT', 'IMAGE')"),
-    by_inference_type: Optional[str] = Query(None, description="Filter by inference type (e.g., 'ON_DEMAND', 'PROVISIONED')"),
-    by_customization_type: Optional[str] = Query(None, description="Filter by customization type (e.g., 'FINE_TUNING', 'CONTINUED_PRE_TRAINING')"),
+    by_provider: Optional[str] = Query(
+        None,
+        regex=_BEDROCK_PROVIDER_RE.pattern,
+        description="Filter by provider name (e.g., 'Anthropic', 'Amazon')",
+    ),
+    by_output_modality: Optional[
+        Literal["SPEECH", "TEXT", "EMBEDDING", "VIDEO", "IMAGE"]
+    ] = Query(None, description="Filter by output modality"),
+    by_inference_type: Optional[
+        Literal[
+            "INFERENCE_PROFILE",
+            "ON_DEMAND",
+            "MODEL_GATEWAY",
+            "PROVISIONED",
+            "PROVISIONED_THROUGHPUT",
+        ]
+    ] = Query(None, description="Filter by inference type"),
+    by_customization_type: Optional[
+        Literal[
+            "REINFORCEMENT_FINE_TUNING",
+            "DISTILLATION",
+            "PREFERENCE_FINE_TUNING",
+            "CONTINUED_PRE_TRAINING",
+            "FINE_TUNING",
+        ]
+    ] = Query(None, description="Filter by customization type"),
     max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return (client-side limit)"),
     admin_user: User = Depends(require_admin),
 ):
@@ -146,26 +175,21 @@ async def list_bedrock_models(
             totalCount=len(model_summaries),
         )
 
-    except ClientError as e:
-        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-        error_message = e.response.get('Error', {}).get('Message', str(e))
-        logger.error("AWS Bedrock API error", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"AWS Bedrock API error: {error_code} - {error_message}"
-        )
-    except BotoCoreError as e:
+    except HTTPException:
+        raise
+    except BotoCoreError:
+        # Connectivity / config error talking to AWS. Generic 502;
+        # full traceback is logged by the global handler chain.
         logger.error("Boto3 error calling Bedrock API", exc_info=True)
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error connecting to AWS Bedrock: {str(e)}"
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Upstream service error.",
         )
-    except Exception as e:
-        logger.error("Unexpected error listing Bedrock models", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error: {str(e)}"
-        )
+    # ClientError is intentionally not caught here — the app-wide
+    # ``register_aws_client_error_handler`` maps ValidationException-class
+    # codes to a generic 400 and other ClientErrors to a generic 502
+    # without echoing the AWS message back. Catching here would re-surface
+    # the AWS message, the user input, and AWS-internal pattern detail.
 
 
 @router.get("/gemini/models", response_model=GeminiModelsResponse)

--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 
 from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.files.repository import InvalidCursorError
 from apis.shared.files.models import (
     PresignRequest,
     PresignResponse,
@@ -267,14 +268,17 @@ async def list_files(
     """
     logger.info("User listing files")
 
-    response = await service.list_user_files(
-        user_id=user.user_id,
-        session_id=session_id,
-        limit=limit,
-        cursor=cursor,
-        sort_by=sort_by.value,
-        sort_order=sort_order.value,
-    )
+    try:
+        response = await service.list_user_files(
+            user_id=user.user_id,
+            session_id=session_id,
+            limit=limit,
+            cursor=cursor,
+            sort_by=sort_by.value,
+            sort_order=sort_order.value,
+        )
+    except InvalidCursorError:
+        raise HTTPException(status_code=400, detail="Invalid pagination cursor.")
     return response
 
 

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -111,8 +111,12 @@ app = FastAPI(
 # Centralized exception handlers: AWS ClientError responses are mapped to
 # generic 400/502 bodies (logged server-side) so AWS error messages, internal
 # parameter names, and reflected user input never leak into HTTP responses.
-from apis.shared.security import register_aws_client_error_handler
+from apis.shared.security import (
+    register_aws_client_error_handler,
+    register_validation_error_handler,
+)
 register_aws_client_error_handler(app)
+register_validation_error_handler(app)
 logger.info("Registered AWS ClientError handler")
 
 # Add CORS middleware - origins from CDK-provided CORS_ORIGINS env var

--- a/backend/src/apis/app_api/memory/routes.py
+++ b/backend/src/apis/app_api/memory/routes.py
@@ -25,6 +25,8 @@ from .services.memory_service import (
     is_memory_available,
     get_memory_config_info,
     delete_memory,
+    get_memory_record_owner,
+    record_namespace_owner,
 )
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
@@ -483,6 +485,22 @@ async def delete_memory_endpoint(
         raise HTTPException(
             status_code=503,
             detail="AgentCore Memory is not available. Memory features require cloud mode with AGENTCORE_MEMORY_ID configured."
+        )
+
+    # Ownership check: the record's namespace encodes the owning user id
+    # (segment after ``/actors/``). Fetch the record and verify the
+    # caller owns it before issuing the delete. A non-owner — or a
+    # missing record — receives 404 (matching the ``GET /memory``
+    # surface's "your records only" contract) so non-owners can't
+    # enumerate record ids by probing.
+    record = await get_memory_record_owner(record_id)
+    if record is None or record_namespace_owner(record) != user_id:
+        logger.warning(
+            "DELETE /memory/{record_id}: ownership check failed; refusing",
+        )
+        raise HTTPException(
+            status_code=404,
+            detail=f"Memory record {record_id} not found",
         )
 
     try:

--- a/backend/src/apis/app_api/memory/services/memory_service.py
+++ b/backend/src/apis/app_api/memory/services/memory_service.py
@@ -416,6 +416,73 @@ def get_memory_config_info() -> Dict[str, Any]:
         }
 
 
+async def get_memory_record_owner(
+    record_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Fetch a memory record's metadata for ownership checks.
+
+    Returns a dict with ``memoryRecordId`` and ``namespaces`` keys if the
+    record exists, else ``None``. The record's namespaces encode the
+    owning user id (the path segment after ``/actors/``); callers
+    compare that against the calling user before proceeding with
+    mutating operations like delete.
+
+    Returning a small dict (rather than the full AWS response) keeps
+    the contract narrow and easy to mock in tests.
+    """
+    import boto3
+
+    config = load_memory_config()
+    if not config.is_cloud_mode:
+        return None
+
+    try:
+        client = boto3.client("bedrock-agentcore", region_name=config.region)
+        response = client.get_memory_record(
+            memoryId=config.memory_id,
+            memoryRecordId=record_id,
+        )
+        record = response.get("memoryRecord", {})
+        if not record:
+            return None
+        return {
+            "memoryRecordId": record.get("memoryRecordId"),
+            "namespaces": list(record.get("namespaces") or []),
+        }
+    except client.exceptions.ResourceNotFoundException:  # type: ignore[union-attr]
+        return None
+    except Exception:
+        # Distinguish "not found" from "lookup failed" — the caller
+        # treats both as 404 (better to fail closed than to allow a
+        # delete to land based on a missed read), but we log the
+        # underlying cause for operator visibility.
+        logger.warning("Memory record lookup failed", exc_info=True)
+        return None
+
+
+def record_namespace_owner(record: Dict[str, Any]) -> Optional[str]:
+    """Return the owning user id encoded in a record's namespace, if any.
+
+    Memory namespaces follow ``/strategies/{strategy_id}/actors/{user_id}``;
+    the owning user is the path segment after the ``/actors/`` marker.
+    A record with no namespaces — or with namespaces that don't follow
+    the expected shape — has no resolvable owner and is treated as
+    unowned.
+    """
+    namespaces = record.get("namespaces") or []
+    for ns in namespaces:
+        if not isinstance(ns, str):
+            continue
+        marker = "/actors/"
+        idx = ns.find(marker)
+        if idx == -1:
+            continue
+        owner = ns[idx + len(marker) :].split("/", 1)[0]
+        if owner:
+            return owner
+    return None
+
+
 async def delete_memory(
     user_id: str,
     record_id: str,

--- a/backend/src/apis/shared/auth_providers/service.py
+++ b/backend/src/apis/shared/auth_providers/service.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 from botocore.exceptions import ClientError
+
+from apis.shared.security import UrlValidationError, validate_external_url
 from fastapi import HTTPException, status
 
 from .cognito_idp_service import (
@@ -55,6 +57,19 @@ class AuthProviderService:
         Raises:
             HTTPException: If discovery fails
         """
+        # Refuse anything the SSRF validator rejects: loopback,
+        # link-local (incl. cloud metadata), private, multicast,
+        # reserved, or schemes other than https. OIDC issuers are
+        # public HTTPS endpoints by spec; we're strict on purpose.
+        try:
+            validate_external_url(issuer_url, allow_schemes={"https"})
+        except UrlValidationError:
+            logger.warning("OIDC discovery refused by URL validator")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Issuer URL is not permitted.",
+            )
+
         discovery_url = issuer_url.rstrip("/") + "/.well-known/openid-configuration"
 
         try:
@@ -417,6 +432,13 @@ class AuthProviderService:
         """
         Test provider connectivity by verifying JWKS and token endpoints are reachable.
 
+        Each stored URL is run through the SSRF validator before any
+        outbound call. URLs that fail validation are reported as
+        unreachable with a generic error string and are not contacted —
+        the same protection applied at the discover endpoint, repeated
+        here as defense in depth so a bad URL persisted from elsewhere
+        cannot be turned into an outbound dispatch.
+
         Returns:
             Dict with test results
         """
@@ -435,11 +457,24 @@ class AuthProviderService:
             "errors": [],
         }
 
+        def _safe(url: Optional[str], schemes: set[str] = {"https"}) -> Optional[str]:
+            """Return the URL if it passes the SSRF validator, else None
+            (and append a generic error to the result map)."""
+            if not url:
+                return None
+            try:
+                validate_external_url(url, allow_schemes=schemes)
+                return url
+            except UrlValidationError:
+                results["errors"].append("Endpoint URL is not permitted.")
+                return None
+
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Test JWKS endpoint
-            if provider.jwks_uri:
+            jwks_uri = _safe(provider.jwks_uri)
+            if jwks_uri:
                 try:
-                    resp = await client.get(provider.jwks_uri)
+                    resp = await client.get(jwks_uri)
                     results["jwks_reachable"] = resp.status_code == 200
                     if resp.status_code != 200:
                         results["errors"].append(
@@ -449,21 +484,24 @@ class AuthProviderService:
                     results["errors"].append(f"JWKS endpoint error: {str(e)}")
 
             # Test OIDC discovery
-            discovery_url = provider.issuer_url.rstrip("/") + "/.well-known/openid-configuration"
-            try:
-                resp = await client.get(discovery_url)
-                results["discovery_reachable"] = resp.status_code == 200
-                if resp.status_code != 200:
-                    results["errors"].append(
-                        f"Discovery endpoint returned {resp.status_code}"
-                    )
-            except Exception as e:
-                results["errors"].append(f"Discovery endpoint error: {str(e)}")
+            issuer = _safe(provider.issuer_url)
+            if issuer:
+                discovery_url = issuer.rstrip("/") + "/.well-known/openid-configuration"
+                try:
+                    resp = await client.get(discovery_url)
+                    results["discovery_reachable"] = resp.status_code == 200
+                    if resp.status_code != 200:
+                        results["errors"].append(
+                            f"Discovery endpoint returned {resp.status_code}"
+                        )
+                except Exception as e:
+                    results["errors"].append(f"Discovery endpoint error: {str(e)}")
 
             # Test token endpoint (HEAD/OPTIONS only)
-            if provider.token_endpoint:
+            token_endpoint = _safe(provider.token_endpoint)
+            if token_endpoint:
                 try:
-                    resp = await client.options(provider.token_endpoint)
+                    resp = await client.options(token_endpoint)
                     results["token_endpoint_reachable"] = resp.status_code < 500
                 except Exception as e:
                     results["errors"].append(f"Token endpoint error: {str(e)}")

--- a/backend/src/apis/shared/files/repository.py
+++ b/backend/src/apis/shared/files/repository.py
@@ -18,6 +18,18 @@ from .models import FileMetadata, UserFileQuota, FileStatus
 logger = logging.getLogger(__name__)
 
 
+class InvalidCursorError(ValueError):
+    """Raised when a pagination cursor cannot be safely used.
+
+    The cursor is base64-encoded JSON containing a DynamoDB
+    ``LastEvaluatedKey``; a cursor whose embedded ``PK`` doesn't match
+    the calling user's expected partition (or that fails to decode at
+    all) cannot be forwarded to DynamoDB without producing a
+    cross-partition mismatch — which historically surfaced as a 500.
+    Routes catch this and return a generic 400.
+    """
+
+
 class FileUploadRepository:
     """
     Repository for File Upload CRUD operations in DynamoDB.
@@ -193,9 +205,25 @@ class FileUploadRepository:
             if cursor:
                 import base64
                 import json
-                query_params["ExclusiveStartKey"] = json.loads(
-                    base64.b64decode(cursor).decode("utf-8")
-                )
+
+                expected_pk = f"USER#{user_id}"
+                try:
+                    decoded = json.loads(base64.b64decode(cursor).decode("utf-8"))
+                except (ValueError, TypeError, UnicodeDecodeError) as exc:
+                    logger.warning("Rejected pagination cursor: decode failed: %s", exc)
+                    raise InvalidCursorError() from exc
+
+                if not isinstance(decoded, dict) or decoded.get("PK") != expected_pk:
+                    # The cursor's partition key doesn't match the
+                    # caller — could be a legitimate stale cursor from
+                    # a different login, or a probe for cross-user data.
+                    # Either way, treat as invalid.
+                    logger.warning(
+                        "Rejected pagination cursor: PK does not match caller"
+                    )
+                    raise InvalidCursorError()
+
+                query_params["ExclusiveStartKey"] = decoded
 
             response = self._table.query(**query_params)
 

--- a/backend/src/apis/shared/security/__init__.py
+++ b/backend/src/apis/shared/security/__init__.py
@@ -19,6 +19,7 @@ from apis.shared.security.ownership import (
 from apis.shared.security.error_handler import (
     register_aws_client_error_handler,
     register_safe_500_handler,
+    register_validation_error_handler,
 )
 from apis.shared.security.python_ast_policy import (
     PolicyError,
@@ -35,6 +36,7 @@ __all__ = [
     "register_ownership_handler",
     "register_aws_client_error_handler",
     "register_safe_500_handler",
+    "register_validation_error_handler",
     "PolicyError",
     "validate_diagram_code",
 ]

--- a/backend/src/apis/shared/security/error_handler.py
+++ b/backend/src/apis/shared/security/error_handler.py
@@ -36,6 +36,38 @@ _CLIENT_ERROR_CODES: frozenset[str] = frozenset(
 _GENERIC_BAD_REQUEST = "Invalid request parameters."
 _GENERIC_UPSTREAM_ERROR = "Upstream service error."
 _GENERIC_INTERNAL_ERROR = "Internal server error."
+_GENERIC_VALIDATION_ERROR = "Invalid request parameters."
+
+
+def register_validation_error_handler(app: Any) -> None:
+    """Install a FastAPI handler for ``RequestValidationError`` that
+    returns a generic body.
+
+    FastAPI's default 422 response includes the offending input value,
+    the field path, and (for regex/length validators) the pattern or
+    bound the value violated. Echoing user input back creates an XSS
+    reflection sink and leaks server-side validation rules. This
+    handler replaces the body with a generic
+    ``{"detail": "Invalid request parameters."}`` while preserving the
+    422 status; the offending input and structural reason are still
+    logged server-side at WARN for operator visibility.
+    """
+    from fastapi import Request
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse
+
+    async def _handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        logger.warning(
+            "Request validation error on %s %s: %s",
+            request.method,
+            request.url.path,
+            # exc.errors() carries the structural detail; safe to log,
+            # never echoed in the response.
+            exc.errors(),
+        )
+        return JSONResponse(status_code=422, content={"detail": _GENERIC_VALIDATION_ERROR})
+
+    app.add_exception_handler(RequestValidationError, _handler)
 
 
 def register_aws_client_error_handler(app: Any) -> None:

--- a/backend/tests/routes/test_admin_bedrock_models.py
+++ b/backend/tests/routes/test_admin_bedrock_models.py
@@ -1,0 +1,230 @@
+"""Tests for ``GET /admin/bedrock/models`` filter validation and error handling.
+
+Two invariants are locked in here:
+
+1. Filter values that don't conform to the AWS API's accepted shapes are
+   rejected at the FastAPI/Pydantic boundary with a 422 — never sent
+   downstream and never reflected in the response body.
+2. When the boto3 call does raise, the response body never reflects the
+   AWS error message, the user input, or AWS-internal pattern detail.
+   The shared ``register_aws_client_error_handler`` (registered on the
+   app at startup) maps ``ValidationException``-class errors to a
+   generic 400, all other ``ClientError``s to a generic 502, and the
+   route itself no longer carries its own reflective handlers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.routes import router
+from apis.shared.auth.rbac import require_admin
+from apis.shared.security import (
+    register_aws_client_error_handler,
+    register_validation_error_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    _app = FastAPI()
+    _app.include_router(router)
+    # Wire the same global handlers the production app installs.
+    register_aws_client_error_handler(_app)
+    register_validation_error_handler(_app)
+    return _app
+
+
+def _admin_client(app: FastAPI, make_user) -> TestClient:
+    user = make_user(roles=["system_admin"])
+    app.dependency_overrides[require_admin] = lambda: user
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic-level rejection: invalid enum values short-circuit before AWS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "param,value",
+    [
+        ("by_output_modality", "INVALID"),
+        ("by_output_modality", "<script>"),
+        ("by_inference_type", "INVALID"),
+        ("by_inference_type", "<img src=x>"),
+        ("by_customization_type", "INVALID"),
+        ("by_customization_type", "garbage"),
+    ],
+)
+def test_invalid_enum_filter_returns_422_without_calling_aws(
+    app, make_user, param: str, value: str
+) -> None:
+    client = _admin_client(app, make_user)
+    with patch("apis.app_api.admin.routes.boto3.client") as boto3_client:
+        resp = client.get(f"/admin/bedrock/models?{param}={value}")
+
+    assert resp.status_code == 422
+    boto3_client.assert_not_called()
+    body_text = resp.text
+    # Whatever the validation error structure is, neither the input
+    # nor the enum's allowed-value set should be reflected back.
+    assert value not in body_text
+    assert "INFERENCE_PROFILE" not in body_text
+    assert "FINE_TUNING" not in body_text
+    assert "EMBEDDING" not in body_text
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "<script>",
+        "<img src=x onerror=alert(1)>",
+        "has/slash",
+        "has,comma",
+        "has\nnewline",
+        "x" * 64,  # longer than AWS's 63-char cap
+    ],
+)
+def test_invalid_provider_filter_returns_422_without_calling_aws(
+    app, make_user, value: str
+) -> None:
+    client = _admin_client(app, make_user)
+    with patch("apis.app_api.admin.routes.boto3.client") as boto3_client:
+        resp = client.get("/admin/bedrock/models", params={"by_provider": value})
+
+    assert resp.status_code == 422
+    boto3_client.assert_not_called()
+    body_text = resp.text
+    assert value not in body_text
+
+
+def test_legitimate_filters_are_accepted(app, make_user) -> None:
+    client = _admin_client(app, make_user)
+
+    fake_bedrock = MagicMock()
+    fake_bedrock.list_foundation_models.return_value = {"modelSummaries": []}
+
+    with patch(
+        "apis.app_api.admin.routes.boto3.client", return_value=fake_bedrock
+    ):
+        resp = client.get(
+            "/admin/bedrock/models",
+            params={
+                "by_provider": "Anthropic",
+                "by_output_modality": "TEXT",
+                "by_inference_type": "ON_DEMAND",
+                "by_customization_type": "FINE_TUNING",
+            },
+        )
+
+    assert resp.status_code == 200
+    fake_bedrock.list_foundation_models.assert_called_once_with(
+        byProvider="Anthropic",
+        byOutputModality="TEXT",
+        byInferenceType="ON_DEMAND",
+        byCustomizationType="FINE_TUNING",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AWS-side errors: response body never reflects upstream detail
+# ---------------------------------------------------------------------------
+
+
+def test_aws_validation_error_returns_400_generic(app, make_user) -> None:
+    """Even if a value passes our Pydantic validators (e.g. an
+    accidentally-configured AWS API regression), the global
+    ClientError handler maps the upstream ValidationException to a
+    generic 400 with no reflection."""
+    client = _admin_client(app, make_user)
+
+    fake_bedrock = MagicMock()
+    fake_bedrock.list_foundation_models.side_effect = ClientError(
+        error_response={
+            "Error": {
+                "Code": "ValidationException",
+                "Message": (
+                    "1 validation error detected: Value '<script>alert(1)</script>' "
+                    "at 'byProvider' failed to satisfy constraint: Member must "
+                    "satisfy regular expression pattern: [A-Za-z0-9- ]{1,63}"
+                ),
+            }
+        },
+        operation_name="ListFoundationModels",
+    )
+
+    with patch(
+        "apis.app_api.admin.routes.boto3.client", return_value=fake_bedrock
+    ):
+        resp = client.get("/admin/bedrock/models", params={"by_provider": "Anthropic"})
+
+    assert resp.status_code == 400
+    body_text = resp.text
+    # AWS error code, the regex, the user input, and the parameter
+    # name all must be absent from the response body.
+    assert "ValidationException" not in body_text
+    assert "<script>" not in body_text
+    assert "[A-Za-z0-9-" not in body_text
+    assert "byProvider" not in body_text
+
+
+def test_aws_other_client_error_returns_502_generic(app, make_user) -> None:
+    client = _admin_client(app, make_user)
+
+    fake_bedrock = MagicMock()
+    fake_bedrock.list_foundation_models.side_effect = ClientError(
+        error_response={
+            "Error": {
+                "Code": "ThrottlingException",
+                "Message": "Rate exceeded for arn:aws:bedrock:us-west-2:123456789012:model/x",
+            }
+        },
+        operation_name="ListFoundationModels",
+    )
+
+    with patch(
+        "apis.app_api.admin.routes.boto3.client", return_value=fake_bedrock
+    ):
+        resp = client.get("/admin/bedrock/models", params={"by_provider": "Anthropic"})
+
+    assert resp.status_code == 502
+    body_text = resp.text
+    assert "ThrottlingException" not in body_text
+    assert "arn:aws" not in body_text
+
+
+def test_unhandled_exception_does_not_reflect_message(app, make_user) -> None:
+    """A non-ClientError raised from inside the route must not leak its
+    str() representation into the response body. FastAPI's default 500
+    handler returns a generic 'Internal Server Error' string."""
+    _admin_client(app, make_user)
+
+    fake_bedrock = MagicMock()
+    fake_bedrock.list_foundation_models.side_effect = RuntimeError(
+        "internal detail at /db/users that must not leak"
+    )
+
+    with patch(
+        "apis.app_api.admin.routes.boto3.client", return_value=fake_bedrock
+    ):
+        resp = TestClient(app, raise_server_exceptions=False).get(
+            "/admin/bedrock/models",
+            params={"by_provider": "Anthropic"},
+        )
+
+    assert resp.status_code == 500
+    body_text = resp.text
+    assert "internal detail" not in body_text
+    assert "/db/users" not in body_text
+    assert "RuntimeError" not in body_text

--- a/backend/tests/routes/test_memory_delete_ownership.py
+++ b/backend/tests/routes/test_memory_delete_ownership.py
@@ -1,0 +1,131 @@
+"""Tests for ``DELETE /memory/{record_id}`` ownership enforcement.
+
+The memory store is keyed at the AWS API level by record id alone — the
+namespace (which encodes the owning user id) is metadata on the record,
+not part of the lookup. The route therefore has to assert ownership
+before calling ``batch_delete_memory_records``; otherwise any user
+holding any record id can delete any other user's record.
+
+These tests pin that contract:
+
+* The owner of a record can delete it (the underlying delete service is
+  invoked exactly once, with the right id).
+* A non-owner asking to delete the same record sees 404 (matching GET's
+  behaviour for resources that aren't theirs) and the underlying delete
+  service is *never* invoked.
+* A record that doesn't exist at all also yields 404 with no delete.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.memory.routes import router
+from tests.routes.conftest import mock_auth_user
+
+
+ROUTES_MODULE = "apis.app_api.memory.routes"
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+def _record_owned_by(user_id: str, *, record_id: str = "mem-abc") -> dict:
+    """Shape that mirrors GetMemoryRecord's response for a record whose
+    owning user id is *user_id*."""
+    return {
+        "memoryRecordId": record_id,
+        "namespaces": [f"/strategies/STRAT/actors/{user_id}"],
+        "content": {"text": "owned content"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Owner can delete
+# ---------------------------------------------------------------------------
+
+
+def test_owner_can_delete_their_record(app, make_user) -> None:
+    user = make_user(user_id="user-owner")
+    mock_auth_user(app, user)
+
+    fetch = AsyncMock(return_value=_record_owned_by("user-owner"))
+    delete = AsyncMock(return_value=True)
+
+    with patch(f"{ROUTES_MODULE}.is_memory_available", return_value=True), patch(
+        f"{ROUTES_MODULE}.get_memory_record_owner", fetch
+    ), patch(f"{ROUTES_MODULE}.delete_memory", delete):
+        resp = TestClient(app).delete("/memory/mem-abc")
+
+    assert resp.status_code == 200
+    fetch.assert_awaited_once_with("mem-abc")
+    delete.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Non-owner cannot delete and triggers no delete call
+# ---------------------------------------------------------------------------
+
+
+def test_non_owner_delete_returns_404_and_skips_delete(app, make_user) -> None:
+    user = make_user(user_id="user-attacker")
+    mock_auth_user(app, user)
+
+    fetch = AsyncMock(return_value=_record_owned_by("user-victim"))
+    delete = AsyncMock(return_value=True)
+
+    with patch(f"{ROUTES_MODULE}.is_memory_available", return_value=True), patch(
+        f"{ROUTES_MODULE}.get_memory_record_owner", fetch
+    ), patch(f"{ROUTES_MODULE}.delete_memory", delete):
+        resp = TestClient(app).delete("/memory/mem-victim")
+
+    assert resp.status_code == 404
+    delete.assert_not_called()
+
+
+def test_record_with_no_namespaces_treated_as_not_yours(app, make_user) -> None:
+    """Defensive: a record without any namespace is not attributable to
+    a user, so a non-owner can't proceed."""
+    user = make_user(user_id="user-attacker")
+    mock_auth_user(app, user)
+
+    record_no_ns = {"memoryRecordId": "mem-x", "namespaces": []}
+    fetch = AsyncMock(return_value=record_no_ns)
+    delete = AsyncMock(return_value=True)
+
+    with patch(f"{ROUTES_MODULE}.is_memory_available", return_value=True), patch(
+        f"{ROUTES_MODULE}.get_memory_record_owner", fetch
+    ), patch(f"{ROUTES_MODULE}.delete_memory", delete):
+        resp = TestClient(app).delete("/memory/mem-x")
+
+    assert resp.status_code == 404
+    delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Missing record → 404 and no delete
+# ---------------------------------------------------------------------------
+
+
+def test_missing_record_returns_404_without_delete(app, make_user) -> None:
+    user = make_user(user_id="user-anyone")
+    mock_auth_user(app, user)
+
+    fetch = AsyncMock(return_value=None)
+    delete = AsyncMock(return_value=True)
+
+    with patch(f"{ROUTES_MODULE}.is_memory_available", return_value=True), patch(
+        f"{ROUTES_MODULE}.get_memory_record_owner", fetch
+    ), patch(f"{ROUTES_MODULE}.delete_memory", delete):
+        resp = TestClient(app).delete("/memory/mem-nonexistent")
+
+    assert resp.status_code == 404
+    delete.assert_not_called()

--- a/backend/tests/shared/test_auth_providers.py
+++ b/backend/tests/shared/test_auth_providers.py
@@ -120,7 +120,15 @@ class TestAuthProviderService:
         mock_response.json.return_value = discovery_data
         mock_response.raise_for_status = MagicMock()
 
-        with patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
+        # The URL validator resolves DNS — fake the lookup so the test
+        # hostname can pass without an internet round-trip.
+        import socket
+        def _fake_getaddrinfo(host, *a, **kw):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+        with patch(
+            "apis.shared.security.url_validator.socket.getaddrinfo", _fake_getaddrinfo
+        ), patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock(get=AsyncMock(return_value=mock_response)))
             mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
             result = await service.discover_endpoints("https://okta.example.com")
@@ -134,7 +142,13 @@ class TestAuthProviderService:
         mock_response.status_code = 404
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("not found", request=MagicMock(), response=mock_response)
 
-        with patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
+        import socket
+        def _fake_getaddrinfo(host, *a, **kw):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+        with patch(
+            "apis.shared.security.url_validator.socket.getaddrinfo", _fake_getaddrinfo
+        ), patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock(get=AsyncMock(return_value=mock_response)))
             mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
             with pytest.raises(HTTPException):

--- a/backend/tests/shared/test_auth_providers_extended.py
+++ b/backend/tests/shared/test_auth_providers_extended.py
@@ -56,7 +56,15 @@ class TestAuthProviderServiceExtended:
         mock_resp.json.return_value = discovery_data
         mock_resp.raise_for_status = MagicMock()
 
-        with patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
+        # The URL validator resolves DNS — fake the lookup so the test
+        # hostname can pass without an internet round-trip.
+        import socket
+        def _fake_getaddrinfo(host, *a, **kw):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+        with patch(
+            "apis.shared.security.url_validator.socket.getaddrinfo", _fake_getaddrinfo
+        ), patch("apis.shared.auth_providers.service.httpx.AsyncClient") as mock_client:
             mock_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock(
                 get=AsyncMock(return_value=mock_resp)
             ))

--- a/backend/tests/shared/test_auth_providers_ssrf.py
+++ b/backend/tests/shared/test_auth_providers_ssrf.py
@@ -1,0 +1,287 @@
+"""Tests for SSRF defense in OIDC discovery and auth-provider connectivity tests.
+
+Two endpoints make outbound HTTP requests against admin-controlled URLs:
+
+* ``POST /admin/auth-providers/discover`` constructs
+  ``{issuer_url}/.well-known/openid-configuration`` and fetches it.
+* ``POST /admin/auth-providers/{id}/test`` fetches every URL stored on
+  the provider (jwks_uri, token_endpoint, issuer_url's discovery doc).
+
+These tests pin the contract that:
+
+* The discover endpoint refuses any issuer URL that fails the SSRF
+  validator (loopback, link-local, RFC1918, multicast, reserved, cloud
+  metadata, or a non-https scheme).
+* The provider-test endpoint validates each stored URL before
+  contacting it; URLs that fail the validator surface as ``False`` in
+  the per-endpoint reachability map alongside a generic error string.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from apis.shared.auth_providers.models import AuthProvider
+from apis.shared.auth_providers.service import AuthProviderService
+
+
+def _fake_getaddrinfo(mapping: dict[str, list[str]]):
+    def _impl(host, *args, **kwargs):
+        if host not in mapping:
+            raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+        results = []
+        for ip in mapping[host]:
+            family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+            results.append((family, socket.SOCK_STREAM, 0, "", (ip, 0)))
+        return results
+
+    return _impl
+
+
+def _service() -> AuthProviderService:
+    """Build an AuthProviderService without touching DynamoDB or
+    secrets."""
+    svc = AuthProviderService.__new__(AuthProviderService)
+    svc._repo = MagicMock()
+    svc._cognito_idp = MagicMock()
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# F13: discover_endpoints validates issuer_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/",
+        "http://127.0.0.1:8000/",
+        "http://10.0.0.5/",
+        "https://192.168.1.1/",
+        "http://[::1]/",
+        # http:// is not acceptable for an OIDC issuer; force https.
+        "http://accounts.google.com/",
+        # data:/file:/javascript: schemes
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+    ],
+)
+@pytest.mark.asyncio
+async def test_discover_rejects_disallowed_issuer_urls(url: str) -> None:
+    svc = _service()
+    with patch("apis.shared.auth_providers.service.httpx.AsyncClient") as client_cls:
+        with pytest.raises(HTTPException) as excinfo:
+            await svc.discover_endpoints(url)
+
+    assert excinfo.value.status_code == 400
+    # No outbound HTTP client was constructed.
+    client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discover_accepts_legitimate_https_issuer() -> None:
+    svc = _service()
+
+    fake_dns = _fake_getaddrinfo({"accounts.google.com": ["142.250.190.46"]})
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "issuer": "https://accounts.google.com",
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+    }
+    response.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "apis.shared.security.url_validator.socket.getaddrinfo", fake_dns
+    ), patch(
+        "apis.shared.auth_providers.service.httpx.AsyncClient", return_value=cm
+    ):
+        result = await svc.discover_endpoints("https://accounts.google.com")
+
+    assert result.issuer == "https://accounts.google.com"
+
+
+# ---------------------------------------------------------------------------
+# F12: test_provider validates each stored URL before contacting it
+# ---------------------------------------------------------------------------
+
+
+def _provider_with_urls(
+    *,
+    jwks_uri: str | None,
+    token_endpoint: str | None,
+    issuer_url: str,
+) -> AuthProvider:
+    """Minimal AuthProvider stub with just the URL fields the test
+    helper reads."""
+    return AuthProvider(
+        provider_id="test-id",
+        display_name="Test",
+        provider_type="oidc",
+        enabled=True,
+        issuer_url=issuer_url,
+        client_id="cid",
+        jwks_uri=jwks_uri,
+        token_endpoint=token_endpoint,
+    )
+
+
+@pytest.mark.asyncio
+async def test_test_provider_skips_disallowed_jwks_uri() -> None:
+    svc = _service()
+    provider = _provider_with_urls(
+        jwks_uri="http://169.254.169.254/jwks",
+        token_endpoint="https://accounts.google.com/o/oauth2/token",
+        issuer_url="https://accounts.google.com",
+    )
+    svc._repo.get_provider = AsyncMock(return_value=provider)
+
+    fake_dns = _fake_getaddrinfo(
+        {"accounts.google.com": ["142.250.190.46"]}
+    )
+
+    # Build a context-manager mock for httpx.AsyncClient; record GET targets.
+    targets: list[str] = []
+
+    async def fake_get(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    async def fake_options(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 204
+        return resp
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=fake_get)
+    client.options = AsyncMock(side_effect=fake_options)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "apis.shared.security.url_validator.socket.getaddrinfo", fake_dns
+    ), patch(
+        "apis.shared.auth_providers.service.httpx.AsyncClient", return_value=cm
+    ):
+        result = await svc.test_provider("test-id")
+
+    # The 169.254 jwks URI must never have been contacted.
+    assert "http://169.254.169.254/jwks" not in targets
+    # And the result reflects that fact.
+    assert result["jwks_reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_test_provider_skips_disallowed_token_endpoint() -> None:
+    svc = _service()
+    provider = _provider_with_urls(
+        jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
+        token_endpoint="http://10.0.0.5/token",
+        issuer_url="https://accounts.google.com",
+    )
+    svc._repo.get_provider = AsyncMock(return_value=provider)
+
+    fake_dns = _fake_getaddrinfo(
+        {
+            "accounts.google.com": ["142.250.190.46"],
+            "www.googleapis.com": ["142.250.190.74"],
+        }
+    )
+
+    targets: list[str] = []
+
+    async def fake_get(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    async def fake_options(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 204
+        return resp
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=fake_get)
+    client.options = AsyncMock(side_effect=fake_options)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "apis.shared.security.url_validator.socket.getaddrinfo", fake_dns
+    ), patch(
+        "apis.shared.auth_providers.service.httpx.AsyncClient", return_value=cm
+    ):
+        result = await svc.test_provider("test-id")
+
+    assert "http://10.0.0.5/token" not in targets
+    assert result["token_endpoint_reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_test_provider_skips_disallowed_issuer() -> None:
+    svc = _service()
+    provider = _provider_with_urls(
+        jwks_uri="https://www.googleapis.com/oauth2/v3/certs",
+        token_endpoint="https://accounts.google.com/o/oauth2/token",
+        issuer_url="http://[fd00:ec2::254]",
+    )
+    svc._repo.get_provider = AsyncMock(return_value=provider)
+
+    fake_dns = _fake_getaddrinfo(
+        {
+            "accounts.google.com": ["142.250.190.46"],
+            "www.googleapis.com": ["142.250.190.74"],
+        }
+    )
+
+    targets: list[str] = []
+
+    async def fake_get(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    async def fake_options(url, *args, **kwargs):
+        targets.append(url)
+        resp = MagicMock()
+        resp.status_code = 204
+        return resp
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=fake_get)
+    client.options = AsyncMock(side_effect=fake_options)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "apis.shared.security.url_validator.socket.getaddrinfo", fake_dns
+    ), patch(
+        "apis.shared.auth_providers.service.httpx.AsyncClient", return_value=cm
+    ):
+        result = await svc.test_provider("test-id")
+
+    assert all("fd00" not in t for t in targets)
+    assert result["discovery_reachable"] is False

--- a/backend/tests/shared/test_files_cursor_validation.py
+++ b/backend/tests/shared/test_files_cursor_validation.py
@@ -1,0 +1,131 @@
+"""Tests for the ``GET /files`` cursor's PK-matches-caller invariant.
+
+The pagination cursor is a base64-encoded JSON object containing the
+DynamoDB ``LastEvaluatedKey`` (which includes the partition key the
+record was queried under). When a client supplies a cursor whose PK
+points at a different user's partition than the calling user's,
+DynamoDB rejects the query with ``ValidationException`` — historically
+surfaced to the caller as a 500. The repository now validates that the
+cursor's PK matches the caller's expected PK before sending it to
+DynamoDB; mismatched cursors yield a generic 400 with no echo.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from apis.shared.files.repository import FileUploadRepository, InvalidCursorError
+
+
+def _cursor(pk: str, sk: str = "FILE#abc") -> str:
+    return base64.b64encode(json.dumps({"PK": pk, "SK": sk}).encode()).decode()
+
+
+def _repo() -> FileUploadRepository:
+    """Build a repository instance without touching DynamoDB."""
+    repo = FileUploadRepository.__new__(FileUploadRepository)
+    repo._table = None  # type: ignore[attr-defined]
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Cursor PK must match the caller
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_with_other_user_pk_is_rejected() -> None:
+    repo = _repo()
+    other_pk_cursor = _cursor("USER#some-other-user")
+
+    with pytest.raises(InvalidCursorError):
+        await repo.list_user_files(user_id="caller-id", cursor=other_pk_cursor)
+
+
+@pytest.mark.asyncio
+async def test_cursor_with_garbage_payload_is_rejected() -> None:
+    repo = _repo()
+    bogus = base64.b64encode(b"not-json-at-all").decode()
+
+    with pytest.raises(InvalidCursorError):
+        await repo.list_user_files(user_id="caller-id", cursor=bogus)
+
+
+@pytest.mark.asyncio
+async def test_cursor_without_pk_field_is_rejected() -> None:
+    repo = _repo()
+    no_pk = base64.b64encode(json.dumps({"SK": "FILE#abc"}).encode()).decode()
+
+    with pytest.raises(InvalidCursorError):
+        await repo.list_user_files(user_id="caller-id", cursor=no_pk)
+
+
+@pytest.mark.asyncio
+async def test_invalid_cursor_returns_400_at_route(tmp_path) -> None:
+    """End-to-end: a malformed cursor surfaces as a 400, not a 500.
+
+    The InvalidCursorError → 400 mapping has to be wired by whichever
+    layer registers the handler. We verify the contract at the
+    repository level (above) and the route's HTTPException-on-error
+    behaviour here, with the repository mocked to raise
+    InvalidCursorError.
+    """
+    from unittest.mock import AsyncMock, patch
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from apis.app_api.files.routes import router
+    from tests.routes.conftest import mock_auth_user
+
+    app = FastAPI()
+    app.include_router(router)
+
+    user_id = "caller-id"
+    from apis.shared.auth.models import User
+
+    mock_auth_user(app, User(user_id=user_id, email="c@x", name="C", roles=[]))
+
+    fake_service = AsyncMock()
+    fake_service.list_user_files = AsyncMock(side_effect=InvalidCursorError())
+
+    with patch(
+        "apis.app_api.files.routes.get_file_upload_service",
+        return_value=fake_service,
+    ):
+        client = TestClient(app)
+        resp = client.get("/files", params={"cursor": _cursor("USER#someone-else")})
+
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Owner's own cursor still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_with_caller_pk_is_accepted(monkeypatch) -> None:
+    """A cursor whose PK matches the caller is unwrapped into
+    ExclusiveStartKey and forwarded to DynamoDB unchanged."""
+    repo = _repo()
+
+    captured: dict = {}
+
+    class FakeTable:
+        def query(self, **kwargs):
+            captured.update(kwargs)
+            return {"Items": [], "LastEvaluatedKey": None}
+
+    repo._table = FakeTable()  # type: ignore[attr-defined]
+
+    own_cursor = _cursor("USER#caller-id")
+    files, next_cursor = await repo.list_user_files(
+        user_id="caller-id", cursor=own_cursor
+    )
+
+    assert files == []
+    assert "ExclusiveStartKey" in captured
+    assert captured["ExclusiveStartKey"]["PK"] == "USER#caller-id"


### PR DESCRIPTION
A handful of related cleanups across admin and data-edge routes that share a common shape: each one either accepted ill-formed input that went on to crash a downstream call, leaked upstream error detail in 500 bodies, or didn't verify ownership before mutating shared records.

Admin/Bedrock model listing
  GET /admin/bedrock/models filter parameters now use Pydantic
  Literal/regex types so out-of-shape values are refused at the
  request boundary with a generic 422 (no input echo, no enum-set
  reflection). The route's bespoke ClientError/BotoCoreError/Exception
  handlers are removed in favour of the app-wide
  register_aws_client_error_handler installed at startup, which maps
  ValidationException-class codes to a generic 400 and other
  ClientErrors to a generic 502. A new register_validation_error_handler
  replaces FastAPI's default 422 body with the same generic body.

Memory-record delete
  DELETE /memory/{record_id} now fetches the record's metadata via
  GetMemoryRecord and verifies the calling user appears in the
  /actors/{user_id} segment of the record's namespace before issuing
  batch_delete_memory_records. Non-owners (and missing records) get a
  generic 404. Two new helpers — get_memory_record_owner and
  record_namespace_owner — encapsulate the lookup and namespace parse.

OIDC discovery + auth-provider connectivity tests
  POST /admin/auth-providers/discover now runs the supplied issuer URL
  through the SSRF validator (https-only, no loopback / link-local /
  private / metadata addresses) before fetching .well-known/openid-
  configuration. POST /admin/auth-providers/{id}/test now applies the
  same validator to each stored URL — jwks_uri, token_endpoint, and
  the issuer-derived discovery URL — independently; a URL that fails
  validation is reported unreachable in the per-endpoint result map
  and is not contacted.

Files pagination cursor
  GET /files now refuses cursors whose embedded PK doesn't match the
  caller's USER#{user_id} partition. The repository raises a new
  InvalidCursorError; the route maps that to a generic 400 instead of
  the previous 500 the cross-partition DynamoDB query produced.

Tests:
- test_admin_bedrock_models.py (16) — Pydantic rejection of bad enum/regex filters short-circuits before any boto3 call; AWS ValidationException maps to 400 with no message reflection; other ClientError maps to 502 generic; legitimate filters reach AWS; unhandled exception → 500 with no exception detail in body.
- test_memory_delete_ownership.py (4) — owner can delete; non-owner gets 404 and no AWS call; record without namespaces treated as not owned; missing record → 404 with no AWS call.
- test_auth_providers_ssrf.py (12) — discover refuses 8 disallowed issuer shapes (loopback, link-local, RFC1918, IPv6 loopback, http://, file://, javascript:); accepts a legitimate https issuer; test endpoint skips disallowed jwks_uri / token_endpoint / issuer URLs individually, marking them unreachable without contacting them.
- test_files_cursor_validation.py (5) — cursor with another user's PK rejected at repository, garbage cursor rejected, cursor without PK rejected, owner's own cursor still works, route maps the error to 400.
- Two existing auth_providers tests updated to mock DNS through the validator's getaddrinfo so their fake hostnames continue to work.