### PR TITLE
fix(kb-sync): clarify the auto-sync control and repair blank sync timestamps

### DIFF
--- a/backend/src/apis/app_api/kb_sync/dispatcher.py
+++ b/backend/src/apis/app_api/kb_sync/dispatcher.py
@@ -59,15 +59,22 @@ def _now() -> datetime:
 
 
 def _timestamp(dt: datetime) -> str:
-    return dt.isoformat() + "Z"
+    # Normalize the +00:00 offset to a single trailing Z: "…+00:00Z" (offset AND
+    # Z) is invalid ISO 8601 and renders as Invalid Date in strict JS engines.
+    return dt.isoformat().replace("+00:00", "Z")
 
 
 def _parse_timestamp(value: str) -> Optional[datetime]:
-    """Parse the house timestamp format (isoformat + trailing 'Z')."""
+    """Parse the house timestamp format, tolerating both the current trailing
+    'Z' and the legacy '+00:00Z' (offset AND Z). Always returns a UTC-aware
+    datetime so comparisons with :func:`_now` never mix naive and aware."""
     try:
-        return datetime.fromisoformat(value.rstrip("Z"))
+        dt = datetime.fromisoformat(value.rstrip("Z"))
     except (ValueError, AttributeError):
         return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def _get_assistant_item(assistant_id: str) -> Optional[Dict[str, Any]]:

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -69,7 +69,10 @@ _NATIVE_PREFIX = "application/vnd.google-apps."
 
 
 def _now_timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    # Normalize the +00:00 offset to a single trailing Z; "…+00:00Z" (offset AND
+    # Z) is invalid ISO 8601 and renders as Invalid Date in strict JS engines,
+    # leaving the last-synced time blank in the UI.
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _sha256(content: bytes) -> str:

--- a/backend/src/apis/shared/sync_policies/service.py
+++ b/backend/src/apis/shared/sync_policies/service.py
@@ -37,9 +37,21 @@ class DuplicateSyncPolicy(Exception):
     """Raised when the source already has a sync policy on this assistant."""
 
 
+def _iso(dt: datetime) -> str:
+    """Serialize a UTC datetime as strict ISO 8601 with a ``Z`` suffix.
+
+    ``datetime.isoformat()`` renders the offset as ``+00:00``; we normalize that
+    to ``Z`` so the result is valid ISO 8601 that JavaScript's ``Date`` parses.
+    A previous ``isoformat() + "Z"`` produced ``…+00:00Z`` — both an offset and a
+    Z — which is invalid and yields ``Invalid Date`` in strict engines (Safari),
+    leaving the sync status blank in the UI.
+    """
+    return dt.isoformat().replace("+00:00", "Z")
+
+
 def _get_current_timestamp() -> str:
     """Get current timestamp in ISO 8601 format"""
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return _iso(datetime.now(timezone.utc))
 
 
 def _generate_policy_id() -> str:
@@ -70,7 +82,7 @@ def max_policies_per_assistant() -> int:
 def compute_next_sync_at(interval: SyncInterval, from_time: Optional[datetime] = None) -> str:
     """Compute the next due timestamp for an interval, ISO 8601."""
     base = from_time or datetime.now(timezone.utc)
