### PR TITLE
feat(interrupted-turn): persist stopped-turn metadata so cost + message badges survive

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -942,6 +942,12 @@ class StreamCoordinator:
                 session_id=session_id,
                 user_id=user_id,
                 partial_text="".join(assistant_text_acc),
+                main_agent_wrapper=main_agent_wrapper,
+                accumulated_metadata=accumulated_metadata,
+                initial_message_count=initial_message_count,
+                current_assistant_message_index=current_assistant_message_index,
+                stream_start_time=stream_start_time,
+                first_token_time=first_token_time,
             )
             raise
         except Exception as e:
@@ -1014,6 +1020,12 @@ class StreamCoordinator:
         session_id: str,
         user_id: str,
         partial_text: str,
+        main_agent_wrapper: Any = None,
+        accumulated_metadata: Optional[Dict[str, Any]] = None,
+        initial_message_count: int = 0,
+        current_assistant_message_index: int = -1,
+        stream_start_time: Optional[float] = None,
+        first_token_time: Optional[float] = None,
     ) -> None:
         """Persist the in-flight partial assistant turn + an interrupted
         marker when a turn is torn down mid-stream.
@@ -1089,6 +1101,52 @@ class StreamCoordinator:
                     session_id, marker_error, exc_info=True,
                 )
 
+            # Partial-turn metadata. On a Stop the client's socket is already
+            # gone, so the `done`-path metadata SSE (usage / cost / context)
+            # never reaches it and BOTH the per-message badges and the session
+            # cost badge stay blank — even after a reload, because nothing was
+            # persisted. Store it here with the same `_store_message_metadata`
+            # the completion path uses: that writes the per-message row AND
+            # bumps the session aggregates that hydrate the cost badge. Runs
+            # only when an assistant message was actually persisted above
+            # (`should_persist`), keyed to the same odd-position index the
+            # messages endpoint re-derives on reload. Best-effort: a cut
+            # generation often never delivered Bedrock's terminal usage event,
+            # so fall back to the context-attribution projection for the input
+            # side (drives the context-% badge + input-side cost; output is
+            # unknown and priced at zero).
+            if should_persist and main_agent_wrapper is not None:
+                try:
+                    metadata_for_message = dict(accumulated_metadata or {})
+                    if not metadata_for_message.get("usage"):
+                        projected = self._projected_input_usage(agent)
+                        if projected:
+                            metadata_for_message = {**metadata_for_message, "usage": projected}
+                    message_id = (
+                        initial_message_count + 2 * current_assistant_message_index + 1
+                        if current_assistant_message_index >= 0
+                        else initial_message_count + 1
+                    )
+                    await self._store_message_metadata(
+                        session_id=session_id,
+                        user_id=user_id,
+                        message_id=message_id,
+                        accumulated_metadata=metadata_for_message,
+                        stream_start_time=stream_start_time if stream_start_time is not None else time.time(),
+                        stream_end_time=time.time(),
+                        first_token_time=first_token_time,
+                        agent=main_agent_wrapper,
+                    )
+                    logger.info(
+                        "📊 Persisted interrupted-turn metadata for session %s (message_id=%s)",
+                        session_id, message_id,
+                    )
+                except Exception as meta_error:
+                    logger.error(
+                        "Failed to persist interrupted-turn metadata for session %s: %s",
+                        session_id, meta_error, exc_info=True,
+                    )
+
         try:
             await asyncio.shield(asyncio.ensure_future(_do()))
         except asyncio.CancelledError:
@@ -1096,6 +1154,38 @@ class StreamCoordinator:
             # the inner task keeps running to completion (that's the point of
             # shield). Swallow here and let the caller re-raise the original.
             logger.debug("interrupted-turn persistence shield cancelled; inner write continues")
+
+    def _projected_input_usage(self, agent: Any) -> Optional[Dict[str, Any]]:
+        """Best-effort input-token usage for an interrupted turn.
+
+        A cut generation frequently never delivers Bedrock's terminal usage
+        event, so ``accumulated_metadata['usage']`` is empty and the turn
+        would persist with no token/cost/context data. The context-attribution
+        hook computed the turn's projected input at ``BeforeModelCallEvent``
+        (before the model call that got interrupted), so use its total as the
+        input-side occupancy. Output is unknown — the turn never finished — so
+        it's reported as zero (input-side cost only). Returns ``None`` if no
+        projection is available, leaving the caller to persist whatever it has.
+        """
+        try:
+            from agents.main_agent.session.hooks.context_attribution import (
+                get_context_breakdown,
+            )
+
+            breakdown = get_context_breakdown(agent)
+            if not breakdown:
+                return None
+            total = (
+                breakdown.get("total")
+                if isinstance(breakdown, dict)
+                else getattr(breakdown, "total", None)
+            )
+            if not total or total <= 0:
+                return None
+            return {"inputTokens": int(total), "outputTokens": 0, "totalTokens": int(total)}
+        except Exception:  # noqa: BLE001 - best-effort enrichment only
+            logger.debug("Could not project interrupted-turn input usage", exc_info=True)
+            return None
 
     async def _persist_paused_turn_snapshot(
         self,

--- a/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
@@ -104,7 +104,7 @@ async def test_cancellation_invokes_interruption_persistence():
     """The CancelledError arm fires and re-raises so cancellation still unwinds."""
     called: Dict[str, Any] = {}
 
-    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text, **kwargs):
         called.update(session_id=session_id, user_id=user_id, partial_text=partial_text)
 
     with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
@@ -120,7 +120,7 @@ async def test_generator_exit_also_invokes_interruption_persistence():
     instead of CancelledError — the arm must catch both."""
     called: Dict[str, Any] = {}
 
