### PR TITLE
feat(schedules): B2 — scheduler dispatcher + worker

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -237,6 +237,78 @@ jobs:
       - name: Deploy kb-sync worker image
         run: bash scripts/build/deploy-image-lambda-one.sh kb-sync-worker
 
+  build-scheduled-runs:
+    name: Build scheduled-runs image
+    needs: test-backend
+    # Native ARM64 runner — both scheduled-runs Lambdas are arm64 (see the
+    # scheduled-runs CDK construct), matching the kb-sync pattern.
+    runs-on: ubuntu-24.04-arm
+    environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    outputs:
+      image_tag: ${{ steps.build.outputs.image_tag }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/build-and-push-image
+        id: build
+        with:
+          image-name: scheduled-runs
+          aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  deploy-scheduled-runs-code:
+    name: Deploy scheduled-runs Lambda images
+    # One image, two functions: dispatcher + worker share the
+    # scheduled-runs image and differ only in ImageConfig.Command
+    # (CDK-owned), so a single job points both at the freshly-built tag.
+    needs: [build-scheduled-runs, test-backend]
+    runs-on: ubuntu-24.04
+    environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'development' }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      CDK_AWS_REGION: ${{ vars.AWS_REGION }}
+      CDK_AWS_ACCOUNT: ${{ vars.CDK_AWS_ACCOUNT }}
+      CDK_PROJECT_PREFIX: ${{ vars.CDK_PROJECT_PREFIX }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ vars.CDK_AWS_ACCOUNT }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Deploy scheduled-runs dispatcher image
+        run: bash scripts/build/deploy-image-lambda-one.sh scheduled-runs-dispatcher
+      - name: Deploy scheduled-runs worker image
+        run: bash scripts/build/deploy-image-lambda-one.sh scheduled-runs-worker
+
   deploy-artifact-render-code:
     name: Deploy artifact-render Lambda code
     # Lambda zip code deploy. Mirrors the build-* jobs but for a

--- a/backend/Dockerfile.scheduled-runs
+++ b/backend/Dockerfile.scheduled-runs
@@ -1,0 +1,43 @@
+# scheduled-runs Lambda image — dispatcher + worker for the F3 scheduled
+# trigger (docs/specs/scheduled-runs-phase-b-brief.md, docs/specs/
+# scheduled-agent-runs.md).
+#
+# One image, two Lambda functions: the CDK construct
+# (infrastructure/lib/constructs/scheduled-runs/scheduled-runs-construct.ts)
+# points both functions at this image with different ImageConfig.Command
+# overrides (dispatcher vs worker handler). The command override is
+# function *configuration*, so the workflow's
+# `update-function-code --image-uri` swaps code on both functions
+# without touching their handlers. Mirrors backend/Dockerfile.kb-sync,
+# except the two handlers are plain top-level modules (dispatcher.py /
+# worker.py) rather than living under the apis.* namespace package — the
+# house rule (CLAUDE.md) keeps standalone Lambda code out of apis/, so
+# there is no natural dotted path to reuse here the way kb-sync reuses
+# apis.app_api.kb_sync.
+#
+# Base image digest-pinned, same pin as the other Lambda images (see
+# backend/Dockerfile.kb-sync and the supply-chain dockerfile-pinning test).
+
+FROM public.ecr.aws/lambda/python:3.12@sha256:745b0eb8a9787e9c4bfd4fc4cae942399a2225831c96394ae70c0c2a7c7c6168
+
+# Dependencies (exact pins)
+COPY backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Application code — namespace-package layout mirrors backend/src for the
+# apis.shared modules the handlers import. If a handler needs more, COPY
+# it here AND add the path to the scheduled-runs SOURCE_DIRS in
+# scripts/build/build-one.sh so the content-hash tag notices changes.
+COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
+COPY backend/src/apis/shared/harness/ ${LAMBDA_TASK_ROOT}/apis/shared/harness/
+COPY backend/src/apis/shared/scheduled_prompts/ ${LAMBDA_TASK_ROOT}/apis/shared/scheduled_prompts/
+COPY backend/src/apis/shared/sessions_bff/ ${LAMBDA_TASK_ROOT}/apis/shared/sessions_bff/
+COPY backend/src/apis/shared/sessions/ ${LAMBDA_TASK_ROOT}/apis/shared/sessions/
+
+# The two handlers themselves, as plain top-level modules.
+COPY backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py ${LAMBDA_TASK_ROOT}/dispatcher.py
+COPY backend/src/lambdas/scheduled_runs_worker/worker.py ${LAMBDA_TASK_ROOT}/worker.py
+
+# Default command: dispatcher. The worker function's CMD is overridden
+# to worker.lambda_handler by its ImageConfig.
+CMD ["dispatcher.lambda_handler"]

--- a/backend/src/apis/shared/scheduled_prompts/models.py
+++ b/backend/src/apis/shared/scheduled_prompts/models.py
@@ -52,6 +52,11 @@ class ScheduledPrompt(BaseModel):
     last_run_status: Optional[str] = Field(None, alias="lastRunStatus", description="Outcome of the last completed run")
     last_run_session_id: Optional[str] = Field(None, alias="lastRunSessionId", description="Session the last run materialized as")
     last_error: Optional[str] = Field(None, alias="lastError", description="Error detail from the last failed run")
+    consecutive_failures: int = Field(
+        0,
+        alias="consecutiveFailures",
+        description="Consecutive error runs; reset to 0 on a completed run. Drives the worker's repeated-failure breaker (mirrors SyncPolicy).",
+    )
     # Runaway guards (B1 fields only — B2 dispatcher/worker enforce these;
     # present now so B2 needs no migration).
     runs_today: int = Field(0, alias="runsToday", description="Runs fired today (runaway-guard counter)")

--- a/backend/src/apis/shared/scheduled_prompts/service.py
+++ b/backend/src/apis/shared/scheduled_prompts/service.py
@@ -321,12 +321,16 @@ async def record_run_result(
     status: str,
     session_id: Optional[str] = None,
     error: Optional[str] = None,
-) -> None:
-    """Record a completed run's outcome and bump the runaway-guard counter.
+) -> int:
+    """Record a run's outcome; return the new consecutive-failure streak.
 
