### PR TITLE
fix(users): normalize sync timestamps to strict ISO 8601 (single Z)

### DIFF
--- a/backend/src/apis/shared/users/repository.py
+++ b/backend/src/apis/shared/users/repository.py
@@ -11,6 +11,18 @@ from .models import UserProfile, UserListItem, UserStatus
 logger = logging.getLogger(__name__)
 
 
+def _heal_iso(value: str) -> str:
+    """Repair legacy ``…+00:00Z`` timestamps persisted before the sync fix.
+
+    Rows written by the old ``isoformat() + "Z"`` code carry both an offset and
+    a ``Z``, which is invalid ISO 8601 and parses to ``Invalid Date`` in strict
+    engines (Safari). ``last_login_at`` self-heals on next login, but
+    ``created_at`` is preserved forever — so normalize on read to a single
+    trailing ``Z`` (a no-op for already-valid values).
+    """
+    return value.replace("+00:00Z", "Z") if value else value
+
+
 class UserRepository:
     """DynamoDB repository for user operations.
 
@@ -289,7 +301,7 @@ class UserRepository:
 
     def _item_to_profile(self, item: dict) -> UserProfile:
         """Convert DynamoDB item to UserProfile."""
-        created_at = item.get("createdAt", "")
+        created_at = _heal_iso(item.get("createdAt", ""))
         return UserProfile(
             user_id=item["userId"],
             email=item["email"],
@@ -298,14 +310,14 @@ class UserRepository:
             picture=item.get("picture"),
             email_domain=item.get("emailDomain", ""),
             created_at=created_at,
-            last_login_at=item.get("lastLoginAt", created_at),
+            last_login_at=_heal_iso(item.get("lastLoginAt", "")) or created_at,
             status=item.get("status", "active")
         )
 
     def _item_to_list_item(self, item: dict) -> UserListItem:
         """Convert DynamoDB item to UserListItem."""
         # GSI queries may not project lastLoginAt, but GSI2SK/GSI3SK contain the same value
-        last_login = (
+        last_login = _heal_iso(
             item.get("lastLoginAt")
             or item.get("GSI3SK")  # StatusLoginIndex sort key
             or item.get("GSI2SK")  # EmailDomainIndex sort key

--- a/backend/src/apis/shared/users/sync.py
+++ b/backend/src/apis/shared/users/sync.py
@@ -10,6 +10,18 @@ from .repository import UserRepository
 logger = logging.getLogger(__name__)
 
 
+def _iso(dt: datetime) -> str:
+    """Serialize a UTC datetime as strict ISO 8601 with a ``Z`` suffix.
+
+    ``datetime.isoformat()`` renders the offset as ``+00:00``; we normalize that
+    to ``Z`` so the result is valid ISO 8601 that JavaScript's ``Date`` parses.
+    A previous ``isoformat() + "Z"`` produced ``…+00:00Z`` — both an offset and a
+    Z — which is invalid and yields ``Invalid Date`` in strict engines (Safari),
+    leaving the admin user list / detail dates blank ("Never").
+    """
+    return dt.isoformat().replace("+00:00", "Z")
+
+
 class UserSyncService:
     """
     Syncs user data from JWT claims to DynamoDB.
@@ -62,7 +74,7 @@ class UserSyncService:
         if "@" in email:
             email_domain = email.split("@")[1]
 
