### PR TITLE
feat(kb-sync): SPA sync-policy controls on assistant knowledge page (PR-6, final)

### DIFF
--- a/backend/src/apis/app_api/documents/models.py
+++ b/backend/src/apis/app_api/documents/models.py
@@ -104,6 +104,14 @@ class DocumentResponse(BaseModel):
     chunk_count: Optional[int] = Field(None, alias="chunkCount", description="Number of chunks")
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 creation timestamp")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 update timestamp")
+    # Provenance-lite for the SPA: which documents were imported from an
+    # external source (and can therefore carry a sync policy) vs uploaded
+    # from the device. Null for device uploads.
+    source_connector_id: Optional[str] = Field(None, alias="sourceConnectorId", description="OAuth connector the file was imported from")
+    source_adapter_key: Optional[str] = Field(None, alias="sourceAdapterKey", description="File-source adapter that fetched the file")
+    source_file_id: Optional[str] = Field(None, alias="sourceFileId", description="Provider-side opaque file identifier")
+    sync_policy_id: Optional[str] = Field(None, alias="syncPolicyId", description="Back-pointer to the covering SyncPolicy")
+    last_synced_at: Optional[str] = Field(None, alias="lastSyncedAt", description="ISO 8601 timestamp of last successful sync run")
 
 
 class DocumentsListResponse(BaseModel):

--- a/backend/src/apis/app_api/web_sources/routes.py
+++ b/backend/src/apis/app_api/web_sources/routes.py
@@ -33,6 +33,7 @@ from apis.app_api.web_sources.crawl_repository import (
     create_crawl_job,
     get_crawl_job,
     list_active_crawls,
+    list_all_crawls,
 )
 from apis.app_api.web_sources.crawler import run_crawl
 from apis.app_api.web_sources.models import (
@@ -172,10 +173,9 @@ async def list_crawls(
     if active:
         crawls = await list_active_crawls(assistant_id)
     else:
-        # The full-history view is reserved for a future "crawl history"
-        # panel; for now we return active only when asked and an empty list
-        # otherwise to keep the contract small.
-        crawls = await list_active_crawls(assistant_id)
+        # Full history: the sync-policy UI needs completed crawls too — a
+        # web_crawl policy's source is the terminal CrawlJob row.
+        crawls = await list_all_crawls(assistant_id)
     return ActiveCrawlsResponse(crawls=crawls)
 
 

--- a/backend/tests/apis/app_api/web_sources/test_routes.py
+++ b/backend/tests/apis/app_api/web_sources/test_routes.py
@@ -193,6 +193,27 @@ class TestListActiveCrawls:
         assert len(body["crawls"]) == 1
         assert body["crawls"][0]["crawlId"] == "CRAWL-1"
 
+    def test_returns_all_jobs_without_active_filter(self, app: FastAPI):
+        """Default (no ?active=true) is full history — the sync-policy UI
+        lists completed crawls as syncable sources."""
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        with patch(
+            "apis.app_api.web_sources.routes.get_assistant",
+            new_callable=AsyncMock,
+            return_value={"assistantId": ASSISTANT_ID},
+        ), patch(
+            "apis.app_api.web_sources.routes.list_all_crawls",
+            new_callable=AsyncMock,
+            return_value=[crawl],
+        ) as mock_all:
+            client = TestClient(app)
+            resp = client.get(f"/assistants/{ASSISTANT_ID}/web-sources/crawls")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["crawls"]) == 1
+        mock_all.assert_awaited_once_with(ASSISTANT_ID)
+
 
 class TestGetCrawl:
     def test_returns_single_crawl(self, app: FastAPI):

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -415,6 +415,51 @@
               </div>
             }
 
