### PR TITLE
feat(export-targets): Google Drive export adapter + transcript renderer — PR-2

### DIFF
--- a/backend/src/apis/app_api/export_targets/adapters/__init__.py
+++ b/backend/src/apis/app_api/export_targets/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete export-target adapters (one module per provider)."""

--- a/backend/src/apis/app_api/export_targets/adapters/google_drive.py
+++ b/backend/src/apis/app_api/export_targets/adapters/google_drive.py
@@ -1,0 +1,264 @@
+"""Google Drive export-target adapter (Drive API v3).
+
+Writes a rendered document into the user's Drive. Uses the least-privilege
+`drive.file` scope: the app can create files and only ever sees the files it
+created — it cannot read the rest of the user's Drive. A `GOOGLE_DOC` export
+uploads an HTML body against the Google Doc MIME type so Drive converts it to
+a native Doc; a `MARKDOWN` export uploads the bytes as a plain `.md` file.
+
+When no destination folder is given, files land in a single app-owned folder
+(find-or-create by name) so exports don't clutter the user's Drive root. With
+`drive.file` the folder search only matches files the app itself created,
+which is exactly the folder we made on a previous export.
+
+`transport` is injectable so tests can drive the adapter with an
+`httpx.MockTransport`; production constructs it with no arguments. Mirrors the
+file-source Drive adapter's HTTP conventions.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from apis.shared.oauth.models import OAuthProviderType
+
+from apis.app_api.export_targets.adapter import (
+    ExportTargetAdapter,
+    ExportTargetMetadata,
+)
+from apis.app_api.export_targets.models import (
+    CreatedFile,
+    ExportDestination,
+    ExportFormat,
+    ExportTargetAuthError,
+    ExportTargetError,
+    ExportTargetNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+DRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
+DRIVE_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
+DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
+
+_FOLDER_MIME = "application/vnd.google-apps.folder"
+_GOOGLE_DOC_MIME = "application/vnd.google-apps.document"
+
+# Single app-owned folder exports land in when no destination is chosen.
+# Overridable per-deployment; the default is intentionally generic.
+_DEFAULT_FOLDER_ENV = "EXPORT_DRIVE_FOLDER_NAME"
+_DEFAULT_FOLDER_NAME = "AI Conversations"
+
+# Fixed multipart boundary — the body never contains it, and a constant keeps
+# uploads deterministic (and easy to assert in tests).
+_MULTIPART_BOUNDARY = "agentcore-export-boundary"
+
+_RETURN_FIELDS = "id,name,webViewLink"
+_TIMEOUT = httpx.Timeout(30.0)
+
+
+def _escape_query_value(value: str) -> str:
+    """Escape a value for safe interpolation into a Drive `q` parameter."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+class GoogleDriveExportAdapter(ExportTargetAdapter):
+    """Drive API v3 export adapter."""
+
+    def __init__(self, transport: Optional[httpx.AsyncBaseTransport] = None) -> None:
+        self._transport = transport
+
+    @property
+    def metadata(self) -> ExportTargetMetadata:
+        return ExportTargetMetadata(
+            key="google-drive",
+            display_name="Google Drive",
+            icon="google-drive",
+            compatible_provider_types=(OAuthProviderType.GOOGLE,),
+            required_scopes=(DRIVE_FILE_SCOPE,),
+            # PDF is intentionally omitted until the render step can produce it
+            # (needs a renderer dependency we don't ship yet).
+            supported_formats=(ExportFormat.GOOGLE_DOC, ExportFormat.MARKDOWN),
+        )
+
+    async def list_destinations(self, access_token: str) -> List[ExportDestination]:
+        # `drive.file` cannot enumerate the user's folders, so the real folder
+        # picker is driven by the combined-scope connector's file-source
+        # `browse` (see the spec). This returns just the implicit roots.
+        roots = [ExportDestination(id="root", name="My Drive")]
+        try:
+            data = await self._get_json(
+                access_token,
+                "/drives",
+                params={"pageSize": 100, "fields": "drives(id,name)"},
+            )
+            for drive in data.get("drives", []):
+                roots.append(ExportDestination(id=drive["id"], name=drive["name"]))
+        except ExportTargetError as err:
+            logger.info("Skipping shared drives for export destinations: %s", err)
+        return roots
+
+    async def create_document(
+        self,
+        access_token: str,
+        *,
+        content: bytes,
+        name: str,
+        source_mime_type: str,
+        target_format: ExportFormat,
+        parent_id: Optional[str] = None,
+    ) -> CreatedFile:
+        if target_format == ExportFormat.GOOGLE_DOC:
+            file_mime = _GOOGLE_DOC_MIME
+        elif target_format == ExportFormat.MARKDOWN:
+            file_mime = source_mime_type or "text/markdown"
+        else:
+            raise ExportTargetError(
+                f"Google Drive export does not support format '{target_format}'"
+            )
+
+        if parent_id is None:
+            parent_id = await self._ensure_default_folder(access_token)
+
+        metadata: Dict[str, Any] = {
+            "name": name,
+            "mimeType": file_mime,
+            "parents": [parent_id],
+        }
+        body, content_type = _multipart_related(metadata, content, source_mime_type)
+
+        data = await self._request_json(
+            access_token,
+            "POST",
+            f"{DRIVE_UPLOAD_BASE}/files",
+            params={
+                "uploadType": "multipart",
+                "supportsAllDrives": "true",
+                "fields": _RETURN_FIELDS,
+            },
+            content=body,
+            content_type=content_type,
+        )
+        return CreatedFile(
+            file_id=data.get("id", ""),
+            name=data.get("name", name),
+            web_view_link=data.get("webViewLink"),
+        )
+
+    # ── internals ───────────────────────────────────────────────────────────
+
+    async def _ensure_default_folder(self, access_token: str) -> str:
+        """Return the id of the app's export folder, creating it if needed."""
+        folder_name = os.environ.get(_DEFAULT_FOLDER_ENV, _DEFAULT_FOLDER_NAME)
+        escaped = _escape_query_value(folder_name)
+        data = await self._get_json(
+            access_token,
+            "/files",
+            params={
+                "q": (
+                    f"name = '{escaped}' and mimeType = '{_FOLDER_MIME}' "
+                    "and trashed = false"
+                ),
+                "spaces": "drive",
+                "fields": "files(id,name)",
+                "pageSize": 1,
+            },
+        )
+        files = data.get("files", [])
+        if files:
+            return files[0]["id"]
+
+        created = await self._request_json(
+            access_token,
+            "POST",
+            f"{DRIVE_API_BASE}/files",
+            params={"fields": "id"},
+            content=json.dumps(
+                {"name": folder_name, "mimeType": _FOLDER_MIME}
+            ).encode("utf-8"),
+            content_type="application/json; charset=UTF-8",
+        )
+        return created["id"]
+
+    @staticmethod
+    def _auth_headers(access_token: str) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        status = response.status_code
+        snippet = response.text[:300]
+        if status in (401, 403):
+            raise ExportTargetAuthError(
+                f"Google Drive rejected the request ({status}): {snippet}"
+            )
+        if status == 404:
+            raise ExportTargetNotFoundError(
+                f"Google Drive resource not found: {snippet}"
+            )
+        raise ExportTargetError(f"Google Drive request failed ({status}): {snippet}")
+
+    async def _get_json(
+        self, access_token: str, path: str, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            transport=self._transport, timeout=_TIMEOUT
+        ) as client:
+            try:
+                response = await client.get(
+                    f"{DRIVE_API_BASE}{path}",
+                    params=params,
+                    headers=self._auth_headers(access_token),
+                )
+            except httpx.HTTPError as err:
+                raise ExportTargetError(f"Google Drive request error: {err}") from err
+        self._raise_for_status(response)
+        data: Dict[str, Any] = response.json()
+        return data
+
+    async def _request_json(
+        self,
+        access_token: str,
+        method: str,
+        url: str,
+        *,
+        params: Dict[str, Any],
+        content: bytes,
+        content_type: str,
+    ) -> Dict[str, Any]:
+        headers = self._auth_headers(access_token)
+        headers["Content-Type"] = content_type
+        async with httpx.AsyncClient(
+            transport=self._transport, timeout=_TIMEOUT
+        ) as client:
+            try:
+                response = await client.request(
+                    method, url, params=params, headers=headers, content=content
+                )
+            except httpx.HTTPError as err:
+                raise ExportTargetError(f"Google Drive upload error: {err}") from err
+        self._raise_for_status(response)
+        data: Dict[str, Any] = response.json()
+        return data
+
+
+def _multipart_related(
+    metadata: Dict[str, Any], media: bytes, media_mime: str
+) -> tuple[bytes, str]:
+    """Build a Drive `multipart/related` upload body (metadata + media)."""
+    boundary = _MULTIPART_BOUNDARY
+    preamble = (
+        f"--{boundary}\r\n"
+        "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+        f"{json.dumps(metadata)}\r\n"
+        f"--{boundary}\r\n"
+        f"Content-Type: {media_mime}\r\n\r\n"
+    ).encode("utf-8")
+    closing = f"\r\n--{boundary}--\r\n".encode("utf-8")
+    body = preamble + media + closing
+    return body, f"multipart/related; boundary={boundary}"

--- a/backend/src/apis/app_api/export_targets/models.py
+++ b/backend/src/apis/app_api/export_targets/models.py
@@ -30,6 +30,27 @@ class ExportFormat(str, Enum):
     PDF = "pdf"
 
 
+class ExportInclude(BaseModel):
+    """Which conversation elements to include in an exported transcript.
+
+    Surfaced as a checkbox group in the SPA's "Save to…" dialog. The two
+    message flags are always on (the transcript itself); they exist so the
+    contract is explicit and a future "redacted" mode has a place to live.
+    Defaults match the dialog's default selection so the common case needs
+    no body.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_messages: bool = Field(True, alias="userMessages")
+    assistant_messages: bool = Field(True, alias="assistantMessages")
+    tool_calls: bool = Field(True, alias="toolCalls")
+    images: bool = Field(True)
+    citations: bool = Field(True)
+    reasoning: bool = Field(False)
+    timestamps: bool = Field(False)
+
+
 class ExportDestination(BaseModel):
     """A top-level write location a destination exposes (e.g. My Drive).
 

--- a/backend/src/apis/app_api/export_targets/registry.py
+++ b/backend/src/apis/app_api/export_targets/registry.py
@@ -55,13 +55,14 @@ class ExportTargetRegistry:
 
 
 def _build_default_registry() -> ExportTargetRegistry:
-    """Construct the registry with every export-target adapter in this release.
+    """Construct the registry with every export-target adapter in this release."""
+    from apis.app_api.export_targets.adapters.google_drive import (
+        GoogleDriveExportAdapter,
+    )
 
-    Empty for now — the Google Drive export adapter is registered here in the
-    following PR. The registry, admin endpoint, and connector validation ship
-    first so the mapping field has somewhere to resolve against.
-    """
-    return ExportTargetRegistry()
+    reg = ExportTargetRegistry()
+    reg.register(GoogleDriveExportAdapter())
+    return reg
 
 
 # Process-wide singleton, populated at import time.

--- a/backend/src/apis/app_api/export_targets/render.py
+++ b/backend/src/apis/app_api/export_targets/render.py
@@ -1,0 +1,235 @@
+"""Render a conversation transcript into an exportable document.
+
+Pure formatting: takes already-fetched messages and produces bytes plus a
+MIME type for an export-target adapter to upload. Paging a session into this
+list (calling `get_messages` until the cursor is exhausted) is the caller's
+job — keeping this module free of I/O so it is trivially unit-testable.
+
+Markdown is the intermediate representation: the `MARKDOWN` format emits it
+directly, and the `GOOGLE_DOC` format converts it to HTML (which Drive's
+import turns into a native Doc, so Markdown structure maps to real styling).
+"""
+
+from __future__ import annotations
+
+import base64
+import html as html_lib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from markdown_it import MarkdownIt
+
+from apis.shared.sessions.models import Citation, MessageContent, MessageResponse
+
+from apis.app_api.export_targets.models import ExportFormat, ExportInclude
+
+_ROLE_LABELS = {"user": "User", "assistant": "Assistant", "system": "System"}
+
+_DEFAULT_TITLE = "Conversation"
+
+
+@dataclass
+class RenderedDocument:
+    """Bytes to upload plus how to upload them.
+
+    `mime_type` is the *source* MIME of `content` (text/markdown or text/html);
+    the destination decides what to convert it into. `suggested_name` is the
+    document title (Google Doc) or filename stem (Markdown file).
+    """
+
+    content: bytes
+    mime_type: str
+    suggested_name: str
+
+
+def render_transcript(
+    title: str,
+    messages: Sequence[MessageResponse],
+    fmt: ExportFormat,
+    include: Optional[ExportInclude] = None,
+) -> RenderedDocument:
+    """Render `messages` into a document of the requested format.
+
+    Raises `ValueError` for a format this renderer cannot produce (e.g. PDF,
+    which needs a renderer dependency we don't ship yet — Drive's export
+    adapter deliberately doesn't advertise it).
+    """
+    include = include or ExportInclude()
+    clean_title = (title or "").strip() or _DEFAULT_TITLE
+    markdown = _to_markdown(clean_title, messages, include)
+
+    if fmt == ExportFormat.MARKDOWN:
+        return RenderedDocument(
+            content=markdown.encode("utf-8"),
+            mime_type="text/markdown",
+            suggested_name=f"{clean_title}.md",
+        )
+    if fmt == ExportFormat.GOOGLE_DOC:
+        return RenderedDocument(
+            content=_markdown_to_html(clean_title, markdown).encode("utf-8"),
+            mime_type="text/html",
+            suggested_name=clean_title,
+        )
+    raise ValueError(f"Unsupported export format for transcript render: {fmt}")
+
+
+# ── markdown assembly ──────────────────────────────────────────────────────
+
+
+def _to_markdown(
+    title: str, messages: Sequence[MessageResponse], include: ExportInclude
+) -> str:
+    lines: List[str] = [f"# {title}", ""]
+    for msg in messages:
+        if msg.role == "user" and not include.user_messages:
+            continue
+        if msg.role == "assistant" and not include.assistant_messages:
+            continue
+
+        heading = _ROLE_LABELS.get(msg.role, msg.role.title())
+        if include.timestamps and msg.created_at:
+            heading = f"{heading} · {msg.created_at}"
+        lines.append(f"## {heading}")
+        lines.append("")
+        lines.extend(_render_blocks(msg.content, include))
+        if include.citations and msg.citations:
+            lines.extend(_render_citations(msg.citations))
+
+    # Collapse to a single trailing newline.
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_blocks(
+    content: Sequence[MessageContent], include: ExportInclude
+) -> List[str]:
+    out: List[str] = []
+    for block in content:
+        btype = block.type
+        if btype == "text" and block.text:
+            out.append(block.text.strip())
+            out.append("")
+        elif btype == "reasoningContent" and include.reasoning:
+            out.extend(_render_reasoning(block.reasoning_content))
+        elif btype == "toolUse" and include.tool_calls:
+            out.extend(_render_tool_use(block.tool_use))
+        elif btype == "toolResult" and include.tool_calls:
+            out.extend(_render_tool_result(block.tool_result))
+        elif btype == "image" and include.images:
+            out.extend(_render_image(block.image))
+        elif btype == "document":
+            # Raw document blobs are never inlined (size + fidelity); always
+            # a placeholder so the reader knows something was attached.
+            name = (block.document or {}).get("name") if block.document else None
+            out.append(f"_[attached document: {name or 'document'}]_")
+            out.append("")
+    return out
+
+
+def _render_tool_use(tool_use: Optional[Dict[str, Any]]) -> List[str]:
+    if not tool_use:
+        return []
+    name = tool_use.get("name", "tool")
+    out = [f"**🛠 Tool call: `{name}`**", ""]
+    tool_input = tool_use.get("input")
+    if tool_input not in (None, {}, ""):
+        out += ["```json", _safe_json(tool_input), "```", ""]
+    return out
+
+
+def _render_tool_result(tool_result: Optional[Dict[str, Any]]) -> List[str]:
+    if not tool_result:
+        return []
+    status = tool_result.get("status")
+    out = [f"**Tool result**{f' ({status})' if status else ''}", ""]
+    text = _tool_result_text(tool_result.get("content"))
+    if text:
+        out += ["```", text, "```", ""]
+    return out
+
+
+def _tool_result_text(content: Any) -> str:
+    if not content:
+        return ""
+    if not isinstance(content, list):
+        return str(content)
+    parts: List[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            parts.append(str(item))
+        elif item.get("text") is not None:
+            parts.append(str(item["text"]))
+        elif "json" in item:
+            parts.append(_safe_json(item["json"]))
+        else:
+            parts.append(_safe_json(item))
+    return "\n".join(p for p in parts if p)
+
+
+def _render_image(image: Optional[Dict[str, Any]]) -> List[str]:
+    if not image:
+        return []
+    fmt = image.get("format", "png")
+    data = (image.get("source") or {}).get("bytes")
+    if isinstance(data, (bytes, bytearray)):
+        data = base64.b64encode(bytes(data)).decode("ascii")
+    if not data:
+        return ["_[image]_", ""]
+    return [f"![image](data:image/{fmt};base64,{data})", ""]
+
+
+def _render_reasoning(reasoning: Optional[Dict[str, Any]]) -> List[str]:
+    text = _reasoning_text(reasoning)
+    if not text:
+        return []
+    out = ["> **Reasoning**", ">"]
+    out += [f"> {line}" for line in text.splitlines()]
+    out.append("")
+    return out
+
+
+def _reasoning_text(reasoning: Optional[Dict[str, Any]]) -> str:
+    if not reasoning:
+        return ""
+    reasoning_text = reasoning.get("reasoningText")
+    if isinstance(reasoning_text, dict):
+        return str(reasoning_text.get("text") or "")
+    if isinstance(reasoning_text, str):
+        return reasoning_text
+    return str(reasoning.get("text") or "")
+
+
+def _render_citations(citations: Sequence[Citation]) -> List[str]:
+    out = ["**Sources:**", ""]
+    out += [f"- {c.file_name}" for c in citations]
+    out.append("")
+    return out
+
+
+def _safe_json(value: Any) -> str:
+    try:
+        return json.dumps(value, indent=2, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+# ── markdown -> html ───────────────────────────────────────────────────────
+
+
+def _markdown_to_html(title: str, markdown: str) -> str:
+    """Convert Markdown to a standalone HTML document.
+
+    Uses the CommonMark preset with `html` forced off — the preset otherwise
+    allows raw HTML passthrough (per the CommonMark spec), so we override it so
+    HTML in message text is escaped, not injected into the uploaded doc — plus
+    the table rule so Markdown tables become real Docs tables on import.
+    """
+    parser = MarkdownIt("commonmark", {"html": False}).enable("table")
+    body = parser.render(markdown)
+    safe_title = html_lib.escape(title)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html><head><meta charset="utf-8">'
+        f"<title>{safe_title}</title></head>\n"
+        f"<body>\n{body}</body></html>\n"
+    )

--- a/backend/src/apis/app_api/export_targets/service.py
+++ b/backend/src/apis/app_api/export_targets/service.py
@@ -1,0 +1,187 @@
+"""Helpers shared by the export-target endpoints.
+
+A connector becomes an *export target* only when an admin maps it to an
+export-target adapter. These helpers centralize the "resolve a connector to a
+usable adapter + token" steps so the export flow stays consistent with the
+connector status/consent routes — the write-side mirror of
+`file_sources.service`.
+"""
+
+import logging
+from typing import List, Tuple
+
+from fastapi import HTTPException, status
+
+from apis.shared.auth import User
+from apis.shared.oauth.agentcore_identity import (
+    CallbackUrlUnavailableError,
+    TokenResult,
+    WorkloadTokenUnavailableError,
+    custom_parameters_for,
+    get_agentcore_identity_client,
+)
+from apis.shared.oauth.models import OAuthProvider
+from apis.shared.oauth.provider_repository import OAuthProviderRepository
+from apis.shared.rbac.service import AppRoleService
+
+from apis.app_api.export_targets.adapter import ExportTargetAdapter
+from apis.app_api.export_targets.models import (
+    ExportTargetAuthError,
+    ExportTargetError,
+    ExportTargetNotFoundError,
+)
+from apis.app_api.export_targets.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def connector_visible_to_user(
+    provider: OAuthProvider, user_role_ids: List[str]
+) -> bool:
+    """True when an enabled connector is usable by a user with these roles.
+
+    An empty `allowed_roles` list means unrestricted access; a non-empty list
+    grants access to users who share at least one AppRole id. Mirrors the
+    connector catalog's visibility rule.
+    """
+    if not provider.enabled:
+        return False
+    if not provider.allowed_roles:
+        return True
+    return bool(set(provider.allowed_roles) & set(user_role_ids))
+
+
+async def resolve_export_target(
+    connector_id: str,
+    current_user: User,
+    provider_repo: OAuthProviderRepository,
+    role_service: AppRoleService,
+) -> Tuple[OAuthProvider, ExportTargetAdapter]:
+    """Resolve a connector id to its provider record and export-target adapter.
+
+    Raises `HTTPException` (404/403) when the connector is missing, disabled,
+    not visible to the caller, not configured as an export target, or mapped
+    to an adapter that is not shipped in this release.
+    """
+    provider = await provider_repo.get_provider(connector_id)
+    if not provider or not provider.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' not found",
+        )
+
+    permissions = await role_service.resolve_user_permissions(current_user)
+    if not connector_visible_to_user(provider, permissions.app_roles):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have access to this connector",
+        )
+
+    if not provider.export_target_adapter_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' is not configured as an export target",
+        )
+
+    adapter = registry.get(provider.export_target_adapter_id)
+    if adapter is None:
+        # An admin mapped an adapter key that no longer ships in this release.
+        # Indistinguishable from "not an export target" to the user.
+        logger.error(
+            "Connector %s maps to unknown export-target adapter '%s'",
+            connector_id,
+            provider.export_target_adapter_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Connector '{connector_id}' is not configured as an export target",
+        )
+    return provider, adapter
+
+
+async def resolve_export_target_token(
+    provider: OAuthProvider, user_id: str
+) -> TokenResult:
+    """Fetch the user's OAuth token for an export-target connector.
+
+    Returns a `TokenResult`: `access_token` is populated when the vault has a
+    usable token, `authorization_url` when the user still needs to consent.
+
+    `custom_parameters` is built with `force_authentication=True` so it matches
+    the consent flow — AgentCore factors `customParameters` into whether
+    `get_resource_oauth2_token` short-circuits to a vaulted token (see the
+    file-source service for the full rationale). Pure read; `force_authentication`
+    stays False on `get_token_for_user` itself.
+    """
+    identity = get_agentcore_identity_client()
+    return await identity.get_token_for_user(
+        provider_name=provider.provider_id,
+        scopes=provider.scopes,
+        user_id=user_id,
+        custom_parameters=custom_parameters_for(
+            provider.provider_type.value,
+            provider.custom_parameters,
+            force_authentication=True,
+        ),
+    )
+
+
+async def require_export_target_token(provider: OAuthProvider, user_id: str) -> str:
+    """Resolve a usable OAuth access token for an export-target connector.
+
+    Turns the two non-token outcomes into `HTTPException`s the route layer can
+    return unchanged:
+
+    - the user has not completed OAuth consent -> 409 Conflict
+    - AgentCore workload/callback context is unavailable -> 503
+
+    Returns the bare access-token string on success.
+    """
+    try:
+        result = await resolve_export_target_token(provider, user_id)
+    except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+        logger.warning(
+            "Export-target token resolution failed for %s: %s",
+            provider.provider_id,
+            err,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(err),
+        )
+
+    if result.requires_consent or not result.access_token:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Connector '{provider.provider_id}' is not connected. "
+                "Complete the OAuth consent flow before saving to it."
+            ),
+        )
+    return result.access_token
+
+
+def http_error_for_export_target_error(err: ExportTargetError) -> HTTPException:
+    """Map an export-target adapter error onto an HTTP response.
+
+    - `ExportTargetAuthError` -> 403 (token rejected / missing scopes)
+    - `ExportTargetNotFoundError` -> 404 (destination folder gone)
+    - any other `ExportTargetError` -> 502 (the provider call itself failed)
+    """
+    if isinstance(err, ExportTargetAuthError):
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "The export target rejected the request. Reconnect the "
+                "connector and try again."
+            ),
+        )
+    if isinstance(err, ExportTargetNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The destination folder no longer exists.",
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="The export target could not be reached. Try again shortly.",
+    )