-        now = datetime.now(timezone.utc).isoformat() + "Z"
+        now = _iso(datetime.now(timezone.utc))
 
         # Build profile from JWT claims
         profile = UserProfile(

--- a/backend/tests/shared/test_users.py
+++ b/backend/tests/shared/test_users.py
@@ -197,3 +197,67 @@ class TestUserSyncService:
         user.picture = None
         profile, is_new = await sync_service.sync_user_from_jwt(user)
         assert is_new is True
+
+    @pytest.mark.asyncio
+    async def test_sync_timestamps_are_strict_iso8601(self, sync_service):
+        """Regression: timestamps must carry a single trailing ``Z`` and no
+        ``+00:00`` offset. The old ``isoformat() + "Z"`` produced ``…+00:00Z``,
+        which is invalid ISO 8601 and parses to ``Invalid Date`` in Safari,
+        blanking the admin user list / detail dates."""
+        from datetime import datetime
+
+        profile, _ = await sync_service.sync_from_jwt(
+            {"sub": "u1", "email": "alice@example.com", "name": "Alice"}
+        )
+        for ts in (profile.created_at, profile.last_login_at):
+            assert ts.endswith("Z")
+            assert "+00:00" not in ts
+            # Parses cleanly as a UTC-aware datetime (JS ``new Date`` parity).
+            assert datetime.fromisoformat(ts.replace("Z", "+00:00")).tzinfo is not None
+
+
+# ===================================================================
+# Legacy timestamp healing on read
+# ===================================================================
+
+class TestTimestampHealingOnRead:
+    """Rows persisted before the sync fix carry ``…+00:00Z``; the read path
+    normalizes them to a single trailing ``Z`` so already-persisted
+    ``created_at`` (never rewritten) still renders in strict engines."""
+
+    def test_item_to_profile_heals_legacy_suffix(self, user_repository):
+        item = {
+            "userId": "u1",
+            "email": "alice@example.com",
+            "name": "Alice",
+            "emailDomain": "example.com",
+            "createdAt": "2026-01-01T00:00:00+00:00Z",
+            "lastLoginAt": "2026-02-02T00:00:00+00:00Z",
+            "status": "active",
+        }
+        profile = user_repository._item_to_profile(item)
+        assert profile.created_at == "2026-01-01T00:00:00Z"
+        assert profile.last_login_at == "2026-02-02T00:00:00Z"
+
+    def test_item_to_profile_leaves_valid_suffix_untouched(self, user_repository):
+        item = {
+            "userId": "u1",
+            "email": "alice@example.com",
+            "emailDomain": "example.com",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "lastLoginAt": "2026-02-02T00:00:00Z",
+            "status": "active",
+        }
+        profile = user_repository._item_to_profile(item)
+        assert profile.created_at == "2026-01-01T00:00:00Z"
+        assert profile.last_login_at == "2026-02-02T00:00:00Z"
+
+    def test_item_to_list_item_heals_legacy_suffix(self, user_repository):
+        item = {
+            "userId": "u1",
+            "email": "alice@example.com",
+            "status": "active",
+            "lastLoginAt": "2026-02-02T00:00:00+00:00Z",
+        }
+        list_item = user_repository._item_to_list_item(item)
+        assert list_item.last_login_at == "2026-02-02T00:00:00Z"


### PR DESCRIPTION
## Problem

`UserSyncService` built timestamps as `datetime.now(timezone.utc).isoformat() + "Z"`, producing `"…+00:00Z"` — both an offset **and** a `Z`. That is invalid ISO 8601 and parses to `Invalid Date` in strict JS engines (Safari).

These timestamps are **not** backend-internal — they flow to the SPA:

`sync_from_jwt` → `createdAt`/`lastLoginAt` in DynamoDB → admin users API → SPA renders both via `new Date(isoString)`:
- `user-list.page.ts` `formatDate()` → falls through to **"Never"**
- `user-detail.page.ts` `formatFullDate()` → **"Never"**

So in Safari the admin **Last login** (list) and **Created / Last login** (detail) show blank. Same class of bug just fixed across the KB-sync feature (service/dispatcher/worker); this applies the identical normalization to the users domain.

## Changes

- **Write path** (`sync.py`): add `_iso()` helper; normalize `created_at`/`last_login_at` to a single trailing `Z`.
- **Read path** (`repository.py`): add `_heal_iso()` and apply it in `_item_to_profile` / `_item_to_list_item` so already-persisted `"+00:00Z"` rows render correctly. This is necessary — not just defensive — because `created_at` is preserved across logins forever (never rewritten), so pre-fix users would otherwise show "Never" in Safari permanently. (`last_login_at` self-heals on next login.) No-op for already-valid values.
- **Tests** (`test_users.py`): write-path invariant (single `Z`, no `+00:00`, parses UTC-aware) + three read-path heal tests.

## GSI sort-key safety

`last_login_at` also backs `GSI2SK`/`GSI3SK` (sort-by-last-login). Narrowing `"+00:00Z"`→`"Z"` is lexicographically safe: ordering is dominated by the microsecond datetime prefix; the suffix only tie-breaks on identical-prefix collisions (effectively impossible at µs precision), and a transient mix of both suffixes across rows during rollout does not corrupt ordering.

## Tests

`tests/shared/test_users.py` — 28 passed (4 new). Related `tests/routes/test_users.py`, `test_users_sync.py`, `tests/shared/test_users_files_extended.py` — 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)