### PR TITLE
feat(export-targets): "Save to…" conversation export SPA + admin mapping dropdown (PR-4)

### DIFF
--- a/frontend/ai.client/src/app/admin/connectors/models/connector.model.ts
+++ b/frontend/ai.client/src/app/admin/connectors/models/connector.model.ts
@@ -58,6 +58,13 @@ export interface Connector {
    * assistant editor. Null/absent means it is not a file source.
    */
   fileSourceAdapterId?: string | null;
+  /**
+   * Export-target adapter key (e.g. `google-drive`) mapping this connector to
+   * a destination. When set, the connector appears in the "Save to…" dialog
+   * as a place to save a conversation. Null/absent means it is not an export
+   * target. The write-direction mirror of `fileSourceAdapterId`.
+   */
+  exportTargetAdapterId?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -96,6 +103,8 @@ export interface ConnectorCreateRequest {
   customParameters?: Record<string, string>;
   /** File-source adapter key; omit when the connector is not a file source. */
   fileSourceAdapterId?: string;
+  /** Export-target adapter key; omit when the connector is not an export target. */
+  exportTargetAdapterId?: string;
 }
 
 /**
@@ -123,6 +132,11 @@ export interface ConnectorUpdateRequest {
    * source); a populated adapter key sets it; `undefined` leaves it alone.
    */
   fileSourceAdapterId?: string;
+  /**
+   * `""` clears the export-target mapping (the connector stops being an export
+   * target); a populated adapter key sets it; `undefined` leaves it alone.
+   */
+  exportTargetAdapterId?: string;
 }
 
 /**
@@ -142,6 +156,28 @@ export interface FileSourceAdapter {
 
 export interface FileSourceAdapterListResponse {
   adapters: FileSourceAdapter[];
+}
+
+/**
+ * An export-target adapter shipped in the backend registry, as returned by
+ * `GET /admin/export-target-adapters`. Read-only — adapters are code, not
+ * config; an admin can only map a connector to an existing one. The
+ * write-direction mirror of {@link FileSourceAdapter}.
+ */
+export interface ExportTargetAdapter {
+  key: string;
+  displayName: string;
+  icon: string;
+  /** OAuth provider types this adapter may be mapped to. */
+  compatibleProviderTypes: ConnectorType[];
+  /** OAuth scopes the connector must grant for the adapter to work. */
+  requiredScopes: string[];
+  /** Output formats this destination can produce (e.g. `google_doc`). */
+  supportedFormats: string[];
+}
+
+export interface ExportTargetAdapterListResponse {
+  adapters: ExportTargetAdapter[];
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
+++ b/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
@@ -73,6 +73,11 @@ interface ConnectorFormGroup {
    * source. On update, sending `''` clears an existing mapping.
    */
   fileSourceAdapterId: FormControl<string>;
+  /**
+   * Export-target adapter key, or `''` when the connector is not an export
+   * target. On update, sending `''` clears an existing mapping.
+   */
+  exportTargetAdapterId: FormControl<string>;
 }
 
 const ICON_DATA_MAX_BYTES = 100 * 1024;
@@ -577,6 +582,47 @@ const ICON_ACCEPTED_MIME_TYPES = [
               }
             </div>
 
+            <div class="rounded-sm border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+              <h2 class="mb-2 text-xl/8 font-semibold text-gray-900 dark:text-white">Export Target</h2>
+              <p class="mb-6 text-sm/6 text-gray-600 dark:text-gray-400">
+                Optionally map this connector to an export-target adapter so users can
+                save a conversation to it from the chat "Save to…" dialog.
+              </p>
+              @if (compatibleExportAdapters().length > 0) {
+                <div>
+                  <label for="exportTargetAdapterId" class="mb-1.5 block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Export-target adapter
+                  </label>
+                  <select
+                    id="exportTargetAdapterId"
+                    formControlName="exportTargetAdapterId"
+                    class="block w-full rounded-sm border border-gray-300 bg-white px-3 py-2.5 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  >
+                    <option value="">Not an export target</option>
+                    @for (adapter of compatibleExportAdapters(); track adapter.key) {
+                      <option [value]="adapter.key">{{ adapter.displayName }}</option>
+                    }
+                  </select>
+                  <p class="mt-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+                    When set, this connector appears as a destination in the "Save to…"
+                    dialog for any user allowed to use it.
+                  </p>
+                  @if (exportScopeCoverageWarning(); as warning) {
+                    <div class="mt-3 rounded-sm border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+                      <div class="flex gap-2">
+                        <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                        <p class="text-sm/6 text-amber-700 dark:text-amber-300">{{ warning }}</p>
+                      </div>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                  No export-target adapter is available for this connector type.
+                </p>
+              }
+            </div>
+
             @if (isEditMode()) {
               <div class="rounded-sm border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
                 <div class="flex gap-3">
@@ -675,6 +721,7 @@ export class ConnectorFormPage implements OnInit {
     iconData: this.fb.control('', { nonNullable: true }),
     customParameters: this.fb.control('', { nonNullable: true }),
     fileSourceAdapterId: this.fb.control('', { nonNullable: true }),
+    exportTargetAdapterId: this.fb.control('', { nonNullable: true }),
   });
 
   readonly pageTitle = computed(() => (this.isEditMode() ? 'Edit Connector' : 'Add Connector'));
@@ -716,12 +763,16 @@ export class ConnectorFormPage implements OnInit {
   // section reacts to. Updated from valueChanges in ngOnInit.
   private readonly scopesSignal = signal<string>('');
   private readonly fileSourceAdapterIdSignal = signal<string>('');
+  private readonly exportTargetAdapterIdSignal = signal<string>('');
 
   /**
    * The file-source adapter mapping loaded from the server, so update can
    * tell a real change (send it, possibly `''` to clear) from a no-op.
    */
   private readonly adapterLoadedFromServer = signal<string>('');
+
+  /** Same tri-state tracking for the export-target mapping. */
+  private readonly exportAdapterLoadedFromServer = signal<string>('');
 
   /** Every file-source adapter shipped in the backend registry. */
   readonly fileSourceAdapters = computed(() =>
@@ -764,6 +815,48 @@ export class ConnectorFormPage implements OnInit {
     );
   });
 
+  /** Every export-target adapter shipped in the backend registry. */
+  readonly exportTargetAdapters = computed(() =>
+    this.connectorsService.getExportTargetAdapters()
+  );
+
+  /** Adapters that may be mapped to the currently-selected provider type. */
+  readonly compatibleExportAdapters = computed(() =>
+    this.exportTargetAdapters().filter(a =>
+      a.compatibleProviderTypes.includes(this.providerTypeSignal())
+    )
+  );
+
+  /** The export-target adapter currently chosen in the dropdown, if any. */
+  readonly selectedExportAdapter = computed(() => {
+    const key = this.exportTargetAdapterIdSignal();
+    if (!key) return null;
+    return this.exportTargetAdapters().find(a => a.key === key) ?? null;
+  });
+
+  /**
+   * Warns when the connector's scopes don't cover the write scope the
+   * selected export target needs — caught here at config time rather than as
+   * a failed save later.
+   */
+  readonly exportScopeCoverageWarning = computed<string | null>(() => {
+    const adapter = this.selectedExportAdapter();
+    if (!adapter) return null;
+    const granted = new Set(
+      this.scopesSignal()
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    );
+    const missing = adapter.requiredScopes.filter(s => !granted.has(s));
+    if (missing.length === 0) return null;
+    return (
+      `This connector's scopes are missing ${missing.join(', ')}, which ` +
+      `${adapter.displayName} needs to save files. Add them above or ` +
+      `saving will fail.`
+    );
+  });
+
   /**
    * Returns a user-facing error string when clientId and clientSecret are
    * inconsistent. Rotation requires both or neither.
@@ -802,6 +895,9 @@ export class ConnectorFormPage implements OnInit {
     this.connectorForm.controls.fileSourceAdapterId.valueChanges.subscribe((value) => {
       this.fileSourceAdapterIdSignal.set(value);
     });
+    this.connectorForm.controls.exportTargetAdapterId.valueChanges.subscribe((value) => {
+      this.exportTargetAdapterIdSignal.set(value);
+    });
   }
 
   /**
@@ -810,16 +906,26 @@ export class ConnectorFormPage implements OnInit {
    * connector to Slack). Keeps the form from submitting an invalid mapping.
    */
   private clearIncompatibleAdapter(): void {
-    const current = this.connectorForm.controls.fileSourceAdapterId.value;
-    if (!current) return;
-    const adapter = this.connectorsService
-      .getFileSourceAdapters()
-      .find(a => a.key === current);
-    const stillCompatible = adapter?.compatibleProviderTypes.includes(
-      this.connectorForm.controls.providerType.value
-    );
-    if (!stillCompatible) {
-      this.connectorForm.controls.fileSourceAdapterId.setValue('');
+    const providerType = this.connectorForm.controls.providerType.value;
+
+    const currentFileSource = this.connectorForm.controls.fileSourceAdapterId.value;
+    if (currentFileSource) {
+      const adapter = this.connectorsService
+        .getFileSourceAdapters()
+        .find(a => a.key === currentFileSource);
+      if (!adapter?.compatibleProviderTypes.includes(providerType)) {
+        this.connectorForm.controls.fileSourceAdapterId.setValue('');
+      }
+    }
+
+    const currentExport = this.connectorForm.controls.exportTargetAdapterId.value;
+    if (currentExport) {
+      const adapter = this.connectorsService
+        .getExportTargetAdapters()
+        .find(a => a.key === currentExport);
+      if (!adapter?.compatibleProviderTypes.includes(providerType)) {
+        this.connectorForm.controls.exportTargetAdapterId.setValue('');
+      }
     }
   }
 
@@ -857,9 +963,11 @@ export class ConnectorFormPage implements OnInit {
         iconData: connector.iconData ?? '',
         customParameters: this.serializeCustomParameters(connector.customParameters ?? null),
         fileSourceAdapterId: connector.fileSourceAdapterId ?? '',
+        exportTargetAdapterId: connector.exportTargetAdapterId ?? '',
       });
       this.iconLoadedFromServer.set(connector.iconData ?? null);
       this.adapterLoadedFromServer.set(connector.fileSourceAdapterId ?? '');
+      this.exportAdapterLoadedFromServer.set(connector.exportTargetAdapterId ?? '');
       this.selectedRoles.set(connector.allowedRoles.length > 0 ? connector.allowedRoles : ['*']);
       this.applyDiscoveryValidator();
     } catch (error) {
@@ -999,6 +1107,11 @@ export class ConnectorFormPage implements OnInit {
         if (currentAdapter !== this.adapterLoadedFromServer()) {
           updates.fileSourceAdapterId = currentAdapter;
         }
+        // Same tri-state for the export-target mapping.
+        const currentExportAdapter = formValue.exportTargetAdapterId || '';
+        if (currentExportAdapter !== this.exportAdapterLoadedFromServer()) {
+          updates.exportTargetAdapterId = currentExportAdapter;
+        }
         if (formValue.clientId && formValue.clientSecret) {
           updates.clientId = formValue.clientId;
           updates.clientSecret = formValue.clientSecret;
@@ -1031,6 +1144,9 @@ export class ConnectorFormPage implements OnInit {
         }
         if (formValue.fileSourceAdapterId) {
           createData.fileSourceAdapterId = formValue.fileSourceAdapterId;
+        }
+        if (formValue.exportTargetAdapterId) {
+          createData.exportTargetAdapterId = formValue.exportTargetAdapterId;
         }
         const created = await this.connectorsService.createConnector(createData);
         this.createdConnector.set(created);

--- a/frontend/ai.client/src/app/admin/connectors/services/connectors.service.ts
+++ b/frontend/ai.client/src/app/admin/connectors/services/connectors.service.ts
@@ -9,6 +9,8 @@ import {
   ConnectorUpdateRequest,
   FileSourceAdapter,
   FileSourceAdapterListResponse,
+  ExportTargetAdapter,
+  ExportTargetAdapterListResponse,
 } from '../models/connector.model';
 
 function toSnakeCase(obj: Record<string, any>): Record<string, any> {
@@ -50,6 +52,10 @@ export class ConnectorsService {
     () => `${this.config.appApiUrl()}/admin/file-source-adapters`
   );
 
+  private readonly exportTargetAdaptersUrl = computed(
+    () => `${this.config.appApiUrl()}/admin/export-target-adapters`
+  );
+
   readonly connectorsResource = resource({
     loader: async () => {
       await Promise.resolve();
@@ -66,6 +72,19 @@ export class ConnectorsService {
     loader: async () => {
       await Promise.resolve();
       return this.fetchFileSourceAdapters();
+    }
+  });
+
+  /**
+   * The export-target adapter registry. Read-only and rarely changes — adapters
+   * ship in releases — so a single eager load when the admin service is first
+   * injected is sufficient. The write-direction mirror of
+   * {@link fileSourceAdaptersResource}.
+   */
+  readonly exportTargetAdaptersResource = resource({
+    loader: async () => {
+      await Promise.resolve();
+      return this.fetchExportTargetAdapters();
     }
   });
 
@@ -102,6 +121,20 @@ export class ConnectorsService {
   async fetchFileSourceAdapters(): Promise<FileSourceAdapterListResponse> {
     return firstValueFrom(
       this.http.get<FileSourceAdapterListResponse>(`${this.fileSourceAdaptersUrl()}/`)
+    );
+  }
+
+  getExportTargetAdapters(): ExportTargetAdapter[] {
+    return this.exportTargetAdaptersResource.value()?.adapters ?? [];
+  }
+
+  /**
+   * Fetch the export-target adapter registry. Like the file-source endpoint
+   * it serializes camelCase already, so no key translation is applied.
+   */
+  async fetchExportTargetAdapters(): Promise<ExportTargetAdapterListResponse> {
+    return firstValueFrom(
+      this.http.get<ExportTargetAdapterListResponse>(`${this.exportTargetAdaptersUrl()}/`)
     );
   }
 

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
@@ -103,6 +103,16 @@
                                                 <button
                                                     cdkMenuItem
                                                     type="button"
+                                                    (click)="onExportClick($event, session)"
+                                                    class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                                                    role="menuitem"
+                                                >
+                                                    <ng-icon name="heroCloudArrowUp" class="size-4" aria-hidden="true" />
+                                                    <span>Save to…</span>
+                                                </button>
+                                                <button
+                                                    cdkMenuItem
+                                                    type="button"
                                                     (click)="onDeleteClick($event, session)"
                                                     class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-red-600 hover:bg-gray-50 focus:bg-gray-50 dark:text-red-400 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
                                                     role="menuitem"

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -5,10 +5,11 @@ import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroPencilSquare, heroArrowUpOnSquare } from '@ng-icons/heroicons/outline';
+import { heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp } from '@ng-icons/heroicons/outline';
 import { heroEllipsisHorizontalSolid } from '@ng-icons/heroicons/solid';
 import { SessionService } from '../../../../session/services/session/session.service';
 import { ShareModalComponent, ShareModalData } from '../../../../session/components/share-modal';
+import { ExportDialogComponent, ExportDialogData } from '../../../../session/components/export-dialog';
 import { UserService } from '../../../../auth/user.service';
 import { SessionMetadata } from '../../../../session/services/models/session-metadata.model';
 import { SidenavService } from '../../../../services/sidenav/sidenav.service';
@@ -18,7 +19,7 @@ import { ConfirmationDialogComponent, ConfirmationDialogData } from '../../../co
 @Component({
   selector: 'app-session-list',
   imports: [RouterLink, RouterLinkActive, NgIcon, CdkMenuTrigger, CdkMenu, CdkMenuItem],
-  providers: [provideIcons({ heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroEllipsisHorizontalSolid, heroPencilSquare, heroArrowUpOnSquare })],
+  providers: [provideIcons({ heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroEllipsisHorizontalSolid, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp })],
   templateUrl: './session-list.html',
   styleUrl: './session-list.css',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -319,6 +320,25 @@ export class SessionList {
         sessionId: session.sessionId,
         ownerEmail: this.userService.currentUser()?.email ?? '',
       } as ShareModalData,
+    });
+  }
+
+  /**
+   * Opens the "Save to…" export dialog for a session, letting the user save
+   * the conversation transcript to a connected app (e.g. Google Drive).
+   *
+   * @param event - Click event (stopped to prevent navigation)
+   * @param session - The session to export
+   */
+  protected onExportClick(event: Event, session: SessionMetadata): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.dialog.open(ExportDialogComponent, {
+      data: {
+        sessionId: session.sessionId,
+        title: session.title,
+      } as ExportDialogData,
     });
   }
 

--- a/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ExportDialogComponent } from './export-dialog.component';
+import { ExportService } from '../../services/export/export.service';
+import { ExportTargetConnector } from '../../services/export/export.model';
+import { UserConnectorsService } from '../../../settings/connectors/services/user-connectors.service';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+import { ToastService } from '../../../services/toast/toast.service';
+
+const CONNECTED: ExportTargetConnector = {
+  providerId: 'gdrive',
+  displayName: 'Google Drive',
+  iconName: 'heroCloud',
+  connected: true,
+  supportedFormats: ['google_doc', 'markdown'],
+};
+const NOT_CONNECTED: ExportTargetConnector = { ...CONNECTED, connected: false };
+
+function setup(exportOverrides: Partial<Record<string, unknown>> = {}) {
+  const exportService = {
+    listExportTargets: vi.fn().mockResolvedValue([CONNECTED]),
+    exportSession: vi.fn().mockResolvedValue({
+      fileId: 'file-123',
+      name: 'My Chat',
+      webViewLink: 'https://drive.example/file-123',
+      receipt: {
+        connectorId: 'gdrive',
+        adapterKey: 'google-drive',
+        format: 'google_doc',
+        fileId: 'file-123',
+        fileName: 'My Chat',
+        webViewLink: 'https://drive.example/file-123',
+        exportedAt: '2026-06-26T00:00:00Z',
+      },
+    }),
+    ...exportOverrides,
+  };
+  const dialogRef = { close: vi.fn() };
+  const connectorsService = { initiateConsent: vi.fn() };
+  const consentService = {
+    completion: signal<unknown>(null),
+    inFlightProviders: signal(new Set<string>()),
+    requestConsent: vi.fn(),
+    openConsentPopup: vi.fn().mockResolvedValue(true),
+    acknowledgeCompletion: vi.fn(),
+  };
+  const toast = { error: vi.fn(), success: vi.fn() };
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: DIALOG_DATA, useValue: { sessionId: 'sess-1', title: 'My Chat' } },
+      { provide: DialogRef, useValue: dialogRef },
+      { provide: ExportService, useValue: exportService },
+      { provide: UserConnectorsService, useValue: connectorsService },
+      { provide: OAuthConsentService, useValue: consentService },
+      { provide: ToastService, useValue: toast },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(ExportDialogComponent);
+  fixture.detectChanges();
+  const component = fixture.componentInstance as unknown as Record<string, never>;
+  return { fixture, component, exportService, dialogRef, connectorsService, consentService, toast };
+}
+
+describe('ExportDialogComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('loads export targets on open and auto-selects a sole destination', async () => {
+    const { component, exportService } = setup();
+    await vi.waitFor(() => {
+      expect(exportService.listExportTargets).toHaveBeenCalled();
+      expect((component['targets'] as () => unknown[])()).toHaveLength(1);
+    });
+    // Single destination is auto-selected with its preferred format.
+    expect((component['selectedConnectorId'] as () => string | null)()).toBe('gdrive');
+    expect((component['selectedFormat'] as () => string | null)()).toBe('google_doc');
+  });
+
+  it('saves a connected destination and surfaces the result', async () => {
+    const { component, exportService } = setup();
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['save'] as () => Promise<void>)();
+
+    expect(exportService.exportSession).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ connectorId: 'gdrive', format: 'google_doc' }),
+    );
+    expect((component['result'] as () => { fileId: string } | null)()?.fileId).toBe('file-123');
+  });
+
+  it('toggles include flags off and back on', async () => {
+    const { component } = setup();
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    const include = () => (component['include'] as () => Record<string, boolean>)();
+    expect(include()['citations']).toBe(true);
+    (component['toggleInclude'] as (k: string) => void)('citations');
+    expect(include()['citations']).toBe(false);
+  });
+
+  it('runs the consent flow when saving to an unconnected destination', async () => {
+    const { component, connectorsService, consentService, exportService } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([NOT_CONNECTED]),
+    });
+    connectorsService.initiateConsent.mockResolvedValue({
+      connected: false,
+      authorizationUrl: 'https://auth.example/x',
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['save'] as () => Promise<void>)();
+
+    expect(connectorsService.initiateConsent).toHaveBeenCalledWith('gdrive');
+    expect(consentService.openConsentPopup).toHaveBeenCalledWith('gdrive');
+    // The save itself is deferred until consent completes.
+    expect(exportService.exportSession).not.toHaveBeenCalled();
+  });
+
+  it('retries the export after consent completes successfully', async () => {
+    const { component, connectorsService, consentService, exportService } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([NOT_CONNECTED]),
+    });
+    connectorsService.initiateConsent.mockResolvedValue({
+      connected: false,
+      authorizationUrl: 'https://auth.example/x',
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['save'] as () => Promise<void>)();
+    // Simulate the /oauth-complete popup broadcasting success.
+    (consentService.completion as ReturnType<typeof signal>).set({
+      type: 'agentcore-oauth-complete',
+      status: 'success',
+      providerId: 'gdrive',
+      error: null,
+    });
+
+    await vi.waitFor(() => {
+      expect(exportService.exportSession).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({ connectorId: 'gdrive' }),
+      );
+    });
+    expect(consentService.acknowledgeCompletion).toHaveBeenCalled();
+  });
+
+  it('cancel closes with the result (undefined before any save)', async () => {
+    const { component, dialogRef } = setup();
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    (component['cancel'] as () => void)();
+    expect(dialogRef.close).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.ts
@@ -1,0 +1,529 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowPath,
+  heroArrowTopRightOnSquare,
+  heroCheckCircle,
+  heroCloudArrowUp,
+  heroExclamationTriangle,
+  heroLink,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import { ExportError, ExportService } from '../../services/export/export.service';
+import {
+  DEFAULT_EXPORT_INCLUDE,
+  ExportFormat,
+  ExportInclude,
+  ExportResponse,
+  ExportTargetConnector,
+} from '../../services/export/export.model';
+import { UserConnectorsService } from '../../../settings/connectors/services/user-connectors.service';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+import { ToastService } from '../../../services/toast/toast.service';
+
+/** Data passed in when the session list opens the export dialog. */
+export interface ExportDialogData {
+  sessionId: string;
+  /** Conversation title, shown for context in the header. */
+  title?: string;
+}
+
+/** Closed with the export result on success, or `undefined` if cancelled. */
+export type ExportDialogResult = ExportResponse;
+
+type ConnectPhase = 'initiating' | 'awaiting';
+
+interface IncludeOption {
+  key: keyof ExportInclude;
+  label: string;
+}
+
+const FORMAT_LABELS: Record<ExportFormat, string> = {
+  google_doc: 'Google Doc',
+  markdown: 'Markdown',
+  pdf: 'PDF',
+};
+
+/**
+ * Modal that saves the current conversation transcript to a connected app
+ * ("Save to…"). Flow: pick a destination connector → choose a format and what
+ * to include → save. An unconnected (or expired) connector runs the shared
+ * OAuth consent popup, then the save retries automatically. On success it
+ * surfaces an "Open in <app>" link.
+ *
+ * Mirrors the file-source browser dialog's consent plumbing; the only data
+ * flow that differs is the direction (write a transcript out vs. read files in).
+ */
+@Component({
+  selector: 'app-export-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({
+      heroArrowPath,
+      heroArrowTopRightOnSquare,
+      heroCheckCircle,
+      heroCloudArrowUp,
+      heroExclamationTriangle,
+      heroLink,
+      heroXMark,
+    }),
+  ],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'cancel()',
+  },
+  template: `
+    <!-- Backdrop -->
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+      aria-hidden="true"
+      (click)="cancel()"
+    ></div>
+
+    <!-- Centering wrapper -->
+    <div class="fixed inset-0 z-10 flex min-h-full items-center justify-center p-4">
+      <div
+        class="dialog-panel relative flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-2xl bg-white shadow-xl dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="export-dialog-title"
+        (click)="$event.stopPropagation()"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between gap-4 border-b border-gray-200 px-5 py-4 dark:border-gray-700">
+          <div class="flex items-center gap-2">
+            <ng-icon name="heroCloudArrowUp" class="size-5 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+            <h2 id="export-dialog-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+              Save conversation
+            </h2>
+          </div>
+          <button
+            type="button"
+            (click)="cancel()"
+            aria-label="Close"
+            class="-mr-1 rounded-2xl p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" />
+          </button>
+        </div>
+
+        <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          @if (result(); as saved) {
+            <!-- ─────────────── Success ─────────────── -->
+            <div class="flex flex-col items-center gap-3 py-4 text-center">
+              <ng-icon name="heroCheckCircle" class="size-10 text-green-600 dark:text-green-400" aria-hidden="true" />
+              <p class="text-sm/6 font-medium text-gray-900 dark:text-white">
+                Saved to {{ selectedTargetName() }}
+              </p>
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">{{ saved.name }}</p>
+              @if (saved.webViewLink) {
+                <a
+                  [href]="saved.webViewLink"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3.5 py-2 text-sm/6 font-semibold text-white shadow-xs hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
+                  Open in {{ selectedTargetName() }}
+                </a>
+              }
+            </div>
+          } @else if (loading()) {
+            <div class="flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
+              <div class="size-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
+              Loading destinations…
+            </div>
+          } @else if (loadError(); as err) {
+            <div class="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+              <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-red-600 dark:text-red-400" aria-hidden="true" />
+              <div>
+                <p class="text-sm/6 text-red-700 dark:text-red-300">{{ err }}</p>
+                <button
+                  type="button"
+                  (click)="loadTargets()"
+                  class="mt-2 text-sm/6 font-medium text-red-700 underline hover:text-red-800 dark:text-red-200"
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          } @else if (targets().length === 0) {
+            <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+              <ng-icon name="heroLink" class="mx-auto size-8 text-gray-400" aria-hidden="true" />
+              <p class="mt-3 text-sm/6 font-medium text-gray-700 dark:text-gray-300">No destinations available</p>
+              <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                Ask an administrator to connect an app you can save conversations to.
+              </p>
+            </div>
+          } @else {
+            <!-- ─────────────── Destination ─────────────── -->
+            <fieldset class="space-y-2">
+              <legend class="mb-1.5 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Destination</legend>
+              @for (target of targets(); track target.providerId) {
+                <label
+                  class="flex cursor-pointer items-center gap-3 rounded-2xl border p-3 transition-colors"
+                  [class]="selectedConnectorId() === target.providerId
+                    ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-500/10'
+                    : 'border-gray-200 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-white/5'"
+                >
+                  <input
+                    type="radio"
+                    name="exportDestination"
+                    class="size-4 text-blue-600 focus:ring-blue-500"
+                    [value]="target.providerId"
+                    [checked]="selectedConnectorId() === target.providerId"
+                    (change)="selectConnector(target)"
+                  />
+                  <span class="flex-1 text-sm/6 font-medium text-gray-900 dark:text-white">{{ target.displayName }}</span>
+                  @if (!target.connected) {
+                    <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                      Not connected
+                    </span>
+                  }
+                </label>
+              }
+            </fieldset>
+
+            <!-- ─────────────── Format ─────────────── -->
+            @if (availableFormats().length > 0) {
+              <div class="mt-4">
+                <label for="export-format" class="mb-1.5 block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Format</label>
+                <select
+                  id="export-format"
+                  class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500/40 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  [value]="selectedFormat()"
+                  (change)="onFormatChange($event)"
+                >
+                  @for (fmt of availableFormats(); track fmt) {
+                    <option [value]="fmt">{{ formatLabel(fmt) }}</option>
+                  }
+                </select>
+              </div>
+            }
+
+            <!-- ─────────────── Include ─────────────── -->
+            <fieldset class="mt-4">
+              <legend class="mb-1.5 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Include</legend>
+              <div class="space-y-1.5">
+                <!-- Messages are the transcript itself: always on, shown disabled. -->
+                <label class="flex items-center gap-2.5 text-sm/6 text-gray-500 dark:text-gray-400">
+                  <input type="checkbox" checked disabled class="size-4 rounded-sm text-blue-600" />
+                  Messages
+                </label>
+                @for (opt of includeOptions; track opt.key) {
+                  <label class="flex cursor-pointer items-center gap-2.5 text-sm/6 text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      class="size-4 rounded-sm text-blue-600 focus:ring-blue-500"
+                      [checked]="include()[opt.key]"
+                      (change)="toggleInclude(opt.key)"
+                    />
+                    {{ opt.label }}
+                  </label>
+                }
+              </div>
+            </fieldset>
+
+            @if (error(); as err) {
+              <div class="mt-4 flex items-start gap-2.5 rounded-2xl border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-red-600 dark:text-red-400" aria-hidden="true" />
+                <p class="text-sm/6 text-red-700 dark:text-red-300">{{ err }}</p>
+              </div>
+            }
+          }
+        </div>
+
+        <!-- Footer -->
+        <div class="flex justify-end gap-3 border-t border-gray-200 px-5 py-4 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="cancel()"
+            class="rounded-2xl bg-white px-3.5 py-2 text-sm/6 font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-white/10 dark:text-white dark:ring-white/10 dark:hover:bg-white/20"
+          >
+            {{ result() ? 'Done' : 'Cancel' }}
+          </button>
+          @if (!result()) {
+            <button
+              type="button"
+              (click)="save()"
+              [disabled]="!canSubmit()"
+              class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3.5 py-2 text-sm/6 font-semibold text-white shadow-xs hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              @if (busy()) {
+                <ng-icon name="heroArrowPath" class="size-4 animate-spin" aria-hidden="true" />
+              }
+              {{ busyLabel() }}
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import 'tailwindcss';
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.95); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class ExportDialogComponent implements OnInit {
+  private readonly dialogRef = inject<DialogRef<ExportDialogResult>>(DialogRef);
+  private readonly data = inject<ExportDialogData>(DIALOG_DATA);
+  private readonly exportService = inject(ExportService);
+  private readonly connectorsService = inject(UserConnectorsService);
+  private readonly consentService = inject(OAuthConsentService);
+  private readonly toast = inject(ToastService);
+
+  protected readonly targets = signal<ExportTargetConnector[]>([]);
+  protected readonly loading = signal<boolean>(true);
+  protected readonly loadError = signal<string | null>(null);
+
+  protected readonly selectedConnectorId = signal<string | null>(null);
+  protected readonly selectedFormat = signal<ExportFormat | null>(null);
+  protected readonly include = signal<ExportInclude>({ ...DEFAULT_EXPORT_INCLUDE });
+
+  protected readonly submitting = signal<boolean>(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly result = signal<ExportResponse | null>(null);
+
+  /** Provider whose consent popup is in flight, plus the UI phase. */
+  protected readonly connectingId = signal<string | null>(null);
+  protected readonly connectPhase = signal<ConnectPhase | null>(null);
+
+  protected readonly includeOptions: readonly IncludeOption[] = [
+    { key: 'toolCalls', label: 'Tool calls & results' },
+    { key: 'images', label: 'Images' },
+    { key: 'citations', label: 'Citations' },
+    { key: 'reasoning', label: 'Reasoning' },
+    { key: 'timestamps', label: 'Timestamps' },
+  ];
+
+  protected readonly selectedTarget = computed<ExportTargetConnector | null>(
+    () => this.targets().find((t) => t.providerId === this.selectedConnectorId()) ?? null,
+  );
+
+  protected readonly selectedTargetName = computed<string>(
+    () => this.selectedTarget()?.displayName ?? 'the destination',
+  );
+
+  protected readonly availableFormats = computed<ExportFormat[]>(
+    () => this.selectedTarget()?.supportedFormats ?? [],
+  );
+
+  /** True while either the save request or a consent popup is in flight. */
+  protected readonly busy = computed<boolean>(
+    () => this.submitting() || this.connectPhase() !== null,
+  );
+
+  protected readonly canSubmit = computed<boolean>(
+    () => !!this.selectedTarget() && !!this.selectedFormat() && !this.busy(),
+  );
+
+  protected readonly busyLabel = computed<string>(() => {
+    if (this.connectPhase()) {
+      return 'Connecting…';
+    }
+    if (this.submitting()) {
+      return 'Saving…';
+    }
+    return 'Save';
+  });
+
+  constructor() {
+    // Drive the connect flow off the shared consent service: the
+    // `/oauth-complete` popup broadcasts a completion the service surfaces
+    // here. Mirrors the file-source browser dialog. On success we retry the
+    // save now that the connector is authorized.
+    effect(() => {
+      const completion = this.consentService.completion();
+      if (!completion || !completion.providerId) {
+        return;
+      }
+      const connecting = this.connectingId();
+      if (completion.providerId !== connecting) {
+        return;
+      }
+      this.consentService.acknowledgeCompletion();
+      this.connectingId.set(null);
+      this.connectPhase.set(null);
+      if (completion.status === 'success') {
+        this.markConnected(connecting);
+        void this.save();
+      } else {
+        this.error.set(completion.error ?? 'Could not connect the destination.');
+      }
+    });
+
+    // If the user closes the popup without finishing, the consent service
+    // drops the provider from `inFlightProviders`. Reset the phase so the
+    // Save button becomes interactive again.
+    effect(() => {
+      const inFlight = this.consentService.inFlightProviders();
+      const connecting = this.connectingId();
+      if (connecting && this.connectPhase() === 'awaiting' && !inFlight.has(connecting)) {
+        this.connectingId.set(null);
+        this.connectPhase.set(null);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    void this.loadTargets();
+  }
+
+  protected async loadTargets(): Promise<void> {
+    this.loading.set(true);
+    this.loadError.set(null);
+    try {
+      const targets = await this.exportService.listExportTargets();
+      this.targets.set(targets);
+      // Auto-select when there's only one destination — the common case.
+      if (targets.length === 1) {
+        this.selectConnector(targets[0]);
+      }
+    } catch (err) {
+      this.loadError.set(this.errorMessage(err));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected selectConnector(target: ExportTargetConnector): void {
+    this.selectedConnectorId.set(target.providerId);
+    this.error.set(null);
+    // Prefer a native Google Doc when offered, else the first supported format.
+    const formats = target.supportedFormats;
+    const preferred: ExportFormat | null = formats.includes('google_doc')
+      ? 'google_doc'
+      : (formats[0] ?? null);
+    this.selectedFormat.set(preferred);
+  }
+
+  protected onFormatChange(event: Event): void {
+    this.selectedFormat.set((event.target as HTMLSelectElement).value as ExportFormat);
+  }
+
+  protected toggleInclude(key: keyof ExportInclude): void {
+    this.include.update((inc) => ({ ...inc, [key]: !inc[key] }));
+  }
+
+  protected formatLabel(fmt: ExportFormat): string {
+    return FORMAT_LABELS[fmt] ?? fmt;
+  }
+
+  protected async save(): Promise<void> {
+    const target = this.selectedTarget();
+    const format = this.selectedFormat();
+    if (!target || !format || this.busy()) {
+      return;
+    }
+
+    // An unconnected destination needs consent first; the completion effect
+    // re-enters save() once authorized.
+    if (!target.connected) {
+      await this.connect(target);
+      return;
+    }
+
+    this.submitting.set(true);
+    this.error.set(null);
+    try {
+      const response = await this.exportService.exportSession(this.data.sessionId, {
+        connectorId: target.providerId,
+        format,
+        include: this.include(),
+      });
+      this.result.set(response);
+    } catch (err) {
+      if (err instanceof ExportError && err.status === 409) {
+        // The catalog said connected, but the token expired or was revoked
+        // before we saved. Flip it to unconnected and run consent → retry.
+        this.submitting.set(false);
+        this.markConnected(target.providerId, false);
+        await this.connect(target);
+        return;
+      }
+      this.error.set(this.errorMessage(err));
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  /** Kick off the OAuth consent popup for a destination connector. */
+  private async connect(target: ExportTargetConnector): Promise<void> {
+    this.connectingId.set(target.providerId);
+    this.connectPhase.set('initiating');
+    this.error.set(null);
+    try {
+      const result = await this.connectorsService.initiateConsent(target.providerId);
+      if (result.connected) {
+        // Authorized in another tab while we were here — proceed straight to save.
+        this.connectingId.set(null);
+        this.connectPhase.set(null);
+        this.markConnected(target.providerId);
+        await this.save();
+        return;
+      }
+      if (!result.authorizationUrl) {
+        this.connectingId.set(null);
+        this.connectPhase.set(null);
+        this.toast.error('Unexpected response from the server.');
+        return;
+      }
+      this.consentService.requestConsent(target.providerId, result.authorizationUrl);
+      void this.consentService.openConsentPopup(target.providerId);
+      this.connectPhase.set('awaiting');
+    } catch (err) {
+      this.connectingId.set(null);
+      this.connectPhase.set(null);
+      this.error.set(this.errorMessage(err));
+    }
+  }
+
+  /** Flip a destination's connected flag in local state. */
+  private markConnected(providerId: string, connected = true): void {
+    this.targets.update((list) =>
+      list.map((t) => (t.providerId === providerId ? { ...t, connected } : t)),
+    );
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close(this.result() ?? undefined);
+  }
+
+  private errorMessage(err: unknown): string {
+    if (err instanceof ExportError) {
+      if (err.status === 409) {
+        return 'This destination needs to be connected before you can save to it.';
+      }
+      return err.message;
+    }
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return 'Something went wrong. Try again.';
+  }
+}

--- a/frontend/ai.client/src/app/session/components/export-dialog/index.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/index.ts
@@ -1,0 +1,5 @@
+export {
+  ExportDialogComponent,
+  type ExportDialogData,
+  type ExportDialogResult,
+} from './export-dialog.component';

--- a/frontend/ai.client/src/app/session/services/export/export.model.ts
+++ b/frontend/ai.client/src/app/session/services/export/export.model.ts
@@ -1,0 +1,89 @@
+/**
+ * Models for saving a conversation out to a connected app ("export targets").
+ *
+ * The write-direction mirror of the file-source models: where a file source
+ * reads documents *into* an assistant, an export target writes a conversation
+ * transcript *out* to a connected app (e.g. Google Drive). Shapes match the
+ * app-api `export_targets` endpoints exactly.
+ */
+
+/** Output format an export produces. Matches the backend `ExportFormat` enum. */
+export type ExportFormat = 'google_doc' | 'markdown' | 'pdf';
+
+/**
+ * A connector the current user can save a conversation to, as returned by
+ * `GET /export-targets`. The write-direction analog of `FileSourceConnector`.
+ */
+export interface ExportTargetConnector {
+  providerId: string;
+  displayName: string;
+  iconName: string;
+  /** Optional admin-uploaded icon (base64 data URL). Wins over `iconName`. */
+  iconData?: string | null;
+  /** True when the vault holds a usable token — the user can save straight away. */
+  connected: boolean;
+  /** Output formats this destination accepts, driving the format picker. */
+  supportedFormats: ExportFormat[];
+}
+
+export interface ExportTargetListResponse {
+  exportTargets: ExportTargetConnector[];
+}
+
+/**
+ * Which conversation elements to include in the exported transcript. Sent as
+ * the `include` object on the export request; omitted fields fall back to the
+ * backend defaults. The two message flags are always on (the transcript
+ * itself) and rendered as disabled-checked in the dialog.
+ */
+export interface ExportInclude {
+  userMessages: boolean;
+  assistantMessages: boolean;
+  toolCalls: boolean;
+  images: boolean;
+  citations: boolean;
+  reasoning: boolean;
+  timestamps: boolean;
+}
+
+/** Default include selection — matches the backend `ExportInclude` defaults. */
+export const DEFAULT_EXPORT_INCLUDE: ExportInclude = {
+  userMessages: true,
+  assistantMessages: true,
+  toolCalls: true,
+  images: true,
+  citations: true,
+  reasoning: false,
+  timestamps: false,
+};
+
+/** Body for `POST /sessions/{id}/export`. */
+export interface ExportRequest {
+  connectorId: string;
+  format?: ExportFormat;
+  parentId?: string;
+  include?: ExportInclude;
+}
+
+/**
+ * Receipt for a successful export, persisted on the session so a
+ * "Saved · Open" affordance survives a reload. Matches the backend
+ * `ExportReceipt`.
+ */
+export interface ExportReceipt {
+  connectorId: string;
+  adapterKey: string;
+  format: string;
+  fileId: string;
+  fileName: string;
+  webViewLink?: string | null;
+  exportedAt: string;
+}
+
+/** Result of `POST /sessions/{id}/export`. */
+export interface ExportResponse {
+  fileId: string;
+  name: string;
+  webViewLink?: string | null;
+  receipt: ExportReceipt;
+}

--- a/frontend/ai.client/src/app/session/services/export/export.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/export/export.service.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { ExportService, ExportError } from './export.service';
+import { ConfigService } from '../../../services/config.service';
+
+const API = 'http://localhost:8000';
+
+describe('ExportService', () => {
+  let service: ExportService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ExportService,
+        { provide: ConfigService, useValue: { appApiUrl: signal(API) } },
+      ],
+    });
+    service = TestBed.inject(ExportService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('lists export targets from the catalog response', async () => {
+    const promise = service.listExportTargets();
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${API}/export-targets`);
+      // app-api needs the callback URL to resolve OAuth tokens — without it
+      // the backend raises CallbackUrlUnavailableError (503).
+      expect(req.request.headers.get('OAuth2CallbackUrl')).toMatch(/\/oauth-complete$/);
+      req.flush({
+        exportTargets: [
+          {
+            providerId: 'gdrive',
+            displayName: 'Google Drive',
+            iconName: 'heroCloud',
+            connected: true,
+            supportedFormats: ['google_doc', 'markdown'],
+          },
+        ],
+      });
+    });
+    const result = await promise;
+    expect(result).toHaveLength(1);
+    expect(result[0].providerId).toBe('gdrive');
+    expect(result[0].supportedFormats).toEqual(['google_doc', 'markdown']);
+  });
+
+  it('posts the export request and returns the result', async () => {
+    const promise = service.exportSession('sess-1', {
+      connectorId: 'gdrive',
+      format: 'google_doc',
+      include: {
+        userMessages: true,
+        assistantMessages: true,
+        toolCalls: true,
+        images: true,
+        citations: true,
+        reasoning: false,
+        timestamps: false,
+      },
+    });
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${API}/sessions/sess-1/export`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.connectorId).toBe('gdrive');
+      expect(req.request.body.format).toBe('google_doc');
+      // Token-resolving call must carry the callback header.
+      expect(req.request.headers.get('OAuth2CallbackUrl')).toMatch(/\/oauth-complete$/);
+      req.flush({
+        fileId: 'file-123',
+        name: 'My Chat',
+        webViewLink: 'https://drive.example/file-123',
+        receipt: {
+          connectorId: 'gdrive',
+          adapterKey: 'google-drive',
+          format: 'google_doc',
+          fileId: 'file-123',
+          fileName: 'My Chat',
+          webViewLink: 'https://drive.example/file-123',
+          exportedAt: '2026-06-26T00:00:00Z',
+        },
+      });
+    });
+    const result = await promise;
+    expect(result.fileId).toBe('file-123');
+    expect(result.receipt.adapterKey).toBe('google-drive');
+  });
+
+  it('encodes the session id in the export URL', async () => {
+    const promise = service.exportSession('a/b c', { connectorId: 'gdrive' });
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${API}/sessions/a%2Fb%20c/export`);
+      req.flush({ fileId: 'f', name: 'n', receipt: {} });
+    });
+    await promise;
+  });
+
+  it('wraps an HTTP 409 into an ExportError carrying the status', async () => {
+    const promise = service.exportSession('sess-1', { connectorId: 'gdrive' });
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne(`${API}/sessions/sess-1/export`)
+        .flush({ detail: 'not connected' }, { status: 409, statusText: 'Conflict' });
+    });
+    await expect(promise).rejects.toMatchObject({
+      name: 'ExportError',
+      code: 'HTTP_409',
+      status: 409,
+    });
+    await expect(promise).rejects.toBeInstanceOf(ExportError);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/export/export.service.ts
+++ b/frontend/ai.client/src/app/session/services/export/export.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, inject, computed } from '@angular/core';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../../auth/error.interceptor';
+import {
+  ExportRequest,
+  ExportResponse,
+  ExportTargetConnector,
+  ExportTargetListResponse,
+} from './export.model';
+
+/**
+ * Error raised by {@link ExportService} for any failed call. `code` is
+ * `HTTP_{status}` for server responses (e.g. `HTTP_409` when the connector
+ * needs consent, `HTTP_404` when it isn't an export target) or `UNKNOWN`.
+ * Mirrors `FileSourceError`.
+ */
+export class ExportError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'ExportError';
+  }
+}
+
+/**
+ * Client for the user-facing export-target endpoints (app-api).
+ *
+ * Lets the chat surface discover which connectors can receive a conversation
+ * and save a transcript out to one. All routes live on app-api — the
+ * AgentCore runtime data plane only proxies `/invocations` and `/ping`. The
+ * write-direction mirror of {@link FileSourceService}.
+ */
+@Injectable({ providedIn: 'root' })
+export class ExportService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+  private readonly baseUrl = computed(() => this.config.appApiUrl());
+
+  /**
+   * Header app-api's `AgentCoreContextMiddleware` bridges into
+   * `BedrockAgentCoreContext` so the identity client has a callback URL for
+   * AgentCore Identity. Every export endpoint resolves an OAuth token
+   * server-side, so this must accompany every call — without it the backend
+   * raises `CallbackUrlUnavailableError` (503). Mirrors `FileSourceService`.
+   *
+   * The backend re-appends `provider_id` itself, and the middleware rejects
+   * URLs carrying a query string as a redirect-pivot guard — so we send a
+   * bare `/oauth-complete`.
+   */
+  private callbackHeaders(): Record<string, string> {
+    const callback = new URL('/oauth-complete', window.location.origin);
+    return { OAuth2CallbackUrl: callback.toString() };
+  }
+
+  /**
+   * Per-request options shared by every export call. `SUPPRESS_ERROR_TOAST`
+   * opts these out of the global error toast — the export dialog renders its
+   * own inline, actionable errors (e.g. a Connect button on a 409), so the
+   * generic toast would only be a confusing duplicate.
+   */
+  private requestOptions(): {
+    headers: Record<string, string>;
+    context: HttpContext;
+  } {
+    return {
+      headers: this.callbackHeaders(),
+      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),
+    };
+  }
+
+  /** List the connectors the current user can save a conversation to. */
+  async listExportTargets(): Promise<ExportTargetConnector[]> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<ExportTargetListResponse>(
+          `${this.baseUrl()}/export-targets`,
+          this.requestOptions(),
+        ),
+      );
+      return response.exportTargets;
+    } catch (err) {
+      throw this.toError(err, 'Failed to load export targets');
+    }
+  }
+
+  /** Save a conversation transcript to a connected app. */
+  async exportSession(
+    sessionId: string,
+    request: ExportRequest,
+  ): Promise<ExportResponse> {
+    try {
+      return await firstValueFrom(
+        this.http.post<ExportResponse>(
+          `${this.baseUrl()}/sessions/${encodeURIComponent(sessionId)}/export`,
+          request,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to save the conversation');
+    }
+  }
+
+  private toError(err: unknown, fallback: string): ExportError {
+    if (err instanceof HttpErrorResponse) {
+      const detail = (err.error as { detail?: string; message?: string } | null) ?? null;
+      const message = detail?.detail || detail?.message || err.message || fallback;
+      return new ExportError(message, `HTTP_${err.status}`, err.status);
+    }
+    if (err instanceof Error) {
+      return new ExportError(err.message || fallback, 'UNKNOWN');
+    }
+    return new ExportError(fallback, 'UNKNOWN');
+  }
+}


### PR DESCRIPTION
## PR-4 — "Save to…" conversation export (SPA + admin dropdown)

Fourth PR in the [conversation-export feature](docs/specs/conversation-export-connectors.md), after #507 (scaffold), #508 (Drive adapter + renderer), and #509 (export endpoint). This is the user-facing frontend plus the folded-in admin mapping dropdown.

> **Depends on #509** for the runtime save path (`GET /export-targets`, `POST /sessions/{id}/export`). The admin dropdown works today against the already-merged `GET /admin/export-target-adapters` (#507). Merge #509 first.

### Save-to dialog (`session/`)
- **`ExportService` + `ExportError`** — client for `GET /export-targets` and `POST /sessions/{id}/export`. Mirrors `FileSourceService`: sends the `OAuth2CallbackUrl` header (so app-api can mint the per-user token), opts out of the global error toast, and wraps failures in an `HTTP_{status}`-coded error.
- **`ExportDialogComponent`** (CDK dialog, modern `rounded-2xl`/`bg-blue-600` idiom):
  - Destination picker (the export-capable connectors), format choice gated by each connector's `supportedFormats`, and the include-checkbox group — messages locked-on; tool calls / images / citations on; reasoning / timestamps off.
  - A **not-connected or 409-expired** destination runs the **shared `OAuthConsentService` popup** and retries the save automatically once consent completes — no new consent machinery (reuses the exact pattern from the file-source browser dialog).
  - Success surfaces an **"Open in &lt;app&gt;"** link from `webViewLink`.
- **Wired into the session-list overflow menu** beside Share/Delete as "Save to…".

### Admin mapping dropdown (`admin/connectors/`) — folded in
The parked PR-1 piece: without it, mapping a connector as an export target needed an API/seed call.
- `exportTargetAdapterId` on the connector model + create/update requests.
- An export-target adapter `resource` over `GET /admin/export-target-adapters`.
- An **"Export Target"** dropdown on the connector form with the same provider-compatibility filter, scope-coverage warning, and tri-state (`''` clears / key sets / unchanged omits) save semantics as the file-source dropdown.

### Testing
- `export.service.spec.ts` (4): catalog load + callback header, export POST body/encoding, 409→`ExportError` mapping.
- `export-dialog.component.spec.ts` (6): targets load + auto-select, save success, include toggles, consent kick-off for an unconnected destination, **consent-then-retry**, and cancel-returns-result.
- Regression specs green: `connectors.service`, `session-list`, `file-source-browser-dialog`.
- **Production `ng build` passes** (template typecheck clean; only the pre-existing bundle-budget warning).

### Notes / decisions
- Based on `develop` (not stacked on #509) so the diff is a clean frontend+admin slice — the standard frontend-follows-backend split. The dialog calls #509's endpoints at runtime, so functional end-to-end testing needs #509 merged and an admin-mapped Drive connector.
- No feature flag: the dialog self-gates — it shows "No destinations available" until an admin maps a connector.

### Manual test (after #509 merges + a Drive connector is mapped as an export target)
1. Admin → Connectors → edit the Drive connector → set **Export Target = Google Drive** → save.
2. Open a conversation → sidebar overflow (…) → **Save to…**.
3. Pick Google Drive, choose a format, adjust includes, **Save**. If not connected, the consent popup runs and the save retries.
4. On success, **Open in Google Drive** opens the created Doc; reload the conversation and confirm the "Saved" affordance persists (from the receipt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)