### PR TITLE
feat(kb-sync): PR-1 — SyncPolicy data layer, DueSyncIndex GSI, delete cascades

### DIFF
--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -397,12 +397,17 @@ async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depe
                 document_ids=[doc.document_id for doc in docs],
             )
 
-        # 3. Hard-delete assistant record
+        # 3. Delete sync policies eagerly so no schedule outlives the assistant
+        #    (the dispatcher's liveness check is the backstop, not the mechanism)
+        from apis.shared.sync_policies.service import delete_sync_policies_for_assistant
+        await delete_sync_policies_for_assistant(assistant_id)
+
+        # 4. Hard-delete assistant record
         success = await delete_assistant(assistant_id=assistant_id, owner_id=user_id)
         if not success:
             raise HTTPException(status_code=404, detail=f"Assistant not found: {assistant_id}")
 
-        # 4. Fire-and-forget background cleanup for all documents
+        # 5. Fire-and-forget background cleanup for all documents
         if docs:
             from apis.app_api.documents.services.cleanup_service import cleanup_assistant_documents
             asyncio.ensure_future(cleanup_assistant_documents(assistant_id, docs))

--- a/backend/src/apis/app_api/documents/models.py
+++ b/backend/src/apis/app_api/documents/models.py
@@ -61,6 +61,11 @@ class Document(BaseModel):
     source_file_id: Optional[str] = Field(None, alias="sourceFileId", description="Provider-side opaque file identifier")
     source_etag: Optional[str] = Field(None, alias="sourceEtag", description="Provider-side version stamp at import time")
     imported_by_user_id: Optional[str] = Field(None, alias="importedByUserId", description="User whose credentials imported the file")
+    # Sync bookkeeping — populated only when the document is covered by a
+    # SyncPolicy (scheduled re-index from source).
+    content_hash: Optional[str] = Field(None, alias="contentHash", description="SHA-256 of the last-ingested raw bytes (change-detection second gate)")
+    last_synced_at: Optional[str] = Field(None, alias="lastSyncedAt", description="ISO 8601 timestamp of last successful sync run")
+    sync_policy_id: Optional[str] = Field(None, alias="syncPolicyId", description="Back-pointer to the covering SyncPolicy (UI badges)")
 
 
 class CreateDocumentRequest(BaseModel):

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -354,6 +354,12 @@ async def delete_document(
         if not document:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}")
 
