### PR TITLE
feat(export-targets): export endpoint + conversation-export receipts (PR-3)

### DIFF
--- a/backend/src/apis/app_api/export_targets/routes.py
+++ b/backend/src/apis/app_api/export_targets/routes.py
@@ -1,0 +1,353 @@
+"""User-facing export-target endpoints: catalog + save-a-conversation.
+
+A connector becomes an *export target* only once an admin maps it to an
+export-target adapter (the write-direction mirror of file sources). These
+endpoints let a signed-in user discover which of their connectors can receive
+a conversation and push a full transcript out to one ("Save this chat to
+Google Drive").
+
+`GET /export-targets` is the catalog the SPA's "Save to…" dialog reads to
+populate its connector picker (and, per connector, which output formats the
+destination accepts). `POST /sessions/{id}/export` renders the conversation
+and creates the document via the resolved adapter.
+
+Like the connector and file-source routes, these live on the app API: the
+AgentCore Runtime that fronts the inference API only proxies `/invocations`
+and `/ping`, so custom paths are unreachable there. The app API can mint
+per-user OAuth tokens via the workload identity, which is exactly what the
+export write needs.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.oauth.agentcore_identity import (
+    CallbackUrlUnavailableError,
+    WorkloadTokenUnavailableError,
+)
+from apis.shared.oauth.disconnect_repository import (
+    OAuthDisconnectRepository,
+    get_disconnect_repository,
+)
+from apis.shared.oauth.models import OAuthProvider
+from apis.shared.oauth.provider_repository import (
+    OAuthProviderRepository,
+    get_provider_repository,
+)
+from apis.shared.rbac.service import AppRoleService, get_app_role_service
+from apis.shared.sessions.messages import get_messages
+from apis.shared.sessions.metadata import add_export_receipt, get_session_metadata
+from apis.shared.sessions.models import ExportReceipt, MessageResponse
+
+from apis.app_api.export_targets.models import (
+    ExportFormat,
+    ExportInclude,
+    ExportTargetError,
+)
+from apis.app_api.export_targets.registry import registry
+from apis.app_api.export_targets.render import render_transcript
+from apis.app_api.export_targets.service import (
+    connector_visible_to_user,
+    http_error_for_export_target_error,
+    require_export_target_token,
+    resolve_export_target,
+    resolve_export_target_token,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["export-targets"])
+
+# Page the transcript out in chunks rather than one unbounded read. The cap is
+# a runaway guard, not a product limit; if a conversation is somehow longer we
+# log and export what we have rather than silently truncating without a trace.
+_EXPORT_PAGE_SIZE = 200
+_MAX_EXPORT_PAGES = 100
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+class ExportTargetConnector(BaseModel):
+    """A connector the current user can save a conversation to."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    provider_id: str = Field(..., alias="providerId")
+    display_name: str = Field(..., alias="displayName")
+    icon_name: str = Field(..., alias="iconName")
+    icon_data: Optional[str] = Field(None, alias="iconData")
+    # True when AgentCore's vault holds a usable token for this user — the SPA
+    # can save straight away. False means it must run the consent flow first.
+    connected: bool
+    # The output formats this destination accepts, so the dialog's format
+    # picker offers only what the adapter can actually produce.
+    supported_formats: List[str] = Field(..., alias="supportedFormats")
+
+
+class ExportTargetListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    export_targets: List[ExportTargetConnector] = Field(..., alias="exportTargets")
+
+
+# ---------------------------------------------------------------------------
+# Export request / response
+# ---------------------------------------------------------------------------
+
+
+class ExportRequest(BaseModel):
+    """Body for `POST /sessions/{id}/export`."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    connector_id: str = Field(..., alias="connectorId", description="Connector to save to")
+    format: ExportFormat = Field(
+        ExportFormat.GOOGLE_DOC, description="Output format; defaults to a native Google Doc"
+    )
+    parent_id: Optional[str] = Field(
+        None,
+        alias="parentId",
+        description="Destination folder id (v2 picker); omit to use the app's default folder",
+    )
+    include: Optional[ExportInclude] = Field(
+        None, description="Which conversation elements to include; omit for defaults"
+    )
+
+
+class ExportResponse(BaseModel):
+    """Result of a successful export."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    file_id: str = Field(..., alias="fileId")
+    name: str
+    web_view_link: Optional[str] = Field(None, alias="webViewLink")
+    # The persisted receipt, so the SPA can update its local session state
+    # without re-fetching metadata.
+    receipt: ExportReceipt
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _is_connected(
+    provider: OAuthProvider,
+    user_id: str,
+    disconnect_repo: OAuthDisconnectRepository,
+) -> bool:
+    """Best-effort check of whether the user has a usable token.
+
+    Mirrors the file-source catalog: a prior disconnect wins over a still-valid
+    vault entry, and workload/callback misconfiguration is treated as "not
+    connected" rather than failing the whole catalog — the user gets the
+    actionable 503 when they try to save.
+    """
+    if await disconnect_repo.is_disconnected(user_id, provider.provider_id):
+        return False
+    try:
+        result = await resolve_export_target_token(provider, user_id)
+    except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+        logger.warning(
+            "Export-target connectivity check failed for %s: %s",
+            provider.provider_id,
+            err,
+        )
+        return False
+    return not result.requires_consent
+
+
+async def _collect_transcript(session_id: str, user_id: str) -> List[MessageResponse]:
+    """Page the whole conversation into a single chronological list.
+
+    Pages are sequence-ordered and returned oldest-first, so concatenating
+    them preserves chronology. Stops at the runaway-guard page cap.
+    """
+    messages: List[MessageResponse] = []
+    next_token: Optional[str] = None
+    for _ in range(_MAX_EXPORT_PAGES):
+        page = await get_messages(
+            session_id=session_id,
+            user_id=user_id,
+            limit=_EXPORT_PAGE_SIZE,
+            next_token=next_token,
+        )
+        messages.extend(page.messages)
+        next_token = page.next_token
+        if not next_token:
+            return messages
+    logger.warning(
+        "Export for session %s hit the %d-page cap; transcript may be truncated",
+        session_id,
+        _MAX_EXPORT_PAGES,
+    )
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/export-targets", response_model=ExportTargetListResponse)
+async def list_export_targets(
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+    disconnect_repo: OAuthDisconnectRepository = Depends(get_disconnect_repository),
+) -> ExportTargetListResponse:
+    """List the connectors the current user can save a conversation to.
+
+    A connector qualifies when it is enabled, mapped to an export-target
+    adapter that ships in this release, and visible to the user's roles.
+    `connected` reflects whether the user already has a usable OAuth token, so
+    the SPA can decide between "Save" and "Connect"; `supportedFormats` drives
+    the format picker.
+    """
+    permissions = await role_service.resolve_user_permissions(current_user)
+    providers = await provider_repo.list_providers(enabled_only=True)
+
+    candidates = []
+    for provider in providers:
+        if not provider.export_target_adapter_id:
+            continue
+        if not connector_visible_to_user(provider, permissions.app_roles):
+            continue
+        adapter = registry.get(provider.export_target_adapter_id)
+        if adapter is None:
+            # Admin mapped an adapter key that no longer ships — hide it rather
+            # than offer a destination that would 404 on save.
+            logger.warning(
+                "Connector %s maps to unknown export-target adapter '%s'; omitting from catalog",
+                provider.provider_id,
+                provider.export_target_adapter_id,
+            )
+            continue
+        candidates.append((provider, adapter))
+
+    connected_flags = await asyncio.gather(
+        *(
+            _is_connected(provider, current_user.user_id, disconnect_repo)
+            for provider, _ in candidates
+        )
+    )
+
+    return ExportTargetListResponse(
+        export_targets=[
+            ExportTargetConnector(
+                provider_id=provider.provider_id,
+                display_name=provider.display_name,
+                icon_name=provider.icon_name,
+                icon_data=provider.icon_data,
+                connected=connected,
+                supported_formats=[
+                    fmt.value for fmt in adapter.metadata.supported_formats
+                ],
+            )
+            for (provider, adapter), connected in zip(candidates, connected_flags)
+        ]
+    )
+
+
+@router.post("/sessions/{session_id}/export", response_model=ExportResponse)
+async def export_session(
+    session_id: str,
+    request: ExportRequest,
+    current_user: User = Depends(get_current_user_from_session),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+    role_service: AppRoleService = Depends(get_app_role_service),
+) -> ExportResponse:
+    """Save a conversation transcript to a connected app.
+
+    Resolves the connector to its export-target adapter, renders the full
+    transcript in the requested format, and creates the document via the
+    user's own OAuth token. A 409 means the user must complete the OAuth
+    consent flow (the SPA reuses the connector consent popup, then retries).
+    """
+    user_id = current_user.user_id
+
+    # Ownership + title source. Session metadata is keyed by user, so a missing
+    # record means the session isn't the caller's (or doesn't exist) — 404
+    # either way, matching the read path so a user can only export their own
+    # conversations.
+    metadata = await get_session_metadata(session_id, user_id)
+    if not metadata:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session not found: {session_id}",
+        )
+
+    provider, adapter = await resolve_export_target(
+        request.connector_id, current_user, provider_repo, role_service
+    )
+
+    if request.format not in adapter.metadata.supported_formats:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"'{provider.display_name}' cannot export to format "
+                f"'{request.format.value}'"
+            ),
+        )
+
+    # 409 (not connected) / 503 (no workload) raised here; the SPA's consent
+    # retry hooks on the 409.
+    access_token = await require_export_target_token(provider, user_id)
+
+    messages = await _collect_transcript(session_id, user_id)
+
+    try:
+        rendered = render_transcript(
+            metadata.title, messages, request.format, request.include
+        )
+    except ValueError as err:
+        # The renderer can't produce this format (e.g. PDF) even though the
+        # adapter claims it — a configuration mismatch, surfaced as 422.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err)
+        )
+
+    try:
+        created = await adapter.create_document(
+            access_token,
+            content=rendered.content,
+            name=rendered.suggested_name,
+            source_mime_type=rendered.mime_type,
+            target_format=request.format,
+            parent_id=request.parent_id,
+        )
+    except ExportTargetError as err:
+        logger.warning(
+            "create_document failed for connector %s: %s", request.connector_id, err
+        )
+        raise http_error_for_export_target_error(err)
+
+    receipt = ExportReceipt(
+        connector_id=provider.provider_id,
+        adapter_key=adapter.metadata.key,
+        format=request.format.value,
+        file_id=created.file_id,
+        file_name=created.name,
+        web_view_link=created.web_view_link,
+        exported_at=datetime.now(timezone.utc).isoformat(),
+    )
+    # Best-effort: swallows its own errors so a metadata-write hiccup never
+    # fails an export that already succeeded.
+    await add_export_receipt(session_id, user_id, receipt)
+
+    return ExportResponse(
+        file_id=created.file_id,
+        name=created.name,
+        web_view_link=created.web_view_link,
+        receipt=receipt,
+    )

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -192,6 +192,7 @@ from apis.app_api.users.routes import router as users_router
 from apis.app_api.user_settings.routes import router as user_settings_router
 from apis.app_api.connectors.routes import router as connectors_router
 from apis.app_api.file_sources.routes import router as file_sources_router
