### PR TITLE
feat(schedules): B1 — schedule data model + CRUD (inert)

### DIFF
--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -201,6 +201,7 @@ from apis.app_api.voice import router as voice_router
 from apis.app_api.user_menu_links.routes import router as user_menu_links_router
 from apis.app_api.system_prompts.routes import router as system_prompts_router
 from apis.app_api.runs.routes import router as runs_router
+from apis.app_api.schedules.routes import router as schedules_router
 
 # Include routers
 app.include_router(health_router)
@@ -235,6 +236,7 @@ app.include_router(voice_router)  # Cookie-authenticated WS proxy for Nova Sonic
 app.include_router(user_menu_links_router)  # Public read of admin-managed user-menu links
 app.include_router(system_prompts_router)   # Public read of admin-managed system prompts
 app.include_router(runs_router)  # Headless "Run now" + grant lifecycle (scheduled-runs PR-1; SCHEDULED_RUNS_ENABLED + RBAC gated at runtime)
+app.include_router(schedules_router)  # Schedule CRUD (scheduled-runs B1; inert — SCHEDULED_RUNS_ENABLED + RBAC gated, nothing fires yet)
 
 # Conditionally register fine-tuning routes
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":

--- a/backend/src/apis/app_api/schedules/__init__.py
+++ b/backend/src/apis/app_api/schedules/__init__.py
@@ -1,0 +1,1 @@
+"""Schedule management routes (scheduled agent runs — B1, inert CRUD)."""

--- a/backend/src/apis/app_api/schedules/models.py
+++ b/backend/src/apis/app_api/schedules/models.py
@@ -1,0 +1,118 @@
+"""Schedule API request/response models."""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from apis.shared.scheduled_prompts.models import ScheduleCadence, ScheduledPrompt, ScheduledPromptState
+
+_MAX_PROMPT_CHARS = 20_000
+
+
+class CreateScheduleRequest(BaseModel):
+    """Request body for creating a scheduled prompt."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., min_length=1, max_length=200)
+    prompt_text: str = Field(..., alias="promptText", min_length=1, max_length=_MAX_PROMPT_CHARS)
+    cadence: ScheduleCadence
+    hour_local: int = Field(..., alias="hourLocal", ge=0, le=23)
+    weekday: Optional[int] = Field(None, ge=0, le=6)
+    timezone: str = Field(..., min_length=1, max_length=64)
+    assistant_id: Optional[str] = Field(None, alias="assistantId")
+    # None = snapshot "all RBAC-allowed at creation" (resolved by the route,
+    # exactly as an attended chat turn resolves defaults); an explicit list
+    # snapshots that subset instead.
+    enabled_tools: Optional[List[str]] = Field(None, alias="enabledTools")
+    deliver_email: bool = Field(False, alias="deliverEmail")
+
+    @model_validator(mode="after")
+    def _weekly_requires_weekday(self) -> "CreateScheduleRequest":
+        if self.cadence == "weekly" and self.weekday is None:
+            raise ValueError("weekday is required when cadence is 'weekly'")
+        return self
+
+
+class UpdateScheduleRequest(BaseModel):
+    """Request body for editing a schedule or pausing/resuming it.
+
+    ``state`` accepts only the user-owned transitions: "paused" and
+    "active". A schedule in "paused_error" can also be resumed here — the
+    resume is an explicit user decision to try again.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: Optional[str] = Field(None, min_length=1, max_length=200)
+    prompt_text: Optional[str] = Field(None, alias="promptText", min_length=1, max_length=_MAX_PROMPT_CHARS)
+    cadence: Optional[ScheduleCadence] = None
+    hour_local: Optional[int] = Field(None, alias="hourLocal", ge=0, le=23)
+    weekday: Optional[int] = Field(None, ge=0, le=6)
+    timezone: Optional[str] = Field(None, min_length=1, max_length=64)
+    assistant_id: Optional[str] = Field(None, alias="assistantId")
+    enabled_tools: Optional[List[str]] = Field(None, alias="enabledTools")
+    deliver_email: Optional[bool] = Field(None, alias="deliverEmail")
+    state: Optional[Literal["active", "paused"]] = None
+
+
+class ScheduledPromptResponse(BaseModel):
+    """Public view of a scheduled prompt."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    schedule_id: str = Field(..., alias="scheduleId")
+    assistant_id: Optional[str] = Field(None, alias="assistantId")
+    label: str
+    prompt_text: str = Field(..., alias="promptText")
+    cadence: ScheduleCadence
+    hour_local: int = Field(..., alias="hourLocal")
+    weekday: Optional[int] = None
+    timezone: str
+    state: ScheduledPromptState
+    state_reason: Optional[str] = Field(None, alias="stateReason")
+    next_run_at: Optional[str] = Field(None, alias="nextRunAt")
+    last_run_at: Optional[str] = Field(None, alias="lastRunAt")
+    last_run_status: Optional[str] = Field(None, alias="lastRunStatus")
+    last_run_session_id: Optional[str] = Field(None, alias="lastRunSessionId")
+    last_error: Optional[str] = Field(None, alias="lastError")
+    runs_today: int = Field(0, alias="runsToday")
+    max_runs_per_day: int = Field(24, alias="maxRunsPerDay")
+    enabled_tools: Optional[List[str]] = Field(None, alias="enabledTools")
+    deliver_email: bool = Field(False, alias="deliverEmail")
+    created_at: str = Field(..., alias="createdAt")
+    updated_at: str = Field(..., alias="updatedAt")
+
+    @classmethod
+    def from_schedule(cls, schedule: ScheduledPrompt) -> "ScheduledPromptResponse":
+        return cls(
+            schedule_id=schedule.schedule_id,
+            assistant_id=schedule.assistant_id,
+            label=schedule.label,
+            prompt_text=schedule.prompt_text,
+            cadence=schedule.cadence,
+            hour_local=schedule.hour_local,
+            weekday=schedule.weekday,
+            timezone=schedule.timezone,
+            state=schedule.state,
+            state_reason=schedule.state_reason,
+            next_run_at=schedule.next_run_at,
+            last_run_at=schedule.last_run_at,
+            last_run_status=schedule.last_run_status,
+            last_run_session_id=schedule.last_run_session_id,
+            last_error=schedule.last_error,
+            runs_today=schedule.runs_today,
+            max_runs_per_day=schedule.max_runs_per_day,
+            enabled_tools=schedule.enabled_tools,
+            deliver_email=schedule.deliver_email,
+            created_at=schedule.created_at,
+            updated_at=schedule.updated_at,
+        )
+
+
+class ScheduledPromptsListResponse(BaseModel):
+    """Response for listing the caller's scheduled prompts."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    schedules: List[ScheduledPromptResponse] = Field(default_factory=list)

