### PR TITLE
docs: add tool-search token-bloat + per-user markdown memory specs

### DIFF
--- a/docs/specs/tool-search-token-bloat-strategy.md
+++ b/docs/specs/tool-search-token-bloat-strategy.md
@@ -1,0 +1,123 @@
+# Cross-source tool-search strategy for MCP token bloat
+
+Status: analysis / not built
+Last updated: 2026-07-04
+
+## Problem
+
+Tool schemas for all four tool sources — built-in (code-interpreter/browser),
+external MCP via Lambda (`mcp_external`), Gateway MCP targets, and A2A — are
+serialized into the Bedrock `toolConfig` on **every turn**. As the catalog
+grows this becomes a large, constant input-token cost (measured as the
+`toolTokens` partition by `ContextAttributionHook`). There is no lazy/deferred
+tool exposure today.
+
+## The convergence seam
+
+All four sources converge only at
+[`BaseAgent._build_filtered_tools()`](../../backend/src/agents/main_agent/base_agent.py) →
+flat list → Strands → serialized into Bedrock `toolConfig` every turn.
+
+Any cross-source search MUST live at this seam — it is the only layer that sees
+all four sources.
+
+## What each mechanism can cover
+
+- **Gateway semantic search** — the built-in `x_amz_bedrock_agentcore_search`
+  tool, enabled at gateway create with `listingMode=DEFAULT`. Embeds each
+  registered target's tool metadata into a serverless vector store; the agent
+  calls it via MCP `tools/call` and gets the top ~10–15. **Covers Gateway
+  targets only** — not built-in, not `mcp_external`, not A2A. We don't consume
+  it yet: `FilteredMCPClient.list_tools_sync` lists all gateway tools and ships
+  all matching schemas, so gateway tools currently pay full token cost.
+  Sub-lever: migrate `mcp_external` → Gateway targets (`protocol=mcp`) to widen
+  vector-store coverage.
+
+- **FastMCP tool-search transform** — server-side, searches only that one
+  server's own tools. Not privy to our catalog. Legit only as an in-server
+  tactic for a single bloated FastMCP server.
+
+- **Anthropic native Tool Search Tool** (`tool_search_tool_bm25_20251119` /
+  `_regex_`) — **RULED OUT on our path.** It is a server-side tool; on Bedrock,
+  server-side tools are available via `InvokeModel` only, not Converse. Strands
+  drives Bedrock via `converse_stream`. (Note: `anthropic_beta` *flags* like
+  fine-grained-tool-streaming DO pass through Converse `additionalRequestFields`;
+  server-side *tools* do not — different mechanism.)
+
+- **AWS Agent Registry (Preview)** — a managed discovery service exposed as a
+  remote **MCP endpoint**. MCP servers, agents, skills, and custom resources are
+  published as *records*, validated against protocol schemas, curated through an
+  approval workflow, and searched via hybrid semantic+keyword. Auth is IAM or
+  corporate JWT. See [Registry as a dynamic tool-discovery tier](#registry-as-a-dynamic-tool-discovery-tier).
+
+## Recommended tiers
+
+0. **Curate first** — assistant/role-scoped `enabled_tools` profiles. Search only
+   pays off when ONE assistant needs a large universe but few tools per turn.
+1. **Consume Gateway semantic search** for the gateway slice + migrate external
+   onto the gateway (mostly AWS-managed, ~80–90% of the win).
+2. **Unified `search_tools(query)` facade** at `_build_filtered_tools`,
+   delegating the gateway slice to `x_amz_bedrock_agentcore_search` and indexing
+   the residual off the DynamoDB catalog / S3 Vectors / Bedrock KB.
+
+### Tier-2 gotchas
+
+Strands fixes the tool list at agent construction (cache keyed on `tools_hash`
+in `inference_api/chat/service.py`) → dynamic promotion needs an agent rebuild
+or runtime tool registration (the real cost). Must **append** schemas (like
+Anthropic native does), not rebuild — a naive rebuild invalidates the prompt
+cache after the insertion point on every search and can cost more than the bloat
+removed.
+
+## Registry as a dynamic tool-discovery tier
+
+AWS Agent Registry is a *discovery + governance* layer, not an execution layer —
+it catalogs and advertises resources but does not run them. That makes it a
+candidate **dynamic-discovery** answer to the token-bloat problem, distinct from
+the tiers above:
+
+- **How it would cut bloat.** Instead of front-loading every tool schema into
+  `toolConfig`, the agent queries the Registry's MCP-native endpoint
+  semantically for the right tool/sub-agent at the point of need, and we promote
+  only the matched schemas at the seam. This is the same "discover then promote"
+  shape as Tier-2, but the index + governance are AWS-managed rather than
+  hand-rolled off DynamoDB/S3 Vectors.
+
+- **Coverage vs. Gateway semantic search.** Gateway search covers Gateway
+  targets only. Registry can catalog **any** resource type — MCP servers,
+  agents, skills, custom records — so in principle it spans sources the Gateway
+  vector store never sees (`mcp_external`, A2A leaf agents, Harness sub-agents).
+  Registry advertises/governs; the Gateway still *connects* the tool for
+  invocation. They are complementary, not overlapping.
+
+- **Bonus: governance for free.** The approval workflow + curation is exactly the
+  admin/RBAC posture in the admin-skills plan — an admin curates which tools and
+  sub-agents are discoverable, rather than us building that workflow.
+
+- **Still needs the seam.** Registry returns *records* (metadata + how to reach
+  the resource), not live Strands tool objects. Discovery via Registry still
+  terminates at `_build_filtered_tools` promotion + the Tier-2 append-not-rebuild
+  constraint. Registry replaces the *index*, not the promotion machinery.
+
+- **Caveats.** Preview / region-gated — not for a delivery-critical path yet.
+  Registries are created via AgentCore control APIs, not CDK — a parallel
+  provisioning surface to own (same posture as Harness and Gateway targets).
+
+**Where it sits in the plan:** an alternative index backing Tier-2, and the
+natural discovery/governance layer if we adopt Harness-as-leaf-sub-agents. Worth
+a spike *after* the Tier-1 Gateway-search measurement, not before — Tier-1 is
+lower-risk and mostly AWS-managed.
+
+## Suggested next step
+
+1-day Tier-1 spike — dev gateway `DEFAULT`/semantic, agent calls
+`x_amz_bedrock_agentcore_search` instead of the full list, measure `toolTokens`
+before/after.
+
+## Related
+
+- `project_gateway_3lo_listing_mode` — `DEFAULT` co-gates 3LO + semantic search
+- `project_issue419_gateway_target_registration`
+- `project_context_attribution_prototype` — `toolTokens` partition is the measurement
+- `project_skills_registry_tool_binding` — Registry for governance/discovery over bound tools
+- `docs/specs/admin-skills-rbac-tool-binding.md` — the RBAC/curation posture Registry approval maps onto

--- a/docs/specs/user-markdown-memory.md
+++ b/docs/specs/user-markdown-memory.md
@@ -1,0 +1,284 @@
+# Per-User Markdown Memory (Karpathy-style "second brain" on S3)
+
+**Status:** Draft / proposal
+**Author:** (drafted with Claude)
+**Date:** 2026-06-27
+**Targets branch:** `develop`
+**Related:** skills reference-file / progressive-disclosure pattern (`agents/main_agent/skills/`, `apis/shared/skills/resource_store.py`), AgentCore Memory write-only limitation (`agents/main_agent/session/turn_based_session_manager.py`), context attribution (`apis/shared/costs/`)
+
+## Summary
+
+Give every user a small, **human-readable markdown memory** that the agent reads at the
+start of a conversation and maintains over time — a per-user "second brain" backed by S3
+instead of a local filesystem. The shape is the one Karpathy popularized and the one this
+very repo's coding agent uses internally: a tiny always-loaded **index** (`MEMORY.md`) of
+one-line pointers, plus a set of **one-fact-per-file** markdown notes fetched on demand.
+
+The architectural move is that we already ship this mechanism — it's the **skills
+reference-file / progressive-disclosure** path ([`skill_registry.read_resource`](../../backend/src/agents/main_agent/skills/skill_registry.py),
+[`SkillResourceStore`](../../backend/src/apis/shared/skills/resource_store.py)): S3
+content-addressed storage, a lightweight DynamoDB manifest, **server-side read
+mid-conversation**, and a Level-1 catalog injected into the system prompt with Level-2+
+files fetched via a tool. Per-user memory is that mechanism **re-scoped from per-skill to
+per-user**, plus a write/consolidation path.
+
+This is the right design (vs. leaning on AgentCore Memory) because **AgentCore Memory is
+write-only in cloud** — the SDK restore branch never fires, so Memory cannot be the
+read-time source of truth today (see
+[`project_session_restore_writeonly_memory`](../../backend/src/agents/main_agent/session/turn_based_session_manager.py)
+analysis). An S3 markdown layer fills a real gap rather than competing with a working
+system.
+
+### Prior art
+
+- **Karpathy's LLM Wiki / second brain** — agent-maintained markdown wiki: immutable raw
+  sources, an AI-generated/-maintained wiki layer, and a schema file governing read/write/
+  reconcile. Core claim: LLMs don't get bored, so the wiki-maintenance burden that kills
+  human wikis disappears. ([gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f))
+- **MRAgent — "Memory is Reconstructed, Not Retrieved"** ([arxiv 2606.06036](https://arxiv.org/abs/2606.06036),
+  [repo](https://github.com/Ji-shuo/MRAgent)) — interleaves LLM reasoning with memory access
+  (active reconstruction) rather than a static retrieve-then-reason step. The transferable
+  lesson: **don't pre-stuff context; let the agent fetch on demand inside its loop.**
+- **This repo's own coding-agent memory** — `MEMORY.md` index + one-fact-per-file markdown
+  with frontmatter (`name`/`description`/`type`), `[[wikilinks]]` between facts, a
+  consolidation pass. The cleanest reference implementation of exactly what we'd build.
+
+## Goals
+
+- A per-user, durable, **human-readable** markdown memory the agent reads at conversation
+  start and updates over time.
+- **Token-bounded**: steady-state cost is the index only; fact bodies are lazy.
+- Reuse the **skills reference-file mechanism** (S3 store + DynamoDB manifest + on-demand
+  read tool) re-scoped to `USER#{user_id}`, with minimal new infrastructure.
+- **User-visible & user-editable**: "here's what I remember about you," with delete/export.
+  This is a feature, not overhead — and likely a compliance requirement.
+- Ship **dark behind a flag** (`USER_MEMORY_ENABLED`, default off), per-environment enable,
+  mirroring `SKILLS_ENABLED`.
+
+## Non-goals (v1)
+
+- A graph/vector memory (MRAgent's full Cue–Tag–Content graph). v1 is flat markdown +
+  an index; the *reconstruction* lesson is adopted (on-demand fetch), the graph is not.
+- Importing raw source documents into a wiki (Karpathy's "raw sources" layer). v1 memory
+  is distilled facts, not a document corpus — that overlaps the existing RAG/assistant KB.
+- Cross-user / org-shared memory. Memory is strictly `USER#{user_id}`-scoped.
+- Memory inside assistant-backed or shared conversations (see [Open questions](#open-questions)).
+- Replacing AgentCore Memory or the compaction/summary path — this is additive.
+
+---
+
+## Background: the pattern we're extending
+
+Skills already do per-skill progressive disclosure end-to-end. The whole of this spec is
+re-pointing it at users and adding writes.
+
+```
+SkillResourceRef (DynamoDB manifest row)        ← lightweight pointer, no bytes
+  filename, content_hash, size, content_type, s3_key
+
+SkillResourceStore (S3, content-addressed)      ← put() dedupes on hash, get() fetches
+  skills/{skill_id}/{content_hash}
+
+Runtime:
+  get_catalog()        → Level-1 listing injected into system prompt
+  get_resource_names() → filenames offered to the model (no bytes)
+  read_resource(name)  → server-side S3 fetch mid-conversation, returns text
+```
+
+Concrete anchors:
+- Manifest model: [`SkillResourceRef`](../../backend/src/apis/shared/skills/models.py)
+- S3 store: [`SkillResourceStore`](../../backend/src/apis/shared/skills/resource_store.py)
+- Runtime disclosure: [`skill_registry.py`](../../backend/src/agents/main_agent/skills/skill_registry.py) (`get_catalog`, `get_resource_names`, `read_resource`)
+- Bucket construct: [`skill-resources-construct.ts`](../../infrastructure/lib/constructs/skills/skill-resources-construct.ts)
+- System-prompt assembly: [`system_prompt_builder.py`](../../backend/src/agents/main_agent/core/system_prompt_builder.py), per-turn resolution in [`system_prompt_resolver.py`](../../backend/src/apis/inference_api/chat/system_prompt_resolver.py)
+- Per-user DynamoDB scoping: `PK=USER#{user_id}, SK=...` (sessions, artifacts, preferences)
+- Token accounting we'll reuse: `contextBreakdown` partitions in [`costs/models.py`](../../backend/src/apis/shared/costs/models.py)
+
+**The asymmetry that matters:** skill resources are **read-only and admin-authored**;
+user memory is **read-write and agent/user-authored**. The store, manifest, and read tool
+transfer directly. The new work is the **write + consolidation** path and the
+**prompt-cache-safe injection** of the index.
+
+---
+
+## Design
+
+### 1. Storage layout (S3 + DynamoDB manifest)
+
+Reuse the skill-resources bucket pattern under a per-user prefix (or a dedicated
+`user-memory` bucket — see [CDK](#5-infrastructure)):
+
+```
+memory/users/{user_id}/MEMORY.md              # the index — small, always-loaded
+memory/users/{user_id}/facts/{slug}.md        # one fact per file, fetched on demand
+```
+
+Each fact file carries frontmatter (mirrors the coding-agent memory shape):
+
+```markdown
+---
+name: prefers-concise-answers
+description: User wants terse, direct responses; skip preamble
+type: user | feedback | project | reference
+updated: 2026-06-27
+---
+
+User has repeatedly asked for shorter answers... Link related facts with [[other-slug]].
+```
+
+Manifest: a small DynamoDB row `PK=USER#{user_id}, SK=MEMORY#INDEX` holding the file list
+(`slug`, `description`, `content_hash`, `size`, `updated`) — structurally a list of
+`SkillResourceRef`. **No bodies in DynamoDB** (400 KB item-limit rule, same reason skills
+went to S3). The index `MEMORY.md` itself lives in S3; the manifest row is the
+fast-path pointer + cache-key input.
+
+### 2. New shared service: `UserMemoryStore`
+
+New package `apis/shared/memory/` (a shared concern: both app-api and inference-api
+consume it, so it lives in `apis.shared` per the import-boundary rule).
+
+```python
+# apis/shared/memory/store.py
+class UserMemoryStore:
+    def read_index(self, user_id: str) -> str: ...                  # MEMORY.md text
+    def list_facts(self, user_id: str) -> list[MemoryFactRef]: ...  # manifest, no bodies
+    def read_fact(self, user_id: str, slug: str) -> str: ...        # one fact body
+    def write_fact(self, user_id: str, slug: str, body: str) -> MemoryFactRef: ...
+    def update_index(self, user_id: str, body: str) -> None: ...
+    def delete_fact(self, user_id: str, slug: str) -> None: ...
+```
+
+Mirror `SkillResourceStore`: lazy boto3 init, content-addressed objects, raise loudly on
+miss (no silent failures), best-effort delete. Env var `S3_USER_MEMORY_BUCKET_NAME`.
+
+### 3. Read path — index in prompt, facts on demand
+
+**Index injection (Level 1).** At conversation start, inject `MEMORY.md` into the system
+prompt as a bounded block. This is the MRAgent discipline applied: only the index is
+pre-loaded; fact bodies are reconstructed on demand.
+
+> **Prompt-cache constraint (decide here, not later).** Per-user content in the system
+> prefix gives each user a distinct cache key and interacts badly with the shared-prefix
+> caching [`system_prompt_resolver.py`](../../backend/src/apis/inference_api/chat/system_prompt_resolver.py)
+> relies on (it deliberately *gates* injection on continuation/prompt-cache turns).
+> Two viable strategies:
+> - **(A) Dedicated cache block.** Append the memory index as its own
+>   `cache_control` breakpoint after the shared platform prefix, so the platform prefix
+>   stays globally cached and the per-user index caches *within* that user's session.
+>   Preferred — keeps both caches working.
+> - **(B) Tool-loaded on turn 1.** Skip the prefix entirely; the agent calls a
+>   `memory_index()` tool on the first turn. Zero prefix-cache disruption, costs one
+>   extra tool round-trip per conversation.
+>
+> Recommend **(A)**; spike both and measure with `contextBreakdown`.
+
+**Fact fetch (Level 2).** A `memory_read(slug)` tool fetches one fact body server-side
+from S3 — a direct analog of `read_resource`. The agent fetches only what the current
+turn needs.
+
+### 4. Write path
+
+Two mechanisms, not mutually exclusive:
+
+- **(W1) Synchronous agentic write** — `memory_write(slug, body)` / `memory_update(slug, body)`
+  tools the model calls mid-turn when it learns something durable, plus an index-update
+  step. Transparent, simple, matches the coding-agent memory model. Risk: relies on the
+  model remembering to write. **v1 default.**
+- **(W2) Async post-turn reflection** — a background job reads the completed turn and
+  proposes memory edits, hung off the existing post-turn hook in
+  [`turn_based_session_manager.update_after_turn`](../../backend/src/agents/main_agent/session/turn_based_session_manager.py)
+  (same seam compaction uses). Reliable, no reliance on in-loop discipline, but adds an
+  LLM call per turn. **Phase 2.**
+
+**Consolidation.** A periodic pass (Karpathy's core insight — LLMs don't get bored) that
+merges duplicate facts, fixes stale ones, prunes the index, and enforces the index cap.
+Run as a scheduled job per active user (or lazily, when the index crosses a size
+threshold). Mirrors the repo's `consolidate-memory` skill conceptually.
+
+### 5. Infrastructure
+
+New `UserMemoryConstruct` (clone of [`skill-resources-construct.ts`](../../infrastructure/lib/constructs/skills/skill-resources-construct.ts)):
+S3 bucket (AES256 or **CMK — see PII below**), block public access, enforce SSL, no
+auto-expiry (memory is durable; deletion is explicit/user-driven). Thread the bucket to
+compute roles via `PlatformComputeRefs` (typed ref, not SSM), per the construct rules.
+Read+write grant to inference-api runtime role and app-api role.
+
+### 6. User-facing surface (app-api + SPA)
+
+Because memory is human-readable markdown, expose it. `app-api` routes under
+`/memory/` (user-facing, `Depends(get_current_user_from_session)` — **not** Bearer, per
+the auth-dependency rule):
+
+- `GET /memory` — list facts (manifest) + index
+- `GET /memory/{slug}` — read one fact
+- `PUT /memory/{slug}` / `DELETE /memory/{slug}` — user edits/deletes a fact
+- `DELETE /memory` — wipe (compliance "forget me")
+
+SPA: a "What I remember about you" panel — view, edit, delete, export. This is the
+differentiator vector RAG can't offer and the FERPA control surface.
+
+---
+
+## Token efficiency analysis
+
+The model's headline advantage, and it's quantifiable.
+
+- **Steady-state overhead = index only.** ~1 line (~15–25 tokens) per fact. 50 facts ≈
+  **~1k tokens/turn**; 200 facts ≈ **~4k tokens/turn**. Bounded and tunable via the
+  consolidation cap. Fact bodies cost **zero** unless fetched.
+- **Lazy bodies (MRAgent discipline).** You pay a fact's body tokens only on turns where
+  the agent fetches it, not every turn.
+- **Versus alternatives:**
+  - *Transcript replay* (today's agent-cache continuity): unbounded, grows every turn —
+    exactly what compaction fights.
+  - *Vector RAG*: pays embedding + opaque chunk injection per query; not user-inspectable.
+  - *AgentCore summaries*: unusable for read in cloud (write-only path).
+- **Measurement.** Add a `memory` partition to `contextBreakdown` so the index cost is
+  visible per turn and we can validate the cap empirically (same method the skills PR-7
+  used to confirm `toolTokens` dropped).
+
+**Net:** capped index + lazy fetch ⇒ **~1–4k tokens/turn steady-state**, far cheaper and
+more controllable than replay or RAG. The one cost risk is prompt-cache disruption, fully
+mitigated by strategy (A) above.
+
+---
+
+## Phasing (proposed PRs)
+
+- **PR-1 — Data layer.** `apis/shared/memory/` (`UserMemoryStore` + `MemoryFactRef` model +
+  manifest repo). `UserMemoryConstruct` (CDK). Unit tests. No runtime wiring. Flag added,
+  default off.
+- **PR-2 — Read path.** Index injection (strategy A) into the system prompt + `memory_read`
+  tool + `memory` partition in `contextBreakdown`. Gated by `USER_MEMORY_ENABLED`.
+- **PR-3 — Write path (agentic, W1).** `memory_write` / `memory_update` tools + index
+  maintenance. Round-trips through the existing tool RBAC/registry.
+- **PR-4 — User surface.** `app-api` `/memory/` CRUD + SPA "What I remember" panel
+  (view/edit/delete/export).
+- **PR-5 — Consolidation.** Scheduled/threshold consolidation pass + index cap enforcement.
+- **PR-6 — Reflection writes (W2), optional.** Post-turn reflection job on the
+  `update_after_turn` seam. Defer until W1 reliability is measured.
+
+---
+
+## Open questions
+
+- **FERPA / student PII (biggest risk).** Durable plaintext per-user memory of an academic
+  chatbot will capture sensitive student data. Need a position *before code*: CMK
+  encryption, retention/TTL policy, a write-side redaction/allowlist policy, and the
+  "forget me" wipe. This shapes the design more than the storage mechanics.
+- **Prompt-cache placement** — confirm strategy (A) vs (B) with a spike + `contextBreakdown`.
+- **Assistant / shared conversations** — whose memory applies, if any? Likely "user memory
+  off when assistant-backed" in v1 (matches skills-mode exclusion precedent).
+- **Write-trigger reliability** — measure how often W1 actually fires before committing to
+  whether W2 is needed.
+- **Index cap & eviction policy** — hard cap on index lines; consolidation decides what to
+  merge vs. drop. What's the cap? (Start ~150 facts / ~3k tokens.)
+- **Multi-device / concurrency** — two concurrent sessions writing memory. Content-addressed
+  writes + last-write-wins on the index, or optimistic-concurrency on the manifest row?
+
+## Validation note
+
+Before/while building PR-2, walk the repo's **own** coding-agent memory
+(`MEMORY.md` + per-fact files + consolidation) end-to-end as the reference behavior — it is
+the exact pattern, already proven, and surfaces the index-maintenance and wikilink edge
+cases early.


### PR DESCRIPTION
Adds two design specs that were sitting untracked in the working tree:

- `docs/specs/tool-search-token-bloat-strategy.md` — cross-source tool-search strategy for MCP token bloat (tiered discovery + AWS Agent Registry tier).
- `docs/specs/user-markdown-memory.md` — per-user markdown "second brain" memory design.

Docs only — no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)