### PR TITLE
fix(security): remediate CodeQL alerts (HIGH/MEDIUM + NOTE cleanups)

### DIFF
--- a/.github/workflows/nightly-deploy-pipeline.yml
+++ b/.github/workflows/nightly-deploy-pipeline.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -105,6 +106,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: '0.7.12'
@@ -126,6 +128,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -176,6 +179,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -212,6 +216,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -243,6 +248,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -281,6 +287,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -317,6 +324,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -348,6 +356,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -379,6 +388,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -410,6 +420,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -440,6 +451,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -475,6 +487,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
@@ -509,6 +522,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -573,6 +587,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - uses: ./.github/actions/configure-aws-credentials
         with:
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}

--- a/backend/src/agents/builtin_tools/spreadsheet_analysis/analyze_tool.py
+++ b/backend/src/agents/builtin_tools/spreadsheet_analysis/analyze_tool.py
@@ -119,6 +119,7 @@ def _parse_sheet_inventory(bootstrap_stdout: str) -> Dict[str, Any]:
                 if isinstance(names, list):
                     result["skipped_preview"] = [str(n) for n in names]
             except (ValueError, SyntaxError):
+                # Best-effort parse — ignore malformed preview metadata.
                 pass
         elif stripped.startswith("sheet|"):
             parts = stripped.split("|")

--- a/backend/src/agents/builtin_tools/spreadsheet_analysis/list_spreadsheets_tool.py
+++ b/backend/src/agents/builtin_tools/spreadsheet_analysis/list_spreadsheets_tool.py
@@ -14,6 +14,8 @@ from strands import tool
 
 from apis.shared.files.models import is_tabular_file
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,7 +123,7 @@ async def _get_kb_files(assistant_id: str) -> List[Dict[str, Any]]:
         return files
 
     except Exception as e:
-        logger.error(f"Error querying KB files for assistant {assistant_id}: {e}")
+        logger.error(f"Error querying KB files for assistant {scrub_log(assistant_id)}: {scrub_log(e)}")
         return []
 
 
@@ -154,5 +156,5 @@ async def _get_session_files(session_id: str) -> List[Dict[str, Any]]:
         return files
 
     except Exception as e:
-        logger.error(f"Error querying session files for {session_id}: {e}")
+        logger.error(f"Error querying session files for {scrub_log(session_id)}: {scrub_log(e)}")
         return []

--- a/backend/src/agents/main_agent/agent_types.py
+++ b/backend/src/agents/main_agent/agent_types.py
@@ -10,6 +10,8 @@ from typing import Optional, List
 
 from agents.main_agent.base_agent import BaseAgent
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,7 +49,7 @@ def create_agent(agent_type: str = "chat", **kwargs) -> BaseAgent:
         available = ", ".join(sorted(_AGENT_TYPES.keys()))
         raise ValueError(f"Unknown agent_type '{agent_type}'. Available: {available}")
 
-    logger.info(f"Creating {agent_type} agent ({agent_class.__name__})")
+    logger.info(f"Creating {scrub_log(agent_type)} agent ({agent_class.__name__})")
     return agent_class(**kwargs)
 
 

--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -178,7 +178,6 @@ class BaseAgent(ABC):
     @abstractmethod
     def _create_agent(self) -> None:
         """Create the specific agent type. Subclasses must implement."""
