### PR TITLE
fix(mcp-apps): retry transient TLS/connect failures on MCP client start

### DIFF
--- a/backend/src/agents/main_agent/integrations/mcp_apps.py
+++ b/backend/src/agents/main_agent/integrations/mcp_apps.py
@@ -36,6 +36,7 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin, urlsplit
 from urllib.request import Request, urlopen
@@ -700,6 +701,51 @@ def ensure_ui_extension_session_patch() -> None:
 # UI-capable MCP client
 # =============================================================================
 
+# Transport-level error type names worth retrying on a fresh connection — a TLS
+# handshake blip (`SSLV3_ALERT_HANDSHAKE_FAILURE` from a middlebox), a reset, or
+# a connect timeout. Matched by class name so we don't hard-import
+# httpx/httpcore/ssl just to classify an exception.
+_TRANSIENT_CONNECT_ERROR_NAMES = frozenset(
+    {
+        "ConnectError",
+        "ConnectTimeout",
+        "ConnectionError",
+        "ConnectionResetError",
+        "ReadTimeout",
+        "PoolTimeout",
+        "SSLError",
+        "SSLEOFError",
+    }
+)
+
+#: MCP client start() retry policy (transient transport failures only).
+_MCP_START_MAX_ATTEMPTS = 3
+_MCP_START_BACKOFF_BASE_S = 0.5
+
+
+def _is_transient_connect_error(exc: BaseException) -> bool:
+    """True if `exc` — or anything in its cause/context/ExceptionGroup chain —
+    is a transport-level connection error worth retrying on a new connection.
+
+    Strands wraps the real failure as `MCPClientInitializationError` whose
+    `__cause__` is an anyio `ExceptionGroup` containing the `httpx.ConnectError`
+    (often itself caused by an `ssl.SSLError`), so we walk the whole tree.
+    """
+    seen: set[int] = set()
+    stack: List[BaseException] = [exc]
+    while stack:
+        e = stack.pop()
+        if id(e) in seen:
+            continue
+        seen.add(id(e))
+        if type(e).__name__ in _TRANSIENT_CONNECT_ERROR_NAMES:
+            return True
+        for nxt in (e.__cause__, e.__context__):
+            if nxt is not None:
+                stack.append(nxt)
+        stack.extend(getattr(e, "exceptions", ()) or ())  # ExceptionGroup
+    return False
+
 
 class UICapableMCPClient(MCPClient):
     """`MCPClient` that records `_meta.ui` and hides app-only tools.
@@ -722,6 +768,46 @@ class UICapableMCPClient(MCPClient):
         self.server_url = server_url
         ensure_ui_extension_session_patch()
         super().__init__(*args, **kwargs)
+
+    def start(self, *args: Any, **kwargs: Any) -> "UICapableMCPClient":
+        """Start the MCP session, retrying transient transport failures.
+
+        A single TLS handshake blip or connection reset at startup otherwise
+        fails the whole agent build: Strands' `start()` raises
+        `MCPClientInitializationError`, the tool fails to load, and agent
+        creation errors out for the user. External MCP endpoints — Lambda
+        Function URLs, third-party servers behind TLS-inspecting middleboxes —
+        hit these intermittently, so retry a few times with exponential backoff
+        before giving up. Non-transient failures (bad URL, auth, protocol
+        mismatch) are re-raised on the first attempt. Strands resets its init
+        future + background thread on failure (via `stop()`), so re-invoking
+        `start()` is safe.
+        """
+        last_exc: Optional[BaseException] = None
+        delay = _MCP_START_BACKOFF_BASE_S
+        for attempt in range(1, _MCP_START_MAX_ATTEMPTS + 1):
+            try:
+                super().start(*args, **kwargs)
+                return self
+            except Exception as exc:  # noqa: BLE001 - classify, then retry/raise
+                last_exc = exc
+                if attempt >= _MCP_START_MAX_ATTEMPTS or not _is_transient_connect_error(
+                    exc
+                ):
+                    raise
+                logger.warning(
+                    "MCP client start failed (attempt %d/%d) with a transient "
+                    "transport error; retrying in %.1fs: %s",
+                    attempt,
+                    _MCP_START_MAX_ATTEMPTS,
+                    delay,
+                    exc,
+                )
+                time.sleep(delay)
+                delay *= 2
+        # Unreachable: the loop returns on success or raises on the last attempt.
+        assert last_exc is not None
+        raise last_exc
 
     def list_tools_sync(self, *args: Any, **kwargs: Any) -> PaginatedList:
         result = super().list_tools_sync(*args, **kwargs)

--- a/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
+++ b/backend/tests/agents/main_agent/integrations/test_mcp_apps.py
@@ -747,3 +747,87 @@ class TestServedManifestIcon:
         )
         assert name == "Excalidraw"
         assert icon == "data:image/png;base64,QUJD"
+
+
+class TestStartRetry:
+    """`UICapableMCPClient.start` retries transient transport failures so a
+    single TLS-handshake blip doesn't fail the whole agent build."""
+
+    @staticmethod
+    def _transient_error() -> BaseException:
+        """Mimic Strands' real failure: MCPClientInitializationError whose
+        __cause__ is an ExceptionGroup wrapping an httpx ConnectError."""
+        import httpx
+        from strands.types.exceptions import MCPClientInitializationError
+
+        err = MCPClientInitializationError("the client initialization failed")
+        err.__cause__ = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [httpx.ConnectError("[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE]")],
+        )
+        return err
+
+    def test_is_transient_detects_connect_error_in_group(self):
+        assert mcp_apps._is_transient_connect_error(self._transient_error()) is True
+
+    def test_is_transient_false_for_non_connect_error(self):
+        from strands.types.exceptions import MCPClientInitializationError
+
+        err = MCPClientInitializationError("bad config")
+        err.__cause__ = ValueError("nope")
+        assert mcp_apps._is_transient_connect_error(err) is False
+
+    def test_start_retries_transient_then_succeeds(self, mcp_apps_clean):
+        client = UICapableMCPClient(lambda: None)
+        calls = {"n": 0}
+
+        def fake_start(self, *a, **k):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise TestStartRetry._transient_error()
+            return self
+
+        with patch.object(
+            strands_mcp_client_mod.MCPClient, "start", fake_start
+        ), patch(
+            "agents.main_agent.integrations.mcp_apps.time.sleep"
+        ) as sleep:
+            assert client.start() is client
+        assert calls["n"] == 3
+        assert sleep.call_count == 2  # backed off before attempts 2 and 3
+
+    def test_start_does_not_retry_non_transient(self, mcp_apps_clean):
+        from strands.types.exceptions import MCPClientInitializationError
+
+        client = UICapableMCPClient(lambda: None)
+        calls = {"n": 0}
+
+        def fake_start(self, *a, **k):
+            calls["n"] += 1
+            err = MCPClientInitializationError("auth failed")
+            err.__cause__ = ValueError("401")
+            raise err
+
+        with patch.object(
+            strands_mcp_client_mod.MCPClient, "start", fake_start
+        ), patch("agents.main_agent.integrations.mcp_apps.time.sleep"):
+            with pytest.raises(MCPClientInitializationError):
+                client.start()
+        assert calls["n"] == 1  # raised on first attempt, no retry
+
+    def test_start_raises_after_max_transient_attempts(self, mcp_apps_clean):
+        from strands.types.exceptions import MCPClientInitializationError
+
+        client = UICapableMCPClient(lambda: None)
+        calls = {"n": 0}
+
+        def fake_start(self, *a, **k):
+            calls["n"] += 1
+            raise TestStartRetry._transient_error()
+
+        with patch.object(
+            strands_mcp_client_mod.MCPClient, "start", fake_start
+        ), patch("agents.main_agent.integrations.mcp_apps.time.sleep"):
+            with pytest.raises(MCPClientInitializationError):
+                client.start()
+        assert calls["n"] == mcp_apps._MCP_START_MAX_ATTEMPTS


