### PR TITLE
docs(infra): correct stale SSM comment on mcp-sandbox origin wiring

### DIFF
--- a/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
+++ b/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
@@ -111,9 +111,11 @@ export interface McpSandboxDistributionConstructProps {
  * lets the construct still synthesize on the CloudFront default domain
  * for unit/synth tests and domain-less local stacks.
  *
- * SSM publication: `/{prefix}/mcp-sandbox/origin` →
- * `https://mcp-sandbox.{domainName}` (or the CloudFront default domain
- * fallback when no custom domain is configured).
+ * Origin exposure: the resolved origin (`https://mcp-sandbox.{domainName}`,
+ * or the CloudFront default domain when no custom domain is configured) is
+ * surfaced as `proxyOrigin` and threaded through `PlatformComputeRefs`
+ * directly into inference-api's `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` env var.
+ * It is no longer published to SSM (pre-#396 the standalone stack did).
  */
 export class McpSandboxDistributionConstruct extends Construct {
   public readonly distribution: cloudfront.Distribution;


### PR DESCRIPTION
## What

Fixes a stale doc comment on `McpSandboxDistributionConstruct` ([mcp-sandbox-distribution-construct.ts](infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts)). The comment claimed the construct publishes the proxy origin to SSM at `/{prefix}/mcp-sandbox/origin` with a CloudFront-default fallback. It no longer does.

## Why

That SSM publication was part of the **pre-#396 standalone `McpSandboxStack`**. The single-stack consolidation (#396) removed it. Today the resolved origin is:

- exposed on the construct as `proxyOrigin`, and
- threaded through `PlatformComputeRefs.mcpSandboxProxyOrigin` directly into inference-api's `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN` runtime env var (see [inference-agentcore-construct.ts:380](infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts:380)).

The construct never calls `ssm.StringParameter` anymore, so `/{prefix}/mcp-sandbox/origin` does not exist in a current deploy. The stale comment is an active trap: while debugging a redeployed dev environment, a missing SSM param reads as a broken sandbox deploy when its absence is actually expected. Verified against the live `dev-boisestateai-v2` environment — the sandbox CloudFront distribution (alias `mcp-sandbox.alpha.boisestate.ai`) is healthy and DNS resolves; only the param (correctly) isn't there.

## Scope

- Comment-only change to one TypeScript file. No behavior change.
- `npx tsc --noEmit` passes.

## Reviewer notes

CLAUDE.md's SSE-event table and some internal notes still describe the old "inference-api consumes the SSM origin only when `CDK_MCP_SANDBOX_ENABLED=true`" wiring, which is likewise stale post-#396 (no SSM read, no enable flag — the construct is always provisioned). Out of scope here, but worth a follow-up doc sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)