### PR TITLE
feat(kb-sync): PR-3 — Drive-file sync path (vault token, change detection, staged re-ingest)

### DIFF
--- a/backend/Dockerfile.kb-sync
+++ b/backend/Dockerfile.kb-sync
@@ -29,7 +29,13 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # scripts/build/build-one.sh so the content-hash tag notices changes.
 COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
 COPY backend/src/apis/shared/sync_policies/ ${LAMBDA_TASK_ROOT}/apis/shared/sync_policies/
+COPY backend/src/apis/shared/oauth/ ${LAMBDA_TASK_ROOT}/apis/shared/oauth/
+COPY backend/src/apis/app_api/file_sources/ ${LAMBDA_TASK_ROOT}/apis/app_api/file_sources/
 COPY backend/src/apis/app_api/kb_sync/ ${LAMBDA_TASK_ROOT}/apis/app_api/kb_sync/
+
+# file_sources/service.py is copied with its package but must never be
+# imported here — it pulls FastAPI, which this image deliberately lacks.
+# The worker uses the oauth primitives + adapters directly.
 
 # Default command: dispatcher. The worker function's CMD is overridden
 # to apis.app_api.kb_sync.worker.lambda_handler by its ImageConfig.

--- a/backend/src/apis/app_api/documents/ingestion/handler.py
+++ b/backend/src/apis/app_api/documents/ingestion/handler.py
@@ -302,5 +302,18 @@ async def _process_document_pipeline(bucket: str, key: str, assistant_id: str, d
     await status_manager.mark_complete(assistant_id=assistant_id, document_id=document_id, vector_store_id=vector_store_id)
     logger.info("Embeddings stored, processing complete")
 
+    # KB sync shrinkage cleanup: vectors are overwritten in place, so a
+    # re-ingested document that produced FEWER chunks strands its old tail
+    # ({doc_id}#{new..prev-1}). The kb-sync worker stashes the pre-sync
+    # chunk count; pop it (atomic) and delete the tail if we shrank. Uses
+    # len(chunks) post-split — the true vector count this run wrote (the
+    # stored chunkCount predates validate_and_split, same as other delete
+    # paths).
+    previous_count = await status_manager.pop_previous_chunk_count(assistant_id=assistant_id, document_id=document_id)
+    if previous_count and previous_count > len(chunks):
+        from embeddings.bedrock_embeddings import delete_vector_tail
+        deleted = await delete_vector_tail(document_id, len(chunks), previous_count)
+        logger.info(f"Shrinkage cleanup: removed {deleted} stale tail vectors for document {document_id}")
+
     # Test s3vector dump (Optional debugging)
     # await test_s3vector_dump()

--- a/backend/src/apis/app_api/documents/ingestion/status.py
+++ b/backend/src/apis/app_api/documents/ingestion/status.py
@@ -284,6 +284,40 @@ class DocumentStatusManager:
             vector_store_id=vector_store_id
         )
     
