### PR TITLE
fix(schedules): make preview-session check importable in lean worker image

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -18,19 +18,12 @@ from decimal import Decimal
 # Relative imports from shared sessions module
 from .models import ExportReceipt, MessageMetadata, PausedTurnSnapshot, PendingInterrupt, SessionMetadata, SessionPreferences
 
-# Preview-session helper — imported lazily (not at module top level) so this
+# Preview-session helper — a dependency-free leaf in apis.shared so this
 # module stays importable in the lean scheduled-runs Lambda image, which
-# deliberately omits the agents/strands packages that preview_session_manager
-# pulls in. The heavy import resolves only when a preview-aware path actually
-# runs — never in a headless run, whose delivery path
-# (ensure_session_metadata_exists / update_session_title) does not touch
-# preview sessions. Public name is unchanged for all callers.
-def is_preview_session(session_id: str) -> bool:
-    from agents.main_agent.session.preview_session_manager import (
-        is_preview_session as _is_preview_session_impl,
-    )
-
-    return _is_preview_session_impl(session_id)
+# omits the agents/strands packages the old agents-side helper pulled in.
+# The headless delivery path (ensure_session_metadata_exists) calls
+# is_preview_session, so a lazy import would only defer the crash.
+from .preview import is_preview_session
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/apis/shared/sessions/preview.py
+++ b/backend/src/apis/shared/sessions/preview.py
@@ -1,0 +1,29 @@
+"""Preview-session detection — a dependency-free leaf helper.
+
+Preview sessions are the in-memory, never-persisted sessions the assistant
+form-builder uses for testing (they keep conversation context for the turn
+but are deliberately excluded from a user's saved history). Detecting one is
+a pure prefix check.
+
+This lives in ``apis.shared`` — with **no imports** — on purpose: the
+canonical implementation used to live in
+``agents.main_agent.session.preview_session_manager``, whose module also
+pulls in ``strands`` and ``agents.main_agent.config`` for the unrelated
+``PreviewSessionManager`` class. That made ``apis.shared.sessions.metadata``
+(which only needs the prefix check) transitively depend on the whole agent
+stack, and the lean scheduled-runs Lambda image — which deliberately omits
+``agents``/``strands`` — crashed at delivery time trying to import it.
+
+The ``"preview-"`` literal is mirrored in
+``agents.main_agent.config.constants.Prefixes.PREVIEW_SESSION`` and
+``apis.inference_api.chat.routes``; ``tests`` assert they stay in lockstep
+(``test_preview_prefix_consistency``).
+"""
+
+#: Session-id prefix marking an in-memory preview session (no persistence).
+PREVIEW_SESSION_PREFIX = "preview-"
+
+
+def is_preview_session(session_id: str) -> bool:
+    """True for an in-memory preview session (excluded from persistence)."""
+    return session_id.startswith(PREVIEW_SESSION_PREFIX)

--- a/backend/tests/shared/test_preview_prefix_consistency.py
+++ b/backend/tests/shared/test_preview_prefix_consistency.py
@@ -1,0 +1,22 @@
+"""Guard: the preview-session prefix stays in lockstep across its copies.
+
+``apis.shared.sessions.preview`` deliberately re-declares the ``"preview-"``
+literal (rather than importing it from ``agents``) so the lean scheduled-runs
+Lambda image can detect preview sessions without pulling in agents/strands.
+This test fails loudly if that copy ever drifts from the canonical
+``agents.main_agent.config.constants.Prefixes.PREVIEW_SESSION``.
+"""
+
+from apis.shared.sessions.preview import PREVIEW_SESSION_PREFIX, is_preview_session
+
+
+def test_shared_prefix_matches_agents_constant() -> None:
+    from agents.main_agent.config.constants import Prefixes
+
+    assert PREVIEW_SESSION_PREFIX == Prefixes.PREVIEW_SESSION
+
+
+def test_is_preview_session_behavior() -> None:
+    assert is_preview_session("preview-abc123")
+    assert not is_preview_session("headless-075af61855bf4240")
+    assert not is_preview_session("")


### PR DESCRIPTION
## What
Follow-up to #566. Dogfooding the **deployed** worker surfaced a second, deferred failure. The scheduled run now reaches the runtime and **completes** (`run … completed (session headless-…)`), but the worker log shows `result delivery failed → ModuleNotFoundError: No module named 'agents'`.

## Root cause
The headless delivery path (`runner` → `ensure_session_metadata_exists`, `metadata.py:773`) **does** call `is_preview_session`. #566's lazy-import wrapper only moved the crash from INIT to run time — the two functions I thought didn't call it, do (my earlier awk range check was a false negative). The runtime materializes the session during the turn, so the run still reports `completed`, but the idempotent session-row ensure + the schedule-label title override are silently skipped.

## Fix
`is_preview_session` is a trivial `startswith("preview-")`; its weight came only from the `agents`/`strands` imports in `agents.main_agent.session.preview_session_manager`. Move a dependency-free copy into `apis/shared/sessions/preview.py` (exactly the pattern `apis.inference_api.chat.routes` already uses with its own local copy) and import it in `metadata.py`. Drift-guard test keeps the literal in lockstep with `Prefixes.PREVIEW_SESSION`.

## Verification
- Lean-image simulation now imports `metadata` and runs `is_preview_session` with **no** agents/strands present.
- 77 targeted tests pass (drift guard, sessions_metadata, worker, import boundaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)