### PR TITLE
chore(kaizen): weekly research scan 2026-06-19

### DIFF
--- a/docs/kaizen/research/2026-06-19.md
+++ b/docs/kaizen/research/2026-06-19.md
@@ -1,0 +1,249 @@
+# Kaizen Research — Friday, June 19, 2026
+> Scan window: June 12 – June 19, 2026 (7 days)
+> Web budget: ~72/50 used (overage — version-pin subagent used ~14 of 72; AWS Summit NYC + Fable suspension made this a signal-rich week; see Web Budget block).
+
+## TL;DR
+
+**Last week's #2 recommendation just reversed itself:** Claude Fable 5 + Mythos 5 were **revoked on Bedrock for all users (June 12–13)** under a US government export directive — three days after their June 9 GA. The queued "[2026-06-12] Add Claude Fable 5 to model settings" item must be **withdrawn** (review-prep should mark it superseded); Opus 4.8 stays the stable harness model. The week's #1 *positive* idea is **wiring configurable Bedrock Guardrails (issue #480)** — a library-native config item (Strands `BedrockModel` already supports `guardrail_id`/`version`) with a real FERPA duty-of-care driver, freshly reinforced by an AWS Summit NYC guardrails cluster (June 16–17). The most pressing internal signal is unchanged but now diagnosed: **Nightly Build & Test has failed ~14 consecutive days, and the cause is an `exit 127` (command-not-found) at the install/setup steps — a CI environment regression, not a test regression.**
+
+## External Scan
+
+### What's moving this week
+
+Two forces dominated. First, **AWS Summit NYC (June 16–17)** dropped an AgentCore + Guardrails cluster that lands squarely on our constructs: managed **Web Search as a Gateway MCP target** (GA, us-east-1 only), **Bedrock Guardrails enforced at the Gateway perimeter** (GA, not us-west-2), a new per-request **`InvokeGuardrailChecks`** API for in-loop checks, AgentCore production-trace **optimization**, and a managed **Knowledge Base** RAG service. The throughline: *Gateway-as-MCP-host is getting first-party AWS connectors and perimeter safety controls* — most of it region-gated away from our us-west-2 dev environment, so it's strategy-shaping rather than drop-in. Second, **a model-availability shock**: Anthropic was ordered to block foreign-national access to Fable 5/Mythos 5, couldn't comply selectively, and asked AWS to pull both for everyone. A model we were about to wire is now unavailable.
+
+Underneath that, the SDKs kept moving fast. **Strands shipped 1.44.0** (now 4 minors ahead of our pin) and quietly **ported its memory + agentic-context-management subsystems to Python** — native equivalents to code we hand-rolled, plus a migration to a `harness-sdk` monorepo with new `python/vX.Y.Z` tag prefixes. **`bedrock-agentcore` hit 1.15.0** (we're 6 minors behind; the #482 SSE-disconnect deadlock fix lives in the 1.14.x line we haven't adopted). The MCP standards track produced two strategically-relevant extensions — **Skills-over-MCP (SEP-2640)** and **Enterprise-Managed Authorization (now STABLE)** — both mapping onto systems we just built (admin skills; external-MCP OAuth consent). Internally it was a **security-hardening week** (admin error sanitization, TLS 1.2 floor, SigV4 scoping, session ownership, URL validation, system-prompt safety floor) plus the merged Dependabot remediation (#487) that, as a side effect, **resolved the queued starlette CVE item** by bumping it to 1.3.1.
+
+### Notable items by source
+
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens.
+> - `*unlocks*:` — capability-unlock lens (net-new product capability this enables).
+
+#### AWS Bedrock / AgentCore
+- **Web Search on AgentCore (GA, June 16)** — Managed agentic web-search exposed as a built-in connector target on **AgentCore Gateway via MCP**, returning ranked results with zero data egress; **us-east-1 only**. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-agentcore-web-search/ — *relevance*: our Gateway (MCP+SigV4) layer + issue #419 admin target registration; an AWS-native IAM-authed MCP target we could register instead of hosting an external web-search MCP server. *unlocks*: first-party web search without maintaining a server — but region gap (us-east-1 vs our us-west-2 dev) makes it a watch-item, not a drop-in.
+- **AgentCore Guardrails in policy (GA, June 16)** — Bedrock Guardrails enforced **at the Gateway perimeter, outside agent code** (prompt-injection / harmful-content / sensitive-data detection); us-east-1, London, Stockholm, Sydney, Tokyo — **not us-west-2**. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-agentcore-policy-guardrails-generally-available — *relevance*: complements admin-skills RBAC by centralizing injection/PII controls outside the agent loop; region gap blocks dev-ai. *unlocks*: perimeter safety enforcement decoupled from inference-api code.
+- **Bedrock Guardrails `InvokeGuardrailChecks` API (June 16)** — Per-request, granular safeguard control for iterative agent loops without standing guardrail resources. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-guardrails-api-ai/ — *relevance*: an in-loop alternative callable from inference-api's Strands loop; lighter-touch than the policy integration and **directly supports issue #480** (configurable guardrails). *unlocks*: selective per-turn content checks.
+- **AgentCore optimization — production trace analysis (June 16)** — Surfaces failure/intent/trajectory insights across hundreds of sessions and generates improvement recommendations from production traces. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-agentcore-new-optimization-capabilities — *relevance*: observability over our AgentCore Runtime sessions; pairs with the context-attribution/compaction telemetry we already emit. Managed alternative to homegrown trace inspection.
+- **Bedrock Managed Knowledge Base (GA, June 16)** — Fully managed RAG (native connectors, "Smart Parsing", agentic multi-step retriever); no vector-DB infra to manage. — https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-managed-knowledge-base/ — *relevance*: lower priority — we run our own `rag-ingestion` — but a strategic watch-item; the agentic retriever overlaps the skills reference-file disclosure path. Light touch.
+
+#### Strands Agents
+- **v1.44.0 (June 16) — current latest; we pin 1.40.0 → 4 minors behind.** — https://github.com/strands-agents/sdk-python/releases/tag/python/v1.44.0 — *relevance*: keystone-bump target advances 1.43 → 1.44 with no new Python breaking changes 1.41–1.44.
+- **v1.44.0 — Memory subsystem ported to Python** (`memory_manager` Agent param, `BedrockKnowledgeBaseStore`, extraction+injection; #2740/#2795/#2834/#2811/#2797). — same release — *relevance*: lands adjacent to our `TurnBasedSessionManager` + AgentCore Memory layer; opt-in (non-breaking) but architecturally significant — **needs a compat read before bumping**, do NOT adopt blindly (see decisions.md compaction scope note).
+- **v1.44.0 — Agentic context management ported to Python** (model-driven compression #2808; turn-based eviction #2648). — same release — *relevance*: native equivalent to our custom compaction → `compaction` SSE event. Candidate to *evaluate*, not swap (decisions.md: not a drop-in — our manager also does tool-truncation, LTM retrieval, DynamoDB checkpoint, SSE-once invariant).
+- **v1.44.0 — internal middleware system for `InvokeModelStage`** (#2760). — same release — *relevance*: a cleaner model-invocation extension point than our `BedrockModel`/`CountTokensBedrockModel` wrapping + stream-coordinator hooks. Worth scoping for token-counting integration.
+- **`OnEviction` hook requested (#2804, OPEN, updated June 19 — in-window)** — feature request to expose context-reduction events. — https://github.com/strands-agents/sdk-python/issues/2804 — *relevance*: maps ~1:1 to our `compaction` SSE surfacing; if it lands natively we could emit the compaction badge off a real Strands hook instead of stashing on the per-session agent.
+- **#2636 (non-ASCII tool-result serialization) STILL OPEN** — fix PRs #2661/#2653 unmerged; not in 1.44.0. — https://github.com/strands-agents/sdk-python/issues/2636 — *relevance*: `dict`-returning tools still `\uXXXX`-escaped (token + debuggability cost); add a known-limitation note on the bump, a second bump follows.
+- **Repo migrated to a `harness-sdk` monorepo** — tags now `python/vX.Y.Z` + `typescript/vX.Y.Z`; old `vX.Y.Z`/`sdk-python` release-tag assumptions 404. — *relevance*: update any tooling/docs that assume the old tag scheme when pinning forward.
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **HEAD `ee4c29e` (June 18) — multi-provider via Mantle, no architectural signal.** Two substantive commits, both model-layer: `ee4c29e` (#130, `ResilientMantleModel` reformats PDFs to OpenAI `filename`+`file_data` for Bedrock Mantle / GPT-5.x/Grok/Gemma) and `fb30d6e` (#131, frontend libvips bundle + auth-gated warmup). Rest are Dependabot. — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main — *applicability*: nothing to port — we run Claude on Converse, not Mantle/OpenAI-format. One-line awareness note: the ref repo is now multi-provider via Mantle, mirroring our own #479 "Amazon Bedrock Mantle" provider add this week.
+
+#### MCP ecosystem
+- **SEP-2640 — Skills Extension (skills over MCP via Resources + `resources/directory/read`)** — `skill://<path>/SKILL.md` URI convention, optional `skill://index.json` enumeration, and a new directory-read method to list skill subdirs without full-catalog enumeration; blesses exactly our pattern (name→origin registry, single `read_skill`-style tool, progressive disclosure). — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640 — *relevance*: **highest this week.** Parallels our `docs/specs/admin-skills-rbac-tool-binding.md` + SkillAgent progressive disclosure + S3 reference-file disclosure (PR #468). This is the emerging *wire* standard for what we built file-based. *unlocks*: future interop — serve/consume skills across MCP hosts. Monitor; no action yet.
+- **Enterprise-Managed Authorization (EMA) — reached STABLE (June 18)** — Zero-touch OAuth: clients get an Identity Assertion JWT Authorization Grant (ID-JAG) during SSO and exchange it for server access with **no per-server consent screen**; adopted by Anthropic, Microsoft, Okta, Figma, Linear, Asana. — https://blog.modelcontextprotocol.io/posts/enterprise-managed-auth/ — *relevance*: bears directly on our external-MCP OAuth token vault + per-provider consent (`apis/shared/oauth/agentcore_identity.py`, `oauth_required` SSE event). The standards-track answer to repeated-consent friction. *unlocks*: collapse multiple providers behind one enterprise consent. Strategic; evaluate against AgentCore Identity OAuth2 providers.
+- **PR #2907 — error-code allocation policy + draft renumber MERGED (June 18)** — last week's tracked renumber landed, now with a formal allocation policy. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2907 — *relevance*: 2026-07-28 RC hardening; grep our MCP JSON-RPC error-code asserts (FilteredMCPClient error surfacing, gateway discover unwrap) before the RC. Low effort.
+- **Interceptors (SEP-2624) — governance staffing, no spec change** — second WG lead added (PR #2935); middleware track staffing up ahead of the RC, no technical movement. — https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2935 — *relevance*: still the likeliest future home for a standardized tool-filter/middleware hook (our `list_tools_sync` filter). Watch, no action.
+- **MCP Apps / ext-apps — quiet, docs-only** — only in-window commit is a map-server doc-link fix (#657, June 17); no `io.modelcontextprotocol/ui` spec change. — https://github.com/modelcontextprotocol/ext-apps/commits/main — *relevance*: our MCP Apps host-renderer (PR #7/#349) is **not at drift risk** this week. Stable.
+
+#### FastMCP
+- **No new release since v3.4.2 (June 6).** — https://github.com/jlowin/fastmcp/releases — *implications for our MCP servers*: nothing to adopt; SEP-2567 sessionless transport has NOT landed (would be directly relevant to our stateless Lambda-backed servers — keep watching). No action.
+
+#### Agentic UI/UX patterns
+- **assistant-stream@0.0.34 — resumable stream primitives + typed attachment errors** — Adds primitives for re-attaching to an interrupted data stream rather than losing the turn, plus `source-document` message parts and typed composer attachment errors. — https://github.com/Yonom/assistant-ui/releases — *fit*: pattern-only (Angular); a resume token + replay-from-checkpoint maps onto our `content_block_delta` SSE — *where it lands*: SSE stream layer / `stream_coordinator.py` (a resume / last-event-id contract) + the streaming message-list service. Pairs with the AgentCore SDK #482 disconnect-deadlock theme.
+- **LibreChat v0.8.7-rc1 — real-time context-window gauge with clickable breakdown + cost** — Live gauge, hover snapshots, per-partition breakdown, rolled-up subagent token accounting. — https://github.com/danny-avila/LibreChat/releases/tag/v0.8.7-rc1 — *fit*: pattern-only; **directly reinforces the queued [2026-06-05] "make the context-breakdown badge interactive" item** (second convergence datapoint after Cursor). — *where it lands*: context-breakdown badge component (data already on the final `metadata` event's `contextBreakdown`).
+- **assistant-ui@0.14.23 + react-langchain — root tool calls, stream-error hooks, file content parts** — Exposes "root tool calls" (top-level vs nested/sub-agent), a `useLangChainError` stream-error hook, and file-content-part conversion. — https://github.com/Yonom/assistant-ui/releases — *fit*: pattern-only; the root/depth flag on tool events is multi-agent-attribution-adjacent (cf. queued [2026-05-10] named A2A participants) — *where it lands*: tool-result renderer registry (a depth/root flag) + `stream_error` semantics.
+- **MCP Enterprise-Managed Authorization — consent-UX direction** (see MCP ecosystem) — the ecosystem is standardizing on single-login / zero-touch consent over per-provider round-trips. — *fit*: strategic, not a direct port — *where it lands*: `oauth_required` event semantics.
+
+#### Frontier model announcements
+- **Claude Fable 5 & Mythos 5 SUSPENDED on Bedrock (June 12–13) — DIRECTLY AFFECTS OUR CONFIG.** Three days after June 9 GA, a US government directive ordered Anthropic to block all foreign-national access; unable to comply selectively, Anthropic asked AWS to revoke both for **all** Bedrock users. All other Anthropic models unaffected. — https://simonwillison.net/2026/Jun/13/us-government-directive-to-suspend-access/ , https://www.cnbc.com/2026/06/12/anthropic-disables-access-to-fable-5-and-mythos-5-to-comply-with-government-directive.html — *relevance*: **critical reversal.** Last week's #2 idea (add `claude-fable-5` to model settings) is now moot; confirm no live config points at `-fable-`/`-mythos-` profiles (those invocations now fail on Bedrock); Opus 4.8 (`[1m]`, our harness model) is the stable fallback. Availability regression, not a capability delta.
+- **OpenAI GPT-5.5/5.4 + Codex on Bedrock — likely our internal "Amazon Bedrock Mantle" provider, but OUT OF WINDOW (GA June 1).** Only in-window related event is GPT-5.2 retiring from ChatGPT (consumer, not API) June 12. — https://www.aboutamazon.com/news/aws/bedrock-openai-models — *relevance*: if `#479` Mantle maps to GPT-5.x on Bedrock, native tool-use schema + structured-output differ from Converse/Anthropic — a harness compatibility check is warranted. Underlying launch predates the window.
+- **Gemini 3.5 Pro GA / Llama — unconfirmed in-window.** Gemini 3.5 Flash GA'd in May (out of window); 3.5 Pro was "targeted for June" but not confirmed June 12–19. No Llama item surfaced. Reported as not-confirmed to avoid fabrication.
+
+#### Agent harness patterns
+- **Claude Code v2.1.183 (from v2.1.163 baseline) — subagent classifier gating + 5-level nesting (v2.1.172/178)** — Auto mode evaluates subagent spawns with a cheap classifier before launch; sub-agents nest up to 5 levels; `availableModels` restrictions apply down the delegation chain. — https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md — *relevance*: maps onto future A2A-server / skill-delegation work (gate a delegated call by a cheap classifier; enforce model-tier limits down-chain). Pattern, not a port yet.
+- **LangChain Deep Agents — `compact_conversation` as an agent-callable tool** — Summarization both as an automatic ~85% threshold AND a tool the model invokes on demand between tasks. — https://reference.langchain.com/python/deepagents/middleware/summarization — *relevance*: our `TurnBasedSessionManager` compaction is auto/threshold-only. Exposing model-initiated compaction (agent decides to compact between turns) is a genuinely net-new, **additive** pattern for our compaction path — does not conflict with the decisions.md "don't replace our compaction" note. *unlocks*: agent-controlled context budgeting. Cleanest net-new idea this week.
+- **Claude Code v2.1.181/176 — prompt-caching + Bedrock credential-expiration fixes** — Fixed caching on custom `ANTHROPIC_BASE_URL`/Foundry; Bedrock credential caching now keys off token `Expiration` not a fixed 1h window. — same changelog — *relevance*: low-effort sanity check against our SigV4 / AgentCore credential refresh (creds are runtime-managed, so likely a non-issue).
+- **No new Anthropic engineering post; no new pydantic-ai release in-window** — engineering blog latest is April 23; pydantic-ai latest v1.107.0 (June 10) is just outside the window. — *relevance*: thin week on this source.
+
+#### opencode (v1.17.8, June 17)
+- **v1.17.8 — MCP timeout preserved during long-running tool progress; tool failures surface the real server error** — https://github.com/anomalyco/opencode/releases — *lens*: Tooling (MCP). Worth confirming our inference-api 600s SSE timeout doesn't kill an MCP tool that's still emitting progress notifications. Errors-as-visible-messages parity we already have.
+- **v1.17.6/8 — OpenAI-compatible providers accept schema-less MCP tools; client capabilities declared at MCP init** — *lens*: Tooling. Minor relevance to FilteredMCPClient / Gateway target schema handling; MCP-interop hygiene.
+- **v1.17.7 — MCP servers receive workspace as client `root`** — *lens*: Context (loosely). Local-filesystem-shaped; doesn't map cleanly to our AgentCore Memory model. Low relevance.
+- Net: quiet patch week — no movement on sub-agent delegation, model routing/cost, or compaction.
+
+#### Pricing / quota
+- **No in-window Bedrock price/quota change.** Fable 5 at $10/$50/M was a June 9 GA datapoint (out of window) and is now suspended anyway. Pricing page returned a stale cache; cross-checked via search — no new change June 12–19. — https://aws.amazon.com/bedrock/pricing/
+
+#### Community + GitHub issues
+- **`strands-agents/shell` — sandboxed shell tool for the Strands agent loop** — "Give your agent a shell without giving it keys to your machine." — https://github.com/strands-agents/shell — *relevance*: we run the Strands loop with no sandboxed shell; intersects the **deferred scripts/code-exec line** in the admin-skills plan. Upstream pattern for a guarded exec tool. Watch.
+- **Strands evals-sdk red-teaming (GOAT strategy)** — First-party adversarial/red-team strategies for agent harnesses. — https://strandsagents.com/docs/user-guide/evals-sdk/red-teaming/strategies/ — *relevance*: we have no agent-eval/red-team harness; pairs with last week's Agent-EvalKit signal as the upstream correctness/safety layer our skills-mode RBAC build lacks.
+- **AgentCore SDK #482 — async-gen-to-sync-gen deadlock on SSE disconnect — still OPEN (updated June 11)** — queue worker loop wedges when an SSE consumer disconnects. — https://github.com/aws/bedrock-agentcore-sdk-python/issues/482 — *relevance*: exactly our inference-api-in-Runtime SSE path; fix lives in the 1.14.x/1.15.0 line we haven't adopted (pinned 1.9.1).
+- **AgentCore SDK #519 — startup crash (ModuleNotFoundError) misreported as "Runtime initialization time exceeded" (June 14)** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/519 — *relevance*: deploy/debug awareness when a Runtime update fails opaquely (cf. our recurring inference-api deploy failures).
+- **"Policy gate for AI coding-agent tool calls" (HN, June)** — Multiple same-week posts on gating/approving tool calls before execution. — https://polymr-platform.github.io/ — *relevance*: external interest in tool-call policy gates is rising; intersects our known BeforeToolCall approval-hook gap (hooks can't see through the tool-fold).
+
+#### Cookbook / courses
+- **No new Anthropic cookbook commits in-window** — last activity June 9 (Sentry-triage scheduled agent #698, async multi-agent #696, Fable-5 classifier #695), all captured last week. — https://github.com/anthropics/anthropic-cookbook/commits/main — nothing new.
+
+#### Seasonal
+- Out of window — no re:Invent, no NeurIPS/ICLR proceedings. None scanned. (AWS Summit NYC items are captured under AWS Bedrock / AgentCore above.)
+
+### Patterns worth considering
+
+- **Library-native + perimeter safety controls converging on Bedrock/AgentCore** — Strands `BedrockModel` already supports guardrail params; AWS shipped Gateway-perimeter Guardrails (GA) + a per-request `InvokeGuardrailChecks` API this week; issue #480 asks for the config wiring. The pieces line up for a clean, low-effort, compliance-driven feature.
+  - **Where**: `inference_api` model construction; `BedrockModel(guardrail_id=…, guardrail_version=…)`; CDK env vars
+  - **Fit**: direct — config wiring, not new capability; zero-cost when unset; matches the `CDK_*_ENABLED` optional-feature pattern
+  - **Verdict**: Worth trying (this is Idea #1)
+
+- **Real-time, clickable context-usage gauge** — Cursor (last month) and now LibreChat v0.8.7-rc1 both ship a live context-window gauge with a per-partition breakdown and cost overlay. We already emit `contextBreakdown` on the final `metadata` event; the badge is currently static.
+  - **Where**: context-breakdown badge component in `frontend/ai.client/src/app/session/`
+  - **Fit**: pattern-only (Angular signals); presentation-layer only — data already on the wire
+  - **Verdict**: Worth trying — reinforces the queued [2026-06-05] item with a second convergence datapoint
+
+- **Model-callable on-demand compaction** — LangChain Deep Agents exposes `compact_conversation` as a tool the model invokes between tasks, on top of the automatic threshold. Additive to (not a replacement for) our auto compaction.
+  - **Where**: a new built-in tool wired to the `TurnBasedSessionManager` compaction path
+  - **Fit**: net-new pattern; clears the decisions.md "don't replace our compaction" bar because it's additive
+  - **Verdict**: Monitor / Worth trying (Idea #5 alternative)
+
+---
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: ~16 (across ~10 PRs + a security-hardening cluster of direct commits)
+- **PRs opened**: 0 currently open — **merged in-window**: ~10 (#481–#487, #476–#479) — **reverted**: 0
+- **Issues opened**: 1 (#480 — configurable Bedrock Guardrails) — **closed**: 0 in-window
+- **CI failures (workflow → count)**: Nightly Build & Test → **~14 consecutive** (June 5–19, every day); Platform Stack (develop, June 19, cert handling) → 1; Backend Deploy (#487, June 18, "runtime may not exist yet") → 1
+
+### Repeated friction signals
+- **Nightly Build & Test: ~14 consecutive failures — now diagnosed as `exit 127` at install/setup steps.** The June 19 run shows `##[error]Process completed with exit code 127` on *Install Frontend Dependencies*, *Install Infrastructure*, and *Test Backend with Coverage* — a command-not-found at the environment-setup stage (cache action `fail-on-cache-miss: false` then a missing binary), plus `Check Stack Dependencies` exit 1. This is a **CI environment / runner regression, not a code or test regression** — last week's "root cause unknown" framing is now narrowed.
+  - **Hypothesis**: a tool that the install steps expect (likely `uv`, `node`/`npm`, or a `setup-*` action whose cache silently missed) is no longer on PATH after a runner-image or action-pin change — every job dies at setup before any test runs.
+  - **Fix candidate**: `gh run view <id> --log` on the full June 19 nightly to see which binary returns 127; re-pin or re-add the missing `setup-*` step. **Prerequisite before any dep bump** — landing Strands 1.44 / agentcore 1.15 on a suite that can't even install is blind.
+
+- **Queue-to-ship conversion still near zero for maintenance items** — Strands keystone still unshipped (pin 1.40.0, latest 1.44.0); bedrock-agentcore still 1.9.1 (latest 1.15.0). The security-hardening + Dependabot remediation work this week shows the team *can* land maintenance when it's framed as security; the kaizen dep-lag items keep slipping because the Nightly gate is red.
+  - **Hypothesis**: the red Nightly is now an active blocker on the dep bumps, not just a hygiene nag — it rationalizes deferring them.
+  - **Fix candidate**: ship the Nightly fix first (Idea #2), then the keystone bumps unblock as a cluster.
+
+### Version-pin lag
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| `strands-agents` | 1.40.0 | **1.44.0** | 4 minors | Native memory + agentic context-mgmt ported to Python; monorepo tag migration; #2636 still open |
+| `strands-agents-tools` | 0.5.2 | **0.8.1** | 3 pre-1.0 minors | Minors may carry breaking tool-interface changes; audit on the keystone bump |
+| `bedrock-agentcore` | 1.9.1 | **1.15.0** | 6 minors | #482 deadlock fix + async_mode + interactive shells live in 1.14.x/1.15.0; lag widening weekly |
+| `mcp` | 1.26.0 | **1.28.0** | 2 minors | Relevant to MCP Apps work; low urgency |
+| `starlette` | 1.3.1 | **1.3.1** | current ✓ | Bumped via PR #487 (June 18) — at latest; queued CVE item RESOLVED |
+| `boto3` / `botocore` | 1.43.9 | **1.43.33** | 24 patches (~10d) | Patch train; low risk |
+| `fastapi` | 0.136.1 | **0.137.2** | 1 minor + patches | Pre-1.0 minor; usually additive |
+| `@angular/core` | 21.2.11 | **22.0.2** | 1 major | Flagged 3+ weeks; migration spike required |
+| `aws-cdk-lib` | 2.251.0 | **2.260.0** | 9 minors | Routine; low urgency |
+| `vitest` | 4.1.5 | **4.1.9** | 4 patches | Low risk |
+| `constructs` | 10.6.0 | **10.6.0** | current ✓ | At latest |
+
+### Retirement candidates
+- **Queue item "[2026-06-12] Add Claude Fable 5 to model settings"** — **withdraw / mark superseded.** Fable 5 + Mythos 5 are revoked on Bedrock for all users (US gov directive, June 12–13). The model-ID-string-matching half of that item still has minor merit (audit `claude-opus-4` gates for future-proofing), but the "add Fable 5 to the dropdown / consider as default" core is dead until/unless the directive lifts. Review-prep should resolve this in `## Resolved`.
+- **`.claude/skills/angualar-best-practices/` (last modified Dec 30, 2025 — 171 days)** — typo'd name; content overlaps `tailwind-ui` (May 22) + `frontend-design` (Jan 18); not referenced in 90+ days. Retire or merge into a corrected `angular-best-practices`. (Carried from 2026-06-12.)
+- **`.claude/skills/frontend-design/` (Jan 18, 2026 — 152 days)** — older than project-level `tailwind-ui`; if covered, retire. (Carried from 2026-06-12.)
+
+### Deferred items up for revisit
+- **[2026-05-10] AgentCore Runtime BYO filesystem / persistent workspaces** — still deferred. This week's Strands native memory-port (1.44) + AgentCore Managed Knowledge Base + `strands-agents/shell` sandboxed exec are all adjacent primitives. Recommend keeping deferred but folding all three into a single "agent workspace / code-exec" architecture decision when it's picked up.
+- **[2026-05-10] Named A2A agent participants in the chat UI** — precondition (an A2A server construct) still unmet. The assistant-ui "root vs nested tool calls" pattern this week is the UI primitive it would build on. Defer.
+
+### Risks introduced this week
+- **Fable 5 / Mythos 5 Bedrock revocation** — any environment pointed at `-fable-`/`-mythos-` inference profiles now fails. *What breaks if ignored*: hard invocation failures on those profiles. Confirm no live config references them; keep Opus 4.8 as default.
+- **Backend Deploy (#487) failed: "[inference-api] Failed to get-agent-runtime — runtime may not exist yet" (exit 3)** — the Dependabot remediation merged but its inference-api deploy didn't complete cleanly. *What breaks if ignored*: the security bumps (starlette/cryptography/pyjwt/urllib3) may not be live on the deployed inference-api Runtime even though they're on `develop`. Same failure class as the recurring inference-api deploy friction (#288). Verify the Runtime is actually running the patched image.
+- **Platform Stack deploy failed (develop, June 19, "consistent domain/cert handling")** — a CFN deploy failed on cert handling. *What breaks if ignored*: infra drift between `develop` and the deployed stack; confirm the cert change rolled or was rolled back cleanly.
+- **Strands #2636 still live** — non-ASCII dict tool-results `\uXXXX`-escaped; cosmetic but token-costly. Carries into the 1.44 bump.
+
+---
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | Wire configurable Bedrock Guardrails (issue #480) | backend + infra | L-M | H | addition only — config wiring, zero-cost when unset, justified by FERPA duty-of-care | institutional content-safety + staff-alerting without code changes |
+| 2 | Fix Nightly Build & Test (`exit 127` at install — ~14 days red) | CI | L | H | no — hygiene; prerequisite for trusting all dep bumps | restores the only automated backend correctness gate |
+| 3 | Bump Strands 1.40 → 1.44 (supersedes the 1.43 keystone) | backend | M | H | yes — library-native `Limits` + `cache_tools_ttl` retire hand-rolled guardrail/TTL | native cost ceilings, 1h prompt caching, accurate attribution |
+| 4 | Bump `bedrock-agentcore` 1.9.1 → 1.15.0 + adopt `async_mode` | backend | L-M | M-H | yes — folds the deferred #482 SSE-disconnect-deadlock guard + retires latent #452 blocking | interactive-shell API; A2A cap prerequisite |
+| 5 | Ship the interactive context-breakdown badge (Cursor + LibreChat convergence) | frontend | M | M | no — addition; reuses `contextBreakdown` already on the wire | user-facing context-cost transparency + "what's eating context" follow-up |
+
+### 1. Wire configurable Bedrock Guardrails (issue #480)
+- **Source**: internal issue #480 (June 15) + AWS Summit NYC Guardrails cluster — `InvokeGuardrailChecks` API (https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-guardrails-api-ai/) and AgentCore policy Guardrails GA (https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-bedrock-agentcore-policy-guardrails-generally-available)
+- **Surface area**: backend (`inference_api` `BedrockModel` construction — `guardrail_id`, `guardrail_version`, `guardrail_stream_processing_mode`, `guardrail_trace`, all already supported by Strands) + infrastructure (new optional `CDK_GUARDRAIL_ID` / `CDK_GUARDRAIL_VERSION` env vars threaded to inference-api runtime env)
+- **Change**: when the env vars are set, pass them into the Strands `BedrockModel` constructor; when unset, behavior is unchanged. Mirrors the existing `CDK_ARTIFACTS_ENABLED` / `CDK_MCP_SANDBOX_ENABLED` optional-feature pattern. Confirm guardrail streaming mode is compatible with our SSE relay.
+- **Subtracts**: addition only — justified because it's config wiring of a capability Strands already exposes, zero-cost when disabled, and answers a filed compliance requirement (FERPA duty-of-care for higher-ed: proactive monitoring + staff alerting for self-harm/crisis language that Claude's reactive safety layer doesn't surface)
+- **Unlocks**: deployers attach content-safety filtering + monitoring to all model invocations without modifying inference-api source; institutional duty-of-care compliance
+- **Effort × Impact**: Low-Med × High
+- **Verdict**: Ship — strongest fit of the week; a filed issue, a library-native path, and an AWS feature cluster all pointing the same way. Verify region availability for the guardrail itself (the *resource* is region-bound even though the model invocation isn't).
+
+### 2. Fix Nightly Build & Test (`exit 127` at install — ~14 consecutive failures)
+- **Source**: internal CI signal — `gh run view 27820449858 --log-failed` shows `exit code 127` on every install/setup step (June 19); failing daily since June 5
+- **Surface area**: `.github/workflows/` nightly workflow — the install/setup steps (`setup-uv`, `setup-node`, or the cache action)
+- **Change**: pull the full nightly log to identify which binary returns 127; re-pin or restore the missing `setup-*` action / runner image. Likely a `uv`/`node` PATH regression after an action or runner-image change. This is environment plumbing, not a test fix.
+- **Subtracts**: no — hygiene
+- **Effort × Impact**: Low × High (restores the only automated backend correctness gate; unblocks the dep-bump cluster)
+- **Verdict**: Ship first — prerequisite for trusting Ideas #3 and #4. Carried from 2026-06-12 with a sharper diagnosis (was "root cause unknown," now "exit 127 at install").
+
+### 3. Bump Strands 1.40 → 1.44 (supersedes the [2026-06-12] 1.43 keystone)
+- **Source**: strands-agents v1.44.0 (June 16) — https://github.com/strands-agents/sdk-python/releases/tag/python/v1.44.0 + the [2026-06-12] keystone queue item
+- **Surface area**: `backend/pyproject.toml` + `uv.lock` (`strands-agents==1.40.0` → `==1.44.0`; `strands-agents-tools` 0.5.2 → 0.8.1 — audit the pre-1.0 tool-interface deltas); agent invocation in `inference_api`; `BedrockModel`/`CacheConfig`; SSE `limit_*` stop-reason; any tooling that assumed the old `vX.Y.Z` tag scheme (now `python/vX.Y.Z` in the `harness-sdk` monorepo)
+- **Change**: same blast-radius audit as the prior keystone, target advanced one minor. Adopt library-native `Limits` and `cache_tools_ttl`. **Do NOT** adopt the new native memory-manager / agentic-context-management on this bump — they overlap our `TurnBasedSessionManager` and the decisions.md scope note bars a bare swap; scope a separate compat review. Add a #2636 known-limitation comment (still live in 1.44.0).
+- **Subtracts**: yes — `Limits` retires the hand-rolled runaway guardrail; `cache_tools_ttl` retires the hand-rolled TTL; collapses the superseded 1.42/1.43 keystone entries and the #2635 guard into one PR
+- **Unlocks**: native per-turn cost ceiling; end-to-end 1h prompt caching; accurate context attribution on tool-heavy turns
+- **Effort × Impact**: Med × High
+- **Verdict**: Ship — after Idea #2 makes the Nightly trustworthy. Flag the native memory/context-management ports as a *future* scoping item, not part of this bump.
+
+### 4. Bump `bedrock-agentcore` 1.9.1 → 1.15.0 + adopt `async_mode`
+- **Source**: bedrock-agentcore v1.15.0 (June 17) — 6 minors behind; SDK issue #482 (SSE-disconnect deadlock, fix in 1.14.x line); consolidates the [2026-06-12] / [2026-05-22] bump + async_mode queue items
+- **Surface area**: `backend/pyproject.toml` + `uv.lock`; `AgentCoreMemoryConfig` construction (`async_mode`); the inference-api `/invocations` SSE worker (the path #482 deadlocks)
+- **Change**: bump to 1.15.0; adopt `async_mode` (retires the latent #452 event-loop-blocking failure mode); verify the #482 deadlock fix is in the adopted version and exercises our SSE-disconnect path. Note the A2A cap fix is a prerequisite for the first A2A server PR.
+- **Subtracts**: yes — folds the deferred [2026-05-22] "#482 SSE-disconnect deadlock guard" into a dep bump (we get the upstream fix instead of hand-rolling a guard); `async_mode` retires the latent #452 mode; consolidates 2–3 queue items
+- **Unlocks**: interactive-shell API access; bearer-token integration; A2A cap prerequisite met
+- **Effort × Impact**: Low-Med × Med-High
+- **Verdict**: Ship — bundle as the "dep hygiene" PR after the Nightly is green; the #482 fold is the standout (upstream closes a defensive item we'd otherwise build).
+
+### 5. Ship the interactive context-breakdown badge (Cursor + LibreChat convergence)
+- **Source**: LibreChat v0.8.7-rc1 real-time context gauge (https://github.com/danny-avila/LibreChat/releases/tag/v0.8.7-rc1) + Cursor Context Usage Report (2026-06-05) + the queued [2026-06-05] item + internal PR #433
+- **Surface area**: frontend (context-breakdown badge component in `frontend/ai.client/src/app/session/` + optional Artifacts docked panel)
+- **Change**: make the static badge interactive — clickable per-partition breakdown (Tools / System / History / etc.) with cost overlay and hover snapshots; all data already arrives on the final `metadata` event's `contextBreakdown`. No backend change.
+- **Subtracts**: no — addition; justified because it lands on a surface we already shipped and reuses data already on the wire
+- **Unlocks**: user-facing context-cost transparency; an actionable "what's eating context / how to trim it" follow-up
+- **Effort × Impact**: Med × Med
+- **Verdict**: Worth trying — now validated by two independent products (Cursor, LibreChat); presentation-layer only. Lower urgency than the dep/CI cluster but the cheapest path to a visible UX win.
+
+---
+
+## Take
+
+The week handed us a rare *negative* signal that matters as much as any positive one: the Fable 5 model we were one PR away from wiring is gone from Bedrock, so the cleanest action is a queue *subtraction* — withdraw that item and re-confirm Opus 4.8 as the floor. Everything else is the same shape as last week, sharpened: the Nightly is still red but now legibly so (`exit 127` at install — fix the runner, not the tests), and that red gate is the single thing blocking a dep-bump cluster (Strands 1.44, agentcore 1.15) that would close more open queue items than any other move. The genuinely new product idea is issue #480's configurable Guardrails — library-native, compliance-driven, and freshly blessed by an AWS feature cluster — which is what Phil would notice first if shipped: a duty-of-care safety layer that costs nothing when off. The system is still trending *with* the ecosystem (Strands ports our hand-rolled subsystems to native; MCP standardizes our skills + consent patterns) — the lag is execution throughput on maintenance, not direction.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock/AgentCore What's New (Summit NYC) | https://aws.amazon.com/about-aws/whats-new/recent/feed/ | 2026-06-19 | 5 |
+| 2 | Strands Agents SDK releases + issues | https://github.com/strands-agents/sdk-python/releases | 2026-06-19 | 7 |
+| 3 | Reference repo commits | https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main | 2026-06-19 | 2 (no signal) |
+| 4 | MCP spec PRs + blog | https://github.com/modelcontextprotocol/modelcontextprotocol/pulls + https://blog.modelcontextprotocol.io | 2026-06-19 | 5 |
+| 5 | MCP ext-apps commits | https://github.com/modelcontextprotocol/ext-apps/commits/main | 2026-06-19 | 1 (quiet) |
+| 6 | FastMCP releases + PyPI | https://github.com/jlowin/fastmcp/releases | 2026-06-19 | 0 (no new) |
+| 7 | assistant-ui releases | https://github.com/Yonom/assistant-ui/releases | 2026-06-19 | 3 |
+| 8 | Anthropic newsroom / frontier (Fable suspension) | https://simonwillison.net/2026/Jun/13/us-government-directive-to-suspend-access/ + https://www.cnbc.com/2026/06/12/ | 2026-06-19 | 3 |
+| 9 | Claude Code changelog | https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md | 2026-06-19 | 3 |
+| 10 | LangChain Deep Agents docs | https://reference.langchain.com/python/deepagents/middleware/summarization | 2026-06-19 | 1 |
+| 11 | opencode releases | https://github.com/anomalyco/opencode/releases | 2026-06-19 | 3 |
+| 12 | LibreChat releases | https://github.com/danny-avila/LibreChat/releases | 2026-06-19 | 1 (rc1) |
+| 13 | bedrock-agentcore-sdk-python issues + PyPI | https://github.com/aws/bedrock-agentcore-sdk-python/issues | 2026-06-19 | 4 |
+| 14 | AWS Bedrock pricing | https://aws.amazon.com/bedrock/pricing/ | 2026-06-19 | 0 (no change) |
+| 15 | HN (Algolia) — Strands shell, evals, policy gates | https://hn.algolia.com/api/v1/search_by_date | 2026-06-19 | 3 |
+| 16 | Anthropic cookbook commits | https://github.com/anthropics/anthropic-cookbook/commits/main | 2026-06-19 | 0 (out of window) |
+| 17 | Version-pin registry checks (PyPI + npm) | https://pypi.org/pypi/<pkg>/json + https://registry.npmjs.org/<pkg>/latest | 2026-06-19 | 14 |
+| 18 | NNGroup AI topic | https://www.nngroup.com/topic/artificial-intelligence/ | 2026-06-19 | Not retrieved (404 — blocked, 2nd week) |
+
+## Web Budget
+
+Used: ~72 / 50 requests (target).
+Overage: +22 — the version-pin subagent used ~14 (one per package; WebFetch mangled PyPI JSON dates so it cross-checked via raw JSON), and the week was unusually signal-rich (AWS Summit NYC cluster, the Fable 5/Mythos 5 suspension, Strands 1.44 + agentcore 1.15 both landing). The overage surfaced the model-availability reversal, two new SDK minors, and confirmed the starlette item is already resolved — all decision-relevant.
+Skipped (unreachable): NNGroup AI topic page (404, second consecutive week — treat as durably blocked). Vercel AI SDK UI docs (nav-only, no datable changelog). Linear/Cursor/Anthropic product blogs (not fetched — assistant-ui + MCP signal was already strong; flag for next week).
+Notes: If version-pin checks stay routine, a single batched raw-JSON fetch would roughly halve the ~14 requests.

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -5,6 +5,52 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 ## Open
 <!-- Newest at top. -->
 
+### [2026-06-19] Wire configurable Bedrock Guardrails (issue #480)
+- **Source**: research/2026-06-19.md ▸ Top 5 #1 — internal issue #480 (June 15) + AWS Summit NYC Guardrails cluster (`InvokeGuardrailChecks` API + AgentCore policy Guardrails GA, June 16). Strands `BedrockModel` already supports `guardrail_id`/`version`/`stream_processing_mode`/`trace`.
+- **Surface**: backend (`inference_api` `BedrockModel` construction) + infrastructure (optional `CDK_GUARDRAIL_ID` / `CDK_GUARDRAIL_VERSION` env vars threaded to inference-api runtime env)
+- **Effort × Impact**: L-M × H
+- **Subtracts**: addition only — config wiring of a capability Strands already exposes; zero-cost when unset; mirrors `CDK_ARTIFACTS_ENABLED`/`CDK_MCP_SANDBOX_ENABLED` optional-feature pattern
+- **Unlocks**: deployers attach content-safety filtering + staff-alerting monitoring to all model invocations without modifying inference-api source (FERPA duty-of-care for higher-ed: proactive self-harm/crisis-language monitoring Claude's reactive layer doesn't surface)
+- **Status**: open — strongest fit of the week (filed issue + library-native path + AWS feature cluster aligned). Verify the guardrail *resource* region availability; confirm guardrail streaming mode is compatible with the SSE relay.
+
+### [2026-06-19] Fix Nightly Build & Test (`exit 127` at install — ~14 consecutive failures)
+- **Source**: research/2026-06-19.md ▸ Internal Audit + Top 5 #2 — `gh run view 27820449858 --log-failed` shows `exit code 127` on every install/setup step (June 19); failing daily since June 5. Carries the [2026-06-12] nightly item forward with a sharper diagnosis (was "root cause unknown").
+- **Surface**: CI — `.github/workflows/` nightly workflow install/setup steps (`setup-uv` / `setup-node` / cache action)
+- **Effort × Impact**: L × H
+- **Subtracts**: no — hygiene; prerequisite for trusting the Strands 1.44 + bedrock-agentcore 1.15 bumps
+- **Status**: open — time-sensitive; CI environment/runner regression (a binary expected by install returns 127, likely `uv`/`node` PATH after an action or runner-image change), NOT a test regression. Do not land dep bumps on a suite that can't install. Supersedes the [2026-06-12] nightly item.
+
+### [2026-06-19] Bump Strands 1.40 → 1.44 — supersedes the [2026-06-12] 1.43 keystone
+- **Source**: research/2026-06-19.md ▸ Top 5 #3 — strands-agents v1.44.0 (June 16). **Supersedes** [2026-06-12] "Strands 1.40 → 1.43" — target advances one more minor; no new Python breaking changes 1.41–1.44.
+- **Surface**: backend (`pyproject.toml`/`uv.lock` — `strands-agents` 1.40→1.44, `strands-agents-tools` 0.5.2→0.8.1; agent invocation in `inference_api`; `BedrockModel`/`CacheConfig`; SSE `limit_*` stop-reason; tooling that assumed the old `vX.Y.Z` tag scheme — now `python/vX.Y.Z` in the `harness-sdk` monorepo)
+- **Effort × Impact**: M × H
+- **Subtracts**: yes — library-native `Limits` retires the hand-rolled runaway guardrail; `cache_tools_ttl` retires hand-rolled TTL; collapses the superseded 1.42/1.43 keystone entries + the #2635 guard into one PR
+- **Unlocks**: native per-turn cost ceiling; 1h prompt caching; accurate context attribution on tool-heavy turns
+- **Status**: open — prerequisite: green Nightly (see above). **Do NOT** adopt the new native memory-manager / agentic-context-management ports on this bump (they overlap `TurnBasedSessionManager`; decisions.md bars a bare swap) — scope a separate compat review. #2636 (non-ASCII) still live in 1.44.0 — add a known-limitation comment; a second bump follows once #2661/#2653 merge.
+
+### [2026-06-19] Bump `bedrock-agentcore` 1.9.1 → 1.15.0 + adopt `async_mode`
+- **Source**: research/2026-06-19.md ▸ Top 5 #4 — bedrock-agentcore v1.15.0 (June 17); 6 minors behind. **Supersedes** the [2026-06-12] "1.9.1 → 1.14.1" item and consolidates the [2026-05-22] bump + async_mode items. The #482 SSE-disconnect-deadlock fix lives in the 1.14.x line.
+- **Surface**: `backend/pyproject.toml` + `uv.lock`; `AgentCoreMemoryConfig` construction (`async_mode`); inference-api `/invocations` SSE worker (the #482 deadlock path)
+- **Effort × Impact**: L-M × M-H
+- **Subtracts**: yes — folds the deferred [2026-05-22] "#482 SSE-disconnect deadlock guard" into a dep bump (upstream fix instead of a hand-rolled guard); `async_mode` retires the latent #452 event-loop-blocking mode; consolidates 2–3 queue items
+- **Unlocks**: interactive-shell API access; bearer-token integration; A2A cap prerequisite for the first A2A server PR
+- **Status**: open — bundle as the "dep hygiene" PR after the Nightly is green; verify the #482 fix exercises our SSE-disconnect path.
+
+### [2026-06-19] Ship the interactive context-breakdown badge (Cursor + LibreChat convergence)
+- **Source**: research/2026-06-19.md ▸ Top 5 #5 — LibreChat v0.8.7-rc1 real-time context gauge + Cursor Context Usage Report (2026-06-05) + internal PR #433. **Reinforces** the [2026-06-05] "make the context-breakdown badge interactive" item with a second independent product datapoint.
+- **Surface**: frontend (context-breakdown badge component in `frontend/ai.client/src/app/session/`)
+- **Effort × Impact**: M × M
+- **Subtracts**: no — addition; lands on a surface we shipped and reuses `contextBreakdown` already on the final `metadata` event
+- **Unlocks**: user-facing context-cost transparency + an actionable "what's eating context / how to trim it" follow-up
+- **Status**: open — presentation-layer only (no backend change). Now validated by two products. Consider folding into / superseding the [2026-06-05] item at review.
+
+### [2026-06-12] Add Claude Fable 5 to model settings + audit model-ID string matching — ⚠️ WITHDRAW (Fable 5 revoked on Bedrock)
+- **Source**: research/2026-06-19.md ▸ Retirement candidates — Fable 5 + Mythos 5 were **revoked on Bedrock for all users (US gov directive, June 12–13)**, three days after their June 9 GA. The "add Fable 5 / consider as default" core of the original [2026-06-12] item is dead until/unless the directive lifts.
+- **Surface**: n/a (withdrawal)
+- **Effort × Impact**: — × —
+- **Subtracts**: yes — removes a queued addition that external availability killed
+- **Status**: open — **recommend review-prep mark the [2026-06-12] Fable 5 item RESOLVED (Decline/superseded)**. Minor residual merit: the `claude-opus-4` capability-gate string-match audit is still worth doing for future-proofing, but decoupled from Fable 5. Opus 4.8 stays the default/floor.
+
 ### [2026-06-12] Bump Strands 1.40 → 1.43 — supersedes [2026-06-05] keystone; closes #2635 + context_manager="auto" + A2A isolation fix
 - **Source**: research/2026-06-12.md ▸ Top 5 #1 — Strands v1.43.0 released June 12, 2026. **Supersedes** [2026-06-05] "Strands 1.40 → 1.42 bump" — target advances one more minor; no additional blast radius. Also closes the [2026-06-05] "#2635 guard" queue item.
 - **Surface**: backend (`pyproject.toml`/`uv.lock` — `strands-agents==1.40.0` → `==1.43.0`; agent invocation in `inference_api`; `BedrockModel`/`CacheConfig`; SSE `limit_*` stop-reason)


### PR DESCRIPTION
## Summary
- External scan: AWS Summit NYC (AgentCore Web Search + Guardrails GA + `InvokeGuardrailChecks`), Strands 1.44 (native memory/context-mgmt ports), bedrock-agentcore 1.15, MCP Skills-over-MCP (SEP-2640) + Enterprise-Managed Auth (STABLE), assistant-ui/LibreChat UI patterns, Claude Code v2.1.183, opencode, frontier models.
- **Headline reversal**: Claude Fable 5 / Mythos 5 were revoked on Bedrock (US gov directive, June 12–13) — last week's #2 "add Fable 5" item is withdrawn.
- Internal audit: ~14-day Nightly failure now diagnosed (`exit 127` at install — CI env regression, not tests); PR #487 resolved the queued starlette CVE item; new issue #480 (configurable Guardrails); version-pin lag (Strands 1.40→1.44, agentcore 1.9.1→1.15.0).
- Top 5 ideas in the dated research doc and queued in `docs/kaizen/review-queue.md`.

## Review
- Read the research doc.
- Comment on the PR with reactions and any weekend POC findings — these become first-class signal for next Friday's `kaizen-review-prep`.
- POC promising ideas over the weekend.

## Decision
Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)