### PR TITLE
fix: clear OAuth consent state on session switch

### DIFF
--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -34,6 +34,7 @@ import {
 import { VoiceChatService } from './services/voice';
 import { SystemPromptsService } from '../services/system-prompts/system-prompts.service';
 import { ChatModeService } from '../services/chat-mode/chat-mode.service';
+import { OAuthConsentService } from '../services/oauth-consent/oauth-consent.service';
 
 @Component({
   selector: 'app-session-page',
@@ -59,6 +60,7 @@ export class ConversationPage implements OnDestroy {
   private mcpAppCardState = inject(McpAppCardStateService);
   private mcpAppCardHttp = inject(McpAppCardHttpService);
   private mcpAppConsent = inject(McpAppConsentService);
+  private oauthConsent = inject(OAuthConsentService);
   private artifactHttp = inject(ArtifactHttpService);
   private assistantService = inject(AssistantService);
   private router = inject(Router);
@@ -406,6 +408,14 @@ export class ConversationPage implements OnDestroy {
       // conversation is dropped fail-closed.
       this.mcpAppCardState.reset();
       this.mcpAppConsent.reset();
+
+      // OAuth "Authorization needed" prompts are held in a root singleton
+      // keyed by providerId (not sessionId), so a prior conversation's
+      // request would otherwise bleed onto the next session — including the
+      // blank welcome screen. Clear fail-closed on conversation change;
+      // loadMessagesForSession below re-seeds this session's own pending
+      // interrupts from the persisted server metadata.
+      this.oauthConsent.clear();
 
       if (id) {
         // Update the messages signal reference (this triggers reactivity)


### PR DESCRIPTION
## Problem

The OAuth **"Authorization needed — Connect …"** banner (raised by the `oauth_required` SSE event) persisted across sessions. It could appear on a brand-new conversation's blank welcome screen even though that session never triggered it.

## Root cause

`OAuthConsentService` is a `providedIn: 'root'` singleton that stores consent requests in a `Map` keyed by **`providerId`, not `sessionId`** (`services/oauth-consent/oauth-consent.service.ts`). Its `pending()` signal drives the banner across the whole app.

Every other per-session UI surface is reset in the route subscription on conversation change — compaction, artifacts, MCP app frames, MCP app cards, and MCP app consent (`session/session.page.ts`). `OAuthConsentService` was the one singleton missing from that block, so a request raised in one session bled into the next.

## Fix

Add `this.oauthConsent.clear()` to that same reset block, mirroring the existing `mcpAppConsent.reset()` fail-closed precedent.

- Runs **before** `loadMessagesForSession()`, which re-seeds the *new* session's own pending interrupts from persisted server metadata (`message-map.service.ts`) — so a session that legitimately needs authorization still shows its banner after the switch.
- `clear()` also wipes `seenInterruptIds`, fixing a latent second bug: without it, a genuinely-needed re-prompt for the same provider in a later session was silently suppressed by the dedup guard.

## Scope note

`clear()` resets the state signals but intentionally does not cancel the popup `closeWatchers` intervals — that's pre-existing and unrelated, and leaving an in-flight watcher alive so a completing popup can still resume its original session is the correct behavior.

## Testing

- `tsc --noEmit` clean.
- No `session.page.spec.ts` exists to extend; the `clear()` contract is already covered by `oauth-consent.service.spec.ts`.
- Manual repro (banner leaking onto a fresh session) requires a live cross-session OAuth flow, not reproducible in preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)