### PR TITLE
fix(skills): resolve and persist subset-scoped external MCP tool bindings

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -25,6 +25,7 @@ from agents.main_agent.tools import (
 )
 from agents.main_agent.multimodal import PromptBuilder
 from agents.main_agent.streaming import StreamCoordinator
+from apis.shared.tools.scoped_ids import base_tool_id
 
 logger = logging.getLogger(__name__)
 
@@ -224,10 +225,22 @@ class BaseAgent(ABC):
             external_tool_ids = []
 
             async def check_tools():
+                # A scoped id (`base::tool`) selects one tool of an MCP server;
+                # the catalog only knows the base id, and the tool filter
+                # classifies by the base too (`base in _external_mcp_tools`), so
+                # look up and register the BASE id. Registering the raw scoped
+                # id would miss the catalog entirely (`get_tool` is an exact PK
+                # lookup) and never match the base-keyed classifier — leaving a
+                # per-tool external binding unclassified and never loaded.
+                seen: set[str] = set()
                 for tool_id in self.enabled_tools:
-                    tool = await repository.get_tool(tool_id)
+                    base = base_tool_id(tool_id)
+                    if base in seen:
+                        continue
+                    seen.add(base)
+                    tool = await repository.get_tool(base)
                     if tool and tool.protocol == "mcp_external":
-                        external_tool_ids.append(tool_id)
+                        external_tool_ids.append(base)
                 return external_tool_ids
 
             try:

--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -26,7 +26,7 @@ from apis.shared.tools.models import (
     MCPTransport,
     ToolDefinition,
 )
-from apis.shared.tools.scoped_ids import collect_tool_name_filters
+from apis.shared.tools.scoped_ids import base_tool_id, collect_tool_name_filters
 from agents.main_agent.integrations import oauth_token_cache
 from agents.main_agent.integrations.mcp_apps import UICapableMCPClient
 from agents.main_agent.integrations.gateway_auth import get_sigv4_auth
@@ -446,11 +446,36 @@ class ExternalMCPIntegration:
         return clients
 
     def get_client(self, tool_id: str, user_id: Optional[str] = None) -> Optional[MCPClient]:
-        if user_id:
-            user_key = f"{user_id}:{tool_id}"
-            if user_key in self.clients:
-                return self.clients[user_key]
-        return self.clients.get(tool_id)
+        """Return the live client for a (possibly-scoped) catalog tool id.
+
+        Clients are cached under the *base* catalog id — optionally
+        ``"{user_id}:"``-prefixed (user-auth tools) and optionally
+        ``"|allow:<names>"``-suffixed when only a subset of the server's tools
+        is selected (per-tool enablement, e.g. a skill binding a subset of a
+        Canvas server's tools). A scoped lookup id (``base::tool``) therefore
+        never matches a stored key directly, so collapse it to its base and
+        match that, tolerating the ``|allow:`` suffix:
+        ``collect_tool_name_filters`` folds every scoped id for one server into
+        a single client per agent build, so the base uniquely identifies it.
+
+        Without this, a skill that bound a *subset* of an external MCP server
+        resolved to no client at fold time → the skill folded zero tools and
+        the model reported the server "not connected" (the OAuth consent gate
+        never fired because no FoldedMCPTool existed to trigger it).
+        """
+        base = base_tool_id(tool_id)
+        # Exact keys win — a whole-server binding has no "|allow:" suffix.
+        exact_keys = [f"{user_id}:{base}", base] if user_id else [base]
+        for key in exact_keys:
+            if key in self.clients:
+                return self.clients[key]
+        # Subset-scoped fallback: cache key is "<base>|allow:<names>".
+        for key in exact_keys:
+            prefix = f"{key}|allow:"
+            for cache_key, client in self.clients.items():
+                if cache_key.startswith(prefix):
+                    return client
+        return None
 
     def add_to_tool_list(self, tools: List[Any]) -> List[Any]:
         for client in self.clients.values():

--- a/backend/src/agents/main_agent/integrations/mcp_tool_folding.py
+++ b/backend/src/agents/main_agent/integrations/mcp_tool_folding.py
@@ -55,6 +55,30 @@ def set_folded_tool_names(client: Any, names: Iterable[str]) -> None:
             logger.debug("could not reset _loaded_tools on %r", client, exc_info=True)
 
 
