### PR TITLE
feat(kb-sync): log workload identity + userId on a reauth pause

### DIFF
--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -111,7 +111,18 @@ async def _resolve_access_token(provider, user_id: str) -> Optional[str]:
 
 
 async def _pause_reauth(policy: SyncPolicy, detail: str, provider_id: Optional[str] = None) -> Dict[str, Any]:
-    logger.warning(f"Sync policy {policy.policy_id}: credentials need re-consent ({detail})")
+    # Log the exact (workload identity, userId) the vault lookup used. The
+    # token is keyed by that pair, so a "requires consent" almost always means
+    # the token was vaulted under a DIFFERENT workload — e.g. a consent done
+    # via local dev (AGENTCORE_RUNTIME_WORKLOAD_NAME=local_dev_inference)
+    # can't be read by the deployed worker (platform-workload). Surfacing both
+    # turns an opaque reauth pause into a one-line mismatch diagnosis.
+    logger.warning(
+        f"Sync policy {policy.policy_id}: credentials need re-consent ({detail}); "
+        f"vault lookup used workload={os.environ.get('AGENTCORE_RUNTIME_WORKLOAD_NAME')!r} "
+        f"userId={policy.created_by_user_id!r} provider={provider_id!r} — a token vaulted "
+        f"under a different workload identity will read as consent-required here"
+    )
     # "skipped" (not "failed"): resets the breaker streaks and clears the
     # run stamp — reauth is its own terminal state, not a failure count.
     await record_sync_result(policy.assistant_id, policy.policy_id, "skipped")


### PR DESCRIPTION
## Why

A KB-sync reauth pause logged only `credentials need re-consent (…)` — opaque. The vault token is keyed by **(workload identity, userId)**, so the overwhelmingly common cause of a false "consent required" is that the token was vaulted under a **different workload identity** than the worker queries.

Concretely: a Google consent done through **local dev** (`AGENTCORE_RUNTIME_WORKLOAD_NAME=local_dev_inference`) is invisible to the **deployed worker** (`platform-workload`) — same user, same provider, different key → `requires_consent`. That exact mismatch cost hours to diagnose because the log gave no hint.

## Change

The pause warning now includes the `workload`, `userId`, and `provider` the vault lookup used, so a workload-name mismatch is a one-line diagnosis instead of a multi-hour investigation.

```
Sync policy syn-…: credentials need re-consent (vault returned authorization URL);
vault lookup used workload='dev-boisestateai-v2-platform-workload' userId='…' provider='google-drive'
— a token vaulted under a different workload identity will read as consent-required here
```

## Tests

`tests/lambdas/test_kb_sync_worker.py` — 22 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)