--- a/backend/tests/apis/app_api/test_export_google_drive.py
+++ b/backend/tests/apis/app_api/test_export_google_drive.py
@@ -1,0 +1,164 @@
+"""Tests for the Google Drive export-target adapter (mocked Drive API v3)."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Tuple
+
+import httpx
+import pytest
+
+from apis.app_api.export_targets.adapters.google_drive import GoogleDriveExportAdapter
+from apis.app_api.export_targets.models import (
+    ExportFormat,
+    ExportTargetAuthError,
+)
+
+
+def _adapter(handler) -> GoogleDriveExportAdapter:
+    return GoogleDriveExportAdapter(transport=httpx.MockTransport(handler))
+
+
+def _parse_multipart(body: bytes) -> Tuple[Dict, str, bytes]:
+    """Split a Drive multipart/related body into (metadata, media_mime, media)."""
+    text = body.decode("utf-8", errors="replace")
+    # Parts are separated by the boundary; the metadata is JSON, the media
+    # follows its own Content-Type header.
+    meta_start = text.index("{")
+    meta_end = text.index("}", meta_start) + 1
+    metadata = json.loads(text[meta_start:meta_end])
+    media_marker = "Content-Type: "
+    second = text.index(media_marker, meta_end)
+    media_mime = text[second + len(media_marker):].split("\r\n", 1)[0]
+    media = text.split("\r\n\r\n", 2)[-1].rsplit("\r\n--", 1)[0]
+    return metadata, media_mime, media.encode("utf-8")
+
+
+class TestCreateDocument:
+    @pytest.mark.asyncio
+    async def test_google_doc_into_existing_folder(self):
+        captured: Dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/drive/v3/files" and request.method == "GET":
+                captured["folder_query"] = request.url.params.get("q")
+                return httpx.Response(200, json={"files": [{"id": "folder-1", "name": "AI Conversations"}]})
+            if request.url.path == "/upload/drive/v3/files":
+                captured["upload_body"] = request.content
+                captured["upload_type"] = request.url.params.get("uploadType")
+                return httpx.Response(
+                    200,
+                    json={"id": "doc-1", "name": "My Chat", "webViewLink": "https://docs/doc-1"},
+                )
+            return httpx.Response(500, text=f"unexpected {request.method} {request.url}")
+
+        result = await _adapter(handler).create_document(
+            "tok",
+            content=b"<h1>hi</h1>",
+            name="My Chat",
+            source_mime_type="text/html",
+            target_format=ExportFormat.GOOGLE_DOC,
+        )
+
+        assert result.file_id == "doc-1"
+        assert result.web_view_link == "https://docs/doc-1"
+        assert captured["upload_type"] == "multipart"
+        assert "AI Conversations" in captured["folder_query"]
+
+        metadata, media_mime, media = _parse_multipart(captured["upload_body"])
+        assert metadata["mimeType"] == "application/vnd.google-apps.document"
+        assert metadata["parents"] == ["folder-1"]
+        assert metadata["name"] == "My Chat"
+        assert media_mime == "text/html"
+        assert b"<h1>hi</h1>" in media
+
+    @pytest.mark.asyncio
+    async def test_creates_folder_when_absent(self):
+        calls: List[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(f"{request.method} {request.url.path}")
+            if request.url.path == "/drive/v3/files" and request.method == "GET":
+                return httpx.Response(200, json={"files": []})
+            if request.url.path == "/drive/v3/files" and request.method == "POST":
+                body = json.loads(request.content)
+                assert body["mimeType"] == "application/vnd.google-apps.folder"
+                return httpx.Response(200, json={"id": "folder-new"})
+            if request.url.path == "/upload/drive/v3/files":
+                metadata, _, _ = _parse_multipart(request.content)
+                assert metadata["parents"] == ["folder-new"]
+                return httpx.Response(200, json={"id": "doc-2", "name": "C"})
+            return httpx.Response(500, text="unexpected")
+
+        result = await _adapter(handler).create_document(
+            "tok",
+            content=b"# c",
+            name="C",
+            source_mime_type="text/markdown",
+            target_format=ExportFormat.MARKDOWN,
+        )
+
+        assert result.file_id == "doc-2"
+        assert result.web_view_link is None
+        assert "POST /drive/v3/files" in calls  # folder was created
+
+    @pytest.mark.asyncio
+    async def test_explicit_parent_skips_folder_lookup(self):
+        calls: List[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(f"{request.method} {request.url.path}")
+            if request.url.path == "/upload/drive/v3/files":
+                metadata, media_mime, _ = _parse_multipart(request.content)
+                assert metadata["parents"] == ["given-folder"]
+                assert metadata["mimeType"] == "text/markdown"
+                assert media_mime == "text/markdown"
+                return httpx.Response(200, json={"id": "doc-3", "name": "C"})
+            return httpx.Response(500, text="unexpected")
+
+        result = await _adapter(handler).create_document(
+            "tok",
+            content=b"# c",
+            name="C",
+            source_mime_type="text/markdown",
+            target_format=ExportFormat.MARKDOWN,
+            parent_id="given-folder",
+        )
+
+        assert result.file_id == "doc-3"
+        assert calls == ["POST /upload/drive/v3/files"]  # no folder search/create
+
+    @pytest.mark.asyncio
+    async def test_auth_error_maps_to_export_target_auth_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, text="forbidden")
+
+        with pytest.raises(ExportTargetAuthError):
+            await _adapter(handler).create_document(
+                "tok",
+                content=b"x",
+                name="C",
+                source_mime_type="text/html",
+                target_format=ExportFormat.GOOGLE_DOC,
+                parent_id="f1",
+            )
+
+
+class TestListDestinations:
+    @pytest.mark.asyncio
+    async def test_lists_my_drive_and_shared_drives(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"drives": [{"id": "sd1", "name": "Team"}]})
+
+        dests = await _adapter(handler).list_destinations("tok")
+        names = [d.name for d in dests]
+        assert "My Drive" in names
+        assert "Team" in names
+
+    @pytest.mark.asyncio
+    async def test_shared_drive_failure_is_tolerated(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, text="no shared drives")
+
+        dests = await _adapter(handler).list_destinations("tok")
+        assert [d.name for d in dests] == ["My Drive"]

--- a/backend/tests/apis/app_api/test_export_render.py
+++ b/backend/tests/apis/app_api/test_export_render.py
@@ -1,0 +1,182 @@
+"""Tests for the conversation transcript renderer."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import pytest
+
+from apis.shared.sessions.models import Citation, MessageContent, MessageResponse
+
+from apis.app_api.export_targets.models import ExportFormat, ExportInclude
+from apis.app_api.export_targets.render import render_transcript
+
+
+def _msg(role: str, blocks: List[MessageContent], created_at: str = "") -> MessageResponse:
+    return MessageResponse(id=f"m-{role}", role=role, content=blocks, createdAt=created_at)
+
+
+def _text(role: str, text: str, created_at: str = "") -> MessageResponse:
+    return _msg(role, [MessageContent(type="text", text=text)], created_at)
+
+
+class TestMarkdownStructure:
+    def test_title_and_role_headings(self):
+        msgs = [_text("user", "hi"), _text("assistant", "hello")]
+        out = render_transcript("My Chat", msgs, ExportFormat.MARKDOWN)
+        body = out.content.decode()
+        assert out.mime_type == "text/markdown"
+        assert out.suggested_name == "My Chat.md"
+        assert body.startswith("# My Chat")
+        assert "## User" in body
+        assert "## Assistant" in body
+        assert "hi" in body and "hello" in body
+
+    def test_empty_messages_still_renders_title(self):
+        out = render_transcript("Empty", [], ExportFormat.MARKDOWN)
+        assert out.content.decode().strip() == "# Empty"
+
+    def test_blank_title_falls_back(self):
+        out = render_transcript("   ", [_text("user", "x")], ExportFormat.MARKDOWN)
+        assert out.content.decode().startswith("# Conversation")
+
+
+class TestIncludeFlags:
+    def test_tool_calls_included_by_default_and_omittable(self):
+        msgs = [
+            _msg(
+                "assistant",
+                [
+                    MessageContent(type="text", text="done"),
+                    MessageContent(type="toolUse", toolUse={"name": "calc", "input": {"x": 1}}),
+                    MessageContent(
+                        type="toolResult",
+                        toolResult={"status": "success", "content": [{"text": "2"}]},
+                    ),
+                ],
+            )
+        ]
+        with_tools = render_transcript("t", msgs, ExportFormat.MARKDOWN).content.decode()
+        assert "Tool call: `calc`" in with_tools
+        assert "Tool result" in with_tools
+
+        without = render_transcript(
+            "t", msgs, ExportFormat.MARKDOWN, ExportInclude(tool_calls=False)
+        ).content.decode()
+        assert "Tool call" not in without
+        assert "done" in without  # text still present
+
+    def test_reasoning_off_by_default_on_when_requested(self):
+        msgs = [
+            _msg(
+                "assistant",
+                [
+                    MessageContent(
+                        type="reasoningContent",
+                        reasoningContent={"reasoningText": {"text": "let me think"}},
+                    ),
+                    MessageContent(type="text", text="answer"),
+                ],
+            )
+        ]
+        default = render_transcript("t", msgs, ExportFormat.MARKDOWN).content.decode()
+        assert "let me think" not in default
+
+        on = render_transcript(
+            "t", msgs, ExportFormat.MARKDOWN, ExportInclude(reasoning=True)
+        ).content.decode()
+        assert "let me think" in on
+        assert "Reasoning" in on
+
+    def test_timestamps_appended_to_heading_when_requested(self):
+        msgs = [_text("user", "hi", created_at="2026-06-25T12:00:00Z")]
+        off = render_transcript("t", msgs, ExportFormat.MARKDOWN).content.decode()
+        assert "2026-06-25" not in off
+        on = render_transcript(
+            "t", msgs, ExportFormat.MARKDOWN, ExportInclude(timestamps=True)
+        ).content.decode()
+        assert "2026-06-25T12:00:00Z" in on
+
+    def test_user_messages_can_be_excluded(self):
+        msgs = [_text("user", "secret prompt"), _text("assistant", "reply")]
+        out = render_transcript(
+            "t", msgs, ExportFormat.MARKDOWN, ExportInclude(user_messages=False)
+        ).content.decode()
+        assert "secret prompt" not in out
+        assert "reply" in out
+
+    def test_images_embedded_as_data_uri_and_omittable(self):
+        msgs = [
+            _msg(
+                "user",
+                [MessageContent(type="image", image={"format": "png", "source": {"bytes": "QUJD"}})],
+            )
+        ]
+        on = render_transcript("t", msgs, ExportFormat.MARKDOWN).content.decode()
+        assert "data:image/png;base64,QUJD" in on
+        off = render_transcript(
+            "t", msgs, ExportFormat.MARKDOWN, ExportInclude(images=False)
+        ).content.decode()
+        assert "data:image" not in off
+
+    def test_document_blocks_become_placeholder(self):
+        msgs = [
+            _msg("user", [MessageContent(type="document", document={"name": "spec.pdf"})])
+        ]
+        out = render_transcript("t", msgs, ExportFormat.MARKDOWN).content.decode()
+        assert "[attached document: spec.pdf]" in out
+
+    def test_citations_rendered_when_present(self):
+        msg = MessageResponse(
+            id="m1",
+            role="assistant",
+            content=[MessageContent(type="text", text="answer")],
+            createdAt="",
+            citations=[
+                Citation(assistantId="a1", documentId="d1", fileName="handbook.pdf", text="x")
+            ],
+        )
+        out = render_transcript("t", [msg], ExportFormat.MARKDOWN).content.decode()
+        assert "Sources:" in out and "handbook.pdf" in out
+
+        off = render_transcript(
+            "t", [msg], ExportFormat.MARKDOWN, ExportInclude(citations=False)
+        ).content.decode()
+        assert "handbook.pdf" not in off
+
+
+class TestGoogleDocHtml:
+    def test_markdown_maps_to_html_styling(self):
+        msgs = [_text("assistant", "# Heading\n\n**bold** and a list:\n\n- one\n- two")]
+        out = render_transcript("Doc", msgs, ExportFormat.GOOGLE_DOC)
+        html = out.content.decode()
+        assert out.mime_type == "text/html"
+        assert out.suggested_name == "Doc"
+        assert "<strong>bold</strong>" in html
+        assert "<li>one</li>" in html
+        assert "<title>Doc</title>" in html
+
+    def test_table_rule_enabled(self):
+        table = "| a | b |\n| - | - |\n| 1 | 2 |"
+        out = render_transcript("t", [_text("assistant", table)], ExportFormat.GOOGLE_DOC)
+        assert "<table>" in out.content.decode()
+
+    def test_raw_html_in_message_is_escaped_not_injected(self):
+        out = render_transcript(
+            "t", [_text("user", "<script>alert(1)</script>")], ExportFormat.GOOGLE_DOC
+        )
+        html = out.content.decode()
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_html_title_is_escaped(self):
+        out = render_transcript(
+            "<b>x</b>", [_text("user", "hi")], ExportFormat.GOOGLE_DOC
+        )
+        assert "<title>&lt;b&gt;x&lt;/b&gt;</title>" in out.content.decode()
+
+
+class TestUnsupportedFormat:
+    def test_pdf_raises(self):
+        with pytest.raises(ValueError):
+            render_transcript("t", [_text("user", "x")], ExportFormat.PDF)