+def reset_folded_tool_names(client: Any) -> None:
+    """Clear any fold set on ``client`` (and its cached tool list).
+
+    The fold set is *per-agent-build* state, but clients are process-global and
+    reused across builds (the external / gateway integrations cache them), and
+    :func:`set_folded_tool_names` only ever *adds*. Each build must therefore
+    start from a clean fold and recompute it from its own skill bindings —
+    otherwise a prior build's fold persists and poisons this build's
+    enumeration: ``resolve_mcp_bindings`` lists an external server through the
+    same fold-filtered ``list_tools_sync``, so a stale fold makes a re-bind see
+    zero tools (the bound tool "works once, then disappears" on the next turn).
+
+    Call this on every client a build is about to (re)bind, *before* resolving,
+    then let the build re-apply the fold via :func:`set_folded_tool_names`.
+    """
+    if getattr(client, _FOLD_ATTR, None):
+        setattr(client, _FOLD_ATTR, set())
+    if getattr(client, "_loaded_tools", None) is not None:
+        try:
+            client._loaded_tools = None
+        except Exception:  # pragma: no cover - defensive; attr is a plain field
+            logger.debug("could not reset _loaded_tools on %r", client, exc_info=True)
+
+
 def folded_tool_names(client: Any) -> set:
     """Return the (copy of the) fold set on ``client``, or an empty set."""
     existing = getattr(client, _FOLD_ATTR, None)

--- a/backend/src/agents/main_agent/skill_agent.py
+++ b/backend/src/agents/main_agent/skill_agent.py
@@ -258,16 +258,34 @@ class SkillAgent(ChatAgent):
             get_external_mcp_integration,
         )
         from agents.main_agent.integrations.mcp_tool_folding import (
+            reset_folded_tool_names,
             set_folded_tool_names,
         )
         from agents.main_agent.skills.mcp_binding import resolve_mcp_bindings
 
         external_integration = get_external_mcp_integration()
 
+        # Clients are process-global and reused across agent builds; a prior
+        # build's fold persists on them (set_folded_tool_names only adds).
+        # resolve_mcp_bindings enumerates an external server through that same
+        # fold-filtered list_tools_sync, so a stale fold makes this re-bind see
+        # zero tools (the bound tool "works once, then disappears"). Reset each
+        # client this build will resolve so enumeration sees the full server;
+        # the fold is recomputed and re-applied from the bindings just below.
+        gateway_client = self.gateway_integration.client
+        if gateway_client is not None:
+            reset_folded_tool_names(gateway_client)
+        seen_clients: set = set()
+        for tid in external_ids:
+            client = external_integration.get_client(tid, self.user_id)
+            if client is not None and id(client) not in seen_clients:
+                seen_clients.add(id(client))
+                reset_folded_tool_names(client)
+
         bindings = resolve_mcp_bindings(
             gateway_ids=gateway_ids,
             external_ids=external_ids,
-            gateway_client=self.gateway_integration.client,
+            gateway_client=gateway_client,
             expand_gateway=self._expand_gateway_tool_ids,
             external_client_lookup=lambda tid: external_integration.get_client(
                 tid, self.user_id

--- a/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
+++ b/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
@@ -376,3 +376,73 @@ class TestLoadExternalToolsScoped:
         assert first == [client_a]
         assert second == [client_b]
         assert len(integration.clients) == 2
+
+
+class TestGetClientResolvesScopedBindings:
+    """`get_client` must map a (possibly-scoped) catalog id back to the client
+    `load_external_tools` cached, including the per-tool `|allow:` cache-key
+    suffix a subset binding produces. Regression: a skill binding a *subset*
+    of an external MCP server (scoped ids like `canvas::courses`) resolved to
+    no client at fold time, so the skill folded zero tools and the model
+    reported the server "not connected"."""
+
+    @staticmethod
+    def _oauth_tool(tool_id="canvas"):
+        return SimpleNamespace(
+            tool_id=tool_id,
+            protocol="mcp_external",
+            mcp_config=SimpleNamespace(
+                server_url="https://example.com/mcp",
+                approval_required_names=lambda: set(),
+            ),
+            forward_auth_token=False,
+            requires_oauth_provider="canvas-oauth",
+            updated_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolves_scoped_oauth_binding_round_trip(self):
+        integration = ExternalMCPIntegration()
+        client = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=self._oauth_tool()))
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+            return_value=client,
+        ):
+            await integration.load_external_tools(
+                ["canvas::courses", "canvas::submissions"], user_id="alice"
+            )
+
+        # Cached under "alice:canvas|allow:courses,submissions"; the skill folds
+        # by the scoped id (or the base) — every form must find that client.
+        assert integration.get_client("canvas::courses", "alice") is client
+        assert integration.get_client("canvas::submissions", "alice") is client
+        assert integration.get_client("canvas", "alice") is client
+
+    @pytest.mark.asyncio
+    async def test_whole_server_binding_still_resolves(self):
+        integration = ExternalMCPIntegration()
+        client = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=self._oauth_tool()))
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+            return_value=client,
+        ):
+            await integration.load_external_tools(["canvas"], user_id="alice")
+
+        # Exact whole-server key resolves, and a scoped lookup against it does too.
+        assert integration.get_client("canvas", "alice") is client
+        assert integration.get_client("canvas::courses", "alice") is client
+
+    def test_missing_returns_none(self):
+        integration = ExternalMCPIntegration()
+        assert integration.get_client("canvas::courses", "alice") is None
+        assert integration.get_client("canvas") is None

