### PR TITLE
fix(kb-sync): grant worker read on the vault's backing OAuth secrets

### DIFF
--- a/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
+++ b/infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts
@@ -166,6 +166,23 @@ export class KbSyncConstruct extends Construct {
       }),
     );
 
+    // GetResourceOauth2Token reads the vaulted refresh token *through* a
+    // Secrets Manager secret the vault auto-creates per provider
+    // (bedrock-agentcore-identity!default/oauth2/<id>) — the bedrock-agentcore
+    // action alone is not enough, the caller must also be able to read that
+    // backing secret. Read-only mirror of the app-api / inference-api grants
+    // (a background fetcher never registers providers, so no write lifecycle).
+    this.workerLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AgentCoreIdentityOAuthSecrets',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: [
+          `arn:aws:secretsmanager:${config.awsRegion}:${config.awsAccount}:secret:bedrock-agentcore-identity!default/oauth2/*`,
+        ],
+      }),
+    );
+
     // Best-effort custom metrics (KBSync namespace). PutMetricData
     // doesn't support resource scoping; condition on the namespace.
     const metricsStatement = new iam.PolicyStatement({

--- a/infrastructure/test/kb-sync.test.ts
+++ b/infrastructure/test/kb-sync.test.ts
@@ -137,6 +137,13 @@ describe('KbSyncConstruct', () => {
               'bedrock-agentcore:GetResourceOauth2Token',
             ],
           }),
+          // GetResourceOauth2Token reads the vaulted token through the
+          // provider's backing Secrets Manager secret — the bedrock-agentcore
+          // action is useless without read access to that secret.
+          Match.objectLike({
+            Sid: 'AgentCoreIdentityOAuthSecrets',
+            Action: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+          }),
         ]),
       },
     });


### PR DESCRIPTION
## Problem

Every Drive KB-sync run returned `failed`. Root cause found by invoking the worker Lambda directly against the live dev-ai fixture:

```
AccessDeniedException … secretsmanager:GetSecretValue on
arn:…:secret:bedrock-agentcore-identity!default/oauth2/google-drive-…
```

The worker resolves the policy creator's Google token from the AgentCore Identity vault via `GetResourceOauth2Token`. That call reads the vaulted refresh token **through** a Secrets Manager secret the vault auto-creates per provider (`bedrock-agentcore-identity!default/oauth2/<id>`). The `KbSyncConstruct` worker role granted only the two `bedrock-agentcore:*` actions (`GetWorkloadAccessTokenForUserId`, `GetResourceOauth2Token`) — not the backing-secret read — so the vault call failed before it could return a token.

Both **app-api** (`app-api-iam-grants.ts`, full lifecycle) and **inference-api** (`inference-api-iam-roles.ts`, read-only) already carry this grant; the KB-sync worker was the only vault consumer missing it.

## Fix

- Add the read-only `AgentCoreIdentityOAuthSecrets` statement (`secretsmanager:GetSecretValue` + `DescribeSecret` on `…!default/oauth2/*`) to the worker role — a background fetcher only ever reads tokens, so no write lifecycle (mirrors inference-api's 2-action grant, not app-api's full set).
- Add a regression assertion in `kb-sync.test.ts` so the trimmed statement can't silently drop this again.

## Verification

- `npx tsc --noEmit` clean; `npx jest kb-sync` → 11/11 pass.
- **Live in dev-ai:** temporarily attaching the same policy to the real worker role flipped the result from `failed` (AccessDenied) → `paused_reauth` — i.e. the worker now gets *past* the vault read. Temp policy removed after verifying (no drift). The remaining `paused_reauth` is a genuine expired/absent Google refresh token (needs an interactive Drive reconnect), not this IAM gap.

## Deploy note

Takes effect on the next `cdk deploy …-PlatformStack` (IAM-only change to the worker role). No app-image rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)