### PR TITLE
feat: interrupted-turn context (partial + marker + reload UX)

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -114,6 +114,20 @@ class StreamCoordinator:
         per_message_metadata: List[Dict[str, Any]] = []
         current_assistant_message_index = -1  # Track which assistant message we're on (0-indexed within this stream)
 
+        # Accumulate the IN-FLIGHT assistant message's TEXT so an interruption
+        # (client Stop / refresh / dropped socket) can persist the partial the
+        # user already saw. Unlike max_tokens truncation — where Strands
+        # recovers and appends the partial itself — a raw cancellation aborts
+        # the turn before Strands commits the current message, so we
+        # reconstruct it from the deltas here. Scope is strictly the message
+        # currently streaming: TurnBasedSessionManager persists each COMPLETED
+        # message immediately via the append_message hook (flush is a no-op),
+        # so the accumulator resets at assistant `message_start` and clears at
+        # `message_stop` — otherwise re-persisting it would duplicate text
+        # from mid-turn messages that already landed in AgentCore Memory.
+        # See the CancelledError/GeneratorExit handler below.
+        assistant_text_acc: List[str] = []
+
         # OPTIMIZATION: Capture initial message count BEFORE streaming starts
         # This allows us to calculate message indices without post-stream AgentCore Memory queries
         # The TurnBasedSessionManager.message_count is initialized from AgentCore Memory at session start
@@ -155,6 +169,10 @@ class StreamCoordinator:
                 if event.get("type") == "message_start":
                     role = event.get("data", {}).get("role")
                     if role == "assistant":
+                        # New in-flight message — drop any leftover deltas
+                        # (a prior message was completed + persisted by the
+                        # append_message hook, or this is the first message).
+                        assistant_text_acc.clear()
                         current_assistant_message_index += 1
                         # Record the start time for this specific assistant message
                         # This enables accurate per-message latency calculation
@@ -177,6 +195,8 @@ class StreamCoordinator:
                     # Only track first token for text deltas (not tool use deltas)
                     # This gives accurate TTFT for actual text generation
                     if event_data.get("type") == "text" and event_data.get("text"):
+                        # Capture the partial for interruption persistence.
+                        assistant_text_acc.append(event_data["text"])
                         if current_assistant_message_index >= 0 and current_assistant_message_index < len(per_message_metadata):
                             if per_message_metadata[current_assistant_message_index]["first_token_time"] is None:
                                 per_message_metadata[current_assistant_message_index]["first_token_time"] = time.time()
@@ -226,6 +246,11 @@ class StreamCoordinator:
 
                 # Track when assistant messages end
                 if event.get("type") == "message_stop":
+                    # Message complete — Strands appends it to agent.messages
+                    # and the append_message hook persists it to AgentCore
+                    # Memory. It is no longer "in flight", so an interruption
+                    # from here on must not re-persist its text.
+                    assistant_text_acc.clear()
                     if current_assistant_message_index >= 0 and current_assistant_message_index < len(per_message_metadata):
                         per_message_metadata[current_assistant_message_index]["end_time"] = time.time()
                         logger.debug(f"📝 Assistant message {current_assistant_message_index} ended")
@@ -894,6 +919,31 @@ class StreamCoordinator:
                 except Exception as e:
                     logger.error(f"Failed to store user displayText: {e}", exc_info=True)
 
+        except (asyncio.CancelledError, GeneratorExit):
+            # Client interruption: Stop click, page refresh, or dropped
+            # socket. Depending on where the generator is suspended when the
+            # disconnect lands, Starlette's teardown surfaces here as either
+            # CancelledError (cancellation delivered at an inner `await`,
+            # e.g. while waiting on model tokens — the common case) or
+            # GeneratorExit (thrown at a `yield` via `aclose()`). Both
+            # subclass BaseException, so the `except Exception` below never
+            # sees them — without this arm the partial is lost and the turn
+            # stays an orphan user message. This server-side arm is the
+            # BEST-EFFORT BACKSTOP (disconnect propagation through the
+            # AgentCore Runtime data plane is not guaranteed in cloud); the
+            # authoritative intent signal is the SPA's stop-signal endpoint
+            # on app-api. Persist the partial the user already saw + mark the
+            # turn, then RE-RAISE so teardown unwinds normally.
+            # `connection_lost` is the fallback reason; a `user_stopped`
+            # client signal, if it lands, wins via reason precedence in
+            # set_interrupted_turn.
+            await self._persist_interruption(
+                agent=agent,
+                session_id=session_id,
+                user_id=user_id,
+                partial_text="".join(assistant_text_acc),
+            )
+            raise
         except Exception as e:
             # Handle errors with emergency flush
             logger.error(f"Error in stream_response: {e}")
@@ -957,6 +1007,95 @@ class StreamCoordinator:
                     logger.warning(
                         "MCP Apps broker unsubscribe failed", exc_info=True
                     )
