### PR TITLE
fix(infra): restore stable IAM role names for AgentCore execution roles

### DIFF
--- a/infrastructure/lib/constructs/agentcore/browser-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/browser-construct.ts
@@ -34,11 +34,16 @@ export class AgentCoreBrowserConstruct extends Construct {
     const { config } = props;
 
     // ── IAM execution role ──
-    // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-    // physical name. A fixed name collides ("already exists") on any redeploy
-    // where a prior role was orphaned (rolled-back/partial deploy), and buys
-    // nothing: every consumer references this role by .roleArn, never by name.
+    // IMPORTANT: keep an explicit, stable roleName. Do NOT switch to a
+    // CFN auto-generated name: this role's ARN is consumed by the
+    // BrowserCustom resource's `executionRoleArn`, which is a CREATE-ONLY
+    // property. Changing the role name on an already-deployed stack
+    // replaces the role (new ARN) → forces BrowserCustom replacement →
+    // CFN re-creates it with the same (create-only) Name → "already
+    // exists" collision → rollback. Orphaned-role collisions on a fresh
+    // deploy are handled by deleting the orphans, not by renaming.
     this.executionRole = new iam.Role(this, 'BrowserExecutionRole', {
+      roleName: getResourceName(config, 'browser-role'),
       assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
       description: 'Execution role for AgentCore Browser',
     });

--- a/infrastructure/lib/constructs/agentcore/code-interpreter-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/code-interpreter-construct.ts
@@ -34,11 +34,13 @@ export class AgentCoreCodeInterpreterConstruct extends Construct {
     const { config } = props;
 
     // ── IAM execution role ──
-    // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-    // physical name. A fixed name collides ("already exists") on any redeploy
-    // where a prior role was orphaned (rolled-back/partial deploy), and buys
-    // nothing: every consumer references this role by .roleArn, never by name.
+    // IMPORTANT: keep an explicit, stable roleName. This role's ARN is
+    // consumed by the CodeInterpreterCustom `executionRoleArn`, a
+    // CREATE-ONLY property — renaming the role replaces it, which forces
+    // CodeInterpreterCustom replacement and a same-Name "already exists"
+    // collision on already-deployed stacks. See browser-construct.ts.
     this.executionRole = new iam.Role(this, 'CodeInterpreterExecutionRole', {
+      roleName: getResourceName(config, 'code-interpreter-role'),
       assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
       description: 'Execution role for AgentCore Code Interpreter',
     });

--- a/infrastructure/lib/constructs/agentcore/memory-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/memory-construct.ts
@@ -43,11 +43,12 @@ export class AgentCoreMemoryConstruct extends Construct {
     const { config } = props;
 
     // ── IAM execution role ──
-    // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-    // physical name. A fixed name collides ("already exists") on any redeploy
-    // where a prior role was orphaned (rolled-back/partial deploy), and buys
-    // nothing: every consumer references this role by .roleArn, never by name.
+    // IMPORTANT: keep an explicit, stable roleName. This role's ARN is
+    // consumed by the Memory `memoryExecutionRoleArn` — renaming the role
+    // (auto-gen) replaces it, risking Memory replacement and loss of
+    // stored conversation history. See browser-construct.ts.
     this.executionRole = new iam.Role(this, 'MemoryExecutionRole', {
+      roleName: getResourceName(config, 'agentcore-memory-role'),
       assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
       description: 'Execution role for AgentCore Memory',
     });

--- a/infrastructure/lib/constructs/fine-tuning/sagemaker-execution-role-construct.ts
+++ b/infrastructure/lib/constructs/fine-tuning/sagemaker-execution-role-construct.ts
@@ -52,12 +52,12 @@ export class SageMakerExecutionRoleConstruct extends Construct {
     const { config, dataBucket, jobsTable, vpc, privateSubnetIdsString } =
       props;
 
-    // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-    // physical name. A fixed name collides ("already exists") on any redeploy
-    // where a prior role was orphaned (rolled-back/partial deploy), and buys
-    // nothing: the role ARN is published to SSM (.../sagemaker-execution-role-arn)
-    // and passed to app-api as SAGEMAKER_EXECUTION_ROLE_ARN — never used by name.
+    // Keep an explicit, stable roleName for consistency with the other
+    // execution roles and to avoid replacing the role (and the dependent
+    // app-api PassRole grant) on already-deployed stacks. Orphaned-role
+    // collisions on a fresh deploy are handled by deleting the orphans.
     this.executionRole = new iam.Role(this, 'SageMakerExecutionRole', {
+      roleName: getResourceName(config, 'sagemaker-exec-role'),
       assumedBy: new iam.ServicePrincipal('sagemaker.amazonaws.com'),
       description:
         'Execution role assumed by SageMaker training and transform jobs',

--- a/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
+++ b/infrastructure/lib/constructs/gateway/agentcore-gateway-construct.ts
@@ -52,12 +52,12 @@ export class AgentCoreGatewayConstruct extends Construct {
     const { config } = props;
     const stack = cdk.Stack.of(this);
 
-    // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-    // physical name. A fixed name collides ("already exists") on any redeploy
-    // where a prior role was orphaned (rolled-back/partial deploy), and buys
-    // nothing: the gateway references this role by .roleArn, and the backend
-    // resolves it at runtime via GetGateway (roleArn), never by name.
+    // IMPORTANT: keep an explicit, stable roleName. This role's ARN is
+    // consumed by the Gateway `roleArn` — renaming the role (auto-gen)
+    // replaces it and risks Gateway replacement on deployed stacks.
+    // See browser-construct.ts.
     this.gatewayRole = new iam.Role(this, 'GatewayExecutionRole', {
+      roleName: getResourceName(config, 'gateway-role'),
       assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
       description: 'Execution role for AgentCore Gateway',
     });

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -10,7 +10,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
-import { AppConfig } from '../../config';
+import { AppConfig, getResourceName } from '../../config';
 import { PlatformComputeRefs } from '../platform-compute-refs';
 
 /**
@@ -22,11 +22,12 @@ export function createRuntimeExecutionRole(
   config: AppConfig,
   refs: PlatformComputeRefs,
 ): iam.Role {
-  // NOTE: no explicit roleName — let CloudFormation auto-generate a unique
-  // physical name. A fixed name collides ("already exists") on any redeploy
-  // where a prior role was orphaned (rolled-back/partial deploy), and buys
-  // nothing: the runtime references this role by .roleArn, never by name.
+  // IMPORTANT: keep an explicit, stable roleName. This role's ARN is the
+  // AgentCore Runtime `roleArn`; renaming the role (auto-gen) replaces it
+  // and risks churning the Runtime on already-deployed stacks. Orphaned-role
+  // collisions on a fresh deploy are handled by deleting the orphans.
   const role = new iam.Role(scope, 'AgentCoreRuntimeExecutionRole', {
+    roleName: getResourceName(config, 'agentcore-runtime-role'),
     assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com', {
       conditions: {
         StringEquals: { 'aws:SourceAccount': config.awsAccount },


### PR DESCRIPTION
Reverts the roleName removal from 7107cf98 for the AgentCore memory/ code-interpreter/browser/gateway/runtime and SageMaker execution roles.

Auto-generating these names is unsafe on an already-deployed stack: the role ARN feeds create-only properties on the AgentCore resources (BrowserCustom/CodeInterpreterCustom executionRoleArn, Memory memoryExecutionRoleArn, Gateway/Runtime roleArn). Renaming the role replaces it (new ARN) -> forces replacement of the dependent AgentCore resource -> CFN re-creates it with the same create-only Name -> 'already exists' collision -> UPDATE_ROLLBACK. Confirmed via ai-sbmt-api-PlatformStack events (BrowserCustom/CodeInterpreterCustom DELETE_COMPLETE with empty PhysicalResourceId during rollback).

Orphaned fixed-name roles on a *fresh* deploy are handled by deleting the orphans before deploying, not by renaming. Added comments on each role to prevent re-introducing the auto-name change.