### PR TITLE
feat(assistants): re-enable tool use for assistants (revert KB-only)

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1105,14 +1105,6 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         logger.info("Assistant RAG requested")
         logger.info("Processing for authenticated user")
 
-        # Assistants are KB-grounded with no external tools available to the consumer.
-        # Override any tools the client sent — server is the source of truth here.
-        if input_data.enabled_tools:
-            logger.warning(
-                "Ignoring enabled_tools on assistant chat (assistants are KB-only)"
-            )
-        input_data.enabled_tools = []
-
         # 1. Check if session already has an assistant attached
         # If it does, verify it's the same assistant (can't change assistants mid-session)
         # If it doesn't, verify session has no messages (can only attach to new sessions)
@@ -1223,13 +1215,6 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         preview_instructions_override = input_data.system_prompt if is_preview_session(input_data.session_id) and input_data.system_prompt else None
         effective_instructions = preview_instructions_override or assistant.instructions
 
-        kb_grounding_directive = (
-            "## Knowledge Base Grounding\n\n"
-            "Answer using only the knowledge base context provided with the user's message. "
-            "If the context does not cover the question, say so plainly rather than guessing. "
-            "You have no external tools available."
-        )
-
         if effective_instructions:
             # Import here to avoid circular dependency
             from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
@@ -1239,7 +1224,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             base_prompt = base_prompt_builder.build(include_date=True)
 
             # Append assistant instructions to the base prompt
