### PR TITLE
refactor(oauth): forward admin customParameters, drop hardcoded vendor baseline

### DIFF
--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -358,23 +358,14 @@ class BaseAgent(ABC):
             provider = await get_provider_repository().get_provider(provider_id)
             return provider.scopes if provider else []
 
-        async def provider_type_lookup(provider_id: str) -> Optional[str]:
-            # AgentCore Identity needs vendor-specific OAuth params
-            # forwarded via `customParameters` (e.g. Google's
-            # `access_type=offline` for refresh tokens). The hook reads
-            # this to forward those.
-            from apis.shared.oauth.provider_repository import get_provider_repository
-
-            provider = await get_provider_repository().get_provider(provider_id)
-            return provider.provider_type.value if provider else None
-
         async def custom_parameters_lookup(
             provider_id: str,
         ) -> Optional[dict[str, str]]:
-            # Admin-supplied OAuth extras (e.g. `hd=mycorp.com` for
-            # Google Workspace domain restriction). Merged with the
-            # vendor baseline by `custom_parameters_for`; baseline wins
-            # on conflict.
+            # The connector's admin-configured OAuth `customParameters`,
+            # forwarded verbatim to AgentCore Identity (e.g. a Google
+            # connector's `access_type=offline` for refresh tokens +
+            # `prompt=consent`, or `hd=mycorp.com` for Workspace domain
+            # restriction).
             from apis.shared.oauth.provider_repository import get_provider_repository
 
             provider = await get_provider_repository().get_provider(provider_id)
@@ -396,7 +387,6 @@ class BaseAgent(ABC):
             user_id=self.user_id,
             provider_lookup=provider_lookup,
             scopes_lookup=scopes_lookup,
-            provider_type_lookup=provider_type_lookup,
             custom_parameters_lookup=custom_parameters_lookup,
             disconnected_lookup=disconnected_lookup,
             tool_use_provider_lookup=tool_use_provider_lookup,

--- a/backend/src/agents/main_agent/session/hooks/oauth_consent.py
+++ b/backend/src/agents/main_agent/session/hooks/oauth_consent.py
@@ -124,16 +124,12 @@ ToolUseProviderLookup = Callable[[dict], Optional[str]]
 # without forcing a sync wrapper.
 ScopesLookup = Callable[[str], Union[list[str], Awaitable[list[str]]]]
 
-# Returns the provider's vendor type (e.g. "google", "microsoft") for a
-# provider_id, or None if unknown / no per-vendor params needed. Optional —
-# omitted in older tests; without it AgentCore Identity gets no
-# `customParameters`, which means Google won't issue a refresh token and
-# the vault entry expires after ~1 hour.
-ProviderTypeLookup = Callable[[str], Union[Optional[str], Awaitable[Optional[str]]]]
-
-# Returns admin-supplied OAuth params (e.g. `hd=mycorp.com` for Google
-# Workspace domain restriction) for a provider_id. Merged with the
-# vendor baseline by `custom_parameters_for`; baseline wins on conflict.
+# Returns the connector's admin-configured OAuth `customParameters` for a
+# provider_id (e.g. a Google connector's `access_type=offline` +
+# `prompt=consent`, or `hd=mycorp.com` for Workspace domain restriction), or
+# None when the connector has no extras. Optional — omitted in older tests;
+# without it AgentCore Identity gets no `customParameters`, so a Google
+# connector configured this way is what makes Google issue a refresh token.
 CustomParametersLookup = Callable[
     [str], Union[Optional[dict[str, str]], Awaitable[Optional[dict[str, str]]]]
 ]
@@ -153,7 +149,6 @@ class OAuthConsentHook(HookProvider):
         user_id: str,
         provider_lookup: ProviderLookup,
         scopes_lookup: ScopesLookup,
-        provider_type_lookup: Optional[ProviderTypeLookup] = None,
         custom_parameters_lookup: Optional[CustomParametersLookup] = None,
         disconnected_lookup: Optional[DisconnectedLookup] = None,
         tool_use_provider_lookup: Optional[ToolUseProviderLookup] = None,
@@ -166,12 +161,10 @@ class OAuthConsentHook(HookProvider):
                 fallback (no-op in production).
             provider_lookup: See `ProviderLookup`.
             scopes_lookup: See `ScopesLookup`.
