### PR TITLE
fix(app-api): grant secretsmanager:PutSecretValue on auth-provider se…

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -204,6 +204,22 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // The admin auth-providers endpoints (POST/DELETE /admin/auth-providers)
+  // read AND write the JSON bag of provider client secrets: the repository
+  // rewrites the whole secret via PutSecretValue on both add and remove
+  // (see apis/shared/auth_providers/repository.py). GetSecretValue is
+  // granted above; PutSecretValue is scoped to just the auth-provider
+  // secret (no other secret is written by the app at runtime). The trailing
+  // wildcard matches the random 6-char suffix AWS appends to the ARN.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'AuthProviderSecretsWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['secretsmanager:PutSecretValue'],
+      resources: [`${props.refs.authProviderSecretsSecret.secretArn}*`],
+    }),
+  );
+
   // ── KMS (OAuth token encryption + BFF cookie signing) ──
   // Two separate statements because the access patterns differ:
   //


### PR DESCRIPTION
…cret

The admin auth-providers endpoints (POST/DELETE /admin/auth-providers) write the provider client-secret bag back to the auth-provider-secrets secret via PutSecretValue (apis/shared/auth_providers/repository.py), but the App API task role was only granted GetSecretValue. Configuring/removing an auth provider failed with AccessDeniedException on secretsmanager:PutSecretValue.

Add a least-privilege PutSecretValue statement scoped to just the auth-provider-secrets secret (trailing wildcard matches the random ARN suffix). No other runtime-written secret needs this.