### PR DESCRIPTION
## Problem

A single transient transport failure when starting an external MCP client fails the **entire agent build**. Observed in the wild as:

```
strands.tools.mcp.mcp_client - ERROR - client failed to initialize
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  └─ httpx.ConnectError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] ssl/tls alert handshake failure
…
ValueError: Failed to load tool <UICapableMCPClient …>: Failed to start MCP client
```

The endpoint was healthy (58/58 isolated connections succeeded immediately after) — a momentary TLS handshake blip, the classic signature of a TLS-inspecting middlebox (VPN/proxy). But Strands' `start()` raises, the tool fails to load, and `Agent` construction errors out for the user. One flaky connection on one server shouldn't tank startup.

## Fix

`UICapableMCPClient.start()` now retries **transient** transport failures with exponential backoff (3 attempts, 0.5s → 1.0s):

- Transience is detected by walking the exception tree (`MCPClientInitializationError.__cause__` → anyio `ExceptionGroup.exceptions` → `httpx.ConnectError` → `ssl.SSLError`), matching connect/SSL/timeout error **class names** so we don't hard-import httpx/httpcore/ssl.
- Non-transient failures (bad URL, auth, protocol mismatch) are re-raised on the first attempt — no masking real config errors.
- Safe to re-invoke: Strands resets its init future + background thread via `stop()` on failure.
- Applies to both external and gateway `UICapableMCPClient` instances.

## Test

4 new tests in `test_mcp_apps.py` (transience classification, retry-then-succeed, no-retry-on-non-transient, raise-after-max). Full module: **38/38 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)