### PR TITLE
feat(tools): forward admin OIDC token on MCP tool discovery

### DIFF
--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -392,7 +392,27 @@ async def admin_discover_mcp_tools(
             "list the tool names manually.",
         )
 
-    client = create_external_mcp_client(config=request.to_config())
+    # Forward-auth servers (same-team MCP that validates a forwarded JWT, behind
+    # a Lambda Function URL with AuthType=NONE) are discovered by signing the
+    # request with the admin's *own* OIDC token — the same bearer the agent loop
+    # forwards for the end-user at runtime — instead of SigV4. The admin is
+    # already trusted to point discovery at an arbitrary URL (see the
+    # trust-boundary note above); forwarding their own session token to that URL
+    # is a strictly lower bar than the end-user token forwarding they're
+    # configuring for the tool.
+    oauth_token: Optional[str] = None
+    if request.forward_auth_token:
+        if not admin.raw_token:
+            raise HTTPException(
+                status_code=400,
+                detail="Forward-auth discovery needs your session token, which "
+                "isn't available on this request. Re-authenticate and retry.",
+            )
+        oauth_token = admin.raw_token
+
+    client = create_external_mcp_client(
+        config=request.to_config(), oauth_token=oauth_token
+    )
     if client is None:
         raise HTTPException(
             status_code=400,

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -1354,9 +1354,17 @@ class MCPDiscoverRequest(BaseModel):
     """Request body for POST /api/admin/tools/discover.
 
     Same fields as MCPServerConfigRequest minus the `tools` list — the
-    point of discovery is to populate that list. OAuth-gated and OIDC-
-    forwarded servers can't be discovered admin-side (no end-user token
-    available); the route returns a 400 in those cases."""
+    point of discovery is to populate that list. Provider-gated OAuth (3LO)
+    servers can't be discovered admin-side (no end-user provider token
+    available); the route returns a 400 in that case.
+
+    `forward_auth_token` mirrors the catalog flag of the same name: when set,
+    the route signs the discovery request with the *admin's own* OIDC token
+    instead of SigV4, matching how the agent loop forwards the end-user's
+    token at runtime. This lets a same-team MCP server that validates a
+    forwarded JWT (Lambda Function URL AuthType=NONE) be discovered without
+    any IAM invoke permission.
+    """
 
     server_url: str = Field(..., alias="serverUrl")
     transport: MCPTransport = Field(default=MCPTransport.STREAMABLE_HTTP)
@@ -1364,6 +1372,7 @@ class MCPDiscoverRequest(BaseModel):
     aws_region: Optional[str] = Field(None, alias="awsRegion")
     api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
     secret_arn: Optional[str] = Field(None, alias="secretArn")
+    forward_auth_token: bool = Field(default=False, alias="forwardAuthToken")
 
     model_config = {"populate_by_name": True, "use_enum_values": True}
 

--- a/backend/tests/apis/app_api/admin/tools/test_discover_forward_auth.py
+++ b/backend/tests/apis/app_api/admin/tools/test_discover_forward_auth.py
@@ -1,0 +1,112 @@
+"""Tests for forward-auth MCP discovery on `/admin/tools/discover`.
+
+A same-team MCP server can validate a forwarded user JWT (Lambda Function URL
+AuthType=NONE) instead of requiring SigV4/IAM. When the admin sets
+`forwardAuthToken`, discovery must sign the request with the admin's *own* OIDC
+token — mirroring how the agent loop forwards the end-user's token at runtime —
+rather than falling back to SigV4. See `apis/app_api/admin/tools/routes.py`.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from apis.app_api.admin.tools import routes
+from apis.shared.auth.models import User
+from apis.shared.tools.models import MCPAuthType, MCPDiscoverRequest
+
+_CREATE_TARGET = (
+    "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client"
+)
+_URL = "https://x.lambda-url.us-west-2.on.aws/mcp"
+
+
+def _admin(raw_token="admin-tok"):
+    return User(
+        email="admin@example.edu",
+        user_id="u1",
+        name="Admin",
+        roles=["system_admin"],
+        raw_token=raw_token,
+    )
+
+
+class _FakeSpec:
+    def __init__(self, name, description=None):
+        self.name = name
+        self.description = description
+
+
+class _FakeTool:
+    """Mirrors Strands' MCPAgentTool: spec lives on `mcp_tool`."""
+
+    def __init__(self, name, description=None):
+        self.mcp_tool = _FakeSpec(name, description)
+        self.tool_name = name
+
+
+class _FakeClient:
+    def __init__(self, tools):
+        self._tools = tools
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def list_tools_sync(self):
+        return list(self._tools)
+
+
+@pytest.mark.asyncio
+async def test_forward_auth_discovery_signs_with_admin_token(monkeypatch):
+    captured = {}
+
+    def fake_create(config, oauth_token=None, **kwargs):
+        captured["oauth_token"] = oauth_token
+        return _FakeClient([_FakeTool("search_classes", "Search the catalog")])
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL, authType=MCPAuthType.NONE, forwardAuthToken=True
+    )
+    resp = await routes.admin_discover_mcp_tools(req, admin=_admin("admin-tok"))
+
+    assert captured["oauth_token"] == "admin-tok"
+    assert [t.name for t in resp.tools] == ["search_classes"]
+
+
+@pytest.mark.asyncio
+async def test_forward_auth_discovery_without_token_returns_400(monkeypatch):
+    def fake_create(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("client must not be built without a forwardable token")
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL, authType=MCPAuthType.NONE, forwardAuthToken=True
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.admin_discover_mcp_tools(req, admin=_admin(raw_token=None))
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_forward_discovery_does_not_forward_token(monkeypatch):
+    """Default (SigV4) discovery must not leak the admin's bearer token."""
+    captured = {}
+
+    def fake_create(config, oauth_token=None, **kwargs):
+        captured["oauth_token"] = oauth_token
+        return _FakeClient([_FakeTool("search_classes")])
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL, authType=MCPAuthType.AWS_IAM, forwardAuthToken=False
+    )
+    await routes.admin_discover_mcp_tools(req, admin=_admin("admin-tok"))
+
+    assert captured["oauth_token"] is None

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -228,6 +228,12 @@ export interface MCPDiscoverRequest {
   awsRegion?: string | null;
   apiKeyHeader?: string | null;
   secretArn?: string | null;
+  /**
+   * When true, discovery is signed with the admin's own OIDC token (matching
+   * the catalog `forwardAuthToken` flag) instead of SigV4 — for same-team MCP
+   * servers that validate a forwarded JWT (Lambda Function URL AuthType=NONE).
+   */
+  forwardAuthToken?: boolean;
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -1097,6 +1097,7 @@ export class ToolFormPage implements OnInit {
         awsRegion: formValue.mcpAwsRegion || null,
         apiKeyHeader: formValue.mcpApiKeyHeader || null,
         secretArn: formValue.mcpSecretArn || null,
+        forwardAuthToken: formValue.forwardAuthToken || false,
       });
 
       // Merge: keep existing rows (and their needsApproval flag), append any


