### PR TITLE
feat(export-targets): destination folder picker for "Save to…" (PR-5)

### DIFF
--- a/backend/src/apis/app_api/export_targets/routes.py
+++ b/backend/src/apis/app_api/export_targets/routes.py
@@ -51,6 +51,7 @@ from apis.app_api.export_targets.models import (
     ExportTargetError,
 )
 from apis.app_api.export_targets.registry import registry
+from apis.app_api.file_sources.registry import registry as file_source_registry
 from apis.app_api.export_targets.render import render_transcript
 from apis.app_api.export_targets.service import (
     connector_visible_to_user,
@@ -91,6 +92,12 @@ class ExportTargetConnector(BaseModel):
     # The output formats this destination accepts, so the dialog's format
     # picker offers only what the adapter can actually produce.
     supported_formats: List[str] = Field(..., alias="supportedFormats")
+    # True when this connector is also mapped as a file source, so the SPA can
+    # reuse the import browse dialog to pick a destination folder. Only the
+    # combined-scope Drive connector (drive.readonly + drive.file) qualifies —
+    # `drive.file` alone cannot list folders. False means the export lands in
+    # the adapter's default app folder and the SPA hides the folder picker.
+    browsable: bool
 
 
 class ExportTargetListResponse(BaseModel):
@@ -165,6 +172,18 @@ async def _is_connected(
         )
         return False
     return not result.requires_consent
+
+
+def _is_browsable(provider: OAuthProvider) -> bool:
+    """True when the connector can also back the import browse dialog.
+
+    The destination folder picker reuses the file-source `roots`/`browse`
+    endpoints, which only resolve when the connector is mapped to a shipped
+    file-source adapter (the combined-scope Drive connector). An export-only
+    connector has no folder picker; its exports land in the app folder.
+    """
+    adapter_id = provider.file_source_adapter_id
+    return bool(adapter_id) and file_source_registry.get(adapter_id) is not None
 
 
 async def _collect_transcript(session_id: str, user_id: str) -> List[MessageResponse]:
@@ -253,6 +272,7 @@ async def list_export_targets(
                 supported_formats=[
                     fmt.value for fmt in adapter.metadata.supported_formats
                 ],
+                browsable=_is_browsable(provider),
             )
             for (provider, adapter), connected in zip(candidates, connected_flags)
         ]

