### PR TITLE
feat(skills): gate skills feature behind SKILLS_ENABLED flag (default off)

### DIFF
--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -861,6 +861,24 @@ S3_ASSISTANTS_VECTOR_STORE_INDEX_NAME=
 S3_SKILL_RESOURCES_BUCKET_NAME=
 
 # =============================================================================
+# SKILLS (OPTIONAL)
+# =============================================================================
+# The Skills feature (admin skills catalog, user-facing skills picker, and
+# skills mode — routing turns through the SkillAgent) is gated by
+# SKILLS_ENABLED. While off, app-api leaves the user + admin skills routes and
+# the chat-mode policy route unmounted (404), GET /system/chat-settings reports
+# tools/chat mode with toggling disabled, and inference-api forces every turn
+# through the plain ChatAgent. All skills data and code remain intact, so the
+# feature can be turned back on by flipping this flag. Set it on BOTH app-api
+# and inference-api containers when enabling.
+
+# Enable the skills feature (OPTIONAL)
+# Purpose: Feature gate. When "true", the skills surfaces are mounted and new
+# conversations may route through the SkillAgent per the chat-mode policy.
+# Default: false
+SKILLS_ENABLED=false
+
+# =============================================================================
 # FINE-TUNING (OPTIONAL)
 # =============================================================================
 # SageMaker-backed model fine-tuning. The whole feature is gated by

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -29,6 +29,7 @@ from apis.shared.models.models import (
     ManagedModel,
 )
 from apis.shared.auth import User, require_admin
