### PR TITLE
fix(schedules): make scheduled-runs worker image importable

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -18,8 +18,19 @@ from decimal import Decimal
 # Relative imports from shared sessions module
 from .models import ExportReceipt, MessageMetadata, PausedTurnSnapshot, PendingInterrupt, SessionMetadata, SessionPreferences
 
-# Import preview session helper
-from agents.main_agent.session.preview_session_manager import is_preview_session
+# Preview-session helper — imported lazily (not at module top level) so this
+# module stays importable in the lean scheduled-runs Lambda image, which
+# deliberately omits the agents/strands packages that preview_session_manager
+# pulls in. The heavy import resolves only when a preview-aware path actually
+# runs — never in a headless run, whose delivery path
+# (ensure_session_metadata_exists / update_session_title) does not touch
+# preview sessions. Public name is unchanged for all callers.
+def is_preview_session(session_id: str) -> bool:
+    from agents.main_agent.session.preview_session_manager import (
+        is_preview_session as _is_preview_session_impl,
+    )
+
+    return _is_preview_session_impl(session_id)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt
+++ b/backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt
@@ -4,3 +4,10 @@ boto3==1.43.9
 pydantic==2.12.5
 httpx==0.28.1
 bedrock-agentcore==1.9.1
+# Worker-only transitive deps (both handlers share ONE image, and the
+# Dockerfile installs THIS file): the worker imports apis.shared.harness ->
+# apis.shared.sessions_bff, whose cookie.py needs cryptography (AESGCM) and
+# cache.py needs cachetools (TTLCache). The dispatcher itself does not import
+# these, but the shared image must satisfy the worker's import chain.
+cryptography==48.0.1
+cachetools==6.2.4

--- a/backend/src/lambdas/scheduled_runs_worker/requirements.txt
+++ b/backend/src/lambdas/scheduled_runs_worker/requirements.txt
@@ -4,3 +4,9 @@ boto3==1.43.9
 pydantic==2.12.5
 httpx==0.28.1
 bedrock-agentcore==1.9.1
+# Worker transitive deps: apis.shared.harness -> apis.shared.sessions_bff,
+# whose cookie.py needs cryptography (AESGCM) and cache.py needs cachetools
+# (TTLCache). Kept in sync with the dispatcher requirements.txt, which is the
+# file Dockerfile.scheduled-runs actually installs for the shared image.
+cryptography==48.0.1
+cachetools==6.2.4


### PR DESCRIPTION
## What
The scheduled-runs **worker** Lambda crashed at INIT in cloud with `Runtime.ImportModuleError`, so **no scheduled run has ever executed**. Surfaced by dogfooding a real schedule in dev-ai (the dispatcher fired correctly; the worker died on import across all 3 async-invoke retries).

## Root cause
Two independent gaps in the lean `Dockerfile.scheduled-runs` image:
1. **Missing pip deps** — the worker imports `apis.shared.harness` → `apis.shared.sessions_bff`, whose `cookie.py` needs `cryptography` (AESGCM) and `cache.py` needs `cachetools` (TTLCache). Neither was in the image requirements. (The dispatcher doesn't import the harness, which is why *it* worked.)
2. **Layering inversion** — `apis/shared/sessions/metadata.py` imported `agents.main_agent...is_preview_session` at **module top level**, dragging the `agents`+`strands` packages (deliberately absent from the lean image) into the worker's runtime delivery path. Neither function the headless delivery path calls (`ensure_session_metadata_exists` / `update_session_title`) uses `is_preview_session`.

## Fix
- Defer the preview-session import to call time in `sessions/metadata.py` (public name + behavior unchanged; live app_api/inference_api callers unaffected).
- Add `cryptography==48.0.1` + `cachetools==6.2.4` to the shared image requirements.

## Verification
- Isolated lean-image simulation (image pins + bundled modules only, no agents/strands): `worker` + `dispatcher` both import cleanly.
- 212 backend tests pass (scheduled_runs worker/dispatcher, sessions_metadata, import boundaries).

## Follow-ups (not in this PR)
- `apis/shared/quota.py` has the same top-level `apis.shared → agents` coupling (not in the worker path, so not a blocker). 
- The import-boundary test (`tests/architecture/test_import_boundaries.py`) guards `apis.shared → app_api/inference_api` but **not** `apis.shared → agents` — closing that gap would have caught this, but it would also flag `quota.py`, so it's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)