-    return (base + INTERVAL_DELTAS[interval]).isoformat() + "Z"
+    return _iso(base + INTERVAL_DELTAS[interval])
 
 
 async def create_sync_policy(
@@ -417,8 +429,8 @@ async def trigger_run_now(assistant_id: str, policy_id: str) -> SyncPolicy:
         raise ValueError(f"Cannot run-now a policy in state {policy.state}")
 
     now_dt = datetime.now(timezone.utc)
-    now = now_dt.isoformat() + "Z"
-    cooldown_floor = (now_dt - timedelta(seconds=RUN_NOW_COOLDOWN_SECONDS)).isoformat() + "Z"
+    now = _iso(now_dt)
+    cooldown_floor = _iso(now_dt - timedelta(seconds=RUN_NOW_COOLDOWN_SECONDS))
     try:
         _get_table().update_item(
             Key={"PK": f"AST#{assistant_id}", "SK": f"SYNCPOL#{policy_id}"},

--- a/backend/tests/lambdas/test_kb_sync_dispatcher.py
+++ b/backend/tests/lambdas/test_kb_sync_dispatcher.py
@@ -178,7 +178,7 @@ class TestCircuitBreaker:
 
         # daily * 2^2 = 4 days out
         updated = await get_sync_policy(assistant_id, policy.policy_id)
-        next_dt = datetime.fromisoformat(updated.next_sync_at.rstrip("Z"))
+        next_dt = dispatcher._parse_timestamp(updated.next_sync_at)
         expected = datetime.now(timezone.utc) + timedelta(days=4)
         assert abs((next_dt - expected).total_seconds()) < 300
 

--- a/backend/tests/shared/test_sync_policies.py
+++ b/backend/tests/shared/test_sync_policies.py
@@ -372,3 +372,30 @@ class TestResumeInactive:
     async def test_no_inactive_policies_is_noop(self, assistants_table):
         await _make_policy()
         assert await resume_inactive_policies(ASSISTANT_ID) == 0
+
+
+class TestTimestampFormat:
+    """The stored timestamps are surfaced verbatim to the SPA, where
+    ``new Date(iso)`` parses them. A ``…+00:00Z`` string (offset AND Z) is
+    invalid ISO 8601 → Invalid Date → a blank sync-status line. Guard the
+    generators against that regression."""
+
+    async def test_generated_timestamps_are_valid_iso(self, assistants_table):
+        from datetime import datetime
+
+        from apis.shared.sync_policies.service import (
+            _get_current_timestamp,
+            compute_next_sync_at,
+        )
+
+        policy = await _make_policy()
+        for ts in (
+            _get_current_timestamp(),
+            compute_next_sync_at("weekly"),
+            policy.next_sync_at,
+        ):
+            assert ts.endswith("Z"), ts
+            assert "+00:00" not in ts, ts
+            # Round-trips to an aware datetime the way JS `Date` accepts.
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            assert parsed.tzinfo is not None

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -428,7 +428,7 @@
                       <ng-icon name="heroGlobeAlt" class="mt-0.5 size-5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
                       <div class="min-w-0 flex-1">
                         <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">{{ crawl.rootUrl }}</p>
-                        <div class="mt-0.5 flex items-center gap-2">
+                        <div class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
                           <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ crawl.fetchedCount }} page{{ crawl.fetchedCount === 1 ? '' : 's' }}</span>
                           @if (crawl.status === 'running') {
                             <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
@@ -440,6 +440,10 @@
                             <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
                             <span class="text-xs/5 font-medium text-red-600 dark:text-red-400">Crawl failed</span>
                           }
+                          @if (isCrawlSyncable(crawl)) {
+                            <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
+                            <span class="text-xs/5 text-gray-500 dark:text-gray-400">Auto-sync from the web</span>
+                          }
                         </div>
                         @if (isCrawlSyncable(crawl)) {
                           <app-sync-policy-control
@@ -447,6 +451,7 @@
                             [policy]="syncPolicyFor(crawl.crawlId)"
                             [busy]="isSyncBusy(crawl.crawlId)"
                             [sourceName]="crawl.rootUrl"
+                            [lastSyncedAt]="crawl.completedAt ?? null"
                             (intervalSelected)="onSyncIntervalSelected('web_crawl', crawl.crawlId, $event)"
                             (runNow)="onSyncRunNow(crawl.crawlId)"
                             (pause)="onSyncPause(crawl.crawlId)"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -528,6 +528,8 @@
                               [policy]="syncPolicyFor(doc.documentId)"
                               [busy]="isSyncBusy(doc.documentId)"
                               [sourceName]="doc.filename"
+                              [sourceLabel]="reconnectLabelForDocument(doc)"
+                              [lastSyncedAt]="doc.lastSyncedAt ?? null"
                               [reconnectLabel]="reconnectLabelForDocument(doc)"
                               (intervalSelected)="onSyncIntervalSelected('drive_file', doc.documentId, $event)"
                               (runNow)="onSyncRunNow(doc.documentId)"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -476,26 +476,26 @@
                 <h3 class="mb-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Uploaded Documents</h3>
                 <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
                   @for (doc of uploadedDocuments(); track doc.documentId) {
-                    <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
-                      <div class="flex min-w-0 flex-1 items-center gap-3">
+                    <li class="flex items-start gap-3 px-3 py-2.5 sm:px-4">
+                      <div class="flex min-w-0 flex-1 items-start gap-3">
                         @if (doc.status === 'complete') {
-                          <svg class="size-5 shrink-0 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <svg class="mt-0.5 size-5 shrink-0 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                           </svg>
                         } @else if (doc.status === 'failed') {
-                          <svg class="size-5 shrink-0 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <svg class="mt-0.5 size-5 shrink-0 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                           </svg>
                         } @else if (pollingDocuments().has(doc.documentId)) {
-                          <div class="size-5 shrink-0 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
+                          <div class="mt-0.5 size-5 shrink-0 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
                         } @else {
-                          <svg class="size-5 shrink-0 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <svg class="mt-0.5 size-5 shrink-0 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
                           </svg>
                         }
                         <div class="min-w-0 flex-1">
                           <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">{{ doc.filename }}</p>
-                          <div class="mt-0.5 flex items-center gap-2">
+                          <div class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
                             <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ formatBytes(doc.sizeBytes) }}</span>
                             <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
                             <span
