### PR TITLE
fix(scheduled-runs): intersect client enabled_tools with RBAC on headless paths

### DIFF
--- a/backend/src/apis/app_api/runs/routes.py
+++ b/backend/src/apis/app_api/runs/routes.py
@@ -45,6 +45,7 @@ from apis.shared.rbac.capabilities import (
     SCHEDULED_RUNS_CAPABILITY,
     user_has_capability,
 )
+from apis.shared.rbac.service import get_app_role_service
 
 logger = logging.getLogger(__name__)
 
@@ -255,6 +256,21 @@ async def run_now(
     """
     await _resolve_grant(request, user)
 
+    # The request body is attacker-controlled within the caller's own session,
+    # and the downstream tool filter performs no RBAC check — so narrow the
+    # requested tools to the caller's actual grant before handing them to the
+    # headless harness. ``None`` keeps "resolve to the user's defaults".
+    enabled_tools = body.enabled_tools
+    if enabled_tools is not None:
+        allowed = await get_app_role_service().filter_requested_tools(user, enabled_tools)
+        if len(allowed) != len(enabled_tools):
+            logger.warning(
+                "Run-now dropped %d requested tool(s) outside user %s's RBAC grant",
+                len(enabled_tools) - len(allowed),
+                user.user_id,
+            )
+        enabled_tools = allowed
+
     try:
         result = await run_agent_headless(
             user_id=user.user_id,
@@ -263,7 +279,7 @@ async def run_now(
             title=body.title,
             model_id=body.model_id,
             rag_assistant_id=body.rag_assistant_id,
-            enabled_tools=body.enabled_tools,
+            enabled_tools=enabled_tools,
             agent_type=body.agent_type,
             trigger="run_now",
         )

--- a/backend/src/apis/app_api/schedules/routes.py
+++ b/backend/src/apis/app_api/schedules/routes.py
@@ -74,14 +74,24 @@ async def require_scheduled_runs_user(
 async def _resolve_enabled_tools_snapshot(user: User, requested: Optional[List[str]]) -> Optional[List[str]]:
     """Snapshot enabled_tools at creation time (Phase A punch #7).
 
-    An explicit list from the caller is trusted as-is (the SPA's tool
-    picker already filters to what the user may select). ``None`` resolves
-    to the user's current RBAC-allowed tool set *right now* and freezes it
-    into the schedule — the catalog shifting later never changes what a
-    sleeping schedule is allowed to call.
+    An explicit list from the caller is intersected with the user's current
+    RBAC grant before it is frozen — the SPA picker filters for UX, but the
+    request body is attacker-controlled within the caller's own session, so
+    the server must not let a crafted list enable a tool the AppRole does not
+    carry (the snapshot is later handed straight to the tool filter, which
+    performs no RBAC check of its own). ``None`` resolves to the user's
+    current RBAC-allowed tool set *right now* and freezes it — the catalog
+    shifting later never changes what a sleeping schedule is allowed to call.
     """
     if requested is not None:
-        return requested
+        allowed = await get_app_role_service().filter_requested_tools(user, requested)
+        if len(allowed) != len(requested):
+            logger.warning(
+                "Dropped %d requested tool(s) outside user %s's RBAC grant on schedule create",
+                len(requested) - len(allowed),
+                user.user_id,
+            )
+        return allowed
     permissions = await get_app_role_service().resolve_user_permissions(user)
     return list(permissions.tools)
 
@@ -162,6 +172,13 @@ async def update_schedule(
             detail="weekday is required when cadence is 'weekly'",
         )
 
+    # An edited tool list is a write path into the same frozen snapshot, so it
+    # gets the same RBAC intersection as creation — a PATCH must not be a way
+    # around the create-time check. ``None`` means "leave tools unchanged".
+    enabled_tools = request.enabled_tools
+    if enabled_tools is not None:
+        enabled_tools = await _resolve_enabled_tools_snapshot(user, enabled_tools)
+
     schedule = await update_scheduled_prompt(
         user.user_id,
         schedule_id,
@@ -172,7 +189,7 @@ async def update_schedule(
         weekday=request.weekday,
         timezone_name=request.timezone,
         assistant_id=request.assistant_id,
-        enabled_tools=request.enabled_tools,
+        enabled_tools=enabled_tools,
         deliver_email=request.deliver_email,
     )
 

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -5,6 +5,7 @@ from typing import List, Set, Optional
 from datetime import datetime, timezone
 
 from apis.shared.auth.models import User
+from apis.shared.tools.scoped_ids import base_tool_id
 
 from .models import AppRole, UserEffectivePermissions
 from .repository import AppRoleRepository
@@ -212,6 +213,33 @@ class AppRoleService:
         """Get list of tool IDs user can access."""
         permissions = await self.resolve_user_permissions(user)
         return permissions.tools
+
+    async def filter_requested_tools(
+        self, user: User, requested: List[str]
+    ) -> List[str]:
+        """Intersect a client-requested tool list with the user's RBAC grant.
+
+        Client-supplied ``enabled_tools`` (from the SPA tool picker, a
+        "Run now" body, or a schedule-creation request) must never *grant*
+        access the caller's AppRole does not already carry — the picker is a
+        UI convenience, not a security boundary. This narrows the request to
+        what the user may actually invoke, preserving the caller's order and
+        scoping (mirrors ``_apply_enabled_skills_filter``'s narrow-never-grant
+        contract on the skills axis).
+
+        A ``"*"`` grant passes everything through. A scoped id (``base::tool``)
+        is allowed when its base server id is granted, so a role that grants a
+        whole MCP server still admits that server's per-tool selections.
+        """
+        permissions = await self.resolve_user_permissions(user)
+        allowed = set(permissions.tools)
+        if "*" in allowed:
+            return list(requested)
+        return [
+            tool_id
+            for tool_id in requested
+            if tool_id in allowed or base_tool_id(tool_id) in allowed
+        ]
 
     async def get_accessible_models(self, user: User) -> List[str]:
         """Get list of model IDs user can access."""

--- a/backend/tests/apis/app_api/test_runs_routes.py
+++ b/backend/tests/apis/app_api/test_runs_routes.py
@@ -19,10 +19,24 @@ from apis.shared.auth.models import User
 from apis.shared.harness.auth import HeadlessAuthError
 from apis.shared.harness.grants import HeadlessGrant
 from apis.shared.harness.models import RunResult, ToolTraceEntry
+from apis.shared.tools.scoped_ids import base_tool_id
 
 from apis.app_api.runs import routes as runs_routes
 
 NOW = int(time.time())
+
+
+class FakeRoleService:
+    """Grants a fixed tool set; mirrors filter_requested_tools' contract."""
+
+    def __init__(self, tools: Optional[list[str]] = None):
+        self.tools = tools if tools is not None else ["class_search", "web_search"]
+
+    async def filter_requested_tools(self, user, requested):
+        allowed = set(self.tools)
+        if "*" in allowed:
+            return list(requested)
+        return [t for t in requested if t in allowed or base_tool_id(t) in allowed]
 
 
 def _user() -> User:
@@ -119,6 +133,7 @@ def _make_client(
     with_session_record: bool = False,
     run_result: Optional[RunResult] = None,
     run_error: Optional[Exception] = None,
+    role_tools: Optional[list[str]] = None,
 ) -> tuple[TestClient, FakeGrantService, list[dict]]:
     monkeypatch.delenv("SKIP_AUTH", raising=False)
     if flag is None:
@@ -134,6 +149,7 @@ def _make_client(
 
     grants = grants or FakeGrantService()
     monkeypatch.setattr(runs_routes, "get_headless_grant_service", lambda: grants)
+    monkeypatch.setattr(runs_routes, "get_app_role_service", lambda: FakeRoleService(role_tools))
 
     run_calls: list[dict] = []
 
@@ -265,6 +281,33 @@ class TestRunNow:
         assert call["enabled_tools"] == ["class_search"]
         assert call["agent_type"] == "chat"
         assert call["trigger"] == "run_now"
+
+    def test_enabled_tools_intersected_with_rbac_before_harness(self, monkeypatch):
+        """A crafted body cannot enable a tool outside the caller's grant.
+
+        FakeRoleService grants {class_search, web_search}; the ungranted
+        ``gmail_search`` must be stripped before the harness (and thus the
+        RBAC-blind tool filter) ever sees it.
+        """
+        client, _, run_calls = _make_client(monkeypatch, with_session_record=True)
+
+        response = client.post(
+            "/runs/now",
+            json={"prompt": "ping", "enabledTools": ["class_search", "gmail_search"]},
+        )
+
+        assert response.status_code == 200
+        (call,) = run_calls
+        assert call["enabled_tools"] == ["class_search"]
+
+    def test_none_enabled_tools_passes_through_as_defaults(self, monkeypatch):
+        """Omitting enabled_tools stays None → harness resolves user defaults."""
+        client, _, run_calls = _make_client(monkeypatch, with_session_record=True)
+
+        assert client.post("/runs/now", json={"prompt": "ping"}).status_code == 200
+
+        (call,) = run_calls
+        assert call["enabled_tools"] is None
 
     def test_create_on_enable_pins_the_live_session_token(self, monkeypatch):
         client, grants, _ = _make_client(monkeypatch, with_session_record=True)

--- a/backend/tests/rbac/test_app_role_service.py
+++ b/backend/tests/rbac/test_app_role_service.py
@@ -329,3 +329,78 @@ async def test_only_enabled_roles_merged(service, mock_app_role_repo, mock_app_r
     assert "tool_a" in perms.tools
     assert "tool_secret" not in perms.tools
     assert "viewer" not in perms.app_roles
+
+
+# ---------------------------------------------------------------------------
+# filter_requested_tools — narrow-never-grant intersection of a client list
+# ---------------------------------------------------------------------------
+
+def _wire_single_role(mock_app_role_repo, role):
+    """Point the mock repo at one role mapped from the user's 'Editor' JWT role."""
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: (
+        [role.role_id] if r == "Editor" else []
+    )
+    mock_app_role_repo.get_role.side_effect = lambda rid: (
+        role if rid == role.role_id else None
+    )
+
+
+@pytest.mark.asyncio
+async def test_filter_requested_tools_drops_ungranted(
+    service, mock_app_role_repo, make_app_role, user
+):
+    """A requested tool outside the user's grant is silently dropped."""
+    _wire_single_role(mock_app_role_repo, make_app_role(role_id="editor", tools=["tool_a", "tool_b"]))
+
+    result = await service.filter_requested_tools(user, ["tool_a", "tool_secret", "tool_b"])
+
+    assert result == ["tool_a", "tool_b"]
+
+
+@pytest.mark.asyncio
+async def test_filter_requested_tools_preserves_caller_order(
+    service, mock_app_role_repo, make_app_role, user
+):
+    """The caller's ordering is preserved, not the grant's."""
+    _wire_single_role(mock_app_role_repo, make_app_role(role_id="editor", tools=["tool_a", "tool_b", "tool_c"]))
+
+    result = await service.filter_requested_tools(user, ["tool_c", "tool_a"])
+
+    assert result == ["tool_c", "tool_a"]
+
+
+@pytest.mark.asyncio
+async def test_filter_requested_tools_wildcard_passes_everything(
+    service, mock_app_role_repo, make_app_role, user
+):
+    """A ``*`` grant admits any requested tool (including ones not enumerated)."""
+    _wire_single_role(mock_app_role_repo, make_app_role(role_id="admin", tools=["*"]))
+
+    requested = ["tool_a", "gateway_anything", "some_admin_tool"]
+    result = await service.filter_requested_tools(user, requested)
+
+    assert result == requested
+
+
+@pytest.mark.asyncio
+async def test_filter_requested_tools_scoped_id_allowed_by_base_grant(
+    service, mock_app_role_repo, make_app_role, user
+):
+    """A scoped id (base::tool) passes when its base server id is granted."""
+    _wire_single_role(mock_app_role_repo, make_app_role(role_id="editor", tools=["gateway_wikipedia"]))
+
+    result = await service.filter_requested_tools(user, ["gateway_wikipedia::search"])
+
+    assert result == ["gateway_wikipedia::search"]
+
+
+@pytest.mark.asyncio
+async def test_filter_requested_tools_empty_grant_drops_all(
+    service, mock_app_role_repo, make_app_role, user
+):
+    """No grant means an empty result — never a passthrough."""
+    _wire_single_role(mock_app_role_repo, make_app_role(role_id="editor", tools=[]))
+
+    result = await service.filter_requested_tools(user, ["tool_a", "tool_b"])
+
+    assert result == []

--- a/backend/tests/routes/test_schedules_routes.py
+++ b/backend/tests/routes/test_schedules_routes.py
@@ -27,6 +27,7 @@ from fastapi.testclient import TestClient
 from apis.app_api.schedules import routes as schedules_routes
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
+from apis.shared.tools.scoped_ids import base_tool_id
 from apis.shared.scheduled_prompts.models import ScheduledPrompt
 from apis.shared.scheduled_prompts.service import ScheduledPromptLimitExceeded
 from tests.routes.conftest import mock_no_auth
@@ -77,6 +78,13 @@ class FakeRoleService:
 
     async def resolve_user_permissions(self, user):
         return _FakePermissions(tools=self.tools)
+
+    async def filter_requested_tools(self, user, requested):
+        """Mirror AppRoleService.filter_requested_tools' narrow-never-grant."""
+        allowed = set(self.tools)
+        if "*" in allowed:
+            return list(requested)
+        return [t for t in requested if t in allowed or base_tool_id(t) in allowed]
 
 
 def _make_client(
@@ -193,7 +201,13 @@ class TestCreateSchedule:
         (call,) = create_mock.call_args_list
         assert call.kwargs["enabled_tools"] == ["class_search", "web_search"]
 
-    def test_explicit_enabled_tools_bypasses_rbac_resolution(self, monkeypatch):
+    def test_explicit_enabled_tools_intersected_with_rbac(self, monkeypatch):
+        """A granted tool is kept; an ungranted one is dropped, not frozen in.
+
+        FakeRoleService grants {class_search, web_search}; ``gmail_search`` is
+        outside the caller's role and must never reach the stored snapshot —
+        the tool filter downstream performs no RBAC check of its own.
+        """
         client = _make_client(monkeypatch)
         create_mock = AsyncMock(return_value=_make_schedule())
         monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
@@ -206,12 +220,33 @@ class TestCreateSchedule:
                 "cadence": "daily",
                 "hourLocal": 9,
                 "timezone": "America/Boise",
-                "enabledTools": ["gmail_search"],
+                "enabledTools": ["class_search", "gmail_search"],
             },
         )
 
         (call,) = create_mock.call_args_list
-        assert call.kwargs["enabled_tools"] == ["gmail_search"]
+        assert call.kwargs["enabled_tools"] == ["class_search"]
+
+    def test_explicit_ungranted_tools_all_dropped(self, monkeypatch):
+        """A request made entirely of ungranted tools freezes an empty set."""
+        client = _make_client(monkeypatch)
+        create_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
+
+        client.post(
+            "/schedules",
+            json={
+                "label": "Briefing",
+                "promptText": "Go",
+                "cadence": "daily",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+                "enabledTools": ["gmail_search", "some_admin_tool"],
+            },
+        )
+
+        (call,) = create_mock.call_args_list
+        assert call.kwargs["enabled_tools"] == []
 
     def test_weekly_without_weekday_is_422(self, monkeypatch):
         client = _make_client(monkeypatch)
@@ -345,6 +380,23 @@ class TestUpdateSchedule:
 
         response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"label": "Renamed"})
         assert response.status_code == 404
+
+    def test_edit_enabled_tools_intersected_with_rbac(self, monkeypatch):
+        """A PATCH is a write into the same snapshot, so it gets the same
+        RBAC intersection — an edit cannot smuggle in an ungranted tool."""
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        update_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", update_mock)
+
+        response = client.patch(
+            f"/schedules/{SCHEDULE_ID}",
+            json={"enabledTools": ["web_search", "gmail_search"]},
+        )
+
+        assert response.status_code == 200
+        (call,) = update_mock.call_args_list
+        assert call.kwargs["enabled_tools"] == ["web_search"]
 
     def test_switching_to_weekly_without_weekday_is_422(self, monkeypatch):
         client = _make_client(monkeypatch)


### PR DESCRIPTION
## Summary

Closes the top finding from a focused security review of the scheduled-runs feature: **client-supplied `enabled_tools` was trusted end-to-end on the headless surfaces, with no server-side RBAC intersection.**

The tool-authorization decision rested entirely on the request body:
- **Schedule create** (`_resolve_enabled_tools_snapshot`) resolved RBAC only for the `None` case; an explicit list was frozen verbatim.
- **Schedule update** (PATCH) forwarded `request.enabled_tools` unchecked — a bypass of even the create-time intent.
- **Run-now** passed `body.enabled_tools` straight to the harness with no resolution at all.
- **inference-api** `tool_filter.filter_tools_extended` materializes any tool ID present in the registry — **registry membership is its only gate, there is no RBAC check.**

**Impact:** a user holding the `scheduled-runs` capability could craft a request enabling a tool outside their AppRole (e.g. a privileged gateway/admin tool). The SPA tool picker filters for UX but is not a security boundary — the body is attacker-controlled within the caller's own session. For schedules this is worse than an attended chat turn: the crafted list is persisted and executed unattended on a recurring cadence.

## Fix

New `AppRoleService.filter_requested_tools(user, requested)` — a **narrow-never-grant** intersection of a requested tool list against the caller's resolved RBAC grant:
- honors the `*` wildcard (passthrough),
- admits a scoped `base::tool` id when its base server id is granted (so whole-server grants still allow per-tool selections),
- preserves the caller's order,
- mirrors the existing `_apply_enabled_skills_filter` contract on the skills axis.

Applied at the three app-api write/entry points where a full `User` (with JWT roles) is already in hand: **schedule create**, **schedule update**, and **run-now**. `None` is preserved as "resolve to the user's defaults". Dropped tools are logged (no hard failure — consistent with the skills-filter behavior).

## Deliberately out of scope (follow-up)

- **Fire-time re-intersection** against *current* RBAC — so that revoking a tool from a user's role also disarms their already-created sleeping schedules (the "orange" finding). The worker/dispatcher only carry a bare `user_id`, not the owner's live roles, so this needs a separate design decision (mint+decode, or a defense-in-depth intersection in inference-api `/invocations`, which also has the JWT). That inference-api enforcement point would additionally close the same trust gap on the **attended chat path**, which is systemic and predates this feature.
- **Dispatcher capability re-check** (spec §6) — same `user_id`-only limitation.

## Testing

- `AppRoleService.filter_requested_tools`: drop-ungranted, order-preservation, wildcard passthrough, scoped-id-by-base-grant, empty-grant-drops-all.
- Schedule create: explicit list intersected; all-ungranted → empty snapshot; `None` still resolves the full RBAC snapshot.
- Schedule update: PATCH intersects (cannot smuggle in an ungranted tool).
- Run-now: crafted body stripped before the harness; `None` passes through as defaults.

```
77 passed  (rbac service + schedules routes + runs routes)
146 passed (+ import boundaries, scheduled_prompts, worker, dispatcher, full rbac suite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)