### PR TITLE
ci(artifacts): plumb CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS through deploy workflows

### DIFF
--- a/.github/workflows/nightly-deploy-pipeline.yml
+++ b/.github/workflows/nightly-deploy-pipeline.yml
@@ -90,6 +90,11 @@ jobs:
       CDK_RETAIN_DATA_ON_DELETE: ${{ vars.CDK_RETAIN_DATA_ON_DELETE }}
       CDK_COGNITO_DOMAIN_PREFIX: ${{ vars.CDK_COGNITO_DOMAIN_PREFIX }}
       CDK_ARTIFACTS_CERTIFICATE_ARN: ${{ vars.CDK_ARTIFACTS_CERTIFICATE_ARN }}
+      # Extra origins allowed to frame the artifacts iframe via CSP
+      # frame-ancestors (beyond the deployed SPA origin) — e.g.
+      # http://localhost:4200 for a local SPA pointed at this deployment.
+      # Empty on prod. Mirrors CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS below.
+      CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
       # MCP Apps sandbox-proxy origin (mcp-sandbox.{domain}). Without the
       # cert ARN the construct silently falls back to the CloudFront default

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -73,6 +73,11 @@ jobs:
       CDK_COGNITO_LOGOUT_URLS: ${{ vars.CDK_COGNITO_LOGOUT_URLS }}
       CDK_COGNITO_SUPPORTED_IDPS: ${{ vars.CDK_COGNITO_SUPPORTED_IDPS }}
       CDK_ARTIFACTS_CERTIFICATE_ARN: ${{ vars.CDK_ARTIFACTS_CERTIFICATE_ARN }}
+      # Extra origins allowed to frame the artifacts iframe via CSP
+      # frame-ancestors (beyond the deployed SPA origin) — e.g.
+      # http://localhost:4200 for a local SPA pointed at this deployment.
+      # Empty on prod. Mirrors CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS below.
+      CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
       # MCP Apps sandbox-proxy origin (mcp-sandbox.{domain}). Without the
       # cert ARN the construct silently falls back to the CloudFront default


### PR DESCRIPTION
## What

Adds `CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS` to the env block of `platform.yml` and `nightly-deploy-pipeline.yml`, mirroring the existing `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS` passthrough.

## Why

The artifacts iframe's CSP `frame-ancestors` list is built in `platform-stack.ts` from the deployed SPA origin **plus** `config.artifacts.extraFrameAncestors`, and is enforced in two places (defense in depth):

- the artifacts CloudFront response-headers-policy (`artifacts-distribution-construct.ts`)
- the render Lambda's `FRAME_ANCESTOR_ORIGIN` env (`artifact-render-lambda-construct.ts`)

`config.ts` already reads `CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS` (and the config comment explicitly cites `http://localhost:4200` for local dev), but **neither deploy workflow passed the var through** — only the MCP-sandbox equivalent was wired. As a result there was no supported way to let a local SPA (`http://localhost:4200`) embed artifacts served by a deployed dev distribution: the iframe fails with `artifacts.<domain> refused to connect` (a `frame-ancestors` block, not a network error).

This closes that gap so a deployed dev environment can opt local origins into the artifacts `frame-ancestors` allow-list.

## Safety

Unset by default — when the GitHub Actions variable isn't set, `config.ts` falls back to `[]`, so prod (and any env that doesn't set it) is a no-op. No infra TypeScript changed, so there's no `cdk synth`/jest snapshot impact.

## How to use (dev)

1. Set repo/environment **Variable** `CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS=http://localhost:4200` on the dev environment (leave unset on prod).
2. Run a platform deploy — updates both the artifacts CloudFront CSP and the render Lambda's `FRAME_ANCESTOR_ORIGIN` (they share one resolved string).
3. Local backend `.env`: `ARTIFACTS_ORIGIN=https://artifacts.alpha.boisestate.ai` so app-api mints render tokens at the dev origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)