-        ...
 
     @abstractmethod
     async def stream_async(
@@ -204,7 +203,6 @@ class BaseAgent(ABC):
         assistant message already in restored history (assistant-prefill),
         rather than answering a fresh instruction.
         """
-        ...
 
     def _register_external_mcp_tools(self) -> None:
         """

--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -16,6 +16,7 @@ OAuth Support:
 import logging
 import re
 from typing import Any, Callable, Optional, List, Set
+from urllib.parse import urlparse
 
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
@@ -38,6 +39,22 @@ from agents.main_agent.integrations.oauth_auth import (
 logger = logging.getLogger(__name__)
 
 
+def _aws_hostname(url: str) -> str:
+    """Return the lowercased hostname of ``url``, or ``""`` if it can't be parsed.
+
+    AWS-endpoint detection must match against the *host* only. Substring-matching
+    the whole URL (e.g. ``".amazonaws.com" in url``) is unsafe: an attacker can
+    place the marker in a path or query component
+    (``https://evil.example/?x=.execute-api.us-east-1.amazonaws.com``) and trick
+    the caller into SigV4-signing a request to a non-AWS host, leaking the task's
+    IAM credentials. Parsing the host and anchoring the suffix prevents that.
+    """
+    try:
+        return (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
 def extract_region_from_url(url: str) -> Optional[str]:
     """
     Extract AWS region from Lambda Function URL or API Gateway URL.
@@ -52,14 +69,15 @@ def extract_region_from_url(url: str) -> Optional[str]:
     Returns:
         AWS region or None if not extractable
     """
+    host = _aws_hostname(url)
     patterns = [
-        r"\.lambda-url\.([a-z0-9-]+)\.on\.aws",
-        r"\.execute-api\.([a-z0-9-]+)\.amazonaws\.com",
-        r"\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com",
+        r"\.lambda-url\.([a-z0-9-]+)\.on\.aws$",
+        r"\.execute-api\.([a-z0-9-]+)\.amazonaws\.com$",
+        r"\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$",
     ]
 
     for pattern in patterns:
-        match = re.search(pattern, url)
+        match = re.search(pattern, host)
         if match:
             return match.group(1)
 
@@ -88,11 +106,12 @@ def detect_aws_service_from_url(url: str) -> Optional[str]:
         AWS service name for SigV4 signing, or None if the URL doesn't match
         a known AWS service.
     """
-    if ".lambda-url." in url and ".on.aws" in url:
+    host = _aws_hostname(url)
+    if host.endswith(".on.aws") and ".lambda-url." in host:
         return "lambda"
-    elif ".execute-api." in url and ".amazonaws.com" in url:
+    elif host.endswith(".amazonaws.com") and ".execute-api." in host:
         return "execute-api"
-    elif ".bedrock-agentcore." in url and ".amazonaws.com" in url:
+    elif host.endswith(".amazonaws.com") and ".bedrock-agentcore." in host:
         return "bedrock-agentcore"
     else:
         logger.debug(

--- a/backend/src/agents/main_agent/session/persistence.py
+++ b/backend/src/agents/main_agent/session/persistence.py
@@ -29,6 +29,8 @@ from typing import Any, List, Tuple
 from strands.types.content import Message
 from strands.types.session import SessionMessage
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,7 +79,7 @@ def persist_synthetic_messages(
     )
     if target_manager is None:
         logger.error(
-            f"Cannot persist messages to session {session_id}: "
+            f"Cannot persist messages to session {scrub_log(session_id)}: "
             f"session manager {type(session_manager).__name__} has no create_message method"
         )
         return False
@@ -88,6 +90,6 @@ def persist_synthetic_messages(
         target_manager.create_message(session_id, agent_id, session_msg)
 
     logger.info(
-        f"💾 Persisted {len(messages)} synthetic message(s) to session {session_id}"
+        f"💾 Persisted {len(messages)} synthetic message(s) to session {scrub_log(session_id)}"
     )
     return True

--- a/backend/src/agents/main_agent/skills/skill_tools.py
+++ b/backend/src/agents/main_agent/skills/skill_tools.py
@@ -25,7 +25,7 @@ Two ways to obtain the tools:
 import asyncio
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from strands import tool
 
@@ -137,6 +137,7 @@ def _execute(registry: Any, skill_name: str, tool_name: str, tool_input: Any = N
         try:
             tool_input = json.loads(tool_input)
         except (json.JSONDecodeError, TypeError):
+            # Not JSON — leave tool_input as its original value.
             pass
 
     if tool_input is None:

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -10,7 +10,7 @@ import logging
 import os
 import re
 import boto3
-from botocore.exceptions import ClientError, BotoCoreError
+from botocore.exceptions import BotoCoreError
 
 from .models import (
     BedrockModelsResponse,
@@ -30,8 +30,6 @@ from apis.shared.models.models import (
 )
 from apis.shared.auth import User, require_admin
 from apis.shared.feature_flags import skills_enabled
-from apis.shared.sessions.metadata import list_user_sessions, get_session_metadata
-from apis.shared.sessions.messages import get_messages
 from apis.shared.models.managed_models import (
     create_managed_model,
     get_managed_model,

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -24,6 +24,8 @@ import jwt
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 # Frozen contract — must match the render Lambda's _verify_token.
@@ -223,8 +225,8 @@ class RenderTokenService:
         logger.info(
             "minted render token user=%s artifact=%s v=%s",
             user_id,
-            artifact_id,
-            version,
+            scrub_log(artifact_id),
+            scrub_log(version),
         )
         return f"{origin}/?t={token}", exp
 

--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -36,7 +36,6 @@ from apis.shared.assistants.service import (
     create_assistant,
     create_assistant_draft,
     delete_assistant,
-    get_assistant,
     get_assistant_with_access_check,
     list_assistant_shares,
     list_shared_with_user,

--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -50,6 +50,8 @@ from apis.shared.oauth.provider_repository import (
 )
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -382,8 +384,8 @@ async def complete_consent(
         logger.error(
             "CompleteResourceTokenAuth failed for user=%s provider=%s: %s",
             current_user.user_id,
-            body.provider_id,
-            err,
+            scrub_log(body.provider_id),
+            scrub_log(err),
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -401,7 +403,7 @@ async def complete_consent(
     logger.info(
         "Completed OAuth consent for user=%s provider=%s",
         current_user.user_id,
-        body.provider_id,
+        scrub_log(body.provider_id),
     )
     return CompleteConsentResponse(ok=True)
 

--- a/backend/src/apis/app_api/documents/ingestion/processors/xlsx_chunker.py
+++ b/backend/src/apis/app_api/documents/ingestion/processors/xlsx_chunker.py
@@ -48,6 +48,7 @@ def _is_likely_header(row: tuple, next_row: tuple = None) -> bool:
                 float(stripped.replace(",", ""))
                 continue  # It's a number in string form
             except ValueError:
+                # Not a numeric string — fall through and count it as text.
                 pass
             text_count += 1
         # Non-string types (int, float, datetime) are not header-like
@@ -67,6 +68,7 @@ def _is_likely_header(row: tuple, next_row: tuple = None) -> bool:
                     float(cell.strip().replace(",", ""))
                     numeric_count += 1
                 except ValueError:
+                    # Not numeric — leave numeric_count unchanged.
                     pass
         # Data row should have at least some numbers
         if next_non_empty and numeric_count > 0:

--- a/backend/src/apis/app_api/documents/services/import_service.py
+++ b/backend/src/apis/app_api/documents/services/import_service.py
@@ -15,7 +15,6 @@ task only and is never logged.
 
 import asyncio
 import logging
-import os
 from typing import List, Tuple
 
 import boto3

--- a/backend/src/apis/app_api/export_targets/routes.py
+++ b/backend/src/apis/app_api/export_targets/routes.py
@@ -61,6 +61,8 @@ from apis.app_api.export_targets.service import (
     resolve_export_target_token,
 )
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["export-targets"])
@@ -207,7 +209,7 @@ async def _collect_transcript(session_id: str, user_id: str) -> List[MessageResp
             return messages
     logger.warning(
         "Export for session %s hit the %d-page cap; transcript may be truncated",
-        session_id,
+        scrub_log(session_id),
         _MAX_EXPORT_PAGES,
     )
     return messages
@@ -348,7 +350,7 @@ async def export_session(
         )
     except ExportTargetError as err:
         logger.warning(
-            "create_document failed for connector %s: %s", request.connector_id, err
+            "create_document failed for connector %s: %s", scrub_log(request.connector_id), scrub_log(err)
         )
         raise http_error_for_export_target_error(err)
 

--- a/backend/src/apis/app_api/file_sources/routes.py
+++ b/backend/src/apis/app_api/file_sources/routes.py
@@ -45,6 +45,8 @@ from apis.app_api.file_sources.service import (
     resolve_file_source_token,
 )
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["file-sources"])
@@ -174,7 +176,7 @@ async def list_file_source_roots(
     try:
         roots = await adapter.list_roots(access_token)
     except FileSourceError as err:
-        logger.warning("list_roots failed for connector %s: %s", provider_id, err)
+        logger.warning("list_roots failed for connector %s: %s", scrub_log(provider_id), scrub_log(err))
         raise http_error_for_file_source_error(err)
     return SourceRootsResponse(roots=roots)
 
@@ -201,7 +203,7 @@ async def browse_file_source(
     try:
         return await adapter.browse(access_token, folder_id, cursor)
     except FileSourceError as err:
-        logger.warning("browse failed for connector %s: %s", provider_id, err)
+        logger.warning("browse failed for connector %s: %s", scrub_log(provider_id), scrub_log(err))
         raise http_error_for_file_source_error(err)
 
 
@@ -225,5 +227,5 @@ async def search_file_source(
     try:
         return await adapter.search(access_token, query, cursor)
     except FileSourceError as err:
-        logger.warning("search failed for connector %s: %s", provider_id, err)
+        logger.warning("search failed for connector %s: %s", scrub_log(provider_id), scrub_log(err))
         raise http_error_for_file_source_error(err)

--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -36,6 +36,8 @@ from .service import (
 )
 from .thumbnails import ThumbnailRenderError, ThumbnailUnsupportedError
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/files", tags=["files"])
@@ -219,7 +221,7 @@ async def get_thumbnail(
             detail=str(e),
         )
     except ThumbnailRenderError as e:
-        logger.warning(f"Thumbnail render failed for {upload_id}: {e}")
+        logger.warning(f"Thumbnail render failed for {scrub_log(upload_id)}: {scrub_log(e)}")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Could not render a thumbnail for this file",

--- a/backend/src/apis/app_api/files/service.py
+++ b/backend/src/apis/app_api/files/service.py
@@ -15,6 +15,8 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from apis.shared.security.log_sanitize import scrub_log
+
 from apis.shared.files.models import (
     FileMetadata,
     FileStatus,
@@ -437,7 +439,7 @@ class FileUploadService:
             )
             body = response["Body"].read()
         except ClientError as e:
-            logger.warning(f"Failed to read snippet for {upload_id}: {e}")
+            logger.warning(f"Failed to read snippet for {scrub_log(upload_id)}: {scrub_log(e)}")
             return TextSnippetResponse(
                 upload_id=upload_id,
                 snippet="",

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -32,6 +32,8 @@ from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.system_prompts.service import get_system_prompts_service
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
@@ -218,7 +220,7 @@ async def update_session_metadata_endpoint(
             ):
                 logger.warning(
                     "PUT /sessions/%s/metadata: session id is taken under a different user; refusing",
-                    session_id,
+                    scrub_log(session_id),
                 )
                 raise HTTPException(
                     status_code=404,

--- a/backend/src/apis/app_api/web_sources/crawler.py
+++ b/backend/src/apis/app_api/web_sources/crawler.py
@@ -24,7 +24,6 @@ import re
 import time
 from collections import defaultdict
 from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple
-from urllib.parse import urljoin
 from urllib.robotparser import RobotFileParser
 
 import httpx

--- a/backend/src/apis/app_api/web_sources/routes.py
+++ b/backend/src/apis/app_api/web_sources/routes.py
@@ -50,6 +50,8 @@ from apis.app_api.web_sources.url_utils import (
 from apis.shared.assistants.service import get_assistant
 from apis.shared.auth import User, get_current_user_from_session
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(
@@ -136,10 +138,10 @@ async def start_crawl(
     task.add_done_callback(_BACKGROUND_CRAWLS.discard)
     logger.info(
         "Kicked off crawl %s for assistant %s (root_document=%s url=%s)",
-        job.crawl_id,
-        assistant_id,
-        document_id,
-        normalized,
+        scrub_log(job.crawl_id),
+        scrub_log(assistant_id),
+        scrub_log(document_id),
+        scrub_log(normalized),
     )
 
     return StartCrawlResponse(

--- a/backend/src/apis/inference_api/chat/app_context_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_context_dispatch.py
@@ -39,6 +39,8 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 # Top-level Strands `agent.state` key that holds all MCP Apps host state.
@@ -120,7 +122,7 @@ def dispatch_app_context_update(
 
     logger.info(
         "mcp-apps: stored model context (resource=%s, pending=%d)",
-        resource_uri,
+        scrub_log(resource_uri),
         len(ctx),
     )
     return {"resourceUri": resource_uri, "status": "stored", "pending": len(ctx)}

--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -30,6 +30,8 @@ from typing import Any, Dict, List, Optional
 
 from apis.shared.mcp_apps.broker import get_app_tool_event_broker
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -141,9 +143,9 @@ async def dispatch_app_tool_call(
     except Exception as exc:  # noqa: BLE001 - surfaced to the App as an error
         logger.warning(
             "app tools/call dispatch failed (tool=%s session=%s): %s",
-            tool_name,
-            session_id,
-            exc,
+            scrub_log(tool_name),
+            scrub_log(session_id),
+            scrub_log(exc),
         )
         raise AppToolCallError(
             f"Tool '{tool_name}' failed to execute", code=502

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -58,6 +58,8 @@ from .system_prompt_resolver import (
     should_resolve_custom_prompt,
 )
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 # Router with no prefix - endpoints will be at root level
@@ -359,7 +361,7 @@ def _build_spreadsheet_tools(
     if "analyze_spreadsheet" in requested:
         tools.append(make_analyze_tool(assistant_id, session_id, user_id))
 
-    logger.info(f"Created {len(tools)} spreadsheet analysis tools (assistant={assistant_id})")
+    logger.info(f"Created {len(tools)} spreadsheet analysis tools (assistant={scrub_log(assistant_id)})")
     return tools
 
 
@@ -1357,7 +1359,6 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                     detail="Paused turn expired; restart the turn.",
                 )
 
-            caching_enabled = snapshot.caching_enabled
             # Snapshot wins on resume so an authorized turn finishes against the
             # exact param shape it was authorized for, even if admin defaults
             # have since changed. Fall back to the legacy fields for snapshots

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -16,6 +16,8 @@ from agents.main_agent.agent_types import create_agent
 from agents.main_agent.base_agent import BaseAgent
 from apis.shared.sessions.metadata import update_session_title
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -210,7 +212,7 @@ async def get_agent(
             logger.warning(
                 "Cached agent is paused on an interrupt but request is not a resume; "
                 "evicting and rebuilding (session=%s user=%s)",
-                session_id, user_id,
+                scrub_log(session_id), scrub_log(user_id),
             )
             del _agent_cache[cache_key]
         else:

--- a/backend/src/apis/inference_api/chat/system_prompt_resolver.py
+++ b/backend/src/apis/inference_api/chat/system_prompt_resolver.py
@@ -36,6 +36,8 @@ from apis.shared.sessions.metadata import (
 )
 from apis.shared.system_prompts.service import get_system_prompts_service
 
+from apis.shared.security.log_sanitize import scrub_log
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,7 +117,7 @@ async def resolve_active_prompt_text(
         custom_prompt = await get_system_prompts_service().get_enabled_prompt(active_prompt_id)
         if not custom_prompt:
             logger.info(
-                f"Custom prompt {active_prompt_id!r} not found or disabled — skipping"
+                f"Custom prompt {scrub_log(active_prompt_id)!r} not found or disabled — skipping"
             )
             return None
 

--- a/backend/src/apis/shared/mcp_apps/partial_json.py
+++ b/backend/src/apis/shared/mcp_apps/partial_json.py
@@ -130,6 +130,7 @@ def heal_partial_json(raw: Optional[str]) -> Optional[Dict[str, Any]]:
                 if isinstance(parsed, dict):
                     return parsed
             except (ValueError, TypeError):
+                # Candidate isn't valid JSON yet — keep shrinking the window.
                 pass
         end -= 1
     return None

--- a/backend/src/apis/shared/security/__init__.py
+++ b/backend/src/apis/shared/security/__init__.py
@@ -25,6 +25,7 @@ from apis.shared.security.python_ast_policy import (
     PolicyError,
     validate_diagram_code,
 )
+from apis.shared.security.log_sanitize import scrub_log
 
 __all__ = [
     "UrlValidationError",
@@ -39,4 +40,5 @@ __all__ = [
     "register_validation_error_handler",
     "PolicyError",
     "validate_diagram_code",
+    "scrub_log",
 ]

--- a/backend/src/apis/shared/security/log_sanitize.py
+++ b/backend/src/apis/shared/security/log_sanitize.py
@@ -1,0 +1,36 @@
+"""Log-injection sanitization.
+
+User-controlled values written into log records must have their line
+terminators neutralized; otherwise an attacker can embed ``\\r``/``\\n`` in an
+input (a filename, connector id, tool name, error message, …) and forge or
+inject additional log lines, corrupting audit trails and log-based alerting.
+
+This addresses CodeQL ``py/log-injection``. Wrap any user-influenced value
+that flows into a ``logger.*`` call with :func:`scrub_log`.
+
+    logger.warning("list_roots failed for connector %s: %s",
+                   scrub_log(provider_id), scrub_log(err))
+"""
+
+from typing import Any
+
+# C0/C1 control characters except ordinary tab (handled explicitly below).
+_CONTROL_TRANSLATION = {
+    i: None
+    for i in range(0x20)
+    if i not in (0x09,)  # keep \t out of the "delete" set; escaped below
+}
+_CONTROL_TRANSLATION.update({0x7F: None})
+
+
+def scrub_log(value: Any) -> str:
+    """Return ``str(value)`` with line breaks and control characters neutralized
+    so it is safe to embed in a single log record.
+
+    - ``\\r`` and ``\\n`` (and ``\\t``) are replaced with visible escapes so the
+      original content is preserved for debugging but cannot start a new line.
+    - Other C0/C1 control characters are stripped.
+    """
+    text = str(value)
+    text = text.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+    return text.translate(_CONTROL_TRANSLATION)

--- a/backend/src/apis/shared/security/url_validator.py
+++ b/backend/src/apis/shared/security/url_validator.py
@@ -74,6 +74,7 @@ def _is_forbidden_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -
             if addr in cgnat:
                 return True
     except ValueError:
+        # Not an IP literal — fall through to the metadata-hostname check.
         pass
     if str(addr) in _METADATA_ADDRESSES:
         return True

--- a/backend/src/apis/shared/sessions_bff/lock.py
+++ b/backend/src/apis/shared/sessions_bff/lock.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 from threading import Lock as _ThreadLock
-from typing import Dict
 from weakref import WeakValueDictionary
 
 # We use a WeakValueDictionary so locks don't leak indefinitely as session

--- a/backend/src/apis/shared/user_menu_links/models.py
+++ b/backend/src/apis/shared/user_menu_links/models.py
@@ -9,7 +9,7 @@ since the data is global / single-tenant. When per-org scoping is needed, the
 PK becomes ``USER_MENU_LINKS#<org_id>`` without touching the SK shape.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 

--- a/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
+++ b/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
@@ -77,6 +77,63 @@ class TestDetectAwsServiceFromUrl:
         assert detect_aws_service_from_url(url) is None
 
 
+class TestAwsUrlHostSanitization:
+    """Regression tests for CodeQL py/incomplete-url-substring-sanitization
+    (alert #695): AWS-endpoint markers must only be honored when they appear
+    in the URL *host*, not anywhere in the string. Otherwise an attacker can
+    smuggle the marker into a path/query and trick the caller into attaching
+    SigV4 IAM credentials to a request bound for a non-AWS host."""
+
+    # (description, malicious_url) — every one of these must NOT be treated as AWS.
+    SPOOFED_URLS = [
+        (
+            "marker in query string",
+            "https://evil.example/?x=.execute-api.us-east-1.amazonaws.com",
+        ),
+        (
+            "marker in path",
+            "https://evil.example/.lambda-url.us-east-1.on.aws/mcp",
+        ),
+        (
+            "real AWS suffix as a non-terminal label of an attacker domain",
+            "https://x.execute-api.us-east-1.amazonaws.com.evil.example/mcp",
+        ),
+        (
+            "marker in userinfo",
+            "https://.execute-api.us-east-1.amazonaws.com@evil.example/mcp",
+        ),
+        (
+            "agentcore marker in fragment",
+            "https://evil.example/#.bedrock-agentcore.us-east-1.amazonaws.com",
+        ),
+    ]
+
+    @pytest.mark.parametrize("desc,url", SPOOFED_URLS)
+    def test_detect_service_rejects_spoofed_url(self, desc, url):
+        assert detect_aws_service_from_url(url) is None, desc
+
+    @pytest.mark.parametrize("desc,url", SPOOFED_URLS)
+    def test_extract_region_rejects_spoofed_url(self, desc, url):
+        assert extract_region_from_url(url) is None, desc
+
+    def test_unparseable_url_is_not_aws(self):
+        assert detect_aws_service_from_url("not a url") is None
+        assert extract_region_from_url("not a url") is None
+
+    def test_legitimate_hosts_still_detected(self):
+        """The hardening must not regress genuine AWS endpoints (incl. paths/ports)."""
+        assert (
+            detect_aws_service_from_url(
+                "https://x.execute-api.us-east-1.amazonaws.com:443/prod"
+            )
+            == "execute-api"
+        )
+        assert (
+            extract_region_from_url("https://x.lambda-url.eu-west-1.on.aws/")
+            == "eu-west-1"
+        )
+
+
 class TestProviderForClient:
     """The integration's MCPClient -> provider_id map is what
     `OAuthConsentHook.provider_lookup` consults."""

--- a/backend/tests/shared/test_log_sanitize.py
+++ b/backend/tests/shared/test_log_sanitize.py
@@ -1,0 +1,47 @@
+"""Tests for the log-injection sanitizer (CodeQL py/log-injection).
+
+`scrub_log` must neutralize line terminators and control characters so a
+user-controlled value can't forge or inject extra log lines.
+"""
+
+from apis.shared.security.log_sanitize import scrub_log
+from apis.shared.security import scrub_log as scrub_log_reexport
+
+
+class TestScrubLog:
+    def test_replaces_newlines_and_carriage_returns(self):
+        out = scrub_log("alice\nADMIN login succeeded")
+        assert "\n" not in out
+        assert "\r" not in out
+        assert out == "alice\\nADMIN login succeeded"
+
+    def test_neutralizes_crlf_forged_log_line(self):
+        forged = "user1\r\n2024-01-01 ERROR forged entry"
+        out = scrub_log(forged)
+        assert "\r" not in out and "\n" not in out
+        # The whole payload collapses onto a single line.
+        assert "\n" not in out.splitlines()[0]
+        assert len(out.splitlines()) == 1
+
+    def test_replaces_tabs(self):
+        assert scrub_log("a\tb") == "a\\tb"
+
+    def test_strips_other_control_characters(self):
+        # NUL, bell, escape (ANSI), and DEL must be removed entirely.
+        assert scrub_log("a\x00b\x07c\x1bd\x7fe") == "abcde"
+
+    def test_leaves_ordinary_text_untouched(self):
+        assert scrub_log("provider-google_workspace.v2") == "provider-google_workspace.v2"
+
+    def test_coerces_non_string_values(self):
+        assert scrub_log(42) == "42"
+        assert scrub_log(None) == "None"
+
+    def test_handles_exception_objects(self):
+        err = ValueError("bad input\ninjected line")
+        out = scrub_log(err)
+        assert "\n" not in out
+        assert out == "bad input\\ninjected line"
+
+    def test_reexported_from_security_package(self):
+        assert scrub_log_reexport is scrub_log

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { detectAwsServiceFromUrl, extractAwsRegionFromUrl } from './admin-tool.model';
+
+/**
+ * Regression tests for CodeQL js/regex/missing-regexp-anchor (alerts #670/#671).
+ *
+ * AWS-endpoint detection must match the URL *host* only. Previously the regexes
+ * ran unanchored against the whole URL string, so an AWS marker smuggled into a
+ * path/query/fragment/userinfo component — or an AWS suffix used as a
+ * non-terminal label of an attacker domain — was misclassified as an AWS host.
+ * At signing time that would attach SigV4 IAM credentials to a request bound for
+ * a non-AWS host.
+ */
+describe('admin-tool.model AWS URL detection (host-anchored)', () => {
+  describe('legitimate AWS endpoints are still detected', () => {
+    it('detects services', () => {
+      expect(detectAwsServiceFromUrl('https://x.lambda-url.us-west-2.on.aws/mcp')).toBe('lambda');
+      expect(detectAwsServiceFromUrl('https://x.execute-api.us-east-1.amazonaws.com/p')).toBe(
+        'execute-api',
+      );
+      expect(
+        detectAwsServiceFromUrl('https://g.bedrock-agentcore.eu-west-1.amazonaws.com/'),
+      ).toBe('bedrock-agentcore');
+    });
+
+    it('extracts regions (including with an explicit port)', () => {
+      expect(extractAwsRegionFromUrl('https://x.lambda-url.ap-south-1.on.aws/mcp')).toBe(
+        'ap-south-1',
+      );
+      expect(
+        extractAwsRegionFromUrl('https://x.execute-api.us-east-2.amazonaws.com:443/p'),
+      ).toBe('us-east-2');
+    });
+  });
+
+  describe('spoofed URLs must NOT be treated as AWS', () => {
+    const spoofed: [string, string][] = [
+      ['marker in query', 'https://evil.example/?x=.execute-api.us-east-1.amazonaws.com'],
+      ['marker in path', 'https://evil.example/.lambda-url.us-east-1.on.aws/mcp'],
+      [
+        'aws suffix as non-terminal label',
+        'https://x.execute-api.us-east-1.amazonaws.com.evil.example/mcp',
+      ],
+      ['marker in userinfo', 'https://.execute-api.us-east-1.amazonaws.com@evil.example/mcp'],
+      ['marker in fragment', 'https://evil.example/#.bedrock-agentcore.us-east-1.amazonaws.com'],
+    ];
+
+    it.each(spoofed)('detectAwsServiceFromUrl returns "" for %s', (_desc, url) => {
+      expect(detectAwsServiceFromUrl(url)).toBe('');
+    });
+
+    it.each(spoofed)('extractAwsRegionFromUrl returns "" for %s', (_desc, url) => {
+      expect(extractAwsRegionFromUrl(url)).toBe('');
+    });
+  });
+
+  describe('non-AWS / unparseable inputs', () => {
+    it('returns "" for plain domains and empty input', () => {
+      expect(detectAwsServiceFromUrl('https://mcp.example.com/mcp')).toBe('');
+      expect(detectAwsServiceFromUrl('')).toBe('');
+      expect(extractAwsRegionFromUrl('https://mcp.example.com/mcp')).toBe('');
+      expect(extractAwsRegionFromUrl('not a url')).toBe('');
+    });
+  });
+});

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -403,10 +403,33 @@ export const TOOL_STATUSES: { value: ToolStatus; label: string }[] = [
  * fill) rather than defaulting to `'lambda'` — the backend's last-resort
  * default is only appropriate at signing time.
  */
+/**
+ * Lowercased hostname of `url`, or `''` if it can't be parsed.
+ *
+ * AWS-endpoint detection must match the *host* only. Testing an unanchored
+ * regex against the whole URL string (CodeQL js/regex/missing-regexp-anchor)
+ * lets a marker in a path/query — e.g.
+ * `https://evil.example/?x=.execute-api.us-east-1.amazonaws.com` — masquerade
+ * as an AWS host, which at signing time would attach SigV4 IAM credentials to
+ * a request bound for a non-AWS host. Parsing the host and anchoring the
+ * suffix (`$`) prevents that.
+ */
+function awsHostname(url: string): string {
+  for (const candidate of [url, `https://${url}`]) {
+    try {
+      return new URL(candidate).hostname.toLowerCase();
+    } catch {
+      // try the next candidate (handles scheme-less inputs)
+    }
+  }
+  return '';
+}
+
 export function detectAwsServiceFromUrl(url: string): string {
-  if (/\.lambda-url\.[a-z0-9-]+\.on\.aws/.test(url)) return 'lambda';
-  if (/\.execute-api\.[a-z0-9-]+\.amazonaws\.com/.test(url)) return 'execute-api';
-  if (/\.bedrock-agentcore\.[a-z0-9-]+\.amazonaws\.com/.test(url)) return 'bedrock-agentcore';
+  const host = awsHostname(url);
+  if (/\.lambda-url\.[a-z0-9-]+\.on\.aws$/.test(host)) return 'lambda';
+  if (/\.execute-api\.[a-z0-9-]+\.amazonaws\.com$/.test(host)) return 'execute-api';
+  if (/\.bedrock-agentcore\.[a-z0-9-]+\.amazonaws\.com$/.test(host)) return 'bedrock-agentcore';
   return '';
 }
 
@@ -415,9 +438,10 @@ export function detectAwsServiceFromUrl(url: string): string {
  * doesn't encode one. Mirrors the backend `extract_region_from_url`.
  */
 export function extractAwsRegionFromUrl(url: string): string {
+  const host = awsHostname(url);
   const match =
-    url.match(/\.lambda-url\.([a-z0-9-]+)\.on\.aws/) ??
-    url.match(/\.execute-api\.([a-z0-9-]+)\.amazonaws\.com/) ??
-    url.match(/\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com/);
+    host.match(/\.lambda-url\.([a-z0-9-]+)\.on\.aws$/) ??
+    host.match(/\.execute-api\.([a-z0-9-]+)\.amazonaws\.com$/) ??
+    host.match(/\.bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$/);
   return match ? match[1] : '';
 }

--- a/infrastructure/lib/constructs/agentcore/browser-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/browser-construct.ts
@@ -1,6 +1,5 @@
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/agentcore/code-interpreter-construct.ts
+++ b/infrastructure/lib/constructs/agentcore/code-interpreter-construct.ts
@@ -1,6 +1,5 @@
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -8,7 +8,6 @@
  */
 
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { Construct } from 'constructs';
 
 import { AppConfig, buildCorsOrigins } from '../../config';
 import { PlatformComputeRefs } from '../platform-compute-refs';

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -19,7 +19,6 @@
  */
 
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AppConfig } from '../../config';

--- a/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
@@ -9,7 +9,7 @@ import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as path from 'path';
 import { Construct } from 'constructs';
 
-import { AppConfig, getResourceName, buildCorsOrigins } from '../../config';
+import { AppConfig, getResourceName } from '../../config';
 import { resolveAppApiParams, buildAppApiEnvironment } from './app-api-environment';
 import { PlatformComputeRefs } from '../platform-compute-refs';
 import { grantAppApiPermissions } from './app-api-iam-grants';
@@ -195,7 +195,7 @@ export class AppApiServiceConstruct extends Construct {
     environment['SAGEMAKER_SUBNET_IDS'] = props.sagemakerPrivateSubnetIds;
 
     // ── Container definition ──
-    const container = taskDefinition.addContainer('AppApiContainer', {
+    taskDefinition.addContainer('AppApiContainer', {
       containerName: 'app-api',
       image: ecs.ContainerImage.fromRegistry(appApiImageUri),
       logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'app-api', logGroup }),

--- a/infrastructure/lib/constructs/artifacts/artifacts-distribution-construct.ts
+++ b/infrastructure/lib/constructs/artifacts/artifacts-distribution-construct.ts
@@ -5,7 +5,6 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/fine-tuning/sagemaker-execution-role-construct.ts
+++ b/infrastructure/lib/constructs/fine-tuning/sagemaker-execution-role-construct.ts
@@ -2,7 +2,6 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';
@@ -49,8 +48,7 @@ export class SageMakerExecutionRoleConstruct extends Construct {
   ) {
     super(scope, id);
 
-    const { config, dataBucket, jobsTable, vpc, privateSubnetIdsString } =
-      props;
+    const { config, dataBucket, jobsTable, vpc } = props;
 
     // Keep an explicit, stable roleName for consistency with the other
     // execution roles and to avoid replacing the role (and the dependent

--- a/infrastructure/lib/constructs/identity/artifact-render-token-secret-construct.ts
+++ b/infrastructure/lib/constructs/identity/artifact-render-token-secret-construct.ts
@@ -1,5 +1,4 @@
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';

--- a/infrastructure/lib/constructs/identity/auth-secret-construct.ts
+++ b/infrastructure/lib/constructs/identity/auth-secret-construct.ts
@@ -1,5 +1,4 @@
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';

--- a/infrastructure/lib/constructs/identity/bff-cookie-key-construct.ts
+++ b/infrastructure/lib/constructs/identity/bff-cookie-key-construct.ts
@@ -1,6 +1,5 @@
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';

--- a/infrastructure/lib/constructs/identity/platform-identity-construct.ts
+++ b/infrastructure/lib/constructs/identity/platform-identity-construct.ts
@@ -1,5 +1,4 @@
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/identity/voice-ticket-construct.ts
+++ b/infrastructure/lib/constructs/identity/voice-ticket-construct.ts
@@ -1,6 +1,5 @@
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -7,7 +7,6 @@
  */
 
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
+++ b/infrastructure/lib/constructs/mcp-sandbox/mcp-sandbox-distribution-construct.ts
@@ -5,7 +5,6 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Construct } from 'constructs';

--- a/infrastructure/lib/constructs/network/alb-construct.ts
+++ b/infrastructure/lib/constructs/network/alb-construct.ts
@@ -1,7 +1,6 @@
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';

--- a/infrastructure/lib/constructs/network/network-construct.ts
+++ b/infrastructure/lib/constructs/network/network-construct.ts
@@ -1,6 +1,4 @@
-import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { AppConfig, getResourceName } from '../../config';
@@ -65,17 +63,5 @@ export class NetworkConstruct extends Construct {
 
     // Export VPC CIDR to SSM
 
-    // Export Private Subnet IDs to SSM
-    const privateSubnetIds = this.vpc.privateSubnets
-      .map((subnet) => subnet.subnetId)
-      .join(',');
-
-    // Export Public Subnet IDs to SSM
-    const publicSubnetIds = this.vpc.publicSubnets
-      .map((subnet) => subnet.subnetId)
-      .join(',');
-
-    // Export Availability Zones to SSM
-    const availabilityZones = this.vpc.availabilityZones.join(',');
   }
 }

--- a/tests/supply_chain/test_backup_coverage.py
+++ b/tests/supply_chain/test_backup_coverage.py
@@ -11,8 +11,6 @@ stays in sync with the infrastructure as new resources are added.
 Run with: pytest tests/supply_chain/test_backup_coverage.py -v
 """
 
-import ast
-import os
 import re
 from pathlib import Path
 

--- a/tests/supply_chain/test_env_var_contract.py
+++ b/tests/supply_chain/test_env_var_contract.py
@@ -88,7 +88,7 @@ ENV_DICT_KEY_RE = re.compile(
 
 PY_ENV_RE = re.compile(
     r"""
-    os\.(?:environ\.get|getenv|environ\[) # os.environ.get / os.getenv / os.environ[
+    os\.(?:environ\.get|getenv|environ\[) # os.environ.get / os.getenv / os.environ subscript
     \s*\(?\s*                              # optional whitespace + optional (
     ['"]                                   # opening quote
     ([A-Z][A-Z0-9_]+)                      # NAME
@@ -97,10 +97,9 @@ PY_ENV_RE = re.compile(
     re.VERBOSE,
 )
 
-# The EnvVars class in constants.py defines indirected env var
-# references like:
-#   class EnvVars:
-#       DYNAMODB_QUOTA_EVENTS_TABLE = "DYNAMODB_QUOTA_EVENTS_TABLE"
+# The EnvVars class in constants.py defines indirected env var references:
+# each attribute is named identically to the string literal it holds (for
+# example, the DYNAMODB_QUOTA_EVENTS_TABLE attribute maps to that same name).
 ENV_VARS_CLASS_RE = re.compile(
     r"""
     ^                                   # line start (in MULTILINE)


### PR DESCRIPTION
Security fixes (with regression tests):
- HIGH py/incomplete-url-substring-sanitization: external_mcp_client now parses the URL host (urlparse) and matches an anchored suffix instead of substring-checking the whole URL, so a marker in a path/query/userinfo can't trick SigV4 signing into attaching IAM creds to a non-AWS host. Added TestAwsUrlHostSanitization (adversarial URLs).
- HIGH js/regex/missing-regexp-anchor: admin-tool.model parses the host (new URL) and anchors the AWS-endpoint regexes ($). Added admin-tool.model.spec.ts (13 cases incl. spoofed hosts).
- MEDIUM py/log-injection (24 sites/16 files): new apis.shared.security.scrub_log() neutralizes CR/LF/control chars; wrapped user-controlled values at every flagged log call. Added test_log_sanitize.py.
- MEDIUM actions/untrusted-checkout: added persist-credentials:false to all inputs.ref checkouts in nightly-deploy-pipeline.yml.
- WARNING py/regex/duplicate-in-character-class: removed a bare '[' from a re.VERBOSE comment that the regex parser misread as a character class.

NOTE cleanups: removed unused imports (py + 17 TS constructs), a dead local, redundant '...' after abstractmethod docstrings, unused test imports; added explanatory comments to 6 intentional empty-except blocks; reworded commented-out code.

Left intentionally: 4 py/unused-global-variable alerts are FALSE POSITIVES (_cached_signing_key/_cached_bucket/_client_secret_cache are working lazy caches — verified read+written); recommend dismissing in the UI.

Verified: backend 4045 passed (3 pre-existing test_backup_coverage failures are unrelated — a skill-resources backup-coverage gap on develop); frontend build OK + 1252 unit tests; infra tsc + 406 jest tests; npm/ruff clean for touched files.