### PR TITLE
docs(specs): agentic platform primitives plan (+ scheduled-runs design + F1 spike brief)

### DIFF
--- a/docs/specs/agentic-platform-primitives.md
+++ b/docs/specs/agentic-platform-primitives.md
@@ -1,0 +1,125 @@
+# Agentic Platform Primitives — Enablement Plan
+
+**Status:** Draft / strategy + handoff (for implementation by Fable)
+**Author:** Phil Merrell (drafted with Claude)
+**Date:** 2026-07-05
+**Targets branch:** `develop`
+**Supersedes framing of:** `docs/specs/scheduled-agent-runs.md` (was "Oliver") — that doc is now the *detailed design for one primitive*, not the deliverable
+**Related explorations this rolls into:**
+- **AgentCore Registry** — catalog + discovery + governance seam (`docs/specs/tool-search-token-bloat-strategy.md`, `project_skills_registry_tool_binding`)
+- **AgentCore Harness** — the agent-execution loop (`agents/main_agent/`), tracked as an external-pattern scan; here it becomes a *headless run entrypoint*
+- Per-user markdown memory (`docs/specs/user-markdown-memory.md`), Admin Skills + RBAC (`docs/specs/admin-skills-rbac-tool-binding.md`), KB sync (`docs/specs/assistant-kb-sync.md`)
+
+---
+
+## 0. Reframe (read first)
+
+We are **not** shipping a chief-of-staff assistant. We are enabling the **primitive layer** underneath it, so that "Oliver" — and a wide range of other non-coding use cases — becomes **configuration on top of platform building blocks, not a bespoke feature**.
+
+The test for every item below is: *is this a clean, reusable primitive that any assistant / skill / schedule / agent could depend on, or is it welded to one feature?* Where a primitive is missing or welded, that's the work.
+
+Two in-flight explorations are the natural home for this, and they carve the space cleanly:
+
+- **Harness** = *how an agent turn runs*. Today a turn only runs from a live, browser-facing chat request that streams SSE. The keystone fundamental is to externalize the loop into a **trigger-agnostic, headless run entrypoint** — "run agent as user U with input P, return a structured result" — that chat, schedules, A2A, and webhooks all share. Everything proactive rides this.
+- **Registry** = *how agents/tools/skills/KBs are cataloged, discovered, and governed*. It's the unifying catalog seam over every primitive, and the place audit + policy hooks attach. Deferred today, but the repository seams already exist.
+
+Oliver is demoted to **one validation use case among several** (§5). Build the primitives; prove them with a few use cases; open them to anyone.
+
+---
+
+## 1. Primitive maturity & gap ledger
+
+| Primitive | Where it lives | Maturity | Reusable today? | Gap to a clean primitive |
+|---|---|---|---|---|
+| **Tools** (multi-protocol catalog, Gateway, per-tool enablement) | `apis/shared/tools/`, `apis/app_api/admin/tools/` | High | **Yes** | Token bloat at scale → dynamic discovery (Registry) |
+| **Skills** (instructions + reference files + bound tools + progressive disclosure) | `apis/shared/skills/`, `apis/app_api/*/skills/` | High | Yes, but **dark behind `SKILLS_ENABLED`** | Un-defer; cross-source tool binding (binds local tools only today) |
+| **Assistants** (persona + RAG + sharing/visibility) | `apis/shared/assistants/`, `apis/app_api/assistants/` | High | **Yes** | No per-assistant tool binding (only skills have it) |
+| **RBAC** (roles → tools/models/skills grants, inheritance, cache) | `apis/shared/rbac/` | High | **Yes** — the uniform gate | Extend the grant vocabulary to new primitives (schedules, KBs) |
+| **Quota + Cost** (tiers, soft/hard limits, per-token attribution) | `apis/shared/quota.py`, `apis/shared/costs/` | High | **Yes** (per-user) | No org/team rollup |
+| **KB / RAG** (ingestion → S3 vectors → search, sync/re-index) | `apis/app_api/documents/`, `kb_sync/`, `constructs/rag*` | High engine, **welded to Assistants** | **No** — KB is a subordinate of an assistant (`AST#{id}/DOC#{id}`) | KB as a **first-class entity** any assistant/skill/schedule can attach |
+| **Memory** (AgentCore Memory; user markdown) | `agents/main_agent/session/`, `apis/app_api/memory/`, `docs/specs/user-markdown-memory.md` | **Low** | **No** — AgentCore Memory is **write-only in cloud**; markdown memory is **spec-only, unbuilt** | Build the read/write user-memory primitive + user-facing CRUD |
+| **Scheduled tasks** | — | **Missing** | No | Net-new; `sync_policies` is the template |
+| **Delivery / events** | `agents/main_agent/streaming/` (SSE) | **SSE-only** | **No** — nothing durable off the live socket | Async result spine: run-record + notification/inbox (+ optional email/webhook) |
+| **Governance: audit / guardrails / data-class / policy** | — (RBAC + quota exist; the rest don't) | **Missing** | No | Audit log, Bedrock Guardrails, PII/FERPA classification, declarative policy — attach at the Registry seam |
+| **Registry** (catalog + discovery + governance) | seams: `SkillCatalogRepository`, `ToolCatalogRepository` | **Deferred**, seams present | Not yet | Stand up as the catalog backing; add audit/policy hooks |
+| **Harness** (agent run loop) | `agents/main_agent/` (inference-api `/invocations`) | Runs; **not externalized** | **No** — only reachable via live chat | A **headless, trigger-agnostic run entrypoint** |
+
+**Read of the ledger:** the *knowledge and tool* primitives are strong; the *proactive, governed, multi-trigger* primitives are the hole. Three clusters are missing or welded: **(a) headless execution + delivery**, **(b) first-class KB + memory**, **(c) catalog + governance**. Those are the fundamentals.
+
+## 2. The missing fundamentals — address now
+
+Ranked by how much each unblocks. F1 is the keystone; without it, scheduled tasks / proactive agents / A2A-server are all separately-hacked instead of one shared seam.
+
+**F1 — Headless, trigger-agnostic agent-run entrypoint (the Harness fundamental).**
+One internal primitive: *run a turn as user U, with input P and a resolved config (assistant/skill/tools/model), without a live browser session, and return a structured result (final message + tool trace + cost).* Today the loop is only reachable via cookie/Bearer chat that streams SSE to a browser; the two hard sub-parts (proven feasible by KB-sync's unattended per-user OAuth path) are **(1) authenticating an unattended caller via workload identity + explicit `user_id`**, and **(2) consuming the run server-side instead of relaying SSE to a browser**. *Unblocks:* scheduled tasks, proactive monitoring, A2A-server, webhooks, "regenerate this" background jobs, eval harnesses. **This is the single highest-leverage build.** Overlaps: this *is* the Harness exploration made concrete. ⚠️ If we expose it as A2A, `CLAUDE.md` is explicit: the first A2A server's `capabilities` **must** include `streaming=True` or clients hang ~40 min.
+
+**F2 — Async result + delivery spine.**
+A headless run needs somewhere to land and a way to be noticed. Minimum viable: a **run-record** + materialize the result as a session (`ensure_session_metadata_exists` + `update_session_title` already exist) + a lightweight **notification/inbox** row. *Unblocks:* every async producer — scheduled tasks, KB-sync-complete, long artifacts, future webhooks/email. Today delivery is ephemeral SSE only; a disconnect loses it. Overlaps: pairs with F1; the event schema is a Registry-adjacent contract.
+
+**F3 — Scheduled trigger.**
+A thin scheduler (EventBridge rate → dispatcher → F1) modeled on `sync_policies`: sparse "due" GSI, conditional re-arm, `paused_error`, runaway guards. It is *just one trigger* on F1 — deliberately thin. Detailed design in `docs/specs/scheduled-agent-runs.md`. *Unblocks:* briefings, digests, periodic re-summarize, monitoring.
+
+**F4 — KB as a first-class primitive.**
+Decouple the (strong) RAG engine from Assistants: a `knowledge_base_id` independent of `assistant_id`, with its own CRUD/permissions/lifecycle, attachable by assistants **and** skills **and** scheduled runs. *Unblocks:* KB-grounded skills, a scheduled "re-summarize this corpus" agent, shared org KBs. Reuse: the ingestion/vector/sync machinery is already general; the change is the ownership model, not the pipeline.
+
+**F5 — Memory primitive.**
+Finish `user-markdown-memory.md` (S3 store + DynamoDB manifest + read/write tools + consolidation) and add user-facing `/memory` CRUD. AgentCore Memory stays the write-only summary sink; the markdown layer is the read-time source of truth. *Unblocks:* any persistent, personalized agent (the thing that makes a "chief of staff" more than a prompt). Independent of F1–F3 — parallelizable.
+
+**F6 — Governance floor + Registry-backed catalog.** *Split into two slices, decided (§6-2) to sequence independently:*
+- **F6a — Governance floor (pulled forward, foundational).** **Audit log**, a **Bedrock Guardrails** hook at inference, and a **PII/FERPA data-classification checkpoint** on what an unattended run may read/emit. This is a *foundation* concern, not a late add-on: the moment F1 runs unattended **as a user**, it touches user data with no human in the loop — the governance floor must exist *before* that ships. Keep it **backend-invisible** wherever possible (audit + inference-time guardrails + classification), so it adds safety without UX friction.
+- **F6b — Registry catalog + dynamic discovery (deferred).** Swap `*CatalogRepository` behind a Registry source (already the seam) for org-wide discovery/governance and to answer tool-search token bloat (index-only discovery). Per `tool-search-token-bloat-strategy.md`, spike this **after** a Tier-1 Gateway-search measurement — so F6b follows, while F6a leads.
+
+*Unblocks:* a regulated-data story for unattended agents (F6a); org-wide discovery + governance across tools/skills/KBs/agents/schedules (F6b). Overlaps: this *is* the Registry exploration, with its governance slice de-coupled and promoted.
+
+## 3. Where the two explorations overlap the primitive work
+
+| Primitive / fundamental | Harness (execution) | Registry (catalog + governance) |
+|---|---|---|
+| F1 headless run entrypoint | **Is the Harness work** | run-config resolved from the catalog |
+| F2 async result / delivery | run-record is a Harness output | event/result schema is a Registry contract |
+| F3 scheduled trigger | a trigger *on* the Harness | schedules are catalog entries (discoverable, governed) |
+| F4 first-class KB | a run can attach a KB headlessly | KBs become catalog resources |
+| F5 memory | memory is loaded inside the Harness run | — |
+| F6 catalog + governance | Harness enforces policy at run time | **Is the Registry work** |
+| Tools token bloat | Harness promotes matched schemas | Registry is the dynamic-discovery index |
+
+Net: **Harness owns "run," Registry owns "catalog + govern."** Every primitive plugs into one or both. That's the unification Phil asked for — this plan is the Harness/Registry roadmap expressed as concrete primitives.
+
+## 4. Sequenced plan (fundamentals first, use-cases last)
+
+- **Phase A — Execution spine (F1 + minimal F2) + governance floor (F6a).** Headless run entrypoint + run-record + session materialization, **with** the audit-log + guardrails + data-classification floor wired in from the start (because A is the first time we run unattended *as a user* — the floor can't be retrofitted after user data is already flowing). **Validation:** a "Run now" action that executes a prompt as a user off the live socket, passes the governance checkpoint, and lands a result. This is the spike that de-risks everything.
+- **Phase B — Scheduled trigger (F3).** Scheduler on top of A. **Validation:** a schedule fires unattended, is governed, and delivers.
+- **Phase C — Knowledge & memory (F4 ∥ F5).** Independent, parallelizable; each stands alone.
+- **Phase D — Registry catalog + dynamic discovery (F6b).** Registry-backed catalog; also resolves tool-search token bloat. Follows the Tier-1 Gateway-search measurement.
+- **Cross-cutting:** cohort gating via a new RBAC capability + a global kill-switch flag (house style), so each primitive ships to prod but scoped, then GAs by granting the capability to the default role — no redeploy. **UX bar:** the foundation buys flexibility, but user-facing surfaces stay minimal — governance is backend-invisible, scheduling is a few fields, defaults are sane.
+
+## 5. Validation use cases (Oliver is just one)
+
+The primitives are proven — and dogfooded — by pointing a few use cases at them:
+
+- **Oliver** — proactive chief-of-staff: scheduled morning briefing (F1+F2+F3), persona + reference files (Assistants + F4/F5), connector tools. The showcase, not the deliverable.
+- **Scheduled corpus re-summarize** — a KB-grounded agent that digests a document set weekly (F3 + F4).
+- **Weekly status digest** — summarize a user's own activity into a shareable update (F1 + F2).
+- **Inbox / meeting-prep triage** — connector tools + memory on a cadence (F1 + F5 + tools).
+- **Proactive monitoring** — a schedule that checks a condition and only notifies on change (F2 + F3).
+
+The point: once F1–F6 exist, each of these is **configuration**, not engineering — which is exactly the dogfooding flywheel.
+
+## 6. Decisions & open questions
+
+**Resolved (2026-07-05 — build to these):**
+
+1. ✅ **Harness surface (F1) = minimal internal function, A2A-ready.** Build `run_agent_headless(...)` as an internal primitive first; keep the seam clean so an A2A server / runtime endpoint can front it later without a rewrite. If that A2A surface lands, its `capabilities` **must** include `streaming=True` (`CLAUDE.md`).
+2. ✅ **Governance is foundational, split from discovery.** Pull the **F6a governance floor** (audit / guardrails / PII-classification) forward into Phase A — it gates the first unattended-as-user run and can't be retrofitted. Keep **F6b Registry discovery** deferred to Phase D (after the Tier-1 Gateway-search measurement). Prioritize a flexible foundation; keep user-facing surfaces minimal and governance backend-invisible.
+
+**Still open:**
+
+3. **KB decoupling appetite (F4).** First-class KB is the biggest refactor here (touches the assistant/document ownership model). Do it now as a fundamental, or defer and let scheduled runs borrow an assistant's KB in the interim?
+4. **Governance floor depth (F6a).** Given decision #2, what's the *minimum* audit / guardrails / classification that's table-stakes before Phase A ships — i.e. how much floor is "enough" to run unattended as a user without over-building?
+5. **Sequencing priority.** Confirm the proactive spine (F1→F2→F3) leads, with knowledge/memory (F4/F5) in parallel — or do knowledge/memory matter more to the use cases you care about first?
+
+---
+
+## Appendix — what changed from the Oliver framing
+
+The prior draft (`scheduled-agent-runs.md`, née "Oliver — Proactive Chief-of-Staff") specified a *feature*. This doc reframes it as a *primitive-enablement plan*: the scheduling engine is one fundamental (F3) on top of a bigger keystone (F1, the headless Harness entrypoint), the assistant persona is one validation use case (§5), and the whole effort is expressed as the concrete roadmap for the Harness and Registry explorations. Deliver the building blocks; let Oliver — and everything like it — fall out as configuration.

--- a/docs/specs/harness-entrypoint-spike-brief.md
+++ b/docs/specs/harness-entrypoint-spike-brief.md
@@ -1,0 +1,63 @@
+# Spike Brief — Headless Agent-Run Entrypoint (F1) + Phase A Design
+
+**For:** Fable 5
+**Status:** Handoff brief — spike, not production
+**Author:** Phil Merrell (drafted with Claude)
+**Date:** 2026-07-05
+**Parents:** `docs/specs/agentic-platform-primitives.md` (F1, F2-minimal, F6a) · `docs/specs/scheduled-agent-runs.md` §4.2 (the risk) · `reference_dev_ai_aws_data` (dev-ai account)
+
+---
+
+## Why you're doing a spike first
+
+The whole primitive layer (scheduled runs, proactive agents, A2A) rests on **one** capability that doesn't exist yet and is genuinely uncertain: **running an agent turn as a specific user, with no live browser session, and capturing the result.** Everything else in the plan is CRUD and pattern-following around this. So before any production code, prove the two hard unknowns and let them force the Phase A design. Over-invest *here*; economize everywhere after.
+
+**Do not build:** the scheduler, the SPA, full Bedrock Guardrails, or the schedule data model. Those are Phase A/B proper. This spike de-risks F1 and produces the design others build against.
+
+## Single success criterion
+
+> Given `(user_id, prompt)` and **no live session**, a headless caller runs an agent turn **as that user**, the turn uses **at least one of that user's authorized connector tools** (e.g. lists a Google Drive file), a **governance checkpoint** sees the run, and the result lands as a **retrievable session** the user can open.
+
+If you demonstrate that end-to-end **in dev-ai**, the spike succeeds. A localhost demo does **not** count — see the boundary note below.
+
+## Critical boundary — must run in dev-ai, not localhost
+
+The entire risk lives in the **AgentCore Runtime gateway auth**. Localhost (`:8001`) bypasses the runtime gateway entirely, so a local success proves nothing about the real question. Run against **dev-ai** (acct `490617140655`, `us-west-2`, prefix `dev-boisestateai-v2`; active runtime id via SSM `/dev-boisestateai-v2/inference-api/runtime-id`). Pick a test user who has a connector already authorized so the connector-token leg is real. (dev-ai SSO login gotcha: use Safari with `--no-browser`, not Brave — see `project_dev_ai_sso_login_gotcha`.)
+
+## Unknown 1 — Unattended auth to the runtime (the core risk)
+
+**Question:** Can a headless caller invoke the runtime `/invocations` *as a user* without a live Cognito token, such that (a) the agent loads that user's context and (b) it can retrieve that user's vaulted connector OAuth tokens?
+
+- **Try first (decided approach):** invoke the runtime with the **platform workload identity**, passing `user_id` explicitly in the payload. This is exactly how the **KB-sync worker** already does unattended per-user work (mints via `GetWorkloadAccessTokenForUserId`, reads the user's vaulted OAuth without a session). Reuse that path.
+- **Fallback if the runtime rejects a workload credential directly:** app-api mints a short-lived per-owner token that the caller relays. Only fall back if you *prove* the first path can't work — document why.
+- **Reuse:** `apis/shared/oauth/agentcore_identity.py` (workload identity, `AGENTCORE_RUNTIME_WORKLOAD_NAME`), KB-sync IAM statements in `infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts` (~152–184: `GetWorkloadAccessTokenForUserId`, `GetResourceOauth2Token`, secret read), runtime URL builder + request shape in `apis/app_api/chat/proxy_routes.py` (~33) and `InvocationRequest` in `apis/inference_api/chat/models.py` (~81).
+- **Watch:** AgentCore `customParameters` are part of the token-vault key — token retrieval must use the **same** customParameters as the consent flow or it falsely reports consent-required (`project_agentcore_custom_parameters_vault_key`).
+
+## Unknown 2 — Server-side SSE consumption
+
+**Question:** Can the headless caller consume the `/invocations` SSE stream to completion (nothing today reads it server-side; the app-api proxy only relays to a browser)?
+
+- **Build:** a small httpx SSE reader that drains to `message_stop`/`done`, extracts the **final assistant message**, and surfaces `stream_error`. Capture enough for a `RunResult` (see below): final text, tool-use trace, and cost/metadata if present.
+- **Reuse:** event shapes in `agents/main_agent/streaming/event_formatter.py`; the SSE event table in `CLAUDE.md`. Mind the 300s runtime timeout (`proxy_routes.py`).
+
+## Design deliverables (the real point of the spike)
+
+Code proves feasibility; **these decisions are what Phase A builds on.** Produce a short design note answering:
+
+1. **`run_agent_headless(...)` interface.** The signature and a `RunResult` shape (final message, tool trace, cost, status, error, `session_id`). This is the internal primitive every trigger will call — keep it **A2A-ready** (clean seam a future A2A server / runtime endpoint can front without a rewrite). ⚠️ If ever exposed as A2A, `capabilities` must include `streaming=True` (`CLAUDE.md`) or clients hang ~40 min.
+2. **Where it lives.** It is *not* an inference-api route (only `/invocations` + `/ping` are reachable in cloud — `CLAUDE.md`). Recommend the module boundary: shared invocation helper vs. an app-api-hosted background caller vs. a dedicated Lambda. Justify against the service-boundary rule (`feedback_service_boundaries`).
+3. **Auth approach chosen**, with evidence — which of Unknown-1's paths, and why.
+4. **Governance-floor hook points (F6a seam only — do not implement guardrails yet).** Where does a run (a) write an **audit record**, (b) pass a **guardrails hook**, (c) hit a **data-classification checkpoint** on what it may read/emit? Place the seams so Phase A can fill them without retrofitting. For the spike, writing **one minimal audit record** is enough to prove the seam exists.
+5. **Delivery (minimal F2).** Confirm result materialization via `ensure_session_metadata_exists` + `update_session_title` (`apis/shared/sessions/metadata.py` ~739 / ~560). Note the run-record shape.
+
+## Out of scope for the spike
+
+Scheduler / EventBridge / dispatcher-worker (Phase B) · SPA (Phase A-UI) · full Bedrock Guardrails + PII classifier implementation (Phase A, seams only here) · schedule data model · cohort RBAC wiring · email delivery.
+
+## House rules (non-negotiable)
+
+- No new routes on **inference-api**. · SPA-facing app-api routes use `Depends(get_current_user_from_session)` (cookie), never bare Bearer. · Exact version pins; **no new packages without Phil's approval**. · Branch from `develop`; conventional commits. · Prove in **dev-ai**, not localhost.
+
+## Expected output
+
+A spike branch demonstrating the success criterion in dev-ai, **plus** a design note (the 5 deliverables above) and a clear **go / no-go + chosen-auth-path recommendation** for Phase A. If it's no-go on the preferred auth path, the fallback analysis *is* the valuable result — say so plainly with the evidence.

--- a/docs/specs/scheduled-agent-runs.md
+++ b/docs/specs/scheduled-agent-runs.md
@@ -1,0 +1,199 @@
+# Scheduled Agent Runs — Headless Run Entrypoint + Scheduled Trigger (Primitives F1 + F2 + F3)
+
+**Status:** Draft / handoff spec (for implementation by Fable)
+**Author:** Phil Merrell (drafted with Claude)
+**Date:** 2026-07-05
+**Targets branch:** `develop` (PRs target `develop`, never `main`)
+**Parent plan:** `docs/specs/agentic-platform-primitives.md` — this is the detailed design for its fundamentals **F1** (headless, trigger-agnostic agent-run entrypoint / the Harness slice), **F2** (async result + delivery spine), and **F3** (scheduled trigger). Read the parent for how these fit the wider primitive layer.
+**Related:**
+- KB-sync scheduled re-index — the scheduling template (`apis/shared/sync_policies/`, `infrastructure/lib/constructs/kb-sync/`)
+- Unattended per-user OAuth (`apis/shared/oauth/agentcore_identity.py`, `AGENTCORE_RUNTIME_WORKLOAD_NAME`)
+- Session metadata (`apis/shared/sessions/metadata.py`) — `ensure_session_metadata_exists`, `update_session_title`
+- Assistants / Skills / RBAC (`apis/shared/assistants/`, `docs/specs/admin-skills-rbac-tool-binding.md`) — the run-config the entrypoint resolves + the cohort gate
+- Per-user markdown memory (`docs/specs/user-markdown-memory.md`) — loaded *inside* a run, tracked separately (F5)
+
+---
+
+## 0. Instructions to Fable (read first)
+
+Build a **generic primitive**, not a feature. The deliverable is a **headless, trigger-agnostic way to run an agent turn** ("run as user U, input P, resolved config C → structured result") plus a **scheduled trigger** on top of it and a **place for the result to land**. A chief-of-staff assistant ("Oliver"), briefings, digests, and monitoring are *validation use cases* (see the parent plan §5) — they must fall out as configuration, so keep every layer free of Oliver-specific assumptions.
+
+**Ship to production, but scoped.** Each layer reaches prod while usable only by a small **feedback cohort** first. Widening the cohort — ultimately to *anyone who wants it* — must be a config change (grant a capability), not a re-architecture.
+
+**Decisions already made (do not re-litigate; build to these):**
+
+1. **The keystone is the headless run entrypoint (F1), not the scheduler.** The scheduler is *one trigger* on it. Build "run an agent turn off the live socket and capture the result" first and generically; a schedule, an A2A call, a webhook, or a "Run now" button are all just callers. Do **not** couple the entrypoint to scheduling.
+2. **Model the scheduler on `sync_policies`**, not from scratch. It already solves the hard parts: a sparse "due" GSI, a dispatcher/worker split, conditional re-arm to prevent double-dispatch, and `paused_error` state. Copy that shape.
+3. **Unattended runs invoke the agent as the run's owner** using the platform workload identity (the same mechanism KB-sync's worker already uses to read a user's vaulted OAuth tokens without a live session). The agent must run *as the user* so it can read their memory and use their connector tokens. **This is the single biggest technical risk — spike it first (PR-2/Phase A), before building UI on top.** ⚠️ If the entrypoint is ever exposed as an A2A server, `CLAUDE.md` requires its `capabilities` include `streaming=True` or clients hang ~40 min.
+4. **Delivery starts as a run-record + an auto-created session** in the user's conversation list (e.g. titled *"Morning Briefing — Jul 6"*), using `ensure_session_metadata_exists` + `update_session_title`. **No new notification system in v1.** A lightweight inbox row and email-via-connector (the agent emails the user its own result as its final tool call) are high-value follow-ons — note them, don't block on them.
+5. **Cohort gating uses RBAC**, not a net-new allowlist table. Create a `scheduled-runs` capability granted by a beta `AppRole`; add testers to it. GA = grant the capability to the default/everyone role. A global `SCHEDULED_RUNS_ENABLED` kill switch wraps the feature per house style (copy the `CDK_KB_SYNC_ENABLED` empty-string ternary exactly).
+6. **The run-config is resolved from existing primitives** (an assistant id, a skill, an explicit tool set, a model) — the entrypoint doesn't invent a new config type. A validation use case like Oliver is then just "a system-seeded `Assistant` + a schedule pointing at it," with no bespoke code.
+
+**House rules that bite here (from `CLAUDE.md` + prior art):**
+- **Do not add routes to `inference-api`.** Only `POST /invocations` and `GET /ping` are reachable in cloud. All CRUD for schedules goes on **app-api**. The worker Lambda invokes the *runtime* `/invocations`, which is allowed.
+- SPA-facing app-api routes use `Depends(get_current_user_from_session)` (cookie), never bare Bearer.
+- Exact version pins; no new packages without explicit approval.
+- Feature flags: **empty-string workflow-var gotcha** — `${{ vars.CDK_SCHEDULED_RUNS_ENABLED }}` is `""` when unset, which must resolve to the default, not "off". Copy the `CDK_KB_SYNC_ENABLED` ternary in `config.ts` exactly.
+
+**When you hit a genuine fork not covered here, stop and ask Phil.** The open questions are in §8.
+
+---
+
+## 1. Summary
+
+Let the agent **act without a live session**. Instead of only responding when a browser is open, a user (or admin) can register a schedule — *"every weekday at 7am, run this prompt as me"* — and that run happens unattended, as the user, with the result waiting in their conversation list when they log in. A validation use case: a system-seeded chief-of-staff assistant ("Oliver") a user schedules a morning briefing against — but the engine knows nothing about Oliver.
+
+Three things are being built (parent-plan fundamentals in parentheses):
+
+- **A headless run entrypoint (F1)** — "run agent as user U, input P, resolved config C → structured result," callable off the live socket by any trigger. The keystone.
+- **A result + delivery spine (F2)** — a run-record plus result materialized as an auto-created session; a lightweight inbox/email as follow-ons.
+- **A scheduled trigger (F3)** — user-owned schedules (`prompt + cadence + timezone + target config`), a dispatcher/worker pair that runs due schedules unattended. Modeled on `sync_policies`.
+
+All ship to prod, gated to a `scheduled_runs_beta` RBAC cohort, behind a `SCHEDULED_RUNS_ENABLED` kill switch, with a documented one-config-change path to GA.
+
+## 2. Goals
+
+- A user can **create, edit, pause, and delete** a scheduled prompt from the SPA.
+- Due schedules run **unattended, as the owning user**, with the owner's memory and connector tokens available.
+- Results are delivered **idempotently** as a titled session the user can open — no duplicate spam if the dispatcher retries.
+- The engine is **generic**: not hard-coded to any persona or to "briefings." Any resolved config (assistant / skill / tools / model) + any prompt + any cadence.
+- **Cohort-scoped in prod**, widenable to GA by granting a role — no redeploy, no schema change.
+- **Safe by default**: per-schedule runaway guards (max runs/day), auto-pause on repeated failure (`paused_error`), and a global kill switch.
+
+## 3. Non-goals (v1)
+
+- A new in-app notification / inbox / push system. Delivery is session-list discoverability (+ optional connector email).
+- Per-assistant tool-binding UI (a scheduled run uses the config's/owner's RBAC-granted tools). Parent-plan F4-adjacent.
+- Full per-user markdown memory. A run leans on system prompt + reference files + existing session continuity; memory is its own spec (`user-markdown-memory.md`, parent-plan F5) and lands in parallel.
+- Arbitrary cron expressions in the UI. v1 offers a **bounded cadence set** (daily / weekday / weekly at an hour + timezone); store a normalized `next_run_at` so the engine stays cron-agnostic.
+- Sharing/scheduling on behalf of *other* users. A schedule runs only as its own owner.
+- Multi-step / conditional workflows. One schedule = one prompt = one run.
+
+---
+
+## 4. Architecture
+
+```
+                    ┌───────────────────────────────────────────────┐
+   SPA  ── cookie ─▶│ app-api  /scheduled-runs/*  (CRUD)          │
+                    │   → ScheduledPromptService (shared)            │
+                    │   → DynamoDB (sparse DueScheduleIndex GSI)     │
+                    └───────────────────────────────────────────────┘
+                                        ▲ writes next_run_at
+   EventBridge rule (rate 5 min,        │
+   enabled iff SCHEDULED_RUNS_ENABLED) ─┐       │
+                                ▼        │
+                    ┌───────────────────────────────┐
+                    │ Dispatcher Lambda             │  query DueScheduleIndex (next_run_at ≤ now)
+                    │  - runaway + kill-switch check │  conditional re-arm (advance next_run_at)
+                    │  - async-invoke worker per due │  → InvocationType="Event"
+                    └───────────────────────────────┘
+                                │ (one per due schedule)
+                                ▼
+                    ┌───────────────────────────────────────────────┐
+                    │ Worker Lambda                                 │
+                    │  1. mint owner workload token (WLI + user_id) │  ← agentcore_identity.py
+                    │  2. POST runtime /invocations (as the user)   │  ← reuse InvocationRequest
+                    │  3. consume SSE → final assistant message     │  ← net-new: server-side SSE reader
+                    │  4. ensure_session_metadata_exists + title    │  ← deliver as a session
+                    │  5. (follow-on) agent emails result via connector │
+                    └───────────────────────────────────────────────┘
+```
+
+### 4.1 Reuse map (copy these, don't invent)
+
+| Need | Reuse from | File |
+|---|---|---|
+| EventBridge rate rule, gated by `enabled` | KB-sync dispatcher rule | `infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts` (~216) |
+| Dispatcher → worker async invoke | KB-sync dispatcher | `apis/app_api/kb_sync/dispatcher.py` (~93) `InvocationType="Event"` |
+| Sparse "due" GSI + conditional re-arm | `SyncPolicy` | `apis/shared/sync_policies/models.py`, `service.py` (`list_due_policies`, `rearm_policy`, `set_policy_state`) |
+| Unattended per-user OAuth / workload token | KB-sync worker | `apis/shared/oauth/agentcore_identity.py`, `AGENTCORE_RUNTIME_WORKLOAD_NAME` + `GetWorkloadAccessTokenForUserId` |
+| Runtime `/invocations` URL builder + request shape | chat proxy | `apis/app_api/chat/proxy_routes.py` (~33), `InvocationRequest` in `apis/inference_api/chat/models.py` |
+| Idempotent session create + title | sessions | `apis/shared/sessions/metadata.py` (`ensure_session_metadata_exists`, `update_session_title`) |
+| Docker Lambda + bootstrap-stub + SSM name export | KB-sync build | `kb-sync-construct.ts`, `backend/Dockerfile.kb-sync`, `bootstrap-assets/kb-sync/` |
+| Global flag threading + empty-string ternary | KB-sync flag | `infrastructure/lib/config.ts` (`kbSync.enabled`), `apis/shared/feature_flags.py` |
+| Cohort gating via role grant | Admin Skills RBAC | `apis/shared/rbac/`, `docs/specs/admin-skills-rbac-tool-binding.md` |
+
+### 4.2 The hard part — unattended invocation (spike this first)
+
+KB-sync proves a Lambda can act *as a user* for **connector tokens** (workload identity → `GetWorkloadAccessTokenForUserId` → vaulted OAuth). It does **not** prove a Lambda can drive a full **agent turn** unattended. Two gaps to close in the PR-2 spike:
+
+1. **Auth to the runtime.** The runtime `/invocations` expects a bearer today (chat proxy relays the user's Cognito token). The worker has no live Cognito session. Validate invoking the runtime with the **platform workload credential**, passing `user_id` explicitly in the payload so the agent loads the right memory/session and mints the right connector tokens. If the runtime cannot accept a workload credential directly, fall back to app-api minting a short-lived owner token (see §8 Q1).
+2. **Server-side SSE consumption.** No code today reads an `/invocations` SSE stream *inside* a Lambda — the app-api proxy only relays it to the browser. Build a small httpx SSE reader in the worker that drains the stream to `message_stop`/`done`, extracts the final assistant message (and surfaces `stream_error`). Net-new but contained.
+
+**Deliverable of the spike:** a worker that, given a `user_id` + prompt, produces a stored session with a real agent answer that used at least one of the user's connector tools. Everything else in this spec is CRUD and wiring around that proof.
+
+---
+
+## 5. Data model
+
+New records, keyed under the owning user. Follow `SyncPolicy`'s inert-record + sparse-index discipline: **the row is data; delete = total revocation; no orphan timers.**
+
+```
+PK = USER#{user_id}
+SK = SCHEDPROMPT#{schedule_id}          # schedule_id = "sched-" + 12 hex
+
+Attributes:
+  scheduleId, userId
+  assistantId: str | None               # target assistant's ast-id (None → default agent)
+  label: str                            # "Morning Briefing"
+  promptText: str                       # what to run
+  cadence: "daily" | "weekday" | "weekly"
+  hourLocal: int (0–23)
+  weekday: int | None                   # for "weekly"
+  timezone: str                         # IANA, e.g. "America/Boise"
+  state: "active" | "paused" | "paused_error"
+  nextRunAt: str                        # ISO 8601 UTC — recomputed on each run/edit
+  lastRunAt, lastRunStatus, lastRunSessionId, lastError: optional
+  runsToday, runsTodayDate: runaway guard
+  deliverEmail: bool = false            # v1.5 connector-email opt-in
+  createdAt, updatedAt
+
+GSI: DueScheduleIndex (sparse)
+  PK = "SCHEDDUE"                        # single hot-partition; fine at this scale (mirror GSI4)
+  SK = nextRunAt                         # dispatcher queries nextRunAt ≤ now, oldest first
+  only projected when state == "active"  # pausing/deleting removes it from the index
+```
+
+Cadence → `next_run_at` is computed in the service (timezone-aware) so the dispatcher stays a dumb "who's due" query. Never dispatch off a cron string.
+
+## 6. Cohort gating & rollout
+
+**Two independent controls:**
+
+- **`SCHEDULED_RUNS_ENABLED`** — global kill switch. CDK context `CDK_SCHEDULED_RUNS_ENABLED` → `config.ts` (copy the `kbSync.enabled` ternary *exactly*, incl. the empty-string→default guard) → threaded into app-api **and** inference-api env, and gates the EventBridge rule's `enabled`. Default: **ON** in the env where we're testing, so the feature *exists* in prod; access is limited by the cohort, not by hiding the feature. (If we want it fully dark in an env, `=false`.)
+- **`scheduled_runs_beta` AppRole** — *who* can create/run schedules. Grants: the `scheduled-runs` capability (plus visibility of any validation assistant seeded for the cohort). Add testers by mapping a JWT group (`jwt_role_mappings: ["group/scheduled-runs-beta"]`) or direct grant. This reuses the mature RBAC resolution path — no net-new allowlist table.
+
+**Enforcement points:**
+- app-api `/scheduled-runs/*` checks the caller resolves the `scheduled-runs` capability via RBAC; 403 otherwise.
+- The dispatcher **re-checks** each due schedule's owner still has the capability before invoking (a revoked tester's schedules silently stop, don't error-spam).
+
+**GA path (one change, no redeploy):** grant `scheduled-runs` to the default/everyone role (or wildcard). The feature flips from "beta cohort" to "anyone who wants it." Keep `SCHEDULED_RUNS_ENABLED` as the permanent kill switch.
+
+## 7. PR plan
+
+Sequence so the risky proof (F1) comes before the trigger and UI investment.
+
+- **PR-1 — Headless run entrypoint (F1) + minimal result spine (F2).** The internal `run_agent_headless(user_id, input, config) → RunResult` primitive: workload-identity invocation of the runtime with explicit `user_id`, the server-side SSE reader, a run-record, and result materialized as an auto-created titled session. Expose a guarded **"Run now"** path (app-api, cookie auth, RBAC-gated) as the validation surface. **Land the §4.2 proof here — this de-risks everything.** No scheduling yet.
+- **PR-2 — Schedule data model + CRUD API + cohort primitive (F3, control plane).** `ScheduledPrompt` model + service (shared), app-api `/scheduled-runs/*` (cookie auth, RBAC-gated), the `scheduled_runs_beta` role + `scheduled-runs` capability, `SCHEDULED_RUNS_ENABLED` flag threaded through CDK. Schedules can be created/listed; not yet fired.
+- **PR-3 — Scheduler engine (F3, data plane).** Dispatcher + worker Lambdas (Docker, bootstrap stub, SSM name export), EventBridge rule gated by `SCHEDULED_RUNS_ENABLED`, IAM (mirror KB-sync). Dispatcher queries due → conditional re-arm → worker calls the PR-1 entrypoint. Delivery = the F2 session.
+- **PR-4 — SPA management UI.** Signal-based schedule list/create/edit/pause under `frontend/ai.client/src/app/`. Pick a target config in the picker; "Schedule this" affordance. Runaway/error state surfaced to the user.
+- **PR-5 — GA flip + docs + (optional) email delivery.** Grant `scheduled-runs` to the default role; release notes; and optionally the `deliverEmail` path (final tool call emails the result via the user's Gmail connector — a strong dogfood of the connector + tool-approval surface).
+
+**Validation use case (separate, thin PR):** seed a system Assistant (e.g. "Oliver") + a schedule pointed at it, to prove the primitives end-to-end. No engine code — pure configuration.
+
+**Parallel dependencies (not blockers):** per-user markdown memory (`docs/specs/user-markdown-memory.md`, F5) and first-class KB (F4) — either sharpens scheduled runs, but the engine must stand without them.
+
+## 8. Open questions for Phil
+
+1. **Unattended runtime auth (Q from §4.2).** Preferred: worker invokes the runtime with the platform **workload credential** + `user_id` in payload. Fallback: app-api mints a short-lived per-owner token the worker relays. Which do we validate first? (Affects the PR-2 spike's shape and the runtime's auth handling.)
+2. **Delivery default.** v1 = session-in-list only, or turn on **connector-email** (`deliverEmail`) for the beta cohort from day one? Email is the better dogfood but adds the connector-token + tool-approval path to the critical path.
+3. **Cohort mechanism.** RBAC `scheduled_runs_beta` role (recommended, reuses mature infra) vs. a `FEATURE_COHORT#scheduled-runs` sentinel item in the auth-providers table (lighter, but net-new gating code). Confirm RBAC.
+4. **Run-config surface.** What can a schedule target in v1 — an Assistant id (recommended, shippable today), a Skill, or an explicit tool+model set? Assistant is simplest; Skill owns tool-binding but is behind the deferred `SKILLS_ENABLED`.
+5. **Run frequency ceiling.** Max schedules per user and max runs/day per schedule for the beta (cost + spam guard)? Proposed: 5 schedules/user, 1 run/day/schedule for the cohort.
+
+---
+
+## Appendix — why this is the right dogfood
+
+The capability we most lack for non-coding daily use is **proactivity**: today the agent only speaks when spoken to. A headless run entrypoint + scheduled trigger flips that — and because it's a *primitive*, a chief-of-staff persona, a weekly digest, and a monitoring alert are all just configuration on top (parent plan §5). Building it also forces us through — from the *user's* seat — the exact surfaces that are hardest and least dogfooded: unattended connector-token use, session creation outside a live chat, RBAC-scoped rollout, and the connector-email + tool-approval loop. Ship it narrow, live in it, widen it.


### PR DESCRIPTION
## What

Reframes the proactive-agent / dogfooding effort from a single **Oliver** feature into a **primitive-enablement plan**, and maps it onto the two in-flight explorations:

- **Harness** = externalize the agent loop into a headless, trigger-agnostic run entrypoint (**F1**, the keystone).
- **Registry** = catalog + discovery + **governance** seam over every primitive (**F6**).

Oliver is demoted to *one validation use case among several*.

## Docs added

| File | Purpose |
|------|---------|
| `docs/specs/agentic-platform-primitives.md` | Umbrella: primitive maturity + **gap ledger**, the six fundamentals (F1–F6), phased plan, Harness/Registry overlap |
| `docs/specs/scheduled-agent-runs.md` | Detailed design for **F1 + F2 + F3** (renamed & generalized from the earlier Oliver draft) |
| `docs/specs/harness-entrypoint-spike-brief.md` | Tight spike brief for the **F1 keystone** (unattended-as-user auth + server-side SSE), to run in dev-ai |

## Resolved decisions (built into the specs)

1. **F1 = minimal internal `run_agent_headless(...)`, A2A-ready seam** (not an A2A server yet).
2. **Governance is foundational** — split F6 into **F6a floor** (audit / guardrails / PII, pulled forward into Phase A, backend-invisible) vs **F6b discovery** (deferred to Phase D, post Tier-1 gateway-search measurement).

## Still open (see umbrella §6)

- KB decoupling appetite (F4 — biggest refactor: do now vs. borrow an assistant's KB).
- Minimum F6a floor depth before Phase A ships.
- Confirm proactive-spine-first sequencing.

## Notes

Docs only — no code changes. The F1 spike (Fable 5) runs next on a separate branch; its go/no-go + design note folds back into `scheduled-agent-runs.md` before any Phase A build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)