+        # Delete any sync policy covering this document so the schedule
+        # cannot outlive its source (drive_file policies use the document
+        # id as source_ref; crawl policies are cascaded with the CrawlJob)
+        from apis.shared.sync_policies.service import delete_sync_policies_for_source
+        await delete_sync_policies_for_source(assistant_id, document_id)
+
         # Fire-and-forget cleanup (response already sent as 204)
         asyncio.ensure_future(
             cleanup_document_resources(

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -22,6 +22,11 @@ class Assistant(BaseModel):
     starters: Optional[List[str]] = Field(default_factory=list, description="Conversation starter prompts")
     emoji: Optional[str] = Field(None, description="Single emoji character for assistant avatar")
     usage_count: int = Field(0, alias="usageCount", description="Number of times used")
+    last_used_at: Optional[str] = Field(
+        None,
+        alias="lastUsedAt",
+        description="ISO 8601 timestamp of last chat use (any user); drives the KB-sync inactivity pause",
+    )
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp of creation")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 timestamp of last update")
     status: Literal["DRAFT", "COMPLETE"] = Field(..., description="Assistant lifecycle status")

--- a/backend/src/apis/shared/sync_policies/__init__.py
+++ b/backend/src/apis/shared/sync_policies/__init__.py
@@ -1,0 +1,49 @@
+"""Sync policies — scheduled re-index of assistant knowledge-base sources."""
+
+from .models import (
+    DUE_INDEX_PK,
+    SyncInterval,
+    SyncPolicy,
+    SyncPolicyState,
+    SyncRunResult,
+    SyncSourceType,
+)
+from .service import (
+    DuplicateSyncPolicy,
+    SyncPolicyLimitExceeded,
+    compute_next_sync_at,
+    create_sync_policy,
+    delete_sync_policies_for_assistant,
+    delete_sync_policies_for_source,
+    delete_sync_policy,
+    get_sync_policy,
+    list_due_policies,
+    list_sync_policies,
+    max_policies_per_assistant,
+    rearm_policy,
+    record_sync_result,
+    set_policy_state,
+)
+
+__all__ = [
+    "DUE_INDEX_PK",
+    "DuplicateSyncPolicy",
+    "SyncInterval",
+    "SyncPolicy",
+    "SyncPolicyLimitExceeded",
+    "SyncPolicyState",
+    "SyncRunResult",
+    "SyncSourceType",
+    "compute_next_sync_at",
+    "create_sync_policy",
+    "delete_sync_policies_for_assistant",
+    "delete_sync_policies_for_source",
+    "delete_sync_policy",
+    "get_sync_policy",
+    "list_due_policies",
+    "list_sync_policies",
+    "max_policies_per_assistant",
+    "rearm_policy",
+    "record_sync_result",
+    "set_policy_state",
+]

--- a/backend/src/apis/shared/sync_policies/models.py
+++ b/backend/src/apis/shared/sync_policies/models.py
@@ -1,0 +1,56 @@
+"""Sync policy models — scheduled re-index of assistant knowledge-base sources.
+
+A SyncPolicy is the single source of truth for "this content source resyncs".
+It is inert data: nothing fires unless the dispatcher reads it from the
+DueSyncIndex, so deleting the record is total revocation of the schedule.
+
+Stored in the assistants table using the adjacency list pattern:
+    PK: AST#{assistant_id}
+    SK: SYNCPOL#{policy_id}
+
+GSI4 (DueSyncIndex) keys are present ONLY while state == "active" (sparse
+index) — a paused policy is physically invisible to the dispatcher, not
+filtered at query time.
+"""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SyncSourceType = Literal["web_crawl", "drive_file"]
+SyncInterval = Literal["daily", "weekly", "monthly"]
+SyncPolicyState = Literal["active", "paused_error", "paused_inactive", "paused_reauth", "paused_user"]
+SyncRunResult = Literal["changed", "unchanged", "failed", "skipped"]
+
+# Sentinel partition key for the sparse due index. Single logical partition —
+# fine at our scale; shard to SYNCDUE#{0..N} if writes ever demand it.
+DUE_INDEX_PK = "SYNCDUE"
+
+
+class SyncPolicy(BaseModel):
+    """Complete sync policy model (internal use)"""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    policy_id: str = Field(..., alias="policyId", description="Sync policy identifier (syn-{12-hex})")
+    assistant_id: str = Field(..., alias="assistantId", description="Parent assistant identifier")
+    source_type: SyncSourceType = Field(..., alias="sourceType", description="Kind of content source this policy re-syncs")
+    source_ref: str = Field(
+        ...,
+        alias="sourceRef",
+        description="web_crawl: crawl_id of the CrawlJob to re-run; drive_file: document_id holding the import provenance",
+    )
+    interval: SyncInterval = Field(..., description="Re-sync cadence (bounded enum — no cron)")
+    state: SyncPolicyState = Field("active", description="Lifecycle state; only 'active' policies appear in DueSyncIndex")
+    state_reason: Optional[str] = Field(None, alias="stateReason", description="Human-readable reason for a paused state")
+    next_sync_at: Optional[str] = Field(None, alias="nextSyncAt", description="ISO 8601 next due time; drives DueSyncIndex sort key")
+    last_sync_at: Optional[str] = Field(None, alias="lastSyncAt", description="ISO 8601 timestamp of the last completed run")
+    last_result: Optional[SyncRunResult] = Field(None, alias="lastResult", description="Outcome of the last completed run")
+    consecutive_failures: int = Field(0, alias="consecutiveFailures", description="Transient-failure streak (circuit breaker input)")
+    consecutive_not_found: int = Field(0, alias="consecutiveNotFound", description="Source-gone streak (404 fast path input)")
+    sync_run_started_at: Optional[str] = Field(
+        None, alias="syncRunStartedAt", description="Set while a worker run is in flight; stale stamps are treated as crashed runs"
+    )
+    created_by_user_id: str = Field(..., alias="createdByUserId", description="User whose credentials background fetches use")
+    created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp of creation")
+    updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 timestamp of last update")

--- a/backend/src/apis/shared/sync_policies/service.py
+++ b/backend/src/apis/shared/sync_policies/service.py
@@ -1,0 +1,313 @@
+"""Sync policy repository — DynamoDB storage for scheduled KB re-sync policies.
+
+Lives in apis.shared because it has three independent consumers: app-api
+(CRUD routes), the sync dispatcher Lambda (due sweep), and the sync worker
+Lambda (run bookkeeping).
+
+Storage (assistants table, adjacency list):
+    PK: AST#{assistant_id} | SK: SYNCPOL#{policy_id}
+    GSI4 (DueSyncIndex, sparse): GSI4_PK = "SYNCDUE", GSI4_SK = "{next_sync_at}#{policy_id}"
+    GSI4 keys exist only while state == "active".
+"""
+
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from .models import DUE_INDEX_PK, SyncInterval, SyncPolicy, SyncPolicyState, SyncRunResult, SyncSourceType
+
+logger = logging.getLogger(__name__)
+
+INTERVAL_DELTAS = {
+    "daily": timedelta(days=1),
+    "weekly": timedelta(days=7),
+    "monthly": timedelta(days=30),
+}
+
+DEFAULT_MAX_POLICIES_PER_ASSISTANT = 10
+
+
+class SyncPolicyLimitExceeded(Exception):
+    """Raised when an assistant already has the maximum number of sync policies."""
+
+
+class DuplicateSyncPolicy(Exception):
+    """Raised when the source already has a sync policy on this assistant."""
+
+
+def _get_current_timestamp() -> str:
+    """Get current timestamp in ISO 8601 format"""
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _generate_policy_id() -> str:
+    return f"syn-{uuid.uuid4().hex[:12]}"
+
+
+def _table_name() -> str:
+    table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return table
+
+
+def _get_table():
+    import boto3
+
+    return boto3.resource("dynamodb").Table(_table_name())
+
+
+def _due_sort_key(next_sync_at: str, policy_id: str) -> str:
+    return f"{next_sync_at}#{policy_id}"
+
+
+def max_policies_per_assistant() -> int:
+    return int(os.environ.get("KB_SYNC_MAX_POLICIES_PER_ASSISTANT", DEFAULT_MAX_POLICIES_PER_ASSISTANT))
+
+
+def compute_next_sync_at(interval: SyncInterval, from_time: Optional[datetime] = None) -> str:
+    """Compute the next due timestamp for an interval, ISO 8601."""
+    base = from_time or datetime.now(timezone.utc)
+    return (base + INTERVAL_DELTAS[interval]).isoformat() + "Z"
+
+
+async def create_sync_policy(
+    assistant_id: str,
+    source_type: SyncSourceType,
+    source_ref: str,
+    interval: SyncInterval,
+    created_by_user_id: str,
+) -> SyncPolicy:
+    """Create an active sync policy due one interval from now.
+
+    Enforces the per-assistant policy cap and one-policy-per-source
+    uniqueness (both checked against the current policy list — bounded by
+    the cap, so the scan is cheap).
+    """
+    existing = await list_sync_policies(assistant_id)
+    if len(existing) >= max_policies_per_assistant():
+        raise SyncPolicyLimitExceeded(
+            f"Assistant {assistant_id} already has {len(existing)} sync policies (max {max_policies_per_assistant()})"
+        )
+    if any(p.source_ref == source_ref for p in existing):
+        raise DuplicateSyncPolicy(f"Source {source_ref} already has a sync policy on assistant {assistant_id}")
+
+    now = _get_current_timestamp()
+    policy = SyncPolicy(
+        policy_id=_generate_policy_id(),
+        assistant_id=assistant_id,
+        source_type=source_type,
+        source_ref=source_ref,
+        interval=interval,
+        state="active",
+        next_sync_at=compute_next_sync_at(interval),
+        created_by_user_id=created_by_user_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+    item = policy.model_dump(by_alias=True, exclude_none=True)
+    item["PK"] = f"AST#{assistant_id}"
+    item["SK"] = f"SYNCPOL#{policy.policy_id}"
+    item["GSI4_PK"] = DUE_INDEX_PK
+    item["GSI4_SK"] = _due_sort_key(policy.next_sync_at, policy.policy_id)
+
+    _get_table().put_item(Item=item)
+    logger.info(f"Created sync policy {policy.policy_id} ({source_type}/{interval}) for assistant {assistant_id}")
+    return policy
+
+
+async def get_sync_policy(assistant_id: str, policy_id: str) -> Optional[SyncPolicy]:
+    response = _get_table().get_item(Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"})
+    item = response.get("Item")
+    return SyncPolicy.model_validate(item) if item else None
+
+
+async def list_sync_policies(assistant_id: str) -> List[SyncPolicy]:
+    from boto3.dynamodb.conditions import Key
+
+    response = _get_table().query(
+        KeyConditionExpression=Key("PK").eq(f"AST#{assistant_id}") & Key("SK").begins_with("SYNCPOL#")
+    )
+    policies = []
+    for item in response.get("Items", []):
+        try:
+            policies.append(SyncPolicy.model_validate(item))
+        except Exception as e:
+            logger.warning(f"Failed to parse sync policy item: {e}")
+    return policies
+
+
+async def list_due_policies(now: Optional[str] = None, limit: int = 20) -> List[SyncPolicy]:
+    """Query the sparse DueSyncIndex for active policies whose next_sync_at has passed.
+
+    Returns policies most-overdue first. Paused policies have no GSI4 keys
+    and are physically absent from this index.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    now = now or _get_current_timestamp()
+    response = _get_table().query(
+        IndexName="DueSyncIndex",
+        # '~' sorts after '#' and all timestamp characters, so this covers
+        # every "{ts}#{policy_id}" key with ts <= now.
+        KeyConditionExpression=Key("GSI4_PK").eq(DUE_INDEX_PK) & Key("GSI4_SK").lte(f"{now}~"),
+        Limit=limit,
+        ScanIndexForward=True,
+    )
+    policies = []
+    for item in response.get("Items", []):
+        try:
+            policies.append(SyncPolicy.model_validate(item))
+        except Exception as e:
+            logger.warning(f"Failed to parse due sync policy item: {e}")
+    return policies
+
+
+async def set_policy_state(
+    assistant_id: str,
+    policy_id: str,
+    state: SyncPolicyState,
+    next_sync_at: Optional[str] = None,
+    state_reason: Optional[str] = None,
+) -> bool:
+    """Transition a policy's lifecycle state.
+
+    Transition to "active" requires next_sync_at and (re)adds the GSI4 keys;
+    any paused state REMOVEs them so the policy drops out of DueSyncIndex.
+    Returns False if the policy does not exist.
+    """
+    from botocore.exceptions import ClientError
+
+    if state == "active" and not next_sync_at:
+        raise ValueError("next_sync_at is required when activating a sync policy")
+
+    names = {"#state": "state"}
+    values = {":state": state, ":updated_at": _get_current_timestamp()}
+    set_parts = ["#state = :state", "updatedAt = :updated_at"]
+    remove_parts = []
+
+    if state == "active":
+        set_parts += ["nextSyncAt = :next", "GSI4_PK = :gsi4pk", "GSI4_SK = :gsi4sk"]
+        values[":next"] = next_sync_at
+        values[":gsi4pk"] = DUE_INDEX_PK
+        values[":gsi4sk"] = _due_sort_key(next_sync_at, policy_id)
+        remove_parts.append("stateReason")
+    else:
+        remove_parts += ["GSI4_PK", "GSI4_SK"]
+        if state_reason:
+            set_parts.append("stateReason = :reason")
+            values[":reason"] = state_reason
+
+    expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        expression += " REMOVE " + ", ".join(remove_parts)
+
+    try:
+        _get_table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+            UpdateExpression=expression,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+            ConditionExpression="attribute_exists(PK)",
+        )
+        logger.info(f"Sync policy {policy_id} -> {state}" + (f" ({state_reason})" if state_reason else ""))
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.warning(f"Cannot set state on missing sync policy {policy_id}")
+            return False
+        raise
+
+
+async def rearm_policy(assistant_id: str, policy_id: str, expected_next_sync_at: str, new_next_sync_at: str) -> bool:
+    """Advance next_sync_at, conditional on the currently stored value.
+
+    The dispatcher re-arms BEFORE invoking the worker; the condition makes a
+    double-fired tick idempotent — the second dispatcher loses the
+    conditional write and skips the policy. Returns True if this caller won.
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        _get_table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+            UpdateExpression="SET nextSyncAt = :new, GSI4_SK = :gsi4sk, updatedAt = :updated_at",
+            ExpressionAttributeValues={
+                ":new": new_next_sync_at,
+                ":gsi4sk": _due_sort_key(new_next_sync_at, policy_id),
+                ":updated_at": _get_current_timestamp(),
+                ":expected": expected_next_sync_at,
+            },
+            ConditionExpression="nextSyncAt = :expected",
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info(f"Sync policy {policy_id} already re-armed by another dispatcher; skipping")
+            return False
+        raise
+
+
+async def record_sync_result(assistant_id: str, policy_id: str, result: SyncRunResult, not_found: bool = False) -> None:
+    """Record a completed run's outcome and maintain the breaker counters.
+
+    Success-ish results (changed/unchanged/skipped) reset both streaks;
+    "failed" increments consecutiveFailures, plus consecutiveNotFound when
+    the failure was a definitive source-gone (404). Clears the in-flight
+    run stamp either way.
+    """
+    now = _get_current_timestamp()
+    values = {":now": now, ":result": result}
+    set_parts = ["lastSyncAt = :now", "lastResult = :result", "updatedAt = :now"]
+
+    if result == "failed":
+        values[":one"] = 1
+        values[":zero"] = 0
+        set_parts.append("consecutiveFailures = if_not_exists(consecutiveFailures, :zero) + :one")
+        if not_found:
+            set_parts.append("consecutiveNotFound = if_not_exists(consecutiveNotFound, :zero) + :one")
+        else:
+            set_parts.append("consecutiveNotFound = :zero")
+    else:
+        values[":zero"] = 0
+        set_parts += ["consecutiveFailures = :zero", "consecutiveNotFound = :zero"]
+
+    _get_table().update_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+        UpdateExpression="SET " + ", ".join(set_parts) + " REMOVE syncRunStartedAt",
+        ExpressionAttributeValues=values,
+    )
+
+
+async def delete_sync_policy(assistant_id: str, policy_id: str) -> bool:
+    _get_table().delete_item(Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"})
+    logger.info(f"Deleted sync policy {policy_id} for assistant {assistant_id}")
+    return True
+
+
+async def delete_sync_policies_for_source(assistant_id: str, source_ref: str) -> int:
+    """Delete all policies referencing a source (document or crawl job).
+
+    Called from the source's delete path so a removed document/crawl never
+    leaves a live schedule behind.
+    """
+    policies = await list_sync_policies(assistant_id)
+    deleted = 0
+    for policy in policies:
+        if policy.source_ref == source_ref:
+            await delete_sync_policy(assistant_id, policy.policy_id)
+            deleted += 1
+    return deleted
+
+
+async def delete_sync_policies_for_assistant(assistant_id: str) -> int:
+    """Delete every sync policy under an assistant (assistant delete cascade)."""
+    policies = await list_sync_policies(assistant_id)
+    for policy in policies:
+        await delete_sync_policy(assistant_id, policy.policy_id)
+    if policies:
+        logger.info(f"Deleted {len(policies)} sync policies for assistant {assistant_id}")
+    return len(policies)

--- a/backend/tests/routes/test_delete_endpoints.py
+++ b/backend/tests/routes/test_delete_endpoints.py
@@ -35,6 +35,23 @@ USER_ID = "user-001"
 DOC_SERVICE = "apis.app_api.documents.services.document_service"
 CLEANUP_SERVICE = "apis.app_api.documents.services.cleanup_service"
 ASSISTANT_SERVICE = "apis.shared.assistants.service"
+SYNC_POLICY_SERVICE = "apis.shared.sync_policies.service"
+
+
+@pytest.fixture(autouse=True)
+def sync_policy_cascades():
+    """Both delete endpoints cascade into the sync-policy repository; stub it
+    so these route tests stay DynamoDB-free."""
+    with patch(
+        f"{SYNC_POLICY_SERVICE}.delete_sync_policies_for_source",
+        new_callable=AsyncMock,
+        return_value=0,
+    ) as for_source, patch(
+        f"{SYNC_POLICY_SERVICE}.delete_sync_policies_for_assistant",
+        new_callable=AsyncMock,
+        return_value=0,
+    ) as for_assistant:
+        yield SimpleNamespace(for_source=for_source, for_assistant=for_assistant)
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +124,31 @@ class TestDocumentDeleteEndpoint:
             resp = client.delete(f"/assistants/{ASSISTANT_ID}/documents/doc-001")
 
         assert resp.status_code == 204
+
+    def test_delete_cascades_sync_policies_for_document(self, app, sync_policy_cascades):
+        """A deleted document must not leave a live sync schedule behind."""
+        doc = _make_document()
+        routes_module = "apis.app_api.documents.routes"
+
+        with patch(
+            f"{routes_module}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner_resolve(USER_ID),
+        ), patch(
+            f"{DOC_SERVICE}.soft_delete_document",
+            new_callable=AsyncMock,
+            return_value=doc,
+        ), patch(
+            f"{CLEANUP_SERVICE}.cleanup_document_resources",
+            new_callable=AsyncMock,
+        ), patch(
+            "asyncio.ensure_future",
+        ):
+            client = TestClient(app)
+            resp = client.delete(f"/assistants/{ASSISTANT_ID}/documents/doc-001")
+
+        assert resp.status_code == 204
+        sync_policy_cascades.for_source.assert_awaited_once_with(ASSISTANT_ID, "doc-001")
 
     def test_delete_returns_404_when_not_found(self, app):
         """Req 1.5: Returns 404 when soft_delete_document returns None."""
@@ -232,6 +274,25 @@ class TestAssistantDeleteEndpoint:
             assistant_id=ASSISTANT_ID,
             owner_id=USER_ID,
         )
+
+    def test_delete_cascades_sync_policies_for_assistant(self, app, sync_policy_cascades):
+        """No sync schedule may outlive its assistant."""
+        with patch(
+            f"{self.ROUTES_MODULE}.list_assistant_documents",
+            new_callable=AsyncMock,
+            return_value=([], None),
+        ), patch(
+            f"{self.ROUTES_MODULE}.delete_assistant",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "asyncio.ensure_future",
+        ):
+            client = TestClient(app)
+            resp = client.delete(f"/assistants/{ASSISTANT_ID}")
+
+        assert resp.status_code == 204
+        sync_policy_cascades.for_assistant.assert_awaited_once_with(ASSISTANT_ID)
 
     def test_delete_fires_cleanup_in_background(self, app):
         """Req 8.2: Background cleanup is scheduled via asyncio.ensure_future."""

--- a/backend/tests/shared/conftest.py
+++ b/backend/tests/shared/conftest.py
@@ -260,11 +260,14 @@ def assistants_table(aws, monkeypatch):
             {"AttributeName": "GSI2_SK", "AttributeType": "S"},
             {"AttributeName": "GSI3_PK", "AttributeType": "S"},
             {"AttributeName": "GSI3_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_SK", "AttributeType": "S"},
         ],
         gsis=[
             _gsi("OwnerStatusIndex", "GSI_PK", "GSI_SK"),
             _gsi("VisibilityStatusIndex", "GSI2_PK", "GSI2_SK"),
             _gsi("SharedWithIndex", "GSI3_PK", "GSI3_SK"),
+            _gsi("DueSyncIndex", "GSI4_PK", "GSI4_SK"),
         ],
     )
 