--- a/backend/tests/apis/app_api/test_export_routes.py
+++ b/backend/tests/apis/app_api/test_export_routes.py
@@ -117,6 +117,7 @@ def _make_provider(
     enabled: bool = True,
     allowed_roles: Optional[list] = None,
     export_target_adapter_id: Optional[str] = ADAPTER_KEY,
+    file_source_adapter_id: Optional[str] = None,
 ) -> OAuthProvider:
     now = datetime.now(timezone.utc).isoformat() + "Z"
     return OAuthProvider(
@@ -130,6 +131,7 @@ def _make_provider(
         created_at=now,
         updated_at=now,
         export_target_adapter_id=export_target_adapter_id,
+        file_source_adapter_id=file_source_adapter_id,
     )
 
 
@@ -285,6 +287,31 @@ class TestListExportTargets:
         assert [t["providerId"] for t in targets] == ["gdrive"]
         assert targets[0]["connected"] is True
         assert targets[0]["supportedFormats"] == ["google_doc", "markdown"]
+        # Export-only connector (no file_source_adapter_id) → no folder picker.
+        assert targets[0]["browsable"] is False
+
+    def test_browsable_true_for_combined_scope_connector(self, app_with_deps):
+        # A connector also mapped to a shipped file-source adapter backs the
+        # destination folder picker via the reused import browse endpoints.
+        ctx = app_with_deps(
+            providers=[_make_provider("gdrive", file_source_adapter_id="google-drive")],
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        targets = response.json()["exportTargets"]
+        assert targets[0]["browsable"] is True
+
+    def test_browsable_false_for_unshipped_file_source_adapter(self, app_with_deps):
+        # An admin can map a file_source_adapter_id that no longer ships; the
+        # picker would 404, so the catalog reports it as not browsable.
+        ctx = app_with_deps(
+            providers=[_make_provider("gdrive", file_source_adapter_id="ghost")],
+        )
+        response = TestClient(ctx.app).get("/export-targets")
+
+        assert response.status_code == 200
+        assert response.json()["exportTargets"][0]["browsable"] is False
 
     def test_includes_role_gated_connector_when_user_has_role(self, app_with_deps):
         ctx = app_with_deps(

--- a/docs/specs/google-tasks-todo.md
+++ b/docs/specs/google-tasks-todo.md
@@ -1,0 +1,276 @@
+# Spec: Google Tasks Todo Integration
+
+**Status:** Approved direction, not yet implemented
+**Audience:** A fresh implementation session with no prior context — this doc is self-contained.
+**Owner:** Phil Merrell
+**Last updated:** 2026-06-23
+
+---
+
+## 1. One-line summary
+
+Give students, staff, and faculty a conversational todo capability by **federating to Google
+Tasks** — the assistant reads and writes tasks in the user's own Google account via the existing
+AgentCore Identity OAuth flow. No new database. The headline value is **syncing Canvas deadlines
+into Google Tasks**, so the list is never empty and tasks land on the user's phone automatically.
+
+---
+
+## 2. Decisions already made (do not re-litigate)
+
+These were settled in a strategy discussion. Treat them as fixed inputs:
+
+| Decision | Choice | Why |
+|---|---|---|
+| **Source of truth** | **Federate to Google Tasks** (not an owned DynamoDB store) | Counters the "empty walled-garden todo app nobody adopts" trap. Tasks appear instantly in Gmail sidebar, Google Calendar, and the Google Tasks mobile app. |
+| **Institutional ecosystem** | **Google Workspace** | Boise State is a Google shop, so Google Tasks/Calendar is the native surface. |
+| **Mechanism** | A **first-party agent tool** calling the Google Tasks REST API with a **user-delegated OAuth token from the AgentCore Identity vault** | The OAuth plumbing already exists; no DB, no custom service, no Gateway SigV4 hop needed. |
+| **Surface (phase 1)** | **Plain local tool** returning structured results | Fastest path to validate the federation loop. |
+| **Surface (later)** | **MCP App panel** (interactive inline checklist) | Highest-payoff UX for a todo list; additive, shares the same Google Tasks calls underneath. |
+
+### Explicitly deferred / non-goals
+
+- **No owned todo DynamoDB table.** Google is the store.
+- **No Microsoft To Do / Graph.** Google-only.
+- **No custom standalone todo service or external MCP server** in phase 1. (An MCP server only
+  appears in phase 3, and only to get the App panel surface.)
+- **No timed push reminders in phase 1** — see the Google Tasks constraints below.
+
+---
+
+## 3. Phasing
+
+1. **Phase 1 — Federation loop (the foundation).** A local tool that lists / creates / completes /
+   updates / deletes tasks in the user's Google Tasks `@default` list. Prove OAuth scopes, consent,
+   and the API calls end-to-end. Returns structured text results.
+2. **Phase 2 — Canvas → Google Tasks sync (the headline value).** Pull the user's Canvas assignment
+   deadlines (the Canvas OAuth provider already exists) and write them into Google Tasks. This is the
+   feature worth marketing; generic CRUD is table stakes.
+3. **Phase 3 — Surface + timed reminders.** Wrap the capability in an **MCP App panel** for an
+   interactive inline checklist, and use **Google Calendar** (same Google OAuth) for anything that
+   needs a time-of-day reminder, since Google Tasks cannot (see §6).
+
+Ship and validate Phase 1 before starting Phase 2.
+
+---
+
+## 4. Existing infrastructure to reuse
+
+> File:line references are orientation pointers gathered during planning — **confirm them against
+> the current code** before relying on them; line numbers drift.
+
+### OAuth token retrieval (already built, production-ready)
+- `apis/shared/oauth/agentcore_identity.py` — `AgentCoreIdentityClient.get_token_for_user()`.
+  Signature (keyword-only):
+  ```python
+  async def get_token_for_user(
+      *, provider_name: str, scopes: List[str],
+      callback_url: Optional[str] = None,
+      force_authentication: bool = False,
+      user_id: Optional[str] = None,
+      custom_state: Optional[str] = None,
+      custom_parameters: Optional[Dict[str, str]] = None,
+  ) -> TokenResult
+  ```
+- `TokenResult` (same file): `access_token: Optional[str]`, `authorization_url: Optional[str]`,
+  and a `requires_consent` property (true when `access_token is None and authorization_url is not
+  None`). Consent-required is a **normal outcome, not an error**.
+- Google baseline `custom_parameters` (`access_type=offline`, plus `prompt=consent` on forced
+  re-auth) is injected automatically by `custom_parameters_for(...)` / `_vendor_baseline_params(...)`
+  in the same file. **Do not hand-roll these.**
+
+### Consent surfacing (already built)
+- `apis/shared/agents/main_agent/session/hooks/oauth_consent.py` — `OAuthConsentHook` is a
+  **BeforeToolCall hook** that calls `get_token_for_user()` *before* the tool runs and, when consent
+  is required, raises a Strands interrupt:
+  ```python
+  event.interrupt(name=f"oauth:{provider_id}", reason={
+      "type": "oauth_required", "providerId": provider_id,
+      "authorizationUrl": url,
+  })
+  ```
+  which becomes the `oauth_required` SSE event the SPA already knows how to handle (popup → consent →
+  `/api/connectors/complete-consent` → resume). **This is the path to reuse for consent — see §5
+  Decision A.**
+
+### OAuth provider records (where scopes live)
+- `apis/shared/oauth/models.py` — `OAuthProvider` dataclass; `scopes: List[str]`,
+  `provider_type: OAuthProviderType` (has `GOOGLE`), `custom_parameters`.
+- `apis/shared/oauth/provider_repository.py` — read/write provider records in the
+  `DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME` table.
+- **Scopes are stored as DATA in DynamoDB, not in code.** The Google provider record's `scopes` list
+  is the source of truth.
+
+### Tool registration
+- New first-party tool → `backend/src/agents/local_tools/<name>.py` decorated with
+  `@tool` from `strands` (pattern: `local_tools/url_fetcher.py`).
+- Export the tool functions in `backend/src/agents/local_tools/__init__.py`'s `__all__`.
+- `backend/src/agents/main_agent/tools/tool_registry.py` discovers them via
+  `registry.register_module_tools(local_tools)` in `create_default_registry()`.
+- **Note a CLAUDE.md discrepancy:** CLAUDE.md says new tools go in
+  `backend/src/agents/main_agent/tools/`. The live code uses `local_tools/` + `builtin_tools/`.
+  Follow the live `local_tools/` pattern (confirm by reading `tool_registry.py`).
+
+### Tool return shape
+Strands-compatible dict, not a plain value:
+```python
+# success
+{"content": [{"json": { ... }}], "status": "success"}
+# error
+{"content": [{"json": {"error": "..."}}], "status": "error"}
+```
+
+### RBAC / tool gating
+- Tool access is granted per-role in DynamoDB AppRole records (`granted_tools` →
+  `effective_permissions.tools`), see `apis/shared/rbac/models.py` and `service.py`.
+- After building the tool, **the tool IDs must be added to the appropriate AppRole(s)** (e.g. a
+  student role) or the tool stays invisible. Persona-scoped grants are a feature here, not a chore —
+  students vs. faculty can get different task tooling via RBAC.
+
+### MCP Apps host (for phase 3 only)
+- Deployed and enabled by default (`AGENTCORE_MCP_APPS_HOST_ENABLED` default true; sandbox origin
+  wired through `PlatformComputeRefs` → `AGENTCORE_MCP_APPS_SANDBOX_ORIGIN`). The `ui_resource` SSE
+  path is emitted from `agents/main_agent/streaming/stream_coordinator.py`.
+- **Important:** the `ui_resource` App-panel path is wired to **MCP** tools. A pure local Strands
+  tool will not get an App panel. Phase 3 therefore means exposing the Google Tasks capability via an
+  **MCP server that advertises a `ui://` resource**, not the phase-1 local tool. Plan for this fork.
+
+---
+
+## 5. Key design decisions to resolve FIRST
+
+### Decision A — How consent is triggered (most important)
+
+The established, working pattern is the **pre-flight `OAuthConsentHook`**: it acquires/refreshes the
+token (and surfaces `oauth_required`) *before* the tool body runs, using a tool→provider mapping.
+The tool body then calls `get_token_for_user()` expecting a token to be present.
+
+- **Recommended:** wire the new Google Tasks tool(s) into the consent hook's tool→provider lookup so
+  consent is handled pre-flight, exactly like existing OAuth-backed tools. Read `oauth_consent.py`
+  and find how it resolves a tool_use to a provider (the `tool_use_provider_lookup` mechanism). This
+  reuses the proven path and the SPA's existing `oauth_required` handling with zero new UX.
+- **Avoid** the naive "tool returns an error dict with `authorization_url`" approach — the tool body
+  has no access to the interrupt mechanism, so it cannot cleanly surface consent mid-execution. If
+  the pre-flight hook cannot be made to cover a first-party local tool, escalate this as a blocker
+  rather than inventing a parallel consent path.
+
+**First task of the implementing session: read `oauth_consent.py` and confirm exactly how a tool is
+associated with a provider, then extend that association for the new tool.**
+
+### Decision B — Which Google provider record, and the scope
+
+- Discover the **actual deployed Google provider id** (do not assume `"google-workspace"`) by
+  inspecting the OAuth providers table / admin connectors UI. Use that id as `provider_name`.
+- Add the Tasks scope **`https://www.googleapis.com/auth/tasks`** (read/write) to that provider
+  record's `scopes` list. Use `tasks.readonly` only if you want a read-only variant.
+- **Vault-key gotcha (known issue, see memory):** the token vault key includes `(provider, scopes,
+  customParameters)`. Token retrieval must request the **same scopes and customParameters** used at
+  consent time, or it falsely reports consent-required. Keep one canonical scope list + let
+  `custom_parameters_for()` own the Google baseline params — don't pass ad-hoc customParameters.
+- **Incremental-auth note:** adding the Tasks scope to an existing Google provider that already
+  requests other scopes (e.g. Drive for RAG) means existing users will be re-prompted to consent to
+  the widened scope. Decide whether to (a) widen the existing provider's scope list (one consent
+  covers everything) or (b) request the tasks scope incrementally. Document the choice.
+
+### Decision C — Where `user_id` comes from inside the tool
+
+The consent hook gets `user_id` from the agent context. Confirm how the tool body obtains the current
+user id in the inference-api agent loop (context injection vs. tool parameter) by following how
+`oauth_consent.py` resolves `self._user_id`. Do **not** invent a new way to pass user identity.
+
+---
+
+## 6. Google Tasks API reference & hard constraints
+
+Design within these — they shape what you can promise users:
+
+- **Scope:** `https://www.googleapis.com/auth/tasks` (rw) or `.../tasks.readonly`.
+- **Base:** `https://tasks.googleapis.com/tasks/v1`. Default task list = `@default`.
+  - List tasks: `GET /lists/@default/tasks`
+  - Create: `POST /lists/@default/tasks`
+  - Update: `PATCH /lists/@default/tasks/{taskId}`
+  - Complete: PATCH with `{"status": "completed"}`
+  - Delete: `DELETE /lists/@default/tasks/{taskId}`
+  - Task lists: `GET/POST /users/@me/lists`
+- **Task fields:** `title`, `notes`, `due`, `status` (`needsAction` | `completed`), `parent`
+  (one level of subtasks), `position`.
+- **CONSTRAINT — `due` is date-only.** The API accepts an RFC-3339 timestamp but **discards the
+  time of day and timezone**. "Submit by 3pm Friday" stores as just "Friday." Do not promise
+  time-of-day due times via Tasks.
+- **CONSTRAINT — no reminder/notification times via the API.** Google Tasks will not push a timed
+  "remind me at 9am" notification; it only surfaces due-*dates*. Proactive timed nudging is **not**
+  achievable with Tasks alone.
+- **CONSTRAINT — thin metadata.** No priority, no tags, no custom fields, one subtask level.
+- **Mitigation for the two constraints above (phase 3):** pair Tasks with **Google Calendar**
+  (same Google OAuth) for time-sensitive items — Calendar events carry times and notifications.
+  Frame it as "Tasks for to-dos, Calendar for timed reminders."
+
+---
+
+## 7. Phase 1 implementation checklist
+
+1. **Confirm the consent wiring (Decision A)** — read `oauth_consent.py`; extend the tool→provider
+   association for the new tool.
+2. **Configure the provider (Decision B)** — find the real Google provider id; add the tasks scope
+   to its DynamoDB record; document the incremental-auth choice.
+3. **Build `backend/src/agents/local_tools/google_tasks.py`** with `@tool`-decorated functions, e.g.
+   `list_tasks`, `create_task`, `complete_task`, `update_task`, `delete_task`. Each:
+   - obtains `user_id` per Decision C,
+   - calls `get_token_for_user(provider_name=<google id>, scopes=["https://www.googleapis.com/auth/tasks"], user_id=...)`,
+   - calls the Google Tasks REST endpoint with the bearer token,
+   - returns the Strands `{"content": [{"json": ...}], "status": ...}` shape,
+   - translates the date-only `due` constraint clearly in its docstring (the docstring is the model's
+     contract — state that time-of-day is not supported).
+4. **Register** the functions in `local_tools/__init__.py` `__all__`.
+5. **Grant** the new tool IDs to the appropriate AppRole(s) so they're visible to target users.
+6. **Tests** — add pytest coverage (mock the Google API + the identity client). See §8.
+7. **Manual verification** — exercise the consent popup → token → CRUD loop against a real Google
+   account in a dev environment.
+
+---
+
+## 8. Conventions & guardrails (from CLAUDE.md / repo memory)
+
+- **Backend pytest is the ONLY correctness gate — it is not run in CI.** Run the full local suite
+  for any shared/auth/tool change:
+  ```bash
+  cd backend && uv sync --extra agentcore --extra dev
+  uv run python -m pytest tests/ -v
+  ```
+- **Service boundaries:** `app_api`, `inference_api`, and `agents/` import only from `apis.shared`,
+  never from each other (enforced by `tests/architecture/test_import_boundaries.py`). The tool lives
+  under `agents/` and must use `apis.shared.oauth.*` for token retrieval.
+- **Do NOT add routes to inference-api.** If any user-facing CRUD endpoint is needed (it should not
+  be for phase 1), it goes in `app_api` with `Depends(get_current_user_from_session)`.
+- **Exact version pins only** — no `^`, `~`, `>=`. **Never install a package without explicit user
+  approval** (prefer `httpx`/stdlib already in the project over a new Google client library; confirm
+  before adding any dependency).
+- **Git:** branch from `develop` (never `main`); branch name `feature/google-tasks-todo`; PR targets
+  `develop`; conventional commits (`feat:`, `fix:`, …); one logical change per commit; no
+  commented-out code.
+- **No `print()`** — use `logging`. Type hints on all signatures.
+
+---
+
+## 9. Open questions for the implementing session
+
+1. **Consent wiring (Decision A):** does the pre-flight `OAuthConsentHook` tool→provider mechanism
+   support a first-party local tool, or is it MCP/Gateway-specific? Resolve before writing the tool.
+2. **Provider id & scope strategy (Decision B):** what is the real Google provider id, and do we
+   widen its existing scope list or request the tasks scope incrementally?
+3. **HTTP client:** confirm an approved HTTP library is already in `agents/` deps before coding the
+   REST calls; do not add a Google SDK without approval.
+4. **Multiple task lists:** phase 1 targets `@default` only — confirm that's acceptable, or whether
+   per-persona task lists are wanted.
+
+---
+
+## 10. Why this shape (one paragraph for reviewers)
+
+The expensive infrastructure — AgentCore Identity OAuth, the token vault, the `oauth_required`
+consent UX, the Google provider, the Canvas provider, and the MCP Apps host — already exists. The
+only genuinely new code is a thin tool that calls Google Tasks with a vaulted token. Federating to
+Google (rather than owning a DynamoDB todo store) trades data ownership and a custom UI for instant
+cross-surface presence (mobile, Gmail, Calendar) and zero new FERPA-relevant storage, and it makes
+the real differentiator — Canvas deadlines flowing into the user's own task surface — a natural
+phase 2 rather than a separate product.

--- a/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.html
+++ b/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.html
@@ -16,7 +16,9 @@
   >
     <div class="flex items-center justify-between gap-4 border-b border-gray-200 px-5 py-4 dark:border-gray-700">
       <h2 id="fsb-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
-        @if (view() === 'browser' && connector(); as conn) {
+        @if (isPicker) {
+          Choose a destination folder
+        } @else if (view() === 'browser' && connector(); as conn) {
           {{ conn.displayName }}
         } @else {
           Import from a connector
@@ -182,7 +184,7 @@
             } @else {
               <button
                 type="button"
-                (click)="openFolder(crumb.id)"
+                (click)="openFolder(crumb.id, crumb.name)"
                 class="rounded-2xl px-1 hover:text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:text-white"
               >
                 {{ crumb.name }}
@@ -229,12 +231,23 @@
         } @else if (displayedEntries().length === 0) {
           <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
             <p class="text-sm/6 text-gray-500 dark:text-gray-400">
-              @if (activeSearch()) {
+              @if (isPicker) {
+                @if (activeSearch()) {
+                  No folders match your search.
+                } @else {
+                  This folder has no subfolders.
+                }
+              } @else if (activeSearch()) {
                 No files match your search.
               } @else {
                 This folder is empty.
               }
             </p>
+            @if (isPicker && currentFolderId() !== null) {
+              <p class="mt-1 text-xs/5 text-gray-400 dark:text-gray-500">
+                You can still save here, or open a subfolder.
+              </p>
+            }
           </div>
         } @else {
           <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
@@ -296,30 +309,59 @@
 
       <!-- Footer -->
       <div class="flex items-center justify-between gap-4 border-t border-gray-200 px-5 py-3 dark:border-gray-700">
-        <span class="text-sm/6 text-gray-500 dark:text-gray-400">{{ selectedCount() }} selected</span>
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            (click)="cancel()"
-            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            (click)="importSelected()"
-            [disabled]="selectedCount() === 0 || importing()"
-            class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
-          >
-            @if (importing()) {
-              <div class="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white"></div>
-              Importing…
+        @if (isPicker) {
+          <span class="min-w-0 flex-1 truncate text-sm/6 text-gray-500 dark:text-gray-400">
+            @if (currentFolderId() !== null) {
+              Save to
+              <span class="font-medium text-gray-700 dark:text-gray-200">{{ currentFolderName() || 'this folder' }}</span>
             } @else {
-              <ng-icon name="heroArrowDownTray" class="size-4" />
-              Import {{ selectedCount() > 0 ? selectedCount() : '' }}
+              Open a folder to choose it
             }
-          </button>
-        </div>
+          </span>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              (click)="cancel()"
+              class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              (click)="pickCurrentFolder()"
+              [disabled]="!canPickCurrentFolder()"
+              class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              <ng-icon name="heroFolder" class="size-4" />
+              Use this folder
+            </button>
+          </div>
+        } @else {
+          <span class="text-sm/6 text-gray-500 dark:text-gray-400">{{ selectedCount() }} selected</span>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              (click)="cancel()"
+              class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              (click)="importSelected()"
+              [disabled]="selectedCount() === 0 || importing()"
+              class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              @if (importing()) {
+                <div class="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white"></div>
+                Importing…
+              } @else {
+                <ng-icon name="heroArrowDownTray" class="size-4" />
+                Import {{ selectedCount() > 0 ? selectedCount() : '' }}
+              }
+            </button>
+          </div>
+        }
       </div>
     }
   </div>

--- a/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.spec.ts
@@ -23,7 +23,10 @@ function fileEntry(over: Partial<FileEntry>): FileEntry {
   return { id: 'f1', name: 'a.txt', type: 'file', selectable: true, ...over };
 }
 
-function setup(fileSourceOverrides: Partial<Record<string, unknown>> = {}) {
+function setup(
+  fileSourceOverrides: Partial<Record<string, unknown>> = {},
+  dialogData: Record<string, unknown> = { assistantId: 'AST-1' },
+) {
   const fileSourceService = {
     listFileSources: vi.fn().mockResolvedValue([CONNECTED]),
     listRoots: vi.fn().mockResolvedValue([{ id: 'root', name: 'My Drive' }]),
@@ -48,7 +51,7 @@ function setup(fileSourceOverrides: Partial<Record<string, unknown>> = {}) {
     providers: [
       provideHttpClient(),
       provideHttpClientTesting(),
-      { provide: DIALOG_DATA, useValue: { assistantId: 'AST-1' } },
+      { provide: DIALOG_DATA, useValue: dialogData },
       { provide: DialogRef, useValue: dialogRef },
       { provide: FileSourceService, useValue: fileSourceService },
       { provide: UserConnectorsService, useValue: connectorsService },
@@ -135,5 +138,65 @@ describe('FileSourceBrowserDialogComponent', () => {
       { fileId: 'f1', name: 'a.txt' },
     ]);
     expect(dialogRef.close).toHaveBeenCalledWith([{ documentId: 'DOC-1' }]);
+  });
+
+  describe('pick-folder mode', () => {
+    it('opens straight into the targeted connector and loads roots', async () => {
+      const { component, fileSourceService } = setup(
+        // Two roots so it stays on the roots list rather than auto-drilling in.
+        {
+          listRoots: vi.fn().mockResolvedValue([
+            { id: 'root', name: 'My Drive' },
+            { id: 'shared', name: 'Shared with me' },
+          ]),
+        },
+        { connector: CONNECTED, mode: 'pick-folder' },
+      );
+
+      await vi.waitFor(() => {
+        expect(fileSourceService.listRoots).toHaveBeenCalledWith('google');
+        expect((component['view'] as () => string)()).toBe('browser');
+      });
+      expect((component['isPicker'] as boolean)).toBe(true);
+      // Nothing selectable until the user drills into a folder.
+      expect((component['canPickCurrentFolder'] as () => boolean)()).toBe(false);
+    });
+
+    it('shows only folders, not files, while browsing', async () => {
+      const { component } = setup(
+        {
+          browse: vi.fn().mockResolvedValue({
+            entries: [
+              fileEntry({ id: 'sub', name: 'Subfolder', type: 'folder', selectable: false }),
+              fileEntry({ id: 'doc', name: 'notes.txt', type: 'file', selectable: true }),
+            ],
+            breadcrumbs: [],
+            nextCursor: null,
+          }),
+        },
+        { connector: CONNECTED, mode: 'pick-folder' },
+      );
+      // Single root auto-drills into the folder, populating entries.
+      await vi.waitFor(() =>
+        expect((component['currentFolderId'] as () => string | null)()).toBe('root'),
+      );
+
+      const shown = (component['displayedEntries'] as () => FileEntry[])();
+      expect(shown.map((e) => e.id)).toEqual(['sub']);
+    });
+
+    it('closes with the current folder as the selection', async () => {
+      const { component, dialogRef } = setup(
+        { browse: vi.fn().mockResolvedValue({ entries: [], breadcrumbs: [], nextCursor: null }) },
+        { connector: CONNECTED, mode: 'pick-folder' },
+      );
+      await vi.waitFor(() =>
+        expect((component['currentFolderId'] as () => string | null)()).toBe('root'),
+      );
+
+      expect((component['canPickCurrentFolder'] as () => boolean)()).toBe(true);
+      (component['pickCurrentFolder'] as () => void)();
+      expect(dialogRef.close).toHaveBeenCalledWith({ folderId: 'root', folderName: 'My Drive' });
+    });
   });
 });

--- a/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/file-source-browser-dialog.component.ts
@@ -35,29 +35,60 @@ import { UserConnectorsService } from '../../settings/connectors/services/user-c
 import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
 import { ToastService } from '../../services/toast/toast.service';
 
-/** Data passed in when the assistant editor opens the browser. */
+/**
+ * What the dialog is for. `import` (default) multi-selects files to ingest
+ * into an assistant; `pick-folder` walks the same folder tree but selects a
+ * single destination folder (the conversation-export folder picker) and never
+ * imports anything.
+ */
+export type FileSourceBrowserMode = 'import' | 'pick-folder';
+
+/** Data passed in when a caller opens the browser. */
 export interface FileSourceBrowserDialogData {
-  assistantId: string;
+  /** Required in `import` mode — the assistant the files are imported into. */
+  assistantId?: string;
   /**
    * When set, the dialog opens straight into this connector — its folder
    * browser if already connected, or an inline Connect prompt if not — and
    * hides the source picker. The assistant editor surfaces each connector as
    * its own button, so the in-modal source list is redundant when targeted.
+   * `pick-folder` mode always targets a connector this way.
    */
   connector?: FileSourceConnector;
+  /** Defaults to `import`. */
+  mode?: FileSourceBrowserMode;
 }
+
+/** A destination folder chosen in `pick-folder` mode. */
+export interface FolderSelection {
+  /** Provider folder id to write into; a provider root id is valid too. */
+  folderId: string;
+  /** Human-readable name of the chosen folder, for display. */
+  folderName: string;
+}
+
+/**
+ * Closed value: the imported {@link Document} records in `import` mode, a
+ * {@link FolderSelection} in `pick-folder` mode, or `undefined` if cancelled.
+ */
+export type FileSourceBrowserDialogResult = Document[] | FolderSelection;
 
 type DialogView = 'sources' | 'browser';
 type ConnectPhase = 'initiating' | 'awaiting';
 
 /**
- * Modal that lets a user import files from a connected file source into an
- * assistant's RAG index.
+ * Modal that walks a connected file source's folder tree.
+ *
+ * In `import` mode (default) the user multi-selects files to ingest into an
+ * assistant's RAG index. In `pick-folder` mode the same browser is reused to
+ * choose a single destination folder — the conversation-export folder picker —
+ * and nothing is imported.
  *
  * Flow: pick a file source (connecting it via the OAuth consent popup if
- * needed) → browse the provider's folder tree or search → multi-select
- * files → import. Closes with the created {@link Document} records, or
- * `undefined` if cancelled.
+ * needed) → browse the provider's folder tree or search → either multi-select
+ * files and import, or select the current folder. Closes with the created
+ * {@link Document} records, a {@link FolderSelection}, or `undefined` if
+ * cancelled.
  */
 @Component({
   selector: 'app-file-source-browser-dialog',
@@ -119,12 +150,18 @@ type ConnectPhase = 'initiating' | 'awaiting';
   `,
 })
 export class FileSourceBrowserDialogComponent {
-  private readonly dialogRef = inject<DialogRef<Document[]>>(DialogRef);
+  private readonly dialogRef =
+    inject<DialogRef<FileSourceBrowserDialogResult>>(DialogRef);
   private readonly data = inject<FileSourceBrowserDialogData>(DIALOG_DATA);
   private readonly fileSourceService = inject(FileSourceService);
   private readonly connectorsService = inject(UserConnectorsService);
   private readonly consentService = inject(OAuthConsentService);
   private readonly toast = inject(ToastService);
+
+  /** `import` (default) or `pick-folder` for the export destination picker. */
+  protected readonly mode: FileSourceBrowserMode = this.data.mode ?? 'import';
+  /** True when choosing a destination folder rather than importing files. */
+  protected readonly isPicker = this.mode === 'pick-folder';
 
   /** True when the dialog was opened targeting a single connector. */
   protected readonly lockedToConnector = !!this.data.connector;
@@ -146,6 +183,12 @@ export class FileSourceBrowserDialogComponent {
   protected readonly roots = signal<SourceRoot[]>([]);
   /** Current folder id; `null` means the top-level roots list is shown. */
   protected readonly currentFolderId = signal<string | null>(null);
+  /**
+   * Name of the current folder, tracked client-side as the user navigates (the
+   * adapter returns a flat page, not a path). Drives the `pick-folder`
+   * selection label; empty at the roots list.
+   */
+  protected readonly currentFolderName = signal<string>('');
   protected readonly breadcrumbs = signal<Breadcrumb[]>([]);
   protected readonly entries = signal<FileEntry[]>([]);
   protected readonly nextCursor = signal<string | null>(null);
@@ -183,10 +226,19 @@ export class FileSourceBrowserDialogComponent {
         selectable: false,
       }));
     }
+    // The folder picker navigates folders only; files would just be noise.
+    if (this.isPicker) {
+      return this.entries().filter((entry) => entry.type === 'folder');
+    }
     return this.entries();
   });
 
   protected readonly selectedCount = computed(() => this.selected().size);
+
+  /** True once the user has drilled into a folder/root they can select. */
+  protected readonly canPickCurrentFolder = computed(
+    () => this.currentFolderId() !== null && !this.browserLoading(),
+  );
 
   constructor() {
     const preselected = this.data.connector;
@@ -312,7 +364,7 @@ export class FileSourceBrowserDialogComponent {
       this.roots.set(roots);
       // A single root is an implementation detail — drop the user straight in.
       if (roots.length === 1) {
-        await this.openFolder(roots[0].id);
+        await this.openFolder(roots[0].id, roots[0].name);
       } else {
         this.browserLoading.set(false);
       }
@@ -333,7 +385,7 @@ export class FileSourceBrowserDialogComponent {
     }
   }
 
-  protected async openFolder(folderId: string): Promise<void> {
+  protected async openFolder(folderId: string, folderName = ''): Promise<void> {
     const connector = this.connector();
     if (!connector) {
       return;
@@ -341,6 +393,7 @@ export class FileSourceBrowserDialogComponent {
     this.activeSearch.set(null);
     this.searchTerm.set('');
     this.currentFolderId.set(folderId);
+    this.currentFolderName.set(folderName);
     this.entries.set([]);
     this.breadcrumbs.set([]);
     this.nextCursor.set(null);
@@ -364,6 +417,7 @@ export class FileSourceBrowserDialogComponent {
     this.activeSearch.set(null);
     this.searchTerm.set('');
     this.currentFolderId.set(null);
+    this.currentFolderName.set('');
     this.entries.set([]);
     this.breadcrumbs.set([]);
     this.nextCursor.set(null);
@@ -373,10 +427,22 @@ export class FileSourceBrowserDialogComponent {
 
   protected onEntryActivate(entry: FileEntry): void {
     if (entry.type === 'folder') {
-      void this.openFolder(entry.id);
+      void this.openFolder(entry.id, entry.name);
     } else {
       this.toggleSelect(entry);
     }
+  }
+
+  /** Close with the current folder as the chosen export destination. */
+  protected pickCurrentFolder(): void {
+    const folderId = this.currentFolderId();
+    if (folderId === null) {
+      return;
+    }
+    this.dialogRef.close({
+      folderId,
+      folderName: this.currentFolderName() || 'Selected folder',
+    });
   }
 
   protected toggleSelect(entry: FileEntry): void {
@@ -466,14 +532,15 @@ export class FileSourceBrowserDialogComponent {
 
   protected async importSelected(): Promise<void> {
     const connector = this.connector();
+    const assistantId = this.data.assistantId;
     const files = [...this.selected().values()];
-    if (!connector || files.length === 0 || this.importing()) {
+    if (!connector || !assistantId || files.length === 0 || this.importing()) {
       return;
     }
     this.importing.set(true);
     try {
       const response = await this.fileSourceService.importDocuments(
-        this.data.assistantId,
+        assistantId,
         connector.providerId,
         files,
       );
@@ -501,6 +568,7 @@ export class FileSourceBrowserDialogComponent {
   private resetBrowserState(): void {
     this.roots.set([]);
     this.currentFolderId.set(null);
+    this.currentFolderName.set('');
     this.breadcrumbs.set([]);
     this.entries.set([]);
     this.nextCursor.set(null);

--- a/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
+import { Dialog, DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExportDialogComponent } from './export-dialog.component';
@@ -17,10 +18,15 @@ const CONNECTED: ExportTargetConnector = {
   iconName: 'heroCloud',
   connected: true,
   supportedFormats: ['google_doc', 'markdown'],
+  browsable: false,
 };
 const NOT_CONNECTED: ExportTargetConnector = { ...CONNECTED, connected: false };
+const BROWSABLE: ExportTargetConnector = { ...CONNECTED, browsable: true };
 
-function setup(exportOverrides: Partial<Record<string, unknown>> = {}) {
+function setup(
+  exportOverrides: Partial<Record<string, unknown>> = {},
+  dialogOverride?: Partial<Record<string, unknown>>,
+) {
   const exportService = {
     listExportTargets: vi.fn().mockResolvedValue([CONNECTED]),
     exportSession: vi.fn().mockResolvedValue({
@@ -49,6 +55,13 @@ function setup(exportOverrides: Partial<Record<string, unknown>> = {}) {
     acknowledgeCompletion: vi.fn(),
   };
   const toast = { error: vi.fn(), success: vi.fn() };
+  // CDK Dialog used to open the folder picker; closes with a FolderSelection.
+  const dialog = {
+    open: vi.fn().mockReturnValue({
+      closed: of({ folderId: 'folder-9', folderName: 'Reports' }),
+    }),
+    ...dialogOverride,
+  };
 
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
@@ -57,6 +70,7 @@ function setup(exportOverrides: Partial<Record<string, unknown>> = {}) {
       provideHttpClientTesting(),
       { provide: DIALOG_DATA, useValue: { sessionId: 'sess-1', title: 'My Chat' } },
       { provide: DialogRef, useValue: dialogRef },
+      { provide: Dialog, useValue: dialog },
       { provide: ExportService, useValue: exportService },
       { provide: UserConnectorsService, useValue: connectorsService },
       { provide: OAuthConsentService, useValue: consentService },
@@ -67,7 +81,7 @@ function setup(exportOverrides: Partial<Record<string, unknown>> = {}) {
   const fixture = TestBed.createComponent(ExportDialogComponent);
   fixture.detectChanges();
   const component = fixture.componentInstance as unknown as Record<string, never>;
-  return { fixture, component, exportService, dialogRef, connectorsService, consentService, toast };
+  return { fixture, component, exportService, dialogRef, dialog, connectorsService, consentService, toast };
 }
 
 describe('ExportDialogComponent', () => {
@@ -152,6 +166,66 @@ describe('ExportDialogComponent', () => {
       );
     });
     expect(consentService.acknowledgeCompletion).toHaveBeenCalled();
+  });
+
+  it('offers the folder picker only for a browsable destination', async () => {
+    const { component } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([BROWSABLE]),
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+    expect((component['canChooseFolder'] as () => boolean)()).toBe(true);
+    // Default destination is the app folder until a folder is chosen.
+    expect((component['destinationLabel'] as () => string)()).toBe('App folder');
+  });
+
+  it('hides the folder picker for a non-browsable destination', async () => {
+    const { component } = setup();
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+    expect((component['canChooseFolder'] as () => boolean)()).toBe(false);
+  });
+
+  it('passes the chosen folder as parentId on save', async () => {
+    const { component, dialog, exportService } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([BROWSABLE]),
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['chooseFolder'] as () => Promise<void>)();
+    expect(dialog.open).toHaveBeenCalled();
+    expect((component['destinationLabel'] as () => string)()).toBe('Reports');
+
+    await (component['save'] as () => Promise<void>)();
+    expect(exportService.exportSession).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ connectorId: 'gdrive', parentId: 'folder-9' }),
+    );
+  });
+
+  it('saves to the app folder (no parentId) when no folder is chosen', async () => {
+    const { component, exportService } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([BROWSABLE]),
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['save'] as () => Promise<void>)();
+    expect(exportService.exportSession).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ connectorId: 'gdrive', parentId: undefined }),
+    );
+  });
+
+  it('resets the chosen folder when the destination changes', async () => {
+    const { component } = setup({
+      listExportTargets: vi.fn().mockResolvedValue([BROWSABLE]),
+    });
+    await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
+
+    await (component['chooseFolder'] as () => Promise<void>)();
+    expect((component['destinationLabel'] as () => string)()).toBe('Reports');
+
+    (component['selectConnector'] as (t: ExportTargetConnector) => void)(BROWSABLE);
+    expect((component['destinationLabel'] as () => string)()).toBe('App folder');
+    expect((component['parentId'] as () => string | null)()).toBeNull();
   });
 
   it('cancel closes with the result (undefined before any save)', async () => {

--- a/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.ts
@@ -7,7 +7,8 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { Dialog, DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowPath,
@@ -15,6 +16,7 @@ import {
   heroCheckCircle,
   heroCloudArrowUp,
   heroExclamationTriangle,
+  heroFolder,
   heroLink,
   heroXMark,
 } from '@ng-icons/heroicons/outline';
@@ -29,6 +31,13 @@ import {
 import { UserConnectorsService } from '../../../settings/connectors/services/user-connectors.service';
 import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
 import { ToastService } from '../../../services/toast/toast.service';
+import {
+  FileSourceBrowserDialogComponent,
+  FileSourceBrowserDialogData,
+  FileSourceBrowserDialogResult,
+  FolderSelection,
+} from '../../../assistants/components/file-source-browser-dialog.component';
+import { FileSourceConnector } from '../../../assistants/models/file-source.model';
 
 /** Data passed in when the session list opens the export dialog. */
 export interface ExportDialogData {
@@ -74,6 +83,7 @@ const FORMAT_LABELS: Record<ExportFormat, string> = {
       heroCheckCircle,
       heroCloudArrowUp,
       heroExclamationTriangle,
+      heroFolder,
       heroLink,
       heroXMark,
     }),
@@ -211,6 +221,33 @@ const FORMAT_LABELS: Record<ExportFormat, string> = {
               </div>
             }
 
+            <!-- ─────────────── Folder ─────────────── -->
+            @if (canChooseFolder()) {
+              <div class="mt-4">
+                <span class="mb-1.5 block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Folder</span>
+                <div class="flex items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-700">
+                  <ng-icon name="heroFolder" class="size-4 shrink-0 text-gray-400" aria-hidden="true" />
+                  <span class="min-w-0 flex-1 truncate text-sm/6 text-gray-900 dark:text-white">{{ destinationLabel() }}</span>
+                  @if (destinationFolderName()) {
+                    <button
+                      type="button"
+                      (click)="resetDestinationFolder()"
+                      class="shrink-0 rounded-2xl px-2 py-1 text-sm/6 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-600 dark:hover:text-gray-200"
+                    >
+                      Default
+                    </button>
+                  }
+                  <button
+                    type="button"
+                    (click)="chooseFolder()"
+                    class="shrink-0 rounded-2xl px-2 py-1 text-sm/6 font-medium text-blue-600 hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400 dark:hover:bg-blue-500/10"
+                  >
+                    Choose…
+                  </button>
+                </div>
+              </div>
+            }
+
             <!-- ─────────────── Include ─────────────── -->
             <fieldset class="mt-4">
               <legend class="mb-1.5 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Include</legend>
@@ -296,6 +333,7 @@ export class ExportDialogComponent implements OnInit {
   private readonly connectorsService = inject(UserConnectorsService);
   private readonly consentService = inject(OAuthConsentService);
   private readonly toast = inject(ToastService);
+  private readonly dialog = inject(Dialog);
 
   protected readonly targets = signal<ExportTargetConnector[]>([]);
   protected readonly loading = signal<boolean>(true);
@@ -304,6 +342,14 @@ export class ExportDialogComponent implements OnInit {
   protected readonly selectedConnectorId = signal<string | null>(null);
   protected readonly selectedFormat = signal<ExportFormat | null>(null);
   protected readonly include = signal<ExportInclude>({ ...DEFAULT_EXPORT_INCLUDE });
+
+  /**
+   * Chosen destination folder for a browsable target. `null` means the
+   * adapter's default app folder — the common case, so no picker interaction
+   * is required to save.
+   */
+  protected readonly parentId = signal<string | null>(null);
+  protected readonly destinationFolderName = signal<string | null>(null);
 
   protected readonly submitting = signal<boolean>(false);
   protected readonly error = signal<string | null>(null);
@@ -331,6 +377,16 @@ export class ExportDialogComponent implements OnInit {
 
   protected readonly availableFormats = computed<ExportFormat[]>(
     () => this.selectedTarget()?.supportedFormats ?? [],
+  );
+
+  /** A folder picker is offered only for combined-scope (browsable) targets. */
+  protected readonly canChooseFolder = computed<boolean>(
+    () => this.selectedTarget()?.browsable ?? false,
+  );
+
+  /** Folder shown in the destination row; the app default until one is picked. */
+  protected readonly destinationLabel = computed<string>(
+    () => this.destinationFolderName() ?? 'App folder',
   );
 
   /** True while either the save request or a consent popup is in flight. */
@@ -414,12 +470,58 @@ export class ExportDialogComponent implements OnInit {
   protected selectConnector(target: ExportTargetConnector): void {
     this.selectedConnectorId.set(target.providerId);
     this.error.set(null);
+    // A folder is destination-specific; reset to the app default when the
+    // destination changes.
+    this.resetDestinationFolder();
     // Prefer a native Google Doc when offered, else the first supported format.
     const formats = target.supportedFormats;
     const preferred: ExportFormat | null = formats.includes('google_doc')
       ? 'google_doc'
       : (formats[0] ?? null);
     this.selectedFormat.set(preferred);
+  }
+
+  /** Clear any chosen folder, falling back to the adapter's app folder. */
+  protected resetDestinationFolder(): void {
+    this.parentId.set(null);
+    this.destinationFolderName.set(null);
+  }
+
+  /**
+   * Open the import browse dialog in folder-pick mode to choose a destination
+   * folder. Only offered for browsable (combined-scope) targets, where the
+   * file-source browse endpoints resolve. A successful pick implies the
+   * connector is authorized, so we reconcile the connected flag too.
+   */
+  protected async chooseFolder(): Promise<void> {
+    const target = this.selectedTarget();
+    if (!target || !target.browsable) {
+      return;
+    }
+    const connector: FileSourceConnector = {
+      providerId: target.providerId,
+      displayName: target.displayName,
+      iconName: target.iconName,
+      iconData: target.iconData,
+      connected: target.connected,
+    };
+    const ref = this.dialog.open<
+      FileSourceBrowserDialogResult,
+      FileSourceBrowserDialogData
+    >(FileSourceBrowserDialogComponent, {
+      data: { connector, mode: 'pick-folder' },
+      hasBackdrop: false,
+    });
+    const result = await firstValueFrom(ref.closed);
+    // Cancelled, or closed in import mode (never happens here) — leave as-is.
+    if (!result || Array.isArray(result)) {
+      return;
+    }
+    const selection: FolderSelection = result;
+    this.parentId.set(selection.folderId);
+    this.destinationFolderName.set(selection.folderName);
+    // Browsing succeeded, so the token is good — keep local state honest.
+    this.markConnected(target.providerId);
   }
 
   protected onFormatChange(event: Event): void {
@@ -454,6 +556,7 @@ export class ExportDialogComponent implements OnInit {
       const response = await this.exportService.exportSession(this.data.sessionId, {
         connectorId: target.providerId,
         format,
+        parentId: this.parentId() ?? undefined,
         include: this.include(),
       });
       this.result.set(response);

--- a/frontend/ai.client/src/app/session/services/export/export.model.ts
+++ b/frontend/ai.client/src/app/session/services/export/export.model.ts
@@ -24,6 +24,12 @@ export interface ExportTargetConnector {
   connected: boolean;
   /** Output formats this destination accepts, driving the format picker. */
   supportedFormats: ExportFormat[];
+  /**
+   * True when this connector is also a file source, so the SPA can reuse the
+   * import browse dialog to pick a destination folder. False means exports land
+   * in the adapter's default app folder and the folder picker is hidden.
+   */
+  browsable: boolean;
 }
 
 export interface ExportTargetListResponse {


### PR DESCRIPTION
## Summary

PR-5 of the conversation-export feature. Lets a "Save to…" export target a **specific Drive folder** instead of only the default app folder, by reusing the import file-source browse dialog as a destination picker.

Unblocked by the combined-scope Drive connector (D-4): `drive.readonly` lets the existing roots/browse endpoints power the picker, `drive.file` writes the file. `parentId` already flowed through the export endpoint and request — this PR adds the UI to choose it.

## Backend

- Add a `browsable` flag to `GET /export-targets`, computed by a new `_is_browsable(provider)` from the connector's `file_source_adapter_id` + the file-source registry. Only a connector that is **also** a shipped file source (the combined-scope Drive connector) is browsable; export-only connectors hide the picker and keep landing in the app folder. This gates the picker so it never offers a "Choose folder" button that would 404 on `/connectors/{id}/roots`.

## Frontend

- Generalize `file-source-browser-dialog` (in `assistants/`) with `mode: 'import' | 'pick-folder'`. Pick-folder mode shows **folders only**, tracks the current folder name client-side, and closes with a `FolderSelection` via a "Use this folder" footer. Import mode is unchanged.
- Wire the picker into the export dialog: a "Folder" row — shown only for browsable targets — opens the picker and threads the chosen `parentId` into the save request; default stays the app folder. A successful pick reconciles the connector's `connected` flag (browsing proves the token is good).

## Tests

- Backend: `test_export_routes` catalog cases for `browsable` true / false / unshipped-adapter.
- Frontend: pick-folder specs for both dialogs (folders-only display, `FolderSelection` close, `parentId` threaded into save, reset-on-destination-change). 19 FE specs pass.
- Full AOT build + architecture import-boundary tests green. Backend pytest is **not** run in CI — ran the full export-target + architecture suites locally (67 passed).

## Known limitation (inherited, not fixed here)

The Drive adapter never populates breadcrumbs (`_to_browse_result` returns a flat page), so there is no "up one level" — picking a folder several levels deep requires Home-then-redrill. Pre-existing in the import dialog; fixing it would change import behavior too, so it's deferred to a focused follow-up.

## Manual test

Can't be previewed locally — needs real Google consent + an admin-mapped **combined-scope** connector. Steps:

1. Map a Drive connector with **both** `file_source_adapter_id=google-drive` **and** `export_target_adapter_id=google-drive`.
2. Open a conversation → overflow menu → **Save to…**.
3. The **Folder** row appears (only because the connector is browsable). Click **Choose…**.
4. Navigate into a subfolder → **Use this folder**.
5. **Save** → the Google Doc lands in the chosen folder; "Open in Google Drive" link points to it.
6. Verify a non-combined-scope (export-only) connector shows **no** Folder row and still saves to the app folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)