-    ``runs_today``/``runs_today_date`` reset when the UTC date rolls over —
-    the B2 dispatcher reads this counter to auto-pause a schedule that
-    exceeds ``max_runs_per_day``. Not called by anything yet in B1.
+    Bumps the runaway-guard counter (``runs_today``/``runs_today_date``,
+    reset on a UTC date rollover) and maintains ``consecutive_failures`` — a
+    ``"completed"`` run resets it to 0, any other status increments it
+    (mirrors ``sync_policies.update_sync_result``). The B2 worker uses the
+    returned streak to trip the repeated-failure breaker at any threshold;
+    the dispatcher reads ``runs_today`` to auto-pause a schedule that exceeds
+    ``max_runs_per_day``.
     """
     today = date.today().isoformat()
     existing = await get_scheduled_prompt(user_id, schedule_id)
@@ -334,12 +338,16 @@ async def record_run_result(
     if existing is not None and existing.runs_today_date == today:
         runs_today = existing.runs_today + 1
 
+    prior_failures = existing.consecutive_failures if existing is not None else 0
+    consecutive_failures = 0 if status == "completed" else prior_failures + 1
+
     now = _get_current_timestamp()
     values = {
         ":now": now,
         ":status": status,
         ":runs_today": runs_today,
         ":today": today,
+        ":cf": consecutive_failures,
     }
     set_parts = [
         "lastRunAt = :now",
@@ -347,6 +355,7 @@ async def record_run_result(
         "updatedAt = :now",
         "runsToday = :runs_today",
         "runsTodayDate = :today",
+        "consecutiveFailures = :cf",
     ]
     if session_id is not None:
         set_parts.append("lastRunSessionId = :session_id")
@@ -360,6 +369,7 @@ async def record_run_result(
         UpdateExpression="SET " + ", ".join(set_parts),
         ExpressionAttributeValues=values,
     )
+    return consecutive_failures
 
 
 async def update_scheduled_prompt(

--- a/backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py
+++ b/backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py
@@ -1,0 +1,203 @@
+"""Scheduled-runs dispatcher — the single initiator of scheduled agent runs.
+
+Fired by one EventBridge rate rule (every 5 minutes). Sweeps the sparse
+DueScheduleIndex (`apis.shared.scheduled_prompts.service.list_due_schedules`)
+and, for each due schedule, applies the runaway guards from
+docs/specs/scheduled-runs-phase-b-brief.md / scheduled-agent-runs.md §7 in
+order, mirroring the KB-sync dispatcher
+(`apis/app_api/kb_sync/dispatcher.py`) almost line for line:
+
+1. Kill switch       — SCHEDULED_RUNS_ENABLED must be "true" or the tick
+                       no-ops (the EventBridge rule itself is also gated
+                       by `config.scheduledRuns.enabled` in CDK — belt and
+                       braces, same as KB-sync).
+2. Runaway guard      — `runs_today` (reset on UTC date rollover) compared
+                       against the schedule's own `max_runs_per_day`. A
+                       schedule that would exceed its ceiling is paused
+                       instead of dispatched.
+3. Re-arm BEFORE work — `next_run_at` advances via a conditional write
+                       (`rearm_schedule`) before the worker is invoked, so
+                       a double-fired tick is idempotent: the second
+                       dispatcher loses the conditional write and skips
+                       the schedule. A crashed worker costs one missed
+                       run, never a hot loop.
+
+Governance note (brief §1): delivery is role/auth-based — the dispatcher's
+only job is "who's due, how many times today, don't double-fire". No
+content classification happens here or in the worker.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict
+
+from apis.shared.scheduled_prompts.service import (
+    list_due_schedules,
+    rearm_schedule,
+    set_schedule_state,
+)
+from apis.shared.scheduled_prompts.models import ScheduledPrompt
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+METRIC_NAMESPACE = "ScheduledRuns"
+
+# Cadence -> a normalized re-arm delta. The dispatcher recomputes the exact
+# next_run_at via the same cadence math the schedule was created with
+# (compute_next_run_at); this constant is only a defensive fallback bound so
+# an unexpected cadence value can never wedge a schedule into a tight loop.
+_FALLBACK_REARM_DELTA = timedelta(hours=1)
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _today() -> str:
+    return date.today().isoformat()
+
+
+def _invoke_worker(payload: Dict[str, Any]) -> None:
+    """Async-invoke the scheduled-runs worker Lambda (fire-and-forget)."""
+    import boto3
+
+    function_name = os.environ["SCHEDULED_RUNS_WORKER_FUNCTION_NAME"]
+    boto3.client("lambda").invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _emit_metrics(counts: Dict[str, int]) -> None:
+    """Best-effort CloudWatch metrics; never fails the tick."""
+    import boto3
+
+    try:
+        metric_data = [
+            {"MetricName": name, "Value": value, "Unit": "Count"} for name, value in counts.items()
+        ]
+        boto3.client("cloudwatch").put_metric_data(Namespace=METRIC_NAMESPACE, MetricData=metric_data)
+    except Exception as e:
+        logger.warning(f"Failed to emit ScheduledRuns metrics: {e}")
+
+
+def _next_run_at(schedule: ScheduledPrompt, now: datetime) -> str:
+    """Recompute the next due timestamp using the schedule's own cadence.
+
+    Reuses the exact cadence math the schedule was created with
+    (`compute_next_run_at`) so a daily/weekday/weekly schedule advances
+    correctly — no cron strings, no engine-side interval table.
+    """
+    from apis.shared.scheduled_prompts.service import compute_next_run_at
+
+    try:
+        return compute_next_run_at(
+            schedule.cadence,
+            schedule.hour_local,
+            schedule.timezone,
+            weekday=schedule.weekday,
+            from_time=now,
+        )
+    except Exception as e:
+        # Defensive fallback — should never trigger for a valid schedule,
+        # but a wedged schedule is worse than a slightly-off re-arm.
+        logger.error(f"Schedule {schedule.schedule_id}: cadence recompute failed ({e}); using fallback delta")
+        return (now + _FALLBACK_REARM_DELTA).isoformat().replace("+00:00", "Z")
+
+
+def _runs_today(schedule: ScheduledPrompt, today: str) -> int:
+    """Runaway-guard counter, reset across a UTC date rollover.
+
+    Mirrors `record_run_result`'s own rollover logic: `runs_today` only
+    counts against `runs_today_date`; a stale date means today's count is
+    effectively zero (the counter has not been touched yet today).
+    """
+    if schedule.runs_today_date == today:
+        return schedule.runs_today
+    return 0
+
+
+async def _dispatch_schedule(schedule: ScheduledPrompt, now: datetime, counts: Dict[str, int]) -> None:
+    today = _today()
+
+    # Guard 2 — runaway: would firing this schedule exceed its own daily
+    # ceiling? Check BEFORE re-arming/invoking, using the rollover-aware
+    # counter (a run this tick would be the (runs_today + 1)th today).
+    runs_today = _runs_today(schedule, today)
+    if runs_today >= schedule.max_runs_per_day:
+        await set_schedule_state(
+            schedule.user_id,
+            schedule.schedule_id,
+            "paused_error",
+            state_reason="max_runs_per_day_exceeded",
+        )
+        logger.warning(
+            f"Schedule {schedule.schedule_id}: runaway guard tripped "
+            f"({runs_today}/{schedule.max_runs_per_day} runs today); pausing"
+        )
+        counts["PausedRunaway"] += 1
+        return
+
+    # Guard 3 — re-arm before work; losing the conditional write means
+    # another dispatcher tick already claimed this schedule.
+    new_next = _next_run_at(schedule, now)
+    won = await rearm_schedule(
+        schedule.user_id, schedule.schedule_id, schedule.next_run_at, new_next
+    )
+    if not won:
+        counts["RearmLost"] += 1
+        return
+
+    _invoke_worker(
+        {
+            "scheduleId": schedule.schedule_id,
+            "userId": schedule.user_id,
+        }
+    )
+    counts["Dispatched"] += 1
+
+
+async def dispatch_once() -> Dict[str, int]:
+    """One dispatcher tick. Returns the metric counts (also emitted)."""
+    counts: Dict[str, int] = {
+        "SchedulesDue": 0,
+        "Dispatched": 0,
+        "PausedRunaway": 0,
+        "RearmLost": 0,
+    }
+
+    if os.environ.get("SCHEDULED_RUNS_ENABLED", "false").lower() != "true":
+        logger.info("SCHEDULED_RUNS_ENABLED is not true; dispatcher tick is a no-op")
+        return counts
+
+    now = _now()
+    limit = _env_int("SCHEDULED_RUNS_DISPATCH_LIMIT", 20)
+    now_iso = now.isoformat().replace("+00:00", "Z")
+    due = await list_due_schedules(now=now_iso, limit=limit)
+    counts["SchedulesDue"] = len(due)
+    logger.info(f"Dispatcher tick: {len(due)} due schedules (limit {limit})")
+
+    for schedule in due:
+        try:
+            await _dispatch_schedule(schedule, now, counts)
+        except Exception as e:
+            # One broken schedule must not starve the rest of the sweep.
+            logger.error(f"Failed to dispatch schedule {schedule.schedule_id}: {e}", exc_info=True)
+
+    _emit_metrics(counts)
+    return counts
+
+
+def lambda_handler(event, context):
+    """EventBridge entry point."""
+    counts = asyncio.run(dispatch_once())
+    return {"statusCode": 200, "body": counts}

--- a/backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt
+++ b/backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt
@@ -1,0 +1,6 @@
+# scheduled-runs Lambda image dependencies (backend/Dockerfile.scheduled-runs).
+# Exact pins per repo policy; versions match backend/uv.lock.
+boto3==1.43.9
+pydantic==2.12.5
+httpx==0.28.1
+bedrock-agentcore==1.9.1

--- a/backend/src/lambdas/scheduled_runs_worker/requirements.txt
+++ b/backend/src/lambdas/scheduled_runs_worker/requirements.txt
@@ -1,0 +1,6 @@
+# scheduled-runs Lambda image dependencies (backend/Dockerfile.scheduled-runs).
+# Exact pins per repo policy; versions match backend/uv.lock.
+boto3==1.43.9
+pydantic==2.12.5
+httpx==0.28.1
+bedrock-agentcore==1.9.1