--- a/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
+++ b/backend/tests/agents/main_agent/skills/test_skill_agent_db.py
@@ -186,3 +186,97 @@ class TestToolUseApprovalLookupWiring:
         assert target.tool_name == "gmail_send"
         assert target.tool_input == {"to": "hr@example.com"}
         assert lookup({"name": "some_other_tool", "input": {}}) is None
+
+
+class _FoldAwareClient:
+    """Stand-in external MCP client that folds like the real ones.
+
+    ``list_tools_sync`` re-derives the full server list every call and applies
+    ``drop_folded_tools`` against the persisted fold set — exactly the seam
+    that poisons a re-bind when the fold from a prior build is still present.
+    """
+
+    def __init__(self, names):
+        self._names = list(names)
+        self._loaded_tools = None
+
+    def list_tools_sync(self):
+        from agents.main_agent.integrations.mcp_tool_folding import (
+            drop_folded_tools,
+        )
+
+        tools = [
+            SimpleNamespace(
+                tool_name=n,
+                tool_spec={"name": n},
+                mcp_tool=SimpleNamespace(name=n),
+            )
+            for n in self._names
+        ]
+        return drop_folded_tools(self, tools)
+
+
+class TestBindMcpToolsRebindsAcrossBuilds:
+    """A skill-bound external server must stay foldable on EVERY agent build,
+    not just the first. Clients are process-global and reused; the fold set
+    persists on them and accumulates, and resolve enumerates through the same
+    fold-filtered list_tools_sync — so without a per-build reset the second
+    build sees zero tools (the reported "works once, then disappears"). """
+
+    @staticmethod
+    def _build_once(client):
+        from agents.main_agent.tools.tool_filter import ToolFilter
+        from agents.main_agent.skills.skill_registry import SkillRegistry
+
+        registry = SkillRegistry()
+        registry.load_records(
+            [
+                SimpleNamespace(
+                    skill_id="canvas_check",
+                    description="",
+                    instructions="",
+                    compose=[],
+                    bound_tool_ids=["canvas::a"],
+                    resources=[],
+                )
+            ]
+        )
+
+        agent = object.__new__(skill_agent.SkillAgent)
+        agent._registry = registry
+        agent._db_mode = True
+        agent.tool_registry = SimpleNamespace(has_tool=lambda _t: False)
+        tool_filter = ToolFilter(SimpleNamespace(has_tool=lambda _b: False))
+        tool_filter.set_external_mcp_tools(["canvas"])
+        agent.tool_filter = tool_filter
+        agent.gateway_integration = SimpleNamespace(client=None)
+        agent._expand_gateway_tool_ids = lambda _ids: []
+        agent.user_id = "u1"
+
+        integration = SimpleNamespace(get_client=lambda _tid, _uid=None: client)
+        with patch(
+            "agents.main_agent.integrations.external_mcp_client.get_external_mcp_integration",
+            return_value=integration,
+        ):
+            agent._bind_mcp_tools()
+        return registry
+
+    def test_second_build_still_resolves_and_folds(self):
+        from agents.main_agent.integrations.mcp_tool_folding import (
+            folded_tool_names,
+        )
+
+        client = _FoldAwareClient(["a", "b"])  # shared across both builds
+
+        reg1 = self._build_once(client)
+        assert reg1.get_tools("canvas_check"), "first build should bind tools"
+        assert folded_tool_names(client) == {"a", "b"}, "first build folds them"
+
+        # Second build: a fresh registry (as in production) but the SAME cached
+        # client, still carrying build 1's fold. The reset must let it rebind.
+        reg2 = self._build_once(client)
+        assert reg2.get_tools("canvas_check"), (
+            "second build must still resolve the bound tools (regression: stale "
+            "fold made list_tools_sync return nothing)"
+        )
+        assert folded_tool_names(client) == {"a", "b"}

