### PR TITLE
feat: default export to messages only

### DIFF
--- a/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/export-dialog/export-dialog.component.spec.ts
@@ -117,9 +117,9 @@ describe('ExportDialogComponent', () => {
     await vi.waitFor(() => expect((component['targets'] as () => unknown[])()).toHaveLength(1));
 
     const include = () => (component['include'] as () => Record<string, boolean>)();
-    expect(include()['citations']).toBe(true);
-    (component['toggleInclude'] as (k: string) => void)('citations');
     expect(include()['citations']).toBe(false);
+    (component['toggleInclude'] as (k: string) => void)('citations');
+    expect(include()['citations']).toBe(true);
   });
 
   it('runs the consent flow when saving to an unconnected destination', async () => {

--- a/frontend/ai.client/src/app/session/services/export/export.model.ts
+++ b/frontend/ai.client/src/app/session/services/export/export.model.ts
@@ -56,9 +56,9 @@ export interface ExportInclude {
 export const DEFAULT_EXPORT_INCLUDE: ExportInclude = {
   userMessages: true,
   assistantMessages: true,
-  toolCalls: true,
-  images: true,
-  citations: true,
+  toolCalls: false,
+  images: false,
+  citations: false,
   reasoning: false,
   timestamps: false,
 };


### PR DESCRIPTION
## Summary
- Include only user and assistant messages by default in conversation exports
- Tool calls, images, and citations must now be explicitly selected by the user

## Test plan
- [ ] Open export dialog in a conversation
- [ ] Verify only Messages checkbox is checked (and disabled)
- [ ] Verify Tool calls, Images, and Citations are unchecked by default
- [ ] Verify Reasoning and Timestamps remain unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)