### PR TITLE
feat(kb-sync): PR-5 — sync-policy API + resume hooks

### DIFF
--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -400,6 +400,22 @@ async def complete_consent(
             current_user.user_id, body.provider_id
         )
 
+        # A fresh grant is the ONLY thing that resumes reauth-paused KB
+        # sync policies (docs/specs/assistant-kb-sync.md §7.6). Resumed
+        # policies come due immediately. Best-effort: a hook failure must
+        # never fail the consent completion itself.
+        try:
+            from apis.shared.sync_policies.service import resume_reauth_policies
+
+            await resume_reauth_policies(current_user.user_id, body.provider_id)
+        except Exception as resume_err:
+            logger.warning(
+                "Failed to resume reauth-paused sync policies for user=%s provider=%s: %s",
+                current_user.user_id,
+                scrub_log(body.provider_id),
+                resume_err,
+            )
+
     logger.info(
         "Completed OAuth consent for user=%s provider=%s",
         current_user.user_id,

--- a/backend/src/apis/app_api/kb_sync/records.py
+++ b/backend/src/apis/app_api/kb_sync/records.py
@@ -80,6 +80,7 @@ def update_document_sync_fields(
     content_hash: Optional[str] = None,
     previous_chunk_count: Optional[int] = None,
     last_synced_at: Optional[str] = None,
+    sync_policy_id: Optional[str] = None,
 ) -> None:
     """Targeted update of the sync-bookkeeping fields on a document record.
 
@@ -100,6 +101,9 @@ def update_document_sync_fields(
     if last_synced_at is not None:
         set_parts.append("lastSyncedAt = :synced")
         values[":synced"] = last_synced_at
+    if sync_policy_id is not None:
+        set_parts.append("syncPolicyId = :spid")
+        values[":spid"] = sync_policy_id
     if not set_parts:
         return
 
@@ -107,4 +111,12 @@ def update_document_sync_fields(
         Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{document_id}"},
         UpdateExpression="SET " + ", ".join(set_parts),
         ExpressionAttributeValues=values,
+    )
+
+
+def clear_document_sync_policy_id(assistant_id: str, document_id: str) -> None:
+    """Remove the SyncPolicy back-pointer when its policy is deleted."""
+    _table().update_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{document_id}"},
+        UpdateExpression="REMOVE syncPolicyId",
     )

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -110,7 +110,7 @@ async def _resolve_access_token(provider, user_id: str) -> Optional[str]:
     return result.access_token
 
 
-async def _pause_reauth(policy: SyncPolicy, detail: str) -> Dict[str, Any]:
+async def _pause_reauth(policy: SyncPolicy, detail: str, provider_id: Optional[str] = None) -> Dict[str, Any]:
     logger.warning(f"Sync policy {policy.policy_id}: credentials need re-consent ({detail})")
     # "skipped" (not "failed"): resets the breaker streaks and clears the
     # run stamp — reauth is its own terminal state, not a failure count.
@@ -121,6 +121,12 @@ async def _pause_reauth(policy: SyncPolicy, detail: str) -> Dict[str, Any]:
         "paused_reauth",
         state_reason="Reconnect Google Drive to resume syncing",
     )
+    if provider_id:
+        # Marker lets the consent-completion hook find this policy without
+        # a table scan; resume re-verifies, so best-effort is fine here.
+        from apis.shared.sync_policies.service import put_reauth_marker
+
+        await put_reauth_marker(policy.created_by_user_id, policy.assistant_id, policy.policy_id, provider_id)
     return {"policyId": policy.policy_id, "result": "paused_reauth"}
 
 
@@ -168,7 +174,7 @@ async def _sync_drive_file(policy: SyncPolicy) -> Dict[str, Any]:
         logger.error(f"Sync policy {policy.policy_id}: workload token unavailable: {e}")
         return await _finish(policy, "failed")
     if access_token is None:
-        return await _pause_reauth(policy, "vault returned authorization URL")
+        return await _pause_reauth(policy, "vault returned authorization URL", provider_id=connector_id)
 
     try:
         # Gate 1 — metadata. Cheap; an unchanged corpus costs one
@@ -214,7 +220,7 @@ async def _sync_drive_file(policy: SyncPolicy) -> Dict[str, Any]:
     except FileSourceAuthError as e:
         # Provider-side revocation the vault can't see (Google rejected the
         # token). Same terminal state as consent-required.
-        return await _pause_reauth(policy, str(e))
+        return await _pause_reauth(policy, str(e), provider_id=connector_id)
     except FileSourceNotFoundError:
         # Deleted OR unshared — Drive won't say which. Never delete our
         # indexed copy on a 404; strike the counter and let the dispatcher

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -194,6 +194,7 @@ from apis.app_api.connectors.routes import router as connectors_router
 from apis.app_api.file_sources.routes import router as file_sources_router
 from apis.app_api.export_targets.routes import router as export_targets_router
 from apis.app_api.web_sources.routes import router as web_sources_router
+from apis.app_api.sync_policies.routes import router as sync_policies_router
 from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
 from apis.app_api.voice import router as voice_router
@@ -224,6 +225,7 @@ app.include_router(connectors_router)  # User-facing connector catalog + consent
 app.include_router(file_sources_router)  # File-source catalog + browse/search over connectors
 app.include_router(export_targets_router)  # Export-target catalog + save-a-conversation to a connector
 app.include_router(web_sources_router)  # Web-crawl ingestion: URL -> documents via BFS + S3 staging
+app.include_router(sync_policies_router)  # KB sync schedules: scheduled re-index of assistant sources
 app.include_router(system_router)  # System status and first-boot endpoints
 app.include_router(conversations_share_router)  # Share conversations endpoints
 app.include_router(shares_router)  # Share management (update, revoke, export)

--- a/backend/src/apis/app_api/sync_policies/__init__.py
+++ b/backend/src/apis/app_api/sync_policies/__init__.py
@@ -1,0 +1,1 @@
+"""Sync-policy management routes (KB sync — scheduled re-index)."""

--- a/backend/src/apis/app_api/sync_policies/models.py
+++ b/backend/src/apis/app_api/sync_policies/models.py
@@ -1,0 +1,82 @@
+"""Sync-policy API request/response models"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from apis.shared.sync_policies.models import SyncInterval, SyncPolicy, SyncPolicyState, SyncSourceType
+
+
+class CreateSyncPolicyRequest(BaseModel):
+    """Request body for creating a sync policy on a content source"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source_type: SyncSourceType = Field(..., alias="sourceType", description="Kind of content source")
+    source_ref: str = Field(
+        ...,
+        alias="sourceRef",
+        min_length=1,
+        max_length=128,
+        description="drive_file: document id; web_crawl: crawl id",
+    )
+    interval: SyncInterval = Field(..., description="Re-sync cadence")
+
+
+class UpdateSyncPolicyRequest(BaseModel):
+    """Request body for changing a policy's interval or pausing/resuming.
+
+    `state` accepts only the user-owned transitions: "paused_user" (pause)
+    and "active" (resume). paused_reauth resumes only via a fresh OAuth
+    consent; the other paused states resume here too since resuming is an
+    explicit user decision.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    interval: Optional[SyncInterval] = Field(None, description="New re-sync cadence")
+    state: Optional[Literal["active", "paused_user"]] = Field(None, description="Pause or resume the policy")
+
+
+class SyncPolicyResponse(BaseModel):
+    """Public view of a sync policy"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    policy_id: str = Field(..., alias="policyId")
+    assistant_id: str = Field(..., alias="assistantId")
+    source_type: SyncSourceType = Field(..., alias="sourceType")
+    source_ref: str = Field(..., alias="sourceRef")
+    interval: SyncInterval
+    state: SyncPolicyState
+    state_reason: Optional[str] = Field(None, alias="stateReason")
+    next_sync_at: Optional[str] = Field(None, alias="nextSyncAt")
+    last_sync_at: Optional[str] = Field(None, alias="lastSyncAt")
+    last_result: Optional[str] = Field(None, alias="lastResult")
+    created_at: str = Field(..., alias="createdAt")
+    updated_at: str = Field(..., alias="updatedAt")
+
+    @classmethod
+    def from_policy(cls, policy: SyncPolicy) -> "SyncPolicyResponse":
+        return cls(
+            policy_id=policy.policy_id,
+            assistant_id=policy.assistant_id,
+            source_type=policy.source_type,
+            source_ref=policy.source_ref,
+            interval=policy.interval,
+            state=policy.state,
+            state_reason=policy.state_reason,
+            next_sync_at=policy.next_sync_at,
+            last_sync_at=policy.last_sync_at,
+            last_result=policy.last_result,
+            created_at=policy.created_at,
+            updated_at=policy.updated_at,
+        )
+
+
+class SyncPoliciesListResponse(BaseModel):
+    """Response for listing an assistant's sync policies"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    policies: List[SyncPolicyResponse] = Field(..., description="Sync policies for the assistant")

--- a/backend/src/apis/app_api/sync_policies/routes.py
+++ b/backend/src/apis/app_api/sync_policies/routes.py
@@ -1,0 +1,194 @@
+"""Sync-policy routes — manage scheduled re-index of assistant KB sources.
+
+All routes are edit-gated (owner or editor share), matching the document
+management surface: whoever can add knowledge can decide whether it stays
+fresh. Every mutation is plain data — nothing here schedules work directly;
+the dispatcher's DueSyncIndex sweep remains the single trigger
+(docs/specs/assistant-kb-sync.md §3).
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.assistants.service import resolve_assistant_permission
+from apis.shared.sync_policies.service import (
+    DuplicateSyncPolicy,
+    RunNowCooldown,
+    SyncPolicyLimitExceeded,
+    change_policy_interval,
+    create_sync_policy,
+    delete_reauth_marker,
+    delete_sync_policy,
+    get_sync_policy,
+    list_sync_policies,
+    set_policy_state,
+    trigger_run_now,
+)
+from apis.shared.sync_policies.service import _get_current_timestamp  # timestamp house-style
+
+from apis.app_api.kb_sync import records
+from apis.app_api.sync_policies.models import (
+    CreateSyncPolicyRequest,
+    SyncPoliciesListResponse,
+    SyncPolicyResponse,
+    UpdateSyncPolicyRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/assistants/{assistant_id}/sync-policies", tags=["sync-policies"])
+
+
+async def _require_edit_permission(assistant_id: str, current_user: User) -> str:
+    """Owner or editor share required — same gate as the documents surface."""
+    assistant, permission = await resolve_assistant_permission(
+        assistant_id=assistant_id, user_id=current_user.user_id, user_email=current_user.email
+    )
+    if not assistant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Assistant not found: {assistant_id}")
+    if permission not in ("owner", "editor"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to manage sync for this assistant",
+        )
+    return assistant.owner_id
+
+
+def _validate_source(assistant_id: str, source_type: str, source_ref: str) -> None:
+    """The source must exist before a schedule can cover it; drive_file
+    sources additionally need import provenance to re-fetch from."""
+    source = records.get_source_item(assistant_id, source_type, source_ref)
+    if source is None or source.get("status") == "deleting":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Sync source not found: {source_ref}",
+        )
+    if source_type == "drive_file" and not source.get("sourceFileId"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Device-uploaded documents have no external source to sync from",
+        )
+
+
+@router.post("", response_model=SyncPolicyResponse, status_code=status.HTTP_201_CREATED)
+async def create_policy(
+    assistant_id: str,
+    request: CreateSyncPolicyRequest,
+    current_user: User = Depends(get_current_user_from_session),
+) -> SyncPolicyResponse:
+    await _require_edit_permission(assistant_id, current_user)
+    _validate_source(assistant_id, request.source_type, request.source_ref)
+
+    try:
+        policy = await create_sync_policy(
+            assistant_id=assistant_id,
+            source_type=request.source_type,
+            source_ref=request.source_ref,
+            interval=request.interval,
+            created_by_user_id=current_user.user_id,
+        )
+    except DuplicateSyncPolicy:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="This source already has a sync policy"
+        )
+    except SyncPolicyLimitExceeded as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    if request.source_type == "drive_file":
+        records.update_document_sync_fields(assistant_id, request.source_ref, sync_policy_id=policy.policy_id)
+
+    return SyncPolicyResponse.from_policy(policy)
+
+
+@router.get("", response_model=SyncPoliciesListResponse)
+async def list_policies(
+    assistant_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> SyncPoliciesListResponse:
+    await _require_edit_permission(assistant_id, current_user)
+    policies = await list_sync_policies(assistant_id)
+    return SyncPoliciesListResponse(policies=[SyncPolicyResponse.from_policy(p) for p in policies])
+
+
+@router.patch("/{policy_id}", response_model=SyncPolicyResponse)
+async def update_policy(
+    assistant_id: str,
+    policy_id: str,
+    request: UpdateSyncPolicyRequest,
+    current_user: User = Depends(get_current_user_from_session),
+) -> SyncPolicyResponse:
+    await _require_edit_permission(assistant_id, current_user)
+    policy = await get_sync_policy(assistant_id, policy_id)
+    if policy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Sync policy not found: {policy_id}")
+
+    if request.state == "active" and policy.state == "paused_reauth":
+        # Only a fresh OAuth consent resumes a reauth pause — resuming here
+        # would just re-fail and burn a run.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Reconnect the content source to resume syncing",
+        )
+
+    if request.interval is not None and request.interval != policy.interval:
+        policy = await change_policy_interval(assistant_id, policy_id, request.interval)
+
+    if request.state is not None and request.state != policy.state:
+        if request.state == "active":
+            await set_policy_state(assistant_id, policy_id, "active", next_sync_at=_get_current_timestamp())
+        else:
+            await set_policy_state(assistant_id, policy_id, "paused_user", state_reason="Paused by user")
+        policy = await get_sync_policy(assistant_id, policy_id)
+
+    return SyncPolicyResponse.from_policy(policy)
+
+
+@router.delete("/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_policy(
+    assistant_id: str,
+    policy_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> None:
+    await _require_edit_permission(assistant_id, current_user)
+    policy = await get_sync_policy(assistant_id, policy_id)
+    if policy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Sync policy not found: {policy_id}")
+
+    await delete_sync_policy(assistant_id, policy_id)
+    await delete_reauth_marker(policy.created_by_user_id, policy_id)
+
+    if policy.source_type == "web_crawl":
+        # Un-synced crawl jobs go back to normal 30-day auto-expiry.
+        from apis.app_api.web_sources.crawl_repository import restore_crawl_ttl
+
+        await restore_crawl_ttl(assistant_id=assistant_id, crawl_id=policy.source_ref)
+    else:
+        records.clear_document_sync_policy_id(assistant_id, policy.source_ref)
+
+    return None
+
+
+@router.post("/{policy_id}/run-now", response_model=SyncPolicyResponse, status_code=status.HTTP_202_ACCEPTED)
+async def run_now(
+    assistant_id: str,
+    policy_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> SyncPolicyResponse:
+    """Make the policy due immediately. Flows through the normal dispatcher
+    sweep, so every runaway guard still applies; ≥10-minute cooldown."""
+    await _require_edit_permission(assistant_id, current_user)
+    try:
+        policy = await trigger_run_now(assistant_id, policy_id)
+    except KeyError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Sync policy not found: {policy_id}")
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except RunNowCooldown:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="A manual sync was already requested recently; try again in a few minutes",
+        )
+    return SyncPolicyResponse.from_policy(policy)

--- a/backend/src/apis/app_api/web_sources/crawl_repository.py
+++ b/backend/src/apis/app_api/web_sources/crawl_repository.py
@@ -292,6 +292,33 @@ async def increment_counters(
         )
 
 
+async def restore_crawl_ttl(*, assistant_id: str, crawl_id: str) -> None:
+    """Re-apply the finalized-row TTL to a terminal crawl job.
+
+    Inverse of the sync path's finalize_crawl(set_ttl=False): when the sync
+    policy covering a crawl is deleted, the job goes back to the normal
+    30-day auto-expiry so un-synced history doesn't accumulate forever.
+    Running jobs are left alone (finalize owns their transition).
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        _table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"CRAWL#{crawl_id}"},
+            UpdateExpression="SET #ttl = :ttl",
+            ExpressionAttributeNames={"#ttl": "ttl", "#status": "status"},
+            ExpressionAttributeValues={
+                ":ttl": int(time.time()) + _FINALIZED_TTL_DAYS * 86400,
+                ":running": "running",
+            },
+            ConditionExpression="attribute_exists(PK) AND #status <> :running",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return  # gone already, or still running — nothing to restore
+        raise
+
+
 async def reset_crawl_for_refresh(*, assistant_id: str, crawl_id: str) -> bool:
     """Rearm an existing crawl job for a KB-sync re-crawl.
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1238,6 +1238,19 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         if assistant.owner_id != user_id:
             await mark_share_as_interacted(assistant_id=input_data.rag_assistant_id, user_email=current_user.email)
 
+        # KB sync inactivity signal: any user's chat use counts. Throttled
+        # to one write/day inside bump_last_used_at (conditional update);
+        # the winning bump also wakes any inactivity-paused sync policies.
+        # Best-effort — a bookkeeping failure must never break a chat turn.
+        try:
+            from apis.shared.assistants.service import bump_last_used_at
+            from apis.shared.sync_policies.service import resume_inactive_policies
+
+            if await bump_last_used_at(input_data.rag_assistant_id):
+                await resume_inactive_policies(input_data.rag_assistant_id)
+        except Exception as bump_err:
+            logger.warning(f"lastUsedAt bump failed for assistant {input_data.rag_assistant_id}: {bump_err}")
+
         # 3. Search assistant knowledge base
         logger.info("Starting knowledge base search for assistant...")
         try:

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
 from .models import Assistant
@@ -291,6 +291,46 @@ async def resolve_assistant_permission(
             return assistant, share_permission
 
     return assistant, None
+
+
+async def bump_last_used_at(assistant_id: str, throttle_hours: int = 24) -> bool:
+    """Record that an assistant was used in chat, throttled to one write
+    per `throttle_hours`.
+
+    Drives the KB-sync inactivity guard (docs/specs/assistant-kb-sync.md
+    §7.3). A conditional write keeps concurrent chat turns from stampeding:
+    only the caller that actually advances the stale timestamp gets True —
+    that winner is responsible for resuming any paused_inactive policies.
+    Any user's use counts, not just the owner's. Never raises.
+    """
+    assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not assistants_table:
+        return False
+
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+
+        now_dt = datetime.now(timezone.utc)
+        floor = (now_dt - timedelta(hours=throttle_hours)).isoformat() + "Z"
+        table = boto3.resource("dynamodb").Table(assistants_table)
+        table.update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"},
+            UpdateExpression="SET lastUsedAt = :now",
+            ExpressionAttributeValues={":now": now_dt.isoformat() + "Z", ":floor": floor},
+            ConditionExpression=(
+                "attribute_exists(PK) AND (attribute_not_exists(lastUsedAt) OR lastUsedAt < :floor)"
+            ),
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False  # fresh enough, or assistant gone — nothing to do
+        logger.warning(f"Failed to bump lastUsedAt for {assistant_id}: {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"Failed to bump lastUsedAt for {assistant_id}: {e}")
+        return False
 
 
 async def assistant_exists(assistant_id: str) -> bool:

--- a/backend/src/apis/shared/sync_policies/models.py
+++ b/backend/src/apis/shared/sync_policies/models.py
@@ -51,6 +51,9 @@ class SyncPolicy(BaseModel):
     sync_run_started_at: Optional[str] = Field(
         None, alias="syncRunStartedAt", description="Set while a worker run is in flight; stale stamps are treated as crashed runs"
     )
+    last_manual_run_at: Optional[str] = Field(
+        None, alias="lastManualRunAt", description="Last 'Sync now' trigger; enforces the manual-run cooldown"
+    )
     created_by_user_id: str = Field(..., alias="createdByUserId", description="User whose credentials background fetches use")
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp of creation")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 timestamp of last update")

--- a/backend/src/apis/shared/sync_policies/service.py
+++ b/backend/src/apis/shared/sync_policies/service.py
@@ -297,6 +297,146 @@ async def record_sync_result(assistant_id: str, policy_id: str, result: SyncRunR
     )
 
 
+# ── Reauth markers ───────────────────────────────────────────────────────────
+#
+# When the worker pauses a policy for re-consent it also writes a marker at
+# PK=USER#{user_id}, SK=SYNCREAUTH#{policy_id} carrying {assistantId,
+# providerId}. Consent completion queries this partition instead of scanning
+# the table for the user's paused policies. Markers are advisory: resume
+# re-verifies the policy still exists and is paused_reauth, so stale markers
+# are harmless and are deleted on sight.
+
+
+async def put_reauth_marker(user_id: str, assistant_id: str, policy_id: str, provider_id: str) -> None:
+    _get_table().put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"SYNCREAUTH#{policy_id}",
+            "assistantId": assistant_id,
+            "policyId": policy_id,
+            "providerId": provider_id,
+            "createdAt": _get_current_timestamp(),
+        }
+    )
+
+
+async def delete_reauth_marker(user_id: str, policy_id: str) -> None:
+    _get_table().delete_item(Key={"PK": f"USER#{user_id}", "SK": f"SYNCREAUTH#{policy_id}"})
+
+
+async def resume_reauth_policies(user_id: str, provider_id: str) -> int:
+    """Reactivate the user's paused_reauth policies for a provider.
+
+    Called from the OAuth consent-completion path: a fresh grant is the ONLY
+    thing that resumes a reauth pause. Resumed policies come due immediately.
+    Returns the number resumed.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    response = _get_table().query(
+        KeyConditionExpression=Key("PK").eq(f"USER#{user_id}") & Key("SK").begins_with("SYNCREAUTH#")
+    )
+    resumed = 0
+    now = _get_current_timestamp()
+    for marker in response.get("Items", []):
+        if marker.get("providerId") != provider_id:
+            continue
+        assistant_id = marker["assistantId"]
+        policy_id = marker["policyId"]
+        policy = await get_sync_policy(assistant_id, policy_id)
+        if policy is not None and policy.state == "paused_reauth":
+            await set_policy_state(assistant_id, policy_id, "active", next_sync_at=now)
+            resumed += 1
+        await delete_reauth_marker(user_id, policy_id)
+    if resumed:
+        logger.info(f"Resumed {resumed} paused_reauth sync policies for user {user_id} / provider {provider_id}")
+    return resumed
+
+
+async def resume_inactive_policies(assistant_id: str) -> int:
+    """Reactivate an assistant's paused_inactive policies (due immediately).
+
+    Called from the lastUsedAt bump path: the first use of a dormant
+    assistant refreshes its knowledge base within a dispatcher tick.
+    """
+    resumed = 0
+    now = _get_current_timestamp()
+    for policy in await list_sync_policies(assistant_id):
+        if policy.state == "paused_inactive":
+            await set_policy_state(assistant_id, policy.policy_id, "active", next_sync_at=now)
+            resumed += 1
+    return resumed
+
+
+async def change_policy_interval(assistant_id: str, policy_id: str, interval: SyncInterval) -> Optional[SyncPolicy]:
+    """Change a policy's cadence. Active policies get re-armed one new
+    interval out (and the due-index key moves with it); paused policies
+    just remember the new interval for when they resume."""
+    policy = await get_sync_policy(assistant_id, policy_id)
+    if policy is None:
+        return None
+
+    values = {":interval": interval, ":updated_at": _get_current_timestamp()}
+    set_parts = ["#interval = :interval", "updatedAt = :updated_at"]
+    if policy.state == "active":
+        next_sync_at = compute_next_sync_at(interval)
+        set_parts += ["nextSyncAt = :next", "GSI4_SK = :gsi4sk"]
+        values[":next"] = next_sync_at
+        values[":gsi4sk"] = _due_sort_key(next_sync_at, policy_id)
+
+    _get_table().update_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+        UpdateExpression="SET " + ", ".join(set_parts),
+        ExpressionAttributeNames={"#interval": "interval"},
+        ExpressionAttributeValues=values,
+    )
+    return await get_sync_policy(assistant_id, policy_id)
+
+
+RUN_NOW_COOLDOWN_SECONDS = 600
+
+
+class RunNowCooldown(Exception):
+    """Raised when a manual sync is requested within the cooldown window."""
+
+
+async def trigger_run_now(assistant_id: str, policy_id: str) -> SyncPolicy:
+    """Make a policy due immediately (manual "Sync now").
+
+    Flows through the normal dispatcher path so every guard still applies.
+    Only active policies can be manually run — paused states have their own
+    explicit resume affordances. A conditional write on lastManualRunAt
+    enforces the 10-minute cooldown atomically.
+    """
+    from botocore.exceptions import ClientError
+
+    policy = await get_sync_policy(assistant_id, policy_id)
+    if policy is None:
+        raise KeyError(policy_id)
+    if policy.state != "active":
+        raise ValueError(f"Cannot run-now a policy in state {policy.state}")
+
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat() + "Z"
+    cooldown_floor = (now_dt - timedelta(seconds=RUN_NOW_COOLDOWN_SECONDS)).isoformat() + "Z"
+    try:
+        _get_table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},
+            UpdateExpression="SET nextSyncAt = :now, GSI4_SK = :gsi4sk, lastManualRunAt = :now, updatedAt = :now",
+            ExpressionAttributeValues={
+                ":now": now,
+                ":gsi4sk": _due_sort_key(now, policy_id),
+                ":floor": cooldown_floor,
+            },
+            ConditionExpression="attribute_not_exists(lastManualRunAt) OR lastManualRunAt < :floor",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise RunNowCooldown(policy_id) from e
+        raise
+    return await get_sync_policy(assistant_id, policy_id)
+
+
 async def delete_sync_policy(assistant_id: str, policy_id: str) -> bool:
     _get_table().delete_item(Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"})
     logger.info(f"Deleted sync policy {policy_id} for assistant {assistant_id}")

--- a/backend/tests/apis/app_api/web_sources/test_crawl_repository.py
+++ b/backend/tests/apis/app_api/web_sources/test_crawl_repository.py
@@ -362,3 +362,49 @@ async def test_cascade_leaves_running_crawl_alone(ddb) -> None:
     await _cascade_delete_orphaned_crawl_jobs(ASSISTANT_ID)
 
     assert await crawl_repository.get_crawl_job(ASSISTANT_ID, crawl.crawl_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_restore_crawl_ttl_reapplies_expiry_to_sync_covered_job(ddb) -> None:
+    """Deleting a crawl's sync policy puts the job back on 30-day auto-expiry."""
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+    # Sync path: finalized with the ttl attribute removed
+    await crawl_repository.finalize_crawl(
+        assistant_id=ASSISTANT_ID, crawl_id=job.crawl_id, status="complete", set_ttl=False
+    )
+    item = ddb.get_item(Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"CRAWL#{job.crawl_id}"})["Item"]
+    assert "ttl" not in item
+
+    before = int(time.time())
+    await crawl_repository.restore_crawl_ttl(assistant_id=ASSISTANT_ID, crawl_id=job.crawl_id)
+
+    item = ddb.get_item(Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"CRAWL#{job.crawl_id}"})["Item"]
+    thirty_days = 30 * 86400
+    assert before + thirty_days - 5 <= int(item["ttl"]) <= int(time.time()) + thirty_days + 5
+
+
+@pytest.mark.asyncio
+async def test_restore_crawl_ttl_leaves_running_job_alone(ddb) -> None:
+    """finalize_crawl owns the running→terminal transition; restore must not race it."""
+    job = await crawl_repository.create_crawl_job(
+        assistant_id=ASSISTANT_ID,
+        root_url="https://example.com/",
+        settings=CrawlSettings(),
+        started_by_user_id=USER_ID,
+    )
+
+    await crawl_repository.restore_crawl_ttl(assistant_id=ASSISTANT_ID, crawl_id=job.crawl_id)
+
+    item = ddb.get_item(Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"CRAWL#{job.crawl_id}"})["Item"]
+    assert "ttl" not in item
+    assert item["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_restore_crawl_ttl_missing_job_is_noop(ddb) -> None:
+    await crawl_repository.restore_crawl_ttl(assistant_id=ASSISTANT_ID, crawl_id="crawl-gone")

--- a/backend/tests/lambdas/test_kb_sync_worker.py
+++ b/backend/tests/lambdas/test_kb_sync_worker.py
@@ -226,6 +226,13 @@ class TestFailureModes:
         assert "Reconnect" in updated.state_reason
         assert updated.consecutive_failures == 0  # reauth is not a failure streak
         assert updated.sync_run_started_at is None
+        # Marker lets consent completion find this policy without a scan
+        marker = assistants_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SYNCREAUTH#{policy.policy_id}"}
+        ).get("Item")
+        assert marker is not None
+        assert marker["providerId"] == CONNECTOR_ID
+        assert marker["assistantId"] == assistant_id
 
     async def test_requires_consent_pauses_reauth(self, assistants_table, staged, provider_ok, monkeypatch):
         async def no_token(provider, user_id):