+from apis.app_api.export_targets.routes import router as export_targets_router
 from apis.app_api.web_sources.routes import router as web_sources_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
@@ -221,6 +222,7 @@ app.include_router(tools_router)  # Tool discovery and permissions
 app.include_router(files_router)  # File upload via pre-signed URLs
 app.include_router(connectors_router)  # User-facing connector catalog + consent flows
 app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors
+app.include_router(export_targets_router)  # Export-target catalog + save-a-conversation to a connector
 app.include_router(web_sources_router)  # Web-crawl ingestion: URL -> documents via BFS + S3 staging
 app.include_router(system_router)  # System status and first-boot endpoints
 app.include_router(conversations_share_router)  # Share conversations endpoints

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -16,7 +16,7 @@ from typing import Iterable, List, Optional, Tuple, Any, Dict
 from decimal import Decimal
 
 # Relative imports from shared sessions module
-from .models import MessageMetadata, PausedTurnSnapshot, PendingInterrupt, SessionMetadata, SessionPreferences
+from .models import ExportReceipt, MessageMetadata, PausedTurnSnapshot, PendingInterrupt, SessionMetadata, SessionPreferences
 
 # Import preview session helper
 from agents.main_agent.session.preview_session_manager import is_preview_session
@@ -1903,6 +1903,62 @@ async def add_pending_interrupt(
         # Persistence failure must not break the live SSE flow — the in-memory
         # consent on the live tab still works; refresh-resume just won't.
         logger.error("Failed to persist pending_interrupt: %s", e, exc_info=True)
+
+
+async def add_export_receipt(
+    session_id: str,
+    user_id: str,
+    receipt: ExportReceipt,
+) -> None:
+    """Append an export receipt to the session record.
+
+    Called after a conversation is successfully saved out to a connected app
+    (e.g. Google Drive) so the SPA can restore a "Saved · Open" affordance
+    after a reload. Uses ``list_append`` with ``if_not_exists`` so it can run
+    concurrently with the full-row ``store_session_metadata`` merge and other
+    targeted writers without a read-modify-write window — the same idiom as
+    ``add_pending_interrupt``.
+
+    Best-effort: a persistence failure is logged and swallowed. The export
+    itself already succeeded and the endpoint returns the receipt in its
+    response, so the live tab still shows the link — only reload-survival is
+    lost. No-op when the session metadata row is missing.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        logger.warning("DYNAMODB_SESSIONS_METADATA_TABLE_NAME not set; skipping export receipt persistence")
+        return
+
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            logger.info("Skipping export receipt add — session %s not found", session_id)
+            return
+
+        sk = existing.get("SK")
+        if not sk:
+            logger.warning("Session %s has no SK; cannot persist export receipt", session_id)
+            return
+
+        new_entry = receipt.model_dump(by_alias=True, exclude_none=True)
+
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="SET #er = list_append(if_not_exists(#er, :empty), :new)",
+            ExpressionAttributeNames={"#er": "exportReceipts"},
+            ExpressionAttributeValues={":empty": [], ":new": [new_entry]},
+        )
+        logger.info(
+            "Persisted export receipt (connector=%s, file=%s) for session %s",
+            receipt.connector_id, receipt.file_id, session_id,
+        )
+    except Exception as e:
+        logger.error("Failed to persist export receipt: %s", e, exc_info=True)
 
 
 async def remove_pending_interrupts(

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -162,6 +162,28 @@ class SessionPreferences(BaseModel):
     )
 
 
+class ExportReceipt(BaseModel):
+    """Record of a successful conversation export to a connected app.
+
+    Persisted on the session (and appended, one per export) so the SPA can
+    show a "Saved to <app> · Open" affordance that survives a page reload.
+    The write-direction mirror of `DocumentProvenance`: it records which
+    connector/adapter produced the file, the remote file's identity and
+    viewer link, and when the export happened. Generic across destinations —
+    Google Drive is the first, OneDrive/Dropbox/Box reuse it unchanged.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    connector_id: str = Field(..., alias="connectorId", description="OAuth connector the conversation was saved to")
+    adapter_key: str = Field(..., alias="adapterKey", description="Export-target adapter that created the file")
+    format: str = Field(..., description="Export format produced (e.g. 'google_doc', 'markdown')")
+    file_id: str = Field(..., alias="fileId", description="Provider-side identifier of the created file")
+    file_name: str = Field(..., alias="fileName", description="Name the file was created with")
+    web_view_link: Optional[str] = Field(None, alias="webViewLink", description="Viewer URL surfaced as 'Open in <app>'; None if the provider returns none")
+    exported_at: str = Field(..., alias="exportedAt", description="ISO 8601 timestamp of the export")
+
+
 class SessionMetadata(BaseModel):
     """Complete session metadata
 
@@ -237,6 +259,15 @@ class SessionMetadata(BaseModel):
         description="Cumulative count of turns rolled into a compaction summary in this session",
     )
 
+    # Receipts for conversation exports to connected apps (e.g. Google Drive),
+    # appended one per successful "Save to…" so the UI can show a "Saved · Open"
+    # affordance that survives a reload. Written race-free via add_export_receipt.
+    export_receipts: Optional[List[ExportReceipt]] = Field(
+        default=None,
+        alias="exportReceipts",
+        description="Receipts for conversation exports to connected apps, newest appended last",
+    )
+
 
 class UpdateSessionMetadataRequest(BaseModel):
     """Request body for updating session metadata"""
@@ -294,6 +325,11 @@ class SessionMetadataResponse(BaseModel):
         default=None,
         alias="lastTurnContinuable",
         description="True when the last turn ended in a recoverable max_tokens truncation, so the client can re-show the 'Continue' affordance after a refresh",
+    )
+    export_receipts: Optional[List[ExportReceipt]] = Field(
+        default=None,
+        alias="exportReceipts",
+        description="Receipts for conversation exports to connected apps, newest appended last; lets the UI restore a 'Saved · Open' affordance after a reload",
     )
 
 

--- a/backend/tests/apis/app_api/test_export_routes.py
+++ b/backend/tests/apis/app_api/test_export_routes.py
@@ -1,0 +1,459 @@
+"""Route-level tests for the user-facing export-target endpoints.
+
+Covers the catalog (`GET /export-targets`) and the save action
+(`POST /sessions/{id}/export`). External boundaries — the provider repository,
+role service, disconnect repository, AgentCore identity client, the adapter
+registry, transcript retrieval, and receipt persistence — are stubbed; we test
+our gating, ordering, error mapping, and response shape, not the downstream
+provider calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.export_targets import routes, service
+from apis.app_api.export_targets.adapter import (
+    ExportTargetAdapter,
+    ExportTargetMetadata,
+)
+from apis.app_api.export_targets.models import (
+    CreatedFile,
+    ExportFormat,
+    ExportTargetAuthError,
+    ExportTargetError,
+    ExportTargetNotFoundError,
+)
+from apis.app_api.export_targets.registry import ExportTargetRegistry
+from apis.shared.auth.models import User
+from apis.shared.oauth.agentcore_identity import (
+    TokenResult,
+    WorkloadTokenUnavailableError,
+)
+from apis.shared.oauth.disconnect_repository import get_disconnect_repository
+from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
+from apis.shared.oauth.provider_repository import get_provider_repository
+from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.rbac.service import get_app_role_service
+from apis.shared.sessions.models import (
+    MessageContent,
+    MessageResponse,
+    MessagesListResponse,
+    SessionMetadata,
+)
+
+ADAPTER_KEY = "stub-drive"
+
+
+class _StubExportAdapter(ExportTargetAdapter):
+    """Adapter that records create_document calls or raises on demand."""
+
+    def __init__(self) -> None:
+        self.supported_formats = (ExportFormat.GOOGLE_DOC, ExportFormat.MARKDOWN)
+        self.created_with: Optional[SimpleNamespace] = None
+        self.raise_error: Optional[ExportTargetError] = None
+
+    @property
+    def metadata(self) -> ExportTargetMetadata:
+        return ExportTargetMetadata(
+            key=ADAPTER_KEY,
+            display_name="Stub Drive",
+            icon="stub",
+            compatible_provider_types=(OAuthProviderType.GOOGLE,),
+            required_scopes=(),
+            supported_formats=self.supported_formats,
+        )
+
+    async def list_destinations(self, access_token):  # type: ignore[no-untyped-def]
+        return []
+
+    async def create_document(  # type: ignore[no-untyped-def]
+        self,
+        access_token,
+        *,
+        content,
+        name,
+        source_mime_type,
+        target_format,
+        parent_id=None,
+    ):
+        if self.raise_error:
+            raise self.raise_error
+        self.created_with = SimpleNamespace(
+            access_token=access_token,
+            content=content,
+            name=name,
+            source_mime_type=source_mime_type,
+            target_format=target_format,
+            parent_id=parent_id,
+        )
+        return CreatedFile(
+            file_id="file-123",
+            name=name,
+            web_view_link="https://drive.example/file-123",
+        )
+
+
+def _make_user(user_id: str = "alice") -> User:
+    return User(
+        user_id=user_id,
+        email=f"{user_id}@example.com",
+        name=user_id.capitalize(),
+        roles=[],
+        raw_token="test-token",
+    )
+
+
+def _make_provider(
+    provider_id: str = "gdrive",
+    *,
+    enabled: bool = True,
+    allowed_roles: Optional[list] = None,
+    export_target_adapter_id: Optional[str] = ADAPTER_KEY,
+) -> OAuthProvider:
+    now = datetime.now(timezone.utc).isoformat() + "Z"
+    return OAuthProvider(
+        provider_id=provider_id,
+        display_name="Google Drive",
+        provider_type=OAuthProviderType.GOOGLE,
+        scopes=["https://www.googleapis.com/auth/drive.file"],
+        allowed_roles=allowed_roles or [],
+        enabled=enabled,
+        custom_parameters=None,
+        created_at=now,
+        updated_at=now,
+        export_target_adapter_id=export_target_adapter_id,
+    )
+
+
+def _make_permissions(
+    user_id: str = "alice", *, roles: Optional[list] = None
+) -> UserEffectivePermissions:
+    return UserEffectivePermissions(
+        user_id=user_id,
+        app_roles=roles or [],
+        tools=[],
+        models=[],
+        quota_tier=None,
+        resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+    )
+
+
+def _make_metadata(title: str = "My Chat", user_id: str = "alice") -> SessionMetadata:
+    now = datetime.now(timezone.utc).isoformat() + "Z"
+    return SessionMetadata(
+        session_id="sess-1",
+        user_id=user_id,
+        title=title,
+        status="active",
+        created_at=now,
+        last_message_at=now,
+        message_count=2,
+    )
+
+
+def _msg(mid: str, role: str, text: str) -> MessageResponse:
+    return MessageResponse(
+        id=mid,
+        role=role,
+        content=[MessageContent(type="text", text=text)],
+        created_at="2026-06-25T00:00:00Z",
+    )
+
+
+class _FakeDisconnectRepo:
+    def __init__(self) -> None:
+        self.disconnected: set = set()
+
+    async def is_disconnected(self, user_id: str, provider_id: str) -> bool:
+        return (user_id, provider_id) in self.disconnected
+
+
+@pytest.fixture
+def app_with_deps(monkeypatch):
+    """Mount the router and stub every external boundary."""
+
+    def _build(
+        user_id: str = "alice",
+        *,
+        providers: Optional[List[OAuthProvider]] = None,
+        permissions: Optional[UserEffectivePermissions] = None,
+        identity_result: Optional[TokenResult] = None,
+        identity_raises: Optional[Exception] = None,
+        adapter: Optional[ExportTargetAdapter] = None,
+        metadata: Optional[SessionMetadata] = _make_metadata(),
+        message_pages: Optional[List[List[MessageResponse]]] = None,
+        disconnect_repo: Optional[_FakeDisconnectRepo] = None,
+    ):
+        providers = [_make_provider()] if providers is None else providers
+        app = FastAPI()
+        app.include_router(routes.router)
+        app.dependency_overrides[routes.get_current_user_from_session] = (
+            lambda: _make_user(user_id)
+        )
+
+        by_id = {p.provider_id: p for p in providers}
+        repo = MagicMock()
+        repo.list_providers = AsyncMock(return_value=list(providers))
+        repo.get_provider = AsyncMock(side_effect=lambda pid: by_id.get(pid))
+        app.dependency_overrides[get_provider_repository] = lambda: repo
+
+        role_service = MagicMock()
+        role_service.resolve_user_permissions = AsyncMock(
+            return_value=permissions or _make_permissions(user_id),
+        )
+        app.dependency_overrides[get_app_role_service] = lambda: role_service
+
+        disconnect_repo = disconnect_repo or _FakeDisconnectRepo()
+        app.dependency_overrides[get_disconnect_repository] = lambda: disconnect_repo
+
+        identity = MagicMock()
+        if identity_raises is not None:
+            identity.get_token_for_user = AsyncMock(side_effect=identity_raises)
+        else:
+            identity.get_token_for_user = AsyncMock(
+                return_value=identity_result or TokenResult(access_token="vault-token"),
+            )
+        monkeypatch.setattr(service, "get_agentcore_identity_client", lambda: identity)
+
+        the_adapter = adapter if adapter is not None else _StubExportAdapter()
+        reg = ExportTargetRegistry()
+        reg.register(the_adapter)
+        # resolve_export_target reads service.registry; the catalog reads
+        # routes.registry — both point at the same stub.
+        monkeypatch.setattr(service, "registry", reg)
+        monkeypatch.setattr(routes, "registry", reg)
+
+        async def fake_get_session_metadata(session_id, user_id):
+            return metadata
+
+        monkeypatch.setattr(routes, "get_session_metadata", fake_get_session_metadata)
+
+        pages = message_pages if message_pages is not None else [[_msg("m1", "user", "hi")]]
+
+        async def fake_get_messages(session_id, user_id, limit=None, next_token=None):
+            idx = int(next_token) if next_token else 0
+            page = pages[idx]
+            nxt = str(idx + 1) if idx + 1 < len(pages) else None
+            return MessagesListResponse(messages=page, next_token=nxt)
+
+        monkeypatch.setattr(routes, "get_messages", fake_get_messages)
+
+        receipts: list = []
+
+        async def fake_add_export_receipt(session_id, user_id, receipt):
+            receipts.append(receipt)
+
+        monkeypatch.setattr(routes, "add_export_receipt", fake_add_export_receipt)
+
+        return SimpleNamespace(
+            app=app,
+            adapter=the_adapter,
+            identity=identity,
+            receipts=receipts,
+            disconnect_repo=disconnect_repo,
+        )
+
+    return _build
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+class TestListExportTargets:
+    def test_lists_only_mapped_visible_connectors(self, app_with_deps):
+        ctx = app_with_deps(
+            providers=[
+                _make_provider("gdrive"),
+                _make_provider("slack", export_target_adapter_id=None),
+                _make_provider("secret", allowed_roles=["admins"]),
+            ],
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        targets = response.json()["exportTargets"]
+        assert [t["providerId"] for t in targets] == ["gdrive"]
+        assert targets[0]["connected"] is True
+        assert targets[0]["supportedFormats"] == ["google_doc", "markdown"]
+
+    def test_includes_role_gated_connector_when_user_has_role(self, app_with_deps):
+        ctx = app_with_deps(
+            providers=[_make_provider("secret", allowed_roles=["admins"])],
+            permissions=_make_permissions(roles=["admins"]),
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        assert [t["providerId"] for t in response.json()["exportTargets"]] == ["secret"]
+
+    def test_connected_false_when_consent_required(self, app_with_deps):
+        ctx = app_with_deps(
+            identity_result=TokenResult(authorization_url="https://auth.example/x"),
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        assert response.json()["exportTargets"][0]["connected"] is False
+
+    def test_unknown_adapter_key_omitted(self, app_with_deps):
+        ctx = app_with_deps(
+            providers=[_make_provider("gdrive", export_target_adapter_id="dropbox")],
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        assert response.json()["exportTargets"] == []
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+class TestExportSession:
+    def test_success_returns_file_and_persists_receipt(self, app_with_deps):
+        ctx = app_with_deps(
+            message_pages=[[_msg("m1", "user", "hello"), _msg("m2", "assistant", "hi there")]],
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["fileId"] == "file-123"
+        assert body["webViewLink"] == "https://drive.example/file-123"
+        assert body["receipt"]["connectorId"] == "gdrive"
+        assert body["receipt"]["adapterKey"] == ADAPTER_KEY
+        assert body["receipt"]["format"] == "google_doc"
+
+        # Default format → native Google Doc → uploads HTML.
+        assert ctx.adapter.created_with.target_format == ExportFormat.GOOGLE_DOC
+        assert ctx.adapter.created_with.source_mime_type == "text/html"
+        assert ctx.adapter.created_with.name == "My Chat"
+        # Receipt persisted exactly once.
+        assert len(ctx.receipts) == 1
+        assert ctx.receipts[0].file_id == "file-123"
+
+    def test_pages_full_transcript(self, app_with_deps):
+        ctx = app_with_deps(
+            message_pages=[
+                [_msg("m1", "user", "page-zero-text")],
+                [_msg("m2", "assistant", "page-one-text")],
+            ],
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export",
+            json={"connectorId": "gdrive", "format": "markdown"},
+        )
+
+        assert response.status_code == 200
+        rendered = ctx.adapter.created_with.content.decode("utf-8")
+        # Both pages made it into the document, in order.
+        assert "page-zero-text" in rendered
+        assert "page-one-text" in rendered
+        assert rendered.index("page-zero-text") < rendered.index("page-one-text")
+
+    def test_404_when_session_missing(self, app_with_deps):
+        ctx = app_with_deps(metadata=None)
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 404
+
+    def test_404_when_not_an_export_target(self, app_with_deps):
+        ctx = app_with_deps(
+            providers=[_make_provider("gdrive", export_target_adapter_id=None)],
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 404
+
+    def test_403_when_user_lacks_role(self, app_with_deps):
+        ctx = app_with_deps(
+            providers=[_make_provider("gdrive", allowed_roles=["admins"])],
+            permissions=_make_permissions(roles=["users"]),
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 403
+
+    def test_409_when_not_connected(self, app_with_deps):
+        ctx = app_with_deps(
+            identity_result=TokenResult(authorization_url="https://auth.example/x"),
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 409
+        # No upload attempted, no receipt persisted on a consent miss.
+        assert ctx.adapter.created_with is None
+        assert ctx.receipts == []
+
+    def test_503_when_workload_unavailable(self, app_with_deps):
+        ctx = app_with_deps(
+            identity_raises=WorkloadTokenUnavailableError("no workload"),
+        )
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 503
+
+    def test_422_when_format_unsupported(self, app_with_deps):
+        ctx = app_with_deps()
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export",
+            json={"connectorId": "gdrive", "format": "pdf"},
+        )
+        assert response.status_code == 422
+        assert ctx.adapter.created_with is None
+
+    def test_502_on_adapter_error(self, app_with_deps):
+        adapter = _StubExportAdapter()
+        adapter.raise_error = ExportTargetError("drive exploded")
+        ctx = app_with_deps(adapter=adapter)
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 502
+        assert ctx.receipts == []
+
+    def test_403_on_adapter_auth_error(self, app_with_deps):
+        adapter = _StubExportAdapter()
+        adapter.raise_error = ExportTargetAuthError("token rejected")
+        ctx = app_with_deps(adapter=adapter)
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export", json={"connectorId": "gdrive"}
+        )
+        assert response.status_code == 403
+
+    def test_404_on_adapter_not_found_error(self, app_with_deps):
+        adapter = _StubExportAdapter()
+        adapter.raise_error = ExportTargetNotFoundError("folder gone")
+        ctx = app_with_deps(adapter=adapter)
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export",
+            json={"connectorId": "gdrive", "parentId": "missing"},
+        )
+        assert response.status_code == 404
+
+    def test_parent_id_passed_to_adapter(self, app_with_deps):
+        ctx = app_with_deps()
+        response = TestClient(ctx.app).post(
+            "/sessions/sess-1/export",
+            json={"connectorId": "gdrive", "parentId": "folder-9"},
+        )
+        assert response.status_code == 200
+        assert ctx.adapter.created_with.parent_id == "folder-9"


### PR DESCRIPTION
## PR-3 — Conversation export endpoint

Third PR in the [conversation-export feature](docs/specs/conversation-export-connectors.md) (after #507 scaffold and #508 Drive adapter + renderer). Adds the app-api endpoint that saves a conversation transcript out to a connected app.

### Endpoints (`apis/app_api/export_targets/routes.py`)

- **`POST /sessions/{session_id}/export`** — `{connectorId, format?=google_doc, parentId?, include?}`
  - Ownership check via `get_session_metadata` (per-user keyed → 404 if not the caller's), matching the read path so a user can only export their own conversations.
  - `resolve_export_target` (404 not-an-export-target / 403 RBAC) → format validated against `adapter.metadata.supported_formats` (422) → `require_export_target_token` (**409** not-connected is the SPA consent hook, **503** no-workload).
  - Pages the **full** transcript (`get_messages` oldest-first, concatenated; 200/page, 100-page runaway guard that logs if hit) → `render_transcript` → `adapter.create_document`. Adapter errors map to 502/403/404.
  - Returns `{fileId, name, webViewLink, receipt}`.
- **`GET /export-targets`** — catalog mirroring `GET /file-sources`, with per-connector `connected` and `supportedFormats`. Lets the PR-4 dialog build its connector + format pickers with no further backend work.

### Export receipt (spec R-2 → persist)

- `ExportReceipt` model + optional `export_receipts` on `SessionMetadata` and `SessionMetadataResponse` so a "Saved · Open" affordance survives a reload via the existing metadata GETs (additive/optional — the matching TS interface lands with the PR-4 SPA).
- `add_export_receipt` — race-free `list_append`/`if_not_exists` writer mirroring `add_pending_interrupt`; best-effort so a metadata hiccup never fails a succeeded export.

### Notes / decisions
- **No new feature flag.** The endpoint self-gates: it 404s until an admin maps a connector's `export_target_adapter_id`, and the catalog is empty until then.
- **`GET /export-targets` included** here (beyond the strict PR-3 line) so PR-4 is purely frontend.
- The 409 path is where the SPA reuses the existing connector `initiate-consent`/`complete-consent` popup, then retries — no new consent machinery.

### Testing
- `tests/apis/app_api/test_export_routes.py` — 16 cases: catalog gating/connected/formats; export success + receipt persistence; multi-page transcript ordering; full 404/403/409/503/422/502 error matrix.
- Architecture import-boundary test green (`export_targets/` only imports `apis.shared` + `apis.app_api`).
- **Full backend suite green: 4030 passed, 3 skipped** (run locally — pytest isn't in CI, and this touches the shared session models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)