### PR TITLE
ci: serialize platform + backend deploys via shared concurrency group

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,8 +17,11 @@ env:
   CDK_REQUIRE_APPROVAL: never
   LOAD_ENV_QUIET: true
 
+# Shared "deploy-<ref>" group with platform.yml so a CFN deploy and these
+# API-driven code deploys never mutate the same ECS service / AgentCore
+# Runtime / Lambda concurrently — they queue instead.
 concurrency:
-  group: backend-${{ github.ref }}
+  group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
 # ------------------------------------------------------------

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -21,11 +21,14 @@ env:
   CDK_REQUIRE_APPROVAL: never
   LOAD_ENV_QUIET: true
 
-# cancel-in-progress: false to avoid leaving CloudFormation in
-# ROLLBACK_IN_PROGRESS / UPDATE_ROLLBACK_FAILED after a mid-deploy
-# cancel. Enforced by tests/supply_chain/test_concurrency_config.py.
+# Shared "deploy-<ref>" group with backend.yml so a CFN deploy and the
+# API-driven backend code deploys never mutate the same ECS service /
+# AgentCore Runtime / Lambda concurrently — they queue instead.
+# cancel-in-progress: false avoids leaving CloudFormation in
+# ROLLBACK_IN_PROGRESS / UPDATE_ROLLBACK_FAILED after a mid-deploy cancel.
+# Enforced by tests/supply_chain/test_concurrency_config.py.
 concurrency:
-  group: platform-${{ github.ref }}
+  group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Put platform.yml and backend.yml in one repo-global concurrency group (deploy-<ref>) so a CloudFormation deploy and the API-driven backend code deploys can't run at the same time and stomp on the same ECS service / AgentCore Runtime / Lambda. They queue instead; order doesn't matter post-initial-deploy since either order converges. Frontend stays independent. cancel-in-progress stays false.