--- a/backend/tests/apis/app_api/test_export_target_adapters_admin.py
+++ b/backend/tests/apis/app_api/test_export_target_adapters_admin.py
@@ -163,10 +163,11 @@ class TestExportTargetRegistry:
         assert reg.adapters_for_provider_type(OAuthProviderType.GOOGLE)
         assert reg.adapters_for_provider_type(OAuthProviderType.SLACK) == []
 
-    def test_default_registry_is_empty_until_an_adapter_ships(self):
-        # The Drive export adapter is registered in a later PR; today the
-        # shipped registry is intentionally empty.
-        assert registry.all() == []
+    def test_default_registry_includes_google_drive(self):
+        # The shipped registry now carries the Google Drive export adapter.
+        drive = registry.get("google-drive")
+        assert drive is not None
+        assert drive.metadata.compatible_provider_types == (OAuthProviderType.GOOGLE,)
 
 
 class TestValidateExportTargetAdapter:
@@ -209,7 +210,14 @@ class TestListExportTargetAdaptersEndpoint:
         assert stub["requiredScopes"] == [_STUB_SCOPE]
         assert stub["supportedFormats"] == ["google_doc", "markdown"]
 
-    def test_empty_when_no_adapters_registered(self, client: TestClient):
+    def test_lists_shipped_google_drive_adapter(self, client: TestClient):
         response = client.get("/export-target-adapters/")
         assert response.status_code == 200