-    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text, **kwargs):
         called.update(session_id=session_id, user_id=user_id, partial_text=partial_text)
 
     with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
@@ -138,7 +138,7 @@ async def test_partial_covers_only_in_flight_message():
     message still streaming at teardown count."""
     called: Dict[str, Any] = {}
 
-    async def _fake_persist(self, *, agent, session_id, user_id, partial_text):
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text, **kwargs):
         called.update(partial_text=partial_text)
 
     events = [
@@ -247,3 +247,90 @@ async def test_empty_partial_skips_synthetic_write_when_tail_is_assistant():
 
     assert persist_sm.calls == []
     assert marker_calls == [{"reason": "connection_lost"}]
+
+
+@pytest.mark.asyncio
+async def test_interruption_persists_partial_turn_metadata():
+    """A Stop with a partial persists per-message metadata (which also bumps
+    the session cost aggregates) keyed to the interrupted message's index, so
+    the token/cost badges + session cost badge hydrate on reload. When the cut
+    generation never delivered Bedrock's terminal usage event, the input side
+    falls back to the context-attribution projection."""
+    persist_sm = _RecordingPersistSessionManager()
+    stored: Dict[str, Any] = {}
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        return None
+
+    async def _fake_store_metadata(self, *, session_id, user_id, message_id, accumulated_metadata, **kwargs):
+        stored.update(
+            message_id=message_id,
+            usage=accumulated_metadata.get("usage"),
+            agent=kwargs.get("agent"),
+        )
+
+    wrapper = object()  # stands in for the MainAgent wrapper (model_config, etc.)
+
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch(
+        "apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted
+    ), patch.object(
+        StreamCoordinator, "_store_message_metadata", _fake_store_metadata
+    ), patch(
+        "agents.main_agent.session.hooks.context_attribution.get_context_breakdown",
+        return_value={"total": 1234, "partitions": []},
+    ):
+        await coordinator._persist_interruption(
+            agent=_InterruptingAgent(),
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="Here is the start of my answ",
+            main_agent_wrapper=wrapper,
+            accumulated_metadata={"usage": {}, "metrics": {}},
+            initial_message_count=4,
+            current_assistant_message_index=0,
+            stream_start_time=100.0,
+            first_token_time=100.2,
+        )
+
+    # Interrupted message sits at initial + 2*idx + 1 = 4 + 0 + 1 = 5 — the same
+    # odd-position index the messages endpoint re-derives as `idx` on reload.
+    assert stored.get("message_id") == 5
+    # Terminal usage never arrived → projected input from context attribution.
+    assert stored.get("usage") == {"inputTokens": 1234, "outputTokens": 0, "totalTokens": 1234}
+    assert stored.get("agent") is wrapper
+
+
+@pytest.mark.asyncio
+async def test_interruption_metadata_skipped_without_wrapper():
+    """No model wrapper (can't identify/price the model) → skip metadata
+    persistence entirely; the partial + marker still land."""
+    persist_sm = _RecordingPersistSessionManager()
+    store_calls: List[Any] = []
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        return None
+
+    async def _fake_store_metadata(self, **kwargs):
+        store_calls.append(kwargs)
+
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch(
+        "apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted
+    ), patch.object(StreamCoordinator, "_store_message_metadata", _fake_store_metadata):
+        await coordinator._persist_interruption(
+            agent=_InterruptingAgent(),
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="partial",
+            main_agent_wrapper=None,
+        )
+
+    assert store_calls == []
+    assert len(persist_sm.calls) == 1  # partial still persisted

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
@@ -29,9 +29,9 @@ describe('ChatHttpService', () => {
         // and lets cookie auth ride along with the request rather than
         // attaching a Bearer manually.
         { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}), handleUnauthorized: vi.fn() } },
-        { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn() } },
+        { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn(), getSessionMetadata: vi.fn().mockResolvedValue({}) } },
         { provide: StreamParserService, useValue: { getCurrentStreamId: vi.fn().mockReturnValue('stream-1'), parseEventSourceMessage: vi.fn() } },
-        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), setLastTurnInterrupted: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()) } },
+        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), setLastTurnInterrupted: vi.fn(), seedSessionAggregates: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()) } },
         { provide: MessageMapService, useValue: { endStreaming: vi.fn() } },
         { provide: ErrorService, useValue: { handleHttpError: vi.fn() } },
       ],
@@ -96,6 +96,52 @@ describe('ChatHttpService', () => {
 
     expect(() => service.cancelChatRequest('s1')).not.toThrow();
     expect(chatStateService.abortRequest).toHaveBeenCalledWith('s1');
+    vi.restoreAllMocks();
+  });
+
+  it('re-seeds the session cost badge after a stop once the backend persisted the interrupted turn', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    const sessionSvc = TestBed.inject(SessionService) as any;
+    sessionSvc.getSessionMetadata = vi
+      .fn()
+      .mockResolvedValue({ totalCost: 0.0123, lastContextTokens: 4200, contextWindow: 200000 });
+
+    service.cancelChatRequest('s1');
+
+    // The refresh is delayed to let the teardown write land, then awaits the fetch.
+    await vi.runAllTimersAsync();
+
+    expect(sessionSvc.getSessionMetadata).toHaveBeenCalledWith('s1');
+    expect(chatStateService.seedSessionAggregates).toHaveBeenCalledWith('s1', {
+      totalCost: 0.0123,
+      lastContextTokens: 4200,
+      contextWindow: 200000,
+    });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries the cost refresh once when the interrupted-turn write has not landed yet', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    const sessionSvc = TestBed.inject(SessionService) as any;
+    // First read races the teardown write (empty aggregates); second succeeds.
+    sessionSvc.getSessionMetadata = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValue({ totalCost: 0.02, lastContextTokens: 100, contextWindow: 200000 });
+
+    service.cancelChatRequest('s1');
+    await vi.runAllTimersAsync();
+
+    expect(sessionSvc.getSessionMetadata).toHaveBeenCalledTimes(2);
+    expect(chatStateService.seedSessionAggregates).toHaveBeenCalledWith('s1', {
+      totalCost: 0.02,
+      lastContextTokens: 100,
+      contextWindow: 200000,
+    });
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -272,6 +272,46 @@ export class ChatHttpService {
     this.chatStateService.abortRequest(sessionId);
     this.messageMapService.endStreaming(sessionId);
     this.chatStateService.setChatLoading(sessionId, false);
+
+    // Aborting the fetch cut the socket before the stream's terminal
+    // `metadata` SSE (usage / cost / context) could arrive, so the session
+    // cost badge would otherwise stay stale for this turn. The backend
+    // persists that metadata during its interruption teardown instead; pull
+    // the freshly-bumped session aggregates to light the badge up live. The
+    // write races our abort, so this fetch is delayed + retried. (The
+    // per-message token/cost badges hydrate from the same persisted row on
+    // the next message reload.)
+    setTimeout(() => void this.refreshAggregatesAfterStop(sessionId), 900);
+  }
+
+  /**
+   * Re-seed a session's cost/context badge after a Stop, once the backend's
+   * interruption teardown has persisted the partial turn's metadata (which
+   * bumps the denormalized session aggregates). Retries once because that
+   * write races the client abort; best-effort — the next navigation's
+   * `seedSessionAggregates` is the durable backstop.
+   */
+  private async refreshAggregatesAfterStop(sessionId: string, retried = false): Promise<void> {
+    try {
+      const metadata = await this.sessionService.getSessionMetadata(sessionId);
+      const hasAggregates =
+        (metadata.totalCost ?? 0) > 0 ||
+        (metadata.lastContextTokens ?? 0) > 0 ||
+        (metadata.contextWindow ?? 0) > 0;
+      if (hasAggregates) {
+        this.chatStateService.seedSessionAggregates(sessionId, {
+          totalCost: metadata.totalCost,
+          lastContextTokens: metadata.lastContextTokens,
+          contextWindow: metadata.contextWindow,
+        });
+        return;
+      }
+      if (!retried) {
+        setTimeout(() => void this.refreshAggregatesAfterStop(sessionId, true), 1500);
+      }
+    } catch (error) {
+      console.error('Failed to refresh session cost after stop:', error);
+    }
   }
 
   /** Fire-and-forget POST to app-api recording deliberate stop intent. */


### PR DESCRIPTION
## What & why

When a user hits **Stop** mid-response, the turn correctly persists the partial text + a "You stopped this response" marker — but **no per-message metadata badges (token/latency/cost) and no session cost-badge update** appeared for that turn, live *or* after a reload.

**Root cause:** both badge families are fed by a single terminal `metadata` SSE emitted only inside the `done` block of `stream_response`. `cancelChatRequest` aborts the fetch immediately, so the socket dies before `done` — the event never arrives. The cancellation path (`_persist_interruption`) persisted only the partial text + marker, never any metadata, so the badges were blank even on reload.

The abort is **load-bearing** — killing the socket is what stops generation and billing — so the backend can't push the metadata to a dead socket. This PR takes the **backend-persist + frontend-refresh** approach instead.

## Changes

**Backend — `stream_coordinator.py`**
- `_persist_interruption` now also calls `_store_message_metadata(...)` — the same call the `done` path uses, which writes the per-message row **and** bumps the denormalized session aggregates that hydrate the cost badge on reload. Keyed to the interrupted message's odd-position index (`initial_message_count + 2*current_assistant_message_index + 1`), gated on `should_persist and main_agent_wrapper is not None`.
- New `_projected_input_usage()`: a cut generation frequently never delivers Bedrock's terminal usage event, so it falls back to the context-attribution projection for input-side tokens/cost (output is unknown → priced at zero).

**Frontend — `chat-http.service.ts`**
- `refreshAggregatesAfterStop()` (delayed 900 ms + one 1500 ms retry, mirroring `refreshTitleFromServer`, since the persist races the abort) re-pulls session metadata → `seedSessionAggregates`, so the cost badge lights up live. Per-message badges hydrate from the same persisted row on the next reload — a live message reload is deliberately avoided so it doesn't disrupt the live "You stopped this response" partial.

## Known limitation

The per-message `contextBreakdown` partition badge is **not a persisted field** (it's live-only even for normal completed turns), so it stays blank on a stopped/reloaded turn. Persisting it is a separate change affecting all turns and is out of scope here.

## Tests

- Backend: `test_interrupted_turn_persistence.py` (+2 new — metadata persisted with the right message id + projected-usage fallback; skipped when no model wrapper) and the full streaming dir (**175 green**).
- Frontend: `chat-http.service.spec.ts` (+2 new — cost badge re-seeded after Stop; retry when the write hasn't landed yet). **7 green.**

## Manual smoke test

Send a long response → hit Stop → confirm the cost badge updates within ~2 s, then reload and confirm the token/latency badges appear on the stopped message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)