### PR DESCRIPTION
## Summary

Fixes a `502` from the admin **Discover from server** button (`POST /api/admin/tools/discover`) when pointed at an IAM-auth MCP server, and lays the groundwork for **Option A: OIDC token passthrough** as the auth model for same-team external MCP servers.

## Root cause

Discovery runs in **app-api** and SigV4-signs the outbound request as the **app-api task role** (service `lambda`). That role has no `lambda:InvokeFunctionUrl` — only the **inference-api** runtime role does (`ExternalMCPLambdaAccess`). Against a Lambda Function URL with `AuthType=AWS_IAM`, the signed request is rejected with `403`, which surfaces during MCP client init as an anyio `TaskGroup` `ExceptionGroup`. `_find_upstream_http_error` can't unwrap it to a clean `httpx.HTTPStatusError`, so the route falls through to a generic `502` — exactly the *"client initialization failed: unhandled errors in a TaskGroup"* message admins were seeing. (The target MCP Lambda is also cross-account, so the name-pattern IAM grants couldn't reach it regardless.)

## Change

For same-team MCP servers that validate a **forwarded user JWT** (Lambda URL `AuthType=NONE`), discovery should mirror the runtime `forward_auth_token` path and sign with the **admin's own OIDC token** instead of SigV4 — no IAM invoke permission required.

- `MCPDiscoverRequest.forward_auth_token` (alias `forwardAuthToken`).
- Discover handler forwards `admin.raw_token` as the bearer when the flag is set (`400` if no session token is available) and skips SigV4. Provider-gated OAuth (3LO) discovery is still rejected — the admin session can't supply an end-user provider token.
- Frontend: thread `forwardAuthToken` through the admin tool form's discover call so the existing **"Forward app authentication token"** checkbox governs discovery too.

The **runtime** forward-auth path already existed (`forward_auth_token` → `OAuthBearerAuth`), so no agent-loop changes were needed.

## Tests

- New `backend/tests/apis/app_api/admin/tools/test_discover_forward_auth.py` (3 cases: token forwarded when flagged; `400` when no token; default SigV4 path forwards no token).
- **Full backend suite: 3963 passed, 3 skipped.**

## Reviewer notes / follow-up (outside this PR)

- To actually use this, the class-search MCP server must flip its Lambda Function URL `AuthType` `AWS_IAM`→`NONE` and validate the forwarded Cognito **access** token (verify signature + issuer + `exp`, `verify_aud=False`, then assert `client_id == COGNITO_BFF_APP_CLIENT_ID` — access tokens carry `client_id`, not `aud`; mirrors `apis/shared/auth/cognito_jwt_validator.py`).
- The catalog tool should then be set to **Auth Type = None** + **Forward auth token** so there's no SigV4 fallback.
- No CDK/IAM changes here. Considered, not pursued: granting the app-api role `lambda:InvokeFunctionUrl` — rejected in favor of the passthrough model, which also removes the cross-account IAM dead-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)