### PR TITLE
feat(assistant-editor): group knowledge base into a contrasted inset panel

### DIFF
--- a/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
+++ b/frontend/ai.client/src/app/assistants/assistant-form/assistant-form.page.html
@@ -253,8 +253,8 @@
             </div>
           </section>
 
-          <!-- Section: Knowledge -->
-          <section class="space-y-4 border-t border-gray-200 pt-8 dark:border-gray-700">
+          <!-- Section: Knowledge (grouped inset — mildly contrasted from the page) -->
+          <section class="space-y-4 rounded-2xl border border-gray-200 bg-gray-100/60 p-5 dark:border-gray-700 dark:bg-gray-800/40 sm:p-6">
             <div class="flex items-center gap-3">
               <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Knowledge base</h2>
               @if (webCrawlActive()) {


### PR DESCRIPTION
## What

Visually distinguishes the **Knowledge base** section on the Assistant editor by wrapping it in a mildly contrasted, grouped inset panel instead of the flat `border-t` divider used by every other section.

## Why

The Knowledge base area is the densest, most interactive part of the editor (uploads, connectors, web crawls, sync controls). Giving it a grouped container makes it read as a distinct workspace rather than one more divider-separated block.

## Changes

Single-line class change on the `<section>` in `assistant-form.page.html`:

- **Before:** `space-y-4 border-t border-gray-200 pt-8 dark:border-gray-700`
- **After:** `space-y-4 rounded-2xl border border-gray-200 bg-gray-100/60 p-5 dark:border-gray-700 dark:bg-gray-800/40 sm:p-6`

## Reviewer notes

- The form column is `bg-gray-50`, so a `gray-100/60` fill is a deliberately **mild** contrast step — grouped, not loud.
- Inner lists (Web sources / Uploaded Documents) are `bg-white`, so they now float on the tint, reinforcing the grouping.
- The `border-t`/`pt-8` divider was dropped because the card provides its own separation; the form's `space-y-8` preserves the gap above it.
- Dark mode uses `dark:bg-gray-800/40` over the `gray-900` column for the same subtle lift.
- Tokens (`rounded-2xl`, `border-gray-200`, `dark:border-gray-700`) match the editor's existing list/dialog idiom.
- Editor is behind auth; not driven through the live preview here. Best eyeballed by opening any assistant's editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)