-            system_prompt = f"{base_prompt}\n\n{kb_grounding_directive}\n\n## Assistant-Specific Instructions\n\n{effective_instructions}"
+            system_prompt = f"{base_prompt}\n\n## Assistant-Specific Instructions\n\n{effective_instructions}"
             if preview_instructions_override:
                 logger.info(
                     "Using live preview instructions override"
@@ -1252,13 +1237,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         else:
             # No assistant instructions - use base prompt if no system_prompt provided
             logger.warning("No instructions found on assistant!")
-            from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
+            if not system_prompt:
+                from agents.main_agent.core.system_prompt_builder import SystemPromptBuilder
 
-            base_prompt_builder = SystemPromptBuilder()
-            base_prompt = base_prompt_builder.build(include_date=True)
-            system_prompt = f"{base_prompt}\n\n{kb_grounding_directive}"
+                base_prompt_builder = SystemPromptBuilder()
+                system_prompt = base_prompt_builder.build(include_date=True)
             logger.info(
-                "Assistant has no instructions - using fallback system prompt with KB grounding"
+                "Assistant has no instructions - using fallback system prompt"
             )
 
         # 6. Save assistant_id to session preferences (persist for future loads)

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.spec.ts
@@ -4,6 +4,7 @@ import { signal } from '@angular/core';
 import { FETCH_EVENT_SOURCE, PreviewChatService } from './preview-chat.service';
 import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { ConfigService } from '../../../services/config.service';
+import { ToolService } from '../../../services/tool/tool.service';
 
 describe('PreviewChatService', () => {
   let service: PreviewChatService;
@@ -32,12 +33,17 @@ describe('PreviewChatService', () => {
       appApiUrl: signal('http://localhost:8000'),
     };
 
+    const toolServiceMock = {
+      getEnabledToolIds: vi.fn().mockReturnValue(['tool1', 'tool2']),
+    };
+
     TestBed.configureTestingModule({
       providers: [
         PreviewChatService,
         { provide: FETCH_EVENT_SOURCE, useValue: mockFetch },
         { provide: BffSessionService, useValue: bffSessionMock },
         { provide: ConfigService, useValue: configServiceMock },
+        { provide: ToolService, useValue: toolServiceMock },
       ],
     });
 
@@ -106,6 +112,16 @@ describe('PreviewChatService', () => {
     expect(service.messages()).toEqual([]);
     expect(service.sessionId()).not.toBe(oldSessionId);
     expect(service.sessionId()).toMatch(/^preview-/);
+  });
+
+  it('forwards the owner enabled tools so the preview can use tools', async () => {
+    await service.sendMessage('Hello', 'assistant-1', 'Test instructions');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0][1]!;
+    const body = JSON.parse(init.body as string);
+    expect(body.enabled_tools).toEqual(['tool1', 'tool2']);
+    expect(body.rag_assistant_id).toBe('assistant-1');
   });
 
   it('attaches the CSRF header from the BFF SessionService when present', async () => {

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
@@ -4,12 +4,20 @@ import { fetchEventSource } from '@microsoft/fetch-event-source';
 import type { EventSourceMessage, FetchEventSourceInit } from '@microsoft/fetch-event-source';
 import { SessionService as BffSessionService } from '../../../auth/session.service';
 import { ConfigService } from '../../../services/config.service';
-import { Message } from '../../../session/services/models/message.model';
+import { ToolService } from '../../../services/tool/tool.service';
+import {
+  Message,
+  type ContentBlock,
+  type ToolUseData,
+  type ToolResultContent,
+} from '../../../session/services/models/message.model';
 import { PREVIEW_SESSION_PREFIX } from '../../../shared/constants/session.constants';
 import {
   processStreamEvent,
   type StreamParserCallbacks,
   type ContentBlockDeltaEvent,
+  type ToolUseEvent,
+  type ToolResultEventData,
 } from '../../../shared/utils/stream-parser';
 
 /**
@@ -39,14 +47,16 @@ export const FETCH_EVENT_SOURCE = new InjectionToken<FetchEventSource>('FETCH_EV
  * Preview sessions use the `preview-{uuid}` session ID format which the backend recognizes
  * and skips persistence for.
  *
- * For preview, we only need basic text streaming - tool use, citations, and other advanced
- * features are not critical for testing assistant instructions.
+ * The preview streams text and tool use so owners can test the assistant exactly as a
+ * consumer would experience it (assistants can use the owner's enabled tools). Citations
+ * and other advanced features remain out of scope for the preview.
  */
 @Injectable()
 export class PreviewChatService {
   private bffSession = inject(BffSessionService);
   private config = inject(ConfigService);
   private fetchEventSource = inject(FETCH_EVENT_SOURCE);
+  private toolService = inject(ToolService);
 
   // Local state signals (isolated from global ChatStateService)
   private readonly messagesSignal = signal<Message[]>([]);
@@ -57,7 +67,14 @@ export class PreviewChatService {
 
   // Abort controller for cancellation
   private abortController: AbortController | null = null;
-  private currentMessageBuilder: { id: string; content: string } | null = null;
+  // Builds the streaming assistant message as an ordered list of content blocks
+  // (text interleaved with tool use), mirroring the main chat so the shared
+  // message-list renders tool cards in the preview. `activeTextIndex` points at
+  // the text block currently accumulating deltas, or -1 when the next text delta
+  // should open a fresh block (e.g. right after a tool block).
+  private currentMessageBuilder:
+    | { id: string; blocks: ContentBlock[]; activeTextIndex: number }
+    | null = null;
 
   // Public readonly signals
   readonly messages = this.messagesSignal.asReadonly();
@@ -80,9 +97,9 @@ export class PreviewChatService {
       },
 
       onContentBlockDelta: (data: ContentBlockDeltaEvent) => {
-        // Only handle text deltas
+        // Only handle text deltas; tool input arrives whole via onToolUse.
         if (data.text && this.currentMessageBuilder) {
-          this.currentMessageBuilder.content += data.text;
+          this.appendText(data.text);
           this.updateCurrentMessage();
         }
       },
@@ -106,19 +123,13 @@ export class PreviewChatService {
               (data as { message?: string; error?: string })?.error ||
               'An error occurred';
 
-        if (this.currentMessageBuilder) {
-          this.currentMessageBuilder.content = `Error: ${errorMessage}`;
-          this.updateCurrentMessage();
-        }
+        this.setErrorMessage(errorMessage);
         this.loadingSignal.set(false);
         this.streamingMessageIdSignal.set(null);
       },
 
       onStreamError: (data) => {
-        if (this.currentMessageBuilder) {
-          this.currentMessageBuilder.content = `Error: ${data.message}`;
-          this.updateCurrentMessage();
-        }
+        this.setErrorMessage(data.message);
         this.loadingSignal.set(false);
         this.streamingMessageIdSignal.set(null);
       },
@@ -127,11 +138,19 @@ export class PreviewChatService {
         console.warn('Preview chat parse error:', message);
       },
 
+      onToolUse: (data: ToolUseEvent) => {
+        this.appendToolUse(data);
+        this.updateCurrentMessage();
+      },
+
+      onToolResult: (data: ToolResultEventData) => {
+        this.applyToolResult(data);
+        this.updateCurrentMessage();
+      },
+
       // Unused callbacks for preview - just ignore these events
       onContentBlockStart: () => {},
       onContentBlockStop: () => {},
-      onToolUse: () => {},
-      onToolResult: () => {},
       onToolProgress: () => {},
       onMetadata: () => {},
       onReasoning: () => {},
@@ -171,7 +190,7 @@ export class PreviewChatService {
 
     // Create placeholder for assistant response
     const assistantMessageId = `msg-${this.sessionIdSignal()}-${this.messagesSignal().length}`;
-    this.currentMessageBuilder = { id: assistantMessageId, content: '' };
+    this.currentMessageBuilder = { id: assistantMessageId, blocks: [], activeTextIndex: -1 };
     const assistantMsg: Message = {
       id: assistantMessageId,
       role: 'assistant',
@@ -210,7 +229,9 @@ export class PreviewChatService {
         rag_assistant_id: assistantId,
         system_prompt: liveInstructions || null, // Send live form instructions for preview
         model_id: null, // Use default model
-        enabled_tools: [], // No tools in preview
+        // Forward the owner's enabled tools so the preview exercises tools the
+        // same way a consumer chat does.
+        enabled_tools: this.toolService.getEnabledToolIds(),
       };
       if (fileUploadIds && fileUploadIds.length > 0) {
         requestBody['file_upload_ids'] = fileUploadIds;
@@ -274,26 +295,120 @@ export class PreviewChatService {
   }
 
   /**
-   * Update the current assistant message in the messages array
+   * Append streamed text to the active text block, opening a new one if the
+   * previous block was a tool use (so text and tools render in order).
+   */
+  private appendText(text: string): void {
+    const builder = this.currentMessageBuilder;
+    if (!builder) {
+      return;
+    }
+    if (builder.activeTextIndex < 0) {
+      builder.blocks.push({ type: 'text', text: '' });
+      builder.activeTextIndex = builder.blocks.length - 1;
+    }
+    const block = builder.blocks[builder.activeTextIndex];
+    block.text = (block.text ?? '') + text;
+  }
+
+  /**
+   * Append a tool-use content block. Subsequent text deltas start a fresh text
+   * block so the tool card renders between the surrounding prose.
+   */
+  private appendToolUse(data: ToolUseEvent): void {
+    const builder = this.currentMessageBuilder;
+    if (!builder) {
+      return;
+    }
+    const toolUse = data.tool_use;
+    let input: Record<string, unknown> = {};
+    try {
+      input = toolUse.input ? JSON.parse(toolUse.input) : {};
+    } catch {
+      // Tool input JSON may be malformed mid-stream; fall back to empty object.
+      input = {};
+    }
+    const toolUseData: ToolUseData = {
+      toolUseId: toolUse.tool_use_id,
+      name: toolUse.name,
+      input,
+      status: 'pending',
+    };
+    builder.blocks.push({ type: 'toolUse', toolUse: toolUseData });
+    builder.activeTextIndex = -1;
+  }
+
+  /**
+   * Attach a tool result to its matching tool-use block. Replaces the block
+   * (new object references) so OnPush message rendering picks up the change.
+   */
+  private applyToolResult(data: ToolResultEventData): void {
+    const builder = this.currentMessageBuilder;
+    if (!builder) {
+      return;
+    }
+    const result = data.tool_result;
+    const index = builder.blocks.findIndex(
+      (block) =>
+        block.type === 'toolUse' &&
+        (block.toolUse as ToolUseData | undefined)?.toolUseId === result.toolUseId,
+    );
+    if (index < 0) {
+      return;
+    }
+    const existing = builder.blocks[index].toolUse as ToolUseData;
+    const status = result.status === 'error' ? 'error' : 'success';
+    builder.blocks[index] = {
+      type: 'toolUse',
+      toolUse: {
+        ...existing,
+        result: {
+          content: (result.content ?? []) as unknown as ToolResultContent[],
+          status,
+        },
+        status: status === 'error' ? 'error' : 'complete',
+      },
+    };
+  }
+
+  /**
+   * Update the current assistant message in the messages array. Rebuilds the
+   * content blocks with fresh object references so OnPush change detection in
+   * the shared message-list re-renders streaming text and tool cards.
    */
   private updateCurrentMessage(): void {
     if (!this.currentMessageBuilder) {
       return;
     }
 
-    const { id, content } = this.currentMessageBuilder;
+    const { id, blocks } = this.currentMessageBuilder;
+    const content: ContentBlock[] =
+      blocks.length > 0 ? blocks.map((block) => ({ ...block })) : [{ type: 'text', text: '' }];
     this.messagesSignal.update((msgs) => {
       const index = msgs.findIndex((m) => m.id === id);
       if (index >= 0) {
         const updated = [...msgs];
         updated[index] = {
           ...updated[index],
-          content: [{ type: 'text', text: content }],
+          content,
         };
         return updated;
       }
       return msgs;
     });
+  }
+
+  /**
+   * Replace the in-flight assistant message with an error notice.
+   */
+  private setErrorMessage(message: string): void {
+    const builder = this.currentMessageBuilder;
+    if (!builder) {
+      return;
+    }
+    builder.blocks = [{ type: 'text', text: `Error: ${message}` }];
+    builder.activeTextIndex = 0;
+    this.updateCurrentMessage();
   }
 
   /**
@@ -305,8 +420,7 @@ export class PreviewChatService {
     this.streamingMessageIdSignal.set(null);
 
     if (this.currentMessageBuilder) {
-      this.currentMessageBuilder.content = `Error: ${error.message}`;
-      this.updateCurrentMessage();
+      this.setErrorMessage(error.message);
       this.currentMessageBuilder = null;
     }
   }

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -117,7 +117,9 @@ describe('ChatRequestService', () => {
     const sent = mockChatHttpService.sendChatRequest.mock.calls[0][0];
     expect('agent_type' in sent).toBe(false);
     expect('enabled_skills' in sent).toBe(false);
-    expect(sent['enabled_tools']).toEqual([]);
+    // Assistants forward the user's tool selection (skills mode is excluded for
+    // assistant turns), so the raw tool picker selection rides along.
+    expect(sent['enabled_tools']).toEqual(['tool1', 'tool2']);
   });
 
   it('should include assistant ID in request', async () => {
@@ -130,13 +132,13 @@ describe('ChatRequestService', () => {
     );
   });
 
-  it('overrides enabled_tools to [] when an assistant ID is set (KB-only consumer chat)', async () => {
+  it('forwards the user tool selection when an assistant ID is set (assistants can use tools)', async () => {
     await service.submitChatRequest('Hello', 'session1', undefined, 'assistant1');
 
     expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         rag_assistant_id: 'assistant1',
-        enabled_tools: [],
+        enabled_tools: ['tool1', 'tool2'],
       })
     );
   });

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -256,8 +256,6 @@ export class ChatRequestService implements OnDestroy {
     // AgentCore Runtime's internal 'assistant_id' field handling (causes 424 error)
     if (assistantId) {
       requestObject['rag_assistant_id'] = assistantId;
-      // Assistants are KB-grounded with no external tools. Backend enforces this too.
-      requestObject['enabled_tools'] = [];
     } else {
       // Forward the active conversation mode for non-assistant turns. The
       // assistant path is intentionally excluded server-side too — assistants


### PR DESCRIPTION
## Summary

Assistants were changed in #382 to run **tool-free** (knowledge-base-grounded only): the consumer chat forced `enabled_tools=[]` and the system prompt told the model it had no external tools. This PR backs that out so **assistants can leverage the user's enabled MCP/tools again**, and brings the editor **preview to parity** so owners can test tool behavior.

KB context is still retrieved and pre-stuffed into the user message, and the assistant's own instructions still apply — assistants just aren't *prevented* from using tools anymore.

## Changes

**Backend — `inference_api/chat/routes.py`**
- Removed the `enabled_tools=[]` override in the `rag_assistant_id` branch (the real enforcement chokepoint) so the client's tool selection flows through to the agent.
- Removed the "Knowledge Base Grounding / You have no external tools available" directive from both the with-instructions and no-instructions prompt paths, restoring the pre-#382 composition.

**Frontend — `chat-request.service.ts`**
- Stopped force-sending `enabled_tools=[]` on assistant turns; the user's tool-picker selection now rides along (skills mode remains gated on non-assistant turns).

**Preview parity — `preview-chat.service.ts`**
- Forwards the owner's enabled tools instead of `[]` so the editor preview exercises tools the same way a consumer chat does.
- Rebuilt the streaming assistant message as ordered content blocks (text interleaved with tool use) and wired `onToolUse`/`onToolResult`, so the shared message-list renders tool cards in the preview.

## Tests
- Updated `chat-request.service.spec.ts` and `preview-chat.service.spec.ts` to assert tools are forwarded on assistant + preview turns.
- All affected specs pass: chat-request 10/10, preview 9/9, assistant-preview component 11/11. Type-checked build is clean.

## Notes / follow-ups
- The backend `test_chat_endpoint` (`app_api/assistants/routes.py`) is **dead code** (no caller) and still passes `enabled_tools=None`; left untouched for a separate cleanup/removal rather than wiring a speculative tool field.
- Not browser-verified: exercising a real tool call in the preview needs a live backend plus a saved assistant with processed docs and tool-triggering input. Unit tests cover request-shaping; the build covers the rendering types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)