-        assert response.json()["adapters"] == []
+        adapters = {a["key"]: a for a in response.json()["adapters"]}
+        assert "google-drive" in adapters
+        drive = adapters["google-drive"]
+        assert drive["displayName"] == "Google Drive"
+        assert drive["requiredScopes"] == [
+            "https://www.googleapis.com/auth/drive.file"
+        ]
+        assert drive["supportedFormats"] == ["google_doc", "markdown"]

--- a/backend/tests/apis/app_api/test_export_target_service.py
+++ b/backend/tests/apis/app_api/test_export_target_service.py
@@ -1,0 +1,130 @@
+"""Tests for the export-target resolve + token helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pytest
+from fastapi import HTTPException
+
+from apis.shared.auth.models import User
+from apis.shared.oauth.agentcore_identity import WorkloadTokenUnavailableError
+from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
+
+from apis.app_api.export_targets import service
+from apis.app_api.export_targets.service import (
+    require_export_target_token,
+    resolve_export_target,
+)
+
+
+def _user() -> User:
+    return User(
+        user_id="u1",
+        email="u1@example.com",
+        name="U",
+        roles=["user"],
+        raw_token="tok",
+    )
+
+
+def _provider(**kw) -> OAuthProvider:
+    defaults = dict(
+        provider_id="gdrive",
+        display_name="Google Drive",
+        provider_type=OAuthProviderType.GOOGLE,
+        scopes=["https://www.googleapis.com/auth/drive.file"],
+        allowed_roles=[],
+        enabled=True,
+        export_target_adapter_id="google-drive",
+    )
+    defaults.update(kw)
+    return OAuthProvider(**defaults)
+
+
+class _Repo:
+    def __init__(self, provider: Optional[OAuthProvider]):
+        self._p = provider
+
+    async def get_provider(self, provider_id: str):
+        return self._p
+
+
+class _Roles:
+    def __init__(self, app_roles: List[str]):
+        self._roles = app_roles
+
+    async def resolve_user_permissions(self, user: User):
+        return SimpleNamespace(app_roles=self._roles)
+
+
+class TestResolveExportTarget:
+    @pytest.mark.asyncio
+    async def test_resolves_provider_and_adapter(self):
+        provider, adapter = await resolve_export_target(
+            "gdrive", _user(), _Repo(_provider()), _Roles([])
+        )
+        assert provider.provider_id == "gdrive"
+        assert adapter.metadata.key == "google-drive"
+
+    @pytest.mark.asyncio
+    async def test_missing_connector_404(self):
+        with pytest.raises(HTTPException) as exc:
+            await resolve_export_target("gdrive", _user(), _Repo(None), _Roles([]))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_not_an_export_target_404(self):
+        provider = _provider(export_target_adapter_id=None)
+        with pytest.raises(HTTPException) as exc:
+            await resolve_export_target("gdrive", _user(), _Repo(provider), _Roles([]))
+        assert exc.value.status_code == 404
+        assert "not configured as an export target" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_unknown_adapter_key_404(self):
+        provider = _provider(export_target_adapter_id="dropbox")
+        with pytest.raises(HTTPException) as exc:
+            await resolve_export_target("gdrive", _user(), _Repo(provider), _Roles([]))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rbac_denied_403(self):
+        provider = _provider(allowed_roles=["admins-only"])
+        with pytest.raises(HTTPException) as exc:
+            await resolve_export_target(
+                "gdrive", _user(), _Repo(provider), _Roles(["plain-user"])
+            )
+        assert exc.value.status_code == 403
+
+
+class TestRequireExportTargetToken:
+    @pytest.mark.asyncio
+    async def test_returns_token_when_connected(self, monkeypatch):
+        async def fake(provider, user_id):
+            return SimpleNamespace(requires_consent=False, access_token="the-token")
+
+        monkeypatch.setattr(service, "resolve_export_target_token", fake)
+        token = await require_export_target_token(_provider(), "u1")
+        assert token == "the-token"
+
+    @pytest.mark.asyncio
+    async def test_consent_required_409(self, monkeypatch):
+        async def fake(provider, user_id):
+            return SimpleNamespace(requires_consent=True, access_token=None)
+
+        monkeypatch.setattr(service, "resolve_export_target_token", fake)
+        with pytest.raises(HTTPException) as exc:
+            await require_export_target_token(_provider(), "u1")
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_workload_unavailable_503(self, monkeypatch):
+        async def fake(provider, user_id):
+            raise WorkloadTokenUnavailableError("no workload")
+
+        monkeypatch.setattr(service, "resolve_export_target_token", fake)
+        with pytest.raises(HTTPException) as exc:
+            await require_export_target_token(_provider(), "u1")
+        assert exc.value.status_code == 503


### PR DESCRIPTION
## Summary

PR-2 of the **Save Conversations to Connected Apps** feature
(spec: `docs/specs/conversation-export-connectors.md`; scaffold landed in #507).

This builds the **write-side capability** on top of PR-1's data/contract scaffold: the first `ExportTargetAdapter` implementation, the transcript renderer, and the connector resolve/token helpers. **There is still no user-facing endpoint** — wiring `POST /sessions/{id}/export` is PR-3. Everything here is independently unit-tested.

## What changed

- **`GoogleDriveExportAdapter`** (`export_targets/adapters/google_drive.py`), now registered in the registry:
  - `drive.file` scope (**least privilege** — the app only ever sees files it created).
  - `create_document` does a `multipart/related` upload to `/upload/drive/v3/files`. `GOOGLE_DOC` uploads an HTML body against `application/vnd.google-apps.document` so Drive converts it to a **native Google Doc**; `MARKDOWN` uploads a plain `.md`. Returns the `webViewLink`.
  - When no destination folder is given, **find-or-creates a single app folder** (`AI Conversations`, overridable via `EXPORT_DRIVE_FOLDER_NAME`) so exports don't clutter Drive root. This works under `drive.file` because the folder search only matches the app's own files.
  - Injectable `httpx` transport (mirrors the file-source Drive adapter) for `MockTransport` tests.
- **`render.py`** — pure `render_transcript(title, messages, fmt, include) -> RenderedDocument`:
  - Markdown is the intermediate representation. `GOOGLE_DOC` converts it to HTML via **`markdown-it-py` (already a dependency — no new install)**, so Markdown structure maps to real Docs styling (headings, bold, lists, tables, links).
  - Honors the `ExportInclude` checkboxes (tool calls / images / citations on by default; reasoning / timestamps off).
  - **Raw HTML in message text is escaped, not injected** — CommonMark's default HTML passthrough is explicitly forced off (covered by a test).
- **`service.py`** — `resolve_export_target` / `require_export_target_token` / `http_error_for_export_target_error`, mirroring the file-source service (404 not-a-target, 403 RBAC, 409 not-connected, 503 no-workload).
- **`ExportInclude`** model added; PR-1 admin tests updated now that the registry ships the Drive adapter.

## Deferred / out of scope

- **PDF format is deferred.** No PDF renderer is in the dependency set, and I didn't want to add one without sign-off — so the Drive adapter advertises only `google_doc` + `markdown`. Adding PDF (e.g. WeasyPrint/reportlab) is a clean follow-up if we want it.
- **`drive.file` data-URI images (R-1 in the spec)** — images render as inline data URIs; Drive's HTML import may not embed them. To be validated alongside PDF in a later pass.

## Testing

- New unit tests: `test_export_render.py`, `test_export_google_drive.py` (httpx `MockTransport`), `test_export_target_service.py`.
- **Full backend suite green: 4012 passed, 3 skipped** (run because the registry now constructs the adapter at import time; pytest is not in CI, so the local run is the gate).

## Reviewer notes

- No `apis/shared` changes in this PR — the new code lives entirely under `apis/app_api/export_targets/` (import-boundary clean).
- The multipart body uses a fixed boundary (`_multipart_related`) — deterministic and asserted in tests; the body never contains the boundary string.
- Next: **PR-3** `POST /sessions/{id}/export` (page `get_messages` to completion → render → `require_export_target_token` → `adapter.create_document`; 409 reuses the existing connectors consent popup) → **PR-4** SPA "Save to…" dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)