### PR TITLE
feat: expose session options menu on top-nav title

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
@@ -50,7 +50,7 @@
                                             [routerLink]="['/s', getSessionId(session.sessionId)]"
                                             [queryParams]="getSessionQueryParams(session)"
                                             routerLinkActive="bg-gray-200 !font-medium !text-secondary-500 dark:bg-white/5 dark:!text-white"
-                                            (click)="onSessionClick()"
+                                            (click)="onSessionClick(session)"
                                             class="block truncate rounded-md px-2 py-1.5 pr-10 text-sm/5 font-normal text-gray-700 hover:bg-gray-50 hover:text-secondary-500 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
                                         >
                                             {{ getSessionTitle(session) }}

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
@@ -69,10 +69,14 @@ describe('SessionList', () => {
     expect(component['getSessionTitle']({ ...mockSession, title: '' })).toBe('Untitled Session');
   });
 
-  it('should close sidenav on session click', async () => {
+  it('closes the sidenav and optimistically sets the clicked session on click', async () => {
     const component = await createComponent();
-    component['onSessionClick']();
+    mockSessionService.currentSession.set({ ...mockSession, sessionId: 'other', title: 'Other' });
+
+    component['onSessionClick'](mockSession);
+
     expect(mockSidenavService.close).toHaveBeenCalled();
+    expect(mockSessionService.currentSession()).toEqual(mockSession);
   });
 
   it('reflects per-session streaming state for the in-progress indicator', async () => {

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -237,9 +237,16 @@ export class SessionList {
   }
 
   /**
-   * Handles session selection, closing the sidenav on mobile.
+   * Handles session selection. Optimistically sets the clicked session as the
+   * current one so the top-nav title updates the instant the item is clicked,
+   * instead of lingering on the previous title until its metadata loads from
+   * the API. The metadata resource reload (triggered by the route change) later
+   * replaces this with the authoritative record.
+   *
+   * @param session - The session that was clicked
    */
-  protected onSessionClick(): void {
+  protected onSessionClick(session: SessionMetadata): void {
+    this.sessionService.currentSession.set(session);
     this.sidenavService.close();
   }
 

--- a/frontend/ai.client/src/app/components/topnav/topnav.css
+++ b/frontend/ai.client/src/app/components/topnav/topnav.css
@@ -2,3 +2,48 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Session options menu animation */
+.session-options-menu {
+  animation: menu-fade-in 150ms ease-out;
+}
+
+@keyframes menu-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-options-menu {
+    animation: none;
+  }
+}
+
+/* Session title entry: gentle left-to-right slide with a fade in. Replays on
+   each session switch because the title span is keyed by session id. */
+.session-title-enter {
+  animation: session-title-enter 220ms ease-out;
+}
+
+@keyframes session-title-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-title-enter {
+    animation: none;
+  }
+}
+

--- a/frontend/ai.client/src/app/components/topnav/topnav.html
+++ b/frontend/ai.client/src/app/components/topnav/topnav.html
@@ -23,7 +23,100 @@
         </svg>
       </button>
 
-      <h1 class="text-base/7 font-semibold text-gray-900 dark:text-white">{{ currentSession().title || '' }}</h1>
+      @if (renaming()) {
+        <!-- Inline rename input -->
+        <input
+          #renameInput
+          type="text"
+          [value]="renameValue()"
+          (input)="renameValue.set(renameInput.value)"
+          (keydown)="onRenameKeydown($event)"
+          (blur)="onRenameSubmit()"
+          class="min-w-0 max-w-xs flex-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-base/7 font-semibold text-gray-900 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-primary-400 dark:focus:ring-primary-400"
+          aria-label="Rename conversation title"
+        />
+      } @else if (currentSession().title) {
+        <!-- Session title with options menu trigger -->
+        <button
+          type="button"
+          [cdkMenuTriggerFor]="sessionMenu"
+          [cdkMenuPosition]="menuPositions"
+          [disabled]="deleting()"
+          class="group/title flex min-w-0 items-center gap-x-2 rounded-md px-1.5 py-1 -mx-1.5 text-gray-900 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-white dark:hover:bg-white/10"
+          [attr.aria-label]="'Options for conversation: ' + currentSession().title"
+          aria-haspopup="menu"
+        >
+          @for (title of [currentSession().title]; track title) {
+            <span class="session-title-enter truncate text-base/7 font-semibold">{{ title }}</span>
+          }
+          <ng-icon
+            name="heroChevronDown"
+            class="shrink-0 text-gray-500 transition-transform duration-150 group-aria-expanded/title:rotate-180 dark:text-gray-400"
+            size="13"
+            aria-hidden="true"
+          />
+        </button>
+
+        <!-- Session options menu -->
+        <ng-template #sessionMenu>
+          <div
+            cdkMenu
+            class="session-options-menu min-w-36 rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
+            role="menu"
+            aria-orientation="vertical"
+          >
+            <button
+              cdkMenuItem
+              type="button"
+              (click)="onRenameClick($event)"
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+            >
+              <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+              <span>Rename</span>
+            </button>
+            <button
+              cdkMenuItem
+              type="button"
+              (click)="onShareClick($event)"
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+            >
+              <ng-icon name="heroArrowUpOnSquare" class="size-4" aria-hidden="true" />
+              <span>Share</span>
+            </button>
+            <button
+              cdkMenuItem
+              type="button"
+              (click)="onExportClick($event)"
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+            >
+              <ng-icon name="heroCloudArrowUp" class="size-4" aria-hidden="true" />
+              <span>Save to…</span>
+            </button>
+            <button
+              cdkMenuItem
+              type="button"
+              (click)="onDeleteClick($event)"
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-red-600 hover:bg-gray-50 focus:bg-gray-50 dark:text-red-400 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+            >
+              <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+              <span>Delete</span>
+            </button>
+          </div>
+        </ng-template>
+      } @else if (currentSession().sessionId || titleLoading()) {
+        <!-- Title not available yet — either a hard refresh (session id + title
+             arrive together once metadata resolves) or a brand-new chat whose
+             title is still generating. Show a skeleton until it lands. -->
+        <div
+          class="h-4 w-40 rounded-md bg-gray-200 animate-pulse motion-reduce:animate-none dark:bg-white/5"
+          role="status"
+          aria-label="Loading conversation title"
+        ></div>
+      }
 
       <!-- Separator -->
       <div aria-hidden="true" class="h-6 w-px bg-gray-200 lg:hidden dark:bg-gray-700"></div>

--- a/frontend/ai.client/src/app/components/topnav/topnav.ts
+++ b/frontend/ai.client/src/app/components/topnav/topnav.ts
@@ -1,19 +1,77 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy, computed, signal, afterNextRender, Injector } from '@angular/core';
 import { Router } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp } from '@ng-icons/heroicons/outline';
 import { SessionService } from '../../session/services/session/session.service';
+import { ShareModalComponent, ShareModalData } from '../../session/components/share-modal';
+import { ExportDialogComponent, ExportDialogData } from '../../session/components/export-dialog';
+import { UserService } from '../../auth/user.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ToastService } from '../../services/toast/toast.service';
+import { ConfirmationDialogComponent, ConfirmationDialogData } from '../confirmation-dialog';
 
 @Component({
   selector: 'app-topnav',
-  imports: [],
+  imports: [NgIcon, CdkMenuTrigger, CdkMenu, CdkMenuItem],
+  providers: [provideIcons({ heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp })],
   templateUrl: './topnav.html',
   styleUrl: './topnav.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Topnav {
   private router = inject(Router);
   protected sidenavService = inject(SidenavService);
   protected sessionService = inject(SessionService);
+  private dialog = inject(Dialog);
+  private toastService = inject(ToastService);
+  private userService = inject(UserService);
+  private injector = inject(Injector);
+
   readonly currentSession = this.sessionService.currentSession;
+
+  /**
+   * True while the active session's metadata is being fetched (e.g. on a hard
+   * refresh, where the session id and title arrive together only once the
+   * request resolves). Drives the title skeleton so the header isn't blank
+   * during that window.
+   */
+  protected readonly titleLoading = computed(() =>
+    this.sessionService.sessionMetadataResource.isLoading()
+  );
+
+  /** True while the title is being edited inline. */
+  protected readonly renaming = signal(false);
+
+  /** Holds the current value of the inline rename input. */
+  protected readonly renameValue = signal('');
+
+  /** True while the current session is being deleted. */
+  protected readonly deleting = signal(false);
+
+  /**
+   * Menu positioning - opens below the trigger, aligned to its start edge,
+   * with an upward fallback.
+   */
+  protected readonly menuPositions: ConnectedPosition[] = [
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetY: 4
+    },
+    {
+      originX: 'start',
+      originY: 'top',
+      overlayX: 'start',
+      overlayY: 'bottom',
+      offsetY: -4
+    }
+  ];
 
   newChat() {
     this.router.navigate(['']);
@@ -21,5 +79,156 @@ export class Topnav {
 
   openSidenav() {
     this.sidenavService.open();
+  }
+
+  /**
+   * Enters inline rename mode, seeding the input with the current title and
+   * focusing it once the template re-renders.
+   */
+  protected onRenameClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.renameValue.set(this.currentSession().title || '');
+    this.renaming.set(true);
+
+    afterNextRender(() => {
+      const input = document.querySelector<HTMLInputElement>('input[aria-label="Rename conversation title"]');
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    }, { injector: this.injector });
+  }
+
+  /**
+   * Applies the rename optimistically: the header and sidenav update
+   * immediately and rename mode exits without waiting on the API. Only on
+   * failure do we revert to the previous title and surface a toast.
+   */
+  protected async onRenameSubmit(): Promise<void> {
+    const session = this.currentSession();
+    const sessionId = session.sessionId;
+    const previousTitle = session.title;
+    const newTitle = this.renameValue().trim();
+
+    if (!newTitle || newTitle === previousTitle) {
+      this.onRenameCancel();
+      return;
+    }
+
+    // Optimistically apply the new title and leave rename mode right away.
+    this.applyTitle(sessionId, newTitle);
+    this.renaming.set(false);
+
+    try {
+      await this.sessionService.updateSessionTitle(sessionId, newTitle);
+      this.sessionService.sessionsResource.reload();
+    } catch (error) {
+      console.error('Failed to rename session:', error);
+      // Roll back the optimistic change.
+      this.applyTitle(sessionId, previousTitle);
+      this.sessionService.sessionsResource.reload();
+      this.toastService.error(
+        'Failed to rename',
+        'There was an error renaming the conversation. Please try again.'
+      );
+    }
+  }
+
+  /**
+   * Reflects a title into the local cache and, when it matches the active
+   * session, the currentSession signal so the header updates instantly.
+   */
+  private applyTitle(sessionId: string, title: string): void {
+    this.sessionService.updateSessionTitleInCache(sessionId, title);
+    if (this.sessionService.currentSession().sessionId === sessionId) {
+      this.sessionService.currentSession.update(current => ({ ...current, title }));
+    }
+  }
+
+  /** Cancels rename mode without saving. */
+  protected onRenameCancel(): void {
+    this.renaming.set(false);
+  }
+
+  /** Enter submits, Escape cancels. */
+  protected onRenameKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.onRenameSubmit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      this.onRenameCancel();
+    }
+  }
+
+  /** Opens the share modal for the current session. */
+  protected onShareClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.dialog.open(ShareModalComponent, {
+      data: {
+        sessionId: this.currentSession().sessionId,
+        ownerEmail: this.userService.currentUser()?.email ?? '',
+      } as ShareModalData,
+    });
+  }
+
+  /** Opens the "Save to…" export dialog for the current session. */
+  protected onExportClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const session = this.currentSession();
+    this.dialog.open(ExportDialogComponent, {
+      data: {
+        sessionId: session.sessionId,
+        title: session.title,
+      } as ExportDialogData,
+    });
+  }
+
+  /**
+   * Confirms and deletes the current session, navigating home afterwards.
+   */
+  protected async onDeleteClick(event: Event): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const sessionId = this.currentSession().sessionId;
+
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: 'Delete Conversation',
+        message: 'Are you sure you want to delete this conversation? This action cannot be undone. Any shared links to this conversation will stop working.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true
+      } as ConfirmationDialogData
+    });
+
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      this.deleting.set(true);
+      await this.sessionService.deleteSession(sessionId);
+      this.toastService.success(
+        'Conversation deleted',
+        'The conversation has been permanently deleted.'
+      );
+      this.router.navigate(['']);
+    } catch (error) {
+      console.error('Failed to delete session:', error);
+      this.toastService.error(
+        'Failed to delete',
+        'There was an error deleting the conversation. Please try again.'
+      );
+    } finally {
+      this.deleting.set(false);
+    }
   }
 }

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -1,14 +1,17 @@
+<!-- Fixed top bar. Rendered once and kept mounted across the skeleton→loaded
+     transition so it never remounts — a remount restarts the fixed wrapper's
+     `left` transition, which reads as the whole bar sweeping across. -->
+@if (showChatTopnav()) {
+  <div
+    class="chat-topnav-wrapper"
+    [class.sidenav-expanded]="!isSidenavCollapsed()"
+    [class.artifact-pane-open]="artifactPanelOpen()">
+    <app-topnav />
+  </div>
+}
+
 <!-- Skeleton loading state -->
 @if (showSkeleton()) {
-  @if (resolvedConfig().fullPageMode) {
-    <!-- Full-page mode: fixed topnav with sidenav awareness -->
-    <div
-      class="chat-topnav-wrapper"
-      [class.sidenav-expanded]="!isSidenavCollapsed()"
-      [class.artifact-pane-open]="artifactPanelOpen()">
-      <app-topnav />
-    </div>
-  }
   <div class="relative pb-30 pt-16 max-w-[720px] mx-auto px-4 py-6 min-w-0">
     <div class="min-w-0 animate-fade-in">
       <app-paragraph-skeleton />
@@ -306,16 +309,7 @@
       </div>
     </div>
   } @else {
-    <!-- Full-page mode: original layout -->
-    @if (resolvedConfig().showTopnav) {
-      <!-- Header (fixed, content scrolls underneath) -->
-      <div
-        class="chat-topnav-wrapper"
-        [class.sidenav-expanded]="!isSidenavCollapsed()"
-      [class.artifact-pane-open]="artifactPanelOpen()">
-        <app-topnav />
-      </div>
-    }
+    <!-- Full-page mode: original layout (top bar rendered once at the root) -->
 
     <!-- Assistant Error Message -->
     @if (assistantError()) {

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -147,6 +147,25 @@ export class ChatContainerComponent {
   protected readonly showSkeleton = computed(
     () => this.isLoadingSession() && !this.hasMessages()
   );
+  /** The greeting/empty state (new chat, nothing loading). No top bar here. */
+  protected readonly isEmptyState = computed(
+    () =>
+      !this.showSkeleton() &&
+      !this.hasMessages() &&
+      this.resolvedConfig().showEmptyState
+  );
+  /**
+   * Whether the fixed top bar should render. Kept as a single computed so one
+   * persistent <app-topnav> spans the skeleton→loaded transition instead of
+   * remounting — a remount restarts the fixed wrapper's `left` transition,
+   * which reads as the whole bar sweeping across the screen.
+   */
+  protected readonly showChatTopnav = computed(
+    () =>
+      this.resolvedConfig().fullPageMode &&
+      this.resolvedConfig().showTopnav &&
+      !this.isEmptyState()
+  );
   protected readonly canCloseAssistant = computed(
     () =>
       this.resolvedConfig().allowCloseAssistant &&


### PR DESCRIPTION
## What

Adds a dropdown to the **top-nav session title** (chevron/arrow trigger) exposing the same actions as the sidenav ellipsis menu — **Rename, Share, Save to…, Delete** — reusing `SessionService` and the existing Share/Export/Confirmation dialogs. No new backend contract.

While building it, a few title-transition issues surfaced and are fixed in the same change.

## Changes

- **Top-nav title menu** (`topnav.html` / `topnav.ts`): chevron-triggered CDK menu with Rename / Share / Save to… / Delete, plus inline rename. Mirrors the sidenav ellipsis wiring (same service methods, dialogs, toasts).
- **Single persistent top bar** (`chat-container`): consolidated the two `<app-topnav>` instances (skeleton vs loaded branch) into one instance rendered above the branches via a new `showChatTopnav` computed. Previously skeleton→loaded destroyed and recreated `Topnav`, remounting the fixed `.chat-topnav-wrapper` at `left: 0` and transitioning it to `left: 18rem` — a ~288px sweep of the whole bar. One instance = no remount = no sweep. Which states show the bar is unchanged.
- **Instant title on click** (`session-list`): `onSessionClick(session)` optimistically sets `currentSession` from the clicked list item so the title updates immediately instead of lingering until metadata loads. The metadata reload still replaces it with the authoritative record.
- **Optimistic rename** (`topnav.ts`): applies the new title and exits rename mode immediately, reverts + toasts on failure, and reloads the sessions resource so the sidenav list reflects the rename (parity with the sidenav flow).
- **Title entry animation** (`topnav.css`): gentle component-scoped slide (8px) + fade, keyed on the title text so it plays once when the new title arrives.
- **Title skeleton** (`topnav.html`): shows while session metadata is loading (`sessionMetadataResource.isLoading()`, e.g. hard refresh) or a brand-new chat's title is still generating.

## Reviewer notes

- Cross-package contract unchanged — this is SPA-only, reusing existing SSE/data flows.
- Verified with `ng build` (template type-checking passes). I couldn't run a browser clickthrough locally (dev server owns port 4200; preview is auth-gated), so a manual pass on: sidenav→topnav parity of the four actions, session switching (no bar sweep, instant title), rename lag/revert, and the refresh skeleton would be good.
- The title skeleton keys off loading state; if title generation ever fails outright it would persist rather than fall back to "Untitled Session" — easy to add a timeout/`Untitled` fallback if preferred.
- A dedicated `TopnavTitle` component was considered but deferred to avoid churn; not required for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)