### PR TITLE
feat(kb-sync): PR-2 — dispatcher/worker Lambdas, EventBridge sweep, image pipeline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -165,6 +165,78 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  build-kb-sync:
+    name: Build kb-sync image
+    needs: test-backend
+    # Native ARM64 runner — both kb-sync Lambdas are arm64 (see the
+    # kb-sync CDK construct), matching the rag-ingestion pattern.
+    runs-on: ubuntu-24.04-arm
+    environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    outputs:
+      image_tag: ${{ steps.build.outputs.image_tag }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/build-and-push-image
+        id: build
+        with:
+          image-name: kb-sync
+          aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  deploy-kb-sync-code:
+    name: Deploy kb-sync Lambda images
+    # One image, two functions: dispatcher + worker share the kb-sync
+    # image and differ only in ImageConfig.Command (CDK-owned), so a
+    # single job points both at the freshly-built tag.
+    needs: [build-kb-sync, test-backend]
+    runs-on: ubuntu-24.04
+    environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Deploy kb-sync dispatcher image
+        run: bash scripts/build/deploy-image-lambda-one.sh kb-sync-dispatcher
+      - name: Deploy kb-sync worker image
+        run: bash scripts/build/deploy-image-lambda-one.sh kb-sync-worker
+
   deploy-artifact-render-code:
     name: Deploy artifact-render Lambda code
     # Lambda zip code deploy. Mirrors the build-* jobs but for a

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -469,6 +469,9 @@ jobs:
       - name: Build rag-ingestion image
         run: docker build -f backend/Dockerfile.rag-ingestion -t rag-ingestion:scan .
 
+      - name: Build kb-sync image
+        run: docker build -f backend/Dockerfile.kb-sync -t kb-sync:scan .
+
       - name: Trivy scan app-api
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -486,6 +489,15 @@ jobs:
           exit-code: '0'
           severity: 'CRITICAL,HIGH'
           output: trivy-inference-api.txt
+
+      - name: Trivy scan kb-sync
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'kb-sync:scan'
+          format: 'table'
+          exit-code: '0'
+          severity: 'CRITICAL,HIGH'
+          output: trivy-kb-sync.txt
 
       - name: Trivy scan rag-ingestion
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/backend/Dockerfile.kb-sync
+++ b/backend/Dockerfile.kb-sync
@@ -1,0 +1,36 @@
+# kb-sync Lambda image — KB sync dispatcher + worker.
+#
+# One image, two Lambda functions: the CDK construct
+# (infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts) points
+# both functions at this image with different ImageConfig.Command
+# overrides (dispatcher vs worker handler). The command override is
+# function *configuration*, so the workflow's
+# `update-function-code --image-uri` swaps code on both functions
+# without touching their handlers.
+#
+# Deliberately lightweight: the worker only fetches source bytes and
+# stages them to S3 — chunking/embedding stays in the rag-ingestion
+# image, triggered by the staged object's S3 event.
+#
+# Base image digest-pinned, same pin as the other Lambda images (see
+# backend/Dockerfile.rag-ingestion and the supply-chain
+# dockerfile-pinning test).
+
+FROM public.ecr.aws/lambda/python:3.12@sha256:745b0eb8a9787e9c4bfd4fc4cae942399a2225831c96394ae70c0c2a7c7c6168
+
+# Dependencies (exact pins)
+COPY backend/src/apis/app_api/kb_sync/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Application code — namespace-package layout mirrors backend/src.
+# Keep this surface minimal: apis.shared domains the handlers import,
+# plus the kb_sync package itself. If a handler needs more, COPY it
+# here AND add the path to the kb-sync SOURCE_DIRS in
+# scripts/build/build-one.sh so the content-hash tag notices changes.
+COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
+COPY backend/src/apis/shared/sync_policies/ ${LAMBDA_TASK_ROOT}/apis/shared/sync_policies/
+COPY backend/src/apis/app_api/kb_sync/ ${LAMBDA_TASK_ROOT}/apis/app_api/kb_sync/
+
+# Default command: dispatcher. The worker function's CMD is overridden
+# to apis.app_api.kb_sync.worker.lambda_handler by its ImageConfig.
+CMD ["apis.app_api.kb_sync.dispatcher.lambda_handler"]

--- a/backend/src/apis/app_api/kb_sync/__init__.py
+++ b/backend/src/apis/app_api/kb_sync/__init__.py
@@ -1,0 +1,14 @@
+"""KB sync Lambdas — scheduled re-index of assistant knowledge-base sources.
+
+Two Lambda entry points packaged in the kb-sync container image
+(backend/Dockerfile.kb-sync), sharing one image with different CMD
+overrides:
+
+- ``dispatcher`` — fired by the EventBridge rate rule; sweeps the sparse
+  DueSyncIndex, applies the runaway guards, and async-invokes the worker.
+- ``worker`` — executes a single policy's sync run (PR-2 ships a stub;
+  the Drive-file path lands in PR-3, web re-crawl in PR-4).
+
+Design: docs/specs/assistant-kb-sync.md. Keep this package importable
+without FastAPI — it deploys outside the app-api container.
+"""

--- a/backend/src/apis/app_api/kb_sync/dispatcher.py
+++ b/backend/src/apis/app_api/kb_sync/dispatcher.py
@@ -1,0 +1,259 @@
+"""KB sync dispatcher — the single initiator of scheduled sync work.
+
+Fired by one EventBridge rate rule (every 15 minutes). Sweeps the sparse
+DueSyncIndex and, for each due policy, applies the runaway guards from
+docs/specs/assistant-kb-sync.md §7 in order:
+
+1. Kill switch      — KB_SYNC_ENABLED must be "true" or the tick no-ops.
+2. Liveness         — assistant and source must still exist; a miss
+                      hard-deletes the policy on the spot (self-healing
+                      backstop behind the eager delete cascades).
+3. Circuit breaker  — consecutive_not_found >= 2 or consecutive_failures
+                      >= 5 pauses the policy instead of dispatching.
+4. Inactivity       — assistant unused for 30 days pauses the policy
+                      (auto-resumed by the chat-path bump, PR-5).
+5. In-flight skip   — a fresh syncRunStartedAt stamp means the previous
+                      run hasn't finished; skip without re-arming. Stale
+                      stamps (crashed runs) are overwritten by the re-arm.
+6. Re-arm BEFORE work — next_sync_at advances (with failure backoff)
+                      via a conditional write, then the worker is
+                      async-invoked. A crashed worker costs one missed
+                      sync, never a hot loop; a double-fired tick loses
+                      the conditional write and skips.
+
+Guard failures transition state (removing the policy from the sparse
+index) — they never reschedule-and-retry.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from apis.shared.sync_policies.models import SyncPolicy
+from apis.shared.sync_policies.service import (
+    INTERVAL_DELTAS,
+    delete_sync_policy,
+    list_due_policies,
+    rearm_policy,
+    set_policy_state,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+METRIC_NAMESPACE = "KBSync"
+
+# Backoff cap from the spec: interval * 2^failures never exceeds 30 days.
+MAX_BACKOFF = timedelta(days=30)
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _timestamp(dt: datetime) -> str:
+    return dt.isoformat() + "Z"
+
+
+def _parse_timestamp(value: str) -> Optional[datetime]:
+    """Parse the house timestamp format (isoformat + trailing 'Z')."""
+    try:
+        return datetime.fromisoformat(value.rstrip("Z"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _get_item(pk: str, sk: str) -> Optional[Dict[str, Any]]:
+    import boto3
+
+    table = boto3.resource("dynamodb").Table(os.environ["DYNAMODB_ASSISTANTS_TABLE_NAME"])
+    response = table.get_item(Key={"PK": pk, "SK": sk})
+    return response.get("Item")
+
+
+def _get_assistant_item(assistant_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch the assistant METADATA record (existence + activity timestamps).
+
+    Raw key lookup rather than apis.shared.assistants — that package's
+    __init__ drags in the embeddings stack, which would bloat the
+    kb-sync image for three timestamp fields. Key patterns are the
+    stable storage contract; the dispatcher tests create assistants
+    through the real service so schema drift breaks loudly here.
+    """
+    return _get_item(f"AST#{assistant_id}", "METADATA")
+
+
+def _get_source_item(assistant_id: str, source_type: str, source_ref: str) -> Optional[Dict[str, Any]]:
+    """Fetch the source record backing a policy (same raw-lookup rationale
+    as _get_assistant_item; DOC#/CRAWL# per documents/web_sources services)."""
+    sk_prefix = "DOC#" if source_type == "drive_file" else "CRAWL#"
+    return _get_item(f"AST#{assistant_id}", f"{sk_prefix}{source_ref}")
+
+
+def _invoke_worker(payload: Dict[str, Any]) -> None:
+    """Async-invoke the sync worker Lambda (fire-and-forget)."""
+    import boto3
+
+    function_name = os.environ["KB_SYNC_WORKER_FUNCTION_NAME"]
+    boto3.client("lambda").invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _emit_metrics(counts: Dict[str, int]) -> None:
+    """Best-effort CloudWatch metrics; never fails the tick."""
+    import boto3
+
+    try:
+        metric_data = [
+            {"MetricName": name, "Value": value, "Unit": "Count"} for name, value in counts.items()
+        ]
+        boto3.client("cloudwatch").put_metric_data(Namespace=METRIC_NAMESPACE, MetricData=metric_data)
+    except Exception as e:
+        logger.warning(f"Failed to emit KBSync metrics: {e}")
+
+
+def _assistant_last_activity(assistant_item: Dict[str, Any]) -> Optional[datetime]:
+    """Reference time for the inactivity guard.
+
+    lastUsedAt when present; otherwise the newest of createdAt /
+    updatedAt so pre-existing assistants aren't paused purely because the
+    tracking field postdates them.
+    """
+    candidates = [assistant_item.get("lastUsedAt"), assistant_item.get("updatedAt"), assistant_item.get("createdAt")]
+    parsed = [ts for ts in (_parse_timestamp(c) for c in candidates if c) if ts]
+    return max(parsed) if parsed else None
+
+
+def _backoff_next_sync_at(policy: SyncPolicy, now: datetime) -> str:
+    """Next due time: the policy interval, doubled per consecutive failure,
+    capped at 30 days."""
+    delay = INTERVAL_DELTAS[policy.interval] * (2**policy.consecutive_failures)
+    return _timestamp(now + min(delay, MAX_BACKOFF))
+
+
+async def _dispatch_policy(policy: SyncPolicy, now: datetime, counts: Dict[str, int]) -> None:
+    assistant_id = policy.assistant_id
+
+    # Guard 2 — liveness: assistant, then source. A miss deletes the policy.
+    assistant = _get_assistant_item(assistant_id)
+    if assistant is None:
+        logger.warning(f"Sync policy {policy.policy_id}: assistant {assistant_id} gone; deleting policy")
+        await delete_sync_policy(assistant_id, policy.policy_id)
+        counts["OrphansDeleted"] += 1
+        return
+
+    source = _get_source_item(assistant_id, policy.source_type, policy.source_ref)
+    if source is None or source.get("status") == "deleting":
+        logger.warning(
+            f"Sync policy {policy.policy_id}: source {policy.source_ref} gone or deleting; deleting policy"
+        )
+        await delete_sync_policy(assistant_id, policy.policy_id)
+        counts["OrphansDeleted"] += 1
+        return
+
+    # Guard 3 — circuit breaker on the streak counters the worker maintains.
+    if policy.consecutive_not_found >= _env_int("KB_SYNC_MAX_NOT_FOUND", 2):
+        await set_policy_state(
+            assistant_id, policy.policy_id, "paused_error", state_reason="source no longer accessible"
+        )
+        counts["PausedBreaker"] += 1
+        return
+    if policy.consecutive_failures >= _env_int("KB_SYNC_MAX_FAILURES", 5):
+        await set_policy_state(
+            assistant_id, policy.policy_id, "paused_error", state_reason="repeated sync failures"
+        )
+        counts["PausedBreaker"] += 1
+        return
+
+    # Guard 4 — inactivity: nobody is using this assistant, stop paying for it.
+    inactivity_days = _env_int("KB_SYNC_INACTIVITY_PAUSE_DAYS", 30)
+    last_activity = _assistant_last_activity(assistant)
+    if last_activity is not None and (now - last_activity) > timedelta(days=inactivity_days):
+        await set_policy_state(
+            assistant_id,
+            policy.policy_id,
+            "paused_inactive",
+            state_reason=f"assistant unused for {inactivity_days}+ days (resumes on next use)",
+        )
+        counts["PausedInactive"] += 1
+        return
+
+    # Guard 5 — in-flight skip: fresh run stamp means the last run is still
+    # going; leave the policy due and let a later tick retry. Stale stamps
+    # are crashed runs — fall through and let the re-arm overwrite them.
+    if policy.sync_run_started_at:
+        started = _parse_timestamp(policy.sync_run_started_at)
+        stale_after = timedelta(hours=_env_int("KB_SYNC_RUN_STAMP_STALE_HOURS", 2))
+        if started is not None and (now - started) < stale_after:
+            logger.info(f"Sync policy {policy.policy_id}: run in flight since {policy.sync_run_started_at}; skipping")
+            counts["InFlightSkipped"] += 1
+            return
+
+    # Guard 6 — re-arm before work; losing the conditional write means
+    # another dispatcher already claimed this policy.
+    new_next = _backoff_next_sync_at(policy, now)
+    won = await rearm_policy(
+        assistant_id, policy.policy_id, policy.next_sync_at, new_next, mark_run_started=True
+    )
+    if not won:
+        counts["RearmLost"] += 1
+        return
+
+    _invoke_worker(
+        {
+            "policyId": policy.policy_id,
+            "assistantId": assistant_id,
+            "sourceType": policy.source_type,
+            "sourceRef": policy.source_ref,
+        }
+    )
+    counts["Dispatched"] += 1
+
+
+async def dispatch_once() -> Dict[str, int]:
+    """One dispatcher tick. Returns the metric counts (also emitted)."""
+    counts: Dict[str, int] = {
+        "PoliciesDue": 0,
+        "Dispatched": 0,
+        "OrphansDeleted": 0,
+        "PausedBreaker": 0,
+        "PausedInactive": 0,
+        "InFlightSkipped": 0,
+        "RearmLost": 0,
+    }
+
+    if os.environ.get("KB_SYNC_ENABLED", "false").lower() != "true":
+        logger.info("KB_SYNC_ENABLED is not true; dispatcher tick is a no-op")
+        return counts
+
+    now = _now()
+    limit = _env_int("KB_SYNC_DISPATCH_LIMIT", 20)
+    due = await list_due_policies(now=_timestamp(now), limit=limit)
+    counts["PoliciesDue"] = len(due)
+    logger.info(f"Dispatcher tick: {len(due)} due policies (limit {limit})")
+
+    for policy in due:
+        try:
+            await _dispatch_policy(policy, now, counts)
+        except Exception as e:
+            # One broken policy must not starve the rest of the sweep.
+            logger.error(f"Failed to dispatch sync policy {policy.policy_id}: {e}", exc_info=True)
+
+    _emit_metrics(counts)
+    return counts
+
+
+def lambda_handler(event, context):
+    """EventBridge entry point."""
+    counts = asyncio.run(dispatch_once())
+    return {"statusCode": 200, "body": counts}

--- a/backend/src/apis/app_api/kb_sync/requirements.txt
+++ b/backend/src/apis/app_api/kb_sync/requirements.txt
@@ -1,0 +1,5 @@
+# kb-sync Lambda image dependencies (backend/Dockerfile.kb-sync).
+# Exact pins per repo policy; versions match backend/uv.lock.
+# PR-3 (Drive sync path) adds httpx + bedrock-agentcore here.
+boto3==1.43.9
+pydantic==2.12.5

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -1,0 +1,36 @@
+"""KB sync worker — executes a single policy's sync run.
+
+PR-2 stub: acknowledges the dispatch, records the run as "skipped" (which
+also clears the in-flight syncRunStartedAt stamp so the dispatcher never
+sees a permanently-fresh stamp from stub runs), and exits. PR-3 replaces
+the body with the Drive-file path (metadata-first change detection →
+conditional download → stage to S3); PR-4 adds web re-crawl.
+
+Payload contract with the dispatcher:
+    {"policyId", "assistantId", "sourceType", "sourceRef"}
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict
+
+from apis.shared.sync_policies.service import record_sync_result
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+async def run_sync(payload: Dict[str, Any]) -> Dict[str, Any]:
+    policy_id = payload["policyId"]
+    assistant_id = payload["assistantId"]
+    logger.info(
+        f"KB sync worker stub: policy {policy_id} ({payload.get('sourceType')}/{payload.get('sourceRef')}) "
+        f"on assistant {assistant_id} — recording skipped (sync execution lands in PR-3/PR-4)"
+    )
+    await record_sync_result(assistant_id, policy_id, "skipped")
+    return {"policyId": policy_id, "result": "skipped"}
+
+
+def lambda_handler(event, context):
+    """Async-invoke entry point (InvocationType=Event from the dispatcher)."""
+    return asyncio.run(run_sync(event))

--- a/backend/src/apis/shared/sync_policies/service.py
+++ b/backend/src/apis/shared/sync_policies/service.py
@@ -222,25 +222,40 @@ async def set_policy_state(
         raise
 
 
-async def rearm_policy(assistant_id: str, policy_id: str, expected_next_sync_at: str, new_next_sync_at: str) -> bool:
+async def rearm_policy(
+    assistant_id: str,
+    policy_id: str,
+    expected_next_sync_at: str,
+    new_next_sync_at: str,
+    mark_run_started: bool = False,
+) -> bool:
     """Advance next_sync_at, conditional on the currently stored value.
 
     The dispatcher re-arms BEFORE invoking the worker; the condition makes a
     double-fired tick idempotent — the second dispatcher loses the
     conditional write and skips the policy. Returns True if this caller won.
+
+    mark_run_started stamps syncRunStartedAt in the same write, so winning
+    the re-arm and claiming the in-flight slot are atomic.
     """
     from botocore.exceptions import ClientError
+
+    update_expression = "SET nextSyncAt = :new, GSI4_SK = :gsi4sk, updatedAt = :updated_at"
+    values = {
+        ":new": new_next_sync_at,
+        ":gsi4sk": _due_sort_key(new_next_sync_at, policy_id),
+        ":updated_at": _get_current_timestamp(),
+        ":expected": expected_next_sync_at,
+    }
+    if mark_run_started:
+        update_expression += ", syncRunStartedAt = :run_started"
+        values[":run_started"] = values[":updated_at"]
 
     try:
         _get_table().update_item(
             Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
-            UpdateExpression="SET nextSyncAt = :new, GSI4_SK = :gsi4sk, updatedAt = :updated_at",
-            ExpressionAttributeValues={
-                ":new": new_next_sync_at,
-                ":gsi4sk": _due_sort_key(new_next_sync_at, policy_id),
-                ":updated_at": _get_current_timestamp(),
-                ":expected": expected_next_sync_at,
-            },
+            UpdateExpression=update_expression,
+            ExpressionAttributeValues=values,
             ConditionExpression="nextSyncAt = :expected",
         )
         return True

--- a/backend/tests/lambdas/conftest.py
+++ b/backend/tests/lambdas/conftest.py
@@ -1,0 +1,63 @@
+"""Lambda-handler test fixtures (moto).
+
+Mirrors the assistants-table fixture from tests/shared/conftest.py —
+pytest dir-scoped conftests don't share fixtures across sibling test
+packages, and the kb-sync Lambda tests need the same table shape the
+services use (including the sparse DueSyncIndex).
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+AWS_REGION = "us-east-1"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def assistants_table(aws, monkeypatch):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    name = "test-assistants"
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", name)
+
+    def gsi(index_name, hash_key, range_key):
+        return {
+            "IndexName": index_name,
+            "KeySchema": [
+                {"AttributeName": hash_key, "KeyType": "HASH"},
+                {"AttributeName": range_key, "KeyType": "RANGE"},
+            ],
+            "Projection": {"ProjectionType": "ALL"},
+        }
+
+    ddb.create_table(
+        TableName=name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            gsi("OwnerStatusIndex", "GSI_PK", "GSI_SK"),
+            gsi("DueSyncIndex", "GSI4_PK", "GSI4_SK"),
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(name)

--- a/backend/tests/lambdas/test_kb_sync_dispatcher.py
+++ b/backend/tests/lambdas/test_kb_sync_dispatcher.py
@@ -1,0 +1,325 @@
+"""KB sync dispatcher tests (moto DynamoDB, stubbed worker invoke).
+
+Sources are created through the REAL assistants/documents services so the
+dispatcher's raw adjacency-list key reads are cross-checked against the
+actual storage schema — if a key pattern drifts, these tests break loudly.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from apis.app_api.documents.services.document_service import create_document
+from apis.app_api.kb_sync import dispatcher
+from apis.shared.assistants.service import create_assistant
+from apis.shared.sync_policies.service import (
+    create_sync_policy,
+    get_sync_policy,
+    list_sync_policies,
+    set_policy_state,
+)
+
+pytestmark = pytest.mark.asyncio
+
+USER_ID = "user-1"
+PAST = "2000-01-01T00:00:00+00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def kb_sync_env(monkeypatch):
+    monkeypatch.setenv("KB_SYNC_ENABLED", "true")
+    monkeypatch.setenv("KB_SYNC_WORKER_FUNCTION_NAME", "test-kb-sync-worker")
+
+
+@pytest.fixture()
+def invoked_workers(monkeypatch):
+    """Capture worker invocations instead of calling Lambda."""
+    payloads = []
+    monkeypatch.setattr(dispatcher, "_invoke_worker", payloads.append)
+    return payloads
+
+
+@pytest.fixture(autouse=True)
+def no_metrics(monkeypatch):
+    monkeypatch.setattr(dispatcher, "_emit_metrics", lambda counts: None)
+
+
+async def _make_assistant():
+    assistant = await create_assistant(
+        owner_id=USER_ID,
+        owner_name="Test User",
+        name="Synced Assistant",
+        description="d",
+        instructions="i",
+        vector_index_id="assistants-index",
+    )
+    return assistant.assistant_id
+
+
+async def _make_document(assistant_id, document_id="doc-1"):
+    doc = await create_document(
+        assistant_id=assistant_id,
+        filename="report.pdf",
+        content_type="application/pdf",
+        size_bytes=10,
+        s3_key=f"assistants/{assistant_id}/documents/{document_id}/report.pdf",
+        document_id=document_id,
+    )
+    return doc.document_id
+
+
+async def _make_due_policy(assistant_id, source_ref="doc-1"):
+    policy = await create_sync_policy(
+        assistant_id=assistant_id,
+        source_type="drive_file",
+        source_ref=source_ref,
+        interval="daily",
+        created_by_user_id=USER_ID,
+    )
+    await set_policy_state(assistant_id, policy.policy_id, "active", next_sync_at=PAST)
+    return await get_sync_policy(assistant_id, policy.policy_id)
+
+
+class TestKillSwitch:
+    async def test_disabled_tick_is_noop(self, assistants_table, invoked_workers, monkeypatch):
+        monkeypatch.setenv("KB_SYNC_ENABLED", "false")
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        await _make_due_policy(assistant_id)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["PoliciesDue"] == 0
+        assert invoked_workers == []
+
+
+class TestLiveness:
+    async def test_missing_assistant_deletes_policy(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        await _make_due_policy(assistant_id)
+        # Simulate a delete path that missed the cascade
+        assistants_table.delete_item(Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"})
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["OrphansDeleted"] == 1
+        assert invoked_workers == []
+        assert await list_sync_policies(assistant_id) == []
+
+    async def test_missing_source_deletes_policy(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_due_policy(assistant_id, source_ref="doc-never-created")
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["OrphansDeleted"] == 1
+        assert await list_sync_policies(assistant_id) == []
+
+    async def test_deleting_source_deletes_policy(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        await _make_due_policy(assistant_id, source_ref=doc_id)
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{doc_id}"},
+            UpdateExpression="SET #s = :deleting",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":deleting": "deleting"},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["OrphansDeleted"] == 1
+        assert invoked_workers == []
+
+
+class TestCircuitBreaker:
+    async def _set_counter(self, table, assistant_id, policy_id, field, value):
+        table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+            UpdateExpression=f"SET {field} = :v",
+            ExpressionAttributeValues={":v": value},
+        )
+
+    async def test_not_found_streak_pauses(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id)
+        await self._set_counter(assistants_table, assistant_id, policy.policy_id, "consecutiveNotFound", 2)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["PausedBreaker"] == 1
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_error"
+        assert "accessible" in updated.state_reason
+        assert invoked_workers == []
+
+    async def test_failure_streak_pauses(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id)
+        await self._set_counter(assistants_table, assistant_id, policy.policy_id, "consecutiveFailures", 5)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["PausedBreaker"] == 1
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_error"
+        assert invoked_workers == []
+
+    async def test_backoff_scales_with_failures(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id)
+        await self._set_counter(assistants_table, assistant_id, policy.policy_id, "consecutiveFailures", 2)
+
+        await dispatcher.dispatch_once()
+
+        # daily * 2^2 = 4 days out
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        next_dt = datetime.fromisoformat(updated.next_sync_at.rstrip("Z"))
+        expected = datetime.now(timezone.utc) + timedelta(days=4)
+        assert abs((next_dt - expected).total_seconds()) < 300
+
+
+class TestInactivityPause:
+    async def test_stale_assistant_pauses_policy(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id)
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"},
+            UpdateExpression="SET createdAt = :old, updatedAt = :old",
+            ExpressionAttributeValues={":old": "2020-01-01T00:00:00+00:00Z"},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["PausedInactive"] == 1
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_inactive"
+        assert invoked_workers == []
+
+    async def test_recent_last_used_at_keeps_policy_active(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        await _make_document(assistant_id)
+        await _make_due_policy(assistant_id)
+        now_ts = datetime.now(timezone.utc).isoformat() + "Z"
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"},
+            UpdateExpression="SET createdAt = :old, updatedAt = :old, lastUsedAt = :now",
+            ExpressionAttributeValues={":old": "2020-01-01T00:00:00+00:00Z", ":now": now_ts},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+
+
+class TestDispatch:
+    async def test_happy_path_dispatches_and_rearms(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id, source_ref=doc_id)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        assert invoked_workers == [
+            {
+                "policyId": policy.policy_id,
+                "assistantId": assistant_id,
+                "sourceType": "drive_file",
+                "sourceRef": doc_id,
+            }
+        ]
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.next_sync_at > datetime.now(timezone.utc).isoformat()
+        assert updated.sync_run_started_at is not None
+
+    async def test_dispatched_policy_not_redispatched_same_day(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        await _make_due_policy(assistant_id, source_ref=doc_id)
+
+        await dispatcher.dispatch_once()
+        counts = await dispatcher.dispatch_once()
+
+        # Re-armed a day out — second tick sees nothing due
+        assert counts["PoliciesDue"] == 0
+        assert len(invoked_workers) == 1
+
+    async def test_fresh_run_stamp_skips_without_rearm(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id, source_ref=doc_id)
+        now_ts = datetime.now(timezone.utc).isoformat() + "Z"
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy.policy_id}"},
+            UpdateExpression="SET syncRunStartedAt = :now",
+            ExpressionAttributeValues={":now": now_ts},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["InFlightSkipped"] == 1
+        assert invoked_workers == []
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.next_sync_at == PAST  # not re-armed; retried next tick
+
+    async def test_stale_run_stamp_is_overwritten_and_dispatched(self, assistants_table, invoked_workers):
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id, source_ref=doc_id)
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy.policy_id}"},
+            UpdateExpression="SET syncRunStartedAt = :old",
+            ExpressionAttributeValues={":old": "2020-01-01T00:00:00+00:00Z"},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.sync_run_started_at > "2020-01-01"
+
+    async def test_broken_policy_does_not_starve_sweep(self, assistants_table, invoked_workers, monkeypatch):
+        assistant_id = await _make_assistant()
+        doc_a = await _make_document(assistant_id, document_id="doc-a")
+        doc_b = await _make_document(assistant_id, document_id="doc-b")
+        await _make_due_policy(assistant_id, source_ref=doc_a)
+        await _make_due_policy(assistant_id, source_ref=doc_b)
+
+        real_get_source = dispatcher._get_source_item
+        calls = {"n": 0}
+
+        def flaky_get_source(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("boom")
+            return real_get_source(*args, **kwargs)
+
+        monkeypatch.setattr(dispatcher, "_get_source_item", flaky_get_source)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+
+
+class TestWorkerStub:
+    async def test_stub_records_skipped_and_clears_stamp(self, assistants_table):
+        from apis.app_api.kb_sync import worker
+
+        assistant_id = await _make_assistant()
+        doc_id = await _make_document(assistant_id)
+        policy = await _make_due_policy(assistant_id, source_ref=doc_id)
+
+        result = await worker.run_sync(
+            {"policyId": policy.policy_id, "assistantId": assistant_id, "sourceType": "drive_file", "sourceRef": doc_id}
+        )
+
+        assert result["result"] == "skipped"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.last_result == "skipped"
+        assert updated.sync_run_started_at is None

--- a/backend/tests/supply_chain/test_docker_scanning.py
+++ b/backend/tests/supply_chain/test_docker_scanning.py
@@ -16,6 +16,7 @@ EXPECTED_DOCKERFILES = [
     "Dockerfile.app-api",
     "Dockerfile.inference-api",
     "Dockerfile.rag-ingestion",
+    "Dockerfile.kb-sync",
 ]
 
 

--- a/backend/tests/supply_chain/test_dockerfile_pinning.py
+++ b/backend/tests/supply_chain/test_dockerfile_pinning.py
@@ -15,6 +15,7 @@ DOCKERFILES = [
     BACKEND_DIR / "Dockerfile.app-api",
     BACKEND_DIR / "Dockerfile.inference-api",
     BACKEND_DIR / "Dockerfile.rag-ingestion",
+    BACKEND_DIR / "Dockerfile.kb-sync",
 ]
 
 # apt-get version pin: package=version (e.g., gcc=4:14.2.0-1)

--- a/infrastructure/bootstrap-assets/kb-sync/Dockerfile
+++ b/infrastructure/bootstrap-assets/kb-sync/Dockerfile
@@ -1,0 +1,26 @@
+# Bootstrap container image for the KB sync Lambdas (dispatcher + worker).
+#
+# Same role as bootstrap-assets/rag-ingestion — the placeholder image
+# PlatformStack ships on first deploy; the real image
+# (backend/Dockerfile.kb-sync) is deployed out-of-band by the backend
+# workflow via `aws lambda update-function-code --image-uri ...`.
+# Keep these files byte-stable so CDK's asset digest never changes.
+#
+# Both KB sync functions use this one build context with different
+# ImageConfig.Command overrides, so the stub modules must live at the
+# SAME dotted paths as the real image's handlers:
+#   apis.app_api.kb_sync.dispatcher.lambda_handler
+#   apis.app_api.kb_sync.worker.lambda_handler
+#
+# DO NOT add functionality here.
+#
+# Pinning rationale: same digest as the real kb-sync image (and the
+# other Lambda images) so the supply-chain dockerfile-pinning test
+# passes.
+
+FROM public.ecr.aws/lambda/python:3.12@sha256:745b0eb8a9787e9c4bfd4fc4cae942399a2225831c96394ae70c0c2a7c7c6168
+
+COPY dispatcher.py ${LAMBDA_TASK_ROOT}/apis/app_api/kb_sync/dispatcher.py
+COPY worker.py ${LAMBDA_TASK_ROOT}/apis/app_api/kb_sync/worker.py
+
+CMD ["apis.app_api.kb_sync.dispatcher.lambda_handler"]

--- a/infrastructure/bootstrap-assets/kb-sync/dispatcher.py
+++ b/infrastructure/bootstrap-assets/kb-sync/dispatcher.py
@@ -1,0 +1,22 @@
+# Bootstrap handler for the KB sync dispatcher Lambda.
+#
+# Same role as the sibling bootstrap stubs — see the Dockerfile in
+# this directory. During the brief first-deploy window before the
+# workflow ships the real image, EventBridge ticks land here. Sync
+# policies stay due in the DueSyncIndex, so the first real dispatcher
+# tick picks them up — nothing is lost by no-op'ing.
+#
+# DO NOT add functionality here.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event: Any, context: Any) -> dict:
+    logger.info("kb-sync dispatcher bootstrap stub invoked; real image not yet deployed")
+    return {"statusCode": 200, "body": "bootstrap"}

--- a/infrastructure/bootstrap-assets/kb-sync/worker.py
+++ b/infrastructure/bootstrap-assets/kb-sync/worker.py
@@ -1,0 +1,21 @@
+# Bootstrap handler for the KB sync worker Lambda.
+#
+# See the sibling dispatcher.py and the Dockerfile in this directory.
+# A dispatch that lands here is dropped; the policy's syncRunStartedAt
+# stamp goes stale and the dispatcher re-dispatches after the stale
+# window — self-healing, nothing is lost.
+#
+# DO NOT add functionality here.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event: Any, context: Any) -> dict:
+    logger.info("kb-sync worker bootstrap stub invoked; real image not yet deployed")
+    return {"statusCode": 200, "body": "bootstrap"}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -48,6 +48,7 @@ export interface AppConfig {
   appApi: AppApiConfig;
   inferenceApi: InferenceApiConfig;
   ragIngestion: RagIngestionConfig;
+  kbSync: KbSyncConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
   mcpSandbox: McpSandboxConfig;
@@ -123,6 +124,19 @@ export interface RagIngestionConfig {
   embeddingModel: string;        // Bedrock model ID (default: "amazon.titan-embed-text-v2")
   vectorDimension: number;       // Embedding dimension (default: 1024)
   vectorDistanceMetric: string;  // Distance metric (default: "cosine")
+}
+
+/**
+ * KB sync — scheduled re-index of assistant knowledge-base sources
+ * (docs/specs/assistant-kb-sync.md).
+ *
+ * `enabled` gates the whole feature: it sets the EventBridge rule's
+ * enabled state AND the KB_SYNC_ENABLED env var on both kb-sync
+ * Lambdas. Default false — the kb-sync PRs merge dark and the feature
+ * lights up with CDK_KB_SYNC_ENABLED=true on a platform deploy.
+ */
+export interface KbSyncConfig {
+  enabled: boolean;
 }
 
 export interface FineTuningConfig {
@@ -250,6 +264,12 @@ export function loadConfig(scope: cdk.App): AppConfig {
       embeddingModel: process.env.CDK_RAG_EMBEDDING_MODEL || scope.node.tryGetContext('ragIngestion')?.embeddingModel,
       vectorDimension: parseIntEnv(process.env.CDK_RAG_VECTOR_DIMENSION) || scope.node.tryGetContext('ragIngestion')?.vectorDimension,
       vectorDistanceMetric: process.env.CDK_RAG_DISTANCE_METRIC || scope.node.tryGetContext('ragIngestion')?.vectorDistanceMetric,
+    },
+    kbSync: {
+      enabled:
+        process.env.CDK_KB_SYNC_ENABLED !== undefined
+          ? process.env.CDK_KB_SYNC_ENABLED === 'true'
+          : scope.node.tryGetContext('kbSync')?.enabled ?? false,
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,

--- a/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
+++ b/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
@@ -1,0 +1,190 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as path from 'path';
+import { Construct } from 'constructs';
+
+import { AppConfig } from '../../config';
+
+export interface KbSyncConstructProps {
+  config: AppConfig;
+  /** RAG assistants table — sync policies live on it (SYNCPOL# items + DueSyncIndex). */
+  assistantsTable: dynamodb.ITable;
+}
+
+/**
+ * KbSyncConstruct — scheduled re-index of assistant knowledge-base
+ * sources (docs/specs/assistant-kb-sync.md).
+ *
+ * Two DockerImage Lambdas sharing ONE image (backend/Dockerfile.kb-sync)
+ * with different ImageConfig.Command overrides:
+ *   - dispatcher — EventBridge rate(15 minutes) tick; sweeps the sparse
+ *     DueSyncIndex, applies the runaway guards, async-invokes the worker.
+ *   - worker — executes a single policy's sync run (stub until PR-3).
+ *
+ * Same platform-as-bootstrap pattern as rag-ingestion: `fromImageAsset`
+ * points at the byte-stable `bootstrap-assets/kb-sync/` stub; the real
+ * image is deployed out-of-band by the backend workflow
+ * (`deploy-image-lambda-one.sh kb-sync-dispatcher|kb-sync-worker`).
+ * The command overrides are function *configuration*, so out-of-band
+ * `update-function-code --image-uri` swaps never touch them — the
+ * override module paths are valid in both the stub and real images.
+ *
+ * Runaway posture: the EventBridge rule is the ONLY initiator of sync
+ * work, and it's created disabled unless `config.kbSync.enabled`. The
+ * dispatcher additionally gates on the KB_SYNC_ENABLED env var, so an
+ * operator can dark-stop the feature either via CFN (rule) or a plain
+ * env flip (function config), whichever is faster.
+ *
+ * SSM publications (consumed by the backend workflow's code-deploy):
+ *   /{prefix}/kb-sync/dispatcher-function-name
+ *   /{prefix}/kb-sync/worker-function-name
+ */
+export class KbSyncConstruct extends Construct {
+  public readonly dispatcherLambda: lambda.DockerImageFunction;
+  public readonly workerLambda: lambda.DockerImageFunction;
+  public readonly scheduleRule: events.Rule;
+
+  constructor(scope: Construct, id: string, props: KbSyncConstructProps) {
+    super(scope, id);
+
+    const { config, assistantsTable } = props;
+
+    const bootstrapDir = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'bootstrap-assets',
+      'kb-sync',
+    );
+
+    const workerLogGroup = new logs.LogGroup(this, 'KbSyncWorkerLogGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.workerLambda = new lambda.DockerImageFunction(this, 'KbSyncWorkerLambda', {
+      // No functionName — CDK auto-generates; deploy script resolves via SSM.
+      code: lambda.DockerImageCode.fromImageAsset(bootstrapDir, {
+        cmd: ['apis.app_api.kb_sync.worker.lambda_handler'],
+      }),
+      architecture: lambda.Architecture.ARM_64,
+      // Worker fetches source bytes and stages to S3; generous timeout
+      // for large files / slow crawls, modest memory (no ML deps).
+      timeout: cdk.Duration.minutes(10),
+      memorySize: 1024,
+      logGroup: workerLogGroup,
+      environment: {
+        DYNAMODB_ASSISTANTS_TABLE_NAME: assistantsTable.tableName,
+        KB_SYNC_ENABLED: config.kbSync.enabled ? 'true' : 'false',
+      },
+      description:
+        'KB sync worker - re-fetches a synced knowledge-base source and stages changed content for re-ingestion',
+    });
+
+    const dispatcherLogGroup = new logs.LogGroup(this, 'KbSyncDispatcherLogGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.dispatcherLambda = new lambda.DockerImageFunction(this, 'KbSyncDispatcherLambda', {
+      code: lambda.DockerImageCode.fromImageAsset(bootstrapDir, {
+        cmd: ['apis.app_api.kb_sync.dispatcher.lambda_handler'],
+      }),
+      architecture: lambda.Architecture.ARM_64,
+      // Sweeps at most KB_SYNC_DISPATCH_LIMIT policies per tick; small.
+      timeout: cdk.Duration.minutes(2),
+      memorySize: 512,
+      logGroup: dispatcherLogGroup,
+      environment: {
+        DYNAMODB_ASSISTANTS_TABLE_NAME: assistantsTable.tableName,
+        KB_SYNC_ENABLED: config.kbSync.enabled ? 'true' : 'false',
+        KB_SYNC_WORKER_FUNCTION_NAME: this.workerLambda.functionName,
+      },
+      description:
+        'KB sync dispatcher - sweeps due sync policies on an EventBridge schedule, applies runaway guards, invokes the worker',
+    });
+
+    // IAM — both functions do policy bookkeeping on the assistants table.
+    assistantsTable.grantReadWriteData(this.dispatcherLambda);
+    assistantsTable.grantReadWriteData(this.workerLambda);
+    this.workerLambda.grantInvoke(this.dispatcherLambda);
+
+    // Best-effort custom metrics (KBSync namespace). PutMetricData
+    // doesn't support resource scoping; condition on the namespace.
+    const metricsStatement = new iam.PolicyStatement({
+      sid: 'KbSyncPutMetrics',
+      effect: iam.Effect.ALLOW,
+      actions: ['cloudwatch:PutMetricData'],
+      resources: ['*'],
+      conditions: { StringEquals: { 'cloudwatch:namespace': 'KBSync' } },
+    });
+    this.dispatcherLambda.addToRolePolicy(metricsStatement);
+    this.workerLambda.addToRolePolicy(metricsStatement);
+
+    // ECR pull on the project's kb-sync repo so `update-function-code
+    // --image-uri` can swap to the real image (same rationale/pattern
+    // as the rag-ingestion construct; GetAuthorizationToken is
+    // unscopeable).
+    const ecrPullStatement = new iam.PolicyStatement({
+      sid: 'EcrPullProjectImage',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'ecr:GetAuthorizationToken',
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:GetDownloadUrlForLayer',
+        'ecr:BatchGetImage',
+      ],
+      resources: ['*'],
+    });
+    this.dispatcherLambda.addToRolePolicy(ecrPullStatement);
+    this.workerLambda.addToRolePolicy(ecrPullStatement);
+
+    // The single trigger. Disabled rule = the whole feature is inert
+    // (policies accumulate as plain data until it's enabled).
+    this.scheduleRule = new events.Rule(this, 'KbSyncSchedule', {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(15)),
+      enabled: config.kbSync.enabled,
+      description: 'KB sync dispatcher tick — the only initiator of scheduled re-index work',
+    });
+    this.scheduleRule.addTarget(new targets.LambdaFunction(this.dispatcherLambda));
+
+    // Error visibility (no SNS wiring in this stack yet; alarms are
+    // dashboard/console signals).
+    new cloudwatch.Alarm(this, 'KbSyncDispatcherErrorAlarm', {
+      alarmName: `${config.projectPrefix}-kb-sync-dispatcher-errors`,
+      metric: this.dispatcherLambda.metricErrors({ period: cdk.Duration.minutes(15) }),
+      threshold: 1,
+      evaluationPeriods: 2,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    new cloudwatch.Alarm(this, 'KbSyncWorkerErrorAlarm', {
+      alarmName: `${config.projectPrefix}-kb-sync-worker-errors`,
+      metric: this.workerLambda.metricErrors({ period: cdk.Duration.minutes(15) }),
+      threshold: 3,
+      evaluationPeriods: 2,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    new ssm.StringParameter(this, 'DispatcherFunctionNameParameter', {
+      parameterName: `/${config.projectPrefix}/kb-sync/dispatcher-function-name`,
+      stringValue: this.dispatcherLambda.functionName,
+      description: 'KB sync dispatcher Lambda function name (consumed by backend workflow code-deploy step)',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'WorkerFunctionNameParameter', {
+      parameterName: `/${config.projectPrefix}/kb-sync/worker-function-name`,
+      stringValue: this.workerLambda.functionName,
+      description: 'KB sync worker Lambda function name (consumed by backend workflow code-deploy step)',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -41,6 +41,7 @@ import { SharedConversationsConstruct } from './constructs/data/shared-conversat
 // RAG (data half lives in Platform)
 import { RagDataConstruct } from './constructs/rag/rag-data-construct';
 import { RagIngestionLambdaConstruct } from './constructs/rag-ingestion/rag-ingestion-lambda-construct';
+import { KbSyncConstruct } from './constructs/kb-sync/kb-sync-construct';
 
 // Artifacts (data + render Lambda + CloudFront distribution).
 // Lambda + distribution + Route53 alias here. The Lambda's
@@ -385,6 +386,16 @@ export class PlatformStack extends cdk.Stack {
       new s3n.LambdaDestination(ragIngestion.lambda),
       { prefix: 'assistants/' },
     );
+
+    // ============================================================
+    // KB sync — scheduled re-index of assistant knowledge bases
+    // (dispatcher + worker Lambdas + EventBridge rate rule; inert
+    // unless config.kbSync.enabled)
+    // ============================================================
+    new KbSyncConstruct(this, 'KbSync', {
+      config,
+      assistantsTable: this.ragAssistantsTable,
+    });
 
     // ============================================================
     // Fine-tuning data

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -45,6 +45,9 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
       vectorDimension: 1024,
       vectorDistanceMetric: 'cosine',
     },
+    kbSync: {
+      enabled: false,
+    },
     fineTuning: {},
     artifacts: {
       retentionDays: 90,

--- a/infrastructure/test/kb-sync.test.ts
+++ b/infrastructure/test/kb-sync.test.ts
@@ -1,0 +1,106 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+
+import { KbSyncConstruct } from '../lib/constructs/kb-sync/kb-sync-construct';
+import { RagDataConstruct } from '../lib/constructs/rag/rag-data-construct';
+import { createMockConfig, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+function synth(kbSyncEnabled: boolean): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'Test', {
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  const config = createMockConfig({ kbSync: { enabled: kbSyncEnabled } });
+  const ragData = new RagDataConstruct(stack, 'RagData', { config });
+  new KbSyncConstruct(stack, 'KbSync', {
+    config,
+    assistantsTable: ragData.assistantsTable,
+  });
+  return Template.fromStack(stack);
+}
+
+describe('KbSyncConstruct', () => {
+  let t: Template;
+  beforeAll(() => {
+    t = synth(false);
+  });
+
+  it('creates dispatcher and worker Lambdas with distinct command overrides on one image', () => {
+    t.hasResourceProperties('AWS::Lambda::Function', {
+      ImageConfig: { Command: ['apis.app_api.kb_sync.dispatcher.lambda_handler'] },
+      PackageType: 'Image',
+    });
+    t.hasResourceProperties('AWS::Lambda::Function', {
+      ImageConfig: { Command: ['apis.app_api.kb_sync.worker.lambda_handler'] },
+      PackageType: 'Image',
+    });
+  });
+
+  it('single EventBridge rate rule targets the dispatcher', () => {
+    t.resourceCountIs('AWS::Events::Rule', 1);
+    t.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'rate(15 minutes)',
+    });
+  });
+
+  it('rule is DISABLED when kbSync.enabled is false (dark by default)', () => {
+    t.hasResourceProperties('AWS::Events::Rule', { State: 'DISABLED' });
+  });
+
+  it('rule is ENABLED when kbSync.enabled is true', () => {
+    const enabled = synth(true);
+    enabled.hasResourceProperties('AWS::Events::Rule', { State: 'ENABLED' });
+  });
+
+  it('KB_SYNC_ENABLED env mirrors the flag on the dispatcher', () => {
+    t.hasResourceProperties('AWS::Lambda::Function', {
+      ImageConfig: { Command: ['apis.app_api.kb_sync.dispatcher.lambda_handler'] },
+      Environment: {
+        Variables: Match.objectLike({
+          KB_SYNC_ENABLED: 'false',
+          KB_SYNC_WORKER_FUNCTION_NAME: Match.anyValue(),
+          DYNAMODB_ASSISTANTS_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+  });
+
+  it('dispatcher may invoke the worker', () => {
+    t.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('custom metrics are namespace-conditioned', () => {
+    t.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: 'cloudwatch:PutMetricData',
+            Condition: { StringEquals: { 'cloudwatch:namespace': 'KBSync' } },
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('publishes function-name SSM parameters for the code-deploy step', () => {
+    t.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: Match.stringLikeRegexp('/kb-sync/dispatcher-function-name$'),
+    });
+    t.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: Match.stringLikeRegexp('/kb-sync/worker-function-name$'),
+    });
+  });
+
+  it('creates error alarms for both functions', () => {
+    t.resourceCountIs('AWS::CloudWatch::Alarm', 2);
+  });
+});

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -7,7 +7,7 @@
 #   build-one.sh <service>
 #
 # Where <service> is one of:
-#   app-api | inference-api | rag-ingestion
+#   app-api | inference-api | rag-ingestion | kb-sync
 #
 # This script encapsulates the per-service spec (which Dockerfile,
 # which source trees, which manifests, which platform) so that:
@@ -105,9 +105,26 @@ case "$SERVICE" in
         PLATFORM="linux/arm64"
         SSM_KEY="/${CDK_PROJECT_PREFIX}/rag-ingestion/image-tag"
         ;;
+    kb-sync)
+        DOCKERFILE="backend/Dockerfile.kb-sync"
+        # One image, two Lambdas (dispatcher + worker via ImageConfig
+        # command overrides). Keep SOURCE_DIRS in lockstep with the
+        # Dockerfile's COPY list — a path copied but not hashed here
+        # would ship stale code under an unchanged content-hash tag.
+        SOURCE_DIRS=(
+            "backend/src/apis/app_api/kb_sync"
+            "backend/src/apis/shared/sync_policies"
+        )
+        # shared/__init__.py hashed as a manifest (same as rag-ingestion);
+        # kb_sync/requirements.txt lives inside the first source dir.
+        MANIFESTS=("backend/src/apis/shared/__init__.py")
+        # Both kb-sync Lambdas are arm64 (see the kb-sync CDK construct).
+        PLATFORM="linux/arm64"
+        SSM_KEY="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
+        ;;
     *)
         echo "Unknown service: $SERVICE" >&2
-        echo "Expected one of: app-api | inference-api | rag-ingestion" >&2
+        echo "Expected one of: app-api | inference-api | rag-ingestion | kb-sync" >&2
         exit 1
         ;;
 esac

--- a/scripts/build/deploy-image-lambda-one.sh
+++ b/scripts/build/deploy-image-lambda-one.sh
@@ -8,7 +8,11 @@
 #   deploy-image-lambda-one.sh <service>
 #
 # Where <service> is one of:
-#   rag-ingestion
+#   rag-ingestion | kb-sync-dispatcher | kb-sync-worker
+#
+# kb-sync-dispatcher and kb-sync-worker are two Lambda functions
+# sharing the single kb-sync image; their handlers differ only via
+# ImageConfig.Command, which `update-function-code` doesn't touch.
 #
 # Pre-requisite: scripts/build/build-one.sh has already run for the
 # same service in this workflow. It pushes the image to ECR and
@@ -19,7 +23,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <service>" >&2
-    echo "  service: rag-ingestion" >&2
+    echo "  service: rag-ingestion | kb-sync-dispatcher | kb-sync-worker" >&2
     exit 1
 fi
 
@@ -40,14 +44,39 @@ case "$SERVICE" in
         IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/${SERVICE}/image-tag"
         ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-${SERVICE}"
         ;;
+    kb-sync-dispatcher)
+        FUNCTION_NAME_SSM="/${CDK_PROJECT_PREFIX}/kb-sync/dispatcher-function-name"
+        IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
+        ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-kb-sync"
+        ;;
+    kb-sync-worker)
+        FUNCTION_NAME_SSM="/${CDK_PROJECT_PREFIX}/kb-sync/worker-function-name"
+        IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
+        ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-kb-sync"
+        ;;
     *)
         echo "Unknown service: $SERVICE" >&2
-        echo "Expected one of: rag-ingestion" >&2
+        echo "Expected one of: rag-ingestion | kb-sync-dispatcher | kb-sync-worker" >&2
         exit 1
         ;;
 esac
 
 cd "$PROJECT_ROOT"
+
+# First-deploy grace: the function-name SSM param is published by
+# PlatformStack when the Lambda's construct first deploys. A backend
+# run that lands before that platform deploy (e.g. the PR introducing
+# a new Lambda) has an image in ECR but no function to point at it —
+# skip gracefully; the next backend run after the platform deploy
+# completes the swap.
+if ! aws ssm get-parameter --region "$AWS_REGION" --name "$FUNCTION_NAME_SSM" >/dev/null 2>&1; then
+    log_warn "SSM ${FUNCTION_NAME_SSM} not found — ${SERVICE} not yet provisioned by PlatformStack; skipping code deploy."
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "image_tag=skipped-not-provisioned" >> "$GITHUB_OUTPUT"
+    fi
+    exit 0
+fi
+
 log_info "Deploying ${SERVICE} container image to Lambda..."
 
 TAG="$(bash "$DEPLOY" \


### PR DESCRIPTION
## Summary

PR-2 of the **assistant KB sync** feature ([spec](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/assistant-kb-sync.md), follows #542). Adds the scheduling machinery: one EventBridge `rate(15 minutes)` rule → dispatcher Lambda → async-invoked worker Lambda. **Dark by default** — the rule deploys DISABLED and both Lambdas carry `KB_SYNC_ENABLED=false` unless `CDK_KB_SYNC_ENABLED=true` is set on a platform deploy.

### Dispatcher (real logic, this PR)
Sweeps the sparse `DueSyncIndex` (≤20 policies/tick) and applies the spec §7 guards in order:
1. **Kill switch** (env, plus the CFN-level disabled rule)
2. **Liveness** — assistant/source gone ⇒ policy hard-deleted on the spot (self-healing backstop behind the #542 cascades)
3. **Circuit breaker** — `consecutiveNotFound ≥ 2` or `consecutiveFailures ≥ 5` ⇒ `paused_error`
4. **Inactivity** — assistant unused 30 days ⇒ `paused_inactive` (auto-resume bump lands in PR-5)
5. **In-flight skip** — fresh `syncRunStartedAt` stamp; stale stamps (crashed runs) are overwritten
6. **Re-arm before work** — `next_sync_at` advances with exponential failure backoff (capped 30 d) via a conditional write that also claims the run stamp atomically; only then is the worker invoked. Crashed worker = one missed sync, never a hot loop; double-fired tick loses the write and skips.

### Worker (stub)
Records the run as `skipped` and clears the stamp. PR-3 = Drive path, PR-4 = web re-crawl.

### Packaging: one image, two functions
New lightweight `Dockerfile.kb-sync` (boto3 + pydantic only — the worker stages bytes to S3; chunking/embedding stays in rag-ingestion). Both functions point at the same image with different `ImageConfig.Command` overrides — command is function *configuration*, so the workflow's `update-function-code --image-uri` swaps code on both without touching handlers. Same platform-as-bootstrap pattern as rag-ingestion (byte-stable `bootstrap-assets/kb-sync/` stub).

The image's import surface is deliberately minimal (`apis.shared.sync_policies` + `kb_sync`): the dispatcher reads assistant/source records by raw adjacency-list key, and its tests create those records through the **real** services so key-schema drift fails tests. (An import-surface simulation caught that importing `apis.shared.assistants` would drag in the embeddings stack — hence this shape.)

### First-deploy ordering
`deploy-image-lambda-one.sh` now skips gracefully when the function-name SSM param doesn't exist yet — this PR's own backend run builds/pushes the image but can't point at functions PlatformStack hasn't created. After the platform deploy, the next backend run completes the swap.

## Testing
- 15 new dispatcher/worker tests (moto) covering every guard, the backoff math, re-arm idempotency, and sweep isolation (one broken policy can't starve the rest)
- 9 new CDK assertions (command overrides, single disabled-by-default rule, invoke grant, namespace-conditioned metrics, SSM params, alarms)
- Backend suite: 4108 passed. Infra: `tsc` clean; the `cloudfront-shared-cert`/`config` jest failures are pre-existing on develop (same 14 on a clean checkout)

## Deploy order
1. Merge → backend.yml builds/pushes the kb-sync image (code-deploy steps no-op gracefully)
2. `platform.yml` → creates functions (bootstrap stub), disabled rule, SSM params
3. Next backend.yml run (or manual dispatch) → points both functions at the real image

Feature stays inert until `CDK_KB_SYNC_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)