### PR TITLE
fix: keep tool card after OAuth/tool-approval resume

### DIFF
--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -12,6 +12,8 @@ import { ToolService } from '../../../services/tool/tool.service';
 import { SkillService } from '../../../services/skill/skill.service';
 import { ChatModeService, ChatMode } from '../../../services/chat-mode/chat-mode.service';
 import { FileUploadService } from '../../../services/file-upload';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+import { ToolApprovalService } from '../../../services/tool-approval/tool-approval.service';
 
 describe('ChatRequestService', () => {
   let service: ChatRequestService;
@@ -20,6 +22,10 @@ describe('ChatRequestService', () => {
   let mockModelService: any;
   let mockToolService: any;
   let currentMode: ChatMode;
+  // Captured from the constructor's setResumeHandler(...) calls so the tests
+  // can drive the (private) resume paths the way the consent/approval UIs do.
+  let oauthResumeHandler: ((interruptIds: string[], context?: { sessionId?: string }) => Promise<void>) | null;
+  let approvalResumeHandler: ((interruptId: string, decision: any, context?: { sessionId?: string }) => Promise<void>) | null;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
@@ -48,7 +54,7 @@ describe('ChatRequestService', () => {
         { provide: ChatHttpService, useValue: mockChatHttpService },
         { provide: Router, useValue: mockRouter },
         { provide: ChatStateService, useValue: { setChatLoading: vi.fn(), setLastTurnContinuable: vi.fn(), createNewAbortController: vi.fn() } },
-        { provide: MessageMapService, useValue: { addUserMessage: vi.fn(), startStreaming: vi.fn(), beginContinuationStreaming: vi.fn(), endStreaming: vi.fn() } },
+        { provide: MessageMapService, useValue: { addUserMessage: vi.fn(), startStreaming: vi.fn(), beginContinuationStreaming: vi.fn(), endStreaming: vi.fn(), reloadMessagesForSession: vi.fn().mockResolvedValue(undefined) } },
         { provide: SessionService, useValue: { addSessionToCache: vi.fn() } },
         { provide: UserService, useValue: { getUser: vi.fn().mockReturnValue({ user_id: 'user1' }) } },
         { provide: ModelService, useValue: mockModelService },
@@ -56,6 +62,22 @@ describe('ChatRequestService', () => {
         { provide: SkillService, useValue: { getEnabledSkillIds: vi.fn().mockReturnValue(['skill_a']) } },
         { provide: ChatModeService, useValue: { mode: () => currentMode } },
         { provide: FileUploadService, useValue: { getReadyFileById: vi.fn() } },
+        {
+          provide: OAuthConsentService,
+          useValue: {
+            setResumeHandler: vi.fn((handler: any) => {
+              oauthResumeHandler = handler;
+            }),
+          },
+        },
+        {
+          provide: ToolApprovalService,
+          useValue: {
+            setResumeHandler: vi.fn((handler: any) => {
+              approvalResumeHandler = handler;
+            }),
+          },
+        },
       ],
     });
     service = TestBed.inject(ChatRequestService);
@@ -177,6 +199,62 @@ describe('ChatRequestService', () => {
     it('is a no-op without a session id', async () => {
       await service.continueTruncatedTurn(null);
       expect(mockChatHttpService.sendChatRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resumeFromOAuthConsent', () => {
+    it('pins existing messages (continuation streaming) and reconciles from server', async () => {
+      const messageMap = TestBed.inject(MessageMapService) as any;
+
+      await oauthResumeHandler!(['int-1'], { sessionId: 'session1' });
+
+      // The paused tool card must NOT be truncated away: continuation
+      // streaming pins it as a prefix instead of the normal truncate-to-user sync.
+      expect(messageMap.beginContinuationStreaming).toHaveBeenCalledWith('session1');
+      expect(messageMap.startStreaming).not.toHaveBeenCalled();
+      // No new user bubble on a resume turn.
+      expect(messageMap.addUserMessage).not.toHaveBeenCalled();
+
+      expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session_id: 'session1',
+          message: '',
+          interrupt_responses: [{ interruptId: 'int-1', response: 'consented' }],
+        }),
+      );
+
+      // The resumed stream can't attach the tool_result live, so we
+      // reconcile from persisted memory to flip the card to its result.
+      expect(messageMap.reloadMessagesForSession).toHaveBeenCalledWith('session1');
+    });
+
+    it('is a no-op without interrupt ids', async () => {
+      await oauthResumeHandler!([], { sessionId: 'session1' });
+      expect(mockChatHttpService.sendChatRequest).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op without a session id', async () => {
+      await oauthResumeHandler!(['int-1'], {});
+      expect(mockChatHttpService.sendChatRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resumeFromToolApproval', () => {
+    it('pins existing messages and reconciles from server after a decision', async () => {
+      const messageMap = TestBed.inject(MessageMapService) as any;
+
+      await approvalResumeHandler!('int-9', 'approved', { sessionId: 'session1' });
+
+      expect(messageMap.beginContinuationStreaming).toHaveBeenCalledWith('session1');
+      expect(messageMap.startStreaming).not.toHaveBeenCalled();
+      expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session_id: 'session1',
+          message: '',
+          interrupt_responses: [{ interruptId: 'int-9', response: 'approved' }],
+        }),
+      );
+      expect(messageMap.reloadMessagesForSession).toHaveBeenCalledWith('session1');
     });
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -18,7 +18,6 @@ import {
   ToolApprovalService,
 } from '../../../services/tool-approval/tool-approval.service';
 import { ErrorService } from '../../../services/error/error.service';
-import { StreamParserService } from './stream-parser.service';
 import { SystemPromptsService } from '../../../services/system-prompts/system-prompts.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
@@ -46,7 +45,6 @@ export class ChatRequestService implements OnDestroy {
   private fileUploadService = inject(FileUploadService);
   private oauthConsentService = inject(OAuthConsentService);
   private toolApprovalService = inject(ToolApprovalService);
-  private streamParserService = inject(StreamParserService);
   private errorService = inject(ErrorService);
   private systemPromptsService = inject(SystemPromptsService);
   private router = inject(Router);
@@ -288,11 +286,17 @@ export class ChatRequestService implements OnDestroy {
       return;
     }
 
-    // Reset the parser so the resumed stream is treated as a fresh batch
-    // of events. Without this, the parser stays in Completed state from
-    // the prior `done` and ignores everything.
-    this.streamParserService.reset(sessionId);
-    this.messageMapService.startStreaming(sessionId);
+    // A resume turn has NO new user message and the resumed stream does not
+    // replay the interrupted `tool_use` block (Strands emits only the
+    // `tool_result` + the final assistant text). Continuation streaming pins
+    // the existing messages — including the assistant message holding the
+    // paused tool card — as a stable prefix and appends the resume after
+    // them, instead of the normal sync which truncates back to the last user
+    // message and would discard the tool card. It also resets the parser
+    // (with the correct starting count) so the resumed stream is a fresh
+    // batch; without that the parser stays Completed from the prior `done`
+    // and ignores everything.
+    this.messageMapService.beginContinuationStreaming(sessionId);
     this.chatStateService.createNewAbortController();
     this.chatStateService.setChatLoading(true);
 
@@ -313,6 +317,11 @@ export class ChatRequestService implements OnDestroy {
 
     try {
       await this.chatHttpService.sendChatRequest(resumeRequest);
+      // The live parser could not attach the resumed `tool_result` to the
+      // paused tool card (its `tool_use` block is in the pinned prefix, not
+      // in the fresh parser). Reconcile from persisted memory so the card
+      // flips from "Running…" to its completed result.
+      await this.messageMapService.reloadMessagesForSession(sessionId);
     } catch (error) {
       this.chatStateService.setChatLoading(false);
       this.messageMapService.endStreaming();
@@ -346,8 +355,11 @@ export class ChatRequestService implements OnDestroy {
       return;
     }
 
-    this.streamParserService.reset(sessionId);
-    this.messageMapService.startStreaming(sessionId);
+    // Same shape as the OAuth resume: no new user message and the resumed
+    // stream carries only the `tool_result` + final text, not the paused
+    // `tool_use` block. Pin the existing messages (with the tool card) as a
+    // prefix and append the resume after them.
+    this.messageMapService.beginContinuationStreaming(sessionId);
     this.chatStateService.createNewAbortController();
     this.chatStateService.setChatLoading(true);
 
@@ -364,6 +376,9 @@ export class ChatRequestService implements OnDestroy {
 
     try {
       await this.chatHttpService.sendChatRequest(resumeRequest);
+      // Reconcile from persisted memory so the approved/declined tool card
+      // shows its result (the live parser can't attach it — see above).
+      await this.messageMapService.reloadMessagesForSession(sessionId);
     } catch (error) {
       this.chatStateService.setChatLoading(false);
       this.messageMapService.endStreaming();

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
@@ -98,6 +98,52 @@ describe('MessageMapService', () => {
     expect(messagesSignal()).toEqual(mockMessages);
   });
 
+  it('reloadMessagesForSession re-fetches even when messages already exist and does not flip loading state', async () => {
+    // Seed an existing (stale) message so the load guard would normally skip.
+    service.addUserMessage('session-reload', 'search');
+
+    // Server holds the authoritative post-resume state: the assistant's
+    // tool_use plus its matching tool_result (in a following user message).
+    const serverMessages = [
+      { id: 'msg-reload-0', role: 'user', content: [{ type: 'text', text: 'search' }] },
+      {
+        id: 'msg-reload-1',
+        role: 'assistant',
+        content: [
+          { type: 'toolUse', toolUse: { toolUseId: 'tu-1', name: 'search_messages', input: {} } },
+        ],
+      },
+      {
+        id: 'msg-reload-2',
+        role: 'user',
+        content: [
+          { type: 'toolResult', toolResult: { toolUseId: 'tu-1', status: 'success', content: [{ text: 'ok' }] } },
+        ],
+      },
+    ];
+    mockSessionService.getMessages.mockResolvedValue({ messages: serverMessages });
+
+    await service.reloadMessagesForSession('session-reload');
+
+    // Bypassed the "already loaded" guard and hit the API.
+    expect(mockSessionService.getMessages).toHaveBeenCalledWith('session-reload');
+    // Never surfaced the skeleton loading state during a live reconcile.
+    expect(service.isLoadingSession()).toBe(null);
+
+    // The tool_use card now carries its result (status flipped to complete).
+    const reloaded = service.getMessagesForSession('session-reload')();
+    const assistant = reloaded.find((m) => m.id === 'msg-reload-1')!;
+    const toolBlock = assistant.content[0] as any;
+    expect(toolBlock.toolUse.status).toBe('complete');
+    expect(toolBlock.toolUse.result).toBeDefined();
+  });
+
+  it('reloadMessagesForSession swallows fetch errors (best-effort reconcile)', async () => {
+    mockSessionService.getMessages.mockRejectedValue(new Error('API error'));
+    await expect(service.reloadMessagesForSession('session-reload-err')).resolves.toBeUndefined();
+    expect(service.isLoadingSession()).toBe(null);
+  });
+
   it('should hydrate pending OAuth interrupts from camelCase wire response', async () => {
     // Regression: backend serializes with by_alias=True so the wire payload uses
     // camelCase (pendingInterrupts, interruptId, providerId, ...). If the consumer

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -304,8 +304,48 @@ export class MessageMapService {
       return;
     }
 
-    // Set loading state for this session
-    this._isLoadingSession.set(sessionId);
+    try {
+      await this.fetchAndApplyMessages(sessionId, /* showLoading */ true);
+    } catch (error) {
+      console.error('Failed to load messages for session:', sessionId, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Force a re-fetch of a session's messages from the server, replacing the
+   * in-memory copy with the authoritative persisted state.
+   *
+   * Unlike {@link loadMessagesForSession} this bypasses the
+   * "already loaded" guard and does NOT flip the skeleton loading state, so
+   * it can reconcile a live thread without a visible flash. It is used after
+   * an interrupt resume (OAuth consent / tool approval): the resumed stream
+   * carries only the `tool_result` + the final assistant text — Strands does
+   * not replay the interrupted `tool_use` block — so the live parser can't
+   * attach the result to the paused tool card. Re-reading persisted memory
+   * (where the backend stored both the `tool_use` and its `tool_result`)
+   * flips the card from "Running…" to its completed result.
+   *
+   * Best-effort: a failure leaves the live-streamed state untouched rather
+   * than disrupting the UI.
+   */
+  async reloadMessagesForSession(sessionId: string): Promise<void> {
+    try {
+      await this.fetchAndApplyMessages(sessionId, /* showLoading */ false);
+    } catch (error) {
+      console.error('Failed to reload messages for session:', sessionId, error);
+    }
+  }
+
+  /**
+   * Fetch a session's messages + file metadata, reconstruct tool results and
+   * file attachments, and replace the message map entry. Shared by the
+   * initial load and the post-resume reconcile.
+   */
+  private async fetchAndApplyMessages(sessionId: string, showLoading: boolean): Promise<void> {
+    if (showLoading) {
+      this._isLoadingSession.set(sessionId);
+    }
 
     try {
       // Fetch messages and file metadata in parallel
@@ -351,12 +391,10 @@ export class MessageMapService {
       // session.page resets McpAppStateService before this load, so the
       // non-clobbering seed lands cleanly.
       this.mcpAppState.seedFromHydration(messagesResponse.uiResources ?? []);
-    } catch (error) {
-      console.error('Failed to load messages for session:', sessionId, error);
-      throw error;
     } finally {
-      // Clear loading state
-      this._isLoadingSession.set(null);
+      if (showLoading) {
+        this._isLoadingSession.set(null);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

When a tool call is gated behind an interrupt — OAuth consent (`oauth_required`) or tool approval — the assistant's tool card **disappears from the thread after the user completes the interrupt**, even though the call succeeded and the final answer streams in. The user is left with the answer but no visible record of the tool that produced it.

## Root cause (two halves)

1. **Backend (working as intended):** on resume, Strands does **not** replay the interrupted `tool_use` block. `agent.stream_async(interrupt_responses)` emits only the `tool_result` (as a user-role message) followed by a fresh assistant `message_start` + final text. The original `tool_use` assistant message already lives in AgentCore Memory from the first (interrupted) turn.

2. **Frontend:** `MessageMapService.syncStreamingMessages()` treats a resume like a normal turn — it truncates everything after the **last user message** and replaces it with the resumed stream. A resume turn has **no new user message** and the resumed stream doesn't carry the `tool_use` block, so the assistant message holding the tool card gets discarded. The freshly-reset parser also silently drops the incoming `tool_result` (no matching `tool_use` in its builder → `handleToolResult` returns early). Net: card gone, only the final text survives.

This is the same shape already solved for the max-tokens **"Continue"** flow (`continueTruncatedTurn` → `beginContinuationStreaming`).

## Fix

Both resume paths in `chat-request.service.ts` (`resumeFromOAuthConsent`, `resumeFromToolApproval`) now:

- Use `messageMapService.beginContinuationStreaming(sessionId)` instead of `startStreaming(sessionId)` — pins the existing messages (including the tool card) as a stable prefix and appends the resume after them, so the card isn't truncated away mid-stream.
- After the resume stream closes, call the new `MessageMapService.reloadMessagesForSession(sessionId)` — force re-reads persisted memory (which holds both `tool_use` and `tool_result`), reconstructs via `matchToolResultsToToolUses`, and flips the card from "Running…" to its completed result. Best-effort (swallows errors, no skeleton flash).

`reloadMessagesForSession` bypasses the "already loaded" guard and does not flip the loading state; the shared fetch/reconcile logic is extracted into `fetchAndApplyMessages()`. Also removed the now-unused `StreamParserService` injection from `ChatRequestService`.

## Why the reload (not a live parser change)

A `tool_use` block with no `result` renders as a perpetual "Running…" (`tool-use.component` status defaults to `pending`). Attaching the resumed `tool_result` to the pinned card live would require threading the pinned prefix's `tool_use` blocks into the parser. Reusing the exact server reconcile the app already trusts on page refresh is lower-risk and authoritative. Backend was not touched — it persists everything correctly.

## Durable rule

Any future interrupt/resume type has this same shape (no new user message, `tool_use` not replayed) and must go through continuation streaming + post-resume reload, not the normal truncate-to-last-user sync.

## Files changed

- `frontend/ai.client/src/app/session/services/chat/chat-request.service.ts` — both resume methods; dropped unused `StreamParserService`
- `frontend/ai.client/src/app/session/services/session/message-map.service.ts` — new `reloadMessagesForSession()`; extracted `fetchAndApplyMessages()`
- `.spec.ts` for both — new coverage

## Testing

- `tsc --noEmit`: clean
- `chat-request.service.spec.ts`: 14 passed (4 new — resume uses continuation streaming + reload, no user bubble, no-op guards for both resume paths)
- `message-map.service.spec.ts`: 23 passed (2 new — `reloadMessagesForSession` force-fetches without loading flash and flips the card to complete; swallows fetch errors)

Requires a real external-provider OAuth flow, so not reproducible in local preview. **Manual test:** invoke a provider-gated tool (e.g. "search gmail…") → Connect → complete consent → the tool card stays, flips to green "Complete" with its result, and the answer streams below it. Refresh → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)