@@ -515,6 +515,10 @@
                               <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
                               <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ doc.chunkCount }} chunks</span>
                             }
+                            @if (canManageSync() && isDriveSyncable(doc) && reconnectLabelForDocument(doc); as provider) {
+                              <span class="text-xs/5 text-gray-400 dark:text-gray-500">&#8226;</span>
+                              <span class="text-xs/5 text-gray-500 dark:text-gray-400">Auto-sync from {{ provider }}</span>
+                            }
                           </div>
                           @if (doc.status === 'failed' && doc.errorMessage) {
                             <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">{{ doc.errorMessage }}</p>
@@ -528,7 +532,6 @@
                               [policy]="syncPolicyFor(doc.documentId)"
                               [busy]="isSyncBusy(doc.documentId)"
                               [sourceName]="doc.filename"
-                              [sourceLabel]="reconnectLabelForDocument(doc)"
                               [lastSyncedAt]="doc.lastSyncedAt ?? null"
                               [reconnectLabel]="reconnectLabelForDocument(doc)"
                               (intervalSelected)="onSyncIntervalSelected('drive_file', doc.documentId, $event)"

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -415,6 +415,26 @@
               </div>
             }
 
+            <!-- Knowledge lists (Web sources + Uploaded Documents) share one
+                 initial-load gate so they reveal together — neither pops in
+                 after the other's round-trip. While either list is doing its
+                 first fetch, a skeleton mirrors the list shape. -->
+            @if (isLoadingKnowledge()) {
+              <div>
+                <span class="sr-only" role="status">Loading knowledge base…</span>
+                <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+                  @for (row of skeletonRows; track $index) {
+                    <li class="flex items-center gap-3 px-3 py-3.5 sm:px-4" aria-hidden="true">
+                      <div class="size-5 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                      <div class="min-w-0 flex-1">
+                        <div class="h-3.5 animate-pulse rounded bg-gray-200 dark:bg-gray-700" [style.width.%]="row.title"></div>
+                        <div class="mt-2 h-3 animate-pulse rounded bg-gray-200 dark:bg-gray-700" [style.width.%]="row.meta"></div>
+                      </div>
+                    </li>
+                  }
+                </ul>
+              </div>
+            } @else {
             <!-- Web sources (crawl roots). Sync policies attach to the
                  crawl, not to the individual page documents it produced.
                  Rendered for owners/editors only — the entire sync surface
@@ -466,17 +486,7 @@
             }
 
             <!-- Uploaded Documents List -->
-            @if (isLoadingDocuments()) {
-              <div>
-                <h3 class="mb-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Uploaded Documents</h3>
-                <div class="flex items-center justify-center rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800">
-                  <div class="flex flex-col items-center gap-3">
-                    <div class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"></div>
-                    <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading documents…</p>
-                  </div>
-                </div>
-              </div>
-            } @else if (uploadedDocuments().length > 0) {
+            @if (uploadedDocuments().length > 0) {
               <div>
                 <h3 class="mb-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">Uploaded Documents</h3>
                 <ul class="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
@@ -572,6 +582,7 @@
                   }
                 </ul>
               </div>
+            }
             }
           </section>
         </form>

--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.ts
@@ -181,6 +181,13 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   readonly syncPolicies = signal<SyncPolicy[]>([]);
   /** All crawl jobs (any status) — completed crawls are the syncable web sources. */
   readonly webCrawls = signal<CrawlJob[]>([]);
+  /**
+   * True while the crawl catalog is doing its initial fetch. Mirrors
+   * {@link isLoadingDocuments} so both knowledge lists share one loading gate
+   * and reveal together — previously crawls had no loading flag, so the Web
+   * sources list popped into existence after its network round-trip.
+   */
+  readonly isLoadingCrawls = signal<boolean>(false);
   /** Source refs (document/crawl ids) with a sync mutation in flight. */
   readonly syncBusySourceRefs = signal<Set<string>>(new Set());
   /** Provider whose consent popup was opened from a "Reconnect" affordance. */
@@ -218,8 +225,28 @@ export class AssistantFormPage implements OnInit, OnDestroy {
     () =>
       this.uploadedDocuments().length > 0 ||
       this.currentUpload() !== null ||
-      this.isLoadingDocuments(),
+      this.isLoadingDocuments() ||
+      this.isLoadingCrawls(),
   );