+            <!-- Web sources (crawl roots). Sync policies attach to the
+                 crawl, not to the individual page documents it produced.
+                 Rendered for owners/editors only — the entire sync surface
+                 is edit-gated, and this list exists to host its controls. -->
+            @if (canManageSync() && webCrawls().length > 0) {
+              <div>
+                <h3 class="mb-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Web sources</h3>
+                <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+                  @for (crawl of webCrawls(); track crawl.crawlId) {
+                    <li class="flex items-start gap-3 px-3 py-2.5 sm:px-4">
+                      <ng-icon name="heroGlobeAlt" class="mt-0.5 size-5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                      <div class="min-w-0 flex-1">
+                        <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">{{ crawl.rootUrl }}</p>
+                        <div class="mt-0.5 flex items-center gap-2">
+                          <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ crawl.fetchedCount }} page{{ crawl.fetchedCount === 1 ? '' : 's' }}</span>
+                          @if (crawl.status === 'running') {
+                            <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
+                            <span class="inline-flex items-center gap-1.5 text-xs/5 font-medium text-blue-600 dark:text-blue-400">
+                              <span class="size-1.5 animate-pulse rounded-full bg-blue-500"></span>
+                              Crawling…
+                            </span>
+                          } @else if (crawl.status === 'failed') {
+                            <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
+                            <span class="text-xs/5 font-medium text-red-600 dark:text-red-400">Crawl failed</span>
+                          }
+                        </div>
+                        @if (isCrawlSyncable(crawl)) {
+                          <app-sync-policy-control
+                            class="mt-1.5 block"
+                            [policy]="syncPolicyFor(crawl.crawlId)"
+                            [busy]="isSyncBusy(crawl.crawlId)"
+                            [sourceName]="crawl.rootUrl"
+                            (intervalSelected)="onSyncIntervalSelected('web_crawl', crawl.crawlId, $event)"
+                            (runNow)="onSyncRunNow(crawl.crawlId)"
+                            (pause)="onSyncPause(crawl.crawlId)"
+                            (resume)="onSyncResume(crawl.crawlId)"
+                          />
+                        }
+                      </div>
+                    </li>
+                  }
+                </ul>
+              </div>
+            }
+
             <!-- Uploaded Documents List -->
             @if (isLoadingDocuments()) {
               <div>
@@ -473,6 +518,23 @@
                           </div>
                           @if (doc.status === 'failed' && doc.errorMessage) {
                             <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">{{ doc.errorMessage }}</p>
+                          }
+                          <!-- "Keep in sync" — only for documents imported from
+                               an external connector (device uploads have no
+                               source of truth to refetch), owners/editors only. -->
+                          @if (canManageSync() && isDriveSyncable(doc)) {
+                            <app-sync-policy-control
+                              class="mt-1.5 block"
+                              [policy]="syncPolicyFor(doc.documentId)"
+                              [busy]="isSyncBusy(doc.documentId)"
+                              [sourceName]="doc.filename"
+                              [reconnectLabel]="reconnectLabelForDocument(doc)"
+                              (intervalSelected)="onSyncIntervalSelected('drive_file', doc.documentId, $event)"
+                              (runNow)="onSyncRunNow(doc.documentId)"
+                              (pause)="onSyncPause(doc.documentId)"
+                              (resume)="onSyncResume(doc.documentId)"
+                              (reconnect)="onSyncReconnect(doc.documentId)"
+                            />
                           }
                         </div>
                       </div>

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
@@ -56,7 +56,14 @@ import {
 } from '../components/web-source-dialog.component';
 import { FileSourceService } from '../services/file-source.service';
 import { WebSourceService } from '../services/web-source.service';
+import { SyncPolicyService } from '../services/sync-policy.service';
 import { FileSourceConnector } from '../models/file-source.model';
+import { CrawlJob } from '../models/web-source.model';
+import { SyncPolicy, SyncSourceType } from '../models/sync-policy.model';
+import {
+  SyncPolicyControlComponent,
+  SyncIntervalSelection,
+} from '../components/sync-policy-control.component';
 import { UserConnectorsService } from '../../settings/connectors/services/user-connectors.service';
 import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
 import { ToastService } from '../../services/toast/toast.service';
@@ -74,6 +81,7 @@ import { ToastService } from '../../services/toast/toast.service';
     PickerComponent,
     CdkOverlayOrigin,
     CdkConnectedOverlay,
+    SyncPolicyControlComponent,
   ],
   providers: [
     provideIcons({
@@ -100,6 +108,7 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   private documentService = inject(DocumentService);
   private fileSourceService = inject(FileSourceService);
   private webSourceService = inject(WebSourceService);
+  private syncPolicyService = inject(SyncPolicyService);
   private readonly connectorsService = inject(UserConnectorsService);
   private readonly consentService = inject(OAuthConsentService);
   readonly sidenavService = inject(SidenavService);
@@ -166,6 +175,40 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   readonly webCrawlActive = signal<boolean>(false);
   private crawlWatcherHandle: ReturnType<typeof setInterval> | null = null;
 
+  // ── KB sync policies ────────────────────────────────────────────────────
+
+  /** Sync policies covering this assistant's sources. Loaded for owners/editors only. */
+  readonly syncPolicies = signal<SyncPolicy[]>([]);
+  /** All crawl jobs (any status) — completed crawls are the syncable web sources. */
+  readonly webCrawls = signal<CrawlJob[]>([]);
+  /** Source refs (document/crawl ids) with a sync mutation in flight. */
+  readonly syncBusySourceRefs = signal<Set<string>>(new Set());
+  /** Provider whose consent popup was opened from a "Reconnect" affordance. */
+  readonly reconnectingProviderId = signal<string | null>(null);
+
+  /**
+   * Sync controls are owner/editor-only: the backend edit-gates the whole
+   * sync-policy surface, so viewers never see the controls (and we never
+   * issue the list call that would 403 for them).
+   */
+  readonly canManageSync = computed(
+    () => this.mode() === 'edit' && this.userPermission() !== 'viewer',
+  );
+
+  private readonly policiesBySourceRef = computed(
+    () => new Map(this.syncPolicies().map((p) => [p.sourceRef, p])),
+  );
+
+  /**
+   * Crawls that can carry a sync policy. A `running` crawl is excluded —
+   * its page set is still forming — but it still renders in the web-sources
+   * list with a progress note.
+   */
+  readonly syncableCrawlStatuses: ReadonlySet<CrawlJob['status']> = new Set([
+    'complete',
+    'failed',
+  ]);
+
   /**
    * True once at least one document exists, is uploading, or is still
    * loading. Drives swapping the full drop zone for a compact "Add files"
@@ -211,6 +254,20 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       if (!completion || !completion.providerId) {
         return;
       }
+      // A consent kicked off from a sync-control "Reconnect" affordance:
+      // a fresh consent auto-resumes paused_reauth policies server-side,
+      // so all that's left here is to refetch and confirm.
+      if (completion.providerId === this.reconnectingProviderId()) {
+        this.consentService.acknowledgeCompletion();
+        this.finishReconnect();
+        if (completion.status === 'success') {
+          this.toast.success('Reconnected — sync will resume automatically.');
+          void this.loadSyncData();
+        } else {
+          this.toast.error(completion.error ?? 'Could not reconnect the content source.');
+        }
+        return;
+      }
       const connecting = this.connectingProviderId();
       if (completion.providerId !== connecting) {
         return;
@@ -233,6 +290,10 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       if (connecting && this.connectPhase() === 'awaiting' && !inFlight.has(connecting)) {
         this.connectingProviderId.set(null);
         this.connectPhase.set(null);
+      }
+      const reconnecting = this.reconnectingProviderId();
+      if (reconnecting && this.reconnectAwaiting && !inFlight.has(reconnecting)) {
+        this.finishReconnect();
       }
     });
   }
@@ -258,9 +319,11 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       status: ['DRAFT'],
     });
 
-    // If editing, load the assistant data and documents
+    // If editing, load the assistant data and documents. Sync data waits on
+    // loadAssistant because it needs the resolved userPermission — the
+    // sync-policy surface is edit-gated and viewers must not trigger a 403.
     if (id) {
-      this.loadAssistant(id);
+      void this.loadAssistant(id).then(() => this.loadSyncData());
       this.loadDocuments();
     }
 
@@ -644,6 +707,9 @@ export class AssistantFormPage implements OnInit, OnDestroy {
       this.toast.success('Crawling web content…');
       await this.loadDocuments();
       this.startCrawlWatcher();
+      // Surface the new crawl in the web-sources list right away (it shows
+      // as running until the watcher sees it finish).
+      void this.loadSyncData();
     }
   }
 
@@ -673,6 +739,9 @@ export class AssistantFormPage implements OnInit, OnDestroy {
           // tick and the server reporting "no crawls running" — still
           // incremental, so no list-wide refresh.
           await this.discoverNewDocuments();
+          // The crawl just went terminal — refresh the web-sources list so
+          // its row flips from "Crawling…" to a syncable source.
+          void this.loadSyncData();
           return;
         }
         await this.discoverNewDocuments();
@@ -891,12 +960,261 @@ export class AssistantFormPage implements OnInit, OnDestroy {
 
     try {
       await this.documentService.deleteDocument(assistantId, documentId);
+      // The backend cascades sync policies with their source — mirror that
+      // locally so a covering policy's control disappears with the row.
+      const covering = this.syncPolicyFor(documentId);
+      if (covering) {
+        this.removePolicy(covering.policyId);
+      }
     } catch (error) {
       this.uploadedDocuments.set(previousDocs);
       const message =
         error instanceof Error ? error.message : 'Failed to delete document.';
       this.toast.error(message);
     }
+  }
+
+  // ── KB sync policy actions ──────────────────────────────────────────────
+
+  /** True while the reconnect consent popup is open (guards the abort effect). */
+  private reconnectAwaiting = false;
+  /** Source ref whose row is busy because of an in-flight reconnect. */
+  private reconnectSourceRef: string | null = null;
+
+  /**
+   * Load sync policies + the crawl catalog for owners/editors. Best-effort:
+   * the sync surface is secondary to the document editor, so a failure logs
+   * and leaves the controls at their previous state instead of blocking.
+   */
+  private async loadSyncData(): Promise<void> {
+    const assistantId = this.assistantId();
+    if (!assistantId || !this.canManageSync()) {
+      return;
+    }
+    const [policies, crawls] = await Promise.allSettled([
+      this.syncPolicyService.listPolicies(assistantId),
+      this.webSourceService.listCrawls(assistantId),
+    ]);
+    if (policies.status === 'fulfilled') {
+      this.syncPolicies.set(policies.value);
+    } else {
+      console.error('Error loading sync policies:', policies.reason);
+    }
+    if (crawls.status === 'fulfilled') {
+      this.webCrawls.set(crawls.value);
+    } else {
+      console.error('Error loading web sources:', crawls.reason);
+    }
+  }
+
+  syncPolicyFor(sourceRef: string): SyncPolicy | null {
+    return this.policiesBySourceRef().get(sourceRef) ?? null;
+  }
+
+  isSyncBusy(sourceRef: string): boolean {
+    return this.syncBusySourceRefs().has(sourceRef);
+  }
+
+  /**
+   * A document is a syncable Drive-import source when it carries import
+   * provenance from a real connector. Web pages carry the sentinel
+   * connector id 'web' — those sync at the crawl level, not per page.
+   */
+  isDriveSyncable(doc: Document): boolean {
+    return !!doc.sourceFileId && !!doc.sourceConnectorId && doc.sourceConnectorId !== 'web';
+  }
+
+  isCrawlSyncable(crawl: CrawlJob): boolean {
+    return this.syncableCrawlStatuses.has(crawl.status);
+  }
+
+  /** Provider display name for a document's reconnect affordance. */
+  reconnectLabelForDocument(doc: Document): string {
+    const provider = this.fileSources().find((s) => s.providerId === doc.sourceConnectorId);
+    return provider?.displayName ?? '';
+  }
+
+  async onSyncIntervalSelected(
+    sourceType: SyncSourceType,
+    sourceRef: string,
+    selection: SyncIntervalSelection,
+  ): Promise<void> {
+    const assistantId = this.assistantId();
+    if (!assistantId) {
+      return;
+    }
+    const existing = this.syncPolicyFor(sourceRef);
+    this.setSyncBusy(sourceRef, true);
+    try {
+      if (selection === 'manual') {
+        if (existing) {
+          await this.syncPolicyService.deletePolicy(assistantId, existing.policyId);
+          this.removePolicy(existing.policyId);
+        }
+      } else if (existing) {
+        this.upsertPolicy(
+          await this.syncPolicyService.updatePolicy(assistantId, existing.policyId, {
+            interval: selection,
+          }),
+        );
+      } else {
+        this.upsertPolicy(
+          await this.syncPolicyService.createPolicy(assistantId, {
+            sourceType,
+            sourceRef,
+            interval: selection,
+          }),
+        );
+      }
+    } catch (error) {
+      this.toastSyncError(error, 'Could not update sync settings.');
+      // A duplicate/not-found conflict means our local view is stale — converge.
+      void this.loadSyncData();
+    } finally {
+      this.setSyncBusy(sourceRef, false);
+    }
+  }
+
+  async onSyncPause(sourceRef: string): Promise<void> {
+    await this.patchSyncState(sourceRef, 'paused_user');
+  }
+
+  async onSyncResume(sourceRef: string): Promise<void> {
+    await this.patchSyncState(sourceRef, 'active');
+  }
+
+  private async patchSyncState(
+    sourceRef: string,
+    state: 'active' | 'paused_user',
+  ): Promise<void> {
+    const assistantId = this.assistantId();
+    const existing = this.syncPolicyFor(sourceRef);
+    if (!assistantId || !existing) {
+      return;
+    }
+    this.setSyncBusy(sourceRef, true);
+    try {
+      this.upsertPolicy(
+        await this.syncPolicyService.updatePolicy(assistantId, existing.policyId, { state }),
+      );
+    } catch (error) {
+      this.toastSyncError(
+        error,
+        state === 'active' ? 'Could not resume sync.' : 'Could not pause sync.',
+      );
+      void this.loadSyncData();
+    } finally {
+      this.setSyncBusy(sourceRef, false);
+    }
+  }
+
+  async onSyncRunNow(sourceRef: string): Promise<void> {
+    const assistantId = this.assistantId();
+    const existing = this.syncPolicyFor(sourceRef);
+    if (!assistantId || !existing) {
+      return;
+    }
+    this.setSyncBusy(sourceRef, true);
+    try {
+      this.upsertPolicy(await this.syncPolicyService.runNow(assistantId, existing.policyId));
+      this.toast.success('Sync requested — it will run within about 15 minutes.');
+    } catch (error) {
+      // 429 (cooldown) and 409 (not active) both carry a user-appropriate
+      // detail message from the server — surface it as-is.
+      this.toastSyncError(error, 'Could not request a sync.');
+    } finally {
+      this.setSyncBusy(sourceRef, false);
+    }
+  }
+
+  /**
+   * "Reconnect <provider>" for a paused_reauth policy. Runs the same OAuth
+   * consent popup as the connector buttons; the backend's consent-complete
+   * hook flips the paused policies back to active, so on success we only
+   * refetch. Reconnect is a Drive-source affair — web crawls fetch
+   * anonymously and can never enter paused_reauth.
+   */
+  async onSyncReconnect(sourceRef: string): Promise<void> {
+    const doc = this.uploadedDocuments().find((d) => d.documentId === sourceRef);
+    const providerId = doc?.sourceConnectorId;
+    if (!providerId || providerId === 'web') {
+      this.toast.error('This source cannot be reconnected from here.');
+      return;
+    }
+    this.reconnectingProviderId.set(providerId);
+    this.reconnectSourceRef = sourceRef;
+    this.setSyncBusy(sourceRef, true);
+    try {
+      const result = await this.connectorsService.initiateConsent(providerId);
+      if (result.connected) {
+        // The vault thinks the token is fine (provider-side revocations are
+        // invisible to it) — no consent popup will open, so the resume hook
+        // won't fire. Refetch and tell the user what actually happened.
+        this.finishReconnect();
+        await this.loadSyncData();
+        if (this.syncPolicyFor(sourceRef)?.state === 'paused_reauth') {
+          this.toast.error(
+            'The connection still needs to be re-authorized. Disconnect and reconnect it under Settings → Connectors, then sync will resume.',
+          );
+        } else {
+          this.toast.success('Reconnected — sync will resume automatically.');
+        }
+        return;
+      }
+      if (!result.authorizationUrl) {
+        this.finishReconnect();
+        this.toast.error('Unexpected response from the server.');
+        return;
+      }
+      this.consentService.requestConsent(providerId, result.authorizationUrl);
+      void this.consentService.openConsentPopup(providerId);
+      this.reconnectAwaiting = true;
+    } catch (error) {
+      this.finishReconnect();
+      const message =
+        error instanceof Error ? error.message : 'Could not start the reconnect flow.';
+      this.toast.error(message);
+    }
+  }
+
+  /** Reset all reconnect bookkeeping (success, failure, or aborted popup). */
+  private finishReconnect(): void {
+    this.reconnectingProviderId.set(null);
+    this.reconnectAwaiting = false;
+    if (this.reconnectSourceRef) {
+      this.setSyncBusy(this.reconnectSourceRef, false);
+      this.reconnectSourceRef = null;
+    }
+  }
+
+  private setSyncBusy(sourceRef: string, busy: boolean): void {
+    this.syncBusySourceRefs.update((set) => {
+      const next = new Set(set);
+      if (busy) {
+        next.add(sourceRef);
+      } else {
+        next.delete(sourceRef);
+      }
+      return next;
+    });
+  }
+
+  private upsertPolicy(policy: SyncPolicy): void {
+    this.syncPolicies.update((list) => {
+      const exists = list.some((p) => p.policyId === policy.policyId);
+      return exists
+        ? list.map((p) => (p.policyId === policy.policyId ? policy : p))
+        : [...list, policy];
+    });
+  }
+
+  private removePolicy(policyId: string): void {
+    this.syncPolicies.update((list) => list.filter((p) => p.policyId !== policyId));
+  }
+
+  private toastSyncError(error: unknown, fallback: string): void {
+    const message = error instanceof Error && error.message ? error.message : fallback;
+    this.toast.error(message);
   }
 
   async startPollingDocument(documentId: string, assistantId: string): Promise<void> {

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SyncPolicyControlComponent, SyncIntervalSelection } from './sync-policy-control.component';
+import { SyncPolicy } from '../models/sync-policy.model';
+
+function stubPolicy(overrides: Partial<SyncPolicy> = {}): SyncPolicy {
+  return {
+    policyId: 'syn-abc123def456',
+    assistantId: 'assistant1',
+    sourceType: 'drive_file',
+    sourceRef: 'doc-1',
+    interval: 'daily',
+    state: 'active',
+    stateReason: null,
+    nextSyncAt: null,
+    lastSyncAt: null,
+    lastResult: null,
+    createdAt: '2026-07-03T00:00:00Z',
+    updatedAt: '2026-07-03T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SyncPolicyControlComponent', () => {
+  let fixture: ComponentFixture<SyncPolicyControlComponent>;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SyncPolicyControlComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(SyncPolicyControlComponent);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function select(): HTMLSelectElement {
+    return fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+  }
+
+  function buttonLabels(): string[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('button')).map((b) =>
+      ((b as HTMLButtonElement).textContent ?? '').trim(),
+    );
+  }
+
+  function statusLine(): string {
+    return ((fixture.nativeElement.querySelector('p')?.textContent as string) ?? '').trim();
+  }
+
+  it('defaults the select to "Manual only" with no policy and shows no actions', () => {
+    fixture.detectChanges();
+    expect(select().value).toBe('manual');
+    expect(buttonLabels()).toEqual([]);
+    expect(fixture.nativeElement.querySelector('p')).toBeNull();
+  });
+
+  it('reflects the policy interval in the select', () => {
+    fixture.componentRef.setInput('policy', stubPolicy({ interval: 'weekly' }));
+    fixture.detectChanges();
+    expect(select().value).toBe('weekly');
+  });
+
+  it('emits intervalSelected when the user picks a new interval, then reverts the DOM', () => {
+    const emitted: SyncIntervalSelection[] = [];
+    fixture.componentInstance.intervalSelected.subscribe((v) => emitted.push(v));
+    fixture.detectChanges();
+
+    select().value = 'daily';
+    select().dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual(['daily']);
+    // The select only moves for real once the page confirms the mutation
+    // and re-renders via the policy input.
+    expect(select().value).toBe('manual');
+  });
+
+  it('does not emit when the selection matches the current interval', () => {
+    const emitted: SyncIntervalSelection[] = [];
+    fixture.componentInstance.intervalSelected.subscribe((v) => emitted.push(v));
+    fixture.componentRef.setInput('policy', stubPolicy({ interval: 'daily' }));
+    fixture.detectChanges();
+
+    select().value = 'daily';
+    select().dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual([]);
+  });
+
+  it('shows Sync now + Pause for an active policy and emits their events', () => {
+    let ranNow = 0;
+    let paused = 0;
+    fixture.componentInstance.runNow.subscribe(() => ranNow++);
+    fixture.componentInstance.pause.subscribe(() => paused++);
+    fixture.componentRef.setInput('policy', stubPolicy({ state: 'active' }));
+    fixture.detectChanges();
+
+    const labels = buttonLabels();
+    expect(labels).toContain('Sync now');
+    expect(labels).toContain('Pause');
+
+    const buttons = fixture.nativeElement.querySelectorAll('button');
+    (buttons[0] as HTMLButtonElement).click();
+    (buttons[1] as HTMLButtonElement).click();
+    expect(ranNow).toBe(1);
+    expect(paused).toBe(1);
+  });
+
+  it('shows Resume for a user-paused policy', () => {
+    let resumed = 0;
+    fixture.componentInstance.resume.subscribe(() => resumed++);
+    fixture.componentRef.setInput('policy', stubPolicy({ state: 'paused_user' }));
+    fixture.detectChanges();
+
+    expect(buttonLabels()).toEqual(['Resume']);
+    expect(statusLine()).toBe('Paused');
+
+    (fixture.nativeElement.querySelector('button') as HTMLButtonElement).click();
+    expect(resumed).toBe(1);
+  });
+
+  it('shows the Reconnect affordance — not Resume — for paused_reauth', () => {
+    let reconnected = 0;
+    fixture.componentInstance.reconnect.subscribe(() => reconnected++);
+    fixture.componentRef.setInput(
+      'policy',
+      stubPolicy({ state: 'paused_reauth', stateReason: 'Google Drive access expired' }),
+    );
+    fixture.componentRef.setInput('reconnectLabel', 'Google Drive');
+    fixture.detectChanges();
+
+    expect(buttonLabels()).toEqual(['Reconnect Google Drive']);
+    expect(statusLine()).toBe('Paused — Google Drive access expired');
+
+    (fixture.nativeElement.querySelector('button') as HTMLButtonElement).click();
+    expect(reconnected).toBe(1);
+  });
+
+  it('shows Resume with the state reason for an error-paused policy', () => {
+    fixture.componentRef.setInput(
+      'policy',
+      stubPolicy({ state: 'paused_error', stateReason: 'source no longer accessible' }),
+    );
+    fixture.detectChanges();
+
+    expect(buttonLabels()).toEqual(['Resume']);
+    expect(statusLine()).toBe('Paused — source no longer accessible');
+  });
+
+  it('shows Resume with an inactivity explanation for paused_inactive', () => {
+    fixture.componentRef.setInput('policy', stubPolicy({ state: 'paused_inactive' }));
+    fixture.detectChanges();
+
+    expect(buttonLabels()).toEqual(['Resume']);
+    expect(statusLine()).toContain('inactive');
+  });
+
+  it('describes last and next sync on the status line for an active policy', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const inThreeDays = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+    fixture.componentRef.setInput(
+      'policy',
+      stubPolicy({ state: 'active', lastSyncAt: twoHoursAgo, nextSyncAt: inThreeDays }),
+    );
+    fixture.detectChanges();
+
+    expect(statusLine()).toBe('Synced 2h ago · next sync in 3d');
+  });
+
+  it('flags a failed last run on the status line', () => {
+    fixture.componentRef.setInput(
+      'policy',
+      stubPolicy({
+        state: 'active',
+        lastResult: 'failed',
+        lastSyncAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(statusLine()).toContain('Last sync failed 1h ago');
+  });
+
+  it('disables all controls while busy', () => {
+    fixture.componentRef.setInput('policy', stubPolicy({ state: 'active' }));
+    fixture.componentRef.setInput('busy', true);
+    fixture.detectChanges();
+
+    expect(select().disabled).toBe(true);
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(button.disabled).toBe(true);
+    }
+  });
+});

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -1,0 +1,218 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowPath, heroChevronDown } from '@ng-icons/heroicons/outline';
+
+import { SyncInterval, SyncPolicy } from '../models/sync-policy.model';
+
+/** The select's "no policy / turn sync off" sentinel. */
+export type SyncIntervalSelection = SyncInterval | 'manual';
+
+/**
+ * Per-source "Keep in sync" control for the assistant knowledge editor.
+ *
+ * Presentational only: renders the interval select, the state-appropriate
+ * action (Sync now / Pause / Resume / Reconnect) and a status line, and
+ * emits the user's intent. The page owns the policy state and the HTTP
+ * round-trips — on failure it simply doesn't update the `policy` input and
+ * the control stays where it was (the select reverts its own DOM value
+ * eagerly so a failed mutation never leaves a stale selection visible).
+ *
+ * `paused_reauth` deliberately has no Resume action — the backend rejects
+ * that resume with 409 because only a fresh OAuth consent can fix it — so
+ * the control renders the Reconnect affordance instead.
+ */
+@Component({
+  selector: 'app-sync-policy-control',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroArrowPath, heroChevronDown })],
+  template: `
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <div class="relative inline-flex">
+        <select
+          [attr.aria-label]="'Keep ' + (sourceName() || 'this source') + ' in sync'"
+          [disabled]="busy()"
+          [value]="selectValue()"
+          (change)="onSelectChange($event)"
+          class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+        >
+          <option value="manual">Manual only</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+        <ng-icon
+          name="heroChevronDown"
+          class="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+      </div>
+
+      @if (policy(); as p) {
+        @if (p.state === 'active') {
+          <button
+            type="button"
+            (click)="runNow.emit()"
+            [disabled]="busy()"
+            [attr.aria-label]="'Sync ' + (sourceName() || 'this source') + ' now'"
+            class="inline-flex items-center gap-1 rounded-2xl px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            <ng-icon name="heroArrowPath" class="size-3.5" aria-hidden="true" />
+            Sync now
+          </button>
+          <button
+            type="button"
+            (click)="pause.emit()"
+            [disabled]="busy()"
+            [attr.aria-label]="'Pause sync for ' + (sourceName() || 'this source')"
+            class="inline-flex items-center rounded-2xl px-2 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            Pause
+          </button>
+        } @else if (p.state === 'paused_reauth') {
+          <button
+            type="button"
+            (click)="reconnect.emit()"
+            [disabled]="busy()"
+            class="inline-flex items-center rounded-2xl px-2 py-1 text-xs/5 font-medium text-blue-600 hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+          >
+            Reconnect {{ reconnectLabel() || 'source' }}
+          </button>
+        } @else {
+          <button
+            type="button"
+            (click)="resume.emit()"
+            [disabled]="busy()"
+            [attr.aria-label]="'Resume sync for ' + (sourceName() || 'this source')"
+            class="inline-flex items-center rounded-2xl px-2 py-1 text-xs/5 font-medium text-blue-600 hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+          >
+            Resume
+          </button>
+        }
+      }
+    </div>
+    @if (statusText(); as text) {
+      <p
+        class="mt-0.5 text-xs/5"
+        [class.text-amber-600]="statusTone() === 'warn'"
+        [class.dark:text-amber-400]="statusTone() === 'warn'"
+        [class.text-gray-500]="statusTone() !== 'warn'"
+        [class.dark:text-gray-400]="statusTone() !== 'warn'"
+      >
+        {{ text }}
+      </p>
+    }
+  `,
+})
+export class SyncPolicyControlComponent {
+  /** The covering policy, or null when the source is manual-only. */
+  readonly policy = input<SyncPolicy | null>(null);
+  /** Disables all controls while the page has a mutation in flight. */
+  readonly busy = input(false);
+  /** Source display name, used for the controls' accessible names. */
+  readonly sourceName = input('');
+  /** Provider display name for the paused_reauth affordance (e.g. "Google Drive"). */
+  readonly reconnectLabel = input('');
+
+  readonly intervalSelected = output<SyncIntervalSelection>();
+  readonly runNow = output<void>();
+  readonly pause = output<void>();
+  readonly resume = output<void>();
+  readonly reconnect = output<void>();
+
+  readonly selectValue = computed<SyncIntervalSelection>(
+    () => this.policy()?.interval ?? 'manual',
+  );
+
+  readonly statusTone = computed<'muted' | 'warn'>(() => {
+    const p = this.policy();
+    if (!p) return 'muted';
+    if (p.state === 'paused_error' || p.state === 'paused_reauth') return 'warn';
+    if (p.state === 'active' && p.lastResult === 'failed') return 'warn';
+    return 'muted';
+  });
+
+  readonly statusText = computed<string>(() => {
+    const p = this.policy();
+    if (!p) return '';
+    switch (p.state) {
+      case 'active': {
+        const parts: string[] = [];
+        if (p.lastResult === 'failed') {
+          parts.push(
+            p.lastSyncAt ? `Last sync failed ${this.formatAgo(p.lastSyncAt)}` : 'Last sync failed',
+          );
+        } else if (p.lastSyncAt) {
+          parts.push(`Synced ${this.formatAgo(p.lastSyncAt)}`);
+        } else {
+          parts.push('Not synced yet');
+        }
+        if (p.nextSyncAt) {
+          parts.push(`next sync ${this.formatUntil(p.nextSyncAt)}`);
+        }
+        return parts.join(' · ');
+      }
+      case 'paused_user':
+        return 'Paused';
+      case 'paused_error':
+        return this.pausedText(p.stateReason, 'Paused after repeated failures');
+      case 'paused_inactive':
+        return this.pausedText(
+          p.stateReason,
+          'Paused while the assistant is inactive — resumes on next use',
+        );
+      case 'paused_reauth':
+        return this.pausedText(p.stateReason, 'Reconnect the content source to resume syncing');
+    }
+  });
+
+  onSelectChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const chosen = select.value as SyncIntervalSelection;
+    const current = this.selectValue();
+    // Revert the DOM eagerly: the select only moves for real once the page
+    // confirms the mutation and the `policy` input re-renders it. A failed
+    // request therefore never strands the select on a value that isn't true.
+    select.value = current;
+    if (chosen === current) {
+      return;
+    }
+    this.intervalSelected.emit(chosen);
+  }
+
+  private pausedText(reason: string | null | undefined, fallback: string): string {
+    return reason ? `Paused — ${reason}` : `Paused — ${fallback}`;
+  }
+
+  private formatAgo(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diffMins = Math.floor((Date.now() - then) / 60_000);
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 30) return `${diffDays}d ago`;
+    return new Date(iso).toLocaleDateString();
+  }
+
+  private formatUntil(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diffMins = Math.ceil((then - Date.now()) / 60_000);
+    // "due now" covers the run-now window: the dispatcher sweeps every
+    // 15 minutes, so a due policy runs within the next tick.
+    if (diffMins <= 15) return 'due now';
+    if (diffMins < 60) return `in ${diffMins}m`;
+    const diffHours = Math.round(diffMins / 60);
+    if (diffHours < 24) return `in ${diffHours}h`;
+    return `in ${Math.round(diffHours / 24)}d`;
+  }
+}