+    async def pop_previous_chunk_count(
+        self,
+        assistant_id: str,
+        document_id: str
+    ) -> Optional[int]:
+        """
+        Atomically read-and-clear the previousChunkCount stash.
+
+        The KB sync worker stashes the pre-sync chunk count on the document
+        record before re-staging its S3 object (docs/specs/assistant-kb-sync.md
+        §6.1 shrinkage cleanup). REMOVE with ReturnValues=UPDATED_OLD makes
+        the pop atomic — a duplicate S3 event can't double-delete the tail.
+
+        Returns:
+            The stashed count, or None if no stash was present (the common
+            case: every non-sync ingestion).
+        """
+        if not self.table_name:
+            return None
+        try:
+            import boto3
+
+            table = boto3.resource('dynamodb').Table(self.table_name)
+            response = table.update_item(
+                Key={'PK': f'AST#{assistant_id}', 'SK': f'DOC#{document_id}'},
+                UpdateExpression='REMOVE previousChunkCount',
+                ReturnValues='UPDATED_OLD',
+            )
+            old_value = response.get('Attributes', {}).get('previousChunkCount')
+            return int(old_value) if old_value is not None else None
+        except Exception as e:
+            logger.warning(f"Failed to pop previousChunkCount for {document_id}: {e}")
+            return None
+
     async def mark_failed(
         self,
         assistant_id: str,

--- a/backend/src/apis/app_api/file_sources/adapters/google_drive.py
+++ b/backend/src/apis/app_api/file_sources/adapters/google_drive.py
@@ -140,6 +140,25 @@ class GoogleDriveAdapter(FileSourceAdapter):
         data = await self._get_json(access_token, "/files", params=params)
         return self._to_browse_result(data)
 
+    async def get_file_metadata(self, access_token: str, file_id: str) -> Dict[str, Any]:
+        """Fetch change-detection metadata for one file (KB sync).
+
+        Cheap files.get — no content transfer. `md5Checksum` is only
+        populated for binary content; native editor files expose
+        `modifiedTime`/`version` instead. A permanently-deleted or
+        unshared file raises FileSourceNotFoundError (Drive returns 404
+        for both, deliberately indistinguishable); an owner-trashed file
+        is a normal 200 with `trashed: true`.
+        """
+        return await self._get_json(
+            access_token,
+            f"/files/{file_id}",
+            params={
+                "fields": "id,name,mimeType,trashed,modifiedTime,version,md5Checksum,size",
+                "supportsAllDrives": "true",
+            },
+        )
+
     async def download(self, access_token: str, file_id: str) -> DownloadedFile:
         meta = await self._get_json(
             access_token,

--- a/backend/src/apis/app_api/kb_sync/dispatcher.py
+++ b/backend/src/apis/app_api/kb_sync/dispatcher.py
@@ -70,31 +70,17 @@ def _parse_timestamp(value: str) -> Optional[datetime]:
         return None
 
 
-def _get_item(pk: str, sk: str) -> Optional[Dict[str, Any]]:
-    import boto3
-
-    table = boto3.resource("dynamodb").Table(os.environ["DYNAMODB_ASSISTANTS_TABLE_NAME"])
-    response = table.get_item(Key={"PK": pk, "SK": sk})
-    return response.get("Item")
-
-
 def _get_assistant_item(assistant_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch the assistant METADATA record (existence + activity timestamps).
+    """See apis.app_api.kb_sync.records for the raw-lookup rationale."""
+    from apis.app_api.kb_sync import records
 
-    Raw key lookup rather than apis.shared.assistants — that package's
-    __init__ drags in the embeddings stack, which would bloat the
-    kb-sync image for three timestamp fields. Key patterns are the
-    stable storage contract; the dispatcher tests create assistants
-    through the real service so schema drift breaks loudly here.
-    """
-    return _get_item(f"AST#{assistant_id}", "METADATA")
+    return records.get_assistant_item(assistant_id)
 
 
 def _get_source_item(assistant_id: str, source_type: str, source_ref: str) -> Optional[Dict[str, Any]]:
-    """Fetch the source record backing a policy (same raw-lookup rationale
-    as _get_assistant_item; DOC#/CRAWL# per documents/web_sources services)."""
-    sk_prefix = "DOC#" if source_type == "drive_file" else "CRAWL#"
-    return _get_item(f"AST#{assistant_id}", f"{sk_prefix}{source_ref}")
+    from apis.app_api.kb_sync import records
+
+    return records.get_source_item(assistant_id, source_type, source_ref)
 
 
 def _invoke_worker(payload: Dict[str, Any]) -> None:

--- a/backend/src/apis/app_api/kb_sync/records.py
+++ b/backend/src/apis/app_api/kb_sync/records.py
@@ -1,0 +1,84 @@
+"""Raw assistants-table record access for the kb-sync Lambdas.
+
+The dispatcher and worker read/write assistant, document, and crawl
+records by their adjacency-list keys instead of importing the app-api
+domain services — the assistants package's __init__ drags in the
+embeddings stack, and keeping the kb-sync image surface minimal is a
+deliberate constraint (see backend/Dockerfile.kb-sync).
+
+The key patterns are the stable storage contract (see
+apis/shared/assistants/service.py, documents/services/document_service.py,
+web_sources). The kb-sync tests create records through those REAL
+services, so any schema drift breaks tests loudly rather than silently
+orphaning sync work.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _table():
+    import boto3
+
+    return boto3.resource("dynamodb").Table(os.environ["DYNAMODB_ASSISTANTS_TABLE_NAME"])
+
+
+def get_item(pk: str, sk: str) -> Optional[Dict[str, Any]]:
+    response = _table().get_item(Key={"PK": pk, "SK": sk})
+    return response.get("Item")
+
+
+def get_assistant_item(assistant_id: str) -> Optional[Dict[str, Any]]:
+    """Assistant METADATA record (existence + activity timestamps)."""
+    return get_item(f"AST#{assistant_id}", "METADATA")
+
+
+def get_document_item(assistant_id: str, document_id: str) -> Optional[Dict[str, Any]]:
+    return get_item(f"AST#{assistant_id}", f"DOC#{document_id}")
+
+
+def get_source_item(assistant_id: str, source_type: str, source_ref: str) -> Optional[Dict[str, Any]]:
+    """The source record backing a sync policy (DOC# or CRAWL#)."""
+    sk_prefix = "DOC#" if source_type == "drive_file" else "CRAWL#"
+    return get_item(f"AST#{assistant_id}", f"{sk_prefix}{source_ref}")
+
+
+def update_document_sync_fields(
+    assistant_id: str,
+    document_id: str,
+    *,
+    source_etag: Optional[str] = None,
+    content_hash: Optional[str] = None,
+    previous_chunk_count: Optional[int] = None,
+    last_synced_at: Optional[str] = None,
+) -> None:
+    """Targeted update of the sync-bookkeeping fields on a document record.
+
+    Only sets the fields passed — safe alongside the ingestion pipeline's
+    own targeted UpdateExpressions (which never touch these attributes).
+    """
+    set_parts = []
+    values: Dict[str, Any] = {}
+    if source_etag is not None:
+        set_parts.append("sourceEtag = :etag")
+        values[":etag"] = source_etag
+    if content_hash is not None:
+        set_parts.append("contentHash = :hash")
+        values[":hash"] = content_hash
+    if previous_chunk_count is not None:
+        set_parts.append("previousChunkCount = :prev")
+        values[":prev"] = previous_chunk_count
+    if last_synced_at is not None:
+        set_parts.append("lastSyncedAt = :synced")
+        values[":synced"] = last_synced_at
+    if not set_parts:
+        return
+
+    _table().update_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{document_id}"},
+        UpdateExpression="SET " + ", ".join(set_parts),
+        ExpressionAttributeValues=values,
+    )

--- a/backend/src/apis/app_api/kb_sync/requirements.txt
+++ b/backend/src/apis/app_api/kb_sync/requirements.txt
@@ -1,5 +1,6 @@
 # kb-sync Lambda image dependencies (backend/Dockerfile.kb-sync).
 # Exact pins per repo policy; versions match backend/uv.lock.
-# PR-3 (Drive sync path) adds httpx + bedrock-agentcore here.
 boto3==1.43.9
 pydantic==2.12.5
+httpx==0.28.1
+bedrock-agentcore==1.9.1

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -1,34 +1,246 @@
 """KB sync worker — executes a single policy's sync run.
 
-PR-2 stub: acknowledges the dispatch, records the run as "skipped" (which
-also clears the in-flight syncRunStartedAt stamp so the dispatcher never
-sees a permanently-fresh stamp from stub runs), and exits. PR-3 replaces
-the body with the Drive-file path (metadata-first change detection →
-conditional download → stage to S3); PR-4 adds web re-crawl.
+Drive-file path (docs/specs/assistant-kb-sync.md §6.1): resolve the
+policy creator's stored Google token from the AgentCore Identity vault
+(no live user session — pure IAM + vaulted refresh token), gate on
+cheap change detection, and only when bytes actually changed, stage
+them to the document's existing S3 key — which re-runs the whole
+existing ingestion pipeline (chunk → embed → overwrite vectors)
+untouched.
+
+Change detection is two gates, cheapest first:
+1. Drive `files.get` metadata — `version` compared against the stored
+   `sourceEtag`. Imports capture Drive's `version` as the provenance
+   etag (FileEntry.etag), so this stays continuous with documents
+   imported before sync existed. `version` over-triggers (bumps on
+   comments/metadata), which the second gate absorbs.
+2. sha256 of the downloaded bytes vs the stored `contentHash` — the
+   authoritative gate; identical bytes never reach Docling/Titan.
+
+Pause/breaker outcomes (spec §7):
+- vault says re-consent (TokenResult.requires_consent) or Google 401/403
+  → policy paused_reauth; only a fresh consent resumes it (PR-5 hook)
+- Drive 404 (deleted OR unshared — indistinguishable) → failed run with
+  not_found=True; the dispatcher pauses after 2 consecutive
+- trashed=true → "skipped" (grace state — recoverable from trash)
+- anything else → failed run; dispatcher backoff/breaker handles it
+
+Web re-crawl (source_type == "web_crawl") lands in PR-4 — until then
+those runs record "skipped".
 
 Payload contract with the dispatcher:
     {"policyId", "assistantId", "sourceType", "sourceRef"}
 """
 
 import asyncio
+import hashlib
 import logging
-from typing import Any, Dict
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
-from apis.shared.sync_policies.service import record_sync_result
+from apis.shared.oauth.agentcore_identity import (
+    AgentCoreIdentityClient,
+    WorkloadTokenUnavailableError,
+    custom_parameters_for,
+)
+from apis.shared.oauth.provider_repository import OAuthProviderRepository
+from apis.shared.sync_policies.models import SyncPolicy
+from apis.shared.sync_policies.service import get_sync_policy, record_sync_result, set_policy_state
+
+from apis.app_api.file_sources.models import (
+    FileSourceAuthError,
+    FileSourceError,
+    FileSourceNotFoundError,
+)
+from apis.app_api.file_sources.registry import registry
+from apis.app_api.kb_sync import records
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+_NATIVE_PREFIX = "application/vnd.google-apps."
+
+
+def _now_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _stage_to_s3(s3_key: str, content: bytes, content_type: str) -> None:
+    """Overwrite the document's existing S3 object — the bucket's
+    ObjectCreated event re-runs the ingestion pipeline on the new bytes."""
+    import boto3
+
+    bucket = os.environ["S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME"]
+    boto3.client("s3").put_object(Bucket=bucket, Key=s3_key, Body=content, ContentType=content_type)
+
+
+async def _resolve_access_token(provider, user_id: str) -> Optional[str]:
+    """Vault token for the policy creator; None means re-consent needed.
+
+    Mirrors file_sources.service.resolve_file_source_token (which we
+    can't import here — it pulls FastAPI): same provider identity, same
+    scopes, and critically the same customParameters — they're part of
+    the vault key, and a mismatched map falsely reports consent-required.
+    """
+    client = AgentCoreIdentityClient()
+    result = await client.get_token_for_user(
+        provider_name=provider.provider_id,
+        scopes=provider.scopes,
+        user_id=user_id,
+        custom_parameters=custom_parameters_for(
+            provider.provider_type.value if provider.provider_type else None,
+            provider.custom_parameters,
+            force_authentication=True,
+        ),
+        callback_url=os.environ.get("AGENTCORE_LOCAL_OAUTH_CALLBACK_URL"),
+    )
+    if result.requires_consent:
+        return None
+    return result.access_token
+
+
+async def _pause_reauth(policy: SyncPolicy, detail: str) -> Dict[str, Any]:
+    logger.warning(f"Sync policy {policy.policy_id}: credentials need re-consent ({detail})")
+    # "skipped" (not "failed"): resets the breaker streaks and clears the
+    # run stamp — reauth is its own terminal state, not a failure count.
+    await record_sync_result(policy.assistant_id, policy.policy_id, "skipped")
+    await set_policy_state(
+        policy.assistant_id,
+        policy.policy_id,
+        "paused_reauth",
+        state_reason="Reconnect Google Drive to resume syncing",
+    )
+    return {"policyId": policy.policy_id, "result": "paused_reauth"}
+
+
+async def _finish(policy: SyncPolicy, result: str, not_found: bool = False) -> Dict[str, Any]:
+    await record_sync_result(policy.assistant_id, policy.policy_id, result, not_found=not_found)
+    return {"policyId": policy.policy_id, "result": result}
+
+
+async def _sync_drive_file(policy: SyncPolicy) -> Dict[str, Any]:
+    assistant_id = policy.assistant_id
+    document = records.get_document_item(assistant_id, policy.source_ref)
+    if document is None or document.get("status") == "deleting":
+        # Dispatcher's liveness check races a just-deleted doc; nothing to do.
+        logger.info(f"Sync policy {policy.policy_id}: document {policy.source_ref} gone; skipping")
+        return await _finish(policy, "skipped")
+
+    connector_id = document.get("sourceConnectorId")
+    file_id = document.get("sourceFileId")
+    adapter_key = document.get("sourceAdapterKey") or "google-drive"
+    if not connector_id or not file_id:
+        logger.error(f"Sync policy {policy.policy_id}: document {policy.source_ref} has no import provenance")
+        await set_policy_state(
+            assistant_id, policy.policy_id, "paused_error", state_reason="document has no import source"
+        )
+        return await _finish(policy, "skipped")
+
+    adapter = registry.get(adapter_key)
+    if adapter is None:
+        await set_policy_state(
+            assistant_id, policy.policy_id, "paused_error", state_reason=f"adapter '{adapter_key}' not available"
+        )
+        return await _finish(policy, "skipped")
+
+    provider = await OAuthProviderRepository().get_provider(connector_id)
+    if provider is None:
+        await set_policy_state(
+            assistant_id, policy.policy_id, "paused_error", state_reason="connector no longer configured"
+        )
+        return await _finish(policy, "skipped")
+
+    try:
+        access_token = await _resolve_access_token(provider, policy.created_by_user_id)
+    except WorkloadTokenUnavailableError as e:
+        # Operator/config error (workload env, IAM) — not the user's grant.
+        logger.error(f"Sync policy {policy.policy_id}: workload token unavailable: {e}")
+        return await _finish(policy, "failed")
+    if access_token is None:
+        return await _pause_reauth(policy, "vault returned authorization URL")
+
+    try:
+        # Gate 1 — metadata. Cheap; an unchanged corpus costs one
+        # files.get per source per interval.
+        metadata = await adapter.get_file_metadata(access_token, file_id)
+        if metadata.get("trashed"):
+            logger.info(f"Sync policy {policy.policy_id}: file {file_id} is trashed; grace-skipping")
+            return await _finish(policy, "skipped")
+
+        new_etag = str(metadata.get("version") or metadata.get("modifiedTime") or "")
+        stored_etag = document.get("sourceEtag")
+        if stored_etag and new_etag and str(stored_etag) == new_etag:
+            return await _finish(policy, "unchanged")
+
+        # Gate 2 — bytes. version over-triggers, so hash before re-embedding.
+        downloaded = await adapter.download(access_token, file_id)
+        content_hash = _sha256(downloaded.content)
+        if document.get("contentHash") and document["contentHash"] == content_hash:
+            # Content identical; advance the etag so gate 1 passes next run.
+            records.update_document_sync_fields(
+                assistant_id, policy.source_ref, source_etag=new_etag, last_synced_at=_now_timestamp()
+            )
+            return await _finish(policy, "unchanged")
+
+        # Changed: stash the old chunk count for the ingestion tail-delete
+        # (shrinkage cleanup) BEFORE staging, then overwrite the S3 object.
+        previous_chunk_count = int(document.get("chunkCount") or 0)
+        records.update_document_sync_fields(
+            assistant_id,
+            policy.source_ref,
+            source_etag=new_etag,
+            content_hash=content_hash,
+            previous_chunk_count=previous_chunk_count,
+            last_synced_at=_now_timestamp(),
+        )
+        _stage_to_s3(document["s3Key"], downloaded.content, downloaded.content_type)
+        logger.info(
+            f"Sync policy {policy.policy_id}: staged {len(downloaded.content)} changed bytes for "
+            f"document {policy.source_ref} (prev chunks: {previous_chunk_count})"
+        )
+        return await _finish(policy, "changed")
+
+    except FileSourceAuthError as e:
+        # Provider-side revocation the vault can't see (Google rejected the
+        # token). Same terminal state as consent-required.
+        return await _pause_reauth(policy, str(e))
+    except FileSourceNotFoundError:
+        # Deleted OR unshared — Drive won't say which. Never delete our
+        # indexed copy on a 404; strike the counter and let the dispatcher
+        # pause at 2.
+        logger.warning(f"Sync policy {policy.policy_id}: file {file_id} not found/accessible")
+        return await _finish(policy, "failed", not_found=True)
+    except FileSourceError as e:
+        logger.error(f"Sync policy {policy.policy_id}: drive error: {e}")
+        return await _finish(policy, "failed")
 
 
 async def run_sync(payload: Dict[str, Any]) -> Dict[str, Any]:
     policy_id = payload["policyId"]
     assistant_id = payload["assistantId"]
-    logger.info(
-        f"KB sync worker stub: policy {policy_id} ({payload.get('sourceType')}/{payload.get('sourceRef')}) "
-        f"on assistant {assistant_id} — recording skipped (sync execution lands in PR-3/PR-4)"
-    )
-    await record_sync_result(assistant_id, policy_id, "skipped")
-    return {"policyId": policy_id, "result": "skipped"}
+
+    policy = await get_sync_policy(assistant_id, policy_id)
+    if policy is None:
+        logger.info(f"KB sync worker: policy {policy_id} no longer exists; dropping run")
+        return {"policyId": policy_id, "result": "dropped"}
+
+    if policy.source_type == "drive_file":
+        try:
+            return await _sync_drive_file(policy)
+        except Exception as e:
+            # Last-resort catch: always record the run so the stamp clears
+            # and the breaker counts, never leave a policy half-run.
+            logger.error(f"KB sync worker: unexpected failure on policy {policy_id}: {e}", exc_info=True)
+            return await _finish(policy, "failed")
+
+    # web_crawl lands in PR-4.
+    logger.info(f"KB sync worker: source_type {policy.source_type} not implemented yet; skipping")
+    return await _finish(policy, "skipped")
 
 
 def lambda_handler(event, context):

--- a/backend/src/apis/shared/embeddings/bedrock_embeddings.py
+++ b/backend/src/apis/shared/embeddings/bedrock_embeddings.py
@@ -292,6 +292,42 @@ async def delete_vectors_for_document_deterministic(
     return chunk_count
 
 
+async def delete_vector_tail(document_id: str, from_index: int, to_index: int) -> int:
+    """
+    Delete vectors {document_id}#{i} for i in [from_index, to_index).
+
+    Shrinkage cleanup for KB sync re-ingestion: when a re-indexed document
+    produces fewer chunks than before, the in-place vector overwrite leaves
+    stale tail chunks behind — this removes exactly that tail. Deletion of
+    non-existent keys is a no-op in the S3 Vectors API.
+
+    Returns:
+        Number of keys sent for deletion (0 if the range is empty)
+    """
+    if to_index <= from_index:
+        return 0
+
+    client = boto3.client("s3vectors", region_name=AWS_REGION)
+    vector_bucket = _get_vector_store_bucket()
+    vector_index = _get_vector_store_index()
+
+    keys = [f"{document_id}#{i}" for i in range(from_index, to_index)]
+    batch_size = 500
+
+    for i in range(0, len(keys), batch_size):
+        batch = keys[i : i + batch_size]
+        client.delete_vectors(
+            vectorBucketName=vector_bucket,
+            indexName=vector_index,
+            keys=batch,
+        )
+
+    logger.info(
+        f"Tail delete: sent {len(keys)} keys ({from_index}..{to_index - 1}) for document {document_id}"
+    )
+    return len(keys)
+
+
 async def delete_vectors_for_assistant(assistant_id: str) -> int:
     """
     Delete ALL vectors belonging to an assistant from the S3 vector store.

--- a/backend/tests/lambdas/test_kb_sync_worker.py
+++ b/backend/tests/lambdas/test_kb_sync_worker.py
@@ -1,0 +1,366 @@
+"""KB sync worker tests — Drive-file path (moto DynamoDB, stubbed Drive/token).
+
+Documents are created through the REAL document service (with import
+provenance) so the worker's raw record reads/writes are cross-checked
+against the actual storage schema. The Drive adapter and token
+resolution are stubbed at the worker's seams.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apis.app_api.documents.models import DocumentProvenance
+from apis.app_api.documents.services.document_service import create_document
+from apis.app_api.file_sources.models import (
+    DownloadedFile,
+    FileSourceAuthError,
+    FileSourceError,
+    FileSourceNotFoundError,
+)
+from apis.app_api.kb_sync import worker
+from apis.shared.assistants.service import create_assistant
+from apis.shared.sync_policies.service import create_sync_policy, get_sync_policy
+
+pytestmark = pytest.mark.asyncio
+
+USER_ID = "user-1"
+FILE_ID = "drive-file-1"
+CONNECTOR_ID = "google-workspace"
+
+
+class FakeDriveAdapter:
+    """Stub with the two methods the worker uses."""
+
+    def __init__(self, metadata=None, content=b"", metadata_error=None, download_error=None):
+        self.metadata = metadata or {}
+        self.content = content
+        self.metadata_error = metadata_error
+        self.download_error = download_error
+        self.download_calls = 0
+
+    async def get_file_metadata(self, access_token, file_id):
+        if self.metadata_error:
+            raise self.metadata_error
+        return self.metadata
+
+    async def download(self, access_token, file_id):
+        self.download_calls += 1
+        if self.download_error:
+            raise self.download_error
+        return DownloadedFile(content=self.content, filename="report.pdf", content_type="application/pdf")
+
+
+@pytest.fixture()
+def staged(monkeypatch):
+    """Capture S3 staging calls."""
+    calls = []
+    monkeypatch.setattr(worker, "_stage_to_s3", lambda *args: calls.append(args))
+    return calls
+
+
+@pytest.fixture()
+def token_ok(monkeypatch):
+    async def fake_resolve(provider, user_id):
+        return "test-access-token"
+
+    monkeypatch.setattr(worker, "_resolve_access_token", fake_resolve)
+
+
+@pytest.fixture()
+def provider_ok(monkeypatch):
+    provider = SimpleNamespace(
+        provider_id=CONNECTOR_ID,
+        provider_type=SimpleNamespace(value="google"),
+        scopes=["https://www.googleapis.com/auth/drive.readonly"],
+        custom_parameters=None,
+    )
+
+    async def fake_get_provider(self, provider_id):
+        return provider if provider_id == CONNECTOR_ID else None
+
+    monkeypatch.setattr(
+        "apis.shared.oauth.provider_repository.OAuthProviderRepository.get_provider", fake_get_provider
+    )
+    return provider
+
+
+def _use_adapter(monkeypatch, adapter):
+    monkeypatch.setattr(worker.registry, "get", lambda key: adapter if key == "google-drive" else None)
+
+
+async def _setup(assistants_table, *, etag="41", content_hash=None, chunk_count=7):
+    assistant = await create_assistant(
+        owner_id=USER_ID, owner_name="U", name="A", description="d",
+        instructions="i", vector_index_id="assistants-index",
+    )
+    assistant_id = assistant.assistant_id
+    doc = await create_document(
+        assistant_id=assistant_id,
+        filename="report.pdf",
+        content_type="application/pdf",
+        size_bytes=10,
+        s3_key=f"assistants/{assistant_id}/documents/doc-1/report.pdf",
+        document_id="doc-1",
+        provenance=DocumentProvenance(
+            source_connector_id=CONNECTOR_ID,
+            source_adapter_key="google-drive",
+            source_file_id=FILE_ID,
+            imported_by_user_id=USER_ID,
+            source_etag=etag,
+        ),
+    )
+    extra = {":cc": chunk_count}
+    expression = "SET chunkCount = :cc"
+    if content_hash:
+        expression += ", contentHash = :ch"
+        extra[":ch"] = content_hash
+    assistants_table.update_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": "DOC#doc-1"},
+        UpdateExpression=expression,
+        ExpressionAttributeValues=extra,
+    )
+    policy = await create_sync_policy(
+        assistant_id=assistant_id, source_type="drive_file", source_ref="doc-1",
+        interval="daily", created_by_user_id=USER_ID,
+    )
+    return assistant_id, doc, policy
+
+
+def _payload(assistant_id, policy):
+    return {
+        "policyId": policy.policy_id,
+        "assistantId": assistant_id,
+        "sourceType": "drive_file",
+        "sourceRef": "doc-1",
+    }
+
+
+class TestChangeDetection:
+    async def test_unchanged_etag_skips_download(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata={"version": "41", "trashed": False})
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table, etag="41")
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "unchanged"
+        assert adapter.download_calls == 0
+        assert staged == []
+
+    async def test_same_bytes_advances_etag_without_staging(
+        self, assistants_table, staged, token_ok, provider_ok, monkeypatch
+    ):
+        content = b"same bytes"
+        adapter = FakeDriveAdapter(metadata={"version": "42", "trashed": False}, content=content)
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(
+            assistants_table, etag="41", content_hash=worker._sha256(content)
+        )
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "unchanged"
+        assert adapter.download_calls == 1
+        assert staged == []
+        doc = assistants_table.get_item(Key={"PK": f"AST#{assistant_id}", "SK": "DOC#doc-1"})["Item"]
+        assert doc["sourceEtag"] == "42"  # gate 1 passes next run
+
+    async def test_changed_bytes_staged_with_stash(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata={"version": "42", "trashed": False}, content=b"new bytes")
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, doc, policy = await _setup(assistants_table, etag="41", chunk_count=7)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "changed"
+        assert len(staged) == 1
+        s3_key, content, content_type = staged[0]
+        assert s3_key == doc.s3_key
+        assert content == b"new bytes"
+        item = assistants_table.get_item(Key={"PK": f"AST#{assistant_id}", "SK": "DOC#doc-1"})["Item"]
+        assert item["sourceEtag"] == "42"
+        assert item["contentHash"] == worker._sha256(b"new bytes")
+        assert item["previousChunkCount"] == 7
+        assert "lastSyncedAt" in item
+        updated_policy = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated_policy.last_result == "changed"
+        assert updated_policy.consecutive_failures == 0
+
+    async def test_trashed_is_grace_skip(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata={"version": "42", "trashed": True})
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "skipped"
+        assert adapter.download_calls == 0
+
+
+class TestFailureModes:
+    async def test_not_found_strikes_counter(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata_error=FileSourceNotFoundError("gone or unshared"))
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "failed"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.consecutive_not_found == 1
+        assert updated.consecutive_failures == 1
+        assert updated.state == "active"  # dispatcher pauses at the 2-strike breaker
+
+    async def test_auth_error_pauses_reauth(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata_error=FileSourceAuthError("401 invalid token"))
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "paused_reauth"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_reauth"
+        assert "Reconnect" in updated.state_reason
+        assert updated.consecutive_failures == 0  # reauth is not a failure streak
+        assert updated.sync_run_started_at is None
+
+    async def test_requires_consent_pauses_reauth(self, assistants_table, staged, provider_ok, monkeypatch):
+        async def no_token(provider, user_id):
+            return None
+
+        monkeypatch.setattr(worker, "_resolve_access_token", no_token)
+        adapter = FakeDriveAdapter(metadata={"version": "42"})
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "paused_reauth"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_reauth"
+
+    async def test_missing_provider_pauses_error(self, assistants_table, staged, token_ok, monkeypatch):
+        async def no_provider(self, provider_id):
+            return None
+
+        monkeypatch.setattr(
+            "apis.shared.oauth.provider_repository.OAuthProviderRepository.get_provider", no_provider
+        )
+        _use_adapter(monkeypatch, FakeDriveAdapter())
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "skipped"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.state == "paused_error"
+        assert "connector" in updated.state_reason
+
+    async def test_drive_error_records_failed(self, assistants_table, staged, token_ok, provider_ok, monkeypatch):
+        adapter = FakeDriveAdapter(metadata_error=FileSourceError("500 backend error"))
+        _use_adapter(monkeypatch, adapter)
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "failed"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.consecutive_failures == 1
+        assert updated.consecutive_not_found == 0
+
+    async def test_unexpected_exception_still_records_run(
+        self, assistants_table, staged, token_ok, provider_ok, monkeypatch
+    ):
+        class ExplodingAdapter(FakeDriveAdapter):
+            async def get_file_metadata(self, access_token, file_id):
+                raise RuntimeError("boom")
+
+        _use_adapter(monkeypatch, ExplodingAdapter())
+        assistant_id, _, policy = await _setup(assistants_table)
+
+        result = await worker.run_sync(_payload(assistant_id, policy))
+
+        assert result["result"] == "failed"
+        updated = await get_sync_policy(assistant_id, policy.policy_id)
+        assert updated.sync_run_started_at is None  # stamp always clears
+
+    async def test_missing_policy_drops_run(self, assistants_table):
+        result = await worker.run_sync(
+            {"policyId": "syn-missing", "assistantId": "ast-x", "sourceType": "drive_file", "sourceRef": "doc-1"}
+        )
+        assert result["result"] == "dropped"
+
+    async def test_web_crawl_still_skips(self, assistants_table):
+        assistant = await create_assistant(
+            owner_id=USER_ID, owner_name="U", name="A", description="d",
+            instructions="i", vector_index_id="assistants-index",
+        )
+        policy = await create_sync_policy(
+            assistant_id=assistant.assistant_id, source_type="web_crawl", source_ref="crawl-1",
+            interval="daily", created_by_user_id=USER_ID,
+        )
+
+        result = await worker.run_sync(
+            {"policyId": policy.policy_id, "assistantId": assistant.assistant_id,
+             "sourceType": "web_crawl", "sourceRef": "crawl-1"}
+        )
+
+        assert result["result"] == "skipped"
+
+
+class TestShrinkageCleanup:
+    async def test_pop_previous_chunk_count_is_atomic(self, assistants_table, monkeypatch):
+        from apis.app_api.documents.ingestion.status import DocumentStatusManager
+
+        assistant = await create_assistant(
+            owner_id=USER_ID, owner_name="U", name="A", description="d",
+            instructions="i", vector_index_id="assistants-index",
+        )
+        assistant_id = assistant.assistant_id
+        await create_document(
+            assistant_id=assistant_id, filename="f.pdf", content_type="application/pdf",
+            size_bytes=1, s3_key="k", document_id="doc-1",
+        )
+        assistants_table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": "DOC#doc-1"},
+            UpdateExpression="SET previousChunkCount = :p",
+            ExpressionAttributeValues={":p": 9},
+        )
+
+        manager = DocumentStatusManager(table_name=assistants_table.table_name)
+        first = await manager.pop_previous_chunk_count(assistant_id=assistant_id, document_id="doc-1")
+        second = await manager.pop_previous_chunk_count(assistant_id=assistant_id, document_id="doc-1")
+
+        assert first == 9
+        assert second is None
+        item = assistants_table.get_item(Key={"PK": f"AST#{assistant_id}", "SK": "DOC#doc-1"})["Item"]
+        assert "previousChunkCount" not in item
+
+    async def test_delete_vector_tail_sends_exact_range(self, monkeypatch):
+        from apis.shared.embeddings import bedrock_embeddings
+
+        deleted_batches = []
+
+        class FakeClient:
+            def delete_vectors(self, vectorBucketName, indexName, keys):
+                deleted_batches.append(keys)
+
+        with patch.object(bedrock_embeddings, "_get_vector_store_bucket", return_value="vb"), patch.object(
+            bedrock_embeddings, "_get_vector_store_index", return_value="vi"
+        ), patch.object(bedrock_embeddings.boto3, "client", return_value=FakeClient()):
+            count = await bedrock_embeddings.delete_vector_tail("doc-1", 3, 7)
+
+        assert count == 4
+        assert deleted_batches == [["doc-1#3", "doc-1#4", "doc-1#5", "doc-1#6"]]
+
+    async def test_delete_vector_tail_empty_range_noop(self, monkeypatch):
+        from apis.shared.embeddings import bedrock_embeddings
+
+        with patch.object(bedrock_embeddings.boto3, "client") as client:
+            count = await bedrock_embeddings.delete_vector_tail("doc-1", 5, 5)
+
+        assert count == 0
+        client.assert_not_called()

--- a/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
+++ b/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
@@ -6,6 +6,7 @@ import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as path from 'path';
 import { Construct } from 'constructs';
@@ -16,6 +17,16 @@ export interface KbSyncConstructProps {
   config: AppConfig;
   /** RAG assistants table — sync policies live on it (SYNCPOL# items + DueSyncIndex). */
   assistantsTable: dynamodb.ITable;
+  /** RAG documents bucket — the worker re-stages changed source bytes here. */
+  documentsBucket: s3.IBucket;
+  /** OAuth providers table — the worker resolves connector config from it. */
+  oauthProvidersTable: dynamodb.ITable;
+  /**
+   * Shared platform workload identity name. Vault entries are keyed by
+   * workload identity — a different workload sees an empty vault, so this
+   * MUST be the same identity app-api/inference-api use.
+   */
+  workloadIdentityName: string;
 }
 
 /**
@@ -54,7 +65,13 @@ export class KbSyncConstruct extends Construct {
   constructor(scope: Construct, id: string, props: KbSyncConstructProps) {
     super(scope, id);
 
-    const { config, assistantsTable } = props;
+    const { config, assistantsTable, documentsBucket, oauthProvidersTable, workloadIdentityName } = props;
+
+    // Same value app-api uses (app-api-environment.ts) — the vault requires
+    // a registered return URL even for non-interactive token reads.
+    const oauthCallbackUrl = config.domainName
+      ? `https://${config.domainName}/oauth-complete`
+      : 'http://localhost:4200/oauth-complete';
 
     const bootstrapDir = path.resolve(
       __dirname,
@@ -83,6 +100,10 @@ export class KbSyncConstruct extends Construct {
       logGroup: workerLogGroup,
       environment: {
         DYNAMODB_ASSISTANTS_TABLE_NAME: assistantsTable.tableName,
+        DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME: oauthProvidersTable.tableName,
+        S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME: documentsBucket.bucketName,
+        AGENTCORE_RUNTIME_WORKLOAD_NAME: workloadIdentityName,
+        AGENTCORE_LOCAL_OAUTH_CALLBACK_URL: oauthCallbackUrl,
         KB_SYNC_ENABLED: config.kbSync.enabled ? 'true' : 'false',
       },
       description:
@@ -116,6 +137,32 @@ export class KbSyncConstruct extends Construct {
     assistantsTable.grantReadWriteData(this.dispatcherLambda);
     assistantsTable.grantReadWriteData(this.workerLambda);
     this.workerLambda.grantInvoke(this.dispatcherLambda);
+
+    // Worker: read connector config, stage changed bytes for re-ingestion.
+    oauthProvidersTable.grantReadData(this.workerLambda);
+    documentsBucket.grantPut(this.workerLambda);
+
+    // Worker: retrieve the policy creator's stored 3LO token from the
+    // AgentCore Identity vault with no live user session. Mirrors app-api's
+    // AgentCoreWorkloadIdentityAccess statement (app-api-iam-grants.ts)
+    // minus consent-completion and provider CRUD — a background fetcher
+    // only ever reads tokens.
+    this.workerLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AgentCoreVaultTokenRead',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'bedrock-agentcore:GetWorkloadAccessTokenForUserId',
+          'bedrock-agentcore:GetResourceOauth2Token',
+        ],
+        resources: [
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/*/oauth2credentialprovider/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/*/workload-identity/*`,
+        ],
+      }),
+    );
 
     // Best-effort custom metrics (KBSync namespace). PutMetricData
     // doesn't support resource scoping; condition on the namespace.

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -395,6 +395,9 @@ export class PlatformStack extends cdk.Stack {
     new KbSyncConstruct(this, 'KbSync', {
       config,
       assistantsTable: this.ragAssistantsTable,
+      documentsBucket: this.ragDocumentsBucket,
+      oauthProvidersTable: this.oauthProvidersTable,
+      workloadIdentityName: this.platformWorkloadIdentity.name,
     });
 
     // ============================================================

--- a/infrastructure/test/kb-sync.test.ts
+++ b/infrastructure/test/kb-sync.test.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 
 import { KbSyncConstruct } from '../lib/constructs/kb-sync/kb-sync-construct';
@@ -12,9 +13,16 @@ function synth(kbSyncEnabled: boolean): Template {
   });
   const config = createMockConfig({ kbSync: { enabled: kbSyncEnabled } });
   const ragData = new RagDataConstruct(stack, 'RagData', { config });
+  const oauthProvidersTable = new dynamodb.Table(stack, 'OAuthProviders', {
+    partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+    sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+  });
   new KbSyncConstruct(stack, 'KbSync', {
     config,
     assistantsTable: ragData.assistantsTable,
+    documentsBucket: ragData.documentsBucket,
+    oauthProvidersTable,
+    workloadIdentityName: 'test-platform-workload',
   });
   return Template.fromStack(stack);
 }
@@ -102,5 +110,40 @@ describe('KbSyncConstruct', () => {
 
   it('creates error alarms for both functions', () => {
     t.resourceCountIs('AWS::CloudWatch::Alarm', 2);
+  });
+
+  it('worker carries the identity + staging env contract', () => {
+    t.hasResourceProperties('AWS::Lambda::Function', {
+      ImageConfig: { Command: ['apis.app_api.kb_sync.worker.lambda_handler'] },
+      Environment: {
+        Variables: Match.objectLike({
+          AGENTCORE_RUNTIME_WORKLOAD_NAME: 'test-platform-workload',
+          AGENTCORE_LOCAL_OAUTH_CALLBACK_URL: Match.stringLikeRegexp('/oauth-complete$'),
+          DYNAMODB_OAUTH_PROVIDERS_TABLE_NAME: Match.anyValue(),
+          S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME: Match.anyValue(),
+        }),
+      },
+    });
+  });
+
+  it('worker may read vault tokens but never complete consent or manage providers', () => {
+    t.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Sid: 'AgentCoreVaultTokenRead',
+            Action: [
+              'bedrock-agentcore:GetWorkloadAccessTokenForUserId',
+              'bedrock-agentcore:GetResourceOauth2Token',
+            ],
+          }),
+        ]),
+      },
+    });
+    // The trimmed statement must not quietly grow write-side actions.
+    const policies = t.findResources('AWS::IAM::Policy');
+    const allActions = JSON.stringify(policies);
+    expect(allActions).not.toContain('CompleteResourceTokenAuth');
+    expect(allActions).not.toContain('CreateOauth2CredentialProvider');
   });
 });

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -113,7 +113,9 @@ case "$SERVICE" in
         # would ship stale code under an unchanged content-hash tag.
         SOURCE_DIRS=(
             "backend/src/apis/app_api/kb_sync"
+            "backend/src/apis/app_api/file_sources"
             "backend/src/apis/shared/sync_policies"
+            "backend/src/apis/shared/oauth"
         )
         # shared/__init__.py hashed as a manifest (same as rag-ingestion);
         # kb_sync/requirements.txt lives inside the first source dir.


### PR DESCRIPTION
## Summary

PR-3 of the **assistant KB sync** feature ([spec §6.1](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/assistant-kb-sync.md), follows #542/#543). The worker now actually syncs `drive_file` policies; still fully dark behind `CDK_KB_SYNC_ENABLED`.

### Sync run, end to end
1. **Token, no user present** — resolves the policy creator's stored Google token from the AgentCore Identity vault (`GetWorkloadAccessTokenForUserId` → `GetResourceOauth2Token`), reusing `apis.shared.oauth.agentcore_identity` verbatim with the exact consent-time `customParameters` (vault-key rule). The FastAPI-flavored `file_sources.service` wrapper is deliberately not imported — the worker uses the oauth primitives directly.
2. **Two-gate change detection** — cheap `files.get` first (new `GoogleDriveAdapter.get_file_metadata`), comparing Drive `version` against the stored `sourceEtag` (imports already capture `version` as provenance, so this is continuous with pre-sync documents). `version` over-triggers by design; the sha256 `contentHash` gate absorbs that — identical bytes never reach Docling/Titan. An unchanged corpus costs one metadata call per source per interval.
3. **Staged re-ingest** — changed bytes overwrite the document's existing S3 key; the untouched ingestion pipeline re-chunks/re-embeds via its S3 event.
4. **Shrinkage cleanup** — the worker stashes `previousChunkCount` before staging; ingestion completion **atomically pops** it (`REMOVE` + `UPDATED_OLD`, so a duplicate S3 event can't double-delete) and removes stale tail vectors `{doc}#{new..prev-1}` via the new `delete_vector_tail`. Uses post-split `len(chunks)` — the true vector count written this run.

### Pause semantics (spec §7)
- Vault says re-consent, or Google rejects the token (revocation AgentCore can't see) → `paused_reauth`, **not** a failure streak; only a fresh consent resumes (hook lands in PR-5)
- Drive 404 — deliberately indistinguishable between *deleted* and *unshared* → `not_found` strike; dispatcher pauses at 2; we never delete indexed content on a 404
- `trashed=true` is a 200 → grace skip
- Connector/adapter/provenance gone → `paused_error` with a specific reason
- Every exit path records the run, so the in-flight stamp always clears

### IAM posture
Worker gets exactly two vault actions (`GetWorkloadAccessTokenForUserId`, `GetResourceOauth2Token`) — no consent completion, no provider CRUD — plus oauth-table read and documents-bucket put. A test asserts the statement never quietly grows write-side actions.

## Testing
- 15 new worker tests: both gates, etag-advance-without-restaging, stash correctness, every pause/strike path, stamp-always-clears, atomic pop, exact tail-delete range
- Documents/assistants created through the **real** services so the worker's raw record access is cross-checked against actual storage schema
- Image import-surface re-simulated (oauth + file_sources are FastAPI-free)
- Backend: 4123 passed. Infra: `tsc` clean, kb-sync/tables/platform-stack suites green (78); the 14 `cloudfront-shared-cert`/`config` failures are pre-existing on develop

## Notes for rollout
- Needs `platform.yml` (worker env/IAM changed) + `backend.yml` (image gained oauth/file_sources) after merge
- Before enabling in dev-ai: do the ~30-min live check — one end-to-end token pull from the deployed worker, and confirm the Google OAuth client's publishing status (Testing-mode clients issue 7-day refresh tokens → weekly `paused_reauth` churn until Published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)