### PR TITLE
fix(nightly): repoint test/install jobs to post-refactor script paths

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Install frontend dependencies
         if: steps.cache-frontend.outputs.cache-hit != 'true'
-        run: bash scripts/stack-frontend/install.sh
+        run: bash scripts/frontend/install.sh
 
       - name: Save frontend node_modules cache
         if: steps.cache-frontend.outputs.cache-hit != 'true'
@@ -307,7 +307,7 @@ jobs:
 
       - name: Run backend tests with coverage
         id: run-tests
-        run: bash scripts/stack-app-api/test.sh
+        run: bash scripts/backend/test.sh
 
       - name: Upload backend coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -348,7 +348,7 @@ jobs:
 
       - name: Run frontend tests with coverage
         id: run-tests
-        run: bash scripts/stack-frontend/test.sh
+        run: bash scripts/frontend/test.sh
 
       - name: Upload frontend coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+# scripts/backend/test.sh — run the backend (App API) pytest suite WITH coverage.
+#
+# Ported from the pre-#396 scripts/stack-app-api/test.sh during the
+# platform-as-bootstrap refactor: the per-stack script dirs (stack-app-api,
+# stack-frontend, …) were deleted and replaced by the single-stack layout,
+# but nightly.yml was never repointed. repo-shape.test.ts now FORBIDS
+# recreating scripts/stack-*, so the coverage variant lives here instead.
+#
+# This is the COVERAGE variant used by nightly.yml's "Test Backend with
+# Coverage" job (it emits backend/coverage.json + backend/htmlcov/ which the
+# workflow uploads as the `backend-coverage` artifact and feeds to the
+# coverage-analysis jobs). The plain, no-coverage gate used by
+# nightly-deploy-pipeline.yml / backend.yml stays inline (`uv run pytest`).
+#
+# Runs on a fresh, isolated GitHub runner: the uv *cache* (~/.cache/uv +
+# backend/.venv) is restored by the install-backend job, but the uv *binary*
+# is not, so this script installs uv if it's missing.
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${PROJECT_ROOT}/backend"
+
+# Logging functions
+log_info() {
+    echo "[INFO] $1"
+}
+
+log_error() {
+    echo "[ERROR] $1" >&2
+}
+
+log_success() {
+    echo "[SUCCESS] $1"
+}
+
+main() {
+    log_info "Running App API tests..."
+
+    # Change to backend directory
+    cd "${BACKEND_DIR}"
+    log_info "Working directory: $(pwd)"
+
+    # Install uv if not present (the runner is fresh; only the cache persists)
+    if ! command -v uv &> /dev/null; then
+        log_info "Installing uv..."
+        curl -LsSf https://astral.sh/uv/0.7.12/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+
+    # Sync dependencies from lock file (includes dev deps for testing)
+    log_info "Syncing dependencies from uv.lock..."
+    uv sync --frozen --extra agentcore --extra dev
+
+    # Verify installation
+    log_info "Verifying installation..."
+    uv run python -c "import fastapi; import uvicorn; print('Core dependencies installed')"
+
+    # Run tests
+    log_info "Executing tests..."
+
+    if [ ! -d "tests" ]; then
+        log_info "No tests/ directory found. Skipping tests."
+        log_success "App API tests completed successfully!"
+        return 0
+    fi
+
+    # Set PYTHONPATH explicitly
+    export PYTHONPATH="${BACKEND_DIR}/src:${PYTHONPATH:-}"
+    log_info "PYTHONPATH=${PYTHONPATH}"
+
+    # Set dummy AWS credentials for tests
+    export AWS_DEFAULT_REGION=us-east-1
+    export AWS_ACCESS_KEY_ID=testing
+    export AWS_SECRET_ACCESS_KEY=testing
+
+    # Test import directly
+    log_info "Testing direct import..."
+    uv run python -c "from agents.main_agent.quota.checker import QuotaChecker; print('Direct import works')"
+
+    # Run pytest with coverage (html + json + term reports)
+    log_info "Running pytest..."
+    uv run python -m pytest tests/ \
+        -v \
+        --tb=short \
+        --color=yes \
+        --disable-warnings \
+        --cov=src \
+        --cov-report=html \
+        --cov-report=json \
+        --cov-report=term
+
+    log_success "App API tests completed successfully!"
+}
+
+main "$@"

