### PR TITLE
fix(mcp-apps): accept spec-array content in ui/message

### DIFF
--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -378,7 +378,7 @@ describe('McpAppBridge', () => {
           id: 'm1',
           method: 'ui/message',
           nonce: NONCE,
-          params: { role: 'user', content: { type: 'text', text: '  hi  ' } },
+          params: { role: 'user', content: [{ type: 'text', text: '  hi  ' }] },
         },
         p.proxy,
       );
@@ -386,6 +386,29 @@ describe('McpAppBridge', () => {
       await Promise.resolve();
       expect(p.sendMessage).toHaveBeenCalledWith('hi');
       expect(p.proxy.byId('m1').result).toEqual({});
+    });
+
+    it('ui/message concatenates multiple text blocks in the array', async () => {
+      p.host.deliver(
+        {
+          jsonrpc: '2.0',
+          id: 'm1b',
+          method: 'ui/message',
+          nonce: NONCE,
+          params: {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'line one' },
+              { type: 'text', text: 'line two' },
+            ],
+          },
+        },
+        p.proxy,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(p.sendMessage).toHaveBeenCalledWith('line one\nline two');
+      expect(p.proxy.byId('m1b').result).toEqual({});
     });
 
     it('ui/message with bad params is invalid-params (-32000), not relayed', () => {
@@ -485,7 +508,7 @@ describe('McpAppBridge', () => {
           id: 'm3',
           method: 'ui/message',
           nonce: NONCE,
-          params: { role: 'user', content: { type: 'text', text: 'go' } },
+          params: { role: 'user', content: [{ type: 'text', text: 'go' }] },
         },
         p.proxy,
       );

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -411,11 +411,17 @@ export class McpAppBridge {
           return;
         }
         const p = msg.params as Partial<MessageParams> | undefined;
+        // `content` is an ARRAY of content blocks per SEP-1865 / the ext-apps
+        // SDK; concatenate the text blocks into the relayed user turn (mirrors
+        // the ui/update-model-context handler's array handling below).
+        const blocks = Array.isArray(p?.content) ? p!.content : [];
         const text =
-          p?.role === 'user' &&
-          p?.content?.type === 'text' &&
-          typeof p.content.text === 'string'
-            ? p.content.text.trim()
+          p?.role === 'user'
+            ? blocks
+                .filter((b) => b?.type === 'text' && typeof b?.text === 'string')
+                .map((b) => b!.text as string)
+                .join('\n')
+                .trim()
             : '';
         if (!text) {
           this.respondError(

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-protocol.ts
@@ -145,10 +145,14 @@ export interface RequestDisplayModeParams {
   mode: DisplayMode;
 }
 
-/** Spec shape of `ui/message` params (View → host). */
+/**
+ * Spec shape of `ui/message` params (View → host). Per SEP-1865 / the
+ * ext-apps SDK, `content` is an ARRAY of content blocks (the View sends
+ * `content: [{ type: 'text', text }]`), not a single block.
+ */
 export interface MessageParams {
   role: 'user';
-  content: { type: 'text'; text: string };
+  content: Array<{ type: string; text?: string }>;
 }
 
 /** Spec shape of `ui/update-model-context` params (View → host). */


### PR DESCRIPTION
## Problem

The MCP Apps host bridge rejected every spec-compliant widget message with `-32000 "Invalid ui/message params"`. A widget calling `app.sendMessage(...)` sends, per SEP-1865 / the `@modelcontextprotocol/ext-apps` SDK:

```json
{ "method": "ui/message", "params": { "role": "user",
  "content": [ { "type": "text", "text": "👋 …" } ] } }
```

…but `mcp-app-bridge.ts` read `content` as a **single block** (`p.content.type` / `p.content.text`). For an array those are `undefined`, so the extracted text was empty and the handler returned `-32000`. The sibling `ui/update-model-context` handler already treats `content` as an array — only `ui/message` had the bug.

Found while exercising a deployed FastMCP MCP App (`hello-world`) whose widget's "Wave back" button calls `app.sendMessage`.

## Fix

- `mcp-app-bridge.ts` — read `content` as an array and concatenate its text blocks (mirrors `ui/update-model-context`).
- `mcp-app-protocol.ts` — `MessageParams.content` → `Array<{ type: string; text?: string }>` (spec shape).
- `mcp-app-bridge.spec.ts` — the two cases that sent single objects now send arrays; added a multi-block concatenation regression test.

No other code consumed `MessageParams`. Widgets need no change — they were already spec-compliant.

## Test

`npx vitest run …/mcp-app-bridge.spec.ts` → **32/32 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)