--- a/backend/src/lambdas/scheduled_runs_worker/worker.py
+++ b/backend/src/lambdas/scheduled_runs_worker/worker.py
@@ -1,0 +1,175 @@
+"""Scheduled-runs worker — executes a single schedule's headless run.
+
+Given `{"scheduleId", "userId"}` from the dispatcher (async-invoked,
+`InvocationType=Event`), resolves the schedule record, calls
+`run_agent_headless(trigger="schedule")` with its snapshotted config, and
+records the outcome via `apis.shared.scheduled_prompts.service`.
+
+Governance (docs/specs/scheduled-runs-phase-b-brief.md §1): a scheduled run
+executes as the owning user with that user's own RBAC and delivers back to
+that same user's session list. Delivery already happens inside
+`run_agent_headless` (the runtime persists the session/messages during the
+turn) — this worker's only job after the call returns is bookkeeping:
+record the outcome, and pause the schedule on the terminal failure modes
+below (mirrors the KB-sync worker's pause/breaker outcomes, `apis/app_api/
+kb_sync/worker.py`).
+
+Failure handling (brief §2, "Worker" bullet):
+  - HeadlessAuthError (no/expired headless grant)  -> paused_error,
+    state_reason="reauth_required". Not a failure streak — the user must
+    log in again and re-enable; retry-spamming a dead grant is pointless.
+  - RunResult.status == "oauth_required" (a connector tool needs (re-)
+    consent; a headless run cannot pop a consent window) -> paused_error,
+    state_reason="oauth_required". The consent URL is recorded in
+    `last_error` for a future B3 surface to render.
+  - Any other error/timeout status (and any unexpected exception) ->
+    record_run_result(status="error"), which increments the persistent
+    ``consecutive_failures`` counter and returns the new streak; after
+    SCHEDULED_RUNS_MAX_FAILURES consecutive failures, paused_error,
+    state_reason="repeated_failures" (same breaker shape as KB-sync's
+    consecutive_failures >= 5).
+  - completed -> record_run_result(status="completed", session_id=...),
+    which resets the streak to 0.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from apis.shared.harness import (
+    CognitoRefreshBearerAuth,
+    HeadlessAuthError,
+    RunResult,
+    run_agent_headless,
+)
+from apis.shared.scheduled_prompts.models import ScheduledPrompt
+from apis.shared.scheduled_prompts.service import (
+    get_scheduled_prompt,
+    record_run_result,
+    set_schedule_state,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
+async def _record_failure_and_maybe_pause(
+    schedule: ScheduledPrompt,
+    *,
+    error: Optional[str],
+    session_id: Optional[str],
+    max_failures: int,
+    result_label: str,
+) -> Dict[str, Any]:
+    """Record an errored run and trip the breaker on a real failure streak.
+
+    ``record_run_result`` maintains the persistent ``consecutive_failures``
+    counter (reset on a completed run) and returns the new streak, so the
+    breaker fires correctly at any ``max_failures`` — a last-status proxy
+    could only ever see one run back and so never reach a threshold > 2.
+    """
+    streak = await record_run_result(
+        schedule.user_id,
+        schedule.schedule_id,
+        status="error",
+        session_id=session_id,
+        error=error,
+    )
+    if streak >= max_failures:
+        await set_schedule_state(
+            schedule.user_id,
+            schedule.schedule_id,
+            "paused_error",
+            state_reason="repeated_failures",
+        )
+        logger.warning(
+            f"Schedule {schedule.schedule_id}: {streak} consecutive failures "
+            f"(max {max_failures}); pausing"
+        )
+        return {"scheduleId": schedule.schedule_id, "result": "paused_error", "reason": "repeated_failures"}
+    return {"scheduleId": schedule.schedule_id, "result": result_label}
+
+
+async def _pause_reauth(schedule: ScheduledPrompt, reason: str, detail: Optional[str] = None) -> Dict[str, Any]:
+    logger.warning(
+        f"Schedule {schedule.schedule_id}: pausing ({reason}) for user {schedule.user_id}"
+        + (f" — {detail}" if detail else "")
+    )
+    await record_run_result(schedule.user_id, schedule.schedule_id, status="error", error=detail or reason)
+    await set_schedule_state(
+        schedule.user_id,
+        schedule.schedule_id,
+        "paused_error",
+        state_reason=reason,
+    )
+    return {"scheduleId": schedule.schedule_id, "result": "paused_error", "reason": reason}
+
+
+async def run_schedule(payload: Dict[str, Any]) -> Dict[str, Any]:
+    schedule_id = payload["scheduleId"]
+    user_id = payload["userId"]
+
+    schedule = await get_scheduled_prompt(user_id, schedule_id)
+    if schedule is None:
+        logger.info(f"Scheduled-runs worker: schedule {schedule_id} no longer exists; dropping run")
+        return {"scheduleId": schedule_id, "result": "dropped"}
+
+    try:
+        result: RunResult = await run_agent_headless(
+            user_id=user_id,
+            prompt=schedule.prompt_text,
+            auth=CognitoRefreshBearerAuth(),
+            title=schedule.label,
+            rag_assistant_id=schedule.assistant_id,
+            enabled_tools=schedule.enabled_tools,
+            trigger="schedule",
+        )
+    except HeadlessAuthError as e:
+        # No active headless grant, or Cognito refused the refresh
+        # exchange — the user must log in and re-enable. Do not
+        # retry-spam a dead credential.
+        return await _pause_reauth(schedule, "reauth_required", str(e))
+    except Exception as e:
+        # Last-resort catch: always record the run so the schedule never
+        # gets stuck silently un-run, and the failure-streak breaker sees it.
+        logger.error(f"Scheduled-runs worker: unexpected failure on schedule {schedule_id}: {e}", exc_info=True)
+        return await _record_failure_and_maybe_pause(
+            schedule,
+            error=str(e),
+            session_id=None,
+            max_failures=_env_int("SCHEDULED_RUNS_MAX_FAILURES", 3),
+            result_label="error",
+        )
+
+    if result.status == "oauth_required":
+        detail = None
+        if result.oauth_required:
+            first = result.oauth_required[0]
+            detail = f"provider={first.provider_id} authorization_url={first.authorization_url}"
+        return await _pause_reauth(schedule, "oauth_required", detail)
+
+    if result.status == "completed":
+        await record_run_result(
+            user_id, schedule_id, status="completed", session_id=result.session_id
+        )
+        logger.info(f"Schedule {schedule_id}: run {result.run_id} completed (session {result.session_id})")
+        return {"scheduleId": schedule_id, "result": "completed", "sessionId": result.session_id}
+
+    # error / timeout — record and apply the consecutive-failure breaker.
+    return await _record_failure_and_maybe_pause(
+        schedule,
+        error=result.error,
+        session_id=result.session_id,
+        max_failures=_env_int("SCHEDULED_RUNS_MAX_FAILURES", 3),
+        result_label=result.status,
+    )
+
+
+def lambda_handler(event, context):
+    """Async-invoke entry point (InvocationType=Event from the dispatcher)."""
+    return asyncio.run(run_schedule(event))

--- a/backend/tests/lambdas/conftest.py
+++ b/backend/tests/lambdas/conftest.py
@@ -1,9 +1,10 @@
 """Lambda-handler test fixtures (moto).
 
-Mirrors the assistants-table fixture from tests/shared/conftest.py —
-pytest dir-scoped conftests don't share fixtures across sibling test
-packages, and the kb-sync Lambda tests need the same table shape the
-services use (including the sparse DueSyncIndex).
+Mirrors the assistants-table / sessions-metadata-table fixtures from
+tests/shared/conftest.py — pytest dir-scoped conftests don't share
+fixtures across sibling test packages, and the kb-sync and scheduled-runs
+Lambda tests need the same table shapes the services use (including the
+sparse DueSyncIndex / DueScheduleIndex).
 """
 
 import boto3
@@ -24,21 +25,22 @@ def aws(monkeypatch):
         yield
 
 
+def _gsi(index_name, hash_key, range_key):
+    return {
+        "IndexName": index_name,
+        "KeySchema": [
+            {"AttributeName": hash_key, "KeyType": "HASH"},
+            {"AttributeName": range_key, "KeyType": "RANGE"},
+        ],
+        "Projection": {"ProjectionType": "ALL"},
+    }
+
+
 @pytest.fixture()
 def assistants_table(aws, monkeypatch):
     ddb = boto3.client("dynamodb", region_name=AWS_REGION)
     name = "test-assistants"
     monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", name)
-
-    def gsi(index_name, hash_key, range_key):
-        return {
-            "IndexName": index_name,
-            "KeySchema": [
-                {"AttributeName": hash_key, "KeyType": "HASH"},
-                {"AttributeName": range_key, "KeyType": "RANGE"},
-            ],
-            "Projection": {"ProjectionType": "ALL"},
-        }
 
     ddb.create_table(
         TableName=name,
@@ -55,8 +57,70 @@ def assistants_table(aws, monkeypatch):
             {"AttributeName": "GSI4_SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            gsi("OwnerStatusIndex", "GSI_PK", "GSI_SK"),
-            gsi("DueSyncIndex", "GSI4_PK", "GSI4_SK"),
+            _gsi("OwnerStatusIndex", "GSI_PK", "GSI_SK"),
+            _gsi("DueSyncIndex", "GSI4_PK", "GSI4_SK"),
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(name)
+
+
+@pytest.fixture()
+def sessions_metadata_table(aws, monkeypatch):
+    """Sessions-metadata table shape used by scheduled_prompts + harness
+    (schedules, the sparse DueScheduleIndex, and RUN# audit records)."""
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    name = "test-sessions-metadata"
+    monkeypatch.setenv("DYNAMODB_SESSIONS_METADATA_TABLE_NAME", name)
+
+    ddb.create_table(
+        TableName=name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI3_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI3_SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            _gsi("UserTimestampIndex", "GSI1PK", "GSI1SK"),
+            _gsi("SessionLookupIndex", "GSI_PK", "GSI_SK"),
+            _gsi("DueScheduleIndex", "GSI3_PK", "GSI3_SK"),
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(name)
+
+
+@pytest.fixture()
+def bff_sessions_table(aws, monkeypatch):
+    """BFF sessions table shape used by HeadlessGrantService (sparse
+    HeadlessGrantUserIndex GSI)."""
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    name = "test-bff-sessions"
+    monkeypatch.setenv("BFF_SESSIONS_TABLE_NAME", name)
+
+    ddb.create_table(
+        TableName=name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "grant_user_id", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "N"},
+        ],
+        GlobalSecondaryIndexes=[
+            _gsi("HeadlessGrantUserIndex", "grant_user_id", "created_at"),
         ],
         BillingMode="PAY_PER_REQUEST",
     )