--- a/backend/tests/agents/main_agent/test_base_agent_external_registration.py
+++ b/backend/tests/agents/main_agent/test_base_agent_external_registration.py
@@ -1,0 +1,75 @@
+"""Regression: external MCP tool *registration* must base-normalize scoped ids.
+
+`_register_external_mcp_tools` queries the catalog and seeds the tool filter's
+external set. The catalog only knows *base* ids and the filter classifies by
+the base (`base in _external_mcp_tools`), so a scoped binding (`base::tool`,
+e.g. a skill that enables a subset of a Canvas server) must register its base.
+
+Before the fix it looked the catalog up with the raw scoped id — an exact PK
+lookup that returns nothing — so the base was never registered, the id was
+never classified as external, and the per-tool binding was never loaded (the
+skill folded zero tools and the model reported the server "not connected").
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from agents.main_agent.base_agent import BaseAgent
+from agents.main_agent.tools.tool_filter import ToolFilter
+
+
+def _make_filter() -> ToolFilter:
+    # The registry only needs has_tool for classification; no local tools here.
+    return ToolFilter(SimpleNamespace(has_tool=lambda _b: False))
+
+
+class TestRegisterExternalMcpToolsScoped:
+    def test_scoped_external_registration_enables_classification(self):
+        tool_filter = _make_filter()
+        agent = SimpleNamespace(
+            enabled_tools=["canvas::list_courses", "canvas::whoami"],
+            tool_filter=tool_filter,
+        )
+
+        async def fake_get_tool(tool_id):
+            # The catalog only knows the base id.
+            if tool_id == "canvas":
+                return SimpleNamespace(protocol="mcp_external")
+            return None
+
+        repo = SimpleNamespace(get_tool=AsyncMock(side_effect=fake_get_tool))
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ):
+            BaseAgent._register_external_mcp_tools(agent)
+
+        # Base id registered (deduped across the two scoped ids)...
+        assert tool_filter._external_mcp_tools == {"canvas"}
+        # ...and the catalog was queried by base, never the raw scoped id.
+        queried = {c.args[0] for c in repo.get_tool.await_args_list}
+        assert queried == {"canvas"}
+        # End-to-end: classification now carries both scoped ids through as
+        # external (the contract load_external_tools / the skill fold rely on).
+        result = tool_filter.filter_tools_extended(
+            ["canvas::list_courses", "canvas::whoami"]
+        )
+        assert result.external_mcp_tool_ids == [
+            "canvas::list_courses",
+            "canvas::whoami",
+        ]
+
+    def test_bare_id_still_registers(self):
+        tool_filter = _make_filter()
+        agent = SimpleNamespace(enabled_tools=["canvas"], tool_filter=tool_filter)
+        repo = SimpleNamespace(
+            get_tool=AsyncMock(
+                return_value=SimpleNamespace(protocol="mcp_external")
+            )
+        )
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ):
+            BaseAgent._register_external_mcp_tools(agent)
+
+        assert tool_filter._external_mcp_tools == {"canvas"}


### PR DESCRIPTION
## Summary

Two related fixes so a skill that binds a **subset** of an external MCP server's tools (per-tool enablement — scoped ids like `canvas::courses`) actually works, on every turn.

### 1. Resolve subset-scoped bindings at fold time (`f5fa2835`)
A subset binding resolved to **no client** when the skill agent folded its tools, so the skill folded zero tools and the model reported the server "not connected" (the OAuth consent gate never fired — no `FoldedMCPTool` existed to trigger it).

- `base_agent`: register/look up external tools by their **base** catalog id (the catalog and tool filter both key on the base), deduping scoped ids for the same server.
- `ExternalMCPIntegration.get_client`: collapse a scoped lookup id to its base and match the cached client, tolerating the `|allow:<names>` subset cache-key suffix.

### 2. Reset stale tool folds across agent builds (`ff0d4bd6`)
MCP clients are process-global and reused across builds; the fold set persists and `set_folded_tool_names` only ever *adds*. `resolve_mcp_bindings` enumerates a server through that same fold-filtered `list_tools_sync`, so a stale fold made a re-bind see zero tools — the bound tool "works once, then disappears" on the next turn.

- `mcp_tool_folding`: add `reset_folded_tool_names` to clear a client's fold set + cached tool list.
- `skill_agent`: reset every client this build will (re)bind before resolving, then recompute and re-apply the fold.

## Testing
`uv run pytest` on the affected suites — **51 passed** (scoped-binding resolution, base-id registration, fold-reset rebind, plus the unrelated system-prompt-builder suite as a regression check).

## Notes
Branched off `develop`; touches only `agents/main_agent` + tests. No infra, API-contract, or security-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