--- a/backend/tests/shared/test_sync_policies.py
+++ b/backend/tests/shared/test_sync_policies.py
@@ -1,0 +1,220 @@
+"""Sync policy repository tests (moto DynamoDB).
+
+Covers the runaway-prevention data invariants:
+- sparse DueSyncIndex (paused policies are physically absent)
+- conditional re-arm (double-fired dispatcher tick is idempotent)
+- breaker counters (failure streaks vs source-gone streaks)
+- per-assistant cap and one-policy-per-source uniqueness
+- delete cascades (per-source and per-assistant)
+"""
+
+import pytest
+
+from apis.shared.sync_policies.models import DUE_INDEX_PK
+from apis.shared.sync_policies.service import (
+    DuplicateSyncPolicy,
+    SyncPolicyLimitExceeded,
+    create_sync_policy,
+    delete_sync_policies_for_assistant,
+    delete_sync_policies_for_source,
+    get_sync_policy,
+    list_due_policies,
+    list_sync_policies,
+    rearm_policy,
+    record_sync_result,
+    set_policy_state,
+)
+
+pytestmark = pytest.mark.asyncio
+
+ASSISTANT_ID = "ast-abc123def456"
+USER_ID = "user-1"
+
+FUTURE = "2999-01-01T00:00:00+00:00Z"
+PAST = "2000-01-01T00:00:00+00:00Z"
+
+
+async def _make_policy(source_ref="doc-1", source_type="drive_file", interval="daily"):
+    return await create_sync_policy(
+        assistant_id=ASSISTANT_ID,
+        source_type=source_type,
+        source_ref=source_ref,
+        interval=interval,
+        created_by_user_id=USER_ID,
+    )
+
+
+class TestCreateAndGet:
+    async def test_create_get_roundtrip(self, assistants_table):
+        policy = await _make_policy()
+
+        assert policy.policy_id.startswith("syn-")
+        assert policy.state == "active"
+        assert policy.next_sync_at is not None
+        assert policy.consecutive_failures == 0
+
+        fetched = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert fetched is not None
+        assert fetched.source_ref == "doc-1"
+        assert fetched.source_type == "drive_file"
+        assert fetched.interval == "daily"
+        assert fetched.created_by_user_id == USER_ID
+
+    async def test_active_policy_has_due_index_keys(self, assistants_table):
+        policy = await _make_policy()
+
+        item = assistants_table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"}
+        )["Item"]
+        assert item["GSI4_PK"] == DUE_INDEX_PK
+        assert item["GSI4_SK"] == f"{policy.next_sync_at}#{policy.policy_id}"
+
+    async def test_get_missing_returns_none(self, assistants_table):
+        assert await get_sync_policy(ASSISTANT_ID, "syn-missing") is None
+
+    async def test_duplicate_source_rejected(self, assistants_table):
+        await _make_policy(source_ref="doc-1")
+        with pytest.raises(DuplicateSyncPolicy):
+            await _make_policy(source_ref="doc-1")
+
+    async def test_per_assistant_cap_enforced(self, assistants_table, monkeypatch):
+        monkeypatch.setenv("KB_SYNC_MAX_POLICIES_PER_ASSISTANT", "2")
+        await _make_policy(source_ref="doc-1")
+        await _make_policy(source_ref="doc-2")
+        with pytest.raises(SyncPolicyLimitExceeded):
+            await _make_policy(source_ref="doc-3")
+
+
+class TestDueSweep:
+    async def test_due_query_returns_only_overdue(self, assistants_table):
+        overdue = await _make_policy(source_ref="doc-1")
+        pending = await _make_policy(source_ref="doc-2")
+
+        # Force one policy overdue and keep one in the future
+        assert await set_policy_state(ASSISTANT_ID, overdue.policy_id, "active", next_sync_at=PAST)
+        assert await set_policy_state(ASSISTANT_ID, pending.policy_id, "active", next_sync_at=FUTURE)
+
+        due = await list_due_policies()
+        assert [p.policy_id for p in due] == [overdue.policy_id]
+
+    async def test_due_query_respects_limit(self, assistants_table):
+        for i in range(3):
+            policy = await _make_policy(source_ref=f"doc-{i}")
+            await set_policy_state(ASSISTANT_ID, policy.policy_id, "active", next_sync_at=PAST)
+
+        due = await list_due_policies(limit=2)
+        assert len(due) == 2
+
+    async def test_paused_policy_leaves_due_index(self, assistants_table):
+        policy = await _make_policy()
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "active", next_sync_at=PAST)
+
+        assert await set_policy_state(
+            ASSISTANT_ID, policy.policy_id, "paused_error", state_reason="source no longer accessible"
+        )
+
+        # Sparse index: paused policy is physically absent, not filtered
+        assert await list_due_policies() == []
+        item = assistants_table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"}
+        )["Item"]
+        assert "GSI4_PK" not in item
+        assert "GSI4_SK" not in item
+        assert item["stateReason"] == "source no longer accessible"
+
+    async def test_reactivation_rejoins_due_index_and_clears_reason(self, assistants_table):
+        policy = await _make_policy()
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "paused_reauth", state_reason="reconnect Google Drive")
+        assert await set_policy_state(ASSISTANT_ID, policy.policy_id, "active", next_sync_at=PAST)
+
+        due = await list_due_policies()
+        assert [p.policy_id for p in due] == [policy.policy_id]
+        assert due[0].state_reason is None
+
+    async def test_activate_without_next_sync_at_raises(self, assistants_table):
+        policy = await _make_policy()
+        with pytest.raises(ValueError):
+            await set_policy_state(ASSISTANT_ID, policy.policy_id, "active")
+
+    async def test_set_state_on_missing_policy_returns_false(self, assistants_table):
+        assert not await set_policy_state(ASSISTANT_ID, "syn-missing", "paused_user")
+
+
+class TestRearm:
+    async def test_rearm_wins_with_expected_value(self, assistants_table):
+        policy = await _make_policy()
+
+        assert await rearm_policy(ASSISTANT_ID, policy.policy_id, policy.next_sync_at, FUTURE)
+
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.next_sync_at == FUTURE
+        item = assistants_table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"}
+        )["Item"]
+        assert item["GSI4_SK"] == f"{FUTURE}#{policy.policy_id}"
+
+    async def test_rearm_loses_on_stale_expected_value(self, assistants_table):
+        policy = await _make_policy()
+        assert await rearm_policy(ASSISTANT_ID, policy.policy_id, policy.next_sync_at, FUTURE)
+
+        # Second dispatcher with the stale pre-rearm value must lose
+        assert not await rearm_policy(ASSISTANT_ID, policy.policy_id, policy.next_sync_at, PAST)
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.next_sync_at == FUTURE
+
+
+class TestRunResults:
+    async def test_failure_increments_streak(self, assistants_table):
+        policy = await _make_policy()
+
+        await record_sync_result(ASSISTANT_ID, policy.policy_id, "failed")
+        await record_sync_result(ASSISTANT_ID, policy.policy_id, "failed")
+
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.consecutive_failures == 2
+        assert updated.consecutive_not_found == 0
+        assert updated.last_result == "failed"
+
+    async def test_not_found_failure_increments_both_streaks(self, assistants_table):
+        policy = await _make_policy()
+
+        await record_sync_result(ASSISTANT_ID, policy.policy_id, "failed", not_found=True)
+
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.consecutive_failures == 1
+        assert updated.consecutive_not_found == 1
+
+    async def test_success_resets_streaks(self, assistants_table):
+        policy = await _make_policy()
+        await record_sync_result(ASSISTANT_ID, policy.policy_id, "failed", not_found=True)
+
+        await record_sync_result(ASSISTANT_ID, policy.policy_id, "unchanged")
+
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.consecutive_failures == 0
+        assert updated.consecutive_not_found == 0
+        assert updated.last_result == "unchanged"
+        assert updated.last_sync_at is not None
+        assert updated.sync_run_started_at is None
+
+
+class TestDeleteCascades:
+    async def test_delete_for_source_removes_only_matching(self, assistants_table):
+        keep = await _make_policy(source_ref="doc-keep")
+        await _make_policy(source_ref="doc-gone")
+
+        deleted = await delete_sync_policies_for_source(ASSISTANT_ID, "doc-gone")
+
+        assert deleted == 1
+        remaining = await list_sync_policies(ASSISTANT_ID)
+        assert [p.policy_id for p in remaining] == [keep.policy_id]
+
+    async def test_delete_for_assistant_removes_all(self, assistants_table):
+        await _make_policy(source_ref="doc-1")
+        await _make_policy(source_ref="crawl-1", source_type="web_crawl")
+
+        deleted = await delete_sync_policies_for_assistant(ASSISTANT_ID)
+
+        assert deleted == 2
+        assert await list_sync_policies(ASSISTANT_ID) == []
+        assert await list_due_policies() == []