+
+    async def _persist_interruption(
+        self,
+        agent: Any,
+        session_id: str,
+        user_id: str,
+        partial_text: str,
+    ) -> None:
+        """Persist the in-flight partial assistant turn + an interrupted
+        marker when a turn is torn down mid-stream.
+
+        Runs from inside the ``except (CancelledError, GeneratorExit)`` arm,
+        i.e. while the request task is being torn down. Any bare ``await``
+        here would itself be cancelled before it completes, so the work is
+        wrapped in ``asyncio.shield`` around an independent task — the writes
+        finish even as the outer stream unwinds. Best-effort throughout: a
+        failure logs and never masks the original teardown exception (the
+        caller re-raises it).
+
+        Only the assistant partial is persisted — the user turn (and any
+        mid-turn message that completed before the interruption) was already
+        committed by Strands' MessageAddedEvent/append_message hook (same
+        reasoning as the error paths; canonical reference in
+        ``session/persistence.py``).
+
+        Role-alternation repair: when the interruption lands before any token
+        of the in-flight message streamed (empty partial), a minimal
+        placeholder assistant turn is persisted ONLY if the last committed
+        message is a user turn — that is the dangling user→user case the
+        placeholder exists to fix. On continuation/resume turns (history tail
+        is an assistant message) or a pre-turn cancellation nothing needs
+        repair, so no synthetic write happens and only the marker is set.
+        """
+        async def _do() -> None:
+            text = partial_text.strip()
+            last_role = None
+            try:
+                messages = getattr(agent, "messages", None) or []
+                if messages:
+                    last_role = messages[-1].get("role")
+            except Exception:  # noqa: BLE001 - diagnostic only
+                logger.debug("Could not read agent.messages tail", exc_info=True)
+
+            message = text if text else "[Response interrupted before any content was generated]"
+            should_persist = bool(text) or last_role == "user"
+            if should_persist:
+                try:
+                    from agents.main_agent.session.persistence import persist_synthetic_messages
+                    from agents.main_agent.session.session_factory import SessionFactory
+
+                    persist_session_manager = SessionFactory.create_session_manager(
+                        session_id=session_id, user_id=user_id, caching_enabled=False
+                    )
+                    persist_synthetic_messages(
+                        persist_session_manager,
+                        session_id,
+                        [("assistant", message)],
+                    )
+                except Exception as persist_error:
+                    logger.error(
+                        "Failed to persist interrupted partial for session %s: %s",
+                        session_id, persist_error, exc_info=True,
+                    )
+            else:
+                logger.info(
+                    "Interruption with no in-flight partial and non-user history tail "
+                    "(role=%s) for session %s — marker only, no synthetic write",
+                    last_role, session_id,
+                )
+
+            try:
+                from apis.shared.sessions.metadata import set_interrupted_turn
+
+                await set_interrupted_turn(
+                    session_id, user_id, reason="connection_lost", source="cancellation"
+                )
+            except Exception as marker_error:
+                logger.error(
+                    "Failed to persist interrupted_turn marker for session %s: %s",
+                    session_id, marker_error, exc_info=True,
+                )
+
+        try:
+            await asyncio.shield(asyncio.ensure_future(_do()))
+        except asyncio.CancelledError:
+            # The shield itself was cancelled from outside while _do() ran —
+            # the inner task keeps running to completion (that's the point of
+            # shield). Swallow here and let the caller re-raise the original.
+            logger.debug("interrupted-turn persistence shield cancelled; inner write continues")
 
     async def _persist_paused_turn_snapshot(
         self,

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime, timezone
 from apis.shared.sessions.models import (
     UpdateSessionMetadataRequest,
+    SessionInterruptRequest,
     SessionMetadataResponse,
     SessionMetadata,
     SessionPreferences,
@@ -24,6 +25,7 @@ from apis.shared.sessions.metadata import (
     get_session_metadata,
     remove_pending_interrupts,
     session_exists_for_other_user,
+    set_interrupted_turn,
     store_session_metadata,
 )
 from .services.session_service import SessionService
@@ -594,6 +596,52 @@ async def get_session_messages_endpoint(
         raise HTTPException(
             status_code=500,
             detail=f"Failed to retrieve messages: {str(e)}"
+        )
+
+
+@router.post("/{session_id}/interrupt", status_code=204)
+async def signal_turn_interrupted_endpoint(
+    session_id: str,
+    body: SessionInterruptRequest,
+    current_user: User = Depends(get_current_user_from_session),
+):
+    """Record that the user deliberately stopped the session's in-flight turn.
+
+    This is the AUTHORITATIVE carrier of stop intent for the interrupted-turn
+    flow: the transport cannot distinguish a Stop click from a dropped socket
+    (both surface as a cancelled stream), so the SPA signals intent here
+    out-of-band when the user clicks Stop — via ``fetch(..., {keepalive:
+    true})`` with the ``X-CSRF-Token`` header (NOT ``navigator.sendBeacon``,
+    which cannot set headers and would be rejected by CSRFMiddleware).
+
+    Lives on app-api, not inference-api: the AgentCore Runtime data plane
+    only proxies ``/invocations`` + ``/ping``, so a custom inference-api
+    route would 404 in cloud.
+
+    ``user_stopped`` takes precedence over the ``connection_lost`` fallback
+    that inference-api's cancellation backstop may race against this write
+    (see ``set_interrupted_turn``). No-op for missing sessions — and the GSI
+    lookup inside ``set_interrupted_turn`` is user-scoped, so a session
+    owned by someone else is also a no-op. Returns 204 either way (the
+    user's intent is recorded best-effort; the client never waits on it).
+    """
+    user_id = current_user.user_id
+
+    logger.info("POST /sessions/.../interrupt (reason=%s)", body.reason)
+
+    try:
+        await set_interrupted_turn(
+            session_id,
+            user_id,
+            reason=body.reason,
+            source="client_signal",
+        )
+        return Response(status_code=204)
+    except Exception:
+        logger.error("Error recording turn interruption", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to record interruption",
         )
 
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -496,6 +496,44 @@ def _build_attachment_guidance(
     return "\n\n".join(parts)
 
 
+def _build_interruption_note(reason: str) -> str:
+    """Reason-driven note prepended to the next turn's prompt when the prior
+    turn was interrupted (see `clear_interrupted_turn`, whose popped reason
+    feeds this).
+
+    Why the note lives HERE and not on the interrupted turn itself: the
+    reason is not knowable at cancellation time — the client's `user_stopped`
+    signal (app-api) races the server-side cancellation backstop
+    (inference-api), and precedence only settles in the session record. By
+    the next turn the marker is authoritative.
+
+    The two reasons carry opposite signal, so the guidance differs:
+    `user_stopped` is deliberate feedback (don't barrel onward);
+    `connection_lost` (or unclassified) is a technical drop (the user likely
+    still wants the answer). The note is prepended to the persisted user
+    message (the `original_message`/displayText split keeps it out of the
+    UI), so it remains an honest in-history record that ages out via
+    compaction rather than a permanent synthetic system turn.
+    """
+    if reason == "user_stopped":
+        guidance = (
+            "The user deliberately stopped your previous response before it "
+            "finished (the last assistant message above is the partial that "
+            "was delivered). Treat that as meaningful feedback — do not "
+            "resume or repeat it on your own; let the user's message below "
+            "set the direction."
+        )
+    else:  # connection_lost / unknown — technical drop, no user intent
+        guidance = (
+            "Your previous response was cut off by a connection interruption "
+            "— the user did not stop it deliberately (the last assistant "
+            "message above is the partial that was delivered). If the user "
+            "asks you to continue, pick up where it left off instead of "
+            "starting over."
+        )
+    return f"<interruption_note>\n{guidance}\n</interruption_note>"
+
+
 async def _build_tabular_inventory(
     session_id: str,
     assistant_id: str | None,
@@ -1002,12 +1040,26 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # turn that isn't an interrupt-resume — both a fresh turn and a
     # continuation supersede it. If a continuation itself re-truncates, the
     # stream_coordinator intercept re-sets the marker.
+    interrupted_turn_reason: Optional[str] = None
     if not is_resume:
         try:
             from apis.shared.sessions.metadata import clear_truncated_turn
             await clear_truncated_turn(input_data.session_id, user_id)
         except Exception as e:
             logger.error("Failed to clear stale truncated_turn on new turn: %s", e, exc_info=True)
+
+        # Same lifecycle for the interrupted-turn marker: any new non-resume
+        # turn supersedes a prior interruption, so a stale marker can't
+        # resurrect the "response interrupted" state against a turn the user
+        # has moved past. The pop returns the settled reason (user_stopped
+        # beats connection_lost via write precedence) so this same read+write
+        # also drives the one-turn interruption note prepended to the prompt
+        # in the stream generator below.
+        try:
+            from apis.shared.sessions.metadata import clear_interrupted_turn
+            interrupted_turn_reason = await clear_interrupted_turn(input_data.session_id, user_id)
+        except Exception as e:
+            logger.error("Failed to clear stale interrupted_turn on new turn: %s", e, exc_info=True)
 
     # First turn → kick off title generation concurrently with the stream.
     # Runs as a background task so it doesn't add latency to TTFT. The
@@ -1611,6 +1663,20 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 pending_ctx_block = merge_and_clear_pending_context(agent)
                 if pending_ctx_block:
                     final_message = f"{pending_ctx_block}\n\n{final_message}"
+
+                # Interrupted-turn context: the prior turn ended early (Stop /
+                # refresh / dropped connection) and its marker was popped at
+                # turn start — tell the model, with reason-appropriate
+                # guidance, before it reads the new message. Prepended last so
+                # the note sits topmost. Rides the same `original_message`
+                # displayText split as the ctx block, so the user never sees
+                # it while it stays an honest part of persisted history.
+                # Continuation turns skip this (Strands ignores the message
+                # there — the model just continues the persisted partial).
+                if interrupted_turn_reason:
+                    final_message = (
+                        f"{_build_interruption_note(interrupted_turn_reason)}\n\n{final_message}"
+                    )
 
             message_will_be_modified = (
                 final_message != input_data.message  # RAG augmentation / attachment guidance / inventory

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -2202,3 +2202,147 @@ async def clear_truncated_turn(session_id: str, user_id: str) -> None:
         logger.info("Cleared truncated_turn for session %s", session_id)
     except Exception as e:
         logger.error("Failed to clear truncated_turn: %s", e, exc_info=True)
+
+
+async def set_interrupted_turn(
+    session_id: str,
+    user_id: str,
+    reason: str = "unknown",
+    source: str = "cancellation",
+) -> None:
+    """Mark that the last turn was interrupted before completion.
+
+    Interruptions come from two racing sources that write the same session
+    record: the client stop signal (app-api ``POST /sessions/{id}/interrupt``,
+    ``reason="user_stopped"``) and the stream cancellation backstop
+    (inference-api, ``reason="connection_lost"`` fallback). ``user_stopped``
+    is the stronger signal, so a ``user_stopped`` write is unconditional
+    while a fallback write is guarded by a condition so it can never
+    downgrade an already-recorded ``user_stopped`` — whichever source lands
+    first, the final reason is correct. Idempotent. Best-effort: a write
+    failure logs but never breaks the live flow. No-op when the session
+    record is missing or the table env var is unset.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        logger.warning("DYNAMODB_SESSIONS_METADATA_TABLE_NAME not set; skipping interrupted_turn persistence")
+        return
+
+    if reason not in ("user_stopped", "connection_lost", "unknown"):
+        reason = "unknown"
+
+    try:
+        import boto3
+        from datetime import datetime, timezone
+        from botocore.exceptions import ClientError
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            logger.info("Skipping interrupted_turn write — session %s not found", session_id)
+            return
+
+        sk = existing.get("SK")
+        if not sk:
+            logger.warning("Session %s has no SK; cannot update interrupted_turn", session_id)
+            return
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        update_kwargs: dict = {
+            "Key": {"PK": f"USER#{user_id}", "SK": sk},
+            "UpdateExpression": "SET #lti = :lti, #ltr = :ltr, #ltia = :ltia",
+            "ExpressionAttributeNames": {
+                "#lti": "lastTurnInterrupted",
+                "#ltr": "lastTurnInterruptReason",
+                "#ltia": "lastTurnInterruptedAt",
+            },
+            "ExpressionAttributeValues": {
+                ":lti": True,
+                ":ltr": reason,
+                ":ltia": now_iso,
+            },
+        }
+
+        # A fallback (non-user_stopped) write must not clobber a stronger
+        # user_stopped reason the beacon may have already landed. The
+        # condition is evaluated against the pre-update item, so this is
+        # race-safe regardless of which source writes first.
+        if reason != "user_stopped":
+            update_kwargs["ConditionExpression"] = "attribute_not_exists(#ltr) OR #ltr <> :user_stopped"
+            update_kwargs["ExpressionAttributeValues"][":user_stopped"] = "user_stopped"
+
+        try:
+            table.update_item(**update_kwargs)
+            logger.info(
+                "Persisted interrupted_turn marker for session %s (reason=%s, source=%s)",
+                session_id, reason, source,
+            )
+        except ClientError as ce:
+            if ce.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                logger.info(
+                    "Skipping interrupted_turn downgrade for session %s — user_stopped already recorded",
+                    session_id,
+                )
+            else:
+                raise
+    except Exception as e:
+        logger.error("Failed to persist interrupted_turn: %s", e, exc_info=True)
+
+
+async def clear_interrupted_turn(session_id: str, user_id: str) -> Optional[str]:
+    """Pop the interrupted-turn marker, returning the reason it recorded.
+
+    Called at the start of any new turn that isn't an interrupt-resume, so a
+    stale marker can't resurrect the "response interrupted" state against a
+    turn the user has already moved past. The return value lets the same
+    single read+write also drive the next-turn model note (see the
+    interruption-note prepend in inference-api's invocations route) —
+    ``None`` when no marker was set.
+
+    The REMOVE uses ``ReturnValues=UPDATED_OLD`` so the pop is atomic at the
+    write: a marker updated between the GSI lookup and the update is still
+    captured and cleared. Best-effort like its siblings — a failure logs and
+    returns ``None``.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        return None
+
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            return None
+
+        sk = existing.get("SK")
+        if not sk:
+            return None
+
+        if "lastTurnInterrupted" not in existing:
+            return None  # Already clear
+
+        response = table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="REMOVE #lti, #ltr, #ltia",
+            ExpressionAttributeNames={
+                "#lti": "lastTurnInterrupted",
+                "#ltr": "lastTurnInterruptReason",
+                "#ltia": "lastTurnInterruptedAt",
+            },
+            ReturnValues="UPDATED_OLD",
+        )
+        cleared_reason = (response.get("Attributes") or {}).get("lastTurnInterruptReason")
+        logger.info(
+            "Cleared interrupted_turn for session %s (reason=%s)",
+            session_id, cleared_reason,
+        )
+        return cleared_reason if isinstance(cleared_reason, str) else None
+    except Exception as e:
+        logger.error("Failed to clear interrupted_turn: %s", e, exc_info=True)
+        return None

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -229,6 +229,21 @@ class SessionMetadata(BaseModel):
         alias="lastTurnContinuable",
         description="True when the last turn ended in a recoverable max_tokens truncation; lets the 'Continue' affordance survive a page refresh. Cleared at the start of any new (non-interrupt-resume) turn",
     )
+    last_turn_interrupted: Optional[bool] = Field(
+        default=None,
+        alias="lastTurnInterrupted",
+        description="True when the last turn was interrupted before completion (user Stop, refresh, or dropped connection). Lets a reload show the 'response interrupted' state. Cleared at the start of any new (non-interrupt-resume) turn",
+    )
+    last_turn_interrupt_reason: Optional[Literal["user_stopped", "connection_lost", "unknown"]] = Field(
+        default=None,
+        alias="lastTurnInterruptReason",
+        description="Why the last turn was interrupted. 'user_stopped' (deliberate Stop, from the client beacon) wins over the 'connection_lost' cancellation fallback",
+    )
+    last_turn_interrupted_at: Optional[str] = Field(
+        default=None,
+        alias="lastTurnInterruptedAt",
+        description="ISO 8601 timestamp when the interruption was detected",
+    )
 
     # Denormalized cost + context aggregates for the session-cost badge.
     # Maintained by _bump_session_aggregates after each turn (write-time
@@ -286,6 +301,20 @@ class UpdateSessionMetadataRequest(BaseModel):
     agent_type: Optional[Literal["skill", "chat"]] = Field(None, alias="agentType", description="Agent mode for this conversation")
 
 
+class SessionInterruptRequest(BaseModel):
+    """Request body for the client stop signal (POST /sessions/{id}/interrupt).
+
+    Only `user_stopped` is accepted from the client — it is the one reason
+    that requires user attestation. `connection_lost` is never client-sent;
+    it is inferred server-side by the stream-cancellation backstop and would
+    otherwise let a client downgrade a deliberate stop.
+    """
+
+    reason: Literal["user_stopped"] = Field(
+        description="Interruption reason. Only the deliberate Stop is client-attested",
+    )
+
+
 class SessionMetadataResponse(BaseModel):
     """Response containing session metadata"""
 
@@ -325,6 +354,21 @@ class SessionMetadataResponse(BaseModel):
         default=None,
         alias="lastTurnContinuable",
         description="True when the last turn ended in a recoverable max_tokens truncation, so the client can re-show the 'Continue' affordance after a refresh",
+    )
+    last_turn_interrupted: Optional[bool] = Field(
+        default=None,
+        alias="lastTurnInterrupted",
+        description="True when the last turn was interrupted before completion (user Stop, refresh, or dropped connection), so the client can show the 'response interrupted' state after a reload",
+    )
+    last_turn_interrupt_reason: Optional[str] = Field(
+        default=None,
+        alias="lastTurnInterruptReason",
+        description="Why the last turn was interrupted: 'user_stopped' (deliberate Stop) or 'connection_lost' (refresh / dropped connection). Drives whether a 'Continue' affordance is offered on reload",
+    )
+    last_turn_interrupted_at: Optional[str] = Field(
+        default=None,
+        alias="lastTurnInterruptedAt",
+        description="ISO 8601 timestamp when the interruption was detected",
     )
     export_receipts: Optional[List[ExportReceipt]] = Field(
         default=None,

--- a/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
@@ -1,0 +1,249 @@
+"""Regression: a turn interrupted mid-stream (client Stop / refresh / dropped
+socket) persists the in-flight partial assistant text + an interrupted marker
+instead of leaving an orphan user turn.
+
+A client teardown surfaces inside the coordinator generator as
+``asyncio.CancelledError`` (cancellation delivered at an inner ``await``) or
+``GeneratorExit`` (thrown at a ``yield`` via ``aclose()``). Both subclass
+``BaseException``, so they slip past ``process_agent_stream``'s ``except
+Exception`` and the coordinator's own ``except Exception`` — without a
+dedicated arm the partial is lost and the turn stays a dangling user message.
+
+Key invariants under test:
+- The partial persisted is ONLY the in-flight message's text. Completed
+  mid-turn messages were already committed by the ``append_message`` hook
+  (``TurnBasedSessionManager`` persists per-message; ``flush`` is a no-op),
+  so re-persisting their text would duplicate history.
+- Assistant-only persistence — the user turn was already committed at turn
+  start by Strands' MessageAddedEvent hook.
+- The empty-partial placeholder exists solely to repair user→user role
+  alternation, so it is gated on the history tail being a user message.
+- The marker's fallback reason is ``connection_lost``; the client's
+  ``user_stopped`` signal wins via precedence in ``set_interrupted_turn``
+  (covered in tests/shared/test_sessions_metadata.py).
+"""
+
+import asyncio
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+
+class _InterruptingAgent:
+    """Agent whose stream yields raw Strands events then raises the given
+    teardown exception, mimicking a client disconnect mid-generation."""
+
+    def __init__(self, events: List[Dict[str, Any]] = None, exc: BaseException = None) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        self._events = events or []
+        self._exc = exc if exc is not None else asyncio.CancelledError()
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for event in self._events:
+                yield event
+            raise self._exc
+
+        return _gen()
+
+
+class _NoopSessionManager:
+    async def update_after_turn(self, input_tokens: int, current_messages=None):
+        return None
+
+
+class _RecordingPersistSessionManager:
+    """Flat ``create_message`` shape matching the current SDK."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def create_message(self, session_id: str, agent_id: str, session_message: Any) -> None:
+        self.calls.append({"session_id": session_id, "agent_id": agent_id, "message": session_message})
+
+
+def _extract_text(session_message: Any) -> str:
+    inner = getattr(session_message, "message", None)
+    content = inner.get("content") if isinstance(inner, dict) else getattr(inner, "content", None)
+    if isinstance(content, list):
+        return "".join(block.get("text", "") for block in content if isinstance(block, dict))
+    return ""
+
+
+def _raw_message_start() -> Dict[str, Any]:
+    return {"event": {"messageStart": {"role": "assistant"}}}
+
+
+def _raw_text_delta(text: str) -> Dict[str, Any]:
+    return {"event": {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": text}}}}
+
+
+def _raw_message_stop() -> Dict[str, Any]:
+    return {"event": {"messageStop": {"stopReason": "end_turn"}}}
+
+
+async def _drive_until_teardown(agent: Any, expected_exc: type) -> None:
+    coordinator = StreamCoordinator()
+    with pytest.raises(expected_exc):
+        async for _sse in coordinator.stream_response(
+            agent=agent,
+            prompt="please write a long essay",
+            session_manager=_NoopSessionManager(),
+            session_id="sess-interrupt",
+            user_id="user-1",
+            main_agent_wrapper=None,
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_cancellation_invokes_interruption_persistence():
+    """The CancelledError arm fires and re-raises so cancellation still unwinds."""
+    called: Dict[str, Any] = {}
+
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+        called.update(session_id=session_id, user_id=user_id, partial_text=partial_text)
+
+    with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
+        await _drive_until_teardown(_InterruptingAgent(), asyncio.CancelledError)
+
+    assert called.get("session_id") == "sess-interrupt"
+    assert called.get("user_id") == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_generator_exit_also_invokes_interruption_persistence():
+    """Starlette teardown can surface as GeneratorExit (aclose at a yield)
+    instead of CancelledError — the arm must catch both."""
+    called: Dict[str, Any] = {}
+
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+        called.update(session_id=session_id, user_id=user_id, partial_text=partial_text)
+
+    with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
+        await _drive_until_teardown(
+            _InterruptingAgent(exc=GeneratorExit()), GeneratorExit
+        )
+
+    assert called.get("session_id") == "sess-interrupt"
+
+
+@pytest.mark.asyncio
+async def test_partial_covers_only_in_flight_message():
+    """Text from a COMPLETED mid-turn message (already persisted by the
+    append_message hook) must not re-enter the partial — only deltas of the
+    message still streaming at teardown count."""
+    called: Dict[str, Any] = {}
+
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+        called.update(partial_text=partial_text)
+
+    events = [
+        _raw_message_start(),
+        _raw_text_delta("Completed first message."),
+        _raw_message_stop(),
+        _raw_message_start(),
+        _raw_text_delta("In-flight par"),
+    ]
+    with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
+        await _drive_until_teardown(
+            _InterruptingAgent(events=events), asyncio.CancelledError
+        )
+
+    assert called.get("partial_text") == "In-flight par"
+
+
+@pytest.mark.asyncio
+async def test_persist_interruption_writes_partial_assistant_only():
+    """Non-empty partial → exactly one assistant create_message with that text,
+    and the connection_lost fallback marker."""
+    persist_sm = _RecordingPersistSessionManager()
+    marker_calls: List[Dict[str, Any]] = []
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        marker_calls.append({"session_id": session_id, "user_id": user_id, "reason": reason, "source": source})
+
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch("apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted):
+        await coordinator._persist_interruption(
+            agent=_InterruptingAgent(),
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="Here is the start of my answ",
+        )
+
+    assert len(persist_sm.calls) == 1
+    call = persist_sm.calls[0]
+    inner = getattr(call["message"], "message", None)
+    role = inner.get("role") if isinstance(inner, dict) else getattr(inner, "role", None)
+    assert role == "assistant"
+    assert _extract_text(call["message"]) == "Here is the start of my answ"
+
+    assert marker_calls == [
+        {"session_id": "sess-interrupt", "user_id": "user-1", "reason": "connection_lost", "source": "cancellation"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_empty_partial_uses_placeholder_when_user_turn_dangles():
+    """Interruption before any token, history tail = user → persist a minimal
+    placeholder assistant turn so user/assistant role alternation stays valid."""
+    persist_sm = _RecordingPersistSessionManager()
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        return None
+
+    agent = _InterruptingAgent()  # messages tail is the user turn
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch("apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted):
+        await coordinator._persist_interruption(
+            agent=agent,
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="   ",
+        )
+
+    assert len(persist_sm.calls) == 1
+    text = _extract_text(persist_sm.calls[0]["message"])
+    assert "interrupted" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_empty_partial_skips_synthetic_write_when_tail_is_assistant():
+    """No in-flight text and history tail = assistant (continuation/resume
+    teardown) → alternation needs no repair, so no synthetic message; the
+    marker is still set."""
+    persist_sm = _RecordingPersistSessionManager()
+    marker_calls: List[Dict[str, Any]] = []
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        marker_calls.append({"reason": reason})
+
+    agent = _InterruptingAgent()
+    agent.messages = [
+        {"role": "user", "content": [{"text": "hi"}]},
+        {"role": "assistant", "content": [{"text": "truncated partial"}]},
+    ]
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch("apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted):
+        await coordinator._persist_interruption(
+            agent=agent,
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="",
+        )
+
+    assert persist_sm.calls == []
+    assert marker_calls == [{"reason": "connection_lost"}]

--- a/backend/tests/apis/inference_api/test_interruption_note.py
+++ b/backend/tests/apis/inference_api/test_interruption_note.py
@@ -1,0 +1,34 @@
+"""The reason-driven interruption note prepended to the turn after an
+interrupted one (see `_build_interruption_note` in inference-api chat routes).
+
+The note is built from the reason POPPED from the session record at turn
+start (`clear_interrupted_turn` returns it), because the reason is not
+knowable at cancellation time — the client's `user_stopped` signal races the
+server-side `connection_lost` backstop and precedence only settles in
+DynamoDB. The two reasons carry opposite guidance, which is the whole point
+of capturing intent.
+"""
+
+from apis.inference_api.chat.routes import _build_interruption_note
+
+
+class TestBuildInterruptionNote:
+    def test_user_stopped_tells_model_not_to_resume(self):
+        note = _build_interruption_note("user_stopped")
+        assert note.startswith("<interruption_note>")
+        assert note.endswith("</interruption_note>")
+        assert "deliberately stopped" in note
+        assert "do not" in note.lower()
+
+    def test_connection_lost_tells_model_it_may_continue(self):
+        note = _build_interruption_note("connection_lost")
+        assert note.startswith("<interruption_note>")
+        assert "did not stop it deliberately" in note
+        assert "continue" in note.lower()
+
+    def test_unknown_reason_treated_as_technical_drop(self):
+        # `unknown` carries no user intent, so it must NOT claim the user
+        # stopped the response.
+        note = _build_interruption_note("unknown")
+        assert "deliberately stopped" not in note
+        assert "did not stop it deliberately" in note

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -762,3 +762,67 @@ class TestGetSessionMessages:
             resp = client.get("/sessions/nonexistent/messages")
 
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/{session_id}/interrupt — client stop signal
+# ---------------------------------------------------------------------------
+
+
+class TestSignalTurnInterrupted:
+    """POST /sessions/{session_id}/interrupt records deliberate stop intent.
+
+    This endpoint is the authoritative carrier of `user_stopped` for the
+    interrupted-turn flow (the stream-cancellation path can only infer
+    `connection_lost`). Cookie-auth via get_current_user_from_session per the
+    app-api auth rule.
+    """
+
+    def test_returns_204_and_records_user_stopped(self, app, make_user, authenticated_client):
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        recorder = AsyncMock()
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            recorder,
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "user_stopped"},
+            )
+
+        assert resp.status_code == 204
+        recorder.assert_awaited_once_with(
+            "sess-001",
+            user.user_id,
+            reason="user_stopped",
+            source="client_signal",
+        )
+
+    def test_rejects_non_client_attested_reason(self, app, make_user, authenticated_client):
+        """`connection_lost` is server-inferred only — a client must not be
+        able to plant (or downgrade to) it through this endpoint."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        recorder = AsyncMock()
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            recorder,
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "connection_lost"},
+            )
+
+        assert resp.status_code == 422
+        recorder.assert_not_awaited()
+
+    def test_returns_401_for_unauthenticated(self, app, unauthenticated_client):
+        client = unauthenticated_client(app)
+        resp = client.post(
+            "/sessions/sess-001/interrupt",
+            json={"reason": "user_stopped"},
+        )
+        assert resp.status_code == 401

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -74,6 +74,99 @@ class TestGetSessionMetadata:
         assert result is None
 
 
+class TestInterruptedTurnMarker:
+    """Refresh-survival marker for a turn interrupted before completion."""
+
+    @pytest.mark.asyncio
+    async def test_set_then_clear(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+            clear_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i1", user_id="u1", session_metadata=_make_session_metadata(session_id="i1"))
+
+        result = await get_session_metadata("i1", "u1")
+        assert not result.last_turn_interrupted
+
+        await set_interrupted_turn("i1", "u1", reason="connection_lost", source="cancellation")
+        result = await get_session_metadata("i1", "u1")
+        assert result.last_turn_interrupted is True
+        assert result.last_turn_interrupt_reason == "connection_lost"
+        assert result.last_turn_interrupted_at
+
+        # The clear is a POP: it returns the settled reason so the turn-start
+        # caller can drive the next-turn model note from the same read+write.
+        cleared_reason = await clear_interrupted_turn("i1", "u1")
+        assert cleared_reason == "connection_lost"
+        result = await get_session_metadata("i1", "u1")
+        assert not result.last_turn_interrupted
+        assert result.last_turn_interrupt_reason is None
+
+        # Idempotent: popping an already-clear marker returns None.
+        assert await clear_interrupted_turn("i1", "u1") is None
+
+    @pytest.mark.asyncio
+    async def test_user_stopped_wins_over_connection_lost(self, sessions_metadata_table):
+        # Client stop signal lands first; the cancellation fallback must NOT
+        # downgrade it.
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i2", user_id="u1", session_metadata=_make_session_metadata(session_id="i2"))
+
+        await set_interrupted_turn("i2", "u1", reason="user_stopped", source="client_signal")
+        await set_interrupted_turn("i2", "u1", reason="connection_lost", source="cancellation")
+
+        result = await get_session_metadata("i2", "u1")
+        assert result.last_turn_interrupt_reason == "user_stopped"
+
+    @pytest.mark.asyncio
+    async def test_user_stopped_upgrades_connection_lost(self, sessions_metadata_table):
+        # Cancellation fallback lands first; a later client signal upgrades it.
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i3", user_id="u1", session_metadata=_make_session_metadata(session_id="i3"))
+
+        await set_interrupted_turn("i3", "u1", reason="connection_lost", source="cancellation")
+        await set_interrupted_turn("i3", "u1", reason="user_stopped", source="client_signal")
+
+        result = await get_session_metadata("i3", "u1")
+        assert result.last_turn_interrupt_reason == "user_stopped"
+
+    @pytest.mark.asyncio
+    async def test_set_noop_when_session_missing(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import set_interrupted_turn, get_session_metadata
+        # No store first — must not raise, and nothing to read back.
+        await set_interrupted_turn("i-missing", "u1", reason="connection_lost")
+        assert await get_session_metadata("i-missing", "u1") is None
+
+    @pytest.mark.asyncio
+    async def test_survives_response_round_trip(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        from apis.shared.sessions.models import SessionMetadataResponse
+
+        await store_session_metadata(session_id="i4", user_id="u1", session_metadata=_make_session_metadata(session_id="i4"))
+        await set_interrupted_turn("i4", "u1", reason="user_stopped", source="client_signal")
+        meta = await get_session_metadata("i4", "u1")
+
+        resp = SessionMetadataResponse.model_validate(meta.model_dump(by_alias=True))
+        assert resp.last_turn_interrupted is True
+        dumped = resp.model_dump(by_alias=True)
+        assert dumped["lastTurnInterrupted"] is True
+        assert dumped["lastTurnInterruptReason"] == "user_stopped"
+
+
 class TestTruncatedTurnMarker:
     """Refresh-survival marker for the max_tokens 'Continue' affordance."""
 

--- a/docs/specs/interrupted-turn-context.md
+++ b/docs/specs/interrupted-turn-context.md
@@ -106,13 +106,15 @@ On the next non-resume, non-continuation turn, the popped reason drives `_build_
 - **Signal arrives after the next turn already popped the marker:** the stale marker is cleared at the turn after. Harmless.
 - **Hard network loss drops the keepalive fetch:** correctly degrades to `connection_lost` via the backstop (when it fires) or to nothing (when the turn actually completed server-side — in which case nothing was lost).
 
-## 7. Follow-up PRs (frontend)
+## 7. Frontend (shipped)
 
-1. **Stop signal (small):** in `chat-http.service.ts` `cancelChatRequest` (line 257), fire the keepalive fetch with the CSRF header *before* `abortRequest`, best-effort/fire-and-forget. Optionally also from the SPA's unload teardown — but note that an unload signal can only honestly say `user_stopped` for an explicit Stop click; don't send it for refresh/close.
-2. **Reload UX:** session hydration already merges Dynamo metadata; surface `lastTurnInterrupted` + reason:
-   - `connection_lost` → "Response interrupted" chip on the partial + a Continue affordance reusing the truncated-turn continuation path (`continue_truncated` works unchanged against the persisted partial).
-   - `user_stopped` → "You stopped this response" chip, **no** Continue.
-   - Sanity-gate the chip on the last message actually looking interrupted (guards the completed-anyway race in §6).
+1. **Stop signal:** `chat-http.service.ts` `cancelChatRequest` fires a best-effort `fetch(..., { keepalive: true })` to `POST {appApi}/sessions/{id}/interrupt` with `{reason:'user_stopped'}` and the `X-CSRF-Token` header (via `bffSession.csrfHeaders()`) *before* `abortRequest` — and reflects the interruption locally (`setLastTurnInterrupted(id, true, 'user_stopped')`) so the chip shows within the session without a reload. Fire-and-forget: a failed signal never blocks Stop teardown.
+2. **Reload UX:** the interrupted flag + reason are per-session signals on `ChatStateService` (mirroring `lastTurnContinuable`), hydrated in `session.page.ts` from the merged Dynamo metadata (only ever set true, never clobbering a live true), and cleared on any new send / continuation / new streamed turn (beside every `setLastTurnContinuable(id,false)`). `message-actions.component.ts` renders the chip on the last message:
+   - `connection_lost` → "Response interrupted" + a Continue button reusing the truncated-turn continuation path (`continueTruncatedTurn` works unchanged against the persisted partial).
+   - `user_stopped` → "You stopped this response", **no** Continue.
+   - Gated (via `interruptedReasonFor`) on `lastTurnInterrupted && !isChatLoading && id === lastMessageId` — the last-message gate is the sanity check against the completed-anyway race in §6. A live max_tokens `canContinue` takes precedence over the interrupted chip.
+
+Specs: `message-actions.component.spec.ts` (both chip variants, Continue emit, max_tokens precedence), `chat-state.service.spec.ts` (set/clear + reason), `chat-http.service.spec.ts` (keepalive signal shape + local reflect + failure isolation), `chat-request.service.spec.ts` (clears on continuation).
 
 ## 8. Test coverage (this branch)
 

--- a/docs/specs/interrupted-turn-context.md
+++ b/docs/specs/interrupted-turn-context.md
@@ -1,0 +1,122 @@
+# Interrupted-Turn Context
+
+**Status:** Backend implemented (this branch); frontend follow-ups scoped below
+**Date:** 2026-07-03
+**Related:** max_tokens truncated-turn flow (`set_truncated_turn`), paused-turn / pending-interrupt flow (`set_paused_turn`), interrupt-resume streaming.
+
+## 1. Problem
+
+When an assistant response is interrupted before it completes — the user clicks **Stop**, the browser is refreshed, or the connection drops — the turn dies silently:
+
+- The **user message was already persisted** at turn start (Strands' MessageAddedEvent hook fires when the user turn is added, before the model streams).
+- The **assistant turn is only persisted on natural completion** — `TurnBasedSessionManager.append_message` (`session/turn_based_session_manager.py:123`) persists each message *as it completes*; nothing persists a message still streaming.
+- A raw teardown surfaces inside the coordinator generator as `asyncio.CancelledError` or `GeneratorExit` — both `BaseException` subclasses that slip past every `except Exception` in the stream path.
+
+**Result:** persisted history ends on a dangling user turn. On reload the user sees their message and nothing else. On the next turn the *model* sees malformed user→user history, has no idea it was cut off, and — critically — cannot tell a deliberate Stop (strong feedback) from a dropped connection (no signal).
+
+## 2. Goals
+
+- Record that a turn was interrupted, durably, surviving refresh.
+- Preserve the **in-flight partial assistant text** the user already saw.
+- Give the **model** legible, reason-aware context on its next turn.
+- Distinguish **`user_stopped`** (deliberate; don't barrel onward) from **`connection_lost`** (technical; user probably still wants the answer). The transport can't make this distinction — both look like a dead stream — so intent is captured out-of-band (§5).
+
+**Non-goals:** no bidirectional SSE channel; no changes to the max_tokens or paused-turn flows; no permanent synthetic "[interrupted]" system turn re-fed into context forever.
+
+## 3. Design decisions (the three contested calls)
+
+### 3.1 Third parallel marker — deliberately NOT unified
+
+We keep `lastTurnInterrupted*` as a third sibling of `lastTurnContinuable` (truncated) and `paused_turn`/`pending_interrupts`, rather than folding all three into a `lastTurnDisposition`. Rationale:
+
+- The three are **different shapes**, not three copies of one shape: paused carries a full resume snapshot + pending-interrupt list; truncated is a bare bool; interrupted is bool + reason + timestamp. A unified record still needs per-state variant payloads and per-state precedence — unification renames the problem.
+- `lastTurnContinuable` and `paused_turn` are **live cross-package contracts** consumed by shipped SPA code; renaming them forces a coordinated frontend migration (CLAUDE.md contract rule) for zero user-visible value and real regression risk in two working flows.
+- The lifecycles genuinely coincide (all cleared at next non-resume turn start), and that is already expressed by three adjacent calls in the invocations route — cheap to read, cheap to keep consistent.
+
+Revisit only if a fourth marker appears; then extract the shared "turn-end disposition" machinery once, with evidence.
+
+### 3.2 The partial IS persisted to Memory as a synthetic assistant message
+
+The alternative considered — display-only metadata (a `displayText`-style side channel) + purely described interruption — was rejected:
+
+- **Text-only is not a "lossy corner-cut"; it's the only valid choice.** A dangling `toolUse` block or an unsigned reasoning block *cannot* be replayed to Bedrock; any persistable partial is necessarily the text. The "reconstruction diverges from what the user saw" objection reduces to blocks that could never be persisted anyway.
+- It **repairs role alternation in the model's actual history** — the whole point of the model-facing half. A display-only partial leaves user→user in Memory and outsources the problem to SDK history-repair.
+- It's the **established mechanism**: error paths already persist synthetic assistant turns via `persist_synthetic_messages` (`session/persistence.py:37`; call sites in `stream_coordinator.py`). Reload hydration then works through the normal Memory read path with zero new storage or merge logic.
+- It's how the sibling flow works: max_tokens partials live verbatim and unannotated in history today, and age out via compaction. Interruption partials behave identically; the *reason* context is delivered separately (§6) because it isn't knowable at persist time.
+
+**Correctness constraint (fixed in this branch):** because `append_message` persists each completed message immediately (flush is a no-op — `turn_based_session_manager.py:949`), the coordinator accumulates **only the in-flight message's** text deltas: the accumulator resets at assistant `message_start` and clears at `message_stop`. Accumulating across the whole stream would duplicate mid-turn messages already committed to Memory.
+
+**Empty partial:** a placeholder assistant turn (`"[Response interrupted before any content was generated]"`) is persisted **only when the history tail is a user message** — that's the dangling-turn case the placeholder exists to repair. On continuation/resume teardowns (tail = assistant) nothing needs repair, so only the marker is written.
+
+### 3.3 Intent capture is primary; server-side detection is the backstop
+
+The original PR-1 framing ("server-side CancelledError is load-bearing, beacon comes later") is inverted:
+
+- **Cloud deliverability of the cancellation is unverified.** The chain is Browser → CloudFront → app-api BFF proxy (`app_api/chat/proxy_routes.py:148`, whose `stream_relay` `finally` closes the upstream httpx stream) → **AgentCore Runtime data plane** → inference-api container. Whether the data plane propagates a caller disconnect into the container's request task is undocumented. Local dev (`localhost:8001`) proves nothing about it. If it doesn't propagate, the container finishes the turn and persists the full response — losing nothing — but the server-side arm never fires.
+- The server-side arm also only ever knows the **low-value reason** (`connection_lost`). The high-value signal — *the user chose to stop* — can only come from the client.
+
+So: the client stop signal is the authoritative carrier of `user_stopped`; the coordinator's teardown arm is a best-effort backstop that contributes the partial text and the `connection_lost` fallback. Both are shipped in this backend change; neither waits on the other.
+
+**`navigator.sendBeacon` is ruled out** — a correction to the earlier draft. App-api's `CSRFMiddleware` (`apis/shared/middleware/csrf.py:56`) rejects unsafe-method cookie requests without a matching `X-CSRF-Token` header, and `sendBeacon` cannot set headers. The SPA must use `fetch(url, { method: 'POST', keepalive: true, headers: { 'X-CSRF-Token': … } })` — keepalive survives page teardown and carries headers. Do **not** exempt the path from CSRF to accommodate sendBeacon.
+
+## 4. Reason taxonomy
+
+| Reason | Source | Signal | Next-turn note (§6) |
+|---|---|---|---|
+| `user_stopped` | `POST /sessions/{id}/interrupt` (client-attested only) | Strong — deliberate | "user stopped you; don't resume on your own" |
+| `connection_lost` | Coordinator teardown arm (server-inferred only) | Weak — technical | "cut off by connection, not the user; continue if asked" |
+| `unknown` | Unclassifiable writes | Weak | treated as `connection_lost` |
+
+The request model (`SessionInterruptRequest`, `apis/shared/sessions/models.py`) accepts **only** `user_stopped` from the client — `connection_lost` from a client would let it downgrade a deliberate stop.
+
+## 5. As built — backend (this branch)
+
+### Marker (`apis/shared/sessions/metadata.py`)
+
+- `set_interrupted_turn(session_id, user_id, reason, source)` (line 2207) — writes `lastTurnInterrupted` / `lastTurnInterruptReason` / `lastTurnInterruptedAt` on the session row. **Precedence, not ordering,** resolves the two racing writers: `user_stopped` writes unconditionally; `connection_lost`/`unknown` writes carry a `ConditionExpression` (`#ltr <> "user_stopped"`) so the fallback can never downgrade the settled reason regardless of arrival order.
+- `clear_interrupted_turn(session_id, user_id) -> Optional[str]` (line 2294) — an atomic **pop**: `REMOVE` with `ReturnValues=UPDATED_OLD` returns the reason it cleared, so a single read+write both enforces the lifecycle *and* feeds the model note. Called at the start of every non-resume turn (beside `clear_truncated_turn` / `clear_paused_turn`, `inference_api/chat/routes.py:1043–1067`).
+
+`SessionMetadata` / `SessionMetadataResponse` (`apis/shared/sessions/models.py`) carry the three aliased optional fields, so the SPA's existing metadata reads surface them with no new endpoint.
+
+### Stop-signal endpoint (`apis/app_api/sessions/routes.py:603`)
+
+`POST /sessions/{session_id}/interrupt`, body `{"reason": "user_stopped"}` → 204. Uses `Depends(get_current_user_from_session)` (app-api auth rule). Lives on **app-api**, not inference-api: the Runtime data plane only proxies `/invocations` + `/ping` (inference-api boundary rule). Ownership enforcement falls out of the user-scoped GSI lookup inside `set_interrupted_turn` — another user's session is a silent no-op.
+
+### Cancellation backstop (`agents/main_agent/streaming/stream_coordinator.py:922`)
+
+`except (asyncio.CancelledError, GeneratorExit)` around the stream loop — teardown surfaces as either, depending on whether the generator was at an inner `await` (cancellation) or a `yield` (`aclose()`). The arm calls `_persist_interruption` (line 1011) and **re-raises**; the MCP-broker `finally` still runs.
+
+`_persist_interruption`:
+- persists the in-flight partial (or the gated placeholder, §3.2) assistant-only via `persist_synthetic_messages` — the user turn is already committed (canonical invariant in `session/persistence.py`);
+- writes the `connection_lost` fallback marker;
+- wraps both in `asyncio.shield(asyncio.ensure_future(...))` so the writes complete even as the request task unwinds mid-`await` — a bare await inside a cancellation handler would itself be cancelled;
+- is best-effort throughout: failures log, never mask the original teardown exception.
+
+### Model-facing note (`apis/inference_api/chat/routes.py:499`, `:1676`)
+
+On the next non-resume, non-continuation turn, the popped reason drives `_build_interruption_note(reason)`, prepended to `final_message` at the same seam as the MCP Apps `pending_ctx_block`. Properties:
+
+- **Why next-turn, not persist-time:** the reason isn't knowable when the partial is persisted — the client signal races the backstop and precedence settles in DynamoDB. By the next turn the marker is authoritative. (This is also why annotating the persisted partial inline was rejected.)
+- The prepend makes `message_will_be_modified` true, so the raw user text is stored as `displayText` — the note is **invisible to the user** but remains an honest part of the persisted user message in Memory, aging out via compaction like everything else. Cache-prefix-safe (appends to the newest message only).
+- Continuation turns skip it structurally (Strands ignores the message; the model simply continues the persisted partial — which is exactly the right behavior for a `connection_lost` "Continue").
+
+## 6. Known residual races (accepted)
+
+- **Stop lands but the container finishes anyway** (data plane didn't propagate): full response persists, marker says `user_stopped`. The note still conveys true intent ("the user clicked stop"); the reload chip may sit next to a complete response. Rare, honest, self-clearing on next turn.
+- **Signal arrives after the next turn already popped the marker:** the stale marker is cleared at the turn after. Harmless.
+- **Hard network loss drops the keepalive fetch:** correctly degrades to `connection_lost` via the backstop (when it fires) or to nothing (when the turn actually completed server-side — in which case nothing was lost).
+
+## 7. Follow-up PRs (frontend)
+
+1. **Stop signal (small):** in `chat-http.service.ts` `cancelChatRequest` (line 257), fire the keepalive fetch with the CSRF header *before* `abortRequest`, best-effort/fire-and-forget. Optionally also from the SPA's unload teardown — but note that an unload signal can only honestly say `user_stopped` for an explicit Stop click; don't send it for refresh/close.
+2. **Reload UX:** session hydration already merges Dynamo metadata; surface `lastTurnInterrupted` + reason:
+   - `connection_lost` → "Response interrupted" chip on the partial + a Continue affordance reusing the truncated-turn continuation path (`continue_truncated` works unchanged against the persisted partial).
+   - `user_stopped` → "You stopped this response" chip, **no** Continue.
+   - Sanity-gate the chip on the last message actually looking interrupted (guards the completed-anyway race in §6).
+
+## 8. Test coverage (this branch)
+
+- `tests/shared/test_sessions_metadata.py` — set/pop lifecycle, pop returns reason, idempotent pop, `user_stopped` precedence in both arrival orders, missing-session no-op, response-model round trip.
+- `tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py` — CancelledError **and** GeneratorExit arms fire + re-raise; partial scoped to the in-flight message (completed mid-turn text excluded); assistant-only write; placeholder gated on user-tail; assistant-tail → marker-only.
+- `tests/routes/test_sessions.py::TestSignalTurnInterrupted` — 204 + recorded `user_stopped`/`client_signal`; 422 for non-client-attested reasons; 401 unauthenticated.
+- `tests/apis/inference_api/test_interruption_note.py` — reason-appropriate guidance, `unknown` treated as technical drop.

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.spec.ts
@@ -58,3 +58,65 @@ describe('MessageActionsComponent — Continue affordance', () => {
     expect(emitted).toBe(1);
   });
 });
+
+describe('MessageActionsComponent — interrupted-turn chip', () => {
+  let fixture: ComponentFixture<MessageActionsComponent>;
+  let component: MessageActionsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessageActionsComponent],
+      providers: [provideMarkdown()],
+    }).compileComponents();
+
+    const markdownService = TestBed.inject(MarkdownService);
+    markdownService.parse = () => '';
+
+    fixture = TestBed.createComponent(MessageActionsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('message', makeMessage('partial answer'));
+  });
+
+  it('shows "Response interrupted" + a Continue button for connection_lost', () => {
+    fixture.componentRef.setInput('interruptedReason', 'connection_lost');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Response interrupted');
+    const btn = fixture.nativeElement.querySelector(
+      'button[aria-label="Continue the interrupted response"]',
+    );
+    expect(btn).not.toBeNull();
+  });
+
+  it('emits continueRequested when the interrupted Continue button is clicked', () => {
+    fixture.componentRef.setInput('interruptedReason', 'connection_lost');
+    fixture.detectChanges();
+
+    let emitted = 0;
+    component.continueRequested.subscribe(() => emitted++);
+    fixture.nativeElement
+      .querySelector('button[aria-label="Continue the interrupted response"]')!
+      .click();
+    expect(emitted).toBe(1);
+  });
+
+  it('shows "You stopped this response" with NO Continue for user_stopped', () => {
+    fixture.componentRef.setInput('interruptedReason', 'user_stopped');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('You stopped this response');
+    expect(
+      fixture.nativeElement.querySelector('button[aria-label="Continue the interrupted response"]'),
+    ).toBeNull();
+  });
+
+  it('max_tokens Continue takes precedence over an interrupted reason', () => {
+    fixture.componentRef.setInput('canContinue', true);
+    fixture.componentRef.setInput('interruptedReason', 'connection_lost');
+    fixture.detectChanges();
+
+    // The truncated-turn label wins; the interrupted chip is not also shown.
+    expect(fixture.nativeElement.textContent).toContain('Response length limit reached');
+    expect(fixture.nativeElement.textContent).not.toContain('Response interrupted');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/message-actions.component.ts
@@ -53,6 +53,25 @@ import { TooltipDirective } from '../../../../components/tooltip';
           <ng-icon name="heroArrowPath" class="size-4" aria-hidden="true" />
           <span>Continue</span>
         </button>
+      } @else if (interruptedReason() === 'connection_lost') {
+        <span class="pl-1 text-xs text-gray-500 dark:text-gray-400">
+          Response interrupted
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-300 dark:hover:bg-blue-950/40"
+          appTooltip="Resume response"
+          appTooltipPosition="top"
+          aria-label="Continue the interrupted response"
+          (click)="continueRequested.emit()"
+        >
+          <ng-icon name="heroArrowPath" class="size-4" aria-hidden="true" />
+          <span>Continue</span>
+        </button>
+      } @else if (interruptedReason() === 'user_stopped') {
+        <span class="pl-1 text-xs text-gray-500 dark:text-gray-400">
+          You stopped this response
+        </span>
       }
     </div>
   `,
@@ -81,7 +100,13 @@ export class MessageActionsComponent {
    *  recoverable max_tokens-truncated turn. */
   canContinue = input<boolean>(false);
 
-  /** Emitted when the user asks to continue the truncated response. */
+  /** When set on the last assistant message of an interrupted turn, shows a
+   *  "Response interrupted" chip (+ Continue for 'connection_lost') or a
+   *  "You stopped this response" chip (for 'user_stopped'). */
+  interruptedReason = input<'user_stopped' | 'connection_lost' | null>(null);
+
+  /** Emitted when the user asks to continue the truncated / interrupted
+   *  response. */
   continueRequested = output<void>();
 
   protected copied = signal(false);

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -22,6 +22,7 @@
                 <app-message-actions
                   [message]="message"
                   [canContinue]="canContinueFor(message.id)"
+                  [interruptedReason]="interruptedReasonFor(message.id)"
                   (continueRequested)="continueRequested.emit()"></app-message-actions>
             </div>
             <div class="invisible mt-1 flex flex-wrap items-center gap-2 opacity-0 transition-opacity duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100" aria-live="polite" aria-atomic="true">

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -92,6 +92,25 @@ export class MessageListComponent implements OnDestroy {
     );
   }
 
+  /** The interruption reason to surface on this message, or null. Only the
+   *  final message of an interrupted turn gets the chip, and only while no
+   *  new response is streaming — mirrors `canContinueFor`, and the
+   *  last-message gate sanity-checks against the "completed anyway" race
+   *  (a new turn clears the flag). `connection_lost` also drives a Continue
+   *  affordance; `user_stopped` shows the chip without one. */
+  protected interruptedReasonFor(messageId: string): 'user_stopped' | 'connection_lost' | null {
+    if (
+      !this.chatStateService.lastTurnInterrupted() ||
+      this.isChatLoading() ||
+      messageId !== this.lastMessageId()
+    ) {
+      return null;
+    }
+    return this.chatStateService.lastTurnInterruptReason() === 'user_stopped'
+      ? 'user_stopped'
+      : 'connection_lost';
+  }
+
   /** Session artifacts, newest first. Anchored ones render inline after
    *  their producing assistant message (`producedByMessageIndex` matches
    *  the `msg-{sessionId}-{index}` id); the rest fall back to the

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
@@ -31,7 +31,7 @@ describe('ChatHttpService', () => {
         { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}), handleUnauthorized: vi.fn() } },
         { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn() } },
         { provide: StreamParserService, useValue: { getCurrentStreamId: vi.fn().mockReturnValue('stream-1'), parseEventSourceMessage: vi.fn() } },
-        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()) } },
+        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), setLastTurnInterrupted: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()) } },
         { provide: MessageMapService, useValue: { endStreaming: vi.fn() } },
         { provide: ErrorService, useValue: { handleHttpError: vi.fn() } },
       ],
@@ -61,11 +61,41 @@ describe('ChatHttpService', () => {
 
   it('should cancel only the target session and tear down its streaming state', () => {
     const messageMap = TestBed.inject(MessageMapService) as any;
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
 
     service.cancelChatRequest('s1');
 
     expect(chatStateService.abortRequest).toHaveBeenCalledWith('s1');
     expect(chatStateService.setChatLoading).toHaveBeenCalledWith('s1', false);
     expect(messageMap.endStreaming).toHaveBeenCalledWith('s1');
+    vi.restoreAllMocks();
+  });
+
+  it('fires a keepalive user_stopped signal and reflects the interruption locally on cancel', () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    service.cancelChatRequest('s1');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('http://localhost:8000/sessions/s1/interrupt');
+    expect(init?.method).toBe('POST');
+    expect(init?.keepalive).toBe(true);
+    expect(init?.credentials).toBe('include');
+    expect(JSON.parse(init?.body as string)).toEqual({ reason: 'user_stopped' });
+
+    // The chip reflects locally without waiting for a reload.
+    expect(chatStateService.setLastTurnInterrupted).toHaveBeenCalledWith('s1', true, 'user_stopped');
+    vi.restoreAllMocks();
+  });
+
+  it('a failed stop signal never blocks the Stop teardown', () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+
+    expect(() => service.cancelChatRequest('s1')).not.toThrow();
+    expect(chatStateService.abortRequest).toHaveBeenCalledWith('s1');
+    vi.restoreAllMocks();
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -255,9 +255,47 @@ export class ChatHttpService {
    * onerror on abort), so the streaming teardown happens here.
    */
   cancelChatRequest(sessionId: string): void {
+    // Authoritative intent signal: the transport can't distinguish a Stop
+    // click from a dropped socket, so we tell the backend explicitly this
+    // was deliberate BEFORE aborting (so the request is queued while the
+    // connection is still alive). `keepalive` survives page teardown and,
+    // unlike `navigator.sendBeacon`, can carry the `X-CSRF-Token` header the
+    // app-api CSRFMiddleware requires on unsafe cookie-authenticated methods.
+    // Best-effort / fire-and-forget — the user's Stop must never block on it.
+    this.signalUserStopped(sessionId);
+    // Reflect the interruption locally right away so the reload chip also
+    // shows within the same session, without waiting for a refresh. The
+    // backend marker (raced with the cancellation backstop) is the
+    // refresh-survival source of truth.
+    this.chatStateService.setLastTurnInterrupted(sessionId, true, 'user_stopped');
+
     this.chatStateService.abortRequest(sessionId);
     this.messageMapService.endStreaming(sessionId);
     this.chatStateService.setChatLoading(sessionId, false);
+  }
+
+  /** Fire-and-forget POST to app-api recording deliberate stop intent. */
+  private signalUserStopped(sessionId: string): void {
+    try {
+      const appApiUrl = this.config.appApiUrl();
+      if (!appApiUrl) return;
+      const baseUrl = appApiUrl.endsWith('/') ? appApiUrl.slice(0, -1) : appApiUrl;
+      void fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
+        method: 'POST',
+        keepalive: true,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.bffSession.csrfHeaders(),
+        },
+        body: JSON.stringify({ reason: 'user_stopped' }),
+      }).catch(() => {
+        // Best-effort: a failed signal degrades to the server-side
+        // connection_lost backstop (or nothing if the turn completed).
+      });
+    } catch {
+      // Never let intent signalling interfere with the Stop action.
+    }
   }
 
   /**

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -53,7 +53,7 @@ describe('ChatRequestService', () => {
         ChatRequestService,
         { provide: ChatHttpService, useValue: mockChatHttpService },
         { provide: Router, useValue: mockRouter },
-        { provide: ChatStateService, useValue: { setChatLoading: vi.fn(), setLastTurnContinuable: vi.fn(), setViewedSession: vi.fn() } },
+        { provide: ChatStateService, useValue: { setChatLoading: vi.fn(), setLastTurnContinuable: vi.fn(), setLastTurnInterrupted: vi.fn(), setViewedSession: vi.fn() } },
         { provide: MessageMapService, useValue: { addUserMessage: vi.fn(), startStreaming: vi.fn(), beginContinuationStreaming: vi.fn(), endStreaming: vi.fn(), reloadMessagesForSession: vi.fn().mockResolvedValue(undefined) } },
         { provide: SessionService, useValue: { addSessionToCache: vi.fn() } },
         { provide: UserService, useValue: { getUser: vi.fn().mockReturnValue({ user_id: 'user1' }) } },

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -76,8 +76,10 @@ export class ChatRequestService implements OnDestroy {
     sessionId = sessionId || uuidv4();
 
     // Any new send (including a "Continue") retires the previous turn's
-    // max_tokens "Continue" affordance immediately, before the stream starts.
+    // max_tokens "Continue" affordance and any interrupted-turn chip
+    // immediately, before the stream starts.
     this.chatStateService.setLastTurnContinuable(sessionId, false);
+    this.chatStateService.setLastTurnInterrupted(sessionId, false);
 
     // We're about to navigate to this session; point the viewed-session
     // facades at it eagerly so the composer's loading state flips before
@@ -152,8 +154,10 @@ export class ChatRequestService implements OnDestroy {
       return;
     }
 
-    // Hide the affordance immediately; retire any stale continuable state.
+    // Hide the affordance immediately; retire any stale continuable /
+    // interrupted state (a Continue resumes the interrupted partial too).
     this.chatStateService.setLastTurnContinuable(sessionId, false);
+    this.chatStateService.setLastTurnInterrupted(sessionId, false);
 
     // Continuation streaming: pins the existing messages (history +
     // truncated partial + error bubble) as a stable prefix and appends the

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
@@ -75,6 +75,25 @@ describe('ChatStateService', () => {
     });
   });
 
+  describe('setLastTurnInterrupted', () => {
+    it('sets the flag + reason per session and clears the reason on false', () => {
+      service.setViewedSession('a');
+      service.setLastTurnInterrupted('a', true, 'user_stopped');
+      expect(service.lastTurnInterrupted()).toBe(true);
+      expect(service.lastTurnInterruptReason()).toBe('user_stopped');
+
+      // Another session's flag doesn't affect the viewed one.
+      service.setLastTurnInterrupted('b', true, 'connection_lost');
+      expect(service.lastTurnInterrupted()).toBe(true);
+      expect(service.lastTurnInterruptReason()).toBe('user_stopped');
+
+      // Clearing drops both the flag and the reason.
+      service.setLastTurnInterrupted('a', false);
+      expect(service.lastTurnInterrupted()).toBe(false);
+      expect(service.lastTurnInterruptReason()).toBeNull();
+    });
+  });
+
   describe('cost / context aggregates', () => {
     it('seeds, accumulates, and isolates per session', () => {
       service.setViewedSession('a');

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -10,6 +10,12 @@ interface SessionChatState {
     loading: WritableSignal<boolean>;
     stopReason: WritableSignal<string | null>;
     lastTurnContinuable: WritableSignal<boolean>;
+    /** True when the last turn was interrupted before completion (Stop /
+     *  refresh / dropped connection). Drives the reload chip. */
+    lastTurnInterrupted: WritableSignal<boolean>;
+    /** Why the last turn was interrupted — gates whether a Continue is
+     *  offered ('connection_lost') or not ('user_stopped'). */
+    lastTurnInterruptReason: WritableSignal<string | null>;
     costDollars: WritableSignal<number>;
     contextTokens: WritableSignal<number>;
     contextWindow: WritableSignal<number>;
@@ -42,6 +48,8 @@ export class ChatStateService {
     readonly isChatLoading = computed(() => this.viewedState()?.loading() ?? false);
     readonly currentStopReason = computed(() => this.viewedState()?.stopReason() ?? null);
     readonly lastTurnContinuable = computed(() => this.viewedState()?.lastTurnContinuable() ?? false);
+    readonly lastTurnInterrupted = computed(() => this.viewedState()?.lastTurnInterrupted() ?? false);
+    readonly lastTurnInterruptReason = computed(() => this.viewedState()?.lastTurnInterruptReason() ?? null);
 
     // ----- Session-level cost / context aggregates ---------------------------
     // Drive the cost badge above the composer. Seeded from session metadata
@@ -104,6 +112,16 @@ export class ChatStateService {
      */
     setLastTurnContinuable(sessionId: string, continuable: boolean): void {
         this.stateFor(sessionId).lastTurnContinuable.set(continuable);
+    }
+
+    /**
+     * Marks (or clears) whether a session's last turn was interrupted before
+     * completion, and why. Setting `interrupted=false` also clears the reason.
+     */
+    setLastTurnInterrupted(sessionId: string, interrupted: boolean, reason: string | null = null): void {
+        const state = this.stateFor(sessionId);
+        state.lastTurnInterrupted.set(interrupted);
+        state.lastTurnInterruptReason.set(interrupted ? reason : null);
     }
 
     /**
@@ -176,6 +194,8 @@ export class ChatStateService {
             loading: signal(false),
             stopReason: signal<string | null>(null),
             lastTurnContinuable: signal(false),
+            lastTurnInterrupted: signal(false),
+            lastTurnInterruptReason: signal<string | null>(null),
             costDollars: signal(0),
             contextTokens: signal(0),
             contextWindow: signal(0),

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -579,8 +579,10 @@ export class StreamParserService {
     this.chatStateService.setStopReason(state.sessionId, null);
 
     // A new assistant turn is streaming — retire any stale "Continue"
-    // affordance from a previous max_tokens truncation.
+    // affordance from a previous max_tokens truncation, and any interrupted
+    // chip from a previous aborted turn.
     this.chatStateService.setLastTurnContinuable(state.sessionId, false);
+    this.chatStateService.setLastTurnInterrupted(state.sessionId, false);
 
     // Compute predictable message ID
     const completedCount = state.completedMessages().length;

--- a/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
@@ -50,6 +50,16 @@ export interface SessionMetadata {
    *  Lets the "Continue" affordance survive a page refresh. Cleared
    *  server-side at the start of any new (non-interrupt-resume) turn. */
   lastTurnContinuable?: boolean;
+  /** True when the last turn was interrupted before completion (user Stop,
+   *  refresh, or dropped connection). Lets the reload chip survive a
+   *  refresh. Cleared server-side at the start of any new turn. */
+  lastTurnInterrupted?: boolean;
+  /** Why the last turn was interrupted. 'user_stopped' (deliberate Stop) →
+   *  no Continue; 'connection_lost' (refresh / dropped connection) → offer
+   *  Continue. */
+  lastTurnInterruptReason?: 'user_stopped' | 'connection_lost' | 'unknown';
+  /** ISO 8601 timestamp when the interruption was detected. */
+  lastTurnInterruptedAt?: string;
 }
 
 // Request model for updating session metadata

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -272,6 +272,18 @@ export class ConversationPage implements OnDestroy {
       if (session.lastTurnContinuable) {
         this.chatStateService.setLastTurnContinuable(session.sessionId, true);
       }
+      // Refresh-survival for the interrupted-turn chip: the partial (or a
+      // placeholder) is already in restored history; the marker + reason are
+      // the missing pieces. Only set true here — a new send / live abort owns
+      // the in-turn signal, so we never clobber a live true with stale
+      // metadata.
+      if (session.lastTurnInterrupted) {
+        this.chatStateService.setLastTurnInterrupted(
+          session.sessionId,
+          true,
+          session.lastTurnInterruptReason ?? 'unknown',
+        );
+      }
     });
 
     // Hydrate the compaction summary indicator from persisted session


### PR DESCRIPTION
## Why

When an assistant response is interrupted before it finishes — the user clicks **Stop**, refreshes, or the connection drops — the turn dies silently. The user message was already persisted at turn start (Strands `MessageAddedEvent`), but the assistant reply only persists on natural completion. Result: the conversation ends on a dangling user turn — no context on reload, and the *model* sees malformed user→user history it has to paper over, with no idea it was cut off (and no way to tell a deliberate Stop from a dropped connection).

This makes the interruption legible to both audiences: the **user** (a reload chip + reason-appropriate Continue) and the **model** (an ephemeral next-turn note).

## Design

Interruption is modeled as **client-side truncation**, reusing the existing max_tokens truncated-turn machinery rather than inventing a parallel mechanism.

- **Marker** (`set/clear_interrupted_turn`) with race-safe reason precedence: `user_stopped` (authoritative client signal) always wins over the `connection_lost` cancellation fallback via a conditional write. `clear` is an atomic pop (`ReturnValues=UPDATED_OLD`) returning the settled reason.
- **Partial persistence** — a `(CancelledError, GeneratorExit)` backstop in the stream coordinator persists the **in-flight** partial assistant text (accumulator scoped to the current message so already-persisted mid-turn messages aren't duplicated) via `asyncio.shield`. Empty partial → a placeholder gated on a user-tail, to repair role alternation only where needed.
- **Intent capture is primary; server-side detection is the backstop.** The SPA is the authoritative carrier of deliberate-stop intent: `cancelChatRequest` fires `fetch(keepalive: true)` to `POST /sessions/{id}/interrupt` with `{reason:'user_stopped'}` + `X-CSRF-Token` (**not** `sendBeacon` — it can't set the CSRF header the middleware requires). The endpoint lives on **app-api** because the AgentCore Runtime data plane only proxies `/invocations` + `/ping`.
- **Model note** — because the reason isn't settled until DynamoDB precedence resolves, the marker is popped at next-turn start and a reason-specific ephemeral note is prepended at the `pending_ctx_block` seam (invisible to the user via the displayText split; ages out via compaction).

## Reload UX

- `connection_lost` → "Response interrupted" chip + **Continue** (reuses `continueTruncatedTurn` against the persisted partial).
- `user_stopped` → "You stopped this response", **no** Continue.
- Gated on last-message + not-loading; a live max_tokens Continue takes precedence.

## Tests

- Backend: marker set/pop lifecycle + precedence (both arrival orders), `CancelledError`/`GeneratorExit` arms fire + re-raise, partial scoped to the in-flight message, assistant-only write, placeholder gating, stop-signal endpoint (204/422/401), model-note prepend. Full backend suite green.
- Frontend: both chip variants + Continue emit + max_tokens precedence, chat-state set/clear, keepalive signal shape + local reflect + failure isolation, continuation clears. Full app build + affected specs green.

Design doc: `docs/specs/interrupted-turn-context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)