### PR TITLE
fix(mcp-apps): widget ui/message turns get the loading + scroll affordances

### DIFF
--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  effect,
   inject,
   input,
   output,
@@ -23,6 +24,7 @@ import { AssistantIndicatorComponent } from '../assistant-indicator/assistant-in
 import { SessionCostBadgeComponent } from '../session-cost-badge/session-cost-badge.component';
 import { VoiceOverlayComponent } from '../voice-overlay';
 import { VoiceChatService } from '../../services/voice';
+import { ChatStateService } from '../../services/chat/chat-state.service';
 
 /**
  * Configuration options for ChatContainerComponent.
@@ -83,6 +85,21 @@ export class ChatContainerComponent {
 
   // Child component reference for scroll functionality
   private messageListComponent = viewChild(MessageListComponent);
+
+  private readonly chatState = inject(ChatStateService);
+
+  // Non-composer submit paths (e.g. an MCP App widget's ui/message) bump
+  // ChatStateService.scrollToLastUserTick to get the same "scroll the new
+  // user message to the top" affordance the composer triggers in
+  // onMessageSubmitted. Skip the initial 0 so we don't scroll on mount.
+  private readonly _scrollOnExternalSubmit = effect(() => {
+    const tick = this.chatState.scrollToLastUserTick();
+    if (tick === 0) return;
+    setTimeout(
+      () => this.messageListComponent()?.scrollToLastUserMessage(),
+      100,
+    );
+  });
 
   // Required inputs
   messages = input.required<Message[]>();

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -27,6 +27,7 @@ import { McpAppConsentPromptComponent } from '../../mcp-app-consent-prompt/mcp-a
 import { JsonSyntaxHighlightPipe } from '../json-syntax-highlight.pipe';
 import type { DisplayMode } from '../../../../../services/mcp-apps/mcp-app-protocol';
 import { ChatRequestService } from '../../../../../services/chat/chat-request.service';
+import { ChatStateService } from '../../../../../services/chat/chat-state.service';
 import { SessionService } from '../../../../../services/session/session.service';
 
 /**
@@ -375,6 +376,7 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   private readonly mcpAppMessage = inject(McpAppMessageService);
   private readonly mcpAppConsent = inject(McpAppConsentService);
   private readonly chatRequest = inject(ChatRequestService);
+  private readonly chatState = inject(ChatStateService);
   private readonly conversation = inject(SessionService);
   private readonly streamParser = inject(StreamParserService);
   private readonly theme = inject(ThemeService);
@@ -829,11 +831,20 @@ export class McpAppFrameComponent implements ToolResultRenderer {
           toolName,
           args,
         ),
-      sendMessage: (text) =>
-        this.chatRequest.submitChatRequest(
+      sendMessage: (text) => {
+        // Mirror the composer's user-turn affordances that a direct
+        // submitChatRequest() would otherwise skip: show the loading indicator
+        // and scroll the new user message to the top. The user message is
+        // added synchronously inside submitChatRequest, so requesting the
+        // scroll right after means it already exists in the list.
+        this.chatState.setChatLoading(true);
+        const result = this.chatRequest.submitChatRequest(
           text,
           this.conversation.currentSession().sessionId || null,
-        ),
+        );
+        this.chatState.requestScrollToLastUser();
+        return result;
+      },
       updateModelContext: (payload) =>
         this.mcpAppMessage.updateModelContext(res.resourceUri, payload),
       requestConsent: (req) => {

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
@@ -54,6 +54,16 @@ describe('ChatStateService', () => {
     });
   });
 
+  describe('requestScrollToLastUser', () => {
+    it('starts at 0 and increments the tick on each request', () => {
+      expect(service.scrollToLastUserTick()).toBe(0);
+      service.requestScrollToLastUser();
+      expect(service.scrollToLastUserTick()).toBe(1);
+      service.requestScrollToLastUser();
+      expect(service.scrollToLastUserTick()).toBe(2);
+    });
+  });
+
   describe('resetState', () => {
     it('should reset all state to initial values', () => {
       service.setChatLoading(true);

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -9,6 +9,13 @@ export class ChatStateService {
     private readonly chatLoading = signal(false);
     readonly isChatLoading: Signal<boolean> = this.chatLoading.asReadonly();
 
+    // Bumped to ask the message list to scroll the latest user message to the
+    // top of the viewport. Lets non-composer submit paths (e.g. an MCP App
+    // widget's ui/message) get the same scroll affordance the composer
+    // triggers in ChatContainerComponent.onMessageSubmitted.
+    private readonly scrollToLastUserSignal = signal(0);
+    readonly scrollToLastUserTick: Signal<number> = this.scrollToLastUserSignal.asReadonly();
+
     private readonly stopReason = signal<string | null>(null);
     readonly currentStopReason: Signal<string | null> = this.stopReason.asReadonly();
 
@@ -46,6 +53,15 @@ export class ChatStateService {
      */
     setChatLoading(loading: boolean): void {
         this.chatLoading.set(loading);
+    }
+
+    /**
+     * Request that the message list scroll the latest user message to the top
+     * of the viewport (e.g. after a programmatic, non-composer user turn such
+     * as an MCP App widget relaying a `ui/message`).
+     */
+    requestScrollToLastUser(): void {
+        this.scrollToLastUserSignal.update(n => n + 1);
     }
 
     /**


### PR DESCRIPTION
## Problem

When an MCP App widget relays a `ui/message` (e.g. a "wave back" button), the message **appears** in the conversation but skips the two affordances a typed message gets: **no loading indicator** and **no scroll-to-position** of the new user message.

Root cause: a normal turn flows **chat-input → chat-container → page**, and that chain does two things the service itself doesn't:
- `session.page.ts:onMessageSubmitted` → `chatStateService.setChatLoading(true)` → the loading indicator.
- `chat-container.ts:onMessageSubmitted` → `setTimeout(() => messageList.scrollToLastUserMessage(), 100)` → the scroll.

The widget delegate ([mcp-app-frame.component.ts](frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts)) calls `chatRequestService.submitChatRequest()` **directly**, bypassing that chain. The message shows because `submitChatRequest` does `addUserMessage` itself, but the affordances live in the page/container layer.

## Fix (additive — composer path untouched)

- **ChatStateService**: add a `scrollToLastUserTick` signal + `requestScrollToLastUser()`.
- **ChatContainer**: an `effect()` that scrolls the last user message to the top when the tick bumps (mirrors `onMessageSubmitted`; skips the initial `0` so it doesn't scroll on mount).
- **Widget delegate**: `setChatLoading(true)` + `requestScrollToLastUser()` around `submitChatRequest` (the user message is added synchronously inside it, so the scroll request lands after it exists).

The composer keeps its own `setTimeout` scroll, so the typed-message path and its tests are unchanged — this is purely additive for the widget regression.

## Verification

- `tsc --noEmit` on **app + spec** tsconfigs: clean.
- `ng test`: **`chat-state.service.spec.ts` 11/11 pass** (incl. a new `requestScrollToLastUser` tick test). Full suite **1218/1219 pass**; the lone failure is `shared-view.page.spec.ts` (export/shared-view — pre-existing, unrelated to these three files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)