--- a/docs/specs/assistant-kb-sync.md
+++ b/docs/specs/assistant-kb-sync.md
@@ -1,0 +1,432 @@
+# Assistant Knowledge Base Sync (Scheduled Re-Index)
+
+Status: DRAFT — design spec, not yet built
+Audience: backend + infra + frontend
+Related: `docs/specs/` siblings; provenance fields added in the file-source import work
+
+## 1. Problem
+
+Assistant knowledge bases are indexed once at import time. Web content and Google
+Drive files drift out of date, and today the only remedy is manual re-import.
+Users creating or editing an Assistant should be able to mark a content source
+as **synced**: refetched and reindexed on an interval they choose.
+
+The dominant design constraint is **preventing runaway background work**:
+
+- No sync may outlive its assistant, its document, or its source.
+- No sync should keep burning embeddings for an assistant nobody uses.
+- No sync should retry a permanently-broken source (deleted Drive file, dead
+  site, revoked OAuth grant) forever.
+- No unchanged content should ever be re-chunked or re-embedded.
+
+Every mechanism below is chosen so that the *default failure mode is silence*,
+not repetition.
+
+## 2. Current state (what we build on)
+
+| Piece | Where | Relevance |
+|---|---|---|
+| Document provenance | `backend/src/apis/app_api/documents/models.py:13-27` — `source_connector_id`, `source_adapter_key`, `source_file_id`, `source_etag`, `imported_by_user_id` | Captured at import explicitly to enable re-index; sync consumes these |
+| Ingestion pipeline | S3 `ObjectCreated` on `assistants/` prefix → rag-ingestion Lambda (`apis/app_api/documents/ingestion/handler.py`) → Docling chunk → Titan embed → S3 Vectors keys `{doc_id}#{i}` | Re-staging a fetched file to the **same S3 key** re-runs the whole pipeline unchanged |
+| Web crawls | `CrawlJob` at `PK=AST#{id}, SK=CRAWL#{crawl_id}`, bounded settings (depth ≤3, pages ≤100, concurrency ≤5) | Re-crawl = re-run with stored settings; bounds already enforced |
+| Drive adapter | `apis/app_api/file_sources/adapters/google_drive.py`, tokens via AgentCore Identity vault | `download(file_id)` is the refetch primitive |
+| Deletion lifecycle | Soft-delete + TTL + fire-and-forget cleanup (`documents/services/cleanup_service.py`) | Sync must join this cascade |
+| Scheduling infra | **None.** No EventBridge, SQS, Step Functions, or cron Lambdas anywhere in `infrastructure/lib/constructs/` | Trigger mechanism is green-field |
+
+## 3. Design overview
+
+Three pieces, one trigger:
+
+```
+EventBridge rate(15 minutes)  ──►  Sync Dispatcher (Lambda, small)
+                                        │  query DueSyncIndex (next_sync_at <= now)
+                                        │  per policy: verify liveness, apply guards
+                                        ▼
+                                   Sync Worker (async-invoked Lambda, rag-ingestion-class image)
+                                        │  Drive: metadata check → conditional download → stage to same S3 key
+                                        │  Web:   conditional re-crawl → diff page set
+                                        ▼
+                                   Existing S3-event ingestion pipeline (unchanged)
+```
+
+A new **SyncPolicy** record is the single source of truth for "this source
+resyncs." There are no per-source schedules, no timers, no self-perpetuating
+jobs. The *only* thing that ever initiates sync work is the dispatcher reading
+`DueSyncIndex` — delete the record and the sync ceases to exist. This
+one-trigger architecture is the primary runaway defense: there is nothing to
+orphan except a DynamoDB item, and that item is inert data.
+
+### Why a sweeper, not per-source EventBridge Scheduler entries
+
+Per-source schedules (EventBridge Scheduler one-per-policy) look natural but
+are exactly the runaway shape we fear: cloud-side timer objects whose lifecycle
+must be kept in perfect distributed agreement with app-side records, with
+orphans firing forever when a delete path misses one. A single `rate(15 min)`
+rule + a due-time GSI keeps all state in the table we already own, inside the
+assistant's partition, covered by the existing delete cascade. Interval
+granularity of ~15 minutes is far finer than any interval we offer (§5).
+
+## 4. Data model
+
+### SyncPolicy record (new item type, existing assistants table)
+
+```
+PK = AST#{assistant_id}
+SK = SYNCPOL#{policy_id}                     policy_id: syn-{12-hex}
+```
+
+```python
+class SyncPolicy(BaseModel):
+    policy_id: str
+    assistant_id: str
+    source_type: Literal["web_crawl", "drive_file"]
+    # web_crawl: crawl_id of the CrawlJob whose settings we re-run
+    # drive_file: document_id of the imported doc (provenance lives there)
+    source_ref: str
+    interval: Literal["daily", "weekly", "monthly"]     # bounded enum, no cron
+    state: Literal["active", "paused_error", "paused_inactive",
+                   "paused_reauth", "paused_user"]
+    next_sync_at: str            # ISO 8601; drives DueSyncIndex
+    last_sync_at: Optional[str]
+    last_result: Optional[Literal["changed", "unchanged", "failed", "skipped"]]
+    consecutive_failures: int = 0
+    consecutive_not_found: int = 0     # source-gone counter (distinct from transient failure)
+    created_by_user_id: str            # whose credentials background fetches use
+    created_at: str
+    updated_at: str
+```
+
+### DueSyncIndex (new GSI on assistants table, GSI4)
+
+```
+GSI4_PK = "SYNCDUE"          (constant; single logical partition — fine at our scale,
+                              shard to SYNCDUE#{0..N} later if ever needed)
+GSI4_SK = {next_sync_at}#{policy_id}
+```
+
+GSI4 attributes are **only present while `state == "active"`** — pausing a
+policy removes it from the index (sparse GSI), so the dispatcher physically
+cannot see paused work. Paused ≠ filtered-at-query-time; paused = invisible.
+
+### Document additions
+
+```python
+content_hash: Optional[str]      # sha256 of last-ingested raw bytes
+last_synced_at: Optional[str]
+sync_policy_id: Optional[str]    # back-pointer for UI badges
+```
+
+### Assistant additions
+
+```python
+last_used_at: Optional[str]      # bumped (throttled, ≤1 write/day) on chat use
+```
+
+## 5. Scheduling
+
+- **Trigger**: one EventBridge rule, `rate(15 minutes)`, on a new small
+  dispatcher Lambda (`backend/src/lambdas/kb-sync-dispatcher/`). CDK construct
+  under `infrastructure/lib/constructs/rag-ingestion/` alongside the existing
+  ingestion construct.
+- **Intervals offered**: Daily / Weekly / Monthly (plus "Manual only" = no
+  policy). Enum, not cron — the floor (24 h) is a hard server-side bound, and
+  a bounded enum can't express "every minute."
+- **Dispatcher tick**:
+  1. Query `DueSyncIndex` for `GSI4_SK <= now`, limit **20 per tick** (global
+     throughput cap; backlog just waits for the next tick — degradation is
+     lateness, never amplification).
+  2. For each due policy, run the liveness + guard checks (§7). Guards that
+     fail transition the policy state (which removes it from the GSI) — they
+     do not reschedule-and-retry.
+  3. **Re-arm before work**: set `next_sync_at = now + interval` *first*, then
+     async-invoke the worker. A crashed worker means one missed sync, not a
+     hot loop; a double-fired dispatcher tick is idempotent because the
+     re-arm is a conditional update on the old `next_sync_at`.
+- **Fan-out**: direct async Lambda invoke of the worker, one per policy, ≤20
+  per tick. No SQS for v1 (nothing else in the stack uses it); if scale ever
+  demands it, the dispatcher→worker seam is where a queue slots in.
+
+## 6. Execution (worker)
+
+Worker is a Lambda sharing the rag-ingestion image class (needs the
+file-source adapters and crawler; lives with them in
+`apis/app_api` packaging like the existing ingestion handler — same import-
+boundary posture as today's ingestion Lambda).
+
+### 6.1 Drive file (`drive_file`)
+
+1. Load document; resolve provider token for `created_by_user_id` from the
+   AgentCore Identity vault. Verified call chain (no live user session
+   needed): `GetWorkloadAccessTokenForUserId(workloadName, userId)` — pure
+   IAM/SigV4 authorization, no user JWT — then
+   `GetResourceOauth2Token(USER_FEDERATION)`; when a valid refresh token is
+   vaulted, AgentCore documented-behavior skips federation and returns an
+   access token non-interactively. Reuse
+   `apis.shared.oauth.agentcore_identity.AgentCoreIdentityClient` verbatim
+   (its mint fallback is exactly this path), and
+   `custom_parameters_for(provider_type, ..., force_authentication=True)` —
+   customParameters are part of the vault key; a mismatched map falsely
+   reports consent-required.
+2. **Metadata-first change detection**: Drive `files.get` with
+   `fields=id,mimeType,trashed,modifiedTime,version,md5Checksum,size`.
+   - **Binary files**: compare `md5Checksum` (exact content identity).
+   - **Native Docs/Sheets** (exported to .docx/.xlsx): `md5Checksum`,
+     `sha256Checksum`, and `headRevisionId` are **not populated** for
+     editor files — use `modifiedTime` as the primary signal (`version` is
+     a strict superset but bumps on comments/metadata → false-positive
+     downloads).
+   - `trashed == true` is a **200, not an error**: treat as
+     `last_result=skipped` (grace state — recoverable from trash; do not
+     delete our copy, do not count as a failure).
+   - If unchanged vs `source_etag` → record `last_result=unchanged`, done.
+     No download, no embed.
+3. If changed: `adapter.download(source_file_id)` → compare sha256 to
+   `content_hash` (export formats can differ byte-wise even when content
+   didn't; hash is the second gate). If equal → `unchanged`, done.
+4. Stage bytes to the **existing S3 key** for the document → S3 event →
+   existing ingestion pipeline re-chunks and re-embeds, overwriting vectors
+   `{doc_id}#{0..n}`.
+5. **Shrinkage cleanup**: before staging, snapshot old `chunk_count`; after
+   ingestion completes with new count `m < n`, delete vectors
+   `{doc_id}#{m..n-1}`. (Without this, in-place overwrite strands stale
+   tail chunks — the one real gap in "reuse the pipeline as-is." Implemented
+   as: worker stashes `previous_chunk_count` on the document record; the
+   ingestion handler's completion step deletes the tail if present.)
+6. Update `source_etag`, `content_hash`, `last_synced_at`, `last_result`.
+
+### 6.2 Web crawl (`web_crawl`)
+
+1. Load the referenced `CrawlJob`; re-run the crawler with its **stored
+   settings** (bounds already capped: ≤3 depth, ≤100 pages, ≤5 concurrency).
+2. Per fetched page, conditional GET (`If-None-Match`/`If-Modified-Since`)
+   where the server supports it; otherwise fetch + content-hash compare.
+   Only changed pages are re-staged/re-embedded.
+3. Diff the page set against existing docs for that crawl root:
+   - **New URLs** → new documents (respecting the max_pages cap — the cap
+     applies to the crawl total, so a synced crawl can never grow past it).
+   - **Missing URLs** → increment a per-doc `consecutive_misses`; delete the
+     document (existing soft-delete + cleanup cascade) only after missing in
+     **2 consecutive** sync runs. A transient outage must not vaporize a
+     knowledge base.
+4. Record results on the policy.
+
+### 6.3 Concurrency & re-entrancy
+
+A policy is skipped if its previous run hasn't finished: the worker sets
+`sync_run_started_at` on the policy at start and clears it at end; the
+dispatcher skips policies with a fresh (<2 h) run-start stamp. Older stamps
+are treated as crashed runs and cleared. Combined with the per-tick cap of 20
+and per-crawl concurrency of ≤5, worst-case parallel fetch pressure is bounded
+and known.
+
+## 7. Runaway-process safeguards (the point of this spec)
+
+Layered, so any single failure of discipline is caught by another layer:
+
+1. **Single trigger, inert state.** Only the dispatcher initiates work, only
+   by reading the GSI. There are no timers, queues, or schedules to orphan.
+   Deleting the policy record is total and instantaneous revocation.
+
+2. **Lifecycle tie via liveness check.** Every dispatch re-verifies, in order:
+   assistant exists → source document / crawl job exists (and isn't
+   `deleting`) → policy state is `active`. Any miss ⇒ the policy is
+   **hard-deleted on the spot** (self-healing against any delete path that
+   forgot the cascade). Additionally, the assistant delete cascade and the
+   document delete path both delete associated `SYNCPOL#` records eagerly —
+   the liveness check is the backstop, not the mechanism.
+
+3. **Inactivity auto-pause.** If `assistant.last_used_at` is older than
+   **30 days** (config: `KB_SYNC_INACTIVITY_PAUSE_DAYS`), the dispatcher
+   transitions the policy to `paused_inactive` instead of running it. This is
+   the direct answer to "reindexing content that isn't being used."
+   **Auto-resume**: the app-api path that bumps `last_used_at` also flips any
+   `paused_inactive` policies back to `active` with `next_sync_at = now` —
+   the first person to use a dormant assistant gets a fresh index within a
+   tick, and nobody has to know a pause happened.
+
+4. **Failure circuit breaker.** Failures back off exponentially
+   (`interval × 2^consecutive_failures`, capped at 30 days). At
+   **5 consecutive failures** the policy transitions to `paused_error`
+   (out of the GSI, no further attempts) and the UI shows a badge with the
+   last error; resume is an explicit user action.
+
+5. **Source-gone fast path.** Drive returns **404 `notFound`** both when a
+   file is permanently deleted and when the user merely lost access —
+   deliberately indistinguishable (anti-enumeration). So: 404 `notFound`
+   increments `consecutive_not_found`; at **2**, the policy goes to
+   `paused_error` with reason "source no longer accessible" (worded as
+   *accessible*, not *deleted* — we cannot know which). We never delete the
+   already-indexed content on 404; the user decides. `trashed=true` (a 200)
+   is a grace state, not a strike. Discriminate Drive errors on
+   `error.errors[0].reason`, **never on bare HTTP status**: 403/429 with
+   `usageLimits` domain (`rateLimitExceeded`, `userRateLimitExceeded`) are
+   transient → backoff-retry, not strikes; 403 `domainPolicy` (Workspace
+   admin disabled Drive apps) pauses connector-wide, not per-policy.
+
+6. **Auth-gone fast path.** Two distinct signals, both ⇒ immediate
+   `paused_reauth`:
+   - **Vault says re-consent**: `GetResourceOauth2Token` returns **HTTP 200
+     with an `authorizationUrl` instead of an `accessToken`** (not an
+     exception) — surfaces as `TokenResult.requires_consent` in our wrapper.
+     Covers refresh-token expiry/revocation AgentCore can detect. The worker
+     must reuse the existing `_ShortCircuitPoller` pattern or the SDK will
+     sit in its consent poll loop.
+   - **Provider-side revocation AgentCore can't see**: the vault can return
+     a token Google then rejects with 401 at the Drive API (documented
+     AgentCore limitation) — our adapter already maps this to
+     `FileSourceAuthError`.
+   Never retried on a timer — only a fresh consent resumes it: the
+   `complete_consent()` success path in app-api
+   (`apis/app_api/connectors/routes.py:379`, right after
+   `complete_resource_token_auth`) flips `paused_reauth` → `active` for that
+   `(user, provider)`'s policies. Infra-class failures
+   (`WorkloadTokenUnavailableError`, `AccessDeniedException`,
+   `ThrottlingException`) are operator errors: alert via metrics, retry with
+   backoff, do **not** pause the user's policy.
+
+7. **Change detection before cost.** Metadata check → conditional GET →
+   content hash, in that order. The expensive tail (Docling + Titan embed)
+   runs only when bytes actually changed. An unchanged corpus on a daily
+   sync costs one metadata call per source per day.
+
+8. **Bounded configuration surface.** Interval is an enum with a 24 h floor;
+   crawl settings are the already-capped stored settings; **≤ 10 sync
+   policies per assistant** (config: `KB_SYNC_MAX_POLICIES_PER_ASSISTANT`);
+   dispatcher processes ≤ 20 policies/tick globally. Every knob has a
+   ceiling; no user input can express unbounded work.
+
+9. **Observability.** Worker emits CloudWatch metrics:
+   `KBSync/RunsStarted`, `RunsChanged`, `RunsUnchanged`, `RunsFailed`,
+   `PoliciesPaused` (by reason), `EmbeddingChunksWritten`. One alarm:
+   `RunsFailed` sustained high, and an anomaly alarm on
+   `EmbeddingChunksWritten` (the "we are somehow re-embedding the world"
+   tripwire). Each policy keeps `last_result` + timestamps so the UI never
+   needs CloudWatch.
+
+10. **Global kill switch.** `KB_SYNC_ENABLED` env var on the dispatcher
+    (default true). Flipping it off stops all sync activity in ≤ 15 minutes
+    with zero data changes — policies simply go stale until re-enabled.
+
+## 8. API & UX
+
+### API (app-api, all `Depends(get_current_user_from_session)`, owner-gated)
+
+```
+POST   /assistants/{id}/sync-policies                {source_type, source_ref, interval}
+PATCH  /assistants/{id}/sync-policies/{policy_id}    {interval? , state?}   # pause/resume/change interval
+DELETE /assistants/{id}/sync-policies/{policy_id}
+GET    /assistants/{id}/sync-policies
+POST   /assistants/{id}/sync-policies/{policy_id}/run-now    # manual trigger; rate-limited 1/10min/policy
+```
+
+`run-now` sets `next_sync_at = now` (state must be `active` or resumable) and
+lets the normal dispatcher path pick it up — even manual sync flows through
+the single trigger, preserving every guard.
+
+### Assistant form UX
+
+Per content-source row (Drive file, web crawl root):
+
+- **"Keep in sync" control**: `Manual only ▾ | Daily | Weekly | Monthly`
+  (Manual only = default; selecting an interval creates the policy).
+- **Status line** under the row: `Synced 2h ago · next Tue` /
+  `Paused — source not found` / `Paused — reconnect Google Drive` /
+  `Paused — assistant inactive (resumes on next use)`.
+- **Sync now** button (calls `run-now`), disabled while a run is in flight.
+- Paused-error rows get the existing error-badge treatment from document
+  status rows.
+
+Device-uploaded files show no sync control (no source of truth to refetch).
+
+## 9. Resolved questions (research pass, 2026-07-03)
+
+All five former open questions are resolved; answers below are grounded in
+AWS AgentCore Identity docs, Google Drive API docs, and code inspection.
+
+1. **Offline token retrieval — RESOLVED: feasible with existing machinery.**
+   `bedrock-agentcore:GetWorkloadAccessTokenForUserId` takes only
+   `{workloadName, userId}` and is authorized purely by IAM/SigV4 — no user
+   JWT. With that workload token, `GetResourceOauth2Token(USER_FEDERATION)`
+   returns the stored token non-interactively when a refresh token is
+   vaulted ("If a valid refresh token is stored, AgentCore skips the user
+   federation flow and directly returns a new access token" — identity
+   devguide). Our `apis.shared.oauth.agentcore_identity` mint fallback IS
+   this path and is reusable from the sync Lambda as-is.
+   **Worker Lambda requirements**:
+   - IAM: `bedrock-agentcore:GetWorkloadAccessTokenForUserId` +
+     `bedrock-agentcore:GetResourceOauth2Token` (mirror the app-api
+     `AgentCoreWorkloadIdentityAccess` statement in
+     `infrastructure/lib/constructs/app-api/app-api-iam-grants.ts`, minus
+     provider-CRUD and `CompleteResourceTokenAuth`). Optionally constrain
+     with the `bedrock-agentcore:userid` condition key.
+   - Env: `AGENTCORE_RUNTIME_WORKLOAD_NAME` = the shared platform workload
+     identity (same SSM value app-api/inference-api use — a different
+     workload sees an empty vault) and `AGENTCORE_LOCAL_OAUTH_CALLBACK_URL`
+     (our wrapper requires it even for pure reads).
+   - Must pass the exact consent-time `customParameters`
+     (`custom_parameters_for(..., force_authentication=True)`) and the exact
+     Cognito `user_id` — both are vault-key components.
+   - **Operational caveat**: Google OAuth clients in *Testing* publishing
+     status issue 7-day refresh tokens — a background sync would hit
+     `paused_reauth` weekly until the client is Published/verified. Also:
+     refresh tokens die after 6 months of non-use and can be silently
+     evicted past ~50 live tokens per user per client.
+
+2. **Drive loss-of-access semantics — RESOLVED (design §7.5 updated).**
+   404 `notFound` deliberately conflates "deleted" with "unshared from this
+   user" — no API call distinguishes them. Owner-trashed files are a 200
+   with `trashed=true` (content still readable) → grace state. Change
+   detection must be per-file-type: `md5Checksum` for binaries;
+   `modifiedTime` for native editor files (checksums/headRevisionId are not
+   populated for them). Error discrimination is by `reason` string, never
+   bare HTTP status (rate-limit 403s look like permission 403s otherwise).
+
+3. **Shrinkage-cleanup stash — RESOLVED: safe.** After the initial
+   `put_item` at creation, the ingestion pipeline only ever issues targeted
+   `UpdateExpression` writes on known fields (status, updatedAt, chunkCount,
+   vectorStoreId, error fields) — `ingestion/status.py:21-108`. A
+   `previous_chunk_count` attribute stashed by the worker survives
+   ingestion untouched. Final `chunk_count` is written at `mark_embedding`
+   (`handler.py:288`); `mark_complete` doesn't touch it — so the worker must
+   snapshot the old count *before* staging the new S3 object. Also
+   confirmed: overwriting a complete document's S3 key simply re-triggers
+   ingestion with no reprocessing guard in the way — the reuse-the-pipeline
+   plan works with zero pipeline changes beyond the tail-delete hook.
+
+4. **Whose policies pause on reauth — DECIDED: keyed to
+   `created_by_user_id`, acceptable for v1 with an escape hatch.** Any
+   editor can delete a paused policy and recreate it (or re-import the
+   file), which re-keys it to their own credentials. No credential
+   "takeover" PATCH in v1. The resume hook attaches at
+   `complete_consent()` success in `apis/app_api/connectors/routes.py:379`.
+
+5. **Shared assistants — DECIDED, with one spec correction.** SHARE records
+   already carry `permission: viewer|editor`, and editors can already
+   upload/import documents (`documents/routes.py:44-60`
+   `_require_edit_permission`) — sync-policy CRUD uses the same helper, so
+   **editors manage sync policies**, consistent with the document surface.
+   Sync always runs on the policy creator's credentials (same posture as
+   import's `imported_by_user_id` today). **Correction**: `usage_count` is
+   never incremented anywhere and no `last_used_at` exists — the inactivity
+   pause needs a net-new bump: app-api, on the chat path where a session
+   resolves its assistant, throttled to ≤1 write/day per assistant, bumping
+   `last_used_at` and flipping any `paused_inactive` policies back to
+   `active` (§7.3). Any user's use counts, not just the owner's.
+
+## 10. Suggested PR breakdown
+
+1. **PR-1 data**: SyncPolicy model + repository, GSI4, document/assistant
+   field additions, delete-cascade integration, unit tests.
+2. **PR-2 infra**: EventBridge rule + dispatcher Lambda construct + worker
+   Lambda construct, kill switch, metrics/alarms. (platform.yml deploy)
+3. **PR-3 worker**: Drive-file sync path incl. change detection + shrinkage
+   cleanup + all pause transitions. (backend.yml deploy)
+4. **PR-4 worker**: web re-crawl path incl. page-set diff + 2-miss deletion.
+5. **PR-5 API**: sync-policy CRUD (owner + editor via
+   `_require_edit_permission`) + run-now + reauth resume hook in
+   `complete_consent()` + **net-new** `last_used_at` bump (throttled) on the
+   app-api chat path with the `paused_inactive` auto-resume.
+6. **PR-6 frontend**: assistant-form sync controls + status lines + badges.
+
+PR-1..2 are inert (nothing schedules until a policy exists and the flag is
+on); each subsequent PR is independently shippable behind `KB_SYNC_ENABLED`.

--- a/infrastructure/lib/constructs/rag/rag-data-construct.ts
+++ b/infrastructure/lib/constructs/rag/rag-data-construct.ts
@@ -26,10 +26,11 @@ export interface RagDataConstructProps {
  *     dimension and distance metric driven by config; Titan V2
  *     embeddings → 1024-dim float32 cosine. The `text` metadata key
  *     is marked non-filterable because it's too large to filter on.
- *   - DynamoDB assistants table with three GSIs:
+ *   - DynamoDB assistants table with four GSIs:
  *       OwnerStatusIndex
  *       VisibilityStatusIndex
  *       SharedWithIndex (projection = ALL)
+ *       DueSyncIndex (sparse, projection = ALL — KB sync due sweep)
  *
  * SSM publications:
  *   /{prefix}/rag/documents-bucket-name
@@ -147,6 +148,16 @@ export class RagDataConstruct extends Construct {
       indexName: 'SharedWithIndex',
       partitionKey: { name: 'GSI3_PK', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'GSI3_SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // Sparse due-sweep index for KB sync policies: GSI4 keys exist only on
+    // SYNCPOL# items while state == "active", so the sync dispatcher's query
+    // physically cannot see paused policies.
+    this.assistantsTable.addGlobalSecondaryIndex({
+      indexName: 'DueSyncIndex',
+      partitionKey: { name: 'GSI4_PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI4_SK', type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL,
     });
 

--- a/infrastructure/test/tables-detailed.test.ts
+++ b/infrastructure/test/tables-detailed.test.ts
@@ -303,12 +303,28 @@ describe('RagDataConstruct — detailed', () => {
     });
   });
 
-  it('assistants table has 3 GSIs', () => {
+  it('assistants table has 4 GSIs', () => {
     t.hasResourceProperties('AWS::DynamoDB::Table', {
       GlobalSecondaryIndexes: Match.arrayWith([
         Match.objectLike({ IndexName: 'OwnerStatusIndex' }),
         Match.objectLike({ IndexName: 'VisibilityStatusIndex' }),
         Match.objectLike({ IndexName: 'SharedWithIndex' }),
+        Match.objectLike({ IndexName: 'DueSyncIndex' }),
+      ]),
+    });
+  });
+
+  it('DueSyncIndex is keyed on GSI4_PK/GSI4_SK with full projection', () => {
+    t.hasResourceProperties('AWS::DynamoDB::Table', {
+      GlobalSecondaryIndexes: Match.arrayWith([
+        Match.objectLike({
+          IndexName: 'DueSyncIndex',
+          KeySchema: [
+            { AttributeName: 'GSI4_PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI4_SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+        }),
       ]),
     });
   });


### PR DESCRIPTION
## Summary

First PR of the **assistant KB sync** feature (scheduled refetch/reindex of knowledge-base content sources). Full design: [docs/specs/assistant-kb-sync.md](https://github.com/Boise-State-Development/agentcore-public-stack/blob/feature/kb-sync-data/docs/specs/assistant-kb-sync.md) (included in this PR).

This PR is the **inert data layer** — nothing schedules or executes until the PR-2 dispatcher exists, and the feature ships behind `KB_SYNC_ENABLED` end-to-end.

- **`apis.shared.sync_policies`** — `SyncPolicy` model + repository. Policies live at `PK=AST#{id}, SK=SYNCPOL#{id}` on the assistants table (adjacency list, covered by the assistant's partition).
- **`DueSyncIndex` (GSI4, sparse)** — `GSI4_PK="SYNCDUE"`, `GSI4_SK="{nextSyncAt}#{policyId}"`. Keys exist **only while `state=active`**: pausing a policy physically removes it from the dispatcher's query, rather than filtering at read time.
- **Conditional re-arm** (`rearm_policy`) — dispatch advances `nextSyncAt` conditionally on the stored value, making a double-fired sweep tick idempotent.
- **Breaker counters** — `record_sync_result` maintains `consecutiveFailures` / `consecutiveNotFound` streaks (reset on any success-ish result) for the PR-3 circuit breaker.
- **Delete cascades** — assistant delete and document delete eagerly remove covering sync policies, so no schedule outlives its source (the dispatcher liveness check in PR-2 is the backstop, not the mechanism).
- **Field additions** — `Document`: `contentHash`, `lastSyncedAt`, `syncPolicyId`; `Assistant`: `lastUsedAt` (input to the 30-day inactivity auto-pause).

## Testing

- 18 new repository tests (moto) covering the sparse-index invariant, conditional re-arm races, breaker counters, cap/uniqueness enforcement, and both cascades
- 2 new route tests asserting the delete endpoints invoke the cascades
- Backend suite: 4088 passed (5 prior failures were the delete-endpoint tests, fixed by stubbing the new cascade)
- Infra: `tsc --noEmit` clean; `tables-detailed.test.ts` updated (4 GSIs + DueSyncIndex key/projection assertions). The `cloudfront-shared-cert`/`config` jest failures reproduce on clean develop — pre-existing, unrelated.

## Deploy note

Adds a GSI to the assistants table → requires a `platform.yml` (CDK) deploy. GSI creation on an existing table is online/non-disruptive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)