### PR TITLE
fix(ci): build arm64 images on native ARM runners

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -111,7 +111,10 @@ jobs:
   build-inference-api:
     name: Build inference-api image
     needs: test-backend
-    runs-on: ubuntu-24.04
+    # Native ARM64 runner — the AgentCore Runtime is arm64. Build
+    # natively here rather than emulating arm64 on amd64 via QEMU
+    # (matches the pre-refactor inference-api.yml on main).
+    runs-on: ubuntu-24.04-arm
     environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
 
     permissions:
@@ -137,7 +140,6 @@ jobs:
         id: build
         with:
           image-name: inference-api
-          platform: linux/arm64
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,7 +148,11 @@ jobs:
   build-rag-ingestion:
     name: Build rag-ingestion image
     needs: test-backend
-    runs-on: ubuntu-24.04
+    # Native ARM64 runner — the RAG ingestion Lambda is arm64. Building
+    # on amd64 (the previous runs-on) produced an amd64 image that the
+    # arm64 Lambda rejected at init with Runtime.InvalidEntrypoint.
+    # Matches the pre-refactor rag-ingestion.yml on main.
+    runs-on: ubuntu-24.04-arm
     environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
 
     permissions:

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -96,7 +96,13 @@ case "$SERVICE" in
         # The requirements.lock lives inside the first source-dir
         # already, so it doesn't need a separate --manifest entry.
         MANIFESTS=("backend/src/apis/shared/__init__.py")
-        PLATFORM=""
+        # The RAG ingestion Lambda is arm64 (see the rag-ingestion CDK
+        # construct), and the Dockerfile installs arm64 torch wheels.
+        # Build for arm64 — an amd64 image fails the arm64 Lambda at
+        # init with Runtime.InvalidEntrypoint. The backend.yml
+        # build-rag-ingestion job runs on a native ubuntu-24.04-arm
+        # runner, so this is a native (non-emulated) build.
+        PLATFORM="linux/arm64"
         SSM_KEY="/${CDK_PROJECT_PREFIX}/rag-ingestion/image-tag"
         ;;
     *)


### PR DESCRIPTION
The RAG ingestion Lambda and AgentCore Runtime are arm64, but the post-refactor backend.yml ran their build jobs on amd64 (ubuntu-24.04). inference-api compensated with QEMU emulation (platform: linux/arm64); rag-ingestion had neither the platform input nor a build-one.sh PLATFORM, so it produced an amd64 image -> the arm64 Lambda failed every invoke with Runtime.InvalidEntrypoint (file uploads stuck 'uploading', no embeddings).

Restore the pre-refactor (main) approach: build both arm images on native ubuntu-24.04-arm runners instead of emulating on amd64.

- backend.yml: build-inference-api and build-rag-ingestion -> runs-on ubuntu-24.04-arm; drop the QEMU-triggering platform input from inference-api (native build needs no emulation).
- build-one.sh: rag-ingestion PLATFORM=linux/arm64 (explicit native build).

Deploy jobs stay on ubuntu-24.04 (API-only, no docker build). Note: the stale amd64 rag-ingestion ECR image must be deleted once so the content-hash build doesn't skip the corrected arm64 build.