--- a/scripts/frontend/install.sh
+++ b/scripts/frontend/install.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# scripts/frontend/install.sh — install Angular frontend + CDK infrastructure deps.
+#
+# Ported from the pre-#396 scripts/stack-frontend/install.sh during the
+# platform-as-bootstrap refactor (the stack-* script dirs were removed and
+# repo-shape.test.ts now forbids recreating them). Used by nightly.yml's
+# install-frontend job, which caches frontend/ai.client/node_modules.
+#
+# Installs, in order:
+#   1. Angular frontend dependencies (npm ci)
+#   2. CDK infrastructure dependencies (npm ci)
+
+set -euo pipefail
+
+# Get the repository root directory
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIR="${REPO_ROOT}/frontend/ai.client"
+INFRA_DIR="${REPO_ROOT}/infrastructure"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+# ===========================================================
+# Install Frontend Dependencies
+# ===========================================================
+
+# Check if frontend directory exists
+if [ ! -d "${FRONTEND_DIR}" ]; then
+    log_error "Frontend directory not found: ${FRONTEND_DIR}"
+    exit 1
+fi
+
+# Check if package.json exists
+if [ ! -f "${FRONTEND_DIR}/package.json" ]; then
+    log_error "package.json not found in ${FRONTEND_DIR}"
+    exit 1
+fi
+
+log_info "Installing frontend dependencies..."
+log_info "Frontend directory: ${FRONTEND_DIR}"
+
+# Change to frontend directory
+cd "${FRONTEND_DIR}"
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    log_error "Node.js is not installed. Please install Node.js first."
+    log_error "Run: scripts/common/install-deps.sh"
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    log_error "npm is not installed. Please install npm first."
+    exit 1
+fi
+
+# Display Node.js and npm versions
+log_info "Node.js version: $(node --version)"
+log_info "npm version: $(npm --version)"
+
+# Use npm ci for clean, reproducible builds
+# npm ci is faster and more reliable than npm install in CI/CD environments
+if [ -f "package-lock.json" ]; then
+    log_info "Running npm ci (clean install from package-lock.json)..."
+    npm ci
+else
+    log_error "package-lock.json not found. Cannot run npm ci."
+    exit 1
+fi
+
+log_success "Frontend dependencies installed successfully!"
+
+# Display Angular CLI version if available
+if [ -f "node_modules/.bin/ng" ]; then
+    log_info "Angular CLI version: $(./node_modules/.bin/ng version --version 2>/dev/null || echo 'unknown')"
+fi
+
+# ===========================================================
+# Install CDK Dependencies
+# ===========================================================
+
+log_info "Installing CDK dependencies..."
+cd "${INFRA_DIR}"
+
+if [ -f "package-lock.json" ]; then
+    log_info "Running npm ci (clean install from package-lock.json)..."
+    npm ci
+else
+    log_error "package-lock.json not found. Cannot run npm ci."
+    exit 1
+fi
+
+log_success "CDK dependencies installed successfully"

--- a/scripts/frontend/test.sh
+++ b/scripts/frontend/test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# scripts/frontend/test.sh — run the Angular test suite (headless) WITH coverage.
+#
+# Ported from the pre-#396 scripts/stack-frontend/test.sh during the
+# platform-as-bootstrap refactor (the stack-* script dirs were removed and
+# repo-shape.test.ts now forbids recreating them). Used by nightly.yml's
+# "Test Frontend with Coverage" job, which uploads frontend/ai.client/coverage/.
+
+set -euo pipefail
+
+# Get the repository root directory
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIR="${REPO_ROOT}/frontend/ai.client"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+# Check if frontend directory exists
+if [ ! -d "${FRONTEND_DIR}" ]; then
+    log_error "Frontend directory not found: ${FRONTEND_DIR}"
+    exit 1
+fi
+
+# Check if node_modules exists
+if [ ! -d "${FRONTEND_DIR}/node_modules" ]; then
+    log_error "node_modules not found. Please run install.sh first."
+    log_error "Run: scripts/frontend/install.sh"
+    exit 1
+fi
+
+log_info "Running frontend tests..."
+log_info "Frontend directory: ${FRONTEND_DIR}"
+
+# Change to frontend directory
+cd "${FRONTEND_DIR}"
+
+# Check if Angular CLI is available
+if [ ! -f "node_modules/.bin/ng" ]; then
+    log_error "Angular CLI not found in node_modules. Please run install.sh first."
+    exit 1
+fi
+
+# Run tests in headless mode (no watch, single run)
+# This is appropriate for CI/CD environments
+log_info "Running: ng test --no-watch --coverage (filtering CSS warnings)"
+
+# Set environment variable for CI
+export CI=true
+
+# Run tests with code coverage
+# Angular uses Vitest which handles headless mode automatically in CI environments
+# The CI=true environment variable triggers headless behavior
+# Filter out jsdom CSS parsing warnings that clutter logs
+# Use PIPESTATUS to preserve test exit code after grep filter
+./node_modules/.bin/ng test --no-watch --coverage 2>&1 | grep -v "Could not parse CSS stylesheet"
+TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+if [ ${TEST_EXIT_CODE} -eq 0 ]; then
+    log_info "All tests passed successfully!"
+
+    # Display coverage summary if available
+    if [ -f "coverage/index.html" ]; then
+        log_info "Coverage report generated: coverage/index.html"
+    fi
+
+    # Display coverage summary from terminal output
+    if [ -d "coverage" ]; then
+        COVERAGE_DIR=$(find coverage -mindepth 1 -maxdepth 1 -type d | head -1)
+        if [ -n "${COVERAGE_DIR}" ] && [ -f "${COVERAGE_DIR}/coverage-summary.json" ]; then
+            log_info "Coverage summary available in: ${COVERAGE_DIR}/coverage-summary.json"
+        fi
+    fi
+else
+    log_error "Tests failed with exit code: ${TEST_EXIT_CODE}"
+    exit ${TEST_EXIT_CODE}
+fi


### PR DESCRIPTION
The single-stack refactor (#396) removed scripts/stack-app-api/ and scripts/stack-frontend/, but nightly.yml's coverage jobs still called them, so test-backend/test-frontend/install-frontend failed with 'No such file or directory'. repo-shape.test.ts forbids recreating the stack-* dirs, so port the three scripts to the sanctioned new layout:

  scripts/stack-app-api/test.sh  -> scripts/backend/test.sh
  scripts/stack-frontend/install.sh -> scripts/frontend/install.sh
  scripts/stack-frontend/test.sh -> scripts/frontend/test.sh

Behavior preserved 1:1 (uv install+sync + pytest --cov for backend; npm ci for frontend+infra; ng test --no-watch --coverage). Only the self-referential help-text paths were updated.