-            provider_type_lookup: See `ProviderTypeLookup`. Optional. When
-                provided, the hook forwards vendor-specific OAuth params
-                (e.g. Google's `access_type=offline`) to AgentCore Identity.
             custom_parameters_lookup: See `CustomParametersLookup`.
-                Optional. Admin-supplied extras to merge with the vendor
-                baseline.
+                Optional. The connector's admin-configured `customParameters`
+                forwarded verbatim to AgentCore Identity (e.g. a Google
+                connector's `access_type=offline` + `prompt=consent`).
             disconnected_lookup: See `DisconnectedLookup`. Optional. When
                 omitted, the hook never bypasses the local token cache —
                 effectively assumes the user has not disconnected. Wire
@@ -185,7 +178,6 @@ class OAuthConsentHook(HookProvider):
         self._user_id = user_id
         self._provider_lookup = provider_lookup
         self._scopes_lookup = scopes_lookup
-        self._provider_type_lookup = provider_type_lookup
         self._custom_parameters_lookup = custom_parameters_lookup
         self._disconnected_lookup = disconnected_lookup
         self._tool_use_provider_lookup = tool_use_provider_lookup
@@ -193,11 +185,10 @@ class OAuthConsentHook(HookProvider):
         # invocation). Avoids repeated DB hits if the same provider is used
         # across multiple tool calls in a single turn.
         self._scopes_cache: dict[str, list[str]] = {}
-        # Same cache shape for provider_type. `None` is a legitimate value
-        # (vendor without extra params), so we use a separate sentinel set
-        # to distinguish "unknown" from "looked up, no extras needed".
-        self._provider_type_cache: dict[str, Optional[str]] = {}
-        self._provider_type_cache_keys: set[str] = set()
+        # Cache the connector's customParameters per provider. `None` is a
+        # legitimate value (connector without extra params), so we use a
+        # separate sentinel set to distinguish "unknown" from "looked up,
+        # no extras".
         self._custom_parameters_cache: dict[str, Optional[dict[str, str]]] = {}
         self._custom_parameters_cache_keys: set[str] = set()
         # Providers that already burned their one 401-retry in the current
@@ -312,7 +303,6 @@ class OAuthConsentHook(HookProvider):
     ) -> Optional[dict]:
         """Return {'token': str|None, 'url': str|None} or None on hard error."""
         scopes = await self._resolve_scopes(provider_id)
-        provider_type = await self._resolve_provider_type(provider_id)
         admin_extras = await self._resolve_custom_parameters(provider_id)
         identity_client = get_agentcore_identity_client()
 
@@ -322,11 +312,7 @@ class OAuthConsentHook(HookProvider):
                 scopes=scopes,
                 user_id=self._user_id,
                 force_authentication=force_authentication,
-                custom_parameters=custom_parameters_for(
-                    provider_type,
-                    admin_extras,
-                    force_authentication=force_authentication,
-                ),
+                custom_parameters=custom_parameters_for(admin_extras),
             )
         except WorkloadTokenUnavailableError:
             logger.error(
@@ -423,20 +409,6 @@ class OAuthConsentHook(HookProvider):
         scopes = list(scopes or [])
         self._scopes_cache[provider_id] = scopes
         return scopes
-
-    async def _resolve_provider_type(self, provider_id: str) -> Optional[str]:
-        if self._provider_type_lookup is None:
-            return None
-        if provider_id in self._provider_type_cache_keys:
-            return self._provider_type_cache.get(provider_id)
-        result = self._provider_type_lookup(provider_id)
-        if inspect.isawaitable(result):
-            provider_type = await result
-        else:
-            provider_type = result
-        self._provider_type_cache[provider_id] = provider_type
-        self._provider_type_cache_keys.add(provider_id)
-        return provider_type
 
     async def _resolve_custom_parameters(
         self, provider_id: str

--- a/backend/src/apis/app_api/connectors/routes.py
+++ b/backend/src/apis/app_api/connectors/routes.py
@@ -230,20 +230,15 @@ async def initiate_consent(
             scopes=provider.scopes,
             user_id=current_user.user_id,
             force_authentication=force_auth,
-            # initiate_consent is by definition a "walk me through consent"
-            # path — the user clicked Connect/Reconnect after seeing they
-            # were not connected. For Google this means we must send
-            # `prompt=consent`, otherwise Google sees a previously-consented
-            # user, skips the consent screen, and re-issues an access_token
-            # WITHOUT a refresh_token. Vault then expires after ~1h and the
-            # user is back here. Decoupled from `force_auth` (which only
-            # toggles the SDK's vault-bypass) so the silent-refresh fast
-            # path elsewhere is unaffected.
-            custom_parameters=custom_parameters_for(
-                provider.provider_type.value,
-                provider.custom_parameters,
-                force_authentication=True,
-            ),
+            # Forward the connector's admin-configured `customParameters`
+            # verbatim. For a Google connector these come from the "Custom
+            # OAuth Parameters" field — typically `access_type=offline` (so
+            # Google issues a refresh token) plus `prompt=consent` (so a
+            # previously-consented user is still shown the consent screen and
+            # a refresh token is re-issued, rather than an access-token-only
+            # grant that expires in ~1h). The same map is sent on the status
+            # read below so AgentCore's vault key matches.
+            custom_parameters=custom_parameters_for(provider.custom_parameters),
             # No custom_state: AgentCore appears to treat its presence as a
             # signal to start a fresh flow, never short-circuiting to the
             # cached token. The frontend passes provider_id via the
@@ -321,15 +316,12 @@ async def connector_status(
             # Match the customParameters `initiate_consent` used to grant the
             # token. AgentCore factors `customParameters` into whether
             # `get_resource_oauth2_token` short-circuits to a vaulted token, so
-            # a status read that omits Google's `prompt=consent` is treated as
-            # a fresh request and reports consent-required even when a usable
-            # token is vaulted. Pure read — `get_token_for_user` itself stays
-            # at `force_authentication=False`.
-            custom_parameters=custom_parameters_for(
-                provider.provider_type.value,
-                provider.custom_parameters,
-                force_authentication=True,
-            ),
+            # a status read that omits the connector's configured params (e.g.
+            # a Google connector's `prompt=consent`) is treated as a fresh
+            # request and reports consent-required even when a usable token is
+            # vaulted. Pure read — `get_token_for_user` itself stays at
+            # `force_authentication=False`.
+            custom_parameters=custom_parameters_for(provider.custom_parameters),
         )
     except WorkloadTokenUnavailableError as err:
         logger.warning("Status check without workload context: %s", err)

--- a/backend/src/apis/app_api/export_targets/service.py
+++ b/backend/src/apis/app_api/export_targets/service.py
@@ -107,22 +107,19 @@ async def resolve_export_target_token(
     Returns a `TokenResult`: `access_token` is populated when the vault has a
     usable token, `authorization_url` when the user still needs to consent.
 
-    `custom_parameters` is built with `force_authentication=True` so it matches
-    the consent flow — AgentCore factors `customParameters` into whether
-    `get_resource_oauth2_token` short-circuits to a vaulted token (see the
-    file-source service for the full rationale). Pure read; `force_authentication`
-    stays False on `get_token_for_user` itself.
+    `custom_parameters` forwards the connector's admin-configured params
+    verbatim so it matches the consent flow — AgentCore factors
+    `customParameters` into whether `get_resource_oauth2_token` short-circuits
+    to a vaulted token (see the file-source service for the full rationale).
+    Pure read; `force_authentication` stays False on `get_token_for_user`
+    itself.
     """
     identity = get_agentcore_identity_client()
     return await identity.get_token_for_user(
         provider_name=provider.provider_id,
         scopes=provider.scopes,
         user_id=user_id,
-        custom_parameters=custom_parameters_for(
-            provider.provider_type.value,
-            provider.custom_parameters,
-            force_authentication=True,
-        ),
+        custom_parameters=custom_parameters_for(provider.custom_parameters),
     )
 
 

--- a/backend/src/apis/app_api/file_sources/service.py
+++ b/backend/src/apis/app_api/file_sources/service.py
@@ -108,13 +108,14 @@ async def resolve_file_source_token(
     Returns a `TokenResult`: `access_token` is populated when the vault has a
     usable token, `authorization_url` when the user still needs to consent.
 
-    `custom_parameters` is built with `force_authentication=True` so it matches
-    the consent flow. AgentCore factors `customParameters` into whether
-    `get_resource_oauth2_token` short-circuits to a vaulted token: connector
-    consent always runs through `initiate_consent`, which sends Google's
-    `prompt=consent` extra — so a retrieval call that omits it is treated as a
-    different request and reports consent-required even though a usable token
-    is vaulted. This is a pure read; `force_authentication` stays False on
+    `custom_parameters` forwards the connector's admin-configured params
+    verbatim so it matches the consent flow. AgentCore factors
+    `customParameters` into whether `get_resource_oauth2_token` short-circuits
+    to a vaulted token: connector consent runs through `initiate_consent`,
+    which sends the same stored map (e.g. a Google connector's `prompt=consent`)
+    — so a retrieval call must send it too, or it's treated as a different
+    request and reports consent-required even though a usable token is vaulted.
+    This is a pure read; `force_authentication` stays False on
     `get_token_for_user` itself.
     """
     identity = get_agentcore_identity_client()
@@ -122,11 +123,7 @@ async def resolve_file_source_token(
         provider_name=provider.provider_id,
         scopes=provider.scopes,
         user_id=user_id,
-        custom_parameters=custom_parameters_for(
-            provider.provider_type.value,
-            provider.custom_parameters,
-            force_authentication=True,
-        ),
+        custom_parameters=custom_parameters_for(provider.custom_parameters),
     )
 
 

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -98,11 +98,7 @@ async def _resolve_access_token(provider, user_id: str) -> Optional[str]:
         provider_name=provider.provider_id,
         scopes=provider.scopes,
         user_id=user_id,
-        custom_parameters=custom_parameters_for(
-            provider.provider_type.value if provider.provider_type else None,
-            provider.custom_parameters,
-            force_authentication=True,
-        ),
+        custom_parameters=custom_parameters_for(provider.custom_parameters),
         callback_url=os.environ.get("AGENTCORE_LOCAL_OAUTH_CALLBACK_URL"),
     )
     if result.requires_consent:

--- a/backend/src/apis/shared/oauth/agentcore_identity.py
+++ b/backend/src/apis/shared/oauth/agentcore_identity.py
@@ -88,64 +88,29 @@ _RUNTIME_WORKLOAD_ENV = "AGENTCORE_RUNTIME_WORKLOAD_NAME"
 _CALLBACK_URL_ENV = "AGENTCORE_LOCAL_OAUTH_CALLBACK_URL"
 
 
-def _vendor_baseline_params(
-    provider_type: Optional[str], *, force_authentication: bool = False
-) -> Dict[str, str]:
-    """Hardcoded params AgentCore Identity *requires* for a given vendor.
-
-    Per the AgentCore Identity authentication docs
-    (https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-authentication.html),
-    Google must receive `access_type=offline` to issue a refresh token —
-    without it the vault entry expires after ~1 hour with no refresh
-    path. This is non-negotiable: it always wins over admin-supplied
-    extras to prevent an admin from accidentally turning it off.
-
-    When `force_authentication=True` we additionally send `prompt=consent`
-    for Google. Google only re-issues a refresh token on subsequent
-    authorizations if the user is shown the consent screen again — so a
-    user who clicks "Disconnect" then "Reconnect" would otherwise get a
-    vault entry with an access token but no refresh token, putting them
-    right back in the hourly-reconsent loop on the next access-token
-    expiry. We only set this on the explicit re-consent path; first-time
-    consent and silent refreshes don't trigger it.
-    """
-    if not provider_type:
-        return {}
-    if provider_type.lower() == "google":
-        params = {"access_type": "offline"}
-        if force_authentication:
-            params["prompt"] = "consent"
-        return params
-    return {}
-
-
 def custom_parameters_for(
-    provider_type: Optional[str],
     admin_extras: Optional[Dict[str, str]] = None,
-    *,
-    force_authentication: bool = False,
 ) -> Optional[Dict[str, str]]:
-    """Build the `customParameters` payload AgentCore Identity wants forwarded.
+    """Normalize a connector's admin-supplied OAuth `customParameters`.
 
-    Merges admin-supplied extras (e.g. Google `hd=mycorp.com` for domain
-    restriction) with the hardcoded vendor baseline. Baseline keys win on
-    conflict — admins cannot turn off a documented requirement.
+    Returns the connector's configured extras verbatim, or None when empty
+    so callers can pass the value straight through to the SDK without
+    sending an empty `customParameters` map.
 
-    `force_authentication=True` mirrors the same flag on
-    `get_token_for_user`: when the caller is forcing AgentCore to bypass
-    the vault and walk the user through consent again, this enables any
-    vendor-specific extras needed for that path (e.g. Google's
-    `prompt=consent` so a refresh token is re-issued).
-
-    Returns None when the merged result would be empty, so callers can
-    pass the value through to the SDK unconditionally without sending
-    an empty `customParameters` map.
+    Vendor-specific requirements are NOT hardcoded here — they're supplied
+    per-connector via the admin "Custom OAuth Parameters" field. Per the
+    AgentCore Identity docs
+    (https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-authentication.html)
+    the delivered vendors do not add these on their own, so for a Google
+    connector an admin must configure `access_type=offline` (to have Google
+    issue a refresh token at all) and typically `prompt=consent` (so a
+    refresh token is re-issued on reconnect). Because every call site now
+    forwards the same stored value, the `customParameters` map matches
+    across the consent grant and later token retrievals — AgentCore factors
+    it into the vault key, so a mismatch would otherwise falsely report
+    consent-required.
     """
-    baseline = _vendor_baseline_params(
-        provider_type, force_authentication=force_authentication
-    )
-    merged = {**(admin_extras or {}), **baseline}
-    return merged or None
+    return dict(admin_extras) if admin_extras else None
 
 
 @dataclass(frozen=True)

--- a/backend/src/apis/shared/oauth/models.py
+++ b/backend/src/apis/shared/oauth/models.py
@@ -114,12 +114,13 @@ class OAuthProvider:
     # CANVAS; both are None for Google/Microsoft/GitHub.
     oauth_discovery_url: Optional[str] = None
     authorization_server_metadata: Optional[Dict[str, Any]] = None
-    # Vendor-specific OAuth parameters merged into AgentCore Identity's
-    # `customParameters` at request time. Examples: Google `hd=mycorp.com`
-    # to restrict to a Workspace domain, `prompt=consent` to force the
-    # consent screen. Hardcoded baselines (e.g. Google's
-    # `access_type=offline`) win on conflict — admins cannot accidentally
-    # turn off a documented requirement.
+    # Vendor-specific OAuth parameters forwarded verbatim into AgentCore
+    # Identity's `customParameters` at request time. The delivered vendors
+    # don't add these on their own, so a Google connector must set
+    # `access_type=offline` here (for Google to issue a refresh token) and
+    # typically `prompt=consent` (so a refresh token is re-issued on
+    # reconnect); other examples: `hd=mycorp.com` to restrict to a Workspace
+    # domain. See the AgentCore Identity docs for each vendor's requirement.
     custom_parameters: Optional[Dict[str, str]] = None
     # Maps this connector to a file-source adapter (e.g. "google-drive"),
     # making it selectable as a file source in the assistant editor. The

--- a/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
+++ b/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
@@ -114,13 +114,13 @@ class TestOAuthConsentHookCacheHit:
         assert kwargs["force_authentication"] is True
 
     @pytest.mark.asyncio
-    async def test_force_authentication_sends_prompt_consent_for_google(self):
-        """Google only re-issues a refresh token on subsequent grants if
-        the user is shown the consent screen — so the explicit re-consent
-        path (force_authentication=True) must propagate prompt=consent
-        through to AgentCore Identity. Without it, a Disconnect/Reconnect
-        cycle leaves the vault with an access token but no refresh token,
-        putting the user back in the hourly-reconsent loop."""
+    async def test_force_authentication_forwards_configured_custom_parameters(self):
+        """On the explicit re-consent path (force_authentication=True) the
+        hook forwards the connector's configured customParameters verbatim.
+        For a Google connector that's `access_type=offline` + `prompt=consent`
+        — Google only re-issues a refresh token when the consent screen is
+        shown, so without prompt=consent a Disconnect/Reconnect cycle leaves
+        the vault with an access token but no refresh token."""
         identity = MagicMock()
         identity.get_token_for_user = AsyncMock(
             return_value=TokenResult(authorization_url="https://accounts/consent")
@@ -130,7 +130,10 @@ class TestOAuthConsentHookCacheHit:
             user_id="alice",
             provider_lookup=lambda _tool: "google",
             scopes_lookup=lambda _: ["openid"],
-            provider_type_lookup=lambda _: "google",
+            custom_parameters_lookup=lambda _: {
+                "access_type": "offline",
+                "prompt": "consent",
+            },
             disconnected_lookup=lambda _pid: True,
         )
         event = _make_event(provider_id="google")
@@ -150,10 +153,14 @@ class TestOAuthConsentHookCacheHit:
         }
 
     @pytest.mark.asyncio
-    async def test_silent_refresh_does_not_send_prompt_consent(self):
-        """The refresh path (force_authentication=False) must not send
-        prompt=consent — that would force the consent screen on every
-        silent refresh, which is the exact UX we're trying to avoid."""
+    async def test_silent_refresh_forwards_same_custom_parameters(self):
+        """The silent-refresh path (force_authentication=False) forwards the
+        SAME configured customParameters as the consent path. AgentCore
+        factors the map into the vault key, so they must match or a usable
+        vaulted token is treated as a fresh request. (prompt=consent is inert
+        on a refresh-token exchange — that hits the token endpoint, not the
+        interactive authorization redirect — so sending it uniformly is
+        safe.)"""
         identity = MagicMock()
         identity.get_token_for_user = AsyncMock(
             return_value=TokenResult(access_token="refreshed-token")
@@ -163,7 +170,10 @@ class TestOAuthConsentHookCacheHit:
             user_id="alice",
             provider_lookup=lambda _tool: "google",
             scopes_lookup=lambda _: ["openid"],
-            provider_type_lookup=lambda _: "google",
+            custom_parameters_lookup=lambda _: {
+                "access_type": "offline",
+                "prompt": "consent",
+            },
         )
         event = _make_event(provider_id="google")
 
@@ -175,8 +185,10 @@ class TestOAuthConsentHookCacheHit:
 
         kwargs = identity.get_token_for_user.call_args.kwargs
         assert kwargs["force_authentication"] is False
-        assert kwargs["custom_parameters"] == {"access_type": "offline"}
-        assert "prompt" not in kwargs["custom_parameters"]
+        assert kwargs["custom_parameters"] == {
+            "access_type": "offline",
+            "prompt": "consent",
+        }
 
     @pytest.mark.asyncio
     async def test_uses_cached_token_without_calling_identity(self):
@@ -785,11 +797,12 @@ class TestOAuthConsentHookErrors:
         assert scopes_lookup.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_provider_type_lookup_forwards_custom_parameters(self):
-        """When the provider is Google, the hook forwards
-        `custom_parameters={"access_type": "offline"}` to AgentCore Identity
-        so Google issues a refresh token (vault entry would otherwise expire
-        after ~1 hour with no refresh path)."""
+    async def test_custom_parameters_lookup_forwards_configured_params(self):
+        """For a Google connector configured with `access_type=offline`, the
+        hook forwards it to AgentCore Identity so Google issues a refresh
+        token (the vault entry would otherwise expire after ~1 hour with no
+        refresh path). The value comes from the connector config, not a
+        hardcoded vendor baseline."""
         identity = MagicMock()
         identity.get_token_for_user = AsyncMock(
             return_value=TokenResult(access_token="t")
@@ -799,7 +812,7 @@ class TestOAuthConsentHookErrors:
             user_id="alice",
             provider_lookup=lambda _tool: "google",
             scopes_lookup=lambda _: ["openid"],
-            provider_type_lookup=lambda _: "google",
+            custom_parameters_lookup=lambda _: {"access_type": "offline"},
         )
 
         event = _make_event(provider_id="google")
@@ -815,10 +828,10 @@ class TestOAuthConsentHookErrors:
         }
 
     @pytest.mark.asyncio
-    async def test_admin_custom_parameters_merge_with_baseline(self):
-        """Hook merges admin-supplied extras (e.g. Google `hd=` for Workspace
-        domain restriction) with the vendor baseline before forwarding to
-        AgentCore. Baseline still wins on conflict."""
+    async def test_custom_parameters_forwarded_verbatim(self):
+        """Hook forwards the connector's configured extras verbatim — no
+        hardcoded baseline is injected or allowed to override. An admin who
+        sets `access_type=online` gets exactly that (their choice)."""
         identity = MagicMock()
         identity.get_token_for_user = AsyncMock(
             return_value=TokenResult(access_token="t")
@@ -828,10 +841,9 @@ class TestOAuthConsentHookErrors:
             user_id="alice",
             provider_lookup=lambda _tool: "google",
             scopes_lookup=lambda _: ["openid"],
-            provider_type_lookup=lambda _: "google",
             custom_parameters_lookup=lambda _: {
                 "hd": "mycompany.com",
-                "access_type": "online",  # admin attempts override; ignored
+                "access_type": "online",
             },
         )
 
@@ -844,15 +856,15 @@ class TestOAuthConsentHookErrors:
 
         identity.get_token_for_user.assert_called_once()
         assert identity.get_token_for_user.call_args.kwargs["custom_parameters"] == {
-            "access_type": "offline",  # baseline wins
+            "access_type": "online",
             "hd": "mycompany.com",
         }
 
     @pytest.mark.asyncio
-    async def test_no_provider_type_lookup_omits_custom_parameters(self):
-        """When the lookup is omitted (legacy callers / non-Google vendors),
-        no `custom_parameters` is sent — AgentCore handles vendor defaults
-        and we don't accidentally inject Google-specific keys elsewhere."""
+    async def test_no_custom_parameters_lookup_omits_custom_parameters(self):
+        """When the lookup is omitted (legacy callers / connectors with no
+        configured extras), no `custom_parameters` is sent — AgentCore handles
+        vendor defaults and we don't inject anything."""
         identity = MagicMock()
         identity.get_token_for_user = AsyncMock(
             return_value=TokenResult(access_token="t")
@@ -862,7 +874,7 @@ class TestOAuthConsentHookErrors:
             user_id="alice",
             provider_lookup=lambda _tool: "github",
             scopes_lookup=lambda _: ["read:user"],
-            # no provider_type_lookup
+            # no custom_parameters_lookup
         )
 
         event = _make_event(provider_id="github")

--- a/backend/tests/apis/app_api/test_connectors_routes.py
+++ b/backend/tests/apis/app_api/test_connectors_routes.py
@@ -405,55 +405,57 @@ class TestForceReauthLifecycle:
 
     def test_status_matches_initiate_consent_custom_parameters(self, app_with_deps):
         # AgentCore factors customParameters into whether get_resource_oauth2_token
-        # short-circuits to a vaulted token. Connector consent always runs through
-        # initiate_consent, which sends Google `prompt=consent`; a status read that
-        # omits it is treated as a fresh request and reports consent-required even
-        # when a usable token is vaulted. So /status MUST send the same
-        # customParameters initiate_consent uses.
+        # short-circuits to a vaulted token. Both /initiate-consent and /status
+        # forward the connector's configured customParameters verbatim, so the
+        # maps match and a usable vaulted token isn't mistaken for a fresh
+        # request that reports consent-required.
+        configured = {"access_type": "offline", "prompt": "consent"}
         app, identity, _ = app_with_deps(
             "alice",
-            provider=_make_provider(),  # default is OAuthProviderType.GOOGLE
+            provider=_make_provider(custom_parameters=configured),
             identity_result=TokenResult(access_token="vault-token"),
         )
         TestClient(app).get("/connectors/google/status")
 
         identity.get_token_for_user.assert_called_once()
-        assert identity.get_token_for_user.call_args.kwargs["custom_parameters"] == {
-            "access_type": "offline",
-            "prompt": "consent",
-        }
+        assert (
+            identity.get_token_for_user.call_args.kwargs["custom_parameters"]
+            == configured
+        )
 
-    def test_initiate_consent_forwards_google_access_type_offline_and_prompt_consent(
+    def test_initiate_consent_forwards_configured_custom_parameters(
         self, app_with_deps
     ):
-        # initiate_consent is a "walk me through consent" path, so for Google
-        # we always send `prompt=consent` (in addition to `access_type=offline`).
-        # Without it, Google sees a previously-consented user, skips the consent
-        # screen, and re-issues an access_token without a refresh_token —
+        # initiate_consent forwards the connector's configured customParameters
+        # verbatim. For a Google connector configured with access_type=offline
+        # + prompt=consent, that's exactly what reaches AgentCore — without
+        # prompt=consent Google skips the consent screen for a previously-
+        # consented user and re-issues an access token with no refresh token,
         # putting the user back in the hourly-reconsent loop.
+        configured = {"access_type": "offline", "prompt": "consent"}
         app, identity, _ = app_with_deps(
             "alice",
-            provider=_make_provider(),
+            provider=_make_provider(custom_parameters=configured),
             identity_result=TokenResult(access_token="vault-token"),
         )
         TestClient(app).post("/connectors/google/initiate-consent")
 
         identity.get_token_for_user.assert_called_once()
-        assert identity.get_token_for_user.call_args.kwargs["custom_parameters"] == {
-            "access_type": "offline",
-            "prompt": "consent",
-        }
+        assert (
+            identity.get_token_for_user.call_args.kwargs["custom_parameters"]
+            == configured
+        )
 
-    def test_admin_custom_parameters_merge_with_google_baseline(self, app_with_deps):
-        # Admin set Workspace domain restriction. The route must merge
-        # admin extras with the hardcoded baseline before forwarding to
-        # AgentCore — and the baseline still wins on key conflict.
+    def test_custom_parameters_forwarded_verbatim(self, app_with_deps):
+        # No hardcoded baseline is injected or allowed to override — the
+        # connector's configured params reach AgentCore exactly as the admin
+        # set them (including access_type=online, if that's their choice).
         app, identity, _ = app_with_deps(
             "alice",
             provider=_make_provider(
                 custom_parameters={
                     "hd": "mycompany.com",
-                    "access_type": "online",  # admin tries to override; ignored
+                    "access_type": "online",
                 },
             ),
             identity_result=TokenResult(access_token="vault-token"),
@@ -462,8 +464,7 @@ class TestForceReauthLifecycle:
 
         kwargs = identity.get_token_for_user.call_args.kwargs
         assert kwargs["custom_parameters"] == {
-            "access_type": "offline",  # baseline wins
-            "prompt": "consent",  # matches the consent flow's customParameters
+            "access_type": "online",
             "hd": "mycompany.com",
         }
 

--- a/backend/tests/apis/shared/oauth/test_agentcore_identity.py
+++ b/backend/tests/apis/shared/oauth/test_agentcore_identity.py
@@ -13,91 +13,45 @@ from apis.shared.oauth.agentcore_identity import (
 
 
 class TestCustomParametersFor:
-    """Merge of vendor baseline + admin extras. Baseline is non-negotiable
-    because admins can't safely turn off documented requirements (e.g.
-    Google's `access_type=offline` for refresh tokens)."""
-
-    def test_google_baseline_alone(self) -> None:
-        assert custom_parameters_for("google") == {"access_type": "offline"}
-
-    def test_google_match_is_case_insensitive(self) -> None:
-        # OAuthProviderType.GOOGLE.value is "google", but defensive against
-        # callers that pass the upper-case enum name.
-        assert custom_parameters_for("Google") == {"access_type": "offline"}
-
-    @pytest.mark.parametrize(
-        "vendor", ["microsoft", "github", "canvas", "custom", "unknown"]
-    )
-    def test_other_vendors_with_no_extras_return_none(self, vendor: str) -> None:
-        # Per the AgentCore Identity docs, only Google requires baseline
-        # extras today. Returning None lets callers pass through.
-        assert custom_parameters_for(vendor) is None
+    """Pass-through normalizer for a connector's admin-configured
+    `customParameters`. There is no hardcoded vendor baseline — vendor
+    requirements (e.g. Google's `access_type=offline` for refresh tokens)
+    are supplied per-connector via the admin "Custom OAuth Parameters"
+    field, since the delivered vendors don't add them on their own."""
 
     def test_none_returns_none(self) -> None:
         assert custom_parameters_for(None) is None
 
-    def test_empty_string_returns_none(self) -> None:
-        assert custom_parameters_for("") is None
+    def test_empty_dict_returns_none(self) -> None:
+        # Callers pass the result straight to the SDK; None keeps an empty
+        # `customParameters` map off the wire.
+        assert custom_parameters_for({}) is None
 
-    def test_admin_extras_merged_with_google_baseline(self) -> None:
-        # Admin can add domain restriction / prompt without losing
-        # the access_type=offline requirement.
-        result = custom_parameters_for(
-            "google", {"hd": "mycompany.com", "prompt": "consent"}
-        )
-        assert result == {
+    def test_admin_extras_passed_through_verbatim(self) -> None:
+        # A Google connector configured for refresh tokens: the exact map
+        # the admin set is forwarded, untouched.
+        extras = {
             "access_type": "offline",
-            "hd": "mycompany.com",
             "prompt": "consent",
+            "hd": "mycompany.com",
+        }
+        assert custom_parameters_for(extras) == extras
+
+    def test_no_baseline_injected_for_google_like_params(self) -> None:
+        # Nothing is added or overridden — if an admin sets access_type=online
+        # that's what gets sent (their choice, their consequence).
+        assert custom_parameters_for({"access_type": "online"}) == {
+            "access_type": "online"
         }
 
-    def test_admin_cannot_override_baseline_keys(self) -> None:
-        # Admin-supplied access_type=online is silently superseded by the
-        # baseline. This is intentional — overriding it would silently
-        # break refresh tokens, the exact bug we hardcoded against.
-        result = custom_parameters_for("google", {"access_type": "online"})
-        assert result == {"access_type": "offline"}
-
-    def test_admin_extras_only_for_non_baseline_vendor(self) -> None:
-        # Vendors with no baseline still pass through admin extras.
-        result = custom_parameters_for("github", {"prompt": "consent"})
-        assert result == {"prompt": "consent"}
-
-    def test_empty_admin_extras_treated_as_none(self) -> None:
-        assert custom_parameters_for("microsoft", {}) is None
-        assert custom_parameters_for("microsoft", None) is None
-
-    def test_force_authentication_adds_prompt_consent_for_google(self) -> None:
-        # Google only re-issues a refresh token on subsequent grants when
-        # the consent screen is shown — so the explicit re-consent path
-        # must add prompt=consent on top of the baseline.
-        result = custom_parameters_for("google", force_authentication=True)
-        assert result == {"access_type": "offline", "prompt": "consent"}
-
-    def test_force_authentication_does_not_set_prompt_for_other_vendors(
-        self,
-    ) -> None:
-        # Other vendors don't have the same constraint — leaving prompt
-        # unset means we don't accidentally annoy a Microsoft / GitHub
-        # user with an unnecessary consent screen on every reconnect.
-        assert custom_parameters_for("microsoft", force_authentication=True) is None
-        assert custom_parameters_for("github", force_authentication=True) is None
-
-    def test_force_authentication_baseline_still_wins_over_admin(self) -> None:
-        # Even when force_authentication adds prompt=consent, an admin
-        # supplying prompt=login can't override it — the re-consent path
-        # needs the consent screen specifically.
-        result = custom_parameters_for(
-            "google", {"prompt": "login"}, force_authentication=True
-        )
-        assert result == {"access_type": "offline", "prompt": "consent"}
-
-    def test_default_force_authentication_is_false(self) -> None:
-        # Silent refresh path must not get prompt=consent — otherwise
-        # every refresh would force the consent screen.
-        result = custom_parameters_for("google")
-        assert result == {"access_type": "offline"}
-        assert "prompt" not in result
+    def test_returns_a_copy(self) -> None:
+        # Defensive: mutating the returned map must not mutate the caller's
+        # stored connector params.
+        extras = {"access_type": "offline"}
+        result = custom_parameters_for(extras)
+        assert result == extras
+        result["prompt"] = "consent"
+        assert "prompt" not in extras
 
 
 class TestTokenResult:


### PR DESCRIPTION
## What

Removes the hardcoded vendor-baseline OAuth params from the token path. `custom_parameters_for` no longer injects Google's `access_type=offline` (or `prompt=consent` on the force-auth path) keyed off `provider_type` — every call site now forwards the connector's **admin-configured** `customParameters` verbatim.

## Why

The baseline-merge made the `customParameters` map depend on the call site (grant vs retrieval, force-auth vs not). AgentCore factors `customParameters` into its vault key, so per-call-site drift is a latent source of "consent-required even though a token is vaulted" bugs. Folding the requirement into admin config (the seeded Google connector already carries `access_type=offline` + `prompt=consent`) makes the map **provably identical** across consent and every retrieval, and removes hidden customizations from the OAuth flow while we're chasing a token-binding issue.

## Scope

Single coherent refactor across all call sites:
- `custom_parameters_for(admin_extras)` — drops `provider_type` + `force_authentication` args; removes `_vendor_baseline_params`
- Consent hook loses the `provider_type_lookup` plumbing; `base_agent` loses the wiring
- Read sites (`connectors`, `file_sources`, `export_targets`, `kb_sync` worker, status) forward the stored map directly

**Behaviour for the existing Google connector is identical** (same resulting map). Net −123 lines.

## Migration note

Because the Google `access_type=offline` baseline is no longer hardcoded, every **Google** connector must carry it in its admin "Custom OAuth Parameters". Verified in dev-ai: `google-drive` has `{hd, prompt=consent, access_type=offline}`; the only other connector (`canvas-faculty`) isn't Google. **Check any other Google connectors in prod/beta before this reaches `main`.**

## Tests

386 passing across `oauth/`, connectors, file-sources, export-targets, kb-sync worker, and agent-session hooks (test files updated in-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)