### PR TITLE
chore(kb-sync): default the feature ON with a kill switch

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -89,12 +89,12 @@ jobs:
       # nonexistent host and MCP Apps fail to load. Cert MUST be in us-east-1.
       CDK_MCP_SANDBOX_CERTIFICATE_ARN: ${{ vars.CDK_MCP_SANDBOX_CERTIFICATE_ARN }}
       CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS }}
-      # KB sync scheduled re-index. When "true", CDK enables the EventBridge
-      # rate(15m) rule AND sets KB_SYNC_ENABLED=true on both kb-sync Lambdas;
-      # anything else (incl. unset) keeps the feature dark (config.ts defaults
-      # to false when absent). Set the `CDK_KB_SYNC_ENABLED` variable to "true"
-      # only in the environment(s) where it should run — development today,
-      # production stays dark until validated there.
+      # KB sync scheduled re-index. Default ON with a kill switch: CDK enables
+      # the EventBridge rate(15m) rule + KB_SYNC_ENABLED on both kb-sync
+      # Lambdas UNLESS this is set to "false". Unset resolves to empty string,
+      # which config.ts treats as the default (on). Set the
+      # `CDK_KB_SYNC_ENABLED` variable to "false" in an environment only to
+      # dark-stop the feature there.
       CDK_KB_SYNC_ENABLED: ${{ vars.CDK_KB_SYNC_ENABLED }}
       # Secrets
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -132,8 +132,9 @@ export interface RagIngestionConfig {
  *
  * `enabled` gates the whole feature: it sets the EventBridge rule's
  * enabled state AND the KB_SYNC_ENABLED env var on both kb-sync
- * Lambdas. Default false — the kb-sync PRs merge dark and the feature
- * lights up with CDK_KB_SYNC_ENABLED=true on a platform deploy.
+ * Lambdas. Default ON with a kill switch — the feature runs unless it's
+ * explicitly turned off with CDK_KB_SYNC_ENABLED=false (or a
+ * `kbSync.enabled: false` cdk.json context).
  */
 export interface KbSyncConfig {
   enabled: boolean;
@@ -266,10 +267,14 @@ export function loadConfig(scope: cdk.App): AppConfig {
       vectorDistanceMetric: process.env.CDK_RAG_DISTANCE_METRIC || scope.node.tryGetContext('ragIngestion')?.vectorDistanceMetric,
     },
     kbSync: {
-      enabled:
-        process.env.CDK_KB_SYNC_ENABLED !== undefined
-          ? process.env.CDK_KB_SYNC_ENABLED === 'true'
-          : scope.node.tryGetContext('kbSync')?.enabled ?? false,
+      // Default ON with a kill switch: enabled unless explicitly disabled.
+      // The workflow forwards `${{ vars.CDK_KB_SYNC_ENABLED }}`, which is an
+      // EMPTY STRING when the variable is unset — so treat empty/unset as
+      // "use the default (on)" and only the literal "false" as the off
+      // switch. A `kbSync.enabled` cdk.json context can also force it off.
+      enabled: process.env.CDK_KB_SYNC_ENABLED
+        ? process.env.CDK_KB_SYNC_ENABLED !== 'false'
+        : scope.node.tryGetContext('kbSync')?.enabled ?? true,
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,

--- a/infrastructure/test/config.test.ts
+++ b/infrastructure/test/config.test.ts
@@ -308,6 +308,44 @@ describe('RAG Ingestion Configuration', () => {
   });
 
   // ============================================================
+  // KB Sync feature flag — default ON with a kill switch
+  // ============================================================
+
+  describe('KB Sync feature flag', () => {
+    test('defaults to enabled when CDK_KB_SYNC_ENABLED is unset', () => {
+      delete process.env.CDK_KB_SYNC_ENABLED;
+
+      expect(loadConfig(app).kbSync.enabled).toBe(true);
+    });
+
+    test('treats empty string (unset GitHub Actions variable) as enabled', () => {
+      // `${{ vars.CDK_KB_SYNC_ENABLED }}` renders to "" when the var is unset.
+      process.env.CDK_KB_SYNC_ENABLED = '';
+
+      expect(loadConfig(app).kbSync.enabled).toBe(true);
+    });
+
+    test('CDK_KB_SYNC_ENABLED="false" is the kill switch', () => {
+      process.env.CDK_KB_SYNC_ENABLED = 'false';
+
+      expect(loadConfig(app).kbSync.enabled).toBe(false);
+    });
+
+    test('CDK_KB_SYNC_ENABLED="true" stays enabled', () => {
+      process.env.CDK_KB_SYNC_ENABLED = 'true';
+
+      expect(loadConfig(app).kbSync.enabled).toBe(true);
+    });
+
+    test('cdk.json context kbSync.enabled=false disables when env is unset', () => {
+      delete process.env.CDK_KB_SYNC_ENABLED;
+      app.node.setContext('kbSync', { enabled: false });
+
+      expect(loadConfig(app).kbSync.enabled).toBe(false);
+    });
+  });
+
+  // ============================================================
   // Configuration Validation Tests
   // ============================================================
 

--- a/infrastructure/test/kb-sync.test.ts
+++ b/infrastructure/test/kb-sync.test.ts
@@ -51,7 +51,7 @@ describe('KbSyncConstruct', () => {
     });
   });
 
-  it('rule is DISABLED when kbSync.enabled is false (dark by default)', () => {
+  it('rule is DISABLED when kbSync.enabled is false (explicit kill switch)', () => {
     t.hasResourceProperties('AWS::Events::Rule', { State: 'DISABLED' });
   });
 


### PR DESCRIPTION
## What

Inverts the KB-sync feature flag from **opt-in** (default off) to **opt-out** (default on with a kill switch). Enabled unless `CDK_KB_SYNC_ENABLED=false` (or a `kbSync.enabled: false` cdk.json context).

## Why

Default-off was a holdover from ship-dark incremental development. The feature is complete and guarded (kill switch, breaker, inactivity pause, liveness, alarms), so anyone deploying/cloning the public stack should get a working feature by default — a hidden default-off flag is bad DX. Per the convention: **feature flags default on with a kill switch** unless there's a strong governance reason for opt-in.

## The empty-string subtlety

The workflow forwards `CDK_KB_SYNC_ENABLED: ${{ vars.CDK_KB_SYNC_ENABLED }}`, which renders to an **empty string** when the variable is unset — so a plain `?? false` fallback wouldn't flip the default. `config.ts` now treats empty/unset as "use the default (on)" and only the literal `"false"` as the off switch:

```ts
enabled: process.env.CDK_KB_SYNC_ENABLED
  ? process.env.CDK_KB_SYNC_ENABLED !== 'false'
  : scope.node.tryGetContext('kbSync')?.enabled ?? true,
```

## Tests

New `KB Sync feature flag` describe in `config.test.ts` covering unset / empty / `"true"` / `"false"` / context-disable. Full infra suite green (423/423).

> Note: chasing a local test failure here surfaced a stale, gitignored `infrastructure/lib/config.js` (compiled artifact) shadowing `config.ts` under jest's default `.js`-before-`.ts` resolution — the real cause of the long-standing "pre-existing config-suite failures" locally. Removing it (it's not in CI; cdk uses `ts-node --prefer-ts-exts`) made all 423 pass. No code change needed for that — just a heads-up for anyone with the stale file locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)