@@ -241,6 +248,11 @@ class TestFailureModes:
         assert result["result"] == "paused_reauth"
         updated = await get_sync_policy(assistant_id, policy.policy_id)
         assert updated.state == "paused_reauth"
+        marker = assistants_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SYNCREAUTH#{policy.policy_id}"}
+        ).get("Item")
+        assert marker is not None
+        assert marker["providerId"] == CONNECTOR_ID
 
     async def test_missing_provider_pauses_error(self, assistants_table, staged, token_ok, monkeypatch):
         async def no_provider(self, provider_id):

--- a/backend/tests/routes/test_sync_policies.py
+++ b/backend/tests/routes/test_sync_policies.py
@@ -1,0 +1,450 @@
+"""Tests for sync-policy routes (KB sync — scheduled re-index).
+
+Endpoints under test (all edit-gated: owner or editor share):
+- POST   /assistants/{id}/sync-policies            → create (201; 404/400 source checks; 409 dup; 400 cap)
+- GET    /assistants/{id}/sync-policies            → list (200)
+- PATCH  /assistants/{id}/sync-policies/{pid}      → interval / pause / resume (409 for reauth pause)
+- DELETE /assistants/{id}/sync-policies/{pid}      → delete + source-specific cleanup (204)
+- POST   /assistants/{id}/sync-policies/{pid}/run-now → manual sync (202; 429 cooldown)
+
+The service layer is mocked — its DynamoDB semantics are covered by
+tests/shared/test_sync_policies.py. These tests pin the HTTP contract:
+status codes, permission gate, source validation, and cleanup fan-out.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.sync_policies.routes import router
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.sync_policies.models import SyncPolicy
+from apis.shared.sync_policies.service import (
+    DuplicateSyncPolicy,
+    RunNowCooldown,
+    SyncPolicyLimitExceeded,
+)
+from tests.routes.conftest import mock_no_auth
+
+ROUTES_MODULE = "apis.app_api.sync_policies.routes"
+ASSISTANT_ID = "ast-001"
+USER_ID = "user-001"
+POLICY_ID = "syn-abc123def456"
+NOW = "2026-07-03T00:00:00+00:00Z"
+
+
+def _make_policy(**overrides) -> SyncPolicy:
+    defaults = dict(
+        policyId=POLICY_ID,
+        assistantId=ASSISTANT_ID,
+        sourceType="drive_file",
+        sourceRef="doc-001",
+        interval="daily",
+        state="active",
+        nextSyncAt=NOW,
+        createdByUserId=USER_ID,
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    defaults.update(overrides)
+    return SyncPolicy.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    """Minimal FastAPI app mounting only the sync-policies router."""
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+def _override_user(app: FastAPI, user_id: str = USER_ID) -> None:
+    app.dependency_overrides[get_current_user_from_session] = lambda: User(
+        user_id=user_id, email=f"{user_id}@example.com", name="Test User", roles=["User"]
+    )
+
+
+def _resolve(permission):
+    """Build a resolve_assistant_permission return value."""
+    assistant = SimpleNamespace(owner_id=USER_ID) if permission else None
+    return AsyncMock(return_value=(assistant, permission))
+
+
+DRIVE_SOURCE = {"status": "complete", "sourceFileId": "drive-file-1"}
+CRAWL_SOURCE = {"status": "complete"}
+
+
+class TestPermissionGate:
+    """Every route shares the owner/editor gate — exercised through create."""
+
+    def test_unauthenticated_401(self, app):
+        mock_no_auth(app)
+        response = TestClient(app).get(f"/assistants/{ASSISTANT_ID}/sync-policies")
+        assert response.status_code == 401
+
+    def test_unknown_assistant_404(self, app):
+        _override_user(app)
+        with patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve(None)):
+            response = TestClient(app).get(f"/assistants/{ASSISTANT_ID}/sync-policies")
+        assert response.status_code == 404
+
+    def test_viewer_share_403(self, app):
+        _override_user(app)
+        with patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("viewer")):
+            response = TestClient(app).post(
+                f"/assistants/{ASSISTANT_ID}/sync-policies",
+                json={"sourceType": "drive_file", "sourceRef": "doc-001", "interval": "daily"},
+            )
+        assert response.status_code == 403
+
+    def test_editor_share_allowed(self, app):
+        _override_user(app, user_id="editor-user")
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("editor")),
+            patch(f"{ROUTES_MODULE}.list_sync_policies", AsyncMock(return_value=[])),
+        ):
+            response = TestClient(app).get(f"/assistants/{ASSISTANT_ID}/sync-policies")
+        assert response.status_code == 200
+
+
+class TestCreatePolicy:
+    def _post(self, app, source_type="drive_file", source_ref="doc-001", interval="daily"):
+        return TestClient(app).post(
+            f"/assistants/{ASSISTANT_ID}/sync-policies",
+            json={"sourceType": source_type, "sourceRef": source_ref, "interval": interval},
+        )
+
+    def test_create_drive_file_201_and_backpointer(self, app):
+        _override_user(app)
+        policy = _make_policy()
+        update_fields = MagicMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value=DRIVE_SOURCE),
+            patch(f"{ROUTES_MODULE}.create_sync_policy", AsyncMock(return_value=policy)) as create,
+            patch(f"{ROUTES_MODULE}.records.update_document_sync_fields", update_fields),
+        ):
+            response = self._post(app)
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["policyId"] == POLICY_ID
+        assert body["sourceType"] == "drive_file"
+        assert body["state"] == "active"
+        create.assert_awaited_once_with(
+            assistant_id=ASSISTANT_ID,
+            source_type="drive_file",
+            source_ref="doc-001",
+            interval="daily",
+            created_by_user_id=USER_ID,
+        )
+        update_fields.assert_called_once_with(ASSISTANT_ID, "doc-001", sync_policy_id=POLICY_ID)
+
+    def test_create_web_crawl_writes_no_document_backpointer(self, app):
+        _override_user(app)
+        policy = _make_policy(sourceType="web_crawl", sourceRef="crawl-001")
+        update_fields = MagicMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value=CRAWL_SOURCE),
+            patch(f"{ROUTES_MODULE}.create_sync_policy", AsyncMock(return_value=policy)),
+            patch(f"{ROUTES_MODULE}.records.update_document_sync_fields", update_fields),
+        ):
+            response = self._post(app, source_type="web_crawl", source_ref="crawl-001")
+
+        assert response.status_code == 201
+        update_fields.assert_not_called()
+
+    def test_missing_source_404(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value=None),
+        ):
+            response = self._post(app)
+        assert response.status_code == 404
+
+    def test_deleting_source_404(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value={"status": "deleting"}),
+        ):
+            response = self._post(app)
+        assert response.status_code == 404
+
+    def test_device_uploaded_document_400(self, app):
+        """No import provenance → nothing external to sync from."""
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value={"status": "complete"}),
+        ):
+            response = self._post(app)
+        assert response.status_code == 400
+
+    def test_duplicate_policy_409(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value=DRIVE_SOURCE),
+            patch(f"{ROUTES_MODULE}.create_sync_policy", AsyncMock(side_effect=DuplicateSyncPolicy("doc-001"))),
+        ):
+            response = self._post(app)
+        assert response.status_code == 409
+
+    def test_policy_cap_400(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.records.get_source_item", return_value=DRIVE_SOURCE),
+            patch(
+                f"{ROUTES_MODULE}.create_sync_policy",
+                AsyncMock(side_effect=SyncPolicyLimitExceeded("limit of 10 reached")),
+            ),
+        ):
+            response = self._post(app)
+        assert response.status_code == 400
+
+    def test_invalid_interval_422(self, app):
+        _override_user(app)
+        with patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")):
+            response = self._post(app, interval="hourly")
+        assert response.status_code == 422
+
+
+class TestListPolicies:
+    def test_list_200_camel_case(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(
+                f"{ROUTES_MODULE}.list_sync_policies",
+                AsyncMock(return_value=[_make_policy(), _make_policy(policyId="syn-2", sourceRef="doc-2")]),
+            ),
+        ):
+            response = TestClient(app).get(f"/assistants/{ASSISTANT_ID}/sync-policies")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [p["policyId"] for p in body["policies"]] == [POLICY_ID, "syn-2"]
+        assert body["policies"][0]["nextSyncAt"] == NOW
+
+
+class TestUpdatePolicy:
+    def _patch(self, app, body):
+        return TestClient(app).patch(f"/assistants/{ASSISTANT_ID}/sync-policies/{POLICY_ID}", json=body)
+
+    def test_interval_change(self, app):
+        _override_user(app)
+        changed = _make_policy(interval="weekly")
+        change = AsyncMock(return_value=changed)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=_make_policy())),
+            patch(f"{ROUTES_MODULE}.change_policy_interval", change),
+        ):
+            response = self._patch(app, {"interval": "weekly"})
+
+        assert response.status_code == 200
+        assert response.json()["interval"] == "weekly"
+        change.assert_awaited_once_with(ASSISTANT_ID, POLICY_ID, "weekly")
+
+    def test_same_interval_is_noop(self, app):
+        _override_user(app)
+        change = AsyncMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=_make_policy())),
+            patch(f"{ROUTES_MODULE}.change_policy_interval", change),
+        ):
+            response = self._patch(app, {"interval": "daily"})
+
+        assert response.status_code == 200
+        change.assert_not_awaited()
+
+    def test_pause(self, app):
+        _override_user(app)
+        set_state = AsyncMock(return_value=True)
+        paused = _make_policy(state="paused_user", stateReason="Paused by user")
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(side_effect=[_make_policy(), paused])),
+            patch(f"{ROUTES_MODULE}.set_policy_state", set_state),
+        ):
+            response = self._patch(app, {"state": "paused_user"})
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "paused_user"
+        set_state.assert_awaited_once_with(
+            ASSISTANT_ID, POLICY_ID, "paused_user", state_reason="Paused by user"
+        )
+
+    def test_resume_comes_due_immediately(self, app):
+        _override_user(app)
+        set_state = AsyncMock(return_value=True)
+        paused = _make_policy(state="paused_user")
+        resumed = _make_policy(state="active")
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(side_effect=[paused, resumed])),
+            patch(f"{ROUTES_MODULE}.set_policy_state", set_state),
+        ):
+            response = self._patch(app, {"state": "active"})
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "active"
+        # Resume re-arms due-now, not one interval out
+        args, kwargs = set_state.await_args
+        assert args == (ASSISTANT_ID, POLICY_ID, "active")
+        assert kwargs["next_sync_at"] is not None
+
+    def test_resume_of_reauth_pause_409(self, app):
+        """Only a fresh OAuth consent resumes a reauth pause."""
+        _override_user(app)
+        set_state = AsyncMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=_make_policy(state="paused_reauth"))),
+            patch(f"{ROUTES_MODULE}.set_policy_state", set_state),
+        ):
+            response = self._patch(app, {"state": "active"})
+
+        assert response.status_code == 409
+        set_state.assert_not_awaited()
+
+    def test_pause_of_reauth_pause_allowed(self, app):
+        """A user may still explicitly park a reauth-paused policy."""
+        _override_user(app)
+        set_state = AsyncMock(return_value=True)
+        reauth = _make_policy(state="paused_reauth")
+        parked = _make_policy(state="paused_user", stateReason="Paused by user")
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(side_effect=[reauth, parked])),
+            patch(f"{ROUTES_MODULE}.set_policy_state", set_state),
+        ):
+            response = self._patch(app, {"state": "paused_user"})
+
+        assert response.status_code == 200
+
+    def test_invalid_state_422(self, app):
+        """paused_reauth / paused_error / paused_inactive are system-owned."""
+        _override_user(app)
+        with patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")):
+            response = self._patch(app, {"state": "paused_reauth"})
+        assert response.status_code == 422
+
+    def test_missing_policy_404(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=None)),
+        ):
+            response = self._patch(app, {"interval": "weekly"})
+        assert response.status_code == 404
+
+
+class TestDeletePolicy:
+    def _delete(self, app):
+        return TestClient(app).delete(f"/assistants/{ASSISTANT_ID}/sync-policies/{POLICY_ID}")
+
+    def test_delete_drive_file_clears_backpointer(self, app):
+        _override_user(app)
+        delete_policy = AsyncMock(return_value=True)
+        delete_marker = AsyncMock()
+        clear_backpointer = MagicMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=_make_policy())),
+            patch(f"{ROUTES_MODULE}.delete_sync_policy", delete_policy),
+            patch(f"{ROUTES_MODULE}.delete_reauth_marker", delete_marker),
+            patch(f"{ROUTES_MODULE}.records.clear_document_sync_policy_id", clear_backpointer),
+        ):
+            response = self._delete(app)
+
+        assert response.status_code == 204
+        delete_policy.assert_awaited_once_with(ASSISTANT_ID, POLICY_ID)
+        delete_marker.assert_awaited_once_with(USER_ID, POLICY_ID)
+        clear_backpointer.assert_called_once_with(ASSISTANT_ID, "doc-001")
+
+    def test_delete_web_crawl_restores_job_ttl(self, app):
+        _override_user(app)
+        policy = _make_policy(sourceType="web_crawl", sourceRef="crawl-001")
+        restore_ttl = AsyncMock()
+        clear_backpointer = MagicMock()
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=policy)),
+            patch(f"{ROUTES_MODULE}.delete_sync_policy", AsyncMock(return_value=True)),
+            patch(f"{ROUTES_MODULE}.delete_reauth_marker", AsyncMock()),
+            patch("apis.app_api.web_sources.crawl_repository.restore_crawl_ttl", restore_ttl),
+            patch(f"{ROUTES_MODULE}.records.clear_document_sync_policy_id", clear_backpointer),
+        ):
+            response = self._delete(app)
+
+        assert response.status_code == 204
+        restore_ttl.assert_awaited_once_with(assistant_id=ASSISTANT_ID, crawl_id="crawl-001")
+        clear_backpointer.assert_not_called()
+
+    def test_missing_policy_404(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.get_sync_policy", AsyncMock(return_value=None)),
+        ):
+            response = self._delete(app)
+        assert response.status_code == 404
+
+
+class TestRunNow:
+    def _post(self, app):
+        return TestClient(app).post(f"/assistants/{ASSISTANT_ID}/sync-policies/{POLICY_ID}/run-now")
+
+    def test_run_now_202(self, app):
+        _override_user(app)
+        triggered = _make_policy(lastManualRunAt=NOW)
+        trigger = AsyncMock(return_value=triggered)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.trigger_run_now", trigger),
+        ):
+            response = self._post(app)
+
+        assert response.status_code == 202
+        assert response.json()["policyId"] == POLICY_ID
+        trigger.assert_awaited_once_with(ASSISTANT_ID, POLICY_ID)
+
+    def test_missing_policy_404(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.trigger_run_now", AsyncMock(side_effect=KeyError(POLICY_ID))),
+        ):
+            response = self._post(app)
+        assert response.status_code == 404
+
+    def test_paused_policy_409(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(
+                f"{ROUTES_MODULE}.trigger_run_now",
+                AsyncMock(side_effect=ValueError("Cannot run-now a policy in state paused_user")),
+            ),
+        ):
+            response = self._post(app)
+        assert response.status_code == 409
+
+    def test_cooldown_429(self, app):
+        _override_user(app)
+        with (
+            patch(f"{ROUTES_MODULE}.resolve_assistant_permission", _resolve("owner")),
+            patch(f"{ROUTES_MODULE}.trigger_run_now", AsyncMock(side_effect=RunNowCooldown(POLICY_ID))),
+        ):
+            response = self._post(app)
+        assert response.status_code == 429

--- a/backend/tests/shared/test_assistants_extended.py
+++ b/backend/tests/shared/test_assistants_extended.py
@@ -125,3 +125,66 @@ class TestRAGServiceExtended:
         ]
         result = augment_prompt_with_context("Q?", chunks, max_context_length=80)
         assert "[Context 1]" in result
+
+
+class TestBumpLastUsedAt:
+    """KB-sync inactivity signal: throttled conditional write on METADATA."""
+
+    @pytest.fixture(autouse=True)
+    def _set_env(self, assistants_table, monkeypatch):
+        monkeypatch.setenv("S3_ASSISTANTS_VECTOR_STORE_INDEX_NAME", "test-index")
+        self.table = assistants_table
+
+    async def _create(self):
+        from apis.shared.assistants.service import create_assistant
+        return await create_assistant(
+            owner_id="u1", owner_name="Alice", name="Bot",
+            description="d", instructions="hi",
+        )
+
+    @pytest.mark.asyncio
+    async def test_first_bump_wins_and_stamps(self):
+        from apis.shared.assistants.service import bump_last_used_at
+        assistant = await self._create()
+
+        assert await bump_last_used_at(assistant.assistant_id) is True
+
+        item = self.table.get_item(
+            Key={"PK": f"AST#{assistant.assistant_id}", "SK": "METADATA"}
+        )["Item"]
+        assert "lastUsedAt" in item
+
+    @pytest.mark.asyncio
+    async def test_second_bump_within_throttle_loses(self):
+        from apis.shared.assistants.service import bump_last_used_at
+        assistant = await self._create()
+        assert await bump_last_used_at(assistant.assistant_id) is True
+
+        # Fresh stamp: concurrent chat turns must not stampede the row —
+        # only the caller that advances a stale timestamp gets True.
+        assert await bump_last_used_at(assistant.assistant_id) is False
+
+    @pytest.mark.asyncio
+    async def test_stale_stamp_bumps_again(self):
+        from apis.shared.assistants.service import bump_last_used_at
+        assistant = await self._create()
+        self.table.update_item(
+            Key={"PK": f"AST#{assistant.assistant_id}", "SK": "METADATA"},
+            UpdateExpression="SET lastUsedAt = :old",
+            ExpressionAttributeValues={":old": "2000-01-01T00:00:00+00:00Z"},
+        )
+
+        assert await bump_last_used_at(assistant.assistant_id) is True
+
+    @pytest.mark.asyncio
+    async def test_missing_assistant_returns_false(self):
+        from apis.shared.assistants.service import bump_last_used_at
+        # attribute_exists(PK) guard: a bump must never create a phantom row
+        assert await bump_last_used_at("ast-missing") is False
+        assert "Item" not in self.table.get_item(Key={"PK": "AST#ast-missing", "SK": "METADATA"})
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_table_returns_false(self, monkeypatch):
+        from apis.shared.assistants.service import bump_last_used_at
+        monkeypatch.delenv("DYNAMODB_ASSISTANTS_TABLE_NAME", raising=False)
+        assert await bump_last_used_at("ast-any") is False

--- a/backend/tests/shared/test_sync_policies.py
+++ b/backend/tests/shared/test_sync_policies.py
@@ -13,16 +13,23 @@ import pytest
 from apis.shared.sync_policies.models import DUE_INDEX_PK
 from apis.shared.sync_policies.service import (
     DuplicateSyncPolicy,
+    RunNowCooldown,
     SyncPolicyLimitExceeded,
+    change_policy_interval,
     create_sync_policy,
+    delete_reauth_marker,
     delete_sync_policies_for_assistant,
     delete_sync_policies_for_source,
     get_sync_policy,
     list_due_policies,
     list_sync_policies,
+    put_reauth_marker,
     rearm_policy,
     record_sync_result,
+    resume_inactive_policies,
+    resume_reauth_policies,
     set_policy_state,
+    trigger_run_now,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -218,3 +225,150 @@ class TestDeleteCascades:
         assert deleted == 2
         assert await list_sync_policies(ASSISTANT_ID) == []
         assert await list_due_policies() == []
+
+
+class TestIntervalChange:
+    async def test_active_policy_rearms_and_moves_due_key(self, assistants_table):
+        policy = await _make_policy(interval="daily")
+        old_next = policy.next_sync_at
+
+        updated = await change_policy_interval(ASSISTANT_ID, policy.policy_id, "monthly")
+
+        assert updated.interval == "monthly"
+        assert updated.next_sync_at > old_next  # one *new* interval out
+        item = assistants_table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"}
+        )["Item"]
+        assert item["GSI4_SK"] == f"{updated.next_sync_at}#{policy.policy_id}"
+
+    async def test_paused_policy_remembers_interval_without_due_keys(self, assistants_table):
+        policy = await _make_policy(interval="daily")
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "paused_user")
+
+        updated = await change_policy_interval(ASSISTANT_ID, policy.policy_id, "weekly")
+
+        assert updated.interval == "weekly"
+        assert updated.state == "paused_user"
+        item = assistants_table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"}
+        )["Item"]
+        assert "GSI4_SK" not in item  # still invisible to the dispatcher
+
+    async def test_missing_policy_returns_none(self, assistants_table):
+        assert await change_policy_interval(ASSISTANT_ID, "syn-missing", "weekly") is None
+
+
+class TestRunNow:
+    async def test_makes_policy_due_immediately(self, assistants_table):
+        policy = await _make_policy(interval="daily")
+        assert await list_due_policies() == []  # created one interval out
+
+        updated = await trigger_run_now(ASSISTANT_ID, policy.policy_id)
+
+        assert updated.last_manual_run_at is not None
+        assert updated.next_sync_at == updated.last_manual_run_at
+        due = await list_due_policies()
+        assert [p.policy_id for p in due] == [policy.policy_id]
+
+    async def test_second_trigger_within_cooldown_rejected(self, assistants_table):
+        policy = await _make_policy()
+        await trigger_run_now(ASSISTANT_ID, policy.policy_id)
+
+        with pytest.raises(RunNowCooldown):
+            await trigger_run_now(ASSISTANT_ID, policy.policy_id)
+
+    async def test_trigger_allowed_after_cooldown_expires(self, assistants_table):
+        policy = await _make_policy()
+        # Simulate an old manual run: stamp beyond the cooldown window.
+        assistants_table.update_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"SYNCPOL#{policy.policy_id}"},
+            UpdateExpression="SET lastManualRunAt = :old",
+            ExpressionAttributeValues={":old": PAST},
+        )
+
+        updated = await trigger_run_now(ASSISTANT_ID, policy.policy_id)
+
+        assert updated.last_manual_run_at > PAST
+
+    async def test_paused_policy_rejected(self, assistants_table):
+        policy = await _make_policy()
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "paused_user")
+
+        with pytest.raises(ValueError):
+            await trigger_run_now(ASSISTANT_ID, policy.policy_id)
+
+    async def test_missing_policy_raises_key_error(self, assistants_table):
+        with pytest.raises(KeyError):
+            await trigger_run_now(ASSISTANT_ID, "syn-missing")
+
+
+class TestReauthMarkers:
+    async def test_fresh_consent_resumes_matching_provider_due_now(self, assistants_table):
+        policy = await _make_policy()
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "paused_reauth", state_reason="Reconnect")
+        await put_reauth_marker(USER_ID, ASSISTANT_ID, policy.policy_id, "google-workspace")
+
+        resumed = await resume_reauth_policies(USER_ID, "google-workspace")
+
+        assert resumed == 1
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.state == "active"
+        assert [p.policy_id for p in await list_due_policies()] == [policy.policy_id]
+        # Marker consumed
+        marker = assistants_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SYNCREAUTH#{policy.policy_id}"}
+        ).get("Item")
+        assert marker is None
+
+    async def test_other_providers_markers_left_alone(self, assistants_table):
+        policy = await _make_policy()
+        await set_policy_state(ASSISTANT_ID, policy.policy_id, "paused_reauth")
+        await put_reauth_marker(USER_ID, ASSISTANT_ID, policy.policy_id, "microsoft-365")
+
+        resumed = await resume_reauth_policies(USER_ID, "google-workspace")
+
+        assert resumed == 0
+        updated = await get_sync_policy(ASSISTANT_ID, policy.policy_id)
+        assert updated.state == "paused_reauth"
+        marker = assistants_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SYNCREAUTH#{policy.policy_id}"}
+        ).get("Item")
+        assert marker is not None  # still waiting on its own provider
+
+    async def test_stale_marker_cleaned_without_resuming(self, assistants_table):
+        # Marker outlived its policy's pause (user resumed another way, or
+        # the policy was deleted): resume must re-verify, not trust it.
+        active = await _make_policy(source_ref="doc-active")
+        await put_reauth_marker(USER_ID, ASSISTANT_ID, active.policy_id, "google-workspace")
+        await put_reauth_marker(USER_ID, ASSISTANT_ID, "syn-deleted", "google-workspace")
+
+        resumed = await resume_reauth_policies(USER_ID, "google-workspace")
+
+        assert resumed == 0
+        for policy_id in (active.policy_id, "syn-deleted"):
+            marker = assistants_table.get_item(
+                Key={"PK": f"USER#{USER_ID}", "SK": f"SYNCREAUTH#{policy_id}"}
+            ).get("Item")
+            assert marker is None
+
+    async def test_delete_marker_is_idempotent(self, assistants_table):
+        await delete_reauth_marker(USER_ID, "syn-never-existed")  # no raise
+
+
+class TestResumeInactive:
+    async def test_resumes_only_inactivity_pauses(self, assistants_table):
+        dormant = await _make_policy(source_ref="doc-dormant")
+        user_paused = await _make_policy(source_ref="doc-user")
+        await set_policy_state(ASSISTANT_ID, dormant.policy_id, "paused_inactive")
+        await set_policy_state(ASSISTANT_ID, user_paused.policy_id, "paused_user")
+
+        resumed = await resume_inactive_policies(ASSISTANT_ID)
+
+        assert resumed == 1
+        assert (await get_sync_policy(ASSISTANT_ID, dormant.policy_id)).state == "active"
+        assert (await get_sync_policy(ASSISTANT_ID, user_paused.policy_id)).state == "paused_user"
+        assert [p.policy_id for p in await list_due_policies()] == [dormant.policy_id]
+
+    async def test_no_inactive_policies_is_noop(self, assistants_table):
+        await _make_policy()
+        assert await resume_inactive_policies(ASSISTANT_ID) == 0


### PR DESCRIPTION
## Summary

PR-5 of the assistant KB sync series (spec: `docs/specs/assistant-kb-sync.md`; follows #542–#545). Adds the user-facing API surface and the two resume hooks, completing the backend. PR-6 (SPA) remains.

### New API — `/assistants/{id}/sync-policies` (edit-gated: owner or editor share)

| Route | Behavior |
|---|---|
| `POST` | Create policy on an existing source. 404 missing/deleting source, 400 device-uploaded doc (no import provenance), 409 duplicate, 400 per-assistant cap. drive_file docs get a `syncPolicyId` back-pointer. |
| `GET` | List the assistant's policies. |
| `PATCH {pid}` | Change interval (active policies re-arm one *new* interval out) and/or pause/resume. Resume comes due immediately. Resume of `paused_reauth` → 409: only a fresh consent can fix credentials. |
| `DELETE {pid}` | Delete + cleanup fan-out: reauth marker removed; web_crawl jobs go back on 30-day TTL (`restore_crawl_ttl`, running jobs untouched); drive_file back-pointer cleared. |
| `POST {pid}/run-now` | 202; makes the policy due now via the normal dispatcher path (every guard applies). Atomic 10-minute cooldown via conditional write on `lastManualRunAt` (429). Active policies only (409). |

### Resume hooks

- **Reauth (§7.6):** when the worker pauses for re-consent it writes a `USER#{id}/SYNCREAUTH#{policy}` marker carrying the provider. `complete_consent()` resumes exactly the matching policies with one query — no table scan. Markers are advisory: resume re-verifies `paused_reauth`, stale markers self-clean. Best-effort; never fails consent.
- **Inactivity (§7.3):** chat use of an assistant bumps `lastUsedAt`, throttled to one conditional write per day (concurrent turns can't stampede; single winner). The winning bump wakes any `paused_inactive` policies due-immediately. Best-effort; never breaks a chat turn. Lives in inference-api's existing chat path but only touches `apis.shared` — boundary-clean.

## Testing

- 40 new tests: service layer (moto — interval change, run-now cooldown, marker lifecycle, inactive resume, `bump_last_used_at` semantics, `restore_crawl_ttl` conditions), worker marker writes, and a full HTTP-contract suite for the router (auth gate, source validation, cleanup fan-out).
- Full backend suite: **4191 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)