### PR TITLE
chore(kb-sync): plumb CDK_KB_SYNC_ENABLED into the platform deploy

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -89,6 +89,13 @@ jobs:
       # nonexistent host and MCP Apps fail to load. Cert MUST be in us-east-1.
       CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
       CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
+      # KB sync scheduled re-index. When "true", CDK enables the EventBridge
+      # rate(15m) rule AND sets KB_SYNC_ENABLED=true on both kb-sync Lambdas;
+      # anything else (incl. unset) keeps the feature dark (config.ts defaults
+      # to false when absent). Set the `CDK_KB_SYNC_ENABLED` variable to "true"
+      # only in the environment(s) where it should run — development today,
+      # production stays dark until validated there.
+      CDK_KB_SYNC_ENABLED: ${{ vars.CDK_KB_SYNC_ENABLED }}
       # Secrets
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## What

Forwards `CDK_KB_SYNC_ENABLED` from the Platform Stack workflow into the CDK synth, as an environment-scoped `${{ vars.CDK_KB_SYNC_ENABLED }}` (matching every other `CDK_` var).

## Why

KB sync ships dark — the EventBridge `rate(15m)` rule is created disabled and the `KB_SYNC_ENABLED` kill switch is `false` unless CDK synths with `CDK_KB_SYNC_ENABLED=true` ([config.ts](infrastructure/lib/config.ts)). `platform.yml` never forwarded that var, so a platform deploy always synthed the feature **off**. The only way to enable it was an out-of-band CLI flip (enable the rule + set the env on both Lambdas), which **reverts on the next `cdk deploy`**.

## Effect

- The **`development`** environment variable `CDK_KB_SYNC_ENABLED` is set to `"true"` → on the next platform deploy, CDK enables the rule + sets `KB_SYNC_ENABLED=true` on both kb-sync Lambdas **durably**, reconciling the current manual flip into managed state.
- **`production`** leaves the variable unset → stays dark until we validate in dev-ai.

Now validated in dev-ai: dispatcher tick sweeps the DueSyncIndex, applies guards, re-arms, and async-invokes the worker end-to-end (worker currently pauses on a known localhost-consent workload mismatch — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)