--- a/frontend/ai.client/src/app/assistants/models/document.model.ts
+++ b/frontend/ai.client/src/app/assistants/models/document.model.ts
@@ -52,6 +52,19 @@ export interface Document {
   chunkCount?: number;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Import provenance — set only for documents imported from an external
+   * source (Google Drive, web crawl); all null/absent for device uploads.
+   * A document is a syncable Drive source when `sourceFileId` is present
+   * and `sourceConnectorId` is a real connector (web pages use the
+   * sentinel connector id 'web' and sync at the crawl level instead).
+   */
+  sourceConnectorId?: string | null;
+  sourceAdapterKey?: string | null;
+  sourceFileId?: string | null;
+  /** Back-pointer to the covering sync policy, when one exists. */
+  syncPolicyId?: string | null;
+  lastSyncedAt?: string | null;
 }
 
 /**

--- a/frontend/ai.client/src/app/assistants/models/sync-policy.model.ts
+++ b/frontend/ai.client/src/app/assistants/models/sync-policy.model.ts
@@ -1,0 +1,56 @@
+/**
+ * Front-end models for assistant KB sync policies — scheduled re-index of
+ * knowledge sources (imported Drive files, web crawls).
+ *
+ * Mirrors the backend contract from `apis/app_api/sync_policies/` — field
+ * names are the camelCase aliases the backend serializes.
+ */
+
+export type SyncSourceType = 'drive_file' | 'web_crawl';
+export type SyncInterval = 'daily' | 'weekly' | 'monthly';
+export type SyncPolicyState =
+  | 'active'
+  | 'paused_error'
+  | 'paused_inactive'
+  | 'paused_reauth'
+  | 'paused_user';
+export type SyncRunResult = 'changed' | 'unchanged' | 'failed' | 'skipped';
+
+/** Public view of a sync policy (backend SyncPolicyResponse). */
+export interface SyncPolicy {
+  policyId: string;
+  assistantId: string;
+  sourceType: SyncSourceType;
+  sourceRef: string;
+  interval: SyncInterval;
+  state: SyncPolicyState;
+  stateReason?: string | null;
+  nextSyncAt?: string | null;
+  lastSyncAt?: string | null;
+  lastResult?: SyncRunResult | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Request body for POST /assistants/{id}/sync-policies. */
+export interface CreateSyncPolicyRequest {
+  sourceType: SyncSourceType;
+  sourceRef: string;
+  interval: SyncInterval;
+}
+
+/**
+ * Request body for PATCH /assistants/{id}/sync-policies/{policyId}.
+ * `state` accepts only the user-owned transitions: 'paused_user' (pause)
+ * and 'active' (resume). Resuming a paused_reauth policy is rejected with
+ * 409 — only a fresh OAuth consent resumes those.
+ */
+export interface UpdateSyncPolicyRequest {
+  interval?: SyncInterval;
+  state?: 'active' | 'paused_user';
+}
+
+/** Response from GET /assistants/{id}/sync-policies. */
+export interface SyncPoliciesListResponse {
+  policies: SyncPolicy[];
+}

--- a/frontend/ai.client/src/app/assistants/services/sync-policy.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/sync-policy.service.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { SyncPolicyService, SyncPolicyError } from './sync-policy.service';
+import { ConfigService } from '../../services/config.service';
+import { SyncPolicy } from '../models/sync-policy.model';
+
+const BASE = 'http://localhost:8000/assistants/assistant1/sync-policies';
+
+function stubPolicy(overrides: Partial<SyncPolicy> = {}): SyncPolicy {
+  return {
+    policyId: 'syn-abc123def456',
+    assistantId: 'assistant1',
+    sourceType: 'drive_file',
+    sourceRef: 'doc-1',
+    interval: 'daily',
+    state: 'active',
+    stateReason: null,
+    nextSyncAt: '2026-07-04T00:00:00Z',
+    lastSyncAt: null,
+    lastResult: null,
+    createdAt: '2026-07-03T00:00:00Z',
+    updatedAt: '2026-07-03T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SyncPolicyService', () => {
+  let service: SyncPolicyService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        SyncPolicyService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(SyncPolicyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('should list policies', async () => {
+    const policies = [stubPolicy()];
+
+    const promise = service.listPolicies('assistant1');
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('GET');
+      req.flush({ policies });
+    });
+
+    expect(await promise).toEqual(policies);
+  });
+
+  it('should create a policy', async () => {
+    const policy = stubPolicy();
+
+    const promise = service.createPolicy('assistant1', {
+      sourceType: 'drive_file',
+      sourceRef: 'doc-1',
+      interval: 'daily',
+    });
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        sourceType: 'drive_file',
+        sourceRef: 'doc-1',
+        interval: 'daily',
+      });
+      req.flush(policy, { status: 201, statusText: 'Created' });
+    });
+
+    expect(await promise).toEqual(policy);
+  });
+
+  it('should update a policy interval', async () => {
+    const policy = stubPolicy({ interval: 'weekly' });
+
+    const promise = service.updatePolicy('assistant1', 'syn-abc123def456', {
+      interval: 'weekly',
+    });
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/syn-abc123def456`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ interval: 'weekly' });
+      req.flush(policy);
+    });
+
+    expect(await promise).toEqual(policy);
+  });
+
+  it('should delete a policy', async () => {
+    const promise = service.deletePolicy('assistant1', 'syn-abc123def456');
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/syn-abc123def456`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+
+    await promise;
+  });
+
+  it('should request run-now', async () => {
+    const policy = stubPolicy({ nextSyncAt: '2026-07-03T00:00:01Z' });
+
+    const promise = service.runNow('assistant1', 'syn-abc123def456');
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/syn-abc123def456/run-now`);
+      expect(req.request.method).toBe('POST');
+      req.flush(policy, { status: 202, statusText: 'Accepted' });
+    });
+
+    expect(await promise).toEqual(policy);
+  });
+
+  it('should surface the server detail and status on a run-now cooldown (429)', async () => {
+    const promise = service.runNow('assistant1', 'syn-abc123def456');
+
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne(`${BASE}/syn-abc123def456/run-now`)
+        .flush(
+          { detail: 'A manual sync was already requested recently; try again in a few minutes' },
+          { status: 429, statusText: 'Too Many Requests' },
+        );
+    });
+
+    const error = await promise.then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SyncPolicyError);
+    expect((error as SyncPolicyError).status).toBe(429);
+    expect((error as SyncPolicyError).code).toBe('HTTP_429');
+    expect((error as SyncPolicyError).message).toContain('try again in a few minutes');
+  });
+
+  it('should surface the reauth-resume conflict (409) from PATCH', async () => {
+    const promise = service.updatePolicy('assistant1', 'syn-abc123def456', { state: 'active' });
+
+    await vi.waitFor(() => {
+      httpMock
+        .expectOne(`${BASE}/syn-abc123def456`)
+        .flush(
+          { detail: 'Reconnect the content source to resume syncing' },
+          { status: 409, statusText: 'Conflict' },
+        );
+    });
+
+    const error = await promise.then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SyncPolicyError);
+    expect((error as SyncPolicyError).status).toBe(409);
+    expect((error as SyncPolicyError).message).toBe(
+      'Reconnect the content source to resume syncing',
+    );
+  });
+
+  it('should fall back to a generic message on non-HTTP failures', async () => {
+    const promise = service.listPolicies('assistant1');
+
+    await vi.waitFor(() => {
+      httpMock.expectOne(BASE).error(new ProgressEvent('error'));
+    });
+
+    const error = await promise.then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SyncPolicyError);
+  });
+});

--- a/frontend/ai.client/src/app/assistants/services/sync-policy.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/sync-policy.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import { ConfigService } from '../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
+import {
+  CreateSyncPolicyRequest,
+  SyncPoliciesListResponse,
+  SyncPolicy,
+  UpdateSyncPolicyRequest,
+} from '../models/sync-policy.model';
+
+/**
+ * Error raised by {@link SyncPolicyService}. `code` is `HTTP_{status}` for
+ * server responses (e.g. `HTTP_429` for the run-now cooldown) or `UNKNOWN`.
+ * `status` lets callers branch on the contract's meaningful conflicts:
+ * 409 (duplicate / reauth-resume / run-now-inactive), 429 (cooldown).
+ */
+export class SyncPolicyError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'SyncPolicyError';
+  }
+}
+
+/**
+ * Client for the sync-policy endpoints (app-api). All endpoints are
+ * edit-gated server-side (owner or editor share) — the knowledge editor
+ * only renders sync controls for those roles, so a 403 here means the
+ * permission changed underneath the open page.
+ */
+@Injectable({ providedIn: 'root' })
+export class SyncPolicyService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+  private readonly baseUrl = computed(() => this.config.appApiUrl());
+
+  /**
+   * The knowledge editor surfaces sync errors inline (status lines and
+   * toasts with the server's wording), so opt out of the global error toast.
+   */
+  private requestOptions(): { context: HttpContext } {
+    return {
+      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),
+    };
+  }
+
+  private policiesUrl(assistantId: string): string {
+    return `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/sync-policies`;
+  }
+
+  /** List all sync policies for an assistant. */
+  async listPolicies(assistantId: string): Promise<SyncPolicy[]> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<SyncPoliciesListResponse>(
+          this.policiesUrl(assistantId),
+          this.requestOptions(),
+        ),
+      );
+      return response.policies;
+    } catch (err) {
+      throw this.toError(err, 'Failed to load sync settings');
+    }
+  }
+
+  /** Create a policy covering a content source. 409 = source already synced. */
+  async createPolicy(
+    assistantId: string,
+    request: CreateSyncPolicyRequest,
+  ): Promise<SyncPolicy> {
+    try {
+      return await firstValueFrom(
+        this.http.post<SyncPolicy>(
+          this.policiesUrl(assistantId),
+          request,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to enable sync');
+    }
+  }
+
+  /**
+   * Change interval and/or pause/resume. Resuming makes the policy due
+   * immediately; resuming a paused_reauth policy is rejected with 409.
+   */
+  async updatePolicy(
+    assistantId: string,
+    policyId: string,
+    request: UpdateSyncPolicyRequest,
+  ): Promise<SyncPolicy> {
+    try {
+      return await firstValueFrom(
+        this.http.patch<SyncPolicy>(
+          `${this.policiesUrl(assistantId)}/${encodeURIComponent(policyId)}`,
+          request,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to update sync settings');
+    }
+  }
+
+  /** Delete a policy — the source goes back to manual-only. */
+  async deletePolicy(assistantId: string, policyId: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.http.delete<void>(
+          `${this.policiesUrl(assistantId)}/${encodeURIComponent(policyId)}`,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to disable sync');
+    }
+  }
+
+  /**
+   * Request an immediate sync (202). The run still flows through the normal
+   * dispatcher sweep, so it starts within ~15 minutes. 429 = within the
+   * 10-minute cooldown; 409 = policy not active.
+   */
+  async runNow(assistantId: string, policyId: string): Promise<SyncPolicy> {
+    try {
+      return await firstValueFrom(
+        this.http.post<SyncPolicy>(
+          `${this.policiesUrl(assistantId)}/${encodeURIComponent(policyId)}/run-now`,
+          null,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to request a sync');
+    }
+  }
+
+  private toError(err: unknown, fallback: string): SyncPolicyError {
+    if (err instanceof HttpErrorResponse) {
+      const detail = (err.error as { detail?: string; message?: string } | null) ?? null;
+      const message = detail?.detail || detail?.message || err.message || fallback;
+      return new SyncPolicyError(message, `HTTP_${err.status}`, err.status);
+    }
+    if (err instanceof Error) {
+      return new SyncPolicyError(err.message || fallback, 'UNKNOWN');
+    }
+    return new SyncPolicyError(fallback, 'UNKNOWN');
+  }
+}

--- a/frontend/ai.client/src/app/assistants/services/web-source.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/web-source.service.ts
@@ -87,6 +87,25 @@ export class WebSourceService {
     }
   }
 
+  /**
+   * List every crawl for an assistant regardless of status. Completed
+   * crawls are the syncable web sources — a web_crawl sync policy's
+   * source is the terminal CrawlJob row.
+   */
+  async listCrawls(assistantId: string): Promise<CrawlJob[]> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<ActiveCrawlsResponse>(
+          `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/web-sources/crawls`,
+          this.requestOptions(),
+        ),
+      );
+      return response.crawls;
+    } catch (err) {
+      throw this.toError(err, 'Failed to load web sources');
+    }
+  }
+
   private toError(err: unknown, fallback: string): WebSourceError {
     if (err instanceof HttpErrorResponse) {
       const detail =


### PR DESCRIPTION
## Summary

PR-6 — the final PR of the assistant KB sync series (#542–#546 merged the backend). Adds the SPA surface for sync policies to the assistant knowledge editor (`assistant-form.page`), per `docs/specs/assistant-kb-sync.md` §8.

### Frontend

- **`SyncPolicyService`** — client for `/assistants/{id}/sync-policies` (list/create/patch/delete/run-now), `SUPPRESS_ERROR_TOAST` + typed `SyncPolicyError` carrying the HTTP status so the page can surface the contract's 409/429 detail messages verbatim.
- **`SyncPolicyControlComponent`** — presentational per-source control: "Keep in sync" select (Manual only / Daily / Weekly / Monthly), state-appropriate action (Sync now + Pause / Resume / Reconnect), and a status line (`Synced 2h ago · next sync in 3d`, `Paused — <reason>`). The select reverts its DOM value eagerly on change so a failed mutation never strands a stale selection (OnPush + native select gotcha).
- **Knowledge page integration**:
  - Drive-imported documents (import provenance from a real connector) get the control on their row; device uploads and web-page docs don't.
  - New **Web sources** list renders crawl roots — a `web_crawl` policy's source is the CrawlJob, not the page documents. Running crawls show progress; completed/failed crawls get the control.
  - **`paused_reauth`** renders "Reconnect <provider>" and routes through the existing OAuth consent popup; the backend's consent-complete hook auto-resumes, the page just refetches. Resume is deliberately not offered (backend 409s it). Also handles the vault-thinks-it's-fine edge (`initiateConsent` → `connected: true`) by refetching and pointing at Settings → Connectors if still paused.
  - Controls are **owner/editor only** (`canManageSync`) — viewers see nothing and the edit-gated list call is never issued for them.
  - Document delete mirrors the backend's policy cascade locally; the crawl watcher refreshes the web-sources list when a crawl goes terminal.

### Backend (additive, same PR per the cross-package contract)

- `DocumentResponse` exposes `sourceConnectorId` / `sourceAdapterKey` / `sourceFileId` / `syncPolicyId` / `lastSyncedAt` — the SPA needs provenance to tell imported docs from device uploads and to route reconnect.
- `GET /web-sources/crawls` without `?active=true` now returns full history via the pre-existing `list_all_crawls` (the route comment reserved exactly this for a future panel; completed crawls are the syncable sources).

## Testing

- Frontend: `ng test --watch=false` — **113 files / 1324 tests green**, including 20 new tests (service: contract + 409/429 error surfacing; component: per-state rendering, emissions, select revert, busy state). DI-token mocking, no `vi.mock`.
- Backend: full suite — **4194 passed** (incl. new full-history crawls-route test).
- `ng build` clean (pre-existing bundle-budget warning only).

## Manual test script

Local SKIP_AUTH is off in this checkout, so a scripted clickthrough for verification:

1. Open an assistant you own with an imported Drive doc + a completed web crawl → both rows show "Manual only"; a device-uploaded doc shows no control.
2. Pick **Daily** on the Drive doc → control shows "Not synced yet · next sync due now". Change to **Weekly** → persists on reload.
3. **Sync now** → success toast; immediate second click → 429 toast ("try again in a few minutes").
4. **Pause** → "Paused" + Resume; **Resume** → back to active, next sync due now.
5. Select **Manual only** → policy deleted (reload: still manual).
6. Web sources list: create a policy on the crawl root; while a crawl is running the row shows "Crawling…" and no control.
7. Revoke the Drive grant (Google account → third-party access), wait for a sync run to pause the policy → row shows "Reconnect Google Drive"; complete the consent popup → policy resumes without a manual resume.
8. Open the assistant as a **viewer** (shared) → no sync controls, no `/sync-policies` request in the network tab.
9. Dark mode + mobile width: select chevron clears the rounded corner; controls wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)