### PR TITLE
feat(schedules): B3 — schedule management SPA + enablement

### DIFF
--- a/backend/src/apis/app_api/runs/routes.py
+++ b/backend/src/apis/app_api/runs/routes.py
@@ -199,6 +199,11 @@ class GrantRevokeResponse(BaseModel):
     revoked: bool
 
 
+class GrantEnableResponse(GrantStatusResponse):
+    """Identical shape to the status response. A distinct name documents
+    intent at the call site (POST = mutate/enable, GET = read status)."""
+
+
 # ─── Routes ─────────────────────────────────────────────────────────────────
 
 
@@ -281,6 +286,25 @@ async def run_now(
         result.session_id,
     )
     return RunNowResponse.from_run_result(result)
+
+
+@router.post(
+    "/grant", response_model=GrantEnableResponse, response_model_by_alias=True
+)
+async def enable_grant(
+    request: Request,
+    user: User = Depends(require_scheduled_runs_user),
+) -> GrantEnableResponse:
+    """Create or refresh the caller's headless grant from their live session.
+
+    Lets a user turn on scheduled runs directly (e.g. from the schedules
+    page) without first having to exercise "Run now". Shares the exact
+    create-on-enable logic ``run_now`` uses via ``_resolve_grant`` — the
+    same 409 applies if the caller has neither an existing grant nor a
+    live session to pin one from (e.g. a stale API-key-only context).
+    """
+    grant = await _resolve_grant(request, user)
+    return GrantEnableResponse.from_grant(grant)
 
 
 @router.get(

--- a/backend/tests/apis/app_api/test_runs_routes.py
+++ b/backend/tests/apis/app_api/test_runs_routes.py
@@ -314,6 +314,67 @@ class TestRunNow:
 # ---------------------------------------------------------------------------
 
 
+class TestEnableGrant:
+    """POST /runs/grant — shares `_resolve_grant` with /runs/now, so this
+    pins the same create-on-enable behavior via a distinct entrypoint that
+    doesn't require running a prompt first."""
+
+    def test_creates_grant_from_live_session(self, monkeypatch):
+        client, grants, _ = _make_client(monkeypatch, with_session_record=True)
+
+        response = client.post("/runs/grant")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["grantId"] == "hlg-abc"
+        assert "rt-stored" not in str(body)
+
+        (enable,) = grants.enable_calls
+        assert enable["user_id"] == "user-1"
+        assert enable["username"] == "user1"
+        assert enable["refresh_token"] == "rt-live"
+        assert enable["token_issued_at"] == NOW - 3600
+
+    def test_refreshes_an_existing_grant_from_a_new_session(self, monkeypatch):
+        grants = FakeGrantService(grant=_grant())
+        client, grants, _ = _make_client(
+            monkeypatch, grants=grants, with_session_record=True
+        )
+
+        response = client.post("/runs/grant")
+
+        assert response.status_code == 200
+        assert len(grants.enable_calls) == 1  # re-pinned, not skipped
+
+    def test_existing_grant_without_a_session_record_is_reused(self, monkeypatch):
+        grants = FakeGrantService(grant=_grant())
+        client, grants, _ = _make_client(monkeypatch, grants=grants)
+
+        response = client.post("/runs/grant")
+
+        assert response.status_code == 200
+        assert response.json()["grantId"] == "hlg-abc"
+        assert grants.enable_calls == []
+
+    def test_no_grant_and_no_session_is_409(self, monkeypatch):
+        client, _, _ = _make_client(monkeypatch)
+
+        assert client.post("/runs/grant").status_code == 409
+
+    def test_kill_switch_off_hides_the_surface_as_404(self, monkeypatch):
+        client, _, _ = _make_client(monkeypatch, flag="false")
+        assert client.post("/runs/grant").status_code == 404
+
+    def test_missing_capability_is_403(self, monkeypatch):
+        client, _, _ = _make_client(monkeypatch, capability=False)
+        assert client.post("/runs/grant").status_code == 403
+
+    def test_unauthenticated_request_is_401(self, monkeypatch):
+        client, _, _ = _make_client(monkeypatch, authed=False)
+        assert client.post("/runs/grant").status_code == 401
+
+
 class TestGrantRoutes:
     def test_grant_status_when_enabled(self, monkeypatch):
         client, _, _ = _make_client(monkeypatch, grants=FakeGrantService(_grant()))

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -50,6 +50,21 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'schedules/new',
+        loadComponent: () => import('./schedules/schedule-form/schedule-form.page').then(m => m.ScheduleFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'schedules/:scheduleId/edit',
+        loadComponent: () => import('./schedules/schedule-form/schedule-form.page').then(m => m.ScheduleFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'schedules',
+        loadComponent: () => import('./schedules/schedules.page').then(m => m.SchedulesPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'memories',
         loadComponent: () => import('./memory/memory-dashboard.page').then(m => m.MemoryDashboardPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -45,6 +45,22 @@
             </div>
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
+
+        <!-- Scheduled runs (capability-gated — hidden until the accessibility probe resolves true) -->
+        @if (showSchedules()) {
+            <a
+                routerLink="/schedules"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Scheduled Runs</span>
+            </a>
+        }
     </div>
 
     <nav class="flex-1 overflow-y-auto px-3 pb-4">

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -6,6 +6,7 @@ import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ScheduleService } from '../../schedules/services/schedule.service';
 
 describe('Sidenav', () => {
   let mockRouter: any;
@@ -13,6 +14,7 @@ describe('Sidenav', () => {
   let mockBffSession: any;
   let mockSidenavService: any;
   let mockUserService: any;
+  let mockScheduleService: any;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
@@ -28,7 +30,15 @@ describe('Sidenav', () => {
       close: vi.fn(),
       toggleCollapsed: vi.fn(),
     };
-    mockUserService = { hasAnyRole: vi.fn().mockReturnValue(false) };
+    mockUserService = {
+      hasAnyRole: vi.fn().mockReturnValue(false),
+      currentUser: signal(null),
+      isAdmin: signal(false),
+    };
+    mockScheduleService = {
+      accessible$: signal<boolean | null>(null),
+      loadSchedules: vi.fn().mockResolvedValue(undefined),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -37,6 +47,7 @@ describe('Sidenav', () => {
         { provide: BffSessionService, useValue: mockBffSession },
         { provide: SidenavService, useValue: mockSidenavService },
         { provide: UserService, useValue: mockUserService },
+        { provide: ScheduleService, useValue: mockScheduleService },
       ],
     });
   });
@@ -47,7 +58,9 @@ describe('Sidenav', () => {
 
   async function createComponent() {
     const { Sidenav } = await import('./sidenav');
-    return TestBed.runInInjectionContext(() => new Sidenav());
+    const component = TestBed.runInInjectionContext(() => new Sidenav());
+    TestBed.tick(); // flush the constructor effect that probes schedule accessibility
+    return component;
   }
 
   it('should compute current session title', async () => {
@@ -76,5 +89,37 @@ describe('Sidenav', () => {
     await component.handleLogout();
     expect(mockBffSession.logout).toHaveBeenCalledTimes(1);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/auth/login']);
+  });
+
+  it('probes schedule accessibility once a user is authenticated', async () => {
+    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
+    await createComponent();
+    expect(mockScheduleService.loadSchedules).toHaveBeenCalled();
+  });
+
+  it('does not probe schedule accessibility while unauthenticated', async () => {
+    mockUserService.currentUser.set(null);
+    await createComponent();
+    expect(mockScheduleService.loadSchedules).not.toHaveBeenCalled();
+  });
+
+  it('hides the Scheduled Runs nav entry until accessibility resolves true', async () => {
+    const component = await createComponent();
+
+    mockScheduleService.accessible$.set(null);
+    expect(component.showSchedules()).toBe(false);
+
+    mockScheduleService.accessible$.set(false);
+    expect(component.showSchedules()).toBe(false);
+
+    mockScheduleService.accessible$.set(true);
+    expect(component.showSchedules()).toBe(true);
+  });
+
+  it('navigates to /schedules and closes the sidenav', async () => {
+    const component = await createComponent();
+    component.navigateToSchedules();
+    expect(mockSidenavService.close).toHaveBeenCalled();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/schedules']);
   });
 });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -1,4 +1,4 @@
-import { Component, inject, computed } from '@angular/core';
+import { Component, effect, inject, computed } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SessionList } from './components/session-list/session-list';
 import { SessionService } from '../../session/services/session/session.service';
@@ -7,6 +7,7 @@ import { SessionService as BffSessionService } from '../../auth/session.service'
 import { UserDropdownComponent } from '../topnav/components/user-dropdown.component';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
+import { ScheduleService } from '../../schedules/services/schedule.service';
 
 @Component({
   selector: 'app-sidenav',
@@ -18,6 +19,7 @@ export class Sidenav {
   private router = inject(Router);
   private sessionService = inject(SessionService);
   private bffSession = inject(BffSessionService);
+  private scheduleService = inject(ScheduleService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -37,6 +39,27 @@ export class Sidenav {
   // Check if user has system_admin AppRole (resolved from backend RBAC)
   protected isAdmin = this.userService.isAdmin;
 
+  /**
+   * Whether to show the "Scheduled runs" nav entry. There is no dedicated
+   * client-side capability signal for `scheduled-runs` yet, so this rides
+   * the schedules list call itself: a successful (even empty) list means
+   * the caller has the capability and the kill switch is on; a 403/404
+   * flips `accessible$` to false and the nav entry stays hidden. `null`
+   * (not yet resolved) also hides it, so the item doesn't flash in before
+   * disappearing.
+   */
+  readonly showSchedules = computed(() => this.scheduleService.accessible$() === true);
+
+  constructor() {
+    // Kick off the accessibility probe once the user is authenticated —
+    // mirrors UserService's own permissions-fetch gating.
+    effect(() => {
+      if (this.userService.currentUser()) {
+        void this.scheduleService.loadSchedules();
+      }
+    });
+  }
+
   newSession() {
     this.sidenavService.close();
     this.router.navigate(['']);
@@ -45,6 +68,11 @@ export class Sidenav {
   navigateToAssistants() {
     this.sidenavService.close();
     this.router.navigate(['/assistants']);
+  }
+
+  navigateToSchedules() {
+    this.sidenavService.close();
+    this.router.navigate(['/schedules']);
   }
 
   toggleCollapse() {

--- a/frontend/ai.client/src/app/schedules/models/grant.model.ts
+++ b/frontend/ai.client/src/app/schedules/models/grant.model.ts
@@ -1,0 +1,20 @@
+/**
+ * Front-end model for the headless-grant status surfaced by
+ * `apis/app_api/runs/routes.py` (`GET/POST/DELETE /runs/grant`).
+ *
+ * The grant is the platform's standing permission to act as the user
+ * without a live session — required before any of the user's schedules
+ * can actually fire. `enabled: false` means no active grant exists.
+ */
+export interface GrantStatus {
+  enabled: boolean;
+  grantId?: string | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  expiresAt?: number | null;
+  lastUsedAt?: number | null;
+}
+
+export interface GrantRevokeResponse {
+  revoked: boolean;
+}

--- a/frontend/ai.client/src/app/schedules/models/schedule.model.ts
+++ b/frontend/ai.client/src/app/schedules/models/schedule.model.ts
@@ -1,0 +1,81 @@
+/**
+ * Front-end models for scheduled agent runs (`/schedules/*`).
+ *
+ * Mirrors the backend contract from `apis/app_api/schedules/` — field names
+ * are the camelCase aliases the backend serializes. Bounded cadence set
+ * only (daily / weekday / weekly) — no cron UI, per
+ * docs/specs/scheduled-agent-runs.md §3.
+ */
+
+export type ScheduleCadence = 'daily' | 'weekday' | 'weekly';
+export type ScheduledPromptState = 'active' | 'paused' | 'paused_error';
+
+/** Public view of a scheduled prompt (backend ScheduledPromptResponse). */
+export interface ScheduledPrompt {
+  scheduleId: string;
+  assistantId?: string | null;
+  label: string;
+  promptText: string;
+  cadence: ScheduleCadence;
+  hourLocal: number;
+  weekday?: number | null;
+  timezone: string;
+  state: ScheduledPromptState;
+  stateReason?: string | null;
+  nextRunAt?: string | null;
+  lastRunAt?: string | null;
+  lastRunStatus?: string | null;
+  lastRunSessionId?: string | null;
+  lastError?: string | null;
+  runsToday: number;
+  maxRunsPerDay: number;
+  enabledTools?: string[] | null;
+  deliverEmail: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Request body for POST /schedules. */
+export interface CreateScheduleRequest {
+  label: string;
+  promptText: string;
+  cadence: ScheduleCadence;
+  hourLocal: number;
+  weekday?: number | null;
+  timezone: string;
+  assistantId?: string | null;
+  enabledTools?: string[] | null;
+  deliverEmail?: boolean;
+}
+
+/**
+ * Request body for PATCH /schedules/{id}.
+ *
+ * The backend's `update_scheduled_prompt` treats `None`/absent fields as
+ * "leave unchanged" (it only appends a SET clause when a value is not
+ * None) — so there is currently NO way to send a null over the wire and
+ * have it clear `assistantId` or `enabledTools`. The form works around
+ * this client-side with explicit "clear" checkboxes that omit the field
+ * from the outgoing JSON instead of sending null (same effective
+ * no-op from the backend's point of view) — see
+ * ScheduleFormPage.buildUpdateRequest. A real "detach assistant" /
+ * "reset tools to defaults" action requires a backend follow-up (a
+ * sentinel value or a separate PATCH endpoint) — flagged in the PR.
+ */
+export interface UpdateScheduleRequest {
+  label?: string;
+  promptText?: string;
+  cadence?: ScheduleCadence;
+  hourLocal?: number;
+  weekday?: number | null;
+  timezone?: string;
+  assistantId?: string | null;
+  enabledTools?: string[] | null;
+  deliverEmail?: boolean;
+  state?: 'active' | 'paused';
+}
+
+/** Response from GET /schedules. */
+export interface ScheduledPromptsListResponse {
+  schedules: ScheduledPrompt[];
+}

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
@@ -1,0 +1,233 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mb-8">
+      <a
+        routerLink="/schedules"
+        class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+        Back to schedules
+      </a>
+      <h1 class="mt-3 text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+        {{ mode() === 'create' ? 'New scheduled run' : 'Edit scheduled run' }}
+      </h1>
+      <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+        Run a prompt automatically on a cadence you choose. Results land in your conversation list.
+      </p>
+    </div>
+
+    @if (loadingSchedule()) {
+      <div class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading…</p>
+      </div>
+    } @else if (loadError()) {
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-6 dark:border-red-900/40 dark:bg-red-900/10">
+        <p class="text-sm/6 text-red-700 dark:text-red-300">{{ loadError() }}</p>
+      </div>
+    } @else {
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-8">
+        <!-- Basics -->
+        <section class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Basics</h2>
+
+          <div class="mt-4">
+            <label for="label" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              Label
+            </label>
+            <input
+              id="label"
+              type="text"
+              formControlName="label"
+              placeholder="Morning Briefing"
+              class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+            />
+            @if (getFieldError('label'); as error) {
+              <p class="mt-1.5 text-xs/5 text-red-600 dark:text-red-400">{{ error }}</p>
+            }
+          </div>
+
+          <div class="mt-4">
+            <label for="promptText" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              Prompt
+            </label>
+            <textarea
+              id="promptText"
+              formControlName="promptText"
+              rows="5"
+              placeholder="Summarize what happened in my classes yesterday and flag anything urgent."
+              class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+            ></textarea>
+            @if (getFieldError('promptText'); as error) {
+              <p class="mt-1.5 text-xs/5 text-red-600 dark:text-red-400">{{ error }}</p>
+            }
+          </div>
+        </section>
+
+        <!-- Cadence -->
+        <section class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">When it runs</h2>
+          <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+            A bounded cadence — daily, weekdays, or a specific day each week. No custom cron.
+          </p>
+
+          <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <label for="cadence" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Cadence
+              </label>
+              <select
+                id="cadence"
+                formControlName="cadence"
+                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+              >
+                <option value="daily">Every day</option>
+                <option value="weekday">Every weekday</option>
+                <option value="weekly">Weekly on a day</option>
+              </select>
+            </div>
+
+            @if (isWeekly()) {
+              <div>
+                <label for="weekday" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                  Day of week
+                </label>
+                <select
+                  id="weekday"
+                  formControlName="weekday"
+                  class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                >
+                  @for (label of weekdayLabels; track label; let idx = $index) {
+                    <option [value]="idx">{{ label }}</option>
+                  }
+                </select>
+              </div>
+            }
+
+            <div>
+              <label for="hourLocal" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Time of day
+              </label>
+              <select
+                id="hourLocal"
+                formControlName="hourLocal"
+                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+              >
+                @for (hour of hourOptions; track hour.value) {
+                  <option [value]="hour.value">{{ hour.label }}</option>
+                }
+              </select>
+            </div>
+          </div>
+
+          <div class="mt-4">
+            <label for="timezone" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              Timezone
+            </label>
+            <select
+              id="timezone"
+              formControlName="timezone"
+              class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            >
+              @for (tz of timezoneOptions; track tz) {
+                <option [value]="tz">{{ tz }}</option>
+              }
+            </select>
+          </div>
+        </section>
+
+        <!-- Target config -->
+        <section class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Target (optional)</h2>
+          <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+            Point this run at a specific assistant, and/or limit which tools it may use. Leave both
+            unset to use your normal defaults.
+          </p>
+
+          <div class="mt-4">
+            <label for="assistantId" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              Assistant
+            </label>
+            <select
+              id="assistantId"
+              formControlName="assistantId"
+              [attr.disabled]="clearAssistant() ? true : null"
+              class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            >
+              <option [value]="null">Default agent</option>
+              @for (assistant of assistants(); track assistant.assistantId) {
+                <option [value]="assistant.assistantId">{{ assistant.name }}</option>
+              }
+            </select>
+
+            @if (mode() === 'edit') {
+              <label class="mt-2 flex items-center gap-2 text-xs/5 text-gray-600 dark:text-gray-400">
+                <input
+                  type="checkbox"
+                  [checked]="clearAssistant()"
+                  (change)="onClearAssistantChange($any($event.target).checked)"
+                  class="size-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                />
+                Detach assistant (use the default agent)
+              </label>
+            }
+          </div>
+
+          <div class="mt-5">
+            <div class="flex items-center justify-between">
+              <span class="block text-sm/6 font-medium text-gray-900 dark:text-white">Tools</span>
+              @if (mode() === 'edit') {
+                <label class="flex items-center gap-2 text-xs/5 text-gray-600 dark:text-gray-400">
+                  <input
+                    type="checkbox"
+                    [checked]="clearTools()"
+                    (change)="onClearToolsChange($any($event.target).checked)"
+                    class="size-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                  />
+                  Reset to all my tools
+                </label>
+              }
+            </div>
+            <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+              The tool set is snapshotted when the schedule is created — later changes to your tool
+              access won't silently expand what a sleeping schedule can do.
+            </p>
+            <div class="mt-2 max-h-56 space-y-1 overflow-y-auto rounded-2xl border border-gray-200 p-2 dark:border-gray-700">
+              @for (tool of tools(); track tool.toolId) {
+                <label class="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm/6 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/40">
+                  <input
+                    type="checkbox"
+                    [checked]="isToolSelected(tool.toolId)"
+                    [disabled]="clearTools()"
+                    (change)="toggleTool(tool.toolId)"
+                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                  />
+                  {{ tool.displayName }}
+                </label>
+              } @empty {
+                <p class="px-2 py-1.5 text-xs/5 text-gray-500 dark:text-gray-400">No tools available.</p>
+              }
+            </div>
+          </div>
+        </section>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            [disabled]="saving()"
+            class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ saving() ? 'Saving…' : mode() === 'create' ? 'Create schedule' : 'Save changes' }}
+          </button>
+        </div>
+      </form>
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
@@ -68,7 +68,11 @@ describe('ScheduleFormPage', () => {
     TestBed.configureTestingModule({
       imports: [ReactiveFormsModule],
       providers: [
-        provideRouter([]),
+        // Register the route the component navigates to on save/cancel
+        // (`router.navigate(['/schedules'])`); an empty `provideRouter([])`
+        // makes that navigation reject with NG04002 as an unhandled
+        // rejection after the test body, failing the whole vitest process.
+        provideRouter([{ path: 'schedules', children: [] }]),
         { provide: ScheduleService, useValue: mockScheduleService },
         { provide: AssistantService, useValue: mockAssistantService },
         { provide: ToolService, useValue: mockToolService },

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
@@ -1,0 +1,208 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { provideRouter, ActivatedRoute } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { signal } from '@angular/core';
+import { ScheduleFormPage } from './schedule-form.page';
+import { ScheduleService } from '../services/schedule.service';
+import { AssistantService } from '../../assistants/services/assistant.service';
+import { ToolService } from '../../services/tool/tool.service';
+import { ToastService } from '../../services/toast/toast.service';
+import { ScheduledPrompt } from '../models/schedule.model';
+
+function stubSchedule(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  return {
+    scheduleId: 'sched-abc123def456',
+    assistantId: 'ast-1',
+    label: 'Morning Briefing',
+    promptText: 'Summarize my classes',
+    cadence: 'daily',
+    hourLocal: 7,
+    weekday: null,
+    timezone: 'America/Boise',
+    state: 'active',
+    stateReason: null,
+    nextRunAt: '2026-07-06T14:00:00Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunSessionId: null,
+    lastError: null,
+    runsToday: 0,
+    maxRunsPerDay: 24,
+    enabledTools: ['class_search'],
+    deliverEmail: false,
+    createdAt: '2026-07-05T00:00:00Z',
+    updatedAt: '2026-07-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ScheduleFormPage', () => {
+  let component: ScheduleFormPage;
+  let fixture: ComponentFixture<ScheduleFormPage>;
+
+  const mockScheduleService = {
+    getSchedule: vi.fn().mockResolvedValue(undefined),
+    createSchedule: vi.fn().mockResolvedValue(stubSchedule()),
+    updateSchedule: vi.fn().mockResolvedValue(stubSchedule()),
+  };
+
+  const mockAssistantService = {
+    assistants$: signal([]),
+    loadAssistants: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mockToolService = {
+    tools: signal([]),
+    initialized: signal(true),
+    loadTools: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mockToast = { success: vi.fn(), error: vi.fn() };
+
+  function configure(routeParams: Record<string, string> = {}) {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+    mockScheduleService.getSchedule.mockResolvedValue(undefined);
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      providers: [
+        provideRouter([]),
+        { provide: ScheduleService, useValue: mockScheduleService },
+        { provide: AssistantService, useValue: mockAssistantService },
+        { provide: ToolService, useValue: mockToolService },
+        { provide: ToastService, useValue: mockToast },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: (key: string) => routeParams[key] ?? null } } },
+        },
+      ],
+    })
+      .overrideComponent(ScheduleFormPage, { set: { template: '<div></div>' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ScheduleFormPage);
+    component = fixture.componentInstance;
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  describe('create mode', () => {
+    beforeEach(() => {
+      configure();
+      component.ngOnInit();
+    });
+
+    it('is in create mode with no scheduleId', () => {
+      expect(component.mode()).toBe('create');
+      expect(component.scheduleId()).toBeNull();
+    });
+
+    it('defaults weekday to Monday the first time weekly is chosen', () => {
+      expect(component.form.controls.weekday.value).toBeNull();
+      component.form.controls.cadence.setValue('weekly');
+      expect(component.form.controls.weekday.value).toBe(1);
+    });
+
+    it('rejects submit when required fields are missing', async () => {
+      await component.onSubmit();
+      expect(mockScheduleService.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('creates a schedule with the selected tools', async () => {
+      component.form.patchValue({
+        label: 'Test',
+        promptText: 'Do the thing',
+        cadence: 'daily',
+        hourLocal: 8,
+        timezone: 'UTC',
+      });
+      component.toggleTool('class_search');
+
+      await component.onSubmit();
+
+      expect(mockScheduleService.createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: 'Test',
+          promptText: 'Do the thing',
+          cadence: 'daily',
+          hourLocal: 8,
+          timezone: 'UTC',
+          enabledTools: ['class_search'],
+        }),
+      );
+    });
+
+    it('requires a weekday when cadence is weekly', async () => {
+      component.form.patchValue({
+        label: 'Test',
+        promptText: 'Do the thing',
+        cadence: 'weekly',
+        hourLocal: 8,
+        timezone: 'UTC',
+        weekday: null,
+      });
+
+      await component.onSubmit();
+
+      expect(mockScheduleService.createSchedule).not.toHaveBeenCalled();
+      expect(component.form.controls.weekday.errors).toEqual({ required: true });
+    });
+  });
+
+  describe('edit mode', () => {
+    beforeEach(() => {
+      configure({ scheduleId: 'sched-abc123def456' });
+      mockScheduleService.getSchedule.mockResolvedValue(stubSchedule());
+    });
+
+    it('loads the existing schedule into the form', async () => {
+      component.ngOnInit();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(component.form.controls.label.value).toBe('Morning Briefing');
+      expect(component.form.controls.assistantId.value).toBe('ast-1');
+      expect(component.selectedToolIds()).toEqual(new Set(['class_search']));
+    });
+
+    it('omits assistantId from the PATCH when unchanged and non-empty', async () => {
+      component.ngOnInit();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await component.onSubmit();
+
+      const [, request] = mockScheduleService.updateSchedule.mock.calls[0];
+      expect(request.assistantId).toBe('ast-1');
+    });
+
+    it('clearing the assistant checkbox omits assistantId (documented gap: cannot actually detach)', async () => {
+      component.ngOnInit();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      component.onClearAssistantChange(true);
+      await component.onSubmit();
+
+      const [, request] = mockScheduleService.updateSchedule.mock.calls[0];
+      expect(request.assistantId).toBeUndefined();
+    });
+
+    it('clearing the tools checkbox omits enabledTools from the PATCH', async () => {
+      component.ngOnInit();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      component.onClearToolsChange(true);
+      await component.onSubmit();
+
+      const [, request] = mockScheduleService.updateSchedule.mock.calls[0];
+      expect(request.enabledTools).toBeUndefined();
+      expect(component.selectedToolIds().size).toBe(0);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
@@ -1,0 +1,306 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import { ScheduleService } from '../services/schedule.service';
+import { AssistantService } from '../../assistants/services/assistant.service';
+import { Assistant } from '../../assistants/models/assistant.model';
+import { ToolService } from '../../services/tool/tool.service';
+import { CreateScheduleRequest, ScheduleCadence, UpdateScheduleRequest } from '../models/schedule.model';
+import { ToastService } from '../../services/toast/toast.service';
+
+const WEEKDAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** All 24 hours, labeled 12-hour-with-suffix for the select. */
+function hourOptions(): { value: number; label: string }[] {
+  return Array.from({ length: 24 }, (_, hour) => ({
+    value: hour,
+    label:
+      hour === 0
+        ? '12:00 AM'
+        : hour < 12
+          ? `${hour}:00 AM`
+          : hour === 12
+            ? '12:00 PM'
+            : `${hour - 12}:00 PM`,
+  }));
+}
+
+/** IANA timezone names, via the runtime's own database when available. */
+function timezoneOptions(): string[] {
+  const intlWithSupport = Intl as typeof Intl & {
+    supportedValuesOf?: (key: string) => string[];
+  };
+  if (typeof intlWithSupport.supportedValuesOf === 'function') {
+    try {
+      return intlWithSupport.supportedValuesOf('timeZone');
+    } catch {
+      // fall through to the static fallback below
+    }
+  }
+  return [
+    'America/Boise',
+    'America/Denver',
+    'America/Los_Angeles',
+    'America/Chicago',
+    'America/New_York',
+    'America/Anchorage',
+    'Pacific/Honolulu',
+    'UTC',
+  ];
+}
+
+/**
+ * Create/edit page for a scheduled agent run. Bounded cadence UI only
+ * (daily / weekday / weekly at an hour + IANA timezone) — no cron field,
+ * per docs/specs/scheduled-agent-runs.md §3.
+ *
+ * Optional fields (assistant, tool selection) use explicit "clear"
+ * checkboxes rather than relying on sending null: the backend's
+ * `update_scheduled_prompt` only writes a field when the incoming value is
+ * not None, so a bare `null` over the wire is silently ignored. The clear
+ * checkboxes here are a client-side workaround — they still can't actually
+ * detach an already-set field on an *edit*, because there is no
+ * value/sentinel the backend currently accepts to mean "erase this". See
+ * `buildUpdateRequest` for exactly where this bites, and the PR notes for
+ * the suggested backend follow-up.
+ */
+@Component({
+  selector: 'app-schedule-form-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, NgIcon, RouterLink],
+  providers: [provideIcons({ heroArrowLeft })],
+  templateUrl: './schedule-form.page.html',
+})
+export class ScheduleFormPage implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+  private readonly scheduleService = inject(ScheduleService);
+  private readonly assistantService = inject(AssistantService);
+  private readonly toolService = inject(ToolService);
+  private readonly toast = inject(ToastService);
+
+  readonly scheduleId = signal<string | null>(null);
+  readonly mode = computed<'create' | 'edit'>(() => (this.scheduleId() ? 'edit' : 'create'));
+  readonly saving = signal(false);
+  readonly loadError = signal<string | null>(null);
+  readonly loadingSchedule = signal(false);
+
+  readonly assistants = this.assistantService.assistants$;
+  readonly tools = this.toolService.tools;
+
+  readonly hourOptions = hourOptions();
+  readonly timezoneOptions = timezoneOptions();
+  readonly weekdayLabels = WEEKDAY_LABELS;
+
+  /**
+   * Whether the assistant/tools sections should send a clear intent on
+   * submit. Only meaningful in edit mode — create simply omits the field
+   * when unchecked and nothing has been picked.
+   */
+  readonly clearAssistant = signal(false);
+  readonly clearTools = signal(false);
+
+  readonly selectedToolIds = signal<Set<string>>(new Set());
+
+  readonly form = this.fb.group({
+    label: ['', [Validators.required, Validators.maxLength(200)]],
+    promptText: ['', [Validators.required, Validators.maxLength(20000)]],
+    cadence: ['daily' as ScheduleCadence, [Validators.required]],
+    hourLocal: [7, [Validators.required]],
+    weekday: new FormControl<number | null>(null),
+    timezone: [this.guessTimezone(), [Validators.required]],
+    assistantId: new FormControl<string | null>(null),
+  });
+
+  readonly isWeekly = computed(() => this.form.controls.cadence.value === 'weekly');
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('scheduleId');
+    this.scheduleId.set(id);
+
+    void this.assistantService.loadAssistants(false, false);
+    if (!this.toolService.initialized()) {
+      void this.toolService.loadTools();
+    }
+
+    if (id) {
+      void this.loadSchedule(id);
+    }
+
+    // "weekly" requires a weekday — default to Monday the first time it's chosen.
+    this.form.controls.cadence.valueChanges.subscribe((cadence) => {
+      if (cadence === 'weekly' && this.form.controls.weekday.value === null) {
+        this.form.controls.weekday.setValue(1);
+      }
+    });
+  }
+
+  private async loadSchedule(id: string): Promise<void> {
+    this.loadingSchedule.set(true);
+    this.loadError.set(null);
+    try {
+      const schedule = await this.scheduleService.getSchedule(id);
+      if (!schedule) {
+        this.loadError.set('This schedule no longer exists.');
+        return;
+      }
+      this.form.patchValue({
+        label: schedule.label,
+        promptText: schedule.promptText,
+        cadence: schedule.cadence,
+        hourLocal: schedule.hourLocal,
+        weekday: schedule.weekday ?? null,
+        timezone: schedule.timezone,
+        assistantId: schedule.assistantId ?? null,
+      });
+      this.selectedToolIds.set(new Set(schedule.enabledTools ?? []));
+    } catch {
+      this.loadError.set('Failed to load this schedule.');
+    } finally {
+      this.loadingSchedule.set(false);
+    }
+  }
+
+  private guessTimezone(): string {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch {
+      return 'UTC';
+    }
+  }
+
+  assistantName(assistantId: string | null): string {
+    if (!assistantId) return '';
+    const match = (this.assistants() as Assistant[]).find((a) => a.assistantId === assistantId);
+    return match?.name ?? assistantId;
+  }
+
+  toggleTool(toolId: string): void {
+    this.selectedToolIds.update((set) => {
+      const next = new Set(set);
+      if (next.has(toolId)) {
+        next.delete(toolId);
+      } else {
+        next.add(toolId);
+      }
+      return next;
+    });
+    this.clearTools.set(false);
+  }
+
+  isToolSelected(toolId: string): boolean {
+    return this.selectedToolIds().has(toolId);
+  }
+
+  onClearAssistantChange(checked: boolean): void {
+    this.clearAssistant.set(checked);
+    if (checked) {
+      this.form.controls.assistantId.setValue(null);
+    }
+  }
+
+  onClearToolsChange(checked: boolean): void {
+    this.clearTools.set(checked);
+    if (checked) {
+      this.selectedToolIds.set(new Set());
+    }
+  }
+
+  getFieldError(fieldName: 'label' | 'promptText'): string | null {
+    const field = this.form.get(fieldName);
+    if (!field || !field.touched || !field.errors) {
+      return null;
+    }
+    if (field.errors['required']) return 'This field is required';
+    if (field.errors['maxlength']) {
+      return `Maximum length is ${field.errors['maxlength'].requiredLength} characters`;
+    }
+    return null;
+  }
+
+  async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const value = this.form.getRawValue();
+    if (value.cadence === 'weekly' && value.weekday === null) {
+      this.form.controls.weekday.setErrors({ required: true });
+      return;
+    }
+
+    this.saving.set(true);
+    try {
+      const toolIds = Array.from(this.selectedToolIds());
+      if (this.mode() === 'create') {
+        const request: CreateScheduleRequest = {
+          label: value.label!,
+          promptText: value.promptText!,
+          cadence: value.cadence!,
+          hourLocal: value.hourLocal!,
+          weekday: value.cadence === 'weekly' ? value.weekday : null,
+          timezone: value.timezone!,
+          assistantId: value.assistantId ?? null,
+          enabledTools: toolIds.length > 0 ? toolIds : null,
+        };
+        await this.scheduleService.createSchedule(request);
+        this.toast.success('Schedule created', `"${request.label}" will run on the cadence you set.`);
+      } else {
+        const request = this.buildUpdateRequest(value, toolIds);
+        await this.scheduleService.updateSchedule(this.scheduleId()!, request);
+        this.toast.success('Schedule updated');
+      }
+      this.router.navigate(['/schedules']);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save the schedule';
+      this.toast.error('Could not save schedule', message);
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  /**
+   * Builds the PATCH body for edit mode. KNOWN GAP: `assistantId` and
+   * `enabledTools` cannot be cleared this way — the backend only applies a
+   * field when it is not None (see UpdateScheduleRequest doc comment), so
+   * omitting the field (or sending null) both leave the stored value
+   * unchanged. The "clear" checkboxes are wired up so the UI intent is at
+   * least explicit and ready to send a real sentinel/clear signal the
+   * moment the backend supports one; until then this method sends the
+   * field only when there's a genuine non-empty value to set.
+   */
+  private buildUpdateRequest(
+    value: ReturnType<ScheduleFormPage['form']['getRawValue']>,
+    toolIds: string[],
+  ): UpdateScheduleRequest {
+    const request: UpdateScheduleRequest = {
+      label: value.label!,
+      promptText: value.promptText!,
+      cadence: value.cadence!,
+      hourLocal: value.hourLocal!,
+      weekday: value.cadence === 'weekly' ? value.weekday : null,
+      timezone: value.timezone!,
+    };
+    if (!this.clearAssistant() && value.assistantId) {
+      request.assistantId = value.assistantId;
+    }
+    if (!this.clearTools() && toolIds.length > 0) {
+      request.enabledTools = toolIds;
+    }
+    return request;
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/schedules']);
+  }
+}

--- a/frontend/ai.client/src/app/schedules/schedules.page.html
+++ b/frontend/ai.client/src/app/schedules/schedules.page.html
@@ -1,0 +1,178 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="mb-8">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+            Scheduled runs
+          </h1>
+          <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+            Run a prompt automatically, on your own cadence, as you.
+          </p>
+        </div>
+
+        @if (accessible() !== false) {
+          <button
+            type="button"
+            (click)="onCreateNew()"
+            class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+            New schedule
+          </button>
+        }
+      </div>
+    </div>
+
+    @if (accessible() === false) {
+      <div class="rounded-2xl border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-sm/6 font-medium text-gray-900 dark:text-white">Scheduled runs aren't available for your account</p>
+        <p class="mt-1.5 text-sm/6 text-gray-500 dark:text-gray-400">
+          This feature is in a limited beta. Reach out if you'd like access.
+        </p>
+      </div>
+    } @else {
+      <!-- Enablement banner -->
+      @if (!loading() && needsEnablement()) {
+        <div class="mb-6 flex flex-col gap-3 rounded-2xl border border-blue-200 bg-blue-50 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-blue-900/40 dark:bg-blue-900/10">
+          <div>
+            <p class="text-sm/6 font-medium text-blue-900 dark:text-blue-200">Scheduled runs are not enabled</p>
+            <p class="mt-0.5 text-xs/5 text-blue-800/80 dark:text-blue-300/80">
+              Turn this on to let your active schedules run unattended, even when you're logged out.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onEnableScheduledRuns()"
+            [disabled]="grantBusy()"
+            class="inline-flex shrink-0 items-center justify-center rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ grantBusy() ? 'Enabling…' : 'Enable scheduled runs' }}
+          </button>
+        </div>
+      }
+
+      <!-- Content -->
+      @if (loading()) {
+        <div class="space-y-3">
+          @for (i of [1, 2, 3]; track i) {
+            <div class="h-20 animate-pulse rounded-2xl border border-gray-200/80 bg-white dark:border-gray-700/60 dark:bg-gray-800/80"></div>
+          }
+        </div>
+      } @else if (sortedSchedules().length === 0) {
+        <div class="rounded-2xl border border-gray-200 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800">
+          <p class="text-sm/6 font-medium text-gray-900 dark:text-white">No schedules yet</p>
+          <p class="mt-1.5 text-sm/6 text-gray-500 dark:text-gray-400">
+            Create your first scheduled run to have the agent work for you on a cadence.
+          </p>
+        </div>
+      } @else {
+        <ul class="space-y-3" role="list">
+          @for (schedule of sortedSchedules(); track schedule.scheduleId) {
+            <li class="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div class="min-w-0">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      (click)="onEdit(schedule)"
+                      class="truncate text-sm/6 font-semibold text-gray-900 hover:underline dark:text-white"
+                    >
+                      {{ schedule.label }}
+                    </button>
+                    <span [class]="stateBadgeClasses(schedule)">{{ stateLabel(schedule) }}</span>
+                  </div>
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    {{ cadenceSummary(schedule) }} · {{ schedule.timezone }}
+                  </p>
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Next run: {{ nextRunLabel(schedule) }}
+                  </p>
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Last run:
+                    @if (schedule.lastRunSessionId) {
+                      <a
+                        [routerLink]="['/s', schedule.lastRunSessionId]"
+                        class="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                      >{{ lastRunLabel(schedule) }}</a>
+                    } @else {
+                      {{ lastRunLabel(schedule) }}
+                    }
+                  </p>
+
+                  @if (needsReauth(schedule)) {
+                    <div class="mt-2 flex flex-wrap items-center gap-2 rounded-xl bg-amber-50 px-3 py-2 dark:bg-amber-900/10">
+                      <ng-icon name="heroExclamationTriangle" class="size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                      <span class="text-xs/5 text-amber-800 dark:text-amber-300">Your access expired.</span>
+                      <button
+                        type="button"
+                        (click)="onReauthenticate(schedule)"
+                        [disabled]="isBusy(schedule.scheduleId)"
+                        class="text-xs/5 font-semibold text-amber-900 underline hover:no-underline disabled:opacity-50 dark:text-amber-200"
+                      >
+                        Log in and re-enable
+                      </button>
+                    </div>
+                  } @else if (needsOAuthReconnect(schedule)) {
+                    <div class="mt-2 flex flex-wrap items-center gap-2 rounded-xl bg-amber-50 px-3 py-2 dark:bg-amber-900/10">
+                      <ng-icon name="heroExclamationTriangle" class="size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                      <span class="text-xs/5 text-amber-800 dark:text-amber-300">
+                        A connected tool needs to be reconnected before this can resume.
+                      </span>
+                      <a
+                        routerLink="/settings/connectors"
+                        class="text-xs/5 font-semibold text-amber-900 underline hover:no-underline dark:text-amber-200"
+                      >
+                        Reconnect a tool
+                      </a>
+                    </div>
+                  } @else if (schedule.state === 'paused_error' && schedule.lastError) {
+                    <p class="mt-2 text-xs/5 text-amber-700 dark:text-amber-400">{{ schedule.lastError }}</p>
+                  }
+                </div>
+
+                <div class="flex shrink-0 items-center gap-2">
+                  @if (schedule.state === 'active') {
+                    <button
+                      type="button"
+                      (click)="onPause(schedule)"
+                      [disabled]="isBusy(schedule.scheduleId)"
+                      class="rounded-2xl px-3 py-1.5 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                    >
+                      Pause
+                    </button>
+                  } @else if (schedule.state === 'paused') {
+                    <button
+                      type="button"
+                      (click)="onResume(schedule)"
+                      [disabled]="isBusy(schedule.scheduleId)"
+                      class="rounded-2xl px-3 py-1.5 text-xs/5 font-medium text-blue-600 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                    >
+                      Resume
+                    </button>
+                  }
+                  <button
+                    type="button"
+                    (click)="onEdit(schedule)"
+                    class="rounded-2xl px-3 py-1.5 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    (click)="onDelete(schedule)"
+                    [disabled]="isBusy(schedule.scheduleId)"
+                    class="rounded-2xl px-3 py-1.5 text-xs/5 font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </li>
+          }
+        </ul>
+      }
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/schedules/schedules.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedules.page.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
+import { SchedulesPage } from './schedules.page';
+import { ScheduleService } from './services/schedule.service';
+import { GrantService } from './services/grant.service';
+import { ToastService } from '../services/toast/toast.service';
+import { ScheduledPrompt } from './models/schedule.model';
+import { GrantStatus } from './models/grant.model';
+
+function stubSchedule(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  return {
+    scheduleId: 'sched-abc123def456',
+    assistantId: null,
+    label: 'Morning Briefing',
+    promptText: 'Summarize my classes',
+    cadence: 'daily',
+    hourLocal: 7,
+    weekday: null,
+    timezone: 'America/Boise',
+    state: 'active',
+    stateReason: null,
+    nextRunAt: '2026-07-06T14:00:00Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunSessionId: null,
+    lastError: null,
+    runsToday: 0,
+    maxRunsPerDay: 24,
+    enabledTools: null,
+    deliverEmail: false,
+    createdAt: '2026-07-05T00:00:00Z',
+    updatedAt: '2026-07-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SchedulesPage', () => {
+  let mockScheduleService: {
+    schedules$: ReturnType<typeof signal<ScheduledPrompt[]>>;
+    loading$: ReturnType<typeof signal<boolean>>;
+    accessible$: ReturnType<typeof signal<boolean | null>>;
+    loadSchedules: ReturnType<typeof vi.fn>;
+    pauseSchedule: ReturnType<typeof vi.fn>;
+    resumeSchedule: ReturnType<typeof vi.fn>;
+    deleteSchedule: ReturnType<typeof vi.fn>;
+  };
+  let mockGrantService: {
+    status$: ReturnType<typeof signal<GrantStatus>>;
+    loading$: ReturnType<typeof signal<boolean>>;
+    loadStatus: ReturnType<typeof vi.fn>;
+    enable: ReturnType<typeof vi.fn>;
+  };
+  let mockToast: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    mockScheduleService = {
+      schedules$: signal<ScheduledPrompt[]>([]),
+      loading$: signal(false),
+      accessible$: signal<boolean | null>(true),
+      loadSchedules: vi.fn().mockResolvedValue(undefined),
+      pauseSchedule: vi.fn().mockResolvedValue(undefined),
+      resumeSchedule: vi.fn().mockResolvedValue(undefined),
+      deleteSchedule: vi.fn().mockResolvedValue(undefined),
+    };
+    mockGrantService = {
+      status$: signal<GrantStatus>({ enabled: false }),
+      loading$: signal(false),
+      loadStatus: vi.fn().mockResolvedValue(undefined),
+      enable: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    mockToast = { success: vi.fn(), error: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: ScheduleService, useValue: mockScheduleService },
+        { provide: GrantService, useValue: mockGrantService },
+        { provide: ToastService, useValue: mockToast },
+      ],
+    });
+    TestBed.overrideComponent(SchedulesPage, { set: { template: '<div></div>' } });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function createComponent() {
+    const fixture = TestBed.createComponent(SchedulesPage);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('loads schedules and grant status on init', () => {
+    createComponent();
+    expect(mockScheduleService.loadSchedules).toHaveBeenCalled();
+    expect(mockGrantService.loadStatus).toHaveBeenCalled();
+  });
+
+  it('needsEnablement is true when the grant is disabled', () => {
+    mockGrantService.status$.set({ enabled: false });
+    const component = createComponent();
+    expect(component.needsEnablement()).toBe(true);
+  });
+
+  it('needsEnablement is false when the grant is active', () => {
+    mockGrantService.status$.set({ enabled: true, grantId: 'hlg-1' });
+    const component = createComponent();
+    expect(component.needsEnablement()).toBe(false);
+  });
+
+  it('onEnableScheduledRuns calls grant.enable() and toasts success', async () => {
+    const component = createComponent();
+    await component.onEnableScheduledRuns();
+    expect(mockGrantService.enable).toHaveBeenCalled();
+    expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it('onEnableScheduledRuns toasts an error on failure', async () => {
+    mockGrantService.enable.mockRejectedValueOnce(new Error('409'));
+    const component = createComponent();
+    await component.onEnableScheduledRuns();
+    expect(mockToast.error).toHaveBeenCalled();
+  });
+
+  it('needsReauth is true only for paused_error with reason reauth_required', () => {
+    const component = createComponent();
+    expect(
+      component.needsReauth(stubSchedule({ state: 'paused_error', stateReason: 'reauth_required' })),
+    ).toBe(true);
+    expect(
+      component.needsReauth(stubSchedule({ state: 'paused_error', stateReason: 'oauth_required' })),
+    ).toBe(false);
+    expect(component.needsReauth(stubSchedule({ state: 'active' }))).toBe(false);
+  });
+
+  it('needsOAuthReconnect is true only for paused_error with reason oauth_required', () => {
+    const component = createComponent();
+    expect(
+      component.needsOAuthReconnect(
+        stubSchedule({ state: 'paused_error', stateReason: 'oauth_required' }),
+      ),
+    ).toBe(true);
+    expect(
+      component.needsOAuthReconnect(
+        stubSchedule({ state: 'paused_error', stateReason: 'reauth_required' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('onReauthenticate re-enables the grant then resumes the schedule', async () => {
+    const component = createComponent();
+    const schedule = stubSchedule({ state: 'paused_error', stateReason: 'reauth_required' });
+
+    await component.onReauthenticate(schedule);
+
+    expect(mockGrantService.enable).toHaveBeenCalled();
+    expect(mockScheduleService.resumeSchedule).toHaveBeenCalledWith(schedule.scheduleId);
+    expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it('onPause pauses the schedule', async () => {
+    const component = createComponent();
+    const schedule = stubSchedule();
+    await component.onPause(schedule);
+    expect(mockScheduleService.pauseSchedule).toHaveBeenCalledWith(schedule.scheduleId);
+  });
+
+  it('onResume resumes the schedule', async () => {
+    const component = createComponent();
+    const schedule = stubSchedule({ state: 'paused' });
+    await component.onResume(schedule);
+    expect(mockScheduleService.resumeSchedule).toHaveBeenCalledWith(schedule.scheduleId);
+  });
+
+  it('onDelete does nothing when the confirm dialog is cancelled', async () => {
+    const component = createComponent();
+    const dialog = TestBed.inject(Dialog);
+    vi.spyOn(dialog, 'open').mockReturnValue({ closed: of(false) } as ReturnType<Dialog['open']>);
+
+    await component.onDelete(stubSchedule());
+
+    expect(mockScheduleService.deleteSchedule).not.toHaveBeenCalled();
+  });
+
+  it('onDelete deletes the schedule when confirmed', async () => {
+    const component = createComponent();
+    const dialog = TestBed.inject(Dialog);
+    vi.spyOn(dialog, 'open').mockReturnValue({ closed: of(true) } as ReturnType<Dialog['open']>);
+
+    const schedule = stubSchedule();
+    await component.onDelete(schedule);
+
+    expect(mockScheduleService.deleteSchedule).toHaveBeenCalledWith(schedule.scheduleId);
+    expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it('cadenceSummary formats daily/weekday/weekly cadences', () => {
+    const component = createComponent();
+    expect(component.cadenceSummary(stubSchedule({ cadence: 'daily', hourLocal: 7 }))).toBe(
+      'Every day at 7:00 AM',
+    );
+    expect(component.cadenceSummary(stubSchedule({ cadence: 'weekday', hourLocal: 13 }))).toBe(
+      'Every weekday at 1:00 PM',
+    );
+    expect(
+      component.cadenceSummary(stubSchedule({ cadence: 'weekly', hourLocal: 0, weekday: 1 })),
+    ).toBe('Every Monday at 12:00 AM');
+  });
+
+  it('stateLabel maps states to display text', () => {
+    const component = createComponent();
+    expect(component.stateLabel(stubSchedule({ state: 'active' }))).toBe('Active');
+    expect(component.stateLabel(stubSchedule({ state: 'paused' }))).toBe('Paused');
+    expect(component.stateLabel(stubSchedule({ state: 'paused_error' }))).toBe('Needs attention');
+  });
+});

--- a/frontend/ai.client/src/app/schedules/schedules.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedules.page.spec.ts
@@ -78,7 +78,13 @@ describe('SchedulesPage', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        provideRouter([]),
+        // Register the routes the component navigates to (new / edit); an
+        // empty provideRouter([]) would make those navigations reject with
+        // NG04002 as unhandled rejections and fail the vitest process.
+        provideRouter([
+          { path: 'schedules/new', children: [] },
+          { path: 'schedules/:scheduleId/edit', children: [] },
+        ]),
         { provide: ScheduleService, useValue: mockScheduleService },
         { provide: GrantService, useValue: mockGrantService },
         { provide: ToastService, useValue: mockToast },

--- a/frontend/ai.client/src/app/schedules/schedules.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedules.page.ts
@@ -1,0 +1,259 @@
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroPlus, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { ScheduleService } from './services/schedule.service';
+import { GrantService } from './services/grant.service';
+import { ScheduledPrompt } from './models/schedule.model';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog/confirmation-dialog.component';
+import { ToastService } from '../services/toast/toast.service';
+
+const WEEKDAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/**
+ * Schedules management page — list, create/edit (routed), pause/resume,
+ * delete, and the grant-enablement UX (docs/specs/scheduled-runs-phase-b-brief.md
+ * §2 B3).
+ *
+ * Visibility gating: this page (and the nav entry that links to it) is only
+ * meaningful for users with the `scheduled-runs` RBAC capability. There is
+ * no client-side capability signal yet (see UserPermissions), so gating
+ * rides the `/schedules` list call itself — a 403/404 (kill switch off or
+ * capability missing) flips `ScheduleService.accessible$` to false and this
+ * page renders a graceful "not available" state instead of an error.
+ */
+@Component({
+  selector: 'app-schedules-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, NgIcon],
+  providers: [provideIcons({ heroPlus, heroExclamationTriangle })],
+  templateUrl: './schedules.page.html',
+})
+export class SchedulesPage implements OnInit {
+  private readonly router = inject(Router);
+  private readonly scheduleService = inject(ScheduleService);
+  private readonly grantService = inject(GrantService);
+  private readonly dialog = inject(Dialog);
+  private readonly toast = inject(ToastService);
+
+  readonly schedules = this.scheduleService.schedules$;
+  readonly loading = this.scheduleService.loading$;
+  readonly accessible = this.scheduleService.accessible$;
+  readonly grantStatus = this.grantService.status$;
+  readonly grantBusy = this.grantService.loading$;
+
+  readonly busyScheduleIds = signal<Set<string>>(new Set());
+
+  readonly sortedSchedules = computed(() =>
+    [...this.schedules()].sort((a, b) => a.label.localeCompare(b.label)),
+  );
+
+  readonly needsEnablement = computed(() => !this.grantStatus().enabled);
+
+  async ngOnInit(): Promise<void> {
+    await Promise.allSettled([
+      this.scheduleService.loadSchedules(),
+      this.grantService.loadStatus(),
+    ]);
+  }
+
+  onCreateNew(): void {
+    this.router.navigate(['/schedules/new']);
+  }
+
+  onEdit(schedule: ScheduledPrompt): void {
+    this.router.navigate(['/schedules', schedule.scheduleId, 'edit']);
+  }
+
+  async onEnableScheduledRuns(): Promise<void> {
+    try {
+      await this.grantService.enable();
+      this.toast.success('Scheduled runs enabled', 'Your active schedules can now run unattended.');
+    } catch {
+      this.toast.error(
+        'Could not enable scheduled runs',
+        'Please try again, or refresh the page and log in again.',
+      );
+    }
+  }
+
+  /** Re-enable path for a paused_error schedule whose reason is reauth_required. */
+  async onReauthenticate(schedule: ScheduledPrompt): Promise<void> {
+    try {
+      await this.grantService.enable();
+      await this.onResume(schedule);
+      this.toast.success('Access renewed', `"${schedule.label}" will resume on its normal cadence.`);
+    } catch {
+      this.toast.error('Could not renew access', 'Please log in again and retry.');
+    }
+  }
+
+  async onPause(schedule: ScheduledPrompt): Promise<void> {
+    this.setBusy(schedule.scheduleId, true);
+    try {
+      await this.scheduleService.pauseSchedule(schedule.scheduleId);
+    } catch {
+      this.toast.error('Could not pause schedule');
+    } finally {
+      this.setBusy(schedule.scheduleId, false);
+    }
+  }
+
+  async onResume(schedule: ScheduledPrompt): Promise<void> {
+    this.setBusy(schedule.scheduleId, true);
+    try {
+      await this.scheduleService.resumeSchedule(schedule.scheduleId);
+    } catch {
+      this.toast.error('Could not resume schedule');
+    } finally {
+      this.setBusy(schedule.scheduleId, false);
+    }
+  }
+
+  async onDelete(schedule: ScheduledPrompt): Promise<void> {
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: 'Delete schedule',
+        message: `Are you sure you want to delete "${schedule.label}"? This cannot be undone.`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData,
+    });
+
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) {
+      return;
+    }
+
+    this.setBusy(schedule.scheduleId, true);
+    try {
+      await this.scheduleService.deleteSchedule(schedule.scheduleId);
+      this.toast.success('Schedule deleted');
+    } catch {
+      this.toast.error('Could not delete schedule');
+      this.setBusy(schedule.scheduleId, false);
+    }
+  }
+
+  isBusy(scheduleId: string): boolean {
+    return this.busyScheduleIds().has(scheduleId);
+  }
+
+  private setBusy(scheduleId: string, busy: boolean): void {
+    this.busyScheduleIds.update((set) => {
+      const next = new Set(set);
+      if (busy) {
+        next.add(scheduleId);
+      } else {
+        next.delete(scheduleId);
+      }
+      return next;
+    });
+  }
+
+  /** "Every day at 7:00 AM (America/Boise)" style summary. */
+  cadenceSummary(schedule: ScheduledPrompt): string {
+    const time = this.formatHour(schedule.hourLocal);
+    switch (schedule.cadence) {
+      case 'daily':
+        return `Every day at ${time}`;
+      case 'weekday':
+        return `Every weekday at ${time}`;
+      case 'weekly': {
+        const day = schedule.weekday !== null && schedule.weekday !== undefined
+          ? WEEKDAY_LABELS[schedule.weekday]
+          : '';
+        return `Every ${day} at ${time}`;
+      }
+      default:
+        return time;
+    }
+  }
+
+  private formatHour(hour: number): string {
+    if (hour === 0) return '12:00 AM';
+    if (hour < 12) return `${hour}:00 AM`;
+    if (hour === 12) return '12:00 PM';
+    return `${hour - 12}:00 PM`;
+  }
+
+  nextRunLabel(schedule: ScheduledPrompt): string {
+    if (schedule.state !== 'active' || !schedule.nextRunAt) {
+      return '—';
+    }
+    return this.formatRelativeFuture(schedule.nextRunAt);
+  }
+
+  private formatRelativeFuture(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '—';
+    const diffMins = Math.round((then - Date.now()) / 60_000);
+    if (diffMins <= 0) return 'due now';
+    if (diffMins < 60) return `in ${diffMins}m`;
+    const diffHours = Math.round(diffMins / 60);
+    if (diffHours < 24) return `in ${diffHours}h`;
+    return `in ${Math.round(diffHours / 24)}d`;
+  }
+
+  stateBadgeClasses(schedule: ScheduledPrompt): string {
+    const base = 'inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-0.5 text-xs/5 font-medium';
+    switch (schedule.state) {
+      case 'active':
+        return `${base} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300`;
+      case 'paused':
+        return `${base} bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300`;
+      case 'paused_error':
+        return `${base} bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300`;
+      default:
+        return `${base} bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300`;
+    }
+  }
+
+  stateLabel(schedule: ScheduledPrompt): string {
+    switch (schedule.state) {
+      case 'active':
+        return 'Active';
+      case 'paused':
+        return 'Paused';
+      case 'paused_error':
+        return 'Needs attention';
+      default:
+        return schedule.state;
+    }
+  }
+
+  /** True for a paused_error schedule whose stateReason marks it as needing re-auth. */
+  needsReauth(schedule: ScheduledPrompt): boolean {
+    return schedule.state === 'paused_error' && schedule.stateReason === 'reauth_required';
+  }
+
+  /** True for a paused_error schedule whose stateReason marks it as needing an OAuth reconnect. */
+  needsOAuthReconnect(schedule: ScheduledPrompt): boolean {
+    return schedule.state === 'paused_error' && schedule.stateReason === 'oauth_required';
+  }
+
+  lastRunLabel(schedule: ScheduledPrompt): string {
+    if (!schedule.lastRunAt) {
+      return 'Never run';
+    }
+    const status = schedule.lastRunStatus ?? 'unknown';
+    return `${status} · ${this.formatRelativePast(schedule.lastRunAt)}`;
+  }
+
+  private formatRelativePast(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diffMins = Math.floor((Date.now() - then) / 60_000);
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    return `${Math.floor(diffHours / 24)}d ago`;
+  }
+}

--- a/frontend/ai.client/src/app/schedules/services/grant-api.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/grant-api.service.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { GrantApiService } from './grant-api.service';
+import { ConfigService } from '../../services/config.service';
+
+const BASE = 'http://localhost:8000/runs/grant';
+
+describe('GrantApiService', () => {
+  let service: GrantApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        GrantApiService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(GrantApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('fetches grant status', async () => {
+    const status = { enabled: true, grantId: 'hlg-1' };
+    const promise = firstValueFrom(service.status());
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('GET');
+      req.flush(status);
+    });
+
+    expect(await promise).toEqual(status);
+  });
+
+  it('enables (creates/refreshes) the grant via POST', async () => {
+    const status = { enabled: true, grantId: 'hlg-1' };
+    const promise = firstValueFrom(service.enable());
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('POST');
+      req.flush(status);
+    });
+
+    expect(await promise).toEqual(status);
+  });
+
+  it('revokes the grant via DELETE', async () => {
+    const promise = firstValueFrom(service.revoke());
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ revoked: true });
+    });
+
+    expect(await promise).toEqual({ revoked: true });
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/grant-api.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/grant-api.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import { GrantRevokeResponse, GrantStatus } from '../models/grant.model';
+
+/**
+ * Thin HTTP layer over `/runs/grant` (app-api, cookie-authed). Backs the
+ * schedules page's enablement UX — a schedule cannot fire unattended
+ * without an active grant.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class GrantApiService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/runs/grant`);
+
+  status(): Observable<GrantStatus> {
+    return this.http.get<GrantStatus>(this.baseUrl());
+  }
+
+  /** Create-on-enable: mints/refreshes the grant from the caller's live session. */
+  enable(): Observable<GrantStatus> {
+    return this.http.post<GrantStatus>(this.baseUrl(), {});
+  }
+
+  revoke(): Observable<GrantRevokeResponse> {
+    return this.http.delete<GrantRevokeResponse>(this.baseUrl());
+  }
+}

--- a/frontend/ai.client/src/app/schedules/services/grant.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/grant.service.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { GrantService } from './grant.service';
+import { GrantApiService } from './grant-api.service';
+
+describe('GrantService', () => {
+  let service: GrantService;
+  let mockApi: {
+    status: ReturnType<typeof vi.fn>;
+    enable: ReturnType<typeof vi.fn>;
+    revoke: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockApi = { status: vi.fn(), enable: vi.fn(), revoke: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [GrantService, { provide: GrantApiService, useValue: mockApi }],
+    });
+    service = TestBed.inject(GrantService);
+  });
+
+  it('defaults to disabled before any load', () => {
+    expect(service.status$()).toEqual({ enabled: false });
+  });
+
+  it('loads the grant status', async () => {
+    mockApi.status.mockReturnValue(of({ enabled: true, grantId: 'hlg-1' }));
+
+    await service.loadStatus();
+
+    expect(service.status$()).toEqual({ enabled: true, grantId: 'hlg-1' });
+  });
+
+  it('falls back to disabled (without throwing) when status load fails', async () => {
+    mockApi.status.mockReturnValue(throwError(() => new Error('boom')));
+
+    await service.loadStatus();
+
+    expect(service.status$()).toEqual({ enabled: false });
+    expect(service.error$()).toBe('boom');
+  });
+
+  it('enables the grant and updates status', async () => {
+    mockApi.enable.mockReturnValue(of({ enabled: true, grantId: 'hlg-2' }));
+
+    const result = await service.enable();
+
+    expect(result).toEqual({ enabled: true, grantId: 'hlg-2' });
+    expect(service.status$()).toEqual({ enabled: true, grantId: 'hlg-2' });
+  });
+
+  it('propagates an enable failure (e.g. 409 no session to pin)', async () => {
+    mockApi.enable.mockReturnValue(throwError(() => new Error('409')));
+
+    await expect(service.enable()).rejects.toThrow('409');
+  });
+
+  it('revokes and resets status to disabled', async () => {
+    mockApi.status.mockReturnValue(of({ enabled: true, grantId: 'hlg-1' }));
+    await service.loadStatus();
+
+    mockApi.revoke.mockReturnValue(of({ revoked: true }));
+    await service.revoke();
+
+    expect(service.status$()).toEqual({ enabled: false });
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/grant.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/grant.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { GrantApiService } from './grant-api.service';
+import { GrantStatus } from '../models/grant.model';
+
+const DISABLED_STATUS: GrantStatus = { enabled: false };
+
+/** Signal-based state for the caller's headless-grant status. */
+@Injectable({
+  providedIn: 'root',
+})
+export class GrantService {
+  private apiService = inject(GrantApiService);
+
+  private status = signal<GrantStatus>(DISABLED_STATUS);
+  private loading = signal<boolean>(false);
+  private error = signal<string | null>(null);
+
+  readonly status$ = this.status.asReadonly();
+  readonly loading$ = this.loading.asReadonly();
+  readonly error$ = this.error.asReadonly();
+
+  async loadStatus(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const status = await firstValueFrom(this.apiService.status());
+      this.status.set(status);
+    } catch (err) {
+      // A 403/404 here means the caller shouldn't be on this page at all —
+      // the schedules list call is the source of truth for that gate, so
+      // just leave the grant looking disabled rather than erroring twice.
+      this.status.set(DISABLED_STATUS);
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load grant status';
+      this.error.set(errorMessage);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async enable(): Promise<GrantStatus> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const status = await firstValueFrom(this.apiService.enable());
+      this.status.set(status);
+      return status;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to enable scheduled runs';
+      this.error.set(errorMessage);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async revoke(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      await firstValueFrom(this.apiService.revoke());
+      this.status.set(DISABLED_STATUS);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to revoke scheduled runs';
+      this.error.set(errorMessage);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/schedules/services/schedule-api.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/schedule-api.service.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ScheduleApiService } from './schedule-api.service';
+import { ConfigService } from '../../services/config.service';
+import { ScheduledPrompt } from '../models/schedule.model';
+
+const BASE = 'http://localhost:8000/schedules';
+
+function stubSchedule(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  return {
+    scheduleId: 'sched-abc123def456',
+    assistantId: null,
+    label: 'Morning Briefing',
+    promptText: 'Summarize my classes',
+    cadence: 'daily',
+    hourLocal: 7,
+    weekday: null,
+    timezone: 'America/Boise',
+    state: 'active',
+    stateReason: null,
+    nextRunAt: '2026-07-06T14:00:00Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunSessionId: null,
+    lastError: null,
+    runsToday: 0,
+    maxRunsPerDay: 24,
+    enabledTools: null,
+    deliverEmail: false,
+    createdAt: '2026-07-05T00:00:00Z',
+    updatedAt: '2026-07-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ScheduleApiService', () => {
+  let service: ScheduleApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ScheduleApiService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(ScheduleApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('lists schedules', async () => {
+    const schedules = [stubSchedule()];
+    const promise = firstValueFrom(service.list());
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('GET');
+      req.flush({ schedules });
+    });
+
+    expect(await promise).toEqual({ schedules });
+  });
+
+  it('creates a schedule', async () => {
+    const created = stubSchedule();
+    const promise = firstValueFrom(service.create({
+      label: 'Morning Briefing',
+      promptText: 'Summarize my classes',
+      cadence: 'daily',
+      hourLocal: 7,
+      timezone: 'America/Boise',
+    }));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(BASE);
+      expect(req.request.method).toBe('POST');
+      req.flush(created);
+    });
+
+    expect(await promise).toEqual(created);
+  });
+
+  it('updates a schedule via PATCH', async () => {
+    const updated = stubSchedule({ label: 'Updated' });
+    const promise = firstValueFrom(service.update('sched-abc123def456', { label: 'Updated' }));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/sched-abc123def456`);
+      expect(req.request.method).toBe('PATCH');
+      req.flush(updated);
+    });
+
+    expect(await promise).toEqual(updated);
+  });
+
+  it('pauses a schedule', async () => {
+    const paused = stubSchedule({ state: 'paused' });
+    const promise = firstValueFrom(service.pause('sched-abc123def456'));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/sched-abc123def456/pause`);
+      expect(req.request.method).toBe('POST');
+      req.flush(paused);
+    });
+
+    expect(await promise).toEqual(paused);
+  });
+
+  it('resumes a schedule', async () => {
+    const resumed = stubSchedule({ state: 'active' });
+    const promise = firstValueFrom(service.resume('sched-abc123def456'));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/sched-abc123def456/resume`);
+      expect(req.request.method).toBe('POST');
+      req.flush(resumed);
+    });
+
+    expect(await promise).toEqual(resumed);
+  });
+
+  it('deletes a schedule', async () => {
+    const promise = firstValueFrom(service.delete('sched-abc123def456'));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/sched-abc123def456`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    await promise;
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/schedule-api.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/schedule-api.service.ts
@@ -1,0 +1,51 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import {
+  CreateScheduleRequest,
+  ScheduledPrompt,
+  ScheduledPromptsListResponse,
+  UpdateScheduleRequest,
+} from '../models/schedule.model';
+
+/**
+ * Thin HTTP layer over `/schedules/*` (app-api, cookie-authed). Mirrors
+ * `AssistantApiService` — no state, just the wire calls.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ScheduleApiService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/schedules`);
+
+  list(): Observable<ScheduledPromptsListResponse> {
+    return this.http.get<ScheduledPromptsListResponse>(this.baseUrl());
+  }
+
+  get(scheduleId: string): Observable<ScheduledPrompt> {
+    return this.http.get<ScheduledPrompt>(`${this.baseUrl()}/${scheduleId}`);
+  }
+
+  create(request: CreateScheduleRequest): Observable<ScheduledPrompt> {
+    return this.http.post<ScheduledPrompt>(this.baseUrl(), request);
+  }
+
+  update(scheduleId: string, request: UpdateScheduleRequest): Observable<ScheduledPrompt> {
+    return this.http.patch<ScheduledPrompt>(`${this.baseUrl()}/${scheduleId}`, request);
+  }
+
+  pause(scheduleId: string): Observable<ScheduledPrompt> {
+    return this.http.post<ScheduledPrompt>(`${this.baseUrl()}/${scheduleId}/pause`, {});
+  }
+
+  resume(scheduleId: string): Observable<ScheduledPrompt> {
+    return this.http.post<ScheduledPrompt>(`${this.baseUrl()}/${scheduleId}/resume`, {});
+  }
+
+  delete(scheduleId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl()}/${scheduleId}`);
+  }
+}

--- a/frontend/ai.client/src/app/schedules/services/schedule.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/schedule.service.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { ScheduleService } from './schedule.service';
+import { ScheduleApiService } from './schedule-api.service';
+import { ScheduledPrompt } from '../models/schedule.model';
+
+function stubSchedule(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  return {
+    scheduleId: 'sched-abc123def456',
+    assistantId: null,
+    label: 'Morning Briefing',
+    promptText: 'Summarize my classes',
+    cadence: 'daily',
+    hourLocal: 7,
+    weekday: null,
+    timezone: 'America/Boise',
+    state: 'active',
+    stateReason: null,
+    nextRunAt: '2026-07-06T14:00:00Z',
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunSessionId: null,
+    lastError: null,
+    runsToday: 0,
+    maxRunsPerDay: 24,
+    enabledTools: null,
+    deliverEmail: false,
+    createdAt: '2026-07-05T00:00:00Z',
+    updatedAt: '2026-07-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ScheduleService', () => {
+  let service: ScheduleService;
+  let mockApi: {
+    list: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockApi = {
+      list: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      delete: vi.fn(),
+    };
+    TestBed.configureTestingModule({
+      providers: [ScheduleService, { provide: ScheduleApiService, useValue: mockApi }],
+    });
+    service = TestBed.inject(ScheduleService);
+  });
+
+  it('loads schedules and marks the feature accessible', async () => {
+    const schedule = stubSchedule();
+    mockApi.list.mockReturnValue(of({ schedules: [schedule] }));
+
+    await service.loadSchedules();
+
+    expect(service.schedules$()).toEqual([schedule]);
+    expect(service.accessible$()).toBe(true);
+    expect(service.loading$()).toBe(false);
+  });
+
+  it('marks the feature inaccessible (not an error) on a 403', async () => {
+    mockApi.list.mockReturnValue(throwError(() => ({ status: 403 })));
+
+    await service.loadSchedules();
+
+    expect(service.accessible$()).toBe(false);
+    expect(service.schedules$()).toEqual([]);
+    expect(service.error$()).toBeNull();
+  });
+
+  it('marks the feature inaccessible on a 404 (kill switch off)', async () => {
+    mockApi.list.mockReturnValue(throwError(() => ({ status: 404 })));
+
+    await service.loadSchedules();
+
+    expect(service.accessible$()).toBe(false);
+  });
+
+  it('surfaces a real error for non-gating failures', async () => {
+    mockApi.list.mockReturnValue(throwError(() => new Error('network blip')));
+
+    await expect(service.loadSchedules()).rejects.toThrow('network blip');
+    expect(service.error$()).toBe('network blip');
+  });
+
+  it('creates a schedule and appends it locally', async () => {
+    const created = stubSchedule();
+    mockApi.create.mockReturnValue(of(created));
+
+    const result = await service.createSchedule({
+      label: created.label,
+      promptText: created.promptText,
+      cadence: created.cadence,
+      hourLocal: created.hourLocal,
+      timezone: created.timezone,
+    });
+
+    expect(result).toEqual(created);
+    expect(service.schedules$()).toEqual([created]);
+  });
+
+  it('replaces the schedule in the list on update', async () => {
+    const original = stubSchedule();
+    mockApi.list.mockReturnValue(of({ schedules: [original] }));
+    await service.loadSchedules();
+
+    const updated = { ...original, label: 'Renamed' };
+    mockApi.update.mockReturnValue(of(updated));
+
+    const result = await service.updateSchedule(original.scheduleId, { label: 'Renamed' });
+
+    expect(result.label).toBe('Renamed');
+    expect(service.schedules$()).toEqual([updated]);
+  });
+
+  it('removes the schedule from the list on delete', async () => {
+    const schedule = stubSchedule();
+    mockApi.list.mockReturnValue(of({ schedules: [schedule] }));
+    await service.loadSchedules();
+
+    mockApi.delete.mockReturnValue(of(undefined));
+    await service.deleteSchedule(schedule.scheduleId);
+
+    expect(service.schedules$()).toEqual([]);
+  });
+
+  it('pause/resume update the schedule state locally', async () => {
+    const schedule = stubSchedule();
+    mockApi.list.mockReturnValue(of({ schedules: [schedule] }));
+    await service.loadSchedules();
+
+    mockApi.pause.mockReturnValue(of({ ...schedule, state: 'paused' }));
+    await service.pauseSchedule(schedule.scheduleId);
+    expect(service.schedules$()[0].state).toBe('paused');
+
+    mockApi.resume.mockReturnValue(of({ ...schedule, state: 'active' }));
+    await service.resumeSchedule(schedule.scheduleId);
+    expect(service.schedules$()[0].state).toBe('active');
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/schedule.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/schedule.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  CreateScheduleRequest,
+  ScheduledPrompt,
+  UpdateScheduleRequest,
+} from '../models/schedule.model';
+import { ScheduleApiService } from './schedule-api.service';
+
+/**
+ * Signal-based state for the schedules feature. Mirrors AssistantService's
+ * shape: a private mutable signal, a readonly public view, and async
+ * methods that round-trip through the API service and keep local state in
+ * sync so the list page never needs a manual reload after a mutation.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ScheduleService {
+  private apiService = inject(ScheduleApiService);
+
+  private schedules = signal<ScheduledPrompt[]>([]);
+  private loading = signal<boolean>(false);
+  private error = signal<string | null>(null);
+  /**
+   * Set once the schedules list call has resolved (success OR a
+   * capability-shaped failure). Lets the page distinguish "still loading"
+   * from "loaded, and the feature isn't available to this user" without a
+   * separate capability signal (see gating note in schedules.page.ts).
+   */
+  private accessible = signal<boolean | null>(null);
+
+  readonly schedules$ = this.schedules.asReadonly();
+  readonly loading$ = this.loading.asReadonly();
+  readonly error$ = this.error.asReadonly();
+  readonly accessible$ = this.accessible.asReadonly();
+
+  async loadSchedules(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const response = await firstValueFrom(this.apiService.list());
+      this.schedules.set(response?.schedules ?? []);
+      this.accessible.set(true);
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 403 || status === 404) {
+        // Kill switch off or caller lacks the scheduled-runs capability —
+        // fail gracefully rather than surfacing an error state.
+        this.accessible.set(false);
+        this.schedules.set([]);
+        return;
+      }
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load schedules';
+      this.error.set(errorMessage);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async createSchedule(request: CreateScheduleRequest): Promise<ScheduledPrompt> {
+    this.error.set(null);
+    try {
+      const schedule = await firstValueFrom(this.apiService.create(request));
+      this.schedules.update((current) => [...current, schedule]);
+      return schedule;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to create schedule';
+      this.error.set(errorMessage);
+      throw err;
+    }
+  }
+
+  async updateSchedule(scheduleId: string, request: UpdateScheduleRequest): Promise<ScheduledPrompt> {
+    this.error.set(null);
+    try {
+      const updated = await firstValueFrom(this.apiService.update(scheduleId, request));
+      this.replaceInList(updated);
+      return updated;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to update schedule';
+      this.error.set(errorMessage);
+      throw err;
+    }
+  }
+
+  async pauseSchedule(scheduleId: string): Promise<ScheduledPrompt> {
+    const updated = await firstValueFrom(this.apiService.pause(scheduleId));
+    this.replaceInList(updated);
+    return updated;
+  }
+
+  async resumeSchedule(scheduleId: string): Promise<ScheduledPrompt> {
+    const updated = await firstValueFrom(this.apiService.resume(scheduleId));
+    this.replaceInList(updated);
+    return updated;
+  }
+
+  async deleteSchedule(scheduleId: string): Promise<void> {
+    await firstValueFrom(this.apiService.delete(scheduleId));
+    this.schedules.update((current) => current.filter((s) => s.scheduleId !== scheduleId));
+  }
+
+  async getSchedule(scheduleId: string): Promise<ScheduledPrompt | undefined> {
+    const cached = this.schedules().find((s) => s.scheduleId === scheduleId);
+    if (cached) {
+      return cached;
+    }
+    const schedule = await firstValueFrom(this.apiService.get(scheduleId));
+    return schedule;
+  }
+
+  private replaceInList(schedule: ScheduledPrompt): void {
+    this.schedules.update((current) => {
+      const idx = current.findIndex((s) => s.scheduleId === schedule.scheduleId);
+      if (idx === -1) {
+        return [...current, schedule];
+      }
+      const next = [...current];
+      next[idx] = schedule;
+      return next;
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Schedules management page (`frontend/ai.client/src/app/schedules/`): signal-based list (label, cadence summary, next run, state badge, last-run status + link to session), create/edit form (label, prompt, bounded cadence — daily/weekday/weekly + hour + IANA timezone, optional assistant, optional tool selection), pause/resume, delete-with-confirm.
- Enablement UX: grant-status banner + "Enable scheduled runs" (calls the new `POST /runs/grant`); `paused_error` with `stateReason: "reauth_required"` surfaces "Your access expired — log in and re-enable"; `stateReason: "oauth_required"` surfaces a "reconnect a tool" hint linking to `/settings/connectors`.
- Visibility gating: no dedicated client-side capability signal exists yet, so the sidenav "Scheduled Runs" entry and page both ride the `/schedules` list call — a 403/404 flips `ScheduleService.accessible$` to `false` and the UI fails gracefully (page shows a "not available" state; nav entry stays hidden).
- Backend: `POST /runs/grant` added to `apis/app_api/runs/routes.py`, reusing the exact create-on-enable `_resolve_grant` logic `POST /runs/now` already used (no duplication) — same cookie + kill-switch + `scheduled-runs` capability gating. Lets a user enable scheduled runs without running a prompt first.

## Known gap (flagged per the brief)

The B1 `PATCH /schedules/{id}` (`update_scheduled_prompt`) only writes a field when the incoming value is not `None` — there is currently **no way to clear** `assistantId` or `enabledTools` over the wire. The edit form has explicit "Detach assistant" / "Reset to all my tools" checkboxes to make the *intent* explicit, but they can only omit the field from the PATCH (a no-op against the current backend), not actually clear a previously-set value. A real fix needs a backend follow-up (e.g. a sentinel value, or splitting into a dedicated clear affordance) — out of scope for this PR per the brief's instruction to consume the B1 CRUD as-is.

## Test plan

- [x] Backend: `uv run python -m pytest tests/apis/app_api/test_runs_routes.py tests/routes/test_schedules_routes.py tests/architecture/ -q` — 62 passed
- [x] Frontend: `npx tsc --noEmit` and `npx ng build` — clean
- [x] Frontend: `npx ng test --watch=false --include='src/app/schedules/**/*.spec.ts'` — 46 passed
- [x] Frontend: `npx ng test --watch=false --include='src/app/components/sidenav/sidenav.spec.ts'` — 8 passed
- [x] Frontend: full `ng test` suite — passes; one pre-existing spec (`shared-view.page.spec.ts`) intermittently times out under full-suite worker-pool load (reproduces the same way on `develop` without these changes once the suite is large enough — documented cross-spec pollution in shared worker pools, not a regression from this PR)

No new npm/uv packages were added — everything is built from existing dependencies (`@angular/forms`, `@angular/cdk/dialog`, `@ng-icons/heroicons`, `Intl.supportedValuesOf` at runtime with a static fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)