+from apis.shared.feature_flags import skills_enabled
 from apis.shared.sessions.metadata import list_user_sessions, get_session_metadata
 from apis.shared.sessions.messages import get_messages
 from apis.shared.models.managed_models import (
@@ -848,10 +849,14 @@ from .tools.routes import router as tools_router
 
 router.include_router(tools_router)
 
-# ========== Include Skills Admin Subrouter ==========
-from .skills.routes import router as skills_router
+# ========== Include Skills Admin Subrouter (conditional) ==========
+# Skills feature deferred to a later release; off by default. While off the
+# admin catalog API is unmounted so the surface 404s, but the data and code
+# remain intact.
+if skills_enabled():
+    from .skills.routes import router as skills_router
 
-router.include_router(skills_router)
+    router.include_router(skills_router)
 
 # ========== Include OAuth Admin Subrouter ==========
 from .oauth.routes import router as oauth_admin_router
@@ -878,10 +883,13 @@ from .system_prompts.routes import router as system_prompts_admin_router
 
 router.include_router(system_prompts_admin_router)
 
-# ========== Include Platform Settings Admin Subrouter ==========
-from .settings.routes import router as settings_admin_router
+# ========== Include Platform Settings Admin Subrouter (conditional) ==========
+# Currently only hosts the chat-mode (skills vs. tools) policy, which is part
+# of the deferred skills feature. Mount it only when skills are enabled.
+if skills_enabled():
+    from .settings.routes import router as settings_admin_router
 
-router.include_router(settings_admin_router)
+    router.include_router(settings_admin_router)
 
 # ========== Include Fine-Tuning Admin Subrouter (conditional) ==========
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -115,6 +115,7 @@ from apis.shared.security import (
     register_aws_client_error_handler,
     register_validation_error_handler,
 )
+from apis.shared.feature_flags import skills_enabled
 register_aws_client_error_handler(app)
 register_validation_error_handler(app)
 logger.info("Registered AWS ClientError handler")
@@ -184,7 +185,6 @@ from apis.app_api.chat.proxy_routes import router as bff_chat_proxy_router
 from apis.app_api.mcp_apps.routes import router as mcp_apps_router
 from apis.app_api.memory.routes import router as memory_router
 from apis.app_api.tools.routes import router as tools_router
-from apis.app_api.skills.routes import router as user_skills_router
 from apis.app_api.files.routes import router as files_router
 from apis.app_api.assistants.routes import router as assistants_router
 from apis.app_api.documents.routes import router as documents_router
@@ -218,7 +218,6 @@ app.include_router(bff_chat_proxy_router)  # Cookie-authenticated SSE proxy (Pha
 app.include_router(mcp_apps_router)  # MCP Apps app-initiated tools/call proxy (PR #5; inert until host flag on)
 app.include_router(memory_router)  # AgentCore Memory access endpoints
 app.include_router(tools_router)  # Tool discovery and permissions
-app.include_router(user_skills_router)  # User-facing skill list + per-skill preferences
 app.include_router(files_router)  # File upload via pre-signed URLs
 app.include_router(connectors_router)  # User-facing connector catalog + consent flows
 app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors
@@ -236,6 +235,13 @@ if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":
     from apis.app_api.fine_tuning.routes import router as fine_tuning_router
     app.include_router(fine_tuning_router)
     logger.info("Fine-tuning routes enabled")
+
+# Conditionally register the user-facing skills surface (skill list +
+# per-skill preferences). Deferred to a later release; off by default.
+if skills_enabled():
+    from apis.app_api.skills.routes import router as user_skills_router
+    app.include_router(user_skills_router)
+    logger.info("Skills routes enabled")
 
 # Conditionally register artifact render-token routes. Infra only sets
 # the secret ARN when the artifacts feature is enabled for the

--- a/backend/src/apis/app_api/system/routes.py
+++ b/backend/src/apis/app_api/system/routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
+from apis.shared.feature_flags import skills_enabled
 from apis.shared.platform_settings.models import ChatSettingsPublicResponse
 from apis.shared.platform_settings.service import get_chat_mode_settings_service
 from apis.shared.users.models import UserProfile, UserStatus
@@ -40,10 +41,19 @@ async def get_system_status() -> SystemStatusResponse:
 async def get_chat_settings(
     current_user: User = Depends(get_current_user_from_session),
 ) -> ChatSettingsPublicResponse:
-    """Chat-mode policy for the SPA: default agent mode + whether the user may toggle."""
+    """Chat-mode policy for the SPA: default agent mode + whether the user may toggle.
+
+    When the skills feature is disabled for this environment, ignore any stored
+    policy and report tools/chat mode with toggling off, so the SPA hides the
+    mode toggle, the skills picker, and the admin skills nav entry.
+    """
+    if not skills_enabled():
+        return ChatSettingsPublicResponse(
+            default_mode="chat", allow_mode_toggle=False, skills_enabled=False
+        )
     service = get_chat_mode_settings_service()
     settings = await service.get_settings()
-    return ChatSettingsPublicResponse.from_settings(settings)
+    return ChatSettingsPublicResponse.from_settings(settings, skills_enabled=True)
 
 
 @router.post("/first-boot", status_code=200)

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -26,6 +26,7 @@ from apis.shared.errors import (
     ErrorCode,
     build_conversational_error_event,
 )
+from apis.shared.feature_flags import skills_enabled
 from apis.shared.files.file_resolver import get_file_resolver
 from apis.shared.models.managed_models import list_managed_models
 from apis.shared.platform_settings.models import DEFAULT_CHAT_MODE, ChatModeSettings
@@ -771,6 +772,12 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     effective_agent_type = _resolve_effective_agent_type(
         input_data.agent_type, chat_mode_settings
     )
+    # Skills feature deferred for this environment: never route a turn through
+    # the SkillAgent, regardless of the client's request or any stored policy.
+    # Only the skill mode is neutralized — voice and other agent types pass
+    # through untouched.
+    if not skills_enabled() and effective_agent_type == "skill":
+        effective_agent_type = "chat"
     # Resolve the user's *effective* skills once for the whole request — only
     # for the skill agent path: the RBAC-accessible set (admin/DB-backed),
     # narrowed by the client's per-turn enabled_skills selection. Threaded into

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -1,0 +1,26 @@
+"""Process-level feature flags resolved from environment variables.
+
+These gate optional product surfaces that ship in the codebase but stay
+disabled for an environment until explicitly turned on — mirroring the
+``FINE_TUNING_ENABLED`` pattern used in app-api. Each flag is read on every
+call (not cached at import) so that:
+
+* import-time callers (conditional router mounting) and per-request callers
+  observe the same value, and
+* tests can flip a flag with ``monkeypatch.setenv`` (per-request paths) or a
+  module reload (import-time paths) without a process restart.
+"""
+
+import os
+
+
+def skills_enabled() -> bool:
+    """Whether the Skills feature is enabled for this environment.
+
+    Covers the admin skills catalog, the user-facing skills picker, and
+    skills mode (routing turns through the ``SkillAgent``). Defaults off;
+    set ``SKILLS_ENABLED=true`` to turn it on. While off, new turns are
+    forced through the plain ``ChatAgent`` and the skills surfaces are
+    unmounted / hidden, but all skills data and code remain intact.
+    """
+    return os.environ.get("SKILLS_ENABLED", "false").lower() == "true"

--- a/backend/src/apis/shared/platform_settings/models.py
+++ b/backend/src/apis/shared/platform_settings/models.py
@@ -80,16 +80,21 @@ class ChatModeSettingsResponse(BaseModel):
 
 
 class ChatSettingsPublicResponse(BaseModel):
-    """User-facing view for the SPA — just the policy flags."""
+    """User-facing view for the SPA — the policy flags plus whether the
+    skills feature is enabled at all (drives the admin nav + mode toggle)."""
 
     model_config = ConfigDict(populate_by_name=True)
 
     default_mode: ChatMode = Field(alias="defaultMode")
     allow_mode_toggle: bool = Field(alias="allowModeToggle")
+    skills_enabled: bool = Field(default=True, alias="skillsEnabled")
 
     @classmethod
-    def from_settings(cls, settings: ChatModeSettings) -> "ChatSettingsPublicResponse":
+    def from_settings(
+        cls, settings: ChatModeSettings, *, skills_enabled: bool = True
+    ) -> "ChatSettingsPublicResponse":
         return cls(
             default_mode=settings.default_mode,
             allow_mode_toggle=settings.allow_mode_toggle,
+            skills_enabled=skills_enabled,
         )

--- a/backend/tests/apis/app_api/test_chat_settings_routes.py
+++ b/backend/tests/apis/app_api/test_chat_settings_routes.py
@@ -64,6 +64,9 @@ def repo() -> _InMemoryRepo:
 
 @pytest.fixture
 def client(repo: _InMemoryRepo, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # These tests exercise the policy surface as it behaves with the skills
+    # feature enabled; the disabled-feature override is covered separately.
+    monkeypatch.setenv("SKILLS_ENABLED", "true")
     service = ChatModeSettingsService(repository=repo, cache_ttl_seconds=0.0)
     monkeypatch.setattr(
         admin_settings_routes, "get_chat_mode_settings_service", lambda: service
@@ -128,9 +131,47 @@ class TestSystemChatSettings:
         response = client.get("/system/chat-settings")
         assert response.status_code == 200
         body = response.json()
-        assert body == {"defaultMode": "chat", "allowModeToggle": False}
+        assert body == {
+            "defaultMode": "chat",
+            "allowModeToggle": False,
+            "skillsEnabled": True,
+        }
 
     def test_defaults_when_unconfigured(self, client: TestClient):
         response = client.get("/system/chat-settings")
         assert response.status_code == 200
-        assert response.json() == {"defaultMode": "skill", "allowModeToggle": True}
+        assert response.json() == {
+            "defaultMode": "skill",
+            "allowModeToggle": True,
+            "skillsEnabled": True,
+        }
+
+
+class TestSystemChatSettingsSkillsDisabled:
+    """When SKILLS_ENABLED is off, the public read ignores any stored policy
+    and forces tools/chat mode so the SPA hides the skills surfaces."""
+
+    @pytest.fixture
+    def client_off(self, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+        monkeypatch.setenv("SKILLS_ENABLED", "false")
+        # A stored policy that *would* enable skills — the flag must win.
+        repo = _InMemoryRepo(
+            ChatModeSettings(default_mode="skill", allow_mode_toggle=True)
+        )
+        service = ChatModeSettingsService(repository=repo, cache_ttl_seconds=0.0)
+        monkeypatch.setattr(
+            system_routes, "get_chat_mode_settings_service", lambda: service
+        )
+        app = FastAPI()
+        app.include_router(system_routes.router)
+        app.dependency_overrides[get_current_user_from_session] = _user
+        return TestClient(app)
+
+    def test_forces_chat_and_reports_disabled(self, client_off: TestClient):
+        response = client_off.get("/system/chat-settings")
+        assert response.status_code == 200
+        assert response.json() == {
+            "defaultMode": "chat",
+            "allowModeToggle": False,
+            "skillsEnabled": False,
+        }

--- a/backend/tests/apis/app_api/test_skills_feature_flag.py
+++ b/backend/tests/apis/app_api/test_skills_feature_flag.py
@@ -1,0 +1,88 @@
+"""Tests for the SKILLS_ENABLED feature gate.
+
+The skills feature (admin catalog, user picker, skills mode) is deferred and
+disabled by default. These tests pin two things:
+
+* the ``skills_enabled()`` helper's parsing + default-off behavior, and
+* that the admin skills + chat-mode-policy subrouters are unmounted while the
+  flag is off and mounted while it is on.
+
+The admin subrouter mounts conditionally at import time, so — like the
+fine-tuning gate in tests/routes/test_admin_lows.py — these reload the module
+with the env set, then restore it on teardown.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+import apis.app_api.admin.routes as admin_routes_module
+from apis.shared.feature_flags import skills_enabled
+
+
+# ---------------------------------------------------------------------------
+# skills_enabled() helper
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsEnabledFlag:
+    def test_defaults_off_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SKILLS_ENABLED", raising=False)
+        assert skills_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("true", True),
+            ("True", True),
+            ("TRUE", True),
+            ("false", False),
+            ("0", False),
+            ("1", False),
+            ("yes", False),
+            ("", False),
+        ],
+    )
+    def test_parses_env_value(self, monkeypatch, value, expected):
+        monkeypatch.setenv("SKILLS_ENABLED", value)
+        assert skills_enabled() is expected
+
+
+# ---------------------------------------------------------------------------
+# Admin subrouter mount gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_router_paths():
+    """Reload the admin router under a chosen SKILLS_ENABLED value and return
+    its route paths. Restores the module (flag off) on teardown so a reload
+    here can't leak mounted skills routes into later tests."""
+
+    def _load(*, enabled: bool) -> set[str]:
+        if enabled:
+            os.environ["SKILLS_ENABLED"] = "true"
+        else:
+            os.environ.pop("SKILLS_ENABLED", None)
+        importlib.reload(admin_routes_module)
+        return {getattr(route, "path", "") for route in admin_routes_module.router.routes}
+
+    yield _load
+
+    os.environ.pop("SKILLS_ENABLED", None)
+    importlib.reload(admin_routes_module)
+
+
+def test_admin_skills_unmounted_when_disabled(admin_router_paths):
+    paths = admin_router_paths(enabled=False)
+    assert not any("/skills" in p for p in paths)
+    assert not any(p.endswith("/settings/chat") for p in paths)
+
+
+def test_admin_skills_mounted_when_enabled(admin_router_paths):
+    paths = admin_router_paths(enabled=True)
+    assert any("/skills" in p for p in paths)
+    assert any(p.endswith("/settings/chat") for p in paths)

--- a/backend/tests/routes/test_agent_mode_policy.py
+++ b/backend/tests/routes/test_agent_mode_policy.py
@@ -45,6 +45,14 @@ def authed_client(app, trusted_user):
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _skills_enabled(monkeypatch):
+    """This module exercises skills-mode behavior, so run with the feature on.
+    The disabled-feature override (force chat) is covered by its own test that
+    flips this back off."""
+    monkeypatch.setenv("SKILLS_ENABLED", "true")
+
+
 class _StubSettingsService:
     def __init__(self, settings: ChatModeSettings):
         self._settings = settings
@@ -206,6 +214,44 @@ class TestInvocationsModePolicy:
         ):
             resp = authed_client.post(
                 "/invocations", json={"session_id": "sess-4", "message": "hi"}
+            )
+            _ = resp.text
+
+        assert resp.status_code == 200
+        resolve_mock.assert_not_awaited()
+        kwargs = get_agent_mock.call_args.kwargs
+        assert kwargs["agent_type"] == "chat"
+        assert kwargs["accessible_skill_ids"] is None
+
+    def test_skills_disabled_forces_chat_over_skill_request(
+        self, authed_client, monkeypatch
+    ):
+        # Feature off + client explicitly asks for skill + policy allows it:
+        # the turn must still route through the ChatAgent with no skills.
+        monkeypatch.setenv("SKILLS_ENABLED", "false")
+        get_agent_mock = MagicMock(return_value=_mock_agent())
+        resolve_mock = AsyncMock(return_value=["web_research"])
+        with patch(
+            "apis.inference_api.chat.routes.get_agent", get_agent_mock
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.inference_api.chat.routes._resolve_accessible_skill_ids",
+            resolve_mock,
+        ), patch(
+            "apis.inference_api.chat.routes.get_chat_mode_settings_service",
+            return_value=_StubSettingsService(
+                ChatModeSettings(default_mode="skill", allow_mode_toggle=True)
+            ),
+        ):
+            resp = authed_client.post(
+                "/invocations",
+                json={
+                    "session_id": "sess-off",
+                    "message": "hi",
+                    "agent_type": "skill",
+                },
             )
             _ = resp.text
 

--- a/backend/tests/routes/test_inference.py
+++ b/backend/tests/routes/test_inference.py
@@ -178,6 +178,13 @@ class TestInvocationsInvalid:
 class TestDefaultAgentTypeFlip:
     """When the client omits agent_type, the turn routes through SkillAgent."""
 
+    @pytest.fixture(autouse=True)
+    def _skills_enabled(self, monkeypatch):
+        # The skill-default behavior only applies when the feature is on; off
+        # by default, every turn is forced to chat (covered in
+        # tests/routes/test_agent_mode_policy.py).
+        monkeypatch.setenv("SKILLS_ENABLED", "true")
+
     def _mock_agent(self):
         agent = MagicMock()
 

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -1,9 +1,11 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  computed,
   inject,
 } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { ChatModeService } from '../services/chat-mode/chat-mode.service';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -86,7 +88,7 @@ interface NavGroup {
                 class="block w-full rounded-sm border-gray-300 bg-white py-2 pl-3 pr-10 text-base text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
                 (change)="onMobileNavChange($event)"
               >
-                @for (group of navGroups; track group.label) {
+                @for (group of navGroups(); track group.label) {
                   <optgroup [label]="group.label">
                     @for (item of group.items; track item.route) {
                       <option [value]="item.route">{{ item.label }}</option>
@@ -99,7 +101,7 @@ interface NavGroup {
             <!-- Desktop sidebar -->
             <nav class="hidden lg:block" aria-label="Admin navigation">
               <div class="flex flex-col gap-6">
-                @for (group of navGroups; track group.label) {
+                @for (group of navGroups(); track group.label) {
                   <div>
                     <h2 class="px-3 text-xs/5 font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                       {{ group.label }}
@@ -135,8 +137,9 @@ interface NavGroup {
 })
 export class AdminLayout {
   private router = inject(Router);
+  private chatMode = inject(ChatModeService);
 
-  readonly navGroups: NavGroup[] = [
+  private readonly allNavGroups: NavGroup[] = [
     {
       label: 'Usage & Spend',
       items: [
@@ -170,6 +173,19 @@ export class AdminLayout {
       ],
     },
   ];
+
+  /**
+   * Nav groups with the Skills entry hidden while the skills feature is
+   * disabled for this environment (deferred release). The pages stay routed
+   * but unlinked; the backend forces tools mode and 404s the skills APIs.
+   */
+  readonly navGroups = computed<NavGroup[]>(() => {
+    if (this.chatMode.skillsEnabled()) return this.allNavGroups;
+    return this.allNavGroups.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => item.route !== '/admin/skills'),
+    }));
+  });
 
   onMobileNavChange(event: Event): void {
     const select = event.target as HTMLSelectElement;

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { ElementRef, signal } from '@angular/core';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService } from '../../services/tool/tool.service';
+import { SkillService } from '../../services/skill/skill.service';
+import { ChatModeService } from '../../services/chat-mode/chat-mode.service';
 import { ManagedModel } from '../../admin/manage-models/models/managed-model.model';
 
 describe('ModelSettings', () => {
@@ -48,6 +50,32 @@ describe('ModelSettings', () => {
       providers: [
         { provide: ModelService, useValue: mockModelService },
         { provide: ToolService, useValue: mockToolService },
+        // Mock the two services that otherwise fire real (failing) HTTP in
+        // this spec — SkillService auto-loads /skills/ via an effect and
+        // ChatModeService fetches /system/chat-settings on construction. Left
+        // real, their async error logs can land during worker teardown and
+        // fail the run with an unhandled rejection.
+        {
+          provide: SkillService,
+          useValue: {
+            skills: signal([]),
+            enabledSkillIds: signal([]),
+            enabledCount: signal(0),
+            hasSkills: signal(false),
+            loading: signal(false),
+            toggleSkill: vi.fn(),
+          },
+        },
+        {
+          provide: ChatModeService,
+          useValue: {
+            mode: signal('chat'),
+            canToggle: signal(false),
+            isSkillsMode: signal(false),
+            skillsEnabled: signal(false),
+            setMode: vi.fn(),
+          },
+        },
         { provide: ElementRef, useValue: { nativeElement: document.createElement('div') } },
       ],
     });

--- a/frontend/ai.client/src/app/services/chat-mode/chat-mode.service.spec.ts
+++ b/frontend/ai.client/src/app/services/chat-mode/chat-mode.service.spec.ts
@@ -57,15 +57,23 @@ describe('ChatModeService', () => {
   });
 
   it('defaults to the admin default mode', async () => {
-    await setup({ defaultMode: 'skill', allowModeToggle: true });
+    await setup({ defaultMode: 'skill', allowModeToggle: true, skillsEnabled: true });
     expect(service.mode()).toBe('skill');
     expect(service.isSkillsMode()).toBe(true);
     expect(service.canToggle()).toBe(true);
+    expect(service.skillsEnabled()).toBe(true);
+  });
+
+  it('reflects skillsEnabled=false from the policy (deferred feature)', async () => {
+    await setup({ defaultMode: 'chat', allowModeToggle: false, skillsEnabled: false });
+    expect(service.skillsEnabled()).toBe(false);
+    expect(service.mode()).toBe('chat');
+    expect(service.canToggle()).toBe(false);
   });
 
   it('uses the user preferred mode when no local selection exists', async () => {
     await setup(
-      { defaultMode: 'skill', allowModeToggle: true },
+      { defaultMode: 'skill', allowModeToggle: true, skillsEnabled: true },
       { defaultModelId: null, preferredAgentMode: 'chat' },
     );
     expect(service.mode()).toBe('chat');
@@ -73,7 +81,7 @@ describe('ChatModeService', () => {
 
   it('policy wins when toggling is disallowed', async () => {
     await setup(
-      { defaultMode: 'skill', allowModeToggle: false },
+      { defaultMode: 'skill', allowModeToggle: false, skillsEnabled: true },
       { defaultModelId: null, preferredAgentMode: 'chat' },
     );
     expect(service.mode()).toBe('skill');
@@ -87,7 +95,7 @@ describe('ChatModeService', () => {
   });
 
   it('setMode flips the mode and persists user + session preferences', async () => {
-    await setup({ defaultMode: 'skill', allowModeToggle: true });
+    await setup({ defaultMode: 'skill', allowModeToggle: true, skillsEnabled: true });
 
     service.setMode('chat', 'sess-1');
 
@@ -98,7 +106,7 @@ describe('ChatModeService', () => {
   });
 
   it('setMode without a session persists only the user preference', async () => {
-    await setup({ defaultMode: 'skill', allowModeToggle: true });
+    await setup({ defaultMode: 'skill', allowModeToggle: true, skillsEnabled: true });
 
     service.setMode('chat');
 
@@ -108,7 +116,7 @@ describe('ChatModeService', () => {
   });
 
   it('hydrateFromSession restores a stored mode and ignores missing ones', async () => {
-    await setup({ defaultMode: 'skill', allowModeToggle: true });
+    await setup({ defaultMode: 'skill', allowModeToggle: true, skillsEnabled: true });
 
     service.hydrateFromSession('chat');
     expect(service.mode()).toBe('chat');
@@ -121,7 +129,7 @@ describe('ChatModeService', () => {
     expect(service.mode()).toBe('skill');
   });
 
-  it('falls back to compiled-in defaults when the policy endpoint fails', async () => {
+  it('falls back to the dark default (skills off) when the policy endpoint fails', async () => {
     userSettings = undefined;
     updateSettings.mockClear();
     updateSessionPreferences.mockClear();
@@ -147,7 +155,8 @@ describe('ChatModeService', () => {
     await vi.waitFor(() => {
       expect(service.policyLoaded()).toBe(true);
     });
-    expect(service.mode()).toBe('skill');
-    expect(service.canToggle()).toBe(true);
+    expect(service.mode()).toBe('chat');
+    expect(service.canToggle()).toBe(false);
+    expect(service.skillsEnabled()).toBe(false);
   });
 });

--- a/frontend/ai.client/src/app/services/chat-mode/chat-mode.service.ts
+++ b/frontend/ai.client/src/app/services/chat-mode/chat-mode.service.ts
@@ -11,10 +11,24 @@ export type ChatMode = 'skill' | 'chat';
 export interface ChatModePolicy {
   defaultMode: ChatMode;
   allowModeToggle: boolean;
+  /**
+   * Whether the skills feature is enabled for this environment at all. When
+   * false the backend forces tools/chat mode; the SPA also hides the admin
+   * skills nav entry. Deferred features report this false.
+   */
+  skillsEnabled: boolean;
 }
 
-/** Mirrors the backend's compiled-in defaults (apis.shared.platform_settings). */
-const DEFAULT_POLICY: ChatModePolicy = { defaultMode: 'skill', allowModeToggle: true };
+/**
+ * Pre-load fallback. Defaults skills off so deferred-feature environments
+ * never flash the skills surfaces before the policy loads; the server is the
+ * source of truth and overrides this on fetch.
+ */
+const DEFAULT_POLICY: ChatModePolicy = {
+  defaultMode: 'chat',
+  allowModeToggle: false,
+  skillsEnabled: false,
+};
 
 /**
  * Holds the user's current agent mode — skills mode (SkillAgent, capabilities
@@ -49,6 +63,9 @@ export class ChatModeService {
   readonly policyLoaded = this._policyLoaded.asReadonly();
 
   readonly canToggle = computed(() => this._policy().allowModeToggle);
+
+  /** Whether the skills feature is enabled at all (gates the admin nav entry). */
+  readonly skillsEnabled = computed(() => this._policy().skillsEnabled);
 
   readonly mode = computed<ChatMode>(() => {
     const policy = this._policy();

--- a/frontend/ai.client/src/app/services/skill/skill.service.spec.ts
+++ b/frontend/ai.client/src/app/services/skill/skill.service.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideHttpClient } from '@angular/common/http';
 import { SkillService, UserSkill, SkillsResponse } from './skill.service';
 import { ConfigService } from '../config.service';
+import { ChatModeService } from '../chat-mode/chat-mode.service';
 import { signal } from '@angular/core';
 
 describe('SkillService', () => {
@@ -17,19 +18,25 @@ describe('SkillService', () => {
 
   const mockResponse: SkillsResponse = { skills: mockSkills, totalCount: 2 };
 
-  async function setup() {
+  function configure(skillsEnabled: boolean) {
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
         SkillService,
         { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+        { provide: ChatModeService, useValue: { skillsEnabled: signal(skillsEnabled) } },
       ],
     });
 
     service = TestBed.inject(SkillService);
     httpMock = TestBed.inject(HttpTestingController);
+    // Flush the constructor effect that gates the auto-load on the policy.
+    TestBed.tick();
+  }
 
+  async function setup() {
+    configure(true);
     await vi.waitFor(() => {
       httpMock.expectOne('http://localhost:8000/skills/').flush(mockResponse);
     });
@@ -38,6 +45,16 @@ describe('SkillService', () => {
   afterEach(() => {
     TestBed.resetTestingModule();
     httpMock.match(() => true);
+  });
+
+  describe('auto-load gating', () => {
+    it('does not fetch skills when the feature is disabled', () => {
+      configure(false);
+      // No /skills/ request is issued; verify() in afterEach would fail on one.
+      httpMock.verify();
+      expect(service.initialized()).toBe(false);
+      expect(service.skills()).toEqual([]);
+    });
   });
 
   describe('loadSkills', () => {

--- a/frontend/ai.client/src/app/services/skill/skill.service.ts
+++ b/frontend/ai.client/src/app/services/skill/skill.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, inject, signal, computed } from '@angular/core';
+import { Injectable, inject, signal, computed, effect } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../config.service';
+import { ChatModeService } from '../chat-mode/chat-mode.service';
 
 /**
  * One skill the user's roles grant, as returned by GET /skills/.
@@ -37,8 +38,12 @@ export interface SkillsResponse {
 export class SkillService {
   private http = inject(HttpClient);
   private config = inject(ConfigService);
+  private chatMode = inject(ChatModeService);
 
   private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/skills`);
+
+  /** Guards the one-time auto-load so it fires at most once. */
+  private autoLoadTriggered = false;
 
   // Internal state signals
   private _skills = signal<UserSkill[]>([]);
@@ -53,8 +58,17 @@ export class SkillService {
   readonly initialized = this._initialized.asReadonly();
 
   constructor() {
-    this.loadSkills().catch(err => {
-      console.error('Failed to load skills on initialization:', err);
+    // Load the user's skills once the feature is known to be enabled. While
+    // skills are deferred (disabled) the /skills API is unmounted, so gating
+    // on the policy avoids a guaranteed 404 on every session; when enabled,
+    // the effect fires as soon as the chat-mode policy resolves.
+    effect(() => {
+      if (this.chatMode.skillsEnabled() && !this.autoLoadTriggered) {
+        this.autoLoadTriggered = true;
+        this.loadSkills().catch(err => {
+          console.error('Failed to load skills on initialization:', err);
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Defers the **skills feature** (user picker, admin catalog, and skills mode) for a release **without removing any merged code**. A new `apis/shared/feature_flags.py::skills_enabled()` reads the `SKILLS_ENABLED` env var (default **false**), mirroring the existing `FINE_TUNING_ENABLED` precedent. The flag overrides PR-7's `DEFAULT_CHAT_MODE = "skill"` at runtime, so that commit stays intact — nothing is reverted.

Deployed environments go dark automatically because the env var is absent (**no CDK change required**). Re-enabling next release = set `SKILLS_ENABLED=true` on **both** the app-api and inference-api containers.

## Gated surfaces (all leave code + data intact)

**Backend**
- `app_api/main.py` — user-facing skills router mounted only when enabled (**unmounted** while off → `/skills/*` 404s).
- `app_api/admin/routes.py` — admin skills catalog + chat-mode-policy routers gated.
- `app_api/system/routes.py` — `GET /system/chat-settings` returns `chat`/no-toggle/`skillsEnabled:false` when off (new `skills_enabled` field on the response).
- `inference_api/chat/routes.py` — forces `skill` → `chat` when off, even if a stale client requests skill; voice/other agent types untouched.

**Frontend**
- `ChatModeService.skillsEnabled` (from `/system/chat-settings`) hides the admin **Skills** nav entry; the mode toggle + skills section auto-hide via `allowModeToggle:false`.
- `SkillService` eager load gated by an `effect` on `skillsEnabled()` so a disabled env never fires the now-404 `GET /skills/`.

## Tests

- Tests default off; skills-mode tests opt in via `SKILLS_ENABLED=true`.
- New off-behavior coverage: forced-chat at the runtime, public chat-settings override, and admin mount gating (`test_skills_feature_flag.py`).
- **Backend full suite green** (one unrelated Hypothesis 200ms-deadline timing flake in `test_pbt_auth_sweep`, passes in isolation).
- **Frontend affected specs green** (chat-mode, skill, model-settings, chat-request) + new deferred-case test; `ng build` clean.

## Re-enable checklist (future release)

- [ ] Set `SKILLS_ENABLED=true` on app-api + inference-api containers
- [ ] (eventually) flip the code default / remove the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)