--- a/backend/src/apis/app_api/schedules/routes.py
+++ b/backend/src/apis/app_api/schedules/routes.py
@@ -1,0 +1,234 @@
+"""Schedule routes — CRUD for scheduled agent runs (`/schedules/*`).
+
+**B1 is deliberately inert**: schedules can be created, listed, edited,
+paused/resumed, and deleted here, but nothing fires yet — the
+dispatcher/worker that reads ``DueScheduleIndex`` and calls
+``run_agent_headless`` is B2 (docs/specs/scheduled-agent-runs.md §7).
+
+Gating mirrors the Phase A "Run now" surface exactly (two independent
+controls, spec §6):
+
+* ``SCHEDULED_RUNS_ENABLED`` — per-environment kill switch (default on).
+  Off -> every route here 404s, as if unmounted.
+* ``scheduled-runs`` RBAC capability -- *who* may use the surface. Granted
+  to the beta cohort's AppRole; missing -> 403. GA = grant to ``default``.
+
+Auth is the standard SPA cookie dependency (``get_current_user_from_session``)
+per the CLAUDE.md app-api rule.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.feature_flags import scheduled_runs_enabled
+from apis.shared.rbac.capabilities import SCHEDULED_RUNS_CAPABILITY, user_has_capability
+from apis.shared.rbac.service import get_app_role_service
+from apis.shared.scheduled_prompts.service import (
+    ScheduledPromptLimitExceeded,
+    compute_next_run_at,
+    create_scheduled_prompt,
+    delete_scheduled_prompt,
+    get_scheduled_prompt,
+    list_scheduled_prompts,
+    set_schedule_state,
+    update_scheduled_prompt,
+)
+
+from apis.app_api.schedules.models import (
+    CreateScheduleRequest,
+    ScheduledPromptResponse,
+    ScheduledPromptsListResponse,
+    UpdateScheduleRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/schedules", tags=["schedules"])
+
+
+async def require_scheduled_runs_user(
+    user: User = Depends(get_current_user_from_session),
+) -> User:
+    """Cookie auth + kill switch + cohort capability, in that order.
+
+    404 when the environment kill switch is off (the surface behaves as if
+    unmounted), 403 when the authenticated caller lacks the
+    ``scheduled-runs`` capability. Mirrors ``apis.app_api.runs.routes``.
+    """
+    if not scheduled_runs_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    if not await user_has_capability(user, SCHEDULED_RUNS_CAPABILITY):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have access to scheduled runs.",
+        )
+    return user
+
+
+async def _resolve_enabled_tools_snapshot(user: User, requested: Optional[List[str]]) -> Optional[List[str]]:
+    """Snapshot enabled_tools at creation time (Phase A punch #7).
+
+    An explicit list from the caller is trusted as-is (the SPA's tool
+    picker already filters to what the user may select). ``None`` resolves
+    to the user's current RBAC-allowed tool set *right now* and freezes it
+    into the schedule — the catalog shifting later never changes what a
+    sleeping schedule is allowed to call.
+    """
+    if requested is not None:
+        return requested
+    permissions = await get_app_role_service().resolve_user_permissions(user)
+    return list(permissions.tools)
+
+
+def _require_schedule_or_404(schedule, schedule_id: str):
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Schedule not found: {schedule_id}")
+    return schedule
+
+
+@router.post("", response_model=ScheduledPromptResponse, status_code=status.HTTP_201_CREATED)
+async def create_schedule(
+    request: CreateScheduleRequest,
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptResponse:
+    enabled_tools = await _resolve_enabled_tools_snapshot(user, request.enabled_tools)
+    try:
+        schedule = await create_scheduled_prompt(
+            user_id=user.user_id,
+            label=request.label,
+            prompt_text=request.prompt_text,
+            cadence=request.cadence,
+            hour_local=request.hour_local,
+            timezone_name=request.timezone,
+            weekday=request.weekday,
+            assistant_id=request.assistant_id,
+            enabled_tools=enabled_tools,
+            deliver_email=request.deliver_email,
+        )
+    except ScheduledPromptLimitExceeded as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+
+    return ScheduledPromptResponse.from_schedule(schedule)
+
+
+@router.get("", response_model=ScheduledPromptsListResponse)
+async def list_schedules(
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptsListResponse:
+    schedules = await list_scheduled_prompts(user.user_id)
+    return ScheduledPromptsListResponse(
+        schedules=[ScheduledPromptResponse.from_schedule(s) for s in schedules]
+    )
+
+
+@router.get("/{schedule_id}", response_model=ScheduledPromptResponse)
+async def get_schedule(
+    schedule_id: str,
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptResponse:
+    schedule = _require_schedule_or_404(await get_scheduled_prompt(user.user_id, schedule_id), schedule_id)
+    return ScheduledPromptResponse.from_schedule(schedule)
+
+
+@router.patch("/{schedule_id}", response_model=ScheduledPromptResponse)
+async def update_schedule(
+    schedule_id: str,
+    request: UpdateScheduleRequest,
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptResponse:
+    """Edit a schedule's fields and/or transition its state.
+
+    Editing any cadence field (cadence/hour_local/weekday/timezone) on an
+    *active* schedule recomputes ``next_run_at`` in the same request — an
+    edited schedule never keeps a stale due time. A ``paused`` schedule just
+    remembers the new cadence for when it resumes (mirrors
+    ``sync_policies.change_policy_interval``).
+    """
+    schedule = _require_schedule_or_404(await get_scheduled_prompt(user.user_id, schedule_id), schedule_id)
+
+    effective_cadence = request.cadence if request.cadence is not None else schedule.cadence
+    effective_weekday = request.weekday if request.weekday is not None else schedule.weekday
+    if effective_cadence == "weekly" and effective_weekday is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="weekday is required when cadence is 'weekly'",
+        )
+
+    schedule = await update_scheduled_prompt(
+        user.user_id,
+        schedule_id,
+        label=request.label,
+        prompt_text=request.prompt_text,
+        cadence=request.cadence,
+        hour_local=request.hour_local,
+        weekday=request.weekday,
+        timezone_name=request.timezone,
+        assistant_id=request.assistant_id,
+        enabled_tools=request.enabled_tools,
+        deliver_email=request.deliver_email,
+    )
+
+    if request.state is not None and request.state != schedule.state:
+        if request.state == "active":
+            next_run_at = compute_next_run_at(
+                schedule.cadence, schedule.hour_local, schedule.timezone, weekday=schedule.weekday
+            )
+            await set_schedule_state(user.user_id, schedule_id, "active", next_run_at=next_run_at)
+        else:
+            await set_schedule_state(user.user_id, schedule_id, "paused", state_reason="Paused by user")
+        schedule = await get_scheduled_prompt(user.user_id, schedule_id)
+
+    return ScheduledPromptResponse.from_schedule(schedule)
+
+
+@router.post("/{schedule_id}/pause", response_model=ScheduledPromptResponse)
+async def pause_schedule(
+    schedule_id: str,
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptResponse:
+    """Pause a schedule — removes it from DueScheduleIndex immediately."""
+    schedule = _require_schedule_or_404(await get_scheduled_prompt(user.user_id, schedule_id), schedule_id)
+    if schedule.state == "paused":
+        return ScheduledPromptResponse.from_schedule(schedule)
+
+    await set_schedule_state(user.user_id, schedule_id, "paused", state_reason="Paused by user")
+    schedule = await get_scheduled_prompt(user.user_id, schedule_id)
+    return ScheduledPromptResponse.from_schedule(schedule)
+
+
+@router.post("/{schedule_id}/resume", response_model=ScheduledPromptResponse)
+async def resume_schedule(
+    schedule_id: str,
+    user: User = Depends(require_scheduled_runs_user),
+) -> ScheduledPromptResponse:
+    """Resume a paused (or paused_error) schedule — recomputes next_run_at
+    fresh from now and re-adds it to DueScheduleIndex."""
+    schedule = _require_schedule_or_404(await get_scheduled_prompt(user.user_id, schedule_id), schedule_id)
+    if schedule.state == "active":
+        return ScheduledPromptResponse.from_schedule(schedule)
+
+    next_run_at = compute_next_run_at(
+        schedule.cadence, schedule.hour_local, schedule.timezone, weekday=schedule.weekday
+    )
+    await set_schedule_state(user.user_id, schedule_id, "active", next_run_at=next_run_at)
+    schedule = await get_scheduled_prompt(user.user_id, schedule_id)
+    return ScheduledPromptResponse.from_schedule(schedule)
+
+
+@router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_schedule(
+    schedule_id: str,
+    user: User = Depends(require_scheduled_runs_user),
+) -> None:
+    """Delete = total revocation (no orphan timers)."""
+    _require_schedule_or_404(await get_scheduled_prompt(user.user_id, schedule_id), schedule_id)
+    await delete_scheduled_prompt(user.user_id, schedule_id)
+    return None

--- a/backend/src/apis/shared/scheduled_prompts/__init__.py
+++ b/backend/src/apis/shared/scheduled_prompts/__init__.py
@@ -1,0 +1,46 @@
+"""Scheduled prompts — schedule data model + CRUD for scheduled agent runs.
+
+B1 (this PR) only creates/edits/pauses/deletes the record. The dispatcher
+that reads DueScheduleIndex and actually fires a run is B2
+(docs/specs/scheduled-agent-runs.md §7).
+"""
+
+from .models import (
+    DUE_INDEX_PK,
+    ScheduleCadence,
+    ScheduledPrompt,
+    ScheduledPromptState,
+)
+from .service import (
+    ScheduledPromptLimitExceeded,
+    compute_next_run_at,
+    create_scheduled_prompt,
+    delete_scheduled_prompt,
+    get_scheduled_prompt,
+    list_due_schedules,
+    list_scheduled_prompts,
+    max_schedules_per_user,
+    rearm_schedule,
+    record_run_result,
+    set_schedule_state,
+    update_scheduled_prompt,
+)
+
+__all__ = [
+    "DUE_INDEX_PK",
+    "ScheduleCadence",
+    "ScheduledPrompt",
+    "ScheduledPromptLimitExceeded",
+    "ScheduledPromptState",
+    "compute_next_run_at",
+    "create_scheduled_prompt",
+    "delete_scheduled_prompt",
+    "get_scheduled_prompt",
+    "list_due_schedules",
+    "list_scheduled_prompts",
+    "max_schedules_per_user",
+    "rearm_schedule",
+    "record_run_result",
+    "set_schedule_state",
+    "update_scheduled_prompt",
+]

--- a/backend/src/apis/shared/scheduled_prompts/models.py
+++ b/backend/src/apis/shared/scheduled_prompts/models.py
@@ -1,0 +1,72 @@
+"""Scheduled-prompt models — the schedule data model for scheduled agent runs.
+
+A ScheduledPrompt is inert data: nothing fires unless the (future, B2)
+dispatcher reads it from the sparse DueScheduleIndex, so deleting the record
+is total revocation of the schedule (docs/specs/scheduled-agent-runs.md §5).
+This module (B1) only creates/edits/pauses/deletes the record — the
+dispatcher/worker that actually calls ``run_agent_headless`` lands in B2.
+
+Stored in the sessions-metadata table under the owning user (adjacency list):
+    PK: USER#{user_id}
+    SK: SCHEDPROMPT#{schedule_id}
+
+DueScheduleIndex (sparse) keys are present ONLY while state == "active" — a
+paused schedule is physically invisible to the dispatcher, not filtered at
+query time (mirrors SyncPolicy's DueSyncIndex discipline exactly).
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ScheduleCadence = Literal["daily", "weekday", "weekly"]
+ScheduledPromptState = Literal["active", "paused", "paused_error"]
+
+#: Sentinel partition key for the sparse due index. Single logical partition
+#: — fine at our scale; shard to SCHEDDUE#{0..N} if writes ever demand it.
+DUE_INDEX_PK = "SCHEDDUE"
+
+
+class ScheduledPrompt(BaseModel):
+    """Complete scheduled-prompt model (internal use)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    schedule_id: str = Field(..., alias="scheduleId", description="Schedule identifier (sched-{12-hex})")
+    user_id: str = Field(..., alias="userId", description="Owning user; every record lives under USER#{user_id}")
+    assistant_id: Optional[str] = Field(
+        None, alias="assistantId", description="Target assistant's ast-id; None runs the default agent"
+    )
+    label: str = Field(..., min_length=1, max_length=200, description="Human-readable schedule name, e.g. 'Morning Briefing'")
+    prompt_text: str = Field(..., alias="promptText", min_length=1, max_length=20_000, description="The prompt to run")
+    cadence: ScheduleCadence = Field(..., description="Re-run cadence (bounded enum — no cron)")
+    hour_local: int = Field(..., alias="hourLocal", ge=0, le=23, description="Local hour of day to run, 0-23")
+    weekday: Optional[int] = Field(
+        None, ge=0, le=6, description="0=Monday..6=Sunday; required when cadence == 'weekly'"
+    )
+    timezone: str = Field(..., description="IANA timezone, e.g. 'America/Boise'")
+    state: ScheduledPromptState = Field("active", description="Lifecycle state; only 'active' schedules appear in DueScheduleIndex")
+    state_reason: Optional[str] = Field(None, alias="stateReason", description="Human-readable reason for a paused state")
+    next_run_at: Optional[str] = Field(None, alias="nextRunAt", description="ISO 8601 UTC next due time; drives DueScheduleIndex sort key")
+    last_run_at: Optional[str] = Field(None, alias="lastRunAt", description="ISO 8601 timestamp of the last completed run")
+    last_run_status: Optional[str] = Field(None, alias="lastRunStatus", description="Outcome of the last completed run")
+    last_run_session_id: Optional[str] = Field(None, alias="lastRunSessionId", description="Session the last run materialized as")
+    last_error: Optional[str] = Field(None, alias="lastError", description="Error detail from the last failed run")
+    # Runaway guards (B1 fields only — B2 dispatcher/worker enforce these;
+    # present now so B2 needs no migration).
+    runs_today: int = Field(0, alias="runsToday", description="Runs fired today (runaway-guard counter)")
+    runs_today_date: Optional[str] = Field(
+        None, alias="runsTodayDate", description="UTC date (YYYY-MM-DD) runsToday is counting against"
+    )
+    max_runs_per_day: int = Field(
+        24, alias="maxRunsPerDay", description="Runaway guard ceiling; the dispatcher auto-pauses a schedule that exceeds this in a day"
+    )
+    # Snapshot at creation (Phase A punch #7) — never resolved lazily at fire
+    # time, so the catalog shifting under a sleeping schedule can't cause a
+    # least-surprise violation.
+    enabled_tools: Optional[List[str]] = Field(
+        None, alias="enabledTools", description="Tool ids snapshot at creation time; None means 'all RBAC-allowed at creation'"
+    )
+    deliver_email: bool = Field(False, alias="deliverEmail", description="v1.5 connector-email opt-in; inert in B1")
+    created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp of creation")
+    updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 timestamp of last update")

--- a/backend/src/apis/shared/scheduled_prompts/service.py
+++ b/backend/src/apis/shared/scheduled_prompts/service.py
@@ -1,0 +1,456 @@
+"""Scheduled-prompt repository — DynamoDB storage for scheduled agent runs.
+
+Lives in apis.shared because it will have (eventually) three independent
+consumers: app-api (this PR's CRUD routes), the B2 dispatcher Lambda (due
+sweep), and the B2 worker Lambda (run bookkeeping). B1 only wires the first.
+
+Storage (sessions-metadata table, adjacency list):
+    PK: USER#{user_id} | SK: SCHEDPROMPT#{schedule_id}
+    DueScheduleIndex (sparse): GSI3_PK = "SCHEDDUE", GSI3_SK = "{next_run_at}#{schedule_id}"
+    DueScheduleIndex keys exist only while state == "active".
+
+Cadence -> next_run_at is computed here, timezone-aware, so the (future)
+dispatcher stays a dumb "who's due" query — no cron strings in the engine
+(docs/specs/scheduled-agent-runs.md §5).
+"""
+
+import logging
+import os
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Optional
+from zoneinfo import ZoneInfo
+
+from .models import DUE_INDEX_PK, ScheduleCadence, ScheduledPrompt, ScheduledPromptState
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_SCHEDULES_PER_USER = 20
+
+_WEEKDAY_CADENCES = {"weekday"}  # Monday-Friday
+
+
+class ScheduledPromptLimitExceeded(Exception):
+    """Raised when a user already has the maximum number of schedules."""
+
+
+def _iso(dt: datetime) -> str:
+    """Serialize a UTC datetime as strict ISO 8601 with a ``Z`` suffix.
+
+    ``datetime.isoformat()`` renders the offset as ``+00:00``; normalize to
+    ``Z`` so the result is valid ISO 8601 that JavaScript's ``Date`` parses
+    (matches the sync_policies house style — see that module's docstring for
+    the Safari ``Invalid Date`` history).
+    """
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _get_current_timestamp() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def _generate_schedule_id() -> str:
+    return f"sched-{uuid.uuid4().hex[:12]}"
+
+
+def _table_name() -> str:
+    table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not table:
+        raise RuntimeError("DYNAMODB_SESSIONS_METADATA_TABLE_NAME environment variable is required")
+    return table
+
+
+def _get_table():
+    import boto3
+
+    return boto3.resource("dynamodb").Table(_table_name())
+
+
+def _due_sort_key(next_run_at: str, schedule_id: str) -> str:
+    return f"{next_run_at}#{schedule_id}"
+
+
+def max_schedules_per_user() -> int:
+    return int(os.environ.get("SCHEDULED_RUNS_MAX_PER_USER", DEFAULT_MAX_SCHEDULES_PER_USER))
+
+
+def compute_next_run_at(
+    cadence: ScheduleCadence,
+    hour_local: int,
+    timezone_name: str,
+    weekday: Optional[int] = None,
+    from_time: Optional[datetime] = None,
+) -> str:
+    """Compute the next due timestamp (ISO 8601 UTC) for a cadence.
+
+    Timezone-aware: the schedule's ``hour_local``/``weekday`` are interpreted
+    in ``timezone_name`` (IANA), then converted to UTC. Always returns a
+    time strictly after ``from_time`` (defaults to now) — a schedule created
+    at 9:05am local for "daily at 9am" fires tomorrow, not immediately.
+
+    ``weekday`` is 0=Monday..6=Sunday (``datetime.weekday()`` convention) and
+    is required for cadence == "weekly"; ignored otherwise.
+    """
+    tz = ZoneInfo(timezone_name)
+    base = (from_time or datetime.now(timezone.utc)).astimezone(tz)
+
+    candidate = base.replace(hour=hour_local, minute=0, second=0, microsecond=0)
+
+    if cadence == "daily":
+        if candidate <= base:
+            candidate += timedelta(days=1)
+    elif cadence == "weekday":
+        if candidate <= base:
+            candidate += timedelta(days=1)
+        while candidate.weekday() >= 5:  # Sat=5, Sun=6
+            candidate += timedelta(days=1)
+    elif cadence == "weekly":
+        if weekday is None:
+            raise ValueError("weekday is required when cadence == 'weekly'")
+        days_ahead = (weekday - candidate.weekday()) % 7
+        candidate += timedelta(days=days_ahead)
+        if candidate <= base:
+            candidate += timedelta(days=7)
+    else:
+        raise ValueError(f"Unknown cadence: {cadence}")
+
+    return _iso(candidate.astimezone(timezone.utc))
+
+
+async def create_scheduled_prompt(
+    user_id: str,
+    label: str,
+    prompt_text: str,
+    cadence: ScheduleCadence,
+    hour_local: int,
+    timezone_name: str,
+    weekday: Optional[int] = None,
+    assistant_id: Optional[str] = None,
+    enabled_tools: Optional[List[str]] = None,
+    deliver_email: bool = False,
+) -> ScheduledPrompt:
+    """Create an active scheduled prompt, due at the next occurrence of its cadence.
+
+    Enforces the per-user schedule cap (bounded by the cap, so the list scan
+    to check it is cheap). ``enabled_tools`` is a snapshot — the caller
+    passes the RBAC-resolved tool set at creation time; it is never
+    re-resolved lazily at fire time (Phase A punch #7).
+    """
+    existing = await list_scheduled_prompts(user_id)
+    if len(existing) >= max_schedules_per_user():
+        raise ScheduledPromptLimitExceeded(
+            f"User {user_id} already has {len(existing)} scheduled prompts (max {max_schedules_per_user()})"
+        )
+
+    now = _get_current_timestamp()
+    next_run_at = compute_next_run_at(cadence, hour_local, timezone_name, weekday=weekday)
+    schedule = ScheduledPrompt(
+        schedule_id=_generate_schedule_id(),
+        user_id=user_id,
+        assistant_id=assistant_id,
+        label=label,
+        prompt_text=prompt_text,
+        cadence=cadence,
+        hour_local=hour_local,
+        weekday=weekday,
+        timezone=timezone_name,
+        state="active",
+        next_run_at=next_run_at,
+        runs_today=0,
+        runs_today_date=None,
+        enabled_tools=enabled_tools,
+        deliver_email=deliver_email,
+        created_at=now,
+        updated_at=now,
+    )
+
+    item = schedule.model_dump(by_alias=True, exclude_none=True)
+    item["PK"] = f"USER#{user_id}"
+    item["SK"] = f"SCHEDPROMPT#{schedule.schedule_id}"
+    item["GSI3_PK"] = DUE_INDEX_PK
+    item["GSI3_SK"] = _due_sort_key(next_run_at, schedule.schedule_id)
+
+    _get_table().put_item(Item=item)
+    logger.info(f"Created scheduled prompt {schedule.schedule_id} ({cadence}) for user {user_id}")
+    return schedule
+
+
+async def get_scheduled_prompt(user_id: str, schedule_id: str) -> Optional[ScheduledPrompt]:
+    response = _get_table().get_item(Key={"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"})
+    item = response.get("Item")
+    return ScheduledPrompt.model_validate(item) if item else None
+
+
+async def list_scheduled_prompts(user_id: str) -> List[ScheduledPrompt]:
+    from boto3.dynamodb.conditions import Key
+
+    response = _get_table().query(
+        KeyConditionExpression=Key("PK").eq(f"USER#{user_id}") & Key("SK").begins_with("SCHEDPROMPT#")
+    )
+    schedules = []
+    for item in response.get("Items", []):
+        try:
+            schedules.append(ScheduledPrompt.model_validate(item))
+        except Exception as e:
+            logger.warning(f"Failed to parse scheduled prompt item: {e}")
+    return schedules
+
+
+async def list_due_schedules(now: Optional[str] = None, limit: int = 20) -> List[ScheduledPrompt]:
+    """Query the sparse DueScheduleIndex for active schedules whose next_run_at has passed.
+
+    Returns schedules most-overdue first. Paused schedules have no GSI keys
+    and are physically absent from this index. Not called by anything yet
+    in B1 — this is the exact query shape B2's dispatcher will use.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    now = now or _get_current_timestamp()
+    response = _get_table().query(
+        IndexName="DueScheduleIndex",
+        # '~' sorts after '#' and all timestamp characters, so this covers
+        # every "{ts}#{schedule_id}" key with ts <= now.
+        KeyConditionExpression=Key("GSI3_PK").eq(DUE_INDEX_PK) & Key("GSI3_SK").lte(f"{now}~"),
+        Limit=limit,
+        ScanIndexForward=True,
+    )
+    schedules = []
+    for item in response.get("Items", []):
+        try:
+            schedules.append(ScheduledPrompt.model_validate(item))
+        except Exception as e:
+            logger.warning(f"Failed to parse due scheduled prompt item: {e}")
+    return schedules
+
+
+async def set_schedule_state(
+    user_id: str,
+    schedule_id: str,
+    state: ScheduledPromptState,
+    next_run_at: Optional[str] = None,
+    state_reason: Optional[str] = None,
+) -> bool:
+    """Transition a schedule's lifecycle state.
+
+    Transition to "active" requires next_run_at and (re)adds the GSI keys;
+    any paused state REMOVEs them so the schedule drops out of
+    DueScheduleIndex. Returns False if the schedule does not exist.
+    """
+    from botocore.exceptions import ClientError
+
+    if state == "active" and not next_run_at:
+        raise ValueError("next_run_at is required when activating a scheduled prompt")
+
+    names = {"#state": "state"}
+    values = {":state": state, ":updated_at": _get_current_timestamp()}
+    set_parts = ["#state = :state", "updatedAt = :updated_at"]
+    remove_parts = []
+
+    if state == "active":
+        set_parts += ["nextRunAt = :next", "GSI3_PK = :gsipk", "GSI3_SK = :gsisk"]
+        values[":next"] = next_run_at
+        values[":gsipk"] = DUE_INDEX_PK
+        values[":gsisk"] = _due_sort_key(next_run_at, schedule_id)
+        remove_parts.append("stateReason")
+    else:
+        remove_parts += ["GSI3_PK", "GSI3_SK"]
+        if state_reason:
+            set_parts.append("stateReason = :reason")
+            values[":reason"] = state_reason
+
+    expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        expression += " REMOVE " + ", ".join(remove_parts)
+
+    try:
+        _get_table().update_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"},
+            UpdateExpression=expression,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+            ConditionExpression="attribute_exists(PK)",
+        )
+        logger.info(f"Scheduled prompt {schedule_id} -> {state}" + (f" ({state_reason})" if state_reason else ""))
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.warning(f"Cannot set state on missing scheduled prompt {schedule_id}")
+            return False
+        raise
+
+
+async def rearm_schedule(
+    user_id: str,
+    schedule_id: str,
+    expected_next_run_at: str,
+    new_next_run_at: str,
+) -> bool:
+    """Advance next_run_at, conditional on the currently stored value.
+
+    Mirrors ``sync_policies.rearm_policy``: the (future) B2 dispatcher
+    re-arms BEFORE invoking the worker, so a double-fired tick is idempotent
+    — the second dispatcher loses the conditional write and skips the
+    schedule. Returns True if this caller won. Not called by anything yet
+    in B1; exercised directly by tests so B2 needs no behavior change here.
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        _get_table().update_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"},
+            UpdateExpression="SET nextRunAt = :new, GSI3_SK = :gsisk, updatedAt = :updated_at",
+            ExpressionAttributeValues={
+                ":new": new_next_run_at,
+                ":gsisk": _due_sort_key(new_next_run_at, schedule_id),
+                ":updated_at": _get_current_timestamp(),
+                ":expected": expected_next_run_at,
+            },
+            ConditionExpression="nextRunAt = :expected",
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info(f"Scheduled prompt {schedule_id} already re-armed by another dispatcher; skipping")
+            return False
+        raise
+
+
+async def record_run_result(
+    user_id: str,
+    schedule_id: str,
+    status: str,
+    session_id: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Record a completed run's outcome and bump the runaway-guard counter.
+
+    ``runs_today``/``runs_today_date`` reset when the UTC date rolls over —
+    the B2 dispatcher reads this counter to auto-pause a schedule that
+    exceeds ``max_runs_per_day``. Not called by anything yet in B1.
+    """
+    today = date.today().isoformat()
+    existing = await get_scheduled_prompt(user_id, schedule_id)
+    runs_today = 1
+    if existing is not None and existing.runs_today_date == today:
+        runs_today = existing.runs_today + 1
+
+    now = _get_current_timestamp()
+    values = {
+        ":now": now,
+        ":status": status,
+        ":runs_today": runs_today,
+        ":today": today,
+    }
+    set_parts = [
+        "lastRunAt = :now",
+        "lastRunStatus = :status",
+        "updatedAt = :now",
+        "runsToday = :runs_today",
+        "runsTodayDate = :today",
+    ]
+    if session_id is not None:
+        set_parts.append("lastRunSessionId = :session_id")
+        values[":session_id"] = session_id
+    if error is not None:
+        set_parts.append("lastError = :error")
+        values[":error"] = error
+
+    _get_table().update_item(
+        Key={"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"},
+        UpdateExpression="SET " + ", ".join(set_parts),
+        ExpressionAttributeValues=values,
+    )
+
+
+async def update_scheduled_prompt(
+    user_id: str,
+    schedule_id: str,
+    *,
+    label: Optional[str] = None,
+    prompt_text: Optional[str] = None,
+    cadence: Optional[ScheduleCadence] = None,
+    hour_local: Optional[int] = None,
+    weekday: Optional[int] = None,
+    timezone_name: Optional[str] = None,
+    assistant_id: Optional[str] = None,
+    enabled_tools: Optional[List[str]] = None,
+    deliver_email: Optional[bool] = None,
+) -> Optional[ScheduledPrompt]:
+    """Edit a schedule's fields in place.
+
+    Any of ``cadence``/``hour_local``/``weekday``/``timezone_name`` changes
+    the due time: for an *active* schedule this recomputes and re-arms
+    ``next_run_at`` (and its GSI key) in the same write; a paused schedule
+    just remembers the new cadence for when it resumes (mirrors
+    ``sync_policies.change_policy_interval``). Returns None if the schedule
+    does not exist.
+    """
+    schedule = await get_scheduled_prompt(user_id, schedule_id)
+    if schedule is None:
+        return None
+
+    new_cadence = cadence if cadence is not None else schedule.cadence
+    new_hour_local = hour_local if hour_local is not None else schedule.hour_local
+    new_weekday = weekday if weekday is not None else schedule.weekday
+    new_timezone = timezone_name if timezone_name is not None else schedule.timezone
+
+    cadence_changed = (
+        new_cadence != schedule.cadence
+        or new_hour_local != schedule.hour_local
+        or new_weekday != schedule.weekday
+        or new_timezone != schedule.timezone
+    )
+
+    names: dict = {}
+    values = {":updated_at": _get_current_timestamp()}
+    set_parts = ["updatedAt = :updated_at"]
+
+    if cadence_changed:
+        names["#tz"] = "timezone"
+        set_parts += ["cadence = :cadence", "hourLocal = :hour_local", "#tz = :timezone"]
+        values[":cadence"] = new_cadence
+        values[":hour_local"] = new_hour_local
+        values[":timezone"] = new_timezone
+        if new_weekday is not None:
+            set_parts.append("weekday = :weekday")
+            values[":weekday"] = new_weekday
+
+        if schedule.state == "active":
+            next_run_at = compute_next_run_at(new_cadence, new_hour_local, new_timezone, weekday=new_weekday)
+            set_parts += ["nextRunAt = :next", "GSI3_PK = :gsipk", "GSI3_SK = :gsisk"]
+            values[":next"] = next_run_at
+            values[":gsipk"] = DUE_INDEX_PK
+            values[":gsisk"] = _due_sort_key(next_run_at, schedule_id)
+
+    field_updates = {
+        "label": label,
+        "promptText": prompt_text,
+        "assistantId": assistant_id,
+        "enabledTools": enabled_tools,
+        "deliverEmail": deliver_email,
+    }
+    for attr, value in field_updates.items():
+        if value is not None:
+            placeholder = f":{attr}"
+            set_parts.append(f"{attr} = {placeholder}")
+            values[placeholder] = value
+
+    update_kwargs = {
+        "Key": {"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"},
+        "UpdateExpression": "SET " + ", ".join(set_parts),
+        "ExpressionAttributeValues": values,
+    }
+    if names:
+        update_kwargs["ExpressionAttributeNames"] = names
+    _get_table().update_item(**update_kwargs)
+
+    return await get_scheduled_prompt(user_id, schedule_id)
+
+
+async def delete_scheduled_prompt(user_id: str, schedule_id: str) -> bool:
+    """Delete = total revocation. No orphan timers: the row's absence is
+    the only signal the (future) dispatcher needs — there is nothing else
+    to clean up."""
+    _get_table().delete_item(Key={"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"})
+    logger.info(f"Deleted scheduled prompt {schedule_id} for user {user_id}")
+    return True

--- a/backend/tests/routes/test_schedules_routes.py
+++ b/backend/tests/routes/test_schedules_routes.py
@@ -1,0 +1,481 @@
+"""Tests for schedule routes (`/schedules/*` — scheduled-runs B1, inert CRUD).
+
+Endpoints under test:
+- POST   /schedules             -> create (201; 400 cap; 422 validation)
+- GET    /schedules             -> list caller's own schedules (200)
+- GET    /schedules/{id}        -> get (200; 404)
+- PATCH  /schedules/{id}        -> edit fields / pause / resume (200; 404; 422)
+- POST   /schedules/{id}/pause  -> pause (200; 404)
+- POST   /schedules/{id}/resume -> resume (200; 404)
+- DELETE /schedules/{id}        -> delete (204; 404)
+
+Every route shares the three-layer gate (cookie auth -> SCHEDULED_RUNS_ENABLED
+kill switch -> `scheduled-runs` RBAC capability), pinned once via `TestGating`
+and assumed enabled/authorized everywhere else. The service layer is mocked
+(DynamoDB semantics are covered by tests/shared/test_scheduled_prompts.py);
+these tests pin the HTTP contract and ownership isolation.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.schedules import routes as schedules_routes
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.scheduled_prompts.models import ScheduledPrompt
+from apis.shared.scheduled_prompts.service import ScheduledPromptLimitExceeded
+from tests.routes.conftest import mock_no_auth
+
+USER_ID = "user-001"
+OTHER_USER_ID = "user-002"
+SCHEDULE_ID = "sched-abc123def456"
+NOW = "2026-07-03T00:00:00Z"
+FUTURE = "2999-01-01T09:00:00Z"
+
+
+def _user(user_id: str = USER_ID) -> User:
+    return User(user_id=user_id, email=f"{user_id}@example.com", name="Test User", roles=["User"])
+
+
+def _make_schedule(**overrides) -> ScheduledPrompt:
+    defaults = dict(
+        scheduleId=SCHEDULE_ID,
+        userId=USER_ID,
+        assistantId=None,
+        label="Morning Briefing",
+        promptText="Summarize my day",
+        cadence="daily",
+        hourLocal=9,
+        weekday=None,
+        timezone="America/Boise",
+        state="active",
+        nextRunAt=FUTURE,
+        runsToday=0,
+        maxRunsPerDay=24,
+        enabledTools=["class_search"],
+        deliverEmail=False,
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    defaults.update(overrides)
+    return ScheduledPrompt.model_validate(defaults)
+
+
+@dataclass
+class _FakePermissions:
+    tools: List[str]
+
+
+class FakeRoleService:
+    def __init__(self, tools: Optional[List[str]] = None):
+        self.tools = tools if tools is not None else ["class_search", "web_search"]
+
+    async def resolve_user_permissions(self, user):
+        return _FakePermissions(tools=self.tools)
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    authed: bool = True,
+    capability: bool = True,
+    flag: Optional[str] = None,
+    user_id: str = USER_ID,
+) -> TestClient:
+    monkeypatch.delenv("SKIP_AUTH", raising=False)
+    if flag is None:
+        monkeypatch.delenv("SCHEDULED_RUNS_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("SCHEDULED_RUNS_ENABLED", flag)
+
+    async def fake_capability(user, capability_id):
+        assert capability_id == "scheduled-runs"
+        return capability
+
+    monkeypatch.setattr(schedules_routes, "user_has_capability", fake_capability)
+    monkeypatch.setattr(schedules_routes, "get_app_role_service", lambda: FakeRoleService())
+
+    app = FastAPI()
+    app.include_router(schedules_routes.router)
+    if authed:
+        app.dependency_overrides[get_current_user_from_session] = lambda: _user(user_id)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+class TestGating:
+    def test_unauthenticated_request_is_401(self, monkeypatch):
+        client = _make_client(monkeypatch, authed=False)
+        mock_no_auth  # (unused import kept for parity with sync_policies test style)
+        assert client.get("/schedules").status_code == 401
+
+    def test_kill_switch_off_hides_the_surface_as_404(self, monkeypatch):
+        client = _make_client(monkeypatch, flag="false")
+        assert client.get("/schedules").status_code == 404
+        assert client.post("/schedules", json={}).status_code == 404
+        assert client.get(f"/schedules/{SCHEDULE_ID}").status_code == 404
+        assert client.delete(f"/schedules/{SCHEDULE_ID}").status_code == 404
+
+    def test_flag_defaults_on_when_unset(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "list_scheduled_prompts", AsyncMock(return_value=[]))
+        assert client.get("/schedules").status_code == 200
+
+    def test_empty_flag_value_stays_on(self, monkeypatch):
+        client = _make_client(monkeypatch, flag="")
+        monkeypatch.setattr(schedules_routes, "list_scheduled_prompts", AsyncMock(return_value=[]))
+        assert client.get("/schedules").status_code == 200
+
+    def test_missing_capability_is_403(self, monkeypatch):
+        client = _make_client(monkeypatch, capability=False)
+        assert client.get("/schedules").status_code == 403
+        assert client.post("/schedules", json={}).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /schedules — create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSchedule:
+    def test_happy_path(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        created = _make_schedule()
+        create_mock = AsyncMock(return_value=created)
+        monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
+
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Morning Briefing",
+                "promptText": "Summarize my day",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+            },
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["scheduleId"] == SCHEDULE_ID
+        assert body["cadence"] == "daily"
+        assert body["state"] == "active"
+
+        (call,) = create_mock.call_args_list
+        assert call.kwargs["user_id"] == USER_ID
+        assert call.kwargs["label"] == "Morning Briefing"
+
+    def test_none_enabled_tools_resolves_rbac_snapshot_at_creation(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        create_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
+
+        client.post(
+            "/schedules",
+            json={
+                "label": "Briefing",
+                "promptText": "Go",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+            },
+        )
+
+        (call,) = create_mock.call_args_list
+        assert call.kwargs["enabled_tools"] == ["class_search", "web_search"]
+
+    def test_explicit_enabled_tools_bypasses_rbac_resolution(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        create_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
+
+        client.post(
+            "/schedules",
+            json={
+                "label": "Briefing",
+                "promptText": "Go",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+                "enabledTools": ["gmail_search"],
+            },
+        )
+
+        (call,) = create_mock.call_args_list
+        assert call.kwargs["enabled_tools"] == ["gmail_search"]
+
+    def test_weekly_without_weekday_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Weekly",
+                "promptText": "Go",
+                "cadence": "weekly",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_over_cap_is_400(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(
+            schedules_routes,
+            "create_scheduled_prompt",
+            AsyncMock(side_effect=ScheduledPromptLimitExceeded("too many")),
+        )
+
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "One too many",
+                "promptText": "Go",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_empty_prompt_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Briefing",
+                "promptText": "",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_hour_out_of_range_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Briefing",
+                "promptText": "Go",
+                "cadence": "daily",
+                "hourLocal": 24,
+                "timezone": "America/Boise",
+            },
+        )
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /schedules, /schedules/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestListAndGet:
+    def test_list_returns_only_the_caller_schedules(self, monkeypatch):
+        client = _make_client(monkeypatch, user_id=USER_ID)
+        list_mock = AsyncMock(return_value=[_make_schedule()])
+        monkeypatch.setattr(schedules_routes, "list_scheduled_prompts", list_mock)
+
+        response = client.get("/schedules")
+
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        list_mock.assert_awaited_once_with(USER_ID)
+
+    def test_get_by_id(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+
+        response = client.get(f"/schedules/{SCHEDULE_ID}")
+
+        assert response.status_code == 200
+        assert response.json()["scheduleId"] == SCHEDULE_ID
+
+    def test_get_missing_is_404(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=None))
+
+        assert client.get(f"/schedules/{SCHEDULE_ID}").status_code == 404
+
+    def test_get_another_users_schedule_is_404_not_leaked(self, monkeypatch):
+        """Ownership isolation: the route always queries by the caller's own
+        user_id, so another user's schedule_id simply resolves to nothing —
+        it can never be fetched cross-account regardless of guessability."""
+        client = _make_client(monkeypatch, user_id=OTHER_USER_ID)
+        get_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", get_mock)
+
+        response = client.get(f"/schedules/{SCHEDULE_ID}")
+
+        assert response.status_code == 404
+        get_mock.assert_awaited_once_with(OTHER_USER_ID, SCHEDULE_ID)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /schedules/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSchedule:
+    def test_edit_label(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        update_mock = AsyncMock(return_value=_make_schedule(label="Renamed"))
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", update_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"label": "Renamed"})
+
+        assert response.status_code == 200
+        assert response.json()["label"] == "Renamed"
+
+    def test_missing_schedule_is_404(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=None))
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"label": "Renamed"})
+        assert response.status_code == 404
+
+    def test_switching_to_weekly_without_weekday_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(
+            schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule(cadence="daily", weekday=None))
+        )
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"cadence": "weekly"})
+        assert response.status_code == 422
+
+    def test_state_transition_to_paused(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        active = _make_schedule(state="active")
+        paused = _make_schedule(state="paused", stateReason="Paused by user")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(side_effect=[active, paused]))
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", AsyncMock(return_value=active))
+        set_state_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", set_state_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"state": "paused"})
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "paused"
+        set_state_mock.assert_awaited_once()
+        assert set_state_mock.call_args.args[2] == "paused"
+
+    def test_state_transition_to_active_recomputes_next_run_at(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        paused = _make_schedule(state="paused", nextRunAt=None)
+        active = _make_schedule(state="active")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(side_effect=[paused, paused, active]))
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", AsyncMock(return_value=paused))
+        set_state_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", set_state_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"state": "active"})
+
+        assert response.status_code == 200
+        set_state_mock.assert_awaited_once()
+        assert set_state_mock.call_args.args[2] == "active"
+        assert set_state_mock.call_args.kwargs["next_run_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# POST /schedules/{id}/pause, /resume
+# ---------------------------------------------------------------------------
+
+
+class TestPauseResume:
+    def test_pause(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        active = _make_schedule(state="active")
+        paused = _make_schedule(state="paused")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(side_effect=[active, paused]))
+        set_state_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", set_state_mock)
+
+        response = client.post(f"/schedules/{SCHEDULE_ID}/pause")
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "paused"
+
+    def test_pause_missing_is_404(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=None))
+
+        assert client.post(f"/schedules/{SCHEDULE_ID}/pause").status_code == 404
+
+    def test_pause_already_paused_is_idempotent(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        paused = _make_schedule(state="paused")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=paused))
+        set_state_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", set_state_mock)
+
+        response = client.post(f"/schedules/{SCHEDULE_ID}/pause")
+
+        assert response.status_code == 200
+        set_state_mock.assert_not_awaited()
+
+    def test_resume(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        paused = _make_schedule(state="paused")
+        active = _make_schedule(state="active")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(side_effect=[paused, active]))
+        set_state_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", set_state_mock)
+
+        response = client.post(f"/schedules/{SCHEDULE_ID}/resume")
+
+        assert response.status_code == 200
+        assert response.json()["state"] == "active"
+        set_state_mock.assert_awaited_once()
+        assert set_state_mock.call_args.args[2] == "active"
+
+    def test_resume_from_paused_error(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        errored = _make_schedule(state="paused_error", stateReason="Too many failures")
+        active = _make_schedule(state="active")
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(side_effect=[errored, active]))
+        monkeypatch.setattr(schedules_routes, "set_schedule_state", AsyncMock(return_value=True))
+
+        response = client.post(f"/schedules/{SCHEDULE_ID}/resume")
+        assert response.status_code == 200
+
+    def test_resume_missing_is_404(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=None))
+
+        assert client.post(f"/schedules/{SCHEDULE_ID}/resume").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /schedules/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSchedule:
+    def test_delete(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        delete_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(schedules_routes, "delete_scheduled_prompt", delete_mock)
+
+        response = client.delete(f"/schedules/{SCHEDULE_ID}")
+
+        assert response.status_code == 204
+        delete_mock.assert_awaited_once_with(USER_ID, SCHEDULE_ID)
+
+    def test_delete_missing_is_404(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=None))
+
+        assert client.delete(f"/schedules/{SCHEDULE_ID}").status_code == 404

--- a/backend/tests/shared/conftest.py
+++ b/backend/tests/shared/conftest.py
@@ -233,10 +233,13 @@ def sessions_metadata_table(aws, monkeypatch):
             {"AttributeName": "GSI1SK", "AttributeType": "S"},
             {"AttributeName": "GSI_PK", "AttributeType": "S"},
             {"AttributeName": "GSI_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI3_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI3_SK", "AttributeType": "S"},
         ],
         gsis=[
             _gsi("UserTimestampIndex", "GSI1PK", "GSI1SK"),
             _gsi("SessionLookupIndex", "GSI_PK", "GSI_SK"),
+            _gsi("DueScheduleIndex", "GSI3_PK", "GSI3_SK"),
         ],
     )
 

--- a/backend/tests/shared/test_scheduled_prompts.py
+++ b/backend/tests/shared/test_scheduled_prompts.py
@@ -1,0 +1,427 @@
+"""Scheduled-prompt repository tests (moto DynamoDB).
+
+Covers:
+- cadence -> next_run_at math (daily/weekday/weekly, timezone-aware, DST-safe)
+- sparse DueScheduleIndex (paused schedules are physically absent)
+- conditional re-arm (double-fired dispatcher tick is idempotent)
+- state transitions (active <-> paused, paused_error)
+- snapshot semantics (enabled_tools frozen at creation)
+- per-user cap
+- delete = total revocation
+"""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from apis.shared.scheduled_prompts.models import DUE_INDEX_PK
+from apis.shared.scheduled_prompts.service import (
+    ScheduledPromptLimitExceeded,
+    compute_next_run_at,
+    create_scheduled_prompt,
+    delete_scheduled_prompt,
+    get_scheduled_prompt,
+    list_due_schedules,
+    list_scheduled_prompts,
+    max_schedules_per_user,
+    rearm_schedule,
+    record_run_result,
+    set_schedule_state,
+    update_scheduled_prompt,
+)
+
+pytestmark = pytest.mark.asyncio
+
+USER_ID = "user-1"
+OTHER_USER_ID = "user-2"
+
+
+async def _make_schedule(
+    label="Morning Briefing",
+    prompt_text="Summarize my day",
+    cadence="daily",
+    hour_local=9,
+    timezone_name="America/Boise",
+    weekday=None,
+    user_id=USER_ID,
+    **kwargs,
+):
+    return await create_scheduled_prompt(
+        user_id=user_id,
+        label=label,
+        prompt_text=prompt_text,
+        cadence=cadence,
+        hour_local=hour_local,
+        timezone_name=timezone_name,
+        weekday=weekday,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_next_run_at — cadence math
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNextRunAt:
+    def test_daily_before_hour_fires_today(self):
+        # 2026-07-05 06:00 Boise time (MDT, UTC-6); "9am daily" -> today 9am.
+        from_time = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)  # 06:00 MDT
+        result = compute_next_run_at("daily", 9, "America/Boise", from_time=from_time)
+        expected_utc = datetime(2026, 7, 5, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected_utc.isoformat().replace("+00:00", "Z")
+
+    def test_daily_after_hour_rolls_to_tomorrow(self):
+        # 2026-07-05 10:00 Boise time; "9am daily" already passed -> tomorrow.
+        from_time = datetime(2026, 7, 5, 16, 0, tzinfo=timezone.utc)  # 10:00 MDT
+        result = compute_next_run_at("daily", 9, "America/Boise", from_time=from_time)
+        expected = datetime(2026, 7, 6, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_daily_exactly_on_hour_rolls_to_tomorrow(self):
+        # candidate <= base is treated as already passed (strictly future guarantee).
+        from_time = datetime(2026, 7, 5, 15, 0, tzinfo=timezone.utc)  # 09:00 MDT exactly
+        result = compute_next_run_at("daily", 9, "America/Boise", from_time=from_time)
+        expected = datetime(2026, 7, 6, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_weekday_skips_weekend(self):
+        # 2026-07-05 is a Sunday in Boise; "9am weekday" should land Monday 7/6.
+        from_time = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)  # Sun 06:00 MDT
+        result = compute_next_run_at("weekday", 9, "America/Boise", from_time=from_time)
+        expected = datetime(2026, 7, 6, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_weekday_friday_afternoon_rolls_to_monday(self):
+        # 2026-07-03 is a Friday; if "9am weekday" already passed, next is Monday 7/6.
+        from_time = datetime(2026, 7, 3, 16, 0, tzinfo=timezone.utc)  # Fri 10:00 MDT
+        result = compute_next_run_at("weekday", 9, "America/Boise", from_time=from_time)
+        expected = datetime(2026, 7, 6, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_weekly_lands_on_requested_weekday(self):
+        # 2026-07-05 is Sunday (weekday()==6). Requesting Wednesday (2).
+        from_time = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)
+        result = compute_next_run_at("weekly", 9, "America/Boise", weekday=2, from_time=from_time)
+        expected = datetime(2026, 7, 8, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_weekly_same_day_but_already_passed_rolls_a_full_week(self):
+        # Sunday (weekday()==6) requesting Sunday, but after 9am -> next Sunday.
+        from_time = datetime(2026, 7, 5, 17, 0, tzinfo=timezone.utc)  # Sun 11:00 MDT
+        result = compute_next_run_at("weekly", 9, "America/Boise", weekday=6, from_time=from_time)
+        expected = datetime(2026, 7, 12, 9, 0, tzinfo=ZoneInfo("America/Boise")).astimezone(timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_weekly_requires_weekday(self):
+        with pytest.raises(ValueError, match="weekday is required"):
+            compute_next_run_at("weekly", 9, "America/Boise", weekday=None)
+
+    def test_unknown_cadence_raises(self):
+        with pytest.raises(ValueError, match="Unknown cadence"):
+            compute_next_run_at("monthly", 9, "America/Boise")  # type: ignore[arg-type]
+
+    def test_different_timezone_produces_different_utc_time(self):
+        from_time = datetime(2026, 7, 5, 0, 0, tzinfo=timezone.utc)
+        boise = compute_next_run_at("daily", 9, "America/Boise", from_time=from_time)
+        tokyo = compute_next_run_at("daily", 9, "Asia/Tokyo", from_time=from_time)
+        assert boise != tokyo
+
+
+# ---------------------------------------------------------------------------
+# create / get / list
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAndGet:
+    async def test_create_get_roundtrip(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+
+        assert schedule.schedule_id.startswith("sched-")
+        assert schedule.state == "active"
+        assert schedule.next_run_at is not None
+        assert schedule.runs_today == 0
+        assert schedule.max_runs_per_day == 24
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched is not None
+        assert fetched.label == "Morning Briefing"
+        assert fetched.prompt_text == "Summarize my day"
+        assert fetched.cadence == "daily"
+        assert fetched.hour_local == 9
+        assert fetched.timezone == "America/Boise"
+
+    async def test_active_schedule_has_due_index_keys(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert item["GSI3_PK"] == DUE_INDEX_PK
+        assert item["GSI3_SK"] == f"{schedule.next_run_at}#{schedule.schedule_id}"
+
+    async def test_get_missing_returns_none(self, sessions_metadata_table):
+        assert await get_scheduled_prompt(USER_ID, "sched-missing") is None
+
+    async def test_list_scopes_to_owner(self, sessions_metadata_table):
+        mine = await _make_schedule(user_id=USER_ID)
+        await _make_schedule(user_id=OTHER_USER_ID, label="Someone else's")
+
+        mine_list = await list_scheduled_prompts(USER_ID)
+        assert [s.schedule_id for s in mine_list] == [mine.schedule_id]
+
+        theirs_list = await list_scheduled_prompts(OTHER_USER_ID)
+        assert len(theirs_list) == 1
+        assert theirs_list[0].schedule_id != mine.schedule_id
+
+    async def test_weekly_requires_weekday_at_creation(self, sessions_metadata_table):
+        with pytest.raises(ValueError):
+            await _make_schedule(cadence="weekly", weekday=None)
+
+    async def test_per_user_cap_enforced(self, sessions_metadata_table, monkeypatch):
+        monkeypatch.setenv("SCHEDULED_RUNS_MAX_PER_USER", "2")
+        assert max_schedules_per_user() == 2
+
+        await _make_schedule(label="one")
+        await _make_schedule(label="two")
+        with pytest.raises(ScheduledPromptLimitExceeded):
+            await _make_schedule(label="three")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot semantics — enabled_tools frozen at creation (Phase A punch #7)
+# ---------------------------------------------------------------------------
+
+
+class TestEnabledToolsSnapshot:
+    async def test_explicit_tools_are_persisted_verbatim(self, sessions_metadata_table):
+        schedule = await _make_schedule(enabled_tools=["class_search", "web_search"])
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.enabled_tools == ["class_search", "web_search"]
+
+    async def test_none_enabled_tools_persists_as_none(self, sessions_metadata_table):
+        # The service itself does no lazy resolution; the route layer is
+        # responsible for resolving "None" to a concrete snapshot before
+        # calling create_scheduled_prompt. Here we assert the service is a
+        # dumb store — it never re-derives tools at read time.
+        schedule = await _make_schedule(enabled_tools=None)
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.enabled_tools is None
+
+    async def test_editing_the_schedule_does_not_change_the_snapshot(self, sessions_metadata_table):
+        schedule = await _make_schedule(enabled_tools=["class_search"])
+        await update_scheduled_prompt(USER_ID, schedule.schedule_id, label="New label")
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.enabled_tools == ["class_search"]
+
+    async def test_explicit_tools_update_replaces_the_snapshot(self, sessions_metadata_table):
+        schedule = await _make_schedule(enabled_tools=["class_search"])
+        await update_scheduled_prompt(USER_ID, schedule.schedule_id, enabled_tools=["gmail_search"])
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.enabled_tools == ["gmail_search"]
+
+
+# ---------------------------------------------------------------------------
+# list_due_schedules — sparse index behavior
+# ---------------------------------------------------------------------------
+
+
+class TestListDueSchedules:
+    async def test_active_overdue_schedule_is_due(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        # Force it overdue by re-arming to the past.
+        await set_schedule_state(USER_ID, schedule.schedule_id, "active", next_run_at="2000-01-01T00:00:00Z")
+
+        due = await list_due_schedules(now="2999-01-01T00:00:00Z")
+        assert schedule.schedule_id in [s.schedule_id for s in due]
+
+    async def test_paused_schedule_is_physically_absent_from_due_index(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await set_schedule_state(USER_ID, schedule.schedule_id, "active", next_run_at="2000-01-01T00:00:00Z")
+        await set_schedule_state(USER_ID, schedule.schedule_id, "paused", state_reason="Paused by user")
+
+        due = await list_due_schedules(now="2999-01-01T00:00:00Z")
+        assert schedule.schedule_id not in [s.schedule_id for s in due]
+
+        # And the row itself has no GSI keys once paused.
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert "GSI3_PK" not in item
+        assert "GSI3_SK" not in item
+
+    async def test_not_yet_due_schedule_is_excluded(self, sessions_metadata_table):
+        schedule = await _make_schedule()  # next_run_at is in the future by construction
+        due = await list_due_schedules(now="2000-01-01T00:00:00Z")
+        assert schedule.schedule_id not in [s.schedule_id for s in due]
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+
+class TestSetScheduleState:
+    async def test_pause_removes_gsi_keys(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        ok = await set_schedule_state(USER_ID, schedule.schedule_id, "paused", state_reason="Paused by user")
+        assert ok is True
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.state == "paused"
+        assert fetched.state_reason == "Paused by user"
+
+    async def test_resume_requires_next_run_at(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await set_schedule_state(USER_ID, schedule.schedule_id, "paused")
+        with pytest.raises(ValueError):
+            await set_schedule_state(USER_ID, schedule.schedule_id, "active")
+
+    async def test_resume_readds_gsi_keys(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await set_schedule_state(USER_ID, schedule.schedule_id, "paused")
+        await set_schedule_state(USER_ID, schedule.schedule_id, "active", next_run_at="2999-01-01T00:00:00Z")
+
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert item["GSI3_PK"] == DUE_INDEX_PK
+        assert item["GSI3_SK"] == f"2999-01-01T00:00:00Z#{schedule.schedule_id}"
+
+    async def test_paused_error_state(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await set_schedule_state(USER_ID, schedule.schedule_id, "paused_error", state_reason="Too many failures")
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.state == "paused_error"
+        assert fetched.state_reason == "Too many failures"
+
+    async def test_set_state_on_missing_schedule_returns_false(self, sessions_metadata_table):
+        ok = await set_schedule_state(USER_ID, "sched-missing", "paused")
+        assert ok is False
+
+
+class TestRearmSchedule:
+    async def test_rearm_advances_next_run_at(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        ok = await rearm_schedule(
+            USER_ID, schedule.schedule_id, expected_next_run_at=schedule.next_run_at, new_next_run_at="2999-06-01T00:00:00Z"
+        )
+        assert ok is True
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.next_run_at == "2999-06-01T00:00:00Z"
+
+    async def test_conditional_rearm_is_idempotent_against_double_dispatch(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        first = await rearm_schedule(
+            USER_ID, schedule.schedule_id, expected_next_run_at=schedule.next_run_at, new_next_run_at="2999-06-01T00:00:00Z"
+        )
+        # A second dispatcher racing on the same stale expected value loses.
+        second = await rearm_schedule(
+            USER_ID, schedule.schedule_id, expected_next_run_at=schedule.next_run_at, new_next_run_at="2999-07-01T00:00:00Z"
+        )
+        assert first is True
+        assert second is False
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.next_run_at == "2999-06-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# record_run_result — runaway-guard counter
+# ---------------------------------------------------------------------------
+
+
+class TestRecordRunResult:
+    async def test_records_status_and_session(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await record_run_result(USER_ID, schedule.schedule_id, status="completed", session_id="sess-1")
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.last_run_status == "completed"
+        assert fetched.last_run_session_id == "sess-1"
+        assert fetched.runs_today == 1
+
+    async def test_records_error(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await record_run_result(USER_ID, schedule.schedule_id, status="failed", error="boom")
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.last_run_status == "failed"
+        assert fetched.last_error == "boom"
+
+    async def test_runs_today_increments_within_same_day(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await record_run_result(USER_ID, schedule.schedule_id, status="completed")
+        await record_run_result(USER_ID, schedule.schedule_id, status="completed")
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched.runs_today == 2
+
+
+# ---------------------------------------------------------------------------
+# update_scheduled_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateScheduledPrompt:
+    async def test_update_missing_returns_none(self, sessions_metadata_table):
+        assert await update_scheduled_prompt(USER_ID, "sched-missing", label="x") is None
+
+    async def test_non_cadence_field_update_does_not_touch_next_run_at(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        original_next_run_at = schedule.next_run_at
+
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, label="Renamed")
+        assert updated.label == "Renamed"
+        assert updated.next_run_at == original_next_run_at
+
+    async def test_cadence_change_on_active_schedule_recomputes_next_run_at(self, sessions_metadata_table):
+        schedule = await _make_schedule(cadence="daily", hour_local=9)
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, hour_local=14)
+
+        assert updated.hour_local == 14
+        assert updated.next_run_at != schedule.next_run_at
+
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert item["GSI3_SK"] == f"{updated.next_run_at}#{schedule.schedule_id}"
+
+    async def test_cadence_change_on_paused_schedule_does_not_touch_due_index(self, sessions_metadata_table):
+        schedule = await _make_schedule(cadence="daily", hour_local=9)
+        await set_schedule_state(USER_ID, schedule.schedule_id, "paused")
+
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, hour_local=14)
+        assert updated.hour_local == 14
+        assert updated.state == "paused"
+
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert "GSI3_PK" not in item
+
+
+# ---------------------------------------------------------------------------
+# Delete = total revocation
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_delete_removes_the_record_entirely(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await delete_scheduled_prompt(USER_ID, schedule.schedule_id)
+
+        assert await get_scheduled_prompt(USER_ID, schedule.schedule_id) is None
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )
+        assert "Item" not in item
+
+    async def test_delete_drops_it_from_due_index_too(self, sessions_metadata_table):
+        schedule = await _make_schedule()
+        await set_schedule_state(USER_ID, schedule.schedule_id, "active", next_run_at="2000-01-01T00:00:00Z")
+        await delete_scheduled_prompt(USER_ID, schedule.schedule_id)
+
+        due = await list_due_schedules(now="2999-01-01T00:00:00Z")
+        assert schedule.schedule_id not in [s.schedule_id for s in due]

--- a/infrastructure/lib/constructs/data/cost-tracking-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/cost-tracking-tables-construct.ts
@@ -13,7 +13,8 @@ export interface CostTrackingTablesConstructProps {
  * and the admin cost dashboard.
  *
  *   - SessionsMetadataTable  — message-level metadata for cost tracking
- *                              (UserTimestampIndex + SessionLookupIndex)
+ *                              (UserTimestampIndex + SessionLookupIndex +
+ *                              DueScheduleIndex — sparse, scheduled-runs B1)
  *   - UserCostSummaryTable   — pre-aggregated user-level cost summaries
  *                              (PeriodCostIndex enables top-N queries)
  *   - SystemCostRollupTable  — pre-aggregated system-wide metrics
@@ -62,6 +63,20 @@ export class CostTrackingTablesConstruct extends Construct {
       indexName: 'SessionLookupIndex',
       partitionKey: { name: 'GSI_PK', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'GSI_SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // DueScheduleIndex — sparse due-sweep index for scheduled prompts
+    // (scheduled-runs B1: apis/shared/scheduled_prompts). GSI3 keys exist
+    // only while a ScheduledPrompt's state == "active"; pausing/deleting a
+    // schedule removes it from this index (mirrors DueSyncIndex/GSI4 on
+    // the RAG assistants table). Distinct GSI3_PK/GSI3_SK attribute names
+    // avoid colliding with SessionLookupIndex's GSI_PK/GSI_SK, which
+    // ordinary session rows already use.
+    this.sessionsMetadataTable.addGlobalSecondaryIndex({
+      indexName: 'DueScheduleIndex',
+      partitionKey: { name: 'GSI3_PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI3_SK', type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL,
     });
 


### PR DESCRIPTION
## Summary

Phase B, item B1 of scheduled agent runs (`docs/specs/scheduled-agent-runs.md`, `docs/specs/scheduled-runs-phase-b-brief.md`). Deliberately **inert**: schedules can be created, listed, edited, paused/resumed, and deleted — nothing fires yet. The dispatcher/worker that reads `DueScheduleIndex` and calls `run_agent_headless` is B2.

- **`ScheduledPrompt` model + `ScheduledPromptService`** in `apis/shared/scheduled_prompts/`, mirroring `apis/shared/sync_policies/` (sparse "due" GSI, `list_due_schedules`/`set_schedule_state`/`rearm_schedule`, conditional writes, delete = total revocation).
- **Cadence → `next_run_at`** (`daily` / `weekday` / `weekly`) computed timezone-aware (stdlib `zoneinfo`, IANA tz) in the service — no cron strings; the future dispatcher stays a dumb "who's due ≤ now" query.
- **app-api CRUD** under `apis/app_api/schedules/` at the `/schedules` prefix: create / list / get / update (fields + pause/resume via `state`) / `POST .../pause` / `POST .../resume` / delete. Every route uses `Depends(get_current_user_from_session)` (cookie auth) + `SCHEDULED_RUNS_ENABLED` flag (404 when off) + `scheduled-runs` RBAC capability (403), reusing Phase A's exact gating pattern from `apis/app_api/runs/routes.py`.
- **`enabled_tools` snapshot at creation** (Phase A punch #7): an explicit list from the caller is trusted as-is; `None` resolves the caller's current RBAC-allowed tool set via `AppRoleService.resolve_user_permissions` and freezes it — never re-resolved lazily at fire time.
- **Runaway-guard fields** (`runsToday`, `runsTodayDate`, `maxRunsPerDay`) present in the model now so B2 needs no migration.
- **CDK**: added a sparse `DueScheduleIndex` GSI (`GSI3_PK`/`GSI3_SK`) to the existing `SessionsMetadataTable` construct (`ScheduledPrompt` rides `PK=USER#{user_id}, SK=SCHEDPROMPT#{schedule_id}` on that table, alongside the harness's `RUN#` audit records). Distinct attribute names avoid colliding with `SessionLookupIndex`'s existing `GSI_PK`/`GSI_SK`. app-api's task role already grants full CRUD + `index/*` on this table, so no IAM changes were needed.

## Test plan

- [x] `cd backend && uv run python -m pytest tests/ -v` — 4283 passed, 3 skipped, 0 failed (includes 68 new tests: cadence math incl. timezone/weekday/weekly, sparse due-index behavior, conditional re-arm, state transitions, snapshot semantics, per-user cap, ownership isolation, and all 3 gating layers)
- [x] `tests/architecture/test_import_boundaries.py` — 6/6 passed (no cross-boundary imports introduced)
- [x] `cd infrastructure && npx tsc --noEmit` — clean
- [x] `cd infrastructure && npx jest` — 429/429 passed

## Explicitly out of scope

Dispatcher/worker Lambdas + EventBridge (B2), SPA (B3), governance/PII work (B0), email delivery, any actual run execution. `ScheduledPrompt` is not wired to `run_agent_headless`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)