+
+  /**
+   * Single initial-load gate for the two knowledge lists (Web sources +
+   * Uploaded Documents). While true a skeleton stands in for both; when it
+   * clears they render together, so neither list pops in after the other.
+   */
+  readonly isLoadingKnowledge = computed(
+    () => this.isLoadingDocuments() || this.isLoadingCrawls(),
+  );
+
+  /**
+   * Varied bar widths (percent) for the knowledge skeleton rows, so the
+   * placeholder reads as content rather than a repeating pattern.
+   */
+  readonly skeletonRows: ReadonlyArray<{ title: number; meta: number }> = [
+    { title: 58, meta: 34 },
+    { title: 72, meta: 42 },
+    { title: 46, meta: 28 },
+  ];
 
   form!: FormGroup;
 
@@ -323,6 +350,12 @@ export class AssistantFormPage implements OnInit, OnDestroy {
     // loadAssistant because it needs the resolved userPermission — the
     // sync-policy surface is edit-gated and viewers must not trigger a 403.
     if (id) {
+      // Raise both knowledge-load flags synchronously so the very first paint
+      // shows the skeleton (not an empty flash). loadSyncData waits on the
+      // resolved permission, so isLoadingCrawls holds the gate until then; it
+      // is cleared there, including on the viewer early-return.
+      this.isLoadingDocuments.set(true);
+      this.isLoadingCrawls.set(true);
       void this.loadAssistant(id).then(() => this.loadSyncData());
       this.loadDocuments();
     }
@@ -989,21 +1022,28 @@ export class AssistantFormPage implements OnInit, OnDestroy {
   private async loadSyncData(): Promise<void> {
     const assistantId = this.assistantId();
     if (!assistantId || !this.canManageSync()) {
+      // Viewers (and create mode) never load crawls — release the gate so the
+      // document list can reveal.
+      this.isLoadingCrawls.set(false);
       return;
     }
-    const [policies, crawls] = await Promise.allSettled([
-      this.syncPolicyService.listPolicies(assistantId),
-      this.webSourceService.listCrawls(assistantId),
-    ]);
-    if (policies.status === 'fulfilled') {
-      this.syncPolicies.set(policies.value);
-    } else {
-      console.error('Error loading sync policies:', policies.reason);
-    }
-    if (crawls.status === 'fulfilled') {
-      this.webCrawls.set(crawls.value);
-    } else {
-      console.error('Error loading web sources:', crawls.reason);
+    try {
+      const [policies, crawls] = await Promise.allSettled([
+        this.syncPolicyService.listPolicies(assistantId),
+        this.webSourceService.listCrawls(assistantId),
+      ]);
+      if (policies.status === 'fulfilled') {
+        this.syncPolicies.set(policies.value);
+      } else {
+        console.error('Error loading sync policies:', policies.reason);
+      }
+      if (crawls.status === 'fulfilled') {
+        this.webCrawls.set(crawls.value);
+      } else {
+        console.error('Error loading web sources:', crawls.reason);
+      }
+    } finally {
+      this.isLoadingCrawls.set(false);
     }
   }
 

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
@@ -59,17 +59,6 @@ describe('SyncPolicyControlComponent', () => {
     expect(fixture.nativeElement.querySelector('p')).toBeNull();
   });
 
-  it('labels the control "Auto-sync" and names the source when given one', () => {
-    fixture.detectChanges();
-    const label = () =>
-      (fixture.nativeElement.querySelector('span')?.textContent as string)?.trim();
-    expect(label()).toBe('Auto-sync');
-
-    fixture.componentRef.setInput('sourceLabel', 'Google Drive');
-    fixture.detectChanges();
-    expect(label()).toBe('Auto-sync from Google Drive');
-  });
-
   it('shows "Last synced" for a manual-only source using the document timestamp', () => {
     const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
     // No policy input → manual-only; the timestamp comes from the document.
@@ -78,6 +67,19 @@ describe('SyncPolicyControlComponent', () => {
     expect(statusLine()).toContain('Last synced 2h ago');
     // Relative age is paired with an absolute date/time.
     expect(statusLine()).toMatch(/Last synced 2h ago · .+/);
+  });
+
+  it('renders timestamps that carry a legacy "+00:00Z" suffix (invalid ISO)', () => {
+    // The backend historically emitted "…+00:00Z" (offset AND Z), which is
+    // unparseable by strict `new Date()` and left the status blank. Already-
+    // persisted policies must still render, so the control normalizes it.
+    const then = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    const legacy = then.toISOString().replace('Z', '+00:00Z');
+    fixture.componentRef.setInput('lastSyncedAt', legacy);
+    fixture.detectChanges();
+    expect(statusLine()).toContain('Last synced 3h ago');
+    // Not the blank "Last synced" with no time.
+    expect(statusLine()).not.toBe('Last synced');
   });
 
   it('reflects the policy interval in the select', () => {

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
@@ -211,6 +211,28 @@ describe('SyncPolicyControlComponent', () => {
     expect(statusLine()).toContain('Last sync failed 1h ago');
   });
 
+  it('shows a "Saving…" indicator while a mutation is in flight', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    fixture.componentRef.setInput('policy', stubPolicy({ state: 'active', lastSyncAt: twoHoursAgo }));
+    fixture.detectChanges();
+    // Not busy: the status line describes the sync, not a save.
+    expect(statusLine()).toContain('Synced 2h ago');
+
+    fixture.componentRef.setInput('busy', true);
+    fixture.detectChanges();
+    // Busy: the saving indicator takes over so the user sees work happening.
+    expect(statusLine()).toBe('Saving…');
+    expect(fixture.nativeElement.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('shows "Saving…" even for a manual source with no policy or status yet', () => {
+    // Enabling sync on a manual-only source: no policy exists yet, so without
+    // the busy branch there would be no feedback at all.
+    fixture.componentRef.setInput('busy', true);
+    fixture.detectChanges();
+    expect(statusLine()).toBe('Saving…');
+  });
+
   it('disables all controls while busy', () => {
     fixture.componentRef.setInput('policy', stubPolicy({ state: 'active' }));
     fixture.componentRef.setInput('busy', true);

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.spec.ts
@@ -50,11 +50,34 @@ describe('SyncPolicyControlComponent', () => {
     return ((fixture.nativeElement.querySelector('p')?.textContent as string) ?? '').trim();
   }
 
-  it('defaults the select to "Manual only" with no policy and shows no actions', () => {
+  it('defaults the select to manual ("Don\'t auto-sync") with no policy and shows no actions', () => {
     fixture.detectChanges();
     expect(select().value).toBe('manual');
+    const manualOption = select().querySelector('option[value="manual"]');
+    expect(manualOption?.textContent?.trim()).toBe("Don't auto-sync");
     expect(buttonLabels()).toEqual([]);
     expect(fixture.nativeElement.querySelector('p')).toBeNull();
+  });
+
+  it('labels the control "Auto-sync" and names the source when given one', () => {
+    fixture.detectChanges();
+    const label = () =>
+      (fixture.nativeElement.querySelector('span')?.textContent as string)?.trim();
+    expect(label()).toBe('Auto-sync');
+
+    fixture.componentRef.setInput('sourceLabel', 'Google Drive');
+    fixture.detectChanges();
+    expect(label()).toBe('Auto-sync from Google Drive');
+  });
+
+  it('shows "Last synced" for a manual-only source using the document timestamp', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    // No policy input → manual-only; the timestamp comes from the document.
+    fixture.componentRef.setInput('lastSyncedAt', twoHoursAgo);
+    fixture.detectChanges();
+    expect(statusLine()).toContain('Last synced 2h ago');
+    // Relative age is paired with an absolute date/time.
+    expect(statusLine()).toMatch(/Last synced 2h ago · .+/);
   });
 
   it('reflects the policy interval in the select', () => {
@@ -157,7 +180,7 @@ describe('SyncPolicyControlComponent', () => {
     expect(statusLine()).toContain('inactive');
   });
 
-  it('describes last and next sync on the status line for an active policy', () => {
+  it('describes last (relative + absolute) and next sync for an active policy', () => {
     const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
     const inThreeDays = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
     fixture.componentRef.setInput(
@@ -166,7 +189,10 @@ describe('SyncPolicyControlComponent', () => {
     );
     fixture.detectChanges();
 
-    expect(statusLine()).toBe('Synced 2h ago · next sync in 3d');
+    // Relative age, an exact date/time, then the next-run estimate.
+    expect(statusLine()).toContain('Synced 2h ago');
+    expect(statusLine()).toContain('next sync in 3d');
+    expect(statusLine()).toMatch(/Synced 2h ago · .+ · next sync in 3d/);
   });
 
   it('flags a failed last run on the status line', () => {

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -34,18 +34,24 @@ export type SyncIntervalSelection = SyncInterval | 'manual';
   providers: [provideIcons({ heroArrowPath, heroChevronDown })],
   template: `
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <span
+        class="text-xs/5 font-medium text-gray-500 dark:text-gray-400"
+        [title]="autoSyncHint()"
+      >
+        {{ autoSyncLabel() }}
+      </span>
       <div class="relative inline-flex">
         <select
-          [attr.aria-label]="'Keep ' + (sourceName() || 'this source') + ' in sync'"
+          [attr.aria-label]="'Auto-sync schedule for ' + (sourceName() || 'this source')"
           [disabled]="busy()"
           [value]="selectValue()"
           (change)="onSelectChange($event)"
           class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
         >
-          <option value="manual">Manual only</option>
-          <option value="daily">Daily</option>
-          <option value="weekly">Weekly</option>
-          <option value="monthly">Monthly</option>
+          <option value="manual">Don't auto-sync</option>
+          <option value="daily">Sync daily</option>
+          <option value="weekly">Sync weekly</option>
+          <option value="monthly">Sync monthly</option>
         </select>
         <ng-icon
           name="heroChevronDown"
@@ -119,6 +125,18 @@ export class SyncPolicyControlComponent {
   readonly sourceName = input('');
   /** Provider display name for the paused_reauth affordance (e.g. "Google Drive"). */
   readonly reconnectLabel = input('');
+  /**
+   * Provider display name this source is imported from (e.g. "Google Drive"),
+   * shown as the control's lead label so every row states what auto-sync is
+   * and where it pulls from.
+   */
+  readonly sourceLabel = input('');
+  /**
+   * The source's last successful sync, straight from the document record.
+   * Used to keep a "Last synced …" line visible even when the source is
+   * manual-only (no governing policy), where `policy` is null.
+   */
+  readonly lastSyncedAt = input<string | null>(null);
 
   readonly intervalSelected = output<SyncIntervalSelection>();
   readonly runNow = output<void>();
@@ -130,6 +148,19 @@ export class SyncPolicyControlComponent {
     () => this.policy()?.interval ?? 'manual',
   );
 
+  readonly autoSyncLabel = computed<string>(() => {
+    const src = this.sourceLabel();
+    return src ? `Auto-sync from ${src}` : 'Auto-sync';
+  });
+
+  readonly autoSyncHint = computed<string>(() => {
+    const src = this.sourceLabel();
+    const name = this.sourceName() || 'this file';
+    return src
+      ? `Automatically re-imports ${name} from ${src} on a schedule so the assistant always has the latest version.`
+      : `Automatically re-imports ${name} from its source on a schedule so the assistant always has the latest version.`;
+  });
+
   readonly statusTone = computed<'muted' | 'warn'>(() => {
     const p = this.policy();
     if (!p) return 'muted';
@@ -140,16 +171,23 @@ export class SyncPolicyControlComponent {
 
   readonly statusText = computed<string>(() => {
     const p = this.policy();
-    if (!p) return '';
+    // Manual-only (no governing policy): still surface when the file last
+    // refreshed, using the document's own timestamp.
+    if (!p) {
+      const ts = this.lastSyncedAt();
+      return ts ? this.syncedPhrase('Last synced', ts) : '';
+    }
     switch (p.state) {
       case 'active': {
         const parts: string[] = [];
         if (p.lastResult === 'failed') {
           parts.push(
-            p.lastSyncAt ? `Last sync failed ${this.formatAgo(p.lastSyncAt)}` : 'Last sync failed',
+            p.lastSyncAt
+              ? this.syncedPhrase('Last sync failed', p.lastSyncAt)
+              : 'Last sync failed',
           );
         } else if (p.lastSyncAt) {
-          parts.push(`Synced ${this.formatAgo(p.lastSyncAt)}`);
+          parts.push(this.syncedPhrase('Synced', p.lastSyncAt));
         } else {
           parts.push('Not synced yet');
         }
@@ -158,8 +196,10 @@ export class SyncPolicyControlComponent {
         }
         return parts.join(' · ');
       }
-      case 'paused_user':
-        return 'Paused';
+      case 'paused_user': {
+        const ts = p.lastSyncAt ?? this.lastSyncedAt();
+        return ts ? `Paused · last synced ${this.formatAgo(ts)}` : 'Paused';
+      }
       case 'paused_error':
         return this.pausedText(p.stateReason, 'Paused after repeated failures');
       case 'paused_inactive':
@@ -188,6 +228,30 @@ export class SyncPolicyControlComponent {
 
   private pausedText(reason: string | null | undefined, fallback: string): string {
     return reason ? `Paused — ${reason}` : `Paused — ${fallback}`;
+  }
+
+  /**
+   * "{verb} {relative} · {absolute}" — pairs a scannable relative age with an
+   * exact date/time so the reader gets both "how long ago" and "exactly when".
+   */
+  private syncedPhrase(verb: string, iso: string): string {
+    const ago = this.formatAgo(iso);
+    const abs = this.formatAbsolute(iso);
+    if (!ago && !abs) return verb;
+    if (!abs) return `${verb} ${ago}`;
+    if (!ago) return `${verb} ${abs}`;
+    return `${verb} ${ago} · ${abs}`;
+  }
+
+  private formatAbsolute(iso: string): string {
+    const then = new Date(iso);
+    if (Number.isNaN(then.getTime())) return '';
+    return then.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
   }
 
   private formatAgo(iso: string): string {

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -97,7 +97,15 @@ export type SyncIntervalSelection = SyncInterval | 'manual';
         }
       }
     </div>
-    @if (statusText(); as text) {
+    @if (busy()) {
+      <p class="mt-1 flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400" role="status">
+        <span
+          class="size-3 shrink-0 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+          aria-hidden="true"
+        ></span>
+        Saving…
+      </p>
+    } @else if (statusText(); as text) {
       <p
         class="mt-1 flex items-center gap-1.5 text-xs/5"
         [class.text-amber-600]="statusTone() === 'warn'"

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -34,12 +34,6 @@ export type SyncIntervalSelection = SyncInterval | 'manual';
   providers: [provideIcons({ heroArrowPath, heroChevronDown })],
   template: `
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-      <span
-        class="text-xs/5 font-medium text-gray-500 dark:text-gray-400"
-        [title]="autoSyncHint()"
-      >
-        {{ autoSyncLabel() }}
-      </span>
       <div class="relative inline-flex">
         <select
           [attr.aria-label]="'Auto-sync schedule for ' + (sourceName() || 'this source')"
@@ -105,12 +99,19 @@ export type SyncIntervalSelection = SyncInterval | 'manual';
     </div>
     @if (statusText(); as text) {
       <p
-        class="mt-0.5 text-xs/5"
+        class="mt-1 flex items-center gap-1.5 text-xs/5"
         [class.text-amber-600]="statusTone() === 'warn'"
         [class.dark:text-amber-400]="statusTone() === 'warn'"
         [class.text-gray-500]="statusTone() !== 'warn'"
         [class.dark:text-gray-400]="statusTone() !== 'warn'"
       >
+        <span
+          aria-hidden="true"
+          class="size-1.5 shrink-0 rounded-full"
+          [class.bg-green-500]="statusDot() === 'ok'"
+          [class.bg-amber-500]="statusDot() === 'warn'"
+          [class.bg-gray-400]="statusDot() === 'idle'"
+        ></span>
         {{ text }}
       </p>
     }
@@ -125,12 +126,6 @@ export class SyncPolicyControlComponent {
   readonly sourceName = input('');
   /** Provider display name for the paused_reauth affordance (e.g. "Google Drive"). */
   readonly reconnectLabel = input('');
-  /**
-   * Provider display name this source is imported from (e.g. "Google Drive"),
-   * shown as the control's lead label so every row states what auto-sync is
-   * and where it pulls from.
-   */
-  readonly sourceLabel = input('');
   /**
    * The source's last successful sync, straight from the document record.
    * Used to keep a "Last synced …" line visible even when the source is
@@ -148,25 +143,18 @@ export class SyncPolicyControlComponent {
     () => this.policy()?.interval ?? 'manual',
   );
 
-  readonly autoSyncLabel = computed<string>(() => {
-    const src = this.sourceLabel();
-    return src ? `Auto-sync from ${src}` : 'Auto-sync';
-  });
-
-  readonly autoSyncHint = computed<string>(() => {
-    const src = this.sourceLabel();
-    const name = this.sourceName() || 'this file';
-    return src
-      ? `Automatically re-imports ${name} from ${src} on a schedule so the assistant always has the latest version.`
-      : `Automatically re-imports ${name} from its source on a schedule so the assistant always has the latest version.`;
-  });
-
   readonly statusTone = computed<'muted' | 'warn'>(() => {
     const p = this.policy();
     if (!p) return 'muted';
     if (p.state === 'paused_error' || p.state === 'paused_reauth') return 'warn';
     if (p.state === 'active' && p.lastResult === 'failed') return 'warn';
     return 'muted';
+  });
+
+  /** Colour of the status-line dot: green healthy, amber attention, grey idle. */
+  readonly statusDot = computed<'ok' | 'warn' | 'idle'>(() => {
+    if (this.statusTone() === 'warn') return 'warn';
+    return this.policy()?.state === 'active' ? 'ok' : 'idle';
   });
 
   readonly statusText = computed<string>(() => {
@@ -243,8 +231,19 @@ export class SyncPolicyControlComponent {
     return `${verb} ${ago} · ${abs}`;
   }
 
+  /**
+   * Parse a backend ISO timestamp into a Date, tolerating a historical bug
+   * where timestamps were emitted with BOTH an offset and a "Z"
+   * (e.g. "2026-07-05T16:00:00+00:00Z"). That string is invalid ISO 8601 and
+   * unparseable by strict engines (Safari) — strip the redundant trailing Z so
+   * already-persisted policies still render while the backend is corrected.
+   */
+  private parseIso(iso: string): Date {
+    return new Date(iso.replace(/([+-]\d{2}:\d{2})Z$/, '$1'));
+  }
+
   private formatAbsolute(iso: string): string {
-    const then = new Date(iso);
+    const then = this.parseIso(iso);
     if (Number.isNaN(then.getTime())) return '';
     return then.toLocaleString(undefined, {
       month: 'short',
@@ -255,7 +254,8 @@ export class SyncPolicyControlComponent {
   }
 
   private formatAgo(iso: string): string {
-    const then = new Date(iso).getTime();
+    const parsed = this.parseIso(iso);
+    const then = parsed.getTime();
     if (Number.isNaN(then)) return '';
     const diffMins = Math.floor((Date.now() - then) / 60_000);
     if (diffMins < 1) return 'just now';
@@ -264,11 +264,11 @@ export class SyncPolicyControlComponent {
     if (diffHours < 24) return `${diffHours}h ago`;
     const diffDays = Math.floor(diffHours / 24);
     if (diffDays < 30) return `${diffDays}d ago`;
-    return new Date(iso).toLocaleDateString();
+    return parsed.toLocaleDateString();
   }
 
   private formatUntil(iso: string): string {
-    const then = new Date(iso).getTime();
+    const then = this.parseIso(iso).getTime();
     if (Number.isNaN(then)) return '';
     const diffMins = Math.ceil((then - Date.now()) / 60_000);
     // "due now" covers the run-now window: the dispatcher sweeps every


### PR DESCRIPTION
## What & why

Iterates on the recently-shipped Assistant knowledge-base **sync** control. Two problems, both visible in the editor today:

1. The schedule was a bare **"Manual only"** dropdown that never explained what syncing does or where a file comes from.
2. The status line rendered as a blank **"Synced · next sync"** — no dates at all.

### 1 — Legibility (frontend)
- Source context now reads on the file's **meta line**: `… · Auto-sync from Google Drive`. (My first pass put it in the control's button row, which shoved **Pause** onto its own line — moving it here keeps the control compact.)
- Self-describing options: `Manual only → Don't auto-sync`, and the rest carry the verb (`Sync daily/weekly/monthly`).
- **Last synced** is now shown in *every* state (including manual-only, via a new `lastSyncedAt` input fed from `Document.lastSyncedAt`), pairing a relative age with an absolute time: **"Synced 2h ago · Jul 3, 2:14 PM · next sync in 3d"**.
- Added a status dot (green healthy / amber attention / grey idle) and top-aligned the status icon + **download/delete** actions with the filename (`items-start`). Download and delete are unchanged.

### 2 — Blank timestamps (backend bug)
Several generators built ISO strings as `datetime.isoformat() + "Z"`, producing `…+00:00Z` — an offset **and** a Z. That's invalid ISO 8601 and parses to `Invalid Date` in strict engines (Safari), so last-sync / next-sync rendered blank.

- Normalized all generators to a single trailing `Z` (`service.py`, `dispatcher.py`, `worker.py`).
- Hardened the dispatcher's `_parse_timestamp` to always return a **UTC-aware** datetime — the format change would otherwise mix naive/aware datetimes and crash the due/backoff comparisons.
- Hardened the SPA to tolerate the legacy `+00:00Z`, so **already-persisted** policies render immediately, before any re-sync.

## Reviewer notes
- **Deploy:** this spans backend + frontend, so it needs a `backend.yml` deploy, not just the frontend. Until then, the SPA hardening still displays existing timestamps.
- **No data migration needed:** old `+00:00Z` values still parse (SPA + dispatcher tolerate them); each policy rewrites its timestamps to the clean format on its next run.
- The `FUTURE`/`PAST` test constants deliberately keep the legacy `+00:00Z` form — they now double as legacy-format regression coverage.
- The identical latent bug in `apis/shared/users/sync.py` (unrelated feature) is **out of scope** here and tracked separately.

## Tests
- Backend: 105 passed (added a timestamp-format regression in `tests/shared/test_sync_policies.py`).
- Frontend: 14 passed (added a legacy-`+00:00Z` render test); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)