--- a/backend/tests/lambdas/test_scheduled_runs_dispatcher.py
+++ b/backend/tests/lambdas/test_scheduled_runs_dispatcher.py
@@ -1,0 +1,209 @@
+"""Scheduled-runs dispatcher tests (moto DynamoDB, stubbed worker invoke).
+
+Mirrors backend/tests/lambdas/test_kb_sync_dispatcher.py's structure: due
+sweep, runaway guard (incl. UTC date rollover), conditional rearm
+win/lose, and invoke fan-out — using the REAL scheduled_prompts service so
+the dispatcher's assumptions about that data plane are cross-checked
+against the actual storage schema.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from apis.shared.scheduled_prompts.service import (
+    get_scheduled_prompt,
+    create_scheduled_prompt,
+    set_schedule_state,
+)
+from lambdas.scheduled_runs_dispatcher import dispatcher
+
+pytestmark = pytest.mark.asyncio
+
+USER_ID = "user-1"
+PAST = "2000-01-01T00:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def scheduled_runs_env(monkeypatch):
+    monkeypatch.setenv("SCHEDULED_RUNS_ENABLED", "true")
+    monkeypatch.setenv("SCHEDULED_RUNS_WORKER_FUNCTION_NAME", "test-scheduled-runs-worker")
+
+
+@pytest.fixture()
+def invoked_workers(monkeypatch):
+    """Capture worker invocations instead of calling Lambda."""
+    payloads = []
+    monkeypatch.setattr(dispatcher, "_invoke_worker", payloads.append)
+    return payloads
+
+
+@pytest.fixture(autouse=True)
+def no_metrics(monkeypatch):
+    monkeypatch.setattr(dispatcher, "_emit_metrics", lambda counts: None)
+
+
+async def _make_due_schedule(sessions_metadata_table, *, max_runs_per_day=24, label="Morning Briefing"):
+    schedule = await create_scheduled_prompt(
+        user_id=USER_ID,
+        label=label,
+        prompt_text="Summarize my day",
+        cadence="daily",
+        hour_local=9,
+        timezone_name="America/Boise",
+    )
+    # Force it due immediately (create_scheduled_prompt always computes a
+    # future next_run_at) and set the runaway-guard ceiling for this test.
+    sessions_metadata_table.update_item(
+        Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"},
+        UpdateExpression="SET nextRunAt = :past, GSI3_SK = :gsisk, maxRunsPerDay = :max",
+        ExpressionAttributeValues={
+            ":past": PAST,
+            ":gsisk": f"{PAST}#{schedule.schedule_id}",
+            ":max": max_runs_per_day,
+        },
+    )
+    return await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+
+
+class TestKillSwitch:
+    async def test_disabled_tick_is_noop(self, sessions_metadata_table, invoked_workers, monkeypatch):
+        monkeypatch.setenv("SCHEDULED_RUNS_ENABLED", "false")
+        await _make_due_schedule(sessions_metadata_table)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["SchedulesDue"] == 0
+        assert invoked_workers == []
+
+
+class TestRunawayGuard:
+    async def test_exceeding_ceiling_pauses_instead_of_dispatching(self, sessions_metadata_table, invoked_workers):
+        schedule = await _make_due_schedule(sessions_metadata_table, max_runs_per_day=3)
+        sessions_metadata_table.update_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"},
+            UpdateExpression="SET runsToday = :n, runsTodayDate = :today",
+            ExpressionAttributeValues={":n": 3, ":today": date.today().isoformat()},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["PausedRunaway"] == 1
+        assert invoked_workers == []
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "paused_error"
+        assert updated.state_reason == "max_runs_per_day_exceeded"
+
+    async def test_under_ceiling_still_dispatches(self, sessions_metadata_table, invoked_workers):
+        schedule = await _make_due_schedule(sessions_metadata_table, max_runs_per_day=3)
+        sessions_metadata_table.update_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"},
+            UpdateExpression="SET runsToday = :n, runsTodayDate = :today",
+            ExpressionAttributeValues={":n": 2, ":today": date.today().isoformat()},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        assert counts["PausedRunaway"] == 0
+
+    async def test_stale_date_rollover_resets_counter(self, sessions_metadata_table, invoked_workers):
+        """runsToday from a previous UTC day must not count against today's
+        ceiling — the rollover-aware counter treats it as zero."""
+        schedule = await _make_due_schedule(sessions_metadata_table, max_runs_per_day=1)
+        sessions_metadata_table.update_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"},
+            UpdateExpression="SET runsToday = :n, runsTodayDate = :yesterday",
+            ExpressionAttributeValues={":n": 5, ":yesterday": "2000-01-01"},
+        )
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        assert counts["PausedRunaway"] == 0
+
+
+class TestConditionalRearm:
+    async def test_happy_path_dispatches_and_rearms(self, sessions_metadata_table, invoked_workers):
+        schedule = await _make_due_schedule(sessions_metadata_table)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        assert invoked_workers == [{"scheduleId": schedule.schedule_id, "userId": USER_ID}]
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.next_run_at > datetime.now(timezone.utc).isoformat()
+
+    async def test_dispatched_schedule_not_redispatched_same_tick(self, sessions_metadata_table, invoked_workers):
+        await _make_due_schedule(sessions_metadata_table)
+
+        await dispatcher.dispatch_once()
+        counts = await dispatcher.dispatch_once()
+
+        # Re-armed a day out (daily cadence) — second tick sees nothing due.
+        assert counts["SchedulesDue"] == 0
+        assert len(invoked_workers) == 1
+
+    async def test_lost_conditional_write_skips_without_double_invoke(
+        self, sessions_metadata_table, invoked_workers, monkeypatch
+    ):
+        """Simulate a double-fired tick: another dispatcher already won the
+        conditional rearm before this call runs `_dispatch_schedule`."""
+        schedule = await _make_due_schedule(sessions_metadata_table)
+
+        real_rearm = dispatcher.rearm_schedule
+
+        async def rearm_and_lose(*args, **kwargs):
+            # A concurrent dispatcher wins first — real rearm succeeds once,
+            # then this call's own attempt (with the stale expected value)
+            # would lose. Simplest simulation: force False directly.
+            return False
+
+        monkeypatch.setattr(dispatcher, "rearm_schedule", rearm_and_lose)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["RearmLost"] == 1
+        assert invoked_workers == []
+        # next_run_at untouched — schedule remains due for the next tick.
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.next_run_at == PAST
+        assert real_rearm is not None  # sanity: we didn't lose the reference
+
+
+class TestBrokenScheduleIsolation:
+    async def test_broken_schedule_does_not_starve_sweep(self, sessions_metadata_table, invoked_workers, monkeypatch):
+        schedule_a = await _make_due_schedule(sessions_metadata_table, label="A")
+        schedule_b = await _make_due_schedule(sessions_metadata_table, label="B")
+
+        real_rearm = dispatcher.rearm_schedule
+        calls = {"n": 0}
+
+        async def flaky_rearm(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("boom")
+            return await real_rearm(*args, **kwargs)
+
+        monkeypatch.setattr(dispatcher, "rearm_schedule", flaky_rearm)
+
+        counts = await dispatcher.dispatch_once()
+
+        assert counts["Dispatched"] == 1
+        assert counts["SchedulesDue"] == 2
+        dispatched_ids = {p["scheduleId"] for p in invoked_workers}
+        assert dispatched_ids <= {schedule_a.schedule_id, schedule_b.schedule_id}
+
+
+class TestCadenceRearm:
+    async def test_next_run_at_uses_schedule_cadence(self, sessions_metadata_table, invoked_workers):
+        schedule = await _make_due_schedule(sessions_metadata_table)
+
+        await dispatcher.dispatch_once()
+
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        next_dt = datetime.fromisoformat(updated.next_run_at.rstrip("Z")).replace(tzinfo=timezone.utc)
+        # Daily at 9am America/Boise from "now" (past due) lands within the
+        # next ~48h — a loose bound that just proves cadence math ran
+        # (not the fallback delta, which would be ~1h out).
+        assert timedelta(hours=1) < (next_dt - datetime.now(timezone.utc)) < timedelta(hours=48)

--- a/backend/tests/lambdas/test_scheduled_runs_worker.py
+++ b/backend/tests/lambdas/test_scheduled_runs_worker.py
@@ -1,0 +1,237 @@
+"""Scheduled-runs worker tests (moto DynamoDB, stubbed run_agent_headless).
+
+Mirrors backend/tests/lambdas/test_kb_sync_worker.py's structure: the real
+scheduled_prompts service manages schedule state so the worker's raw
+bookkeeping is cross-checked against the actual storage schema; only
+run_agent_headless (the harness's HTTP/SSE boundary) is stubbed.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from apis.shared.harness.auth import HeadlessAuthError
+from apis.shared.harness.models import OAuthConsentRequired, RunResult
+from apis.shared.scheduled_prompts.service import create_scheduled_prompt, get_scheduled_prompt
+from lambdas.scheduled_runs_worker import worker
+
+pytestmark = pytest.mark.asyncio
+
+USER_ID = "user-1"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _result(status: str, **overrides) -> RunResult:
+    base = dict(
+        run_id="run-1",
+        session_id="sess-1",
+        user_id=USER_ID,
+        status=status,
+        started_at=_now_iso(),
+        finished_at=_now_iso(),
+    )
+    base.update(overrides)
+    return RunResult(**base)
+
+
+async def _make_schedule(**overrides):
+    kwargs = dict(
+        user_id=USER_ID,
+        label="Morning Briefing",
+        prompt_text="Summarize my day",
+        cadence="daily",
+        hour_local=9,
+        timezone_name="America/Boise",
+    )
+    kwargs.update(overrides)
+    return await create_scheduled_prompt(**kwargs)
+
+
+def _payload(schedule):
+    return {"scheduleId": schedule.schedule_id, "userId": USER_ID}
+
+
+class TestSuccess:
+    async def test_completed_run_records_session(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            assert kwargs["user_id"] == USER_ID
+            assert kwargs["prompt"] == schedule.prompt_text
+            assert kwargs["trigger"] == "schedule"
+            return _result("completed", session_id="sess-abc")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "completed"
+        assert result["sessionId"] == "sess-abc"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.last_run_status == "completed"
+        assert updated.last_run_session_id == "sess-abc"
+        assert updated.state == "active"
+
+
+class TestHeadlessAuthFailure:
+    async def test_auth_error_pauses_reauth_required(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            raise HeadlessAuthError("no active grant")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "paused_error"
+        assert result["reason"] == "reauth_required"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "paused_error"
+        assert updated.state_reason == "reauth_required"
+        assert updated.last_run_status == "error"
+
+
+class TestOAuthRequired:
+    async def test_oauth_required_pauses(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            return _result(
+                "oauth_required",
+                oauth_required=[
+                    OAuthConsentRequired(provider_id="google-drive", authorization_url="https://example.com/consent")
+                ],
+            )
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "paused_error"
+        assert result["reason"] == "oauth_required"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "paused_error"
+        assert updated.state_reason == "oauth_required"
+        assert "google-drive" in (updated.last_error or "")
+        assert "https://example.com/consent" in (updated.last_error or "")
+
+
+class TestGenericFailure:
+    async def test_single_error_records_without_pausing(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            return _result("error", error="transport: boom")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "error"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "active"  # not paused on an isolated failure
+        assert updated.last_run_status == "error"
+
+    async def test_repeated_failures_pause(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            return _result("error", error="transport: boom")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+        monkeypatch.setenv("SCHEDULED_RUNS_MAX_FAILURES", "2")
+
+        first = await worker.run_schedule(_payload(schedule))
+        assert first["result"] == "error"
+
+        second = await worker.run_schedule(_payload(schedule))
+
+        assert second["result"] == "paused_error"
+        assert second["reason"] == "repeated_failures"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "paused_error"
+        assert updated.state_reason == "repeated_failures"
+
+    async def test_repeated_failures_pause_at_default_threshold(
+        self, sessions_metadata_table, bff_sessions_table, monkeypatch
+    ):
+        """The breaker must trip at the PRODUCTION default (3), not only at 2.
+
+        Regression guard: the original last-status proxy capped the streak at
+        2, so with the default SCHEDULED_RUNS_MAX_FAILURES=3 it could never
+        pause. The persistent counter must reach 3.
+        """
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            return _result("error", error="transport: boom")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+        # No SCHEDULED_RUNS_MAX_FAILURES override — exercise the default of 3.
+
+        assert (await worker.run_schedule(_payload(schedule)))["result"] == "error"
+        assert (await worker.run_schedule(_payload(schedule)))["result"] == "error"
+        third = await worker.run_schedule(_payload(schedule))
+
+        assert third["result"] == "paused_error"
+        assert third["reason"] == "repeated_failures"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.state == "paused_error"
+        assert updated.consecutive_failures == 3
+
+    async def test_completed_run_resets_failure_streak(
+        self, sessions_metadata_table, bff_sessions_table, monkeypatch
+    ):
+        """A successful run clears the streak so old failures don't accumulate."""
+        schedule = await _make_schedule()
+        statuses = iter(["error", "completed"])
+
+        async def fake_run(**kwargs):
+            return _result(next(statuses), session_id="sess-x")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        await worker.run_schedule(_payload(schedule))  # error -> streak 1
+        await worker.run_schedule(_payload(schedule))  # completed -> streak 0
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.consecutive_failures == 0
+        assert updated.state == "active"
+
+    async def test_timeout_status_treated_as_failure(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def fake_run(**kwargs):
+            return _result("timeout", error="stream exceeded 300s budget")
+
+        monkeypatch.setattr(worker, "run_agent_headless", fake_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "timeout"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.last_run_status == "error"
+
+    async def test_unexpected_exception_still_records_run(self, sessions_metadata_table, bff_sessions_table, monkeypatch):
+        schedule = await _make_schedule()
+
+        async def exploding_run(**kwargs):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(worker, "run_agent_headless", exploding_run)
+
+        result = await worker.run_schedule(_payload(schedule))
+
+        assert result["result"] == "error"
+        updated = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert updated.last_run_status == "error"
+        assert "kaboom" in (updated.last_error or "")
+
+
+class TestMissingSchedule:
+    async def test_missing_schedule_drops_run(self, sessions_metadata_table, bff_sessions_table):
+        result = await worker.run_schedule({"scheduleId": "sched-missing", "userId": USER_ID})
+        assert result["result"] == "dropped"

--- a/backend/tests/supply_chain/test_dockerfile_pinning.py
+++ b/backend/tests/supply_chain/test_dockerfile_pinning.py
@@ -16,6 +16,7 @@ DOCKERFILES = [
     BACKEND_DIR / "Dockerfile.inference-api",
     BACKEND_DIR / "Dockerfile.rag-ingestion",
     BACKEND_DIR / "Dockerfile.kb-sync",
+    BACKEND_DIR / "Dockerfile.scheduled-runs",
 ]
 
 # apt-get version pin: package=version (e.g., gcc=4:14.2.0-1)

--- a/infrastructure/bootstrap-assets/scheduled-runs/Dockerfile
+++ b/infrastructure/bootstrap-assets/scheduled-runs/Dockerfile
@@ -1,0 +1,27 @@
+# Bootstrap container image for the scheduled-runs Lambdas (dispatcher +
+# worker).
+#
+# Same role as bootstrap-assets/kb-sync — the placeholder image
+# PlatformStack ships on first deploy; the real image
+# (backend/Dockerfile.scheduled-runs) is deployed out-of-band by the
+# backend workflow via `aws lambda update-function-code --image-uri ...`.
+# Keep these files byte-stable so CDK's asset digest never changes.
+#
+# Both scheduled-runs functions use this one build context with different
+# ImageConfig.Command overrides, so the stub modules must live at the
+# SAME plain module paths as the real image's handlers:
+#   dispatcher.lambda_handler
+#   worker.lambda_handler
+#
+# DO NOT add functionality here.
+#
+# Pinning rationale: same digest as the real scheduled-runs image (and
+# the other Lambda images) so the supply-chain dockerfile-pinning test
+# passes.
+
+FROM public.ecr.aws/lambda/python:3.12@sha256:745b0eb8a9787e9c4bfd4fc4cae942399a2225831c96394ae70c0c2a7c7c6168
+
+COPY dispatcher.py ${LAMBDA_TASK_ROOT}/dispatcher.py
+COPY worker.py ${LAMBDA_TASK_ROOT}/worker.py
+
+CMD ["dispatcher.lambda_handler"]

--- a/infrastructure/bootstrap-assets/scheduled-runs/dispatcher.py
+++ b/infrastructure/bootstrap-assets/scheduled-runs/dispatcher.py
@@ -1,0 +1,22 @@
+# Bootstrap handler for the scheduled-runs dispatcher Lambda.
+#
+# Same role as the sibling bootstrap stubs — see the Dockerfile in this
+# directory. During the brief first-deploy window before the workflow
+# ships the real image, EventBridge ticks land here. Schedules stay due
+# in the DueScheduleIndex, so the first real dispatcher tick picks them
+# up — nothing is lost by no-op'ing.
+#
+# DO NOT add functionality here.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event: Any, context: Any) -> dict:
+    logger.info("scheduled-runs dispatcher bootstrap stub invoked; real image not yet deployed")
+    return {"statusCode": 200, "body": "bootstrap"}

--- a/infrastructure/bootstrap-assets/scheduled-runs/worker.py
+++ b/infrastructure/bootstrap-assets/scheduled-runs/worker.py
@@ -1,0 +1,22 @@
+# Bootstrap handler for the scheduled-runs worker Lambda.
+#
+# See the sibling dispatcher.py and the Dockerfile in this directory. A
+# dispatch that lands here is dropped; the schedule's next_run_at was
+# already re-armed by the dispatcher before invoking, so the schedule
+# fires again on its normal cadence — self-healing, nothing is lost
+# beyond one missed run.
+#
+# DO NOT add functionality here.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event: Any, context: Any) -> dict:
+    logger.info("scheduled-runs worker bootstrap stub invoked; real image not yet deployed")
+    return {"statusCode": 200, "body": "bootstrap"}

--- a/infrastructure/lib/constructs/scheduled-runs/scheduled-runs-construct.ts
+++ b/infrastructure/lib/constructs/scheduled-runs/scheduled-runs-construct.ts
@@ -1,0 +1,316 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as path from 'path';
+import { Construct } from 'constructs';
+
+import { AppConfig } from '../../config';
+
+export interface ScheduledRunsConstructProps {
+  config: AppConfig;
+  /** Sessions-metadata table — schedules (SCHEDPROMPT# items + sparse
+   * DueScheduleIndex), the run-audit trail (RUN# items), and delivered
+   * session rows all live here. */
+  sessionsMetadataTable: dynamodb.ITable;
+  /** BFF sessions table — headless-grant records
+   * (PK=HEADLESS-GRANT#{id}) live here behind the sparse
+   * HeadlessGrantUserIndex GSI. */
+  bffSessionsTable: dynamodb.ITable;
+  /** BFF Cognito app client — the worker mints a per-owner access token
+   * via REFRESH_TOKEN_AUTH against this (confidential) client. */
+  bffAppClient: cognito.IUserPoolClient;
+  bffAppClientSecret: secretsmanager.ISecret;
+  /**
+   * Shared platform workload identity name. Vault entries are keyed by
+   * workload identity — a different workload sees an empty vault, so this
+   * MUST be the same identity app-api/inference-api use.
+   */
+  workloadIdentityName: string;
+  /** AgentCore Runtime `/invocations` data-plane base URL — the worker's
+   * only HTTP dependency (via run_agent_headless). */
+  inferenceApiRuntimeEndpointUrl: string;
+  cognitoRegion: string;
+}
+
+/**
+ * ScheduledRunsConstruct — the scheduler engine (B2) for the F3 scheduled
+ * trigger (docs/specs/scheduled-runs-phase-b-brief.md,
+ * docs/specs/scheduled-agent-runs.md §4/§7). Mirrors KbSyncConstruct
+ * (infrastructure/lib/constructs/kb-sync/kb-sync-construct.ts) closely.
+ *
+ * Two DockerImage Lambdas sharing ONE image
+ * (backend/Dockerfile.scheduled-runs) with different ImageConfig.Command
+ * overrides:
+ *   - dispatcher — EventBridge rate(5 minutes) tick; sweeps the sparse
+ *     DueScheduleIndex, applies the runaway guard, conditionally re-arms,
+ *     async-invokes the worker.
+ *   - worker — resolves the schedule, calls run_agent_headless as the
+ *     owning user, records the outcome (and pauses on terminal failure
+ *     modes — reauth_required / oauth_required / repeated_failures).
+ *
+ * Same platform-as-bootstrap pattern as kb-sync: `fromImageAsset` points
+ * at the byte-stable `bootstrap-assets/scheduled-runs/` stub; the real
+ * image is deployed out-of-band by the backend workflow
+ * (`deploy-image-lambda-one.sh scheduled-runs-dispatcher|scheduled-runs-worker`).
+ * The command overrides are function *configuration*, so out-of-band
+ * `update-function-code --image-uri` swaps never touch them.
+ *
+ * Runaway posture: the EventBridge rule is the ONLY initiator of
+ * scheduled-run work, and it's created disabled unless
+ * `config.scheduledRuns.enabled`. The dispatcher additionally gates on
+ * the SCHEDULED_RUNS_ENABLED env var, so an operator can dark-stop the
+ * feature either via CFN (rule) or a plain env flip (function config),
+ * whichever is faster.
+ *
+ * SSM publications (consumed by the backend workflow's code-deploy):
+ *   /{prefix}/scheduled-runs/dispatcher-function-name
+ *   /{prefix}/scheduled-runs/worker-function-name
+ */
+export class ScheduledRunsConstruct extends Construct {
+  public readonly dispatcherLambda: lambda.DockerImageFunction;
+  public readonly workerLambda: lambda.DockerImageFunction;
+  public readonly scheduleRule: events.Rule;
+
+  constructor(scope: Construct, id: string, props: ScheduledRunsConstructProps) {
+    super(scope, id);
+
+    const {
+      config,
+      sessionsMetadataTable,
+      bffSessionsTable,
+      bffAppClient,
+      bffAppClientSecret,
+      workloadIdentityName,
+      inferenceApiRuntimeEndpointUrl,
+      cognitoRegion,
+    } = props;
+
+    // Same value app-api uses (app-api-environment.ts) — the vault requires
+    // a registered return URL even for non-interactive token reads.
+    const oauthCallbackUrl = config.domainName
+      ? `https://${config.domainName}/oauth-complete`
+      : 'http://localhost:4200/oauth-complete';
+
+    const bootstrapDir = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'bootstrap-assets',
+      'scheduled-runs',
+    );
+
+    const sharedEnvironment = {
+      DYNAMODB_SESSIONS_METADATA_TABLE_NAME: sessionsMetadataTable.tableName,
+      BFF_SESSIONS_TABLE_NAME: bffSessionsTable.tableName,
+      COGNITO_BFF_APP_CLIENT_ID: bffAppClient.userPoolClientId,
+      COGNITO_BFF_APP_CLIENT_SECRET_ARN: bffAppClientSecret.secretArn,
+      COGNITO_REGION: cognitoRegion,
+      INFERENCE_API_URL: inferenceApiRuntimeEndpointUrl,
+      AGENTCORE_RUNTIME_WORKLOAD_NAME: workloadIdentityName,
+      AGENTCORE_LOCAL_OAUTH_CALLBACK_URL: oauthCallbackUrl,
+      SCHEDULED_RUNS_ENABLED: config.scheduledRuns.enabled ? 'true' : 'false',
+    };
+
+    const workerLogGroup = new logs.LogGroup(this, 'ScheduledRunsWorkerLogGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.workerLambda = new lambda.DockerImageFunction(this, 'ScheduledRunsWorkerLambda', {
+      // No functionName — CDK auto-generates; deploy script resolves via SSM.
+      code: lambda.DockerImageCode.fromImageAsset(bootstrapDir, {
+        cmd: ['worker.lambda_handler'],
+      }),
+      architecture: lambda.Architecture.ARM_64,
+      // Worker drains a full agent turn's SSE stream through the harness
+      // (run_agent_headless's own budget is 300s); give it rag-ingestion's
+      // ceiling + headroom for retries/bookkeeping. Same memory class as
+      // rag-ingestion (no heavy ML deps here, but the httpx stream +
+      // json accumulation benefit from headroom over the dispatcher's).
+      timeout: cdk.Duration.minutes(15),
+      memorySize: 1024,
+      logGroup: workerLogGroup,
+      environment: {
+        ...sharedEnvironment,
+        SCHEDULED_RUNS_MAX_FAILURES: '3',
+      },
+      description:
+        'Scheduled-runs worker - executes one schedule\'s headless agent run via run_agent_headless',
+    });
+
+    const dispatcherLogGroup = new logs.LogGroup(this, 'ScheduledRunsDispatcherLogGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.dispatcherLambda = new lambda.DockerImageFunction(this, 'ScheduledRunsDispatcherLambda', {
+      code: lambda.DockerImageCode.fromImageAsset(bootstrapDir, {
+        cmd: ['dispatcher.lambda_handler'],
+      }),
+      architecture: lambda.Architecture.ARM_64,
+      // Sweeps at most SCHEDULED_RUNS_DISPATCH_LIMIT schedules per tick; small.
+      timeout: cdk.Duration.minutes(2),
+      memorySize: 512,
+      logGroup: dispatcherLogGroup,
+      environment: {
+        DYNAMODB_SESSIONS_METADATA_TABLE_NAME: sessionsMetadataTable.tableName,
+        SCHEDULED_RUNS_ENABLED: config.scheduledRuns.enabled ? 'true' : 'false',
+        SCHEDULED_RUNS_WORKER_FUNCTION_NAME: this.workerLambda.functionName,
+      },
+      description:
+        'Scheduled-runs dispatcher - sweeps due schedules on an EventBridge tick, applies the runaway guard, invokes the worker',
+    });
+
+    // IAM — dispatcher only touches the schedule/due-index bookkeeping on
+    // the sessions-metadata table (list_due_schedules, rearm_schedule,
+    // set_schedule_state).
+    sessionsMetadataTable.grantReadWriteData(this.dispatcherLambda);
+    this.workerLambda.grantInvoke(this.dispatcherLambda);
+
+    // Worker: schedule bookkeeping + run-audit trail + delivered session
+    // rows, all on the same adjacency-list table (governance.py's
+    // RunAuditRecorder and the harness's ensure_session_metadata_exists /
+    // update_session_title both write here too).
+    sessionsMetadataTable.grantReadWriteData(this.workerLambda);
+
+    // Worker: resolve + touch the caller's headless-grant record
+    // (HeadlessGrantService — get_active_grant / persist_rotated_refresh_token
+    // / record_use), keyed by the sparse HeadlessGrantUserIndex GSI.
+    bffSessionsTable.grantReadWriteData(this.workerLambda);
+
+    // Worker: CognitoRefreshClient's REFRESH_TOKEN_AUTH exchange. Cognito's
+    // InitiateAuth is an unauthenticated data-plane API (no IAM action
+    // exists for it — gated by the app client itself), so no IAM
+    // statement is needed for the Cognito call; only the secret read that
+    // resolves SECRET_HASH is an IAM action.
+    bffAppClientSecret.grantRead(this.workerLambda);
+
+    // Worker: retrieve the schedule owner's stored 3LO connector tokens
+    // from the AgentCore Identity vault with no live user session (the
+    // headless run resolves enabled_tools' connector tokens exactly as an
+    // attended chat turn would). Mirrors app-api's
+    // AgentCoreWorkloadIdentityAccess statement (app-api-iam-grants.ts)
+    // minus consent-completion and provider CRUD — a background runner
+    // only ever reads tokens. Same statement shape as KbSyncConstruct.
+    this.workerLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AgentCoreVaultTokenRead',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'bedrock-agentcore:GetWorkloadAccessTokenForUserId',
+          'bedrock-agentcore:GetResourceOauth2Token',
+        ],
+        resources: [
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/*/oauth2credentialprovider/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/*`,
+          `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:workload-identity-directory/*/workload-identity/*`,
+        ],
+      }),
+    );
+
+    // GetResourceOauth2Token reads the vaulted refresh token *through* a
+    // Secrets Manager secret the vault auto-creates per provider
+    // (bedrock-agentcore-identity!default/oauth2/<id>) — the bedrock-agentcore
+    // action alone is not enough, the caller must also be able to read that
+    // backing secret. Read-only mirror of the app-api / inference-api / kb-sync
+    // grants (a background runner never registers providers, so no write
+    // lifecycle).
+    this.workerLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AgentCoreIdentityOAuthSecrets',
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
+        resources: [
+          `arn:aws:secretsmanager:${config.awsRegion}:${config.awsAccount}:secret:bedrock-agentcore-identity!default/oauth2/*`,
+        ],
+      }),
+    );
+
+    // Worker: the AgentCore Runtime data-plane invocation itself is
+    // authenticated via the minted Cognito bearer over HTTPS (see
+    // apis.shared.harness.runner), not SigV4/invoke_agent_runtime — so no
+    // separate `bedrock-agentcore:InvokeAgentRuntime` IAM action is needed
+    // here (matches the "Run now" route's app-api role, which also grants
+    // no such action).
+
+    // Best-effort custom metrics (ScheduledRuns namespace). PutMetricData
+    // doesn't support resource scoping; condition on the namespace.
+    const metricsStatement = new iam.PolicyStatement({
+      sid: 'ScheduledRunsPutMetrics',
+      effect: iam.Effect.ALLOW,
+      actions: ['cloudwatch:PutMetricData'],
+      resources: ['*'],
+      conditions: { StringEquals: { 'cloudwatch:namespace': 'ScheduledRuns' } },
+    });
+    this.dispatcherLambda.addToRolePolicy(metricsStatement);
+    this.workerLambda.addToRolePolicy(metricsStatement);
+
+    // ECR pull on the project's scheduled-runs repo so `update-function-code
+    // --image-uri` can swap to the real image (same rationale/pattern
+    // as the rag-ingestion/kb-sync constructs; GetAuthorizationToken is
+    // unscopeable).
+    const ecrPullStatement = new iam.PolicyStatement({
+      sid: 'EcrPullProjectImage',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'ecr:GetAuthorizationToken',
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:GetDownloadUrlForLayer',
+        'ecr:BatchGetImage',
+      ],
+      resources: ['*'],
+    });
+    this.dispatcherLambda.addToRolePolicy(ecrPullStatement);
+    this.workerLambda.addToRolePolicy(ecrPullStatement);
+
+    // The single trigger. Disabled rule = the whole feature is inert
+    // (schedules accumulate as plain data until it's enabled).
+    this.scheduleRule = new events.Rule(this, 'ScheduledRunsSchedule', {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5)),
+      enabled: config.scheduledRuns.enabled,
+      description: 'Scheduled-runs dispatcher tick — the only initiator of scheduled agent-run work',
+    });
+    this.scheduleRule.addTarget(new targets.LambdaFunction(this.dispatcherLambda));
+
+    // Error visibility (no SNS wiring in this stack yet; alarms are
+    // dashboard/console signals).
+    new cloudwatch.Alarm(this, 'ScheduledRunsDispatcherErrorAlarm', {
+      alarmName: `${config.projectPrefix}-scheduled-runs-dispatcher-errors`,
+      metric: this.dispatcherLambda.metricErrors({ period: cdk.Duration.minutes(5) }),
+      threshold: 1,
+      evaluationPeriods: 2,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    new cloudwatch.Alarm(this, 'ScheduledRunsWorkerErrorAlarm', {
+      alarmName: `${config.projectPrefix}-scheduled-runs-worker-errors`,
+      metric: this.workerLambda.metricErrors({ period: cdk.Duration.minutes(5) }),
+      threshold: 3,
+      evaluationPeriods: 2,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    new ssm.StringParameter(this, 'DispatcherFunctionNameParameter', {
+      parameterName: `/${config.projectPrefix}/scheduled-runs/dispatcher-function-name`,
+      stringValue: this.dispatcherLambda.functionName,
+      description: 'Scheduled-runs dispatcher Lambda function name (consumed by backend workflow code-deploy step)',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'WorkerFunctionNameParameter', {
+      parameterName: `/${config.projectPrefix}/scheduled-runs/worker-function-name`,
+      stringValue: this.workerLambda.functionName,
+      description: 'Scheduled-runs worker Lambda function name (consumed by backend workflow code-deploy step)',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -42,6 +42,7 @@ import { SharedConversationsConstruct } from './constructs/data/shared-conversat
 import { RagDataConstruct } from './constructs/rag/rag-data-construct';
 import { RagIngestionLambdaConstruct } from './constructs/rag-ingestion/rag-ingestion-lambda-construct';
 import { KbSyncConstruct } from './constructs/kb-sync/kb-sync-construct';
+import { ScheduledRunsConstruct } from './constructs/scheduled-runs/scheduled-runs-construct';
 
 // Artifacts (data + render Lambda + CloudFront distribution).
 // Lambda + distribution + Route53 alias here. The Lambda's
@@ -706,6 +707,24 @@ export class PlatformStack extends cdk.Stack {
       sagemakerExecutionRoleArn: sagemaker.executionRole.roleArn,
       sagemakerSecurityGroupId: sagemaker.securityGroup.securityGroupId,
       sagemakerPrivateSubnetIds,
+    });
+
+    // ============================================================
+    // Scheduled runs — the F3 scheduled trigger's engine (dispatcher +
+    // worker Lambdas + EventBridge rate rule; inert unless
+    // config.scheduledRuns.enabled). Needs inferenceApi.runtimeEndpointUrl,
+    // so it lands here in wireCompute() rather than the constructor
+    // (unlike KbSyncConstruct, which has no such dependency).
+    // ============================================================
+    new ScheduledRunsConstruct(this, 'ScheduledRuns', {
+      config: this._config,
+      sessionsMetadataTable: this.sessionsMetadataTable,
+      bffSessionsTable: this.bffSessionsTable,
+      bffAppClient: this.bffAppClient,
+      bffAppClientSecret: this.bffAppClientSecret,
+      workloadIdentityName: this.platformWorkloadIdentity.name,
+      inferenceApiRuntimeEndpointUrl: inferenceApi.runtimeEndpointUrl,
+      cognitoRegion: this._config.awsRegion,
     });
   }
 }

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -7,7 +7,7 @@
 #   build-one.sh <service>
 #
 # Where <service> is one of:
-#   app-api | inference-api | rag-ingestion | kb-sync
+#   app-api | inference-api | rag-ingestion | kb-sync | scheduled-runs
 #
 # This script encapsulates the per-service spec (which Dockerfile,
 # which source trees, which manifests, which platform) so that:
@@ -127,9 +127,31 @@ case "$SERVICE" in
         PLATFORM="linux/arm64"
         SSM_KEY="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
         ;;
+    scheduled-runs)
+        DOCKERFILE="backend/Dockerfile.scheduled-runs"
+        # One image, two Lambdas (dispatcher + worker via ImageConfig
+        # command overrides). Keep SOURCE_DIRS in lockstep with the
+        # Dockerfile's COPY list — a path copied but not hashed here
+        # would ship stale code under an unchanged content-hash tag.
+        SOURCE_DIRS=(
+            "backend/src/lambdas/scheduled_runs_dispatcher"
+            "backend/src/lambdas/scheduled_runs_worker"
+            "backend/src/apis/shared/harness"
+            "backend/src/apis/shared/scheduled_prompts"
+            "backend/src/apis/shared/sessions_bff"
+            "backend/src/apis/shared/sessions"
+        )
+        # shared/__init__.py hashed as a manifest (same as kb-sync/rag-ingestion);
+        # the dispatcher's requirements.txt lives inside its own source dir.
+        MANIFESTS=("backend/src/apis/shared/__init__.py")
+        # Both scheduled-runs Lambdas are arm64 (see the scheduled-runs
+        # CDK construct).
+        PLATFORM="linux/arm64"
+        SSM_KEY="/${CDK_PROJECT_PREFIX}/scheduled-runs/image-tag"
+        ;;
     *)
         echo "Unknown service: $SERVICE" >&2
-        echo "Expected one of: app-api | inference-api | rag-ingestion | kb-sync" >&2
+        echo "Expected one of: app-api | inference-api | rag-ingestion | kb-sync | scheduled-runs" >&2
         exit 1
         ;;
 esac

--- a/scripts/build/deploy-image-lambda-one.sh
+++ b/scripts/build/deploy-image-lambda-one.sh
@@ -8,11 +8,13 @@
 #   deploy-image-lambda-one.sh <service>
 #
 # Where <service> is one of:
-#   rag-ingestion | kb-sync-dispatcher | kb-sync-worker
+#   rag-ingestion | kb-sync-dispatcher | kb-sync-worker |
+#   scheduled-runs-dispatcher | scheduled-runs-worker
 #
-# kb-sync-dispatcher and kb-sync-worker are two Lambda functions
-# sharing the single kb-sync image; their handlers differ only via
-# ImageConfig.Command, which `update-function-code` doesn't touch.
+# kb-sync-dispatcher/kb-sync-worker (and scheduled-runs-dispatcher/
+# scheduled-runs-worker) are pairs of Lambda functions sharing a single
+# image; their handlers differ only via ImageConfig.Command, which
+# `update-function-code` doesn't touch.
 #
 # Pre-requisite: scripts/build/build-one.sh has already run for the
 # same service in this workflow. It pushes the image to ECR and
@@ -23,7 +25,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <service>" >&2
-    echo "  service: rag-ingestion | kb-sync-dispatcher | kb-sync-worker" >&2
+    echo "  service: rag-ingestion | kb-sync-dispatcher | kb-sync-worker | scheduled-runs-dispatcher | scheduled-runs-worker" >&2
     exit 1
 fi
 
@@ -54,9 +56,19 @@ case "$SERVICE" in
         IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
         ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-kb-sync"
         ;;
+    scheduled-runs-dispatcher)
+        FUNCTION_NAME_SSM="/${CDK_PROJECT_PREFIX}/scheduled-runs/dispatcher-function-name"
+        IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/scheduled-runs/image-tag"
+        ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-scheduled-runs"
+        ;;
+    scheduled-runs-worker)
+        FUNCTION_NAME_SSM="/${CDK_PROJECT_PREFIX}/scheduled-runs/worker-function-name"
+        IMAGE_URI_SSM="/${CDK_PROJECT_PREFIX}/scheduled-runs/image-tag"
+        ECR_REPO_URI="${REGISTRY}/${CDK_PROJECT_PREFIX}-scheduled-runs"
+        ;;
     *)
         echo "Unknown service: $SERVICE" >&2
-        echo "Expected one of: rag-ingestion | kb-sync-dispatcher | kb-sync-worker" >&2
+        echo "Expected one of: rag-ingestion | kb-sync-dispatcher | kb-sync-worker | scheduled-runs-dispatcher | scheduled-runs-worker" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## What

The **scheduler engine** (Phase B, F3): an EventBridge rate rule fires due schedules through the Phase A headless harness. Completes end-to-end scheduled runs behind the `SCHEDULED_RUNS_ENABLED` flag + `scheduled-runs` capability.

- **Dispatcher** (`backend/src/lambdas/scheduled_runs_dispatcher/`): `rate(5m)` → sweeps the sparse `DueScheduleIndex` → per schedule: runaway guard (`runs_today` vs `max_runs_per_day`, UTC-rollover-aware) → **conditional re-arm before invoking** (a double-tick is idempotent) → async-invoke the worker (`InvocationType=Event`).
- **Worker** (`backend/src/lambdas/scheduled_runs_worker/`): mints a per-owner Cognito bearer via `CognitoRefreshBearerAuth` → `run_agent_headless(trigger="schedule")` as the owner → records the outcome. Pauses cleanly (never retry-spams) on `reauth_required` (expired grant), `oauth_required` (connector needs consent), or `repeated_failures`.
- **CDK** (`scheduled-runs-construct.ts`): two Docker Lambdas sharing one image via `ImageConfig.Command`, bootstrap-stub + out-of-band deploy mirroring KB-sync. EventBridge rule gated by `config.scheduledRuns.enabled`; IAM scoped to sessions-metadata RW + BFF-grant table RW + app-client secret read + AgentCore vault token/oauth-secret read. **No** `InvokeAgentRuntime`/SigV4 — the minted bearer is the front door (matches the Run-now path).

Delivery flows straight through — governance is role/auth-based (run-as-user, deliver-to-self), no content gate.

## Orchestrator note (this was finished + reviewed on Opus)

The Sonnet build stalled before committing; I finished it and reviewed the code directly. The CDK/IAM is tightly scoped and correct as built. **I fixed one real defect I found in review:** the failure breaker used a last-run-status proxy that caps the streak at 2, so with the production default `SCHEDULED_RUNS_MAX_FAILURES=3` the `repeated_failures` pause could *never* fire (the existing test only passed because it set the threshold to 2). Fixed with a persistent `consecutive_failures` counter (model + `record_run_result`, mirroring `sync_policies`), unified the worker's two error paths, and added regression tests at the default threshold.

## Tests
- Backend full suite: **4302 passed, 3 skipped** (incl. 2 new breaker regression tests).
- Infra: `tsc --noEmit` clean; `jest` **429 passed**.
- No new packages.

Part of #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)