### PR TITLE
feat(schedules): PR-5a hardening — lean-image guard + clearable schedule fields

### DIFF
--- a/backend/src/apis/app_api/schedules/models.py
+++ b/backend/src/apis/app_api/schedules/models.py
@@ -54,6 +54,20 @@ class UpdateScheduleRequest(BaseModel):
     enabled_tools: Optional[List[str]] = Field(None, alias="enabledTools")
     deliver_email: Optional[bool] = Field(None, alias="deliverEmail")
     state: Optional[Literal["active", "paused"]] = None
+    # A bare null cannot express "clear" for assistant_id / enabled_tools (the
+    # service reads null as "leave unchanged"), so clearing is an explicit
+    # intent. clear_tools re-snapshots the caller's current RBAC-allowed tools
+    # (mirrors creation), clear_assistant reverts to the default agent.
+    clear_assistant: bool = Field(False, alias="clearAssistant")
+    clear_tools: bool = Field(False, alias="clearTools")
+
+    @model_validator(mode="after")
+    def _clear_excludes_value(self) -> "UpdateScheduleRequest":
+        if self.clear_assistant and self.assistant_id is not None:
+            raise ValueError("clearAssistant cannot be combined with assistantId")
+        if self.clear_tools and self.enabled_tools is not None:
+            raise ValueError("clearTools cannot be combined with enabledTools")
+        return self
 
 
 class ScheduledPromptResponse(BaseModel):

--- a/backend/src/apis/app_api/schedules/routes.py
+++ b/backend/src/apis/app_api/schedules/routes.py
@@ -30,6 +30,7 @@ from apis.shared.feature_flags import scheduled_runs_enabled
 from apis.shared.rbac.capabilities import SCHEDULED_RUNS_CAPABILITY, user_has_capability
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.scheduled_prompts.service import (
+    UNSET,
     ScheduledPromptLimitExceeded,
     compute_next_run_at,
     create_scheduled_prompt,
@@ -172,12 +173,25 @@ async def update_schedule(
             detail="weekday is required when cadence is 'weekly'",
         )
 
-    # An edited tool list is a write path into the same frozen snapshot, so it
-    # gets the same RBAC intersection as creation — a PATCH must not be a way
-    # around the create-time check. ``None`` means "leave tools unchanged".
-    enabled_tools = request.enabled_tools
-    if enabled_tools is not None:
-        enabled_tools = await _resolve_enabled_tools_snapshot(user, enabled_tools)
+    # Clear intent is explicit — a bare null means "leave unchanged", so the
+    # service uses the UNSET sentinel for "untouched". Clearing the assistant
+    # reverts to the default agent; clearing tools re-snapshots the caller's
+    # current RBAC-allowed set. An edited tool list is a write path into the
+    # same frozen snapshot, so it gets the same create-time resolution — a
+    # PATCH must not route around the create-time check.
+    if request.clear_assistant:
+        assistant_arg = None
+    elif request.assistant_id is not None:
+        assistant_arg = request.assistant_id
+    else:
+        assistant_arg = UNSET
+
+    if request.clear_tools:
+        tools_arg = await _resolve_enabled_tools_snapshot(user, None)
+    elif request.enabled_tools is not None:
+        tools_arg = await _resolve_enabled_tools_snapshot(user, request.enabled_tools)
+    else:
+        tools_arg = UNSET
 
     schedule = await update_scheduled_prompt(
         user.user_id,
@@ -188,8 +202,8 @@ async def update_schedule(
         hour_local=request.hour_local,
         weekday=request.weekday,
         timezone_name=request.timezone,
-        assistant_id=request.assistant_id,
-        enabled_tools=enabled_tools,
+        assistant_id=assistant_arg,
+        enabled_tools=tools_arg,
         deliver_email=request.deliver_email,
     )
 

--- a/backend/src/apis/shared/scheduled_prompts/service.py
+++ b/backend/src/apis/shared/scheduled_prompts/service.py
@@ -18,12 +18,35 @@ import logging
 import os
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from typing import List, Optional
+from typing import List, Optional, Union
 from zoneinfo import ZoneInfo
 
 from .models import DUE_INDEX_PK, ScheduleCadence, ScheduledPrompt, ScheduledPromptState
 
 logger = logging.getLogger(__name__)
+
+
+class _Unset:
+    """Singleton sentinel meaning "argument not provided".
+
+    Distinct from ``None``, which on the *clearable* update fields
+    (``assistant_id`` / ``enabled_tools``) means "clear this field". A plain
+    ``None`` default cannot tell "leave unchanged" from "clear".
+    """
+
+    _instance: Optional["_Unset"] = None
+
+    def __new__(cls) -> "_Unset":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "UNSET"
+
+
+#: Sentinel for update_scheduled_prompt's clearable fields (see _Unset).
+UNSET = _Unset()
 
 DEFAULT_MAX_SCHEDULES_PER_USER = 20
 
@@ -382,8 +405,8 @@ async def update_scheduled_prompt(
     hour_local: Optional[int] = None,
     weekday: Optional[int] = None,
     timezone_name: Optional[str] = None,
-    assistant_id: Optional[str] = None,
-    enabled_tools: Optional[List[str]] = None,
+    assistant_id: Union[str, None, _Unset] = UNSET,
+    enabled_tools: Union[List[str], None, _Unset] = UNSET,
     deliver_email: Optional[bool] = None,
 ) -> Optional[ScheduledPrompt]:
     """Edit a schedule's fields in place.
@@ -394,6 +417,12 @@ async def update_scheduled_prompt(
     just remembers the new cadence for when it resumes (mirrors
     ``sync_policies.change_policy_interval``). Returns None if the schedule
     does not exist.
+
+    ``assistant_id`` and ``enabled_tools`` are *clearable*: pass ``UNSET``
+    (the default) to leave them untouched, a value to set them, or ``None``
+    to clear them (the attribute is removed — the schedule falls back to the
+    default agent / all-RBAC-allowed tools). All other fields keep the plain
+    ``None`` == "leave unchanged" contract.
     """
     schedule = await get_scheduled_prompt(user_id, schedule_id)
     if schedule is None:
@@ -432,22 +461,31 @@ async def update_scheduled_prompt(
             values[":gsipk"] = DUE_INDEX_PK
             values[":gsisk"] = _due_sort_key(next_run_at, schedule_id)
 
-    field_updates = {
-        "label": label,
-        "promptText": prompt_text,
-        "assistantId": assistant_id,
-        "enabledTools": enabled_tools,
-        "deliverEmail": deliver_email,
-    }
-    for attr, value in field_updates.items():
+    # Non-clearable fields: None == "leave unchanged".
+    for attr, value in (("label", label), ("promptText", prompt_text), ("deliverEmail", deliver_email)):
         if value is not None:
-            placeholder = f":{attr}"
-            set_parts.append(f"{attr} = {placeholder}")
-            values[placeholder] = value
+            set_parts.append(f"{attr} = :{attr}")
+            values[f":{attr}"] = value
+
+    # Clearable fields: UNSET == leave, None == clear (REMOVE the attribute),
+    # any other value == set.
+    remove_parts: List[str] = []
+    for attr, value in (("assistantId", assistant_id), ("enabledTools", enabled_tools)):
+        if isinstance(value, _Unset):
+            continue
+        if value is None:
+            remove_parts.append(attr)
+        else:
+            set_parts.append(f"{attr} = :{attr}")
+            values[f":{attr}"] = value
+
+    update_expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        update_expression += " REMOVE " + ", ".join(remove_parts)
 
     update_kwargs = {
         "Key": {"PK": f"USER#{user_id}", "SK": f"SCHEDPROMPT#{schedule_id}"},
-        "UpdateExpression": "SET " + ", ".join(set_parts),
+        "UpdateExpression": update_expression,
         "ExpressionAttributeValues": values,
     }
     if names:

--- a/backend/tests/architecture/test_import_boundaries.py
+++ b/backend/tests/architecture/test_import_boundaries.py
@@ -171,6 +171,54 @@ class TestSharedIsolation:
         )
 
 
+class TestScheduledRunsLeanImageIsImportable:
+    """The scheduled-runs Lambda image must not import agents/ or strands.
+
+    ``backend/Dockerfile.scheduled-runs`` bundles only a handful of
+    ``apis.shared`` subpackages plus the two Lambda handlers — it deliberately
+    omits the ``agents``/``strands`` packages to stay small. Any import of
+    those (top level *or* lazy — a deferred import still crashes at call time
+    in the lean image) breaks the dispatcher/worker at runtime. This test is
+    the guard that would have caught the ``ModuleNotFoundError: No module
+    named 'agents'`` that shipped in the first cut of the worker.
+
+    Keep ``_BUNDLED_DIRS`` in lockstep with the ``COPY`` lines in
+    ``backend/Dockerfile.scheduled-runs`` and the ``scheduled-runs``
+    ``SOURCE_DIRS`` in ``scripts/build/build-one.sh``.
+    """
+
+    # Paths (relative to backend/src) the scheduled-runs image COPYs in.
+    _BUNDLED_DIRS = (
+        Path("apis/shared/harness"),
+        Path("apis/shared/scheduled_prompts"),
+        Path("apis/shared/sessions_bff"),
+        Path("apis/shared/sessions"),
+        Path("lambdas/scheduled_runs_dispatcher"),
+        Path("lambdas/scheduled_runs_worker"),
+    )
+
+    def test_no_agents_or_strands_imports(self):
+        violations: List[str] = []
+        for rel_dir in self._BUNDLED_DIRS:
+            source = _BACKEND_SRC / rel_dir
+            if not source.exists():
+                pytest.skip(f"{rel_dir} not found")
+            violations += _find_violations(
+                source,
+                {"agents", "strands"},
+                "scheduled-runs lean image → agents/strands (unavailable in image)",
+            )
+
+        assert violations == [], (
+            "The scheduled-runs Lambda image bundles modules that import "
+            "agents/ or strands, which are NOT in the image:\n"
+            + "\n".join(violations)
+            + "\n\nMove the needed helper into a dependency-free apis.shared "
+            "leaf (see apis/shared/sessions/preview.py), or add the package to "
+            "the image requirements if it truly belongs there."
+        )
+
+
 class TestAppApiDoesNotImportInferenceApi:
     """app_api must not import from inference_api.
 

--- a/backend/tests/routes/test_schedules_routes.py
+++ b/backend/tests/routes/test_schedules_routes.py
@@ -398,6 +398,56 @@ class TestUpdateSchedule:
         (call,) = update_mock.call_args_list
         assert call.kwargs["enabled_tools"] == ["web_search"]
 
+    def test_omitted_clearable_fields_pass_unset(self, monkeypatch):
+        """A label-only PATCH must leave assistant/tools untouched (UNSET)."""
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        update_mock = AsyncMock(return_value=_make_schedule(label="Renamed"))
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", update_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"label": "Renamed"})
+
+        assert response.status_code == 200
+        (call,) = update_mock.call_args_list
+        assert call.kwargs["assistant_id"] is schedules_routes.UNSET
+        assert call.kwargs["enabled_tools"] is schedules_routes.UNSET
+
+    def test_clear_assistant_passes_none(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        update_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", update_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"clearAssistant": True})
+
+        assert response.status_code == 200
+        (call,) = update_mock.call_args_list
+        assert call.kwargs["assistant_id"] is None
+
+    def test_clear_tools_resnapshots_current_rbac(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+        update_mock = AsyncMock(return_value=_make_schedule())
+        monkeypatch.setattr(schedules_routes, "update_scheduled_prompt", update_mock)
+
+        response = client.patch(f"/schedules/{SCHEDULE_ID}", json={"clearTools": True})
+
+        assert response.status_code == 200
+        (call,) = update_mock.call_args_list
+        # clear = re-snapshot the caller's full RBAC-allowed set (FakeRoleService default).
+        assert call.kwargs["enabled_tools"] == ["class_search", "web_search"]
+
+    def test_clear_flag_with_value_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "get_scheduled_prompt", AsyncMock(return_value=_make_schedule()))
+
+        assert client.patch(
+            f"/schedules/{SCHEDULE_ID}", json={"clearAssistant": True, "assistantId": "ast-1"}
+        ).status_code == 422
+        assert client.patch(
+            f"/schedules/{SCHEDULE_ID}", json={"clearTools": True, "enabledTools": ["web_search"]}
+        ).status_code == 422
+
     def test_switching_to_weekly_without_weekday_is_422(self, monkeypatch):
         client = _make_client(monkeypatch)
         monkeypatch.setattr(

--- a/backend/tests/shared/test_scheduled_prompts.py
+++ b/backend/tests/shared/test_scheduled_prompts.py
@@ -401,6 +401,46 @@ class TestUpdateScheduledPrompt:
         )["Item"]
         assert "GSI3_PK" not in item
 
+    async def test_unset_clearable_field_leaves_it_unchanged(self, sessions_metadata_table):
+        schedule = await _make_schedule(assistant_id="ast-123", enabled_tools=["gmail_search"])
+        # A label-only edit must not disturb the clearable fields (default UNSET).
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, label="Renamed")
+        assert updated.assistant_id == "ast-123"
+        assert updated.enabled_tools == ["gmail_search"]
+
+    async def test_set_clearable_field_updates_it(self, sessions_metadata_table):
+        schedule = await _make_schedule(assistant_id="ast-123", enabled_tools=["gmail_search"])
+        updated = await update_scheduled_prompt(
+            USER_ID, schedule.schedule_id, assistant_id="ast-456", enabled_tools=["calendar_list"]
+        )
+        assert updated.assistant_id == "ast-456"
+        assert updated.enabled_tools == ["calendar_list"]
+
+    async def test_clear_assistant_removes_attribute(self, sessions_metadata_table):
+        schedule = await _make_schedule(assistant_id="ast-123")
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, assistant_id=None)
+        assert updated.assistant_id is None
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert "assistantId" not in item
+
+    async def test_clear_enabled_tools_removes_attribute(self, sessions_metadata_table):
+        schedule = await _make_schedule(enabled_tools=["gmail_search"])
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, enabled_tools=None)
+        assert updated.enabled_tools is None
+        item = sessions_metadata_table.get_item(
+            Key={"PK": f"USER#{USER_ID}", "SK": f"SCHEDPROMPT#{schedule.schedule_id}"}
+        )["Item"]
+        assert "enabledTools" not in item
+
+    async def test_clear_is_a_noop_when_field_already_absent(self, sessions_metadata_table):
+        # REMOVE on a missing attribute is harmless — no error, still absent.
+        schedule = await _make_schedule()  # no assistant_id
+        updated = await update_scheduled_prompt(USER_ID, schedule.schedule_id, assistant_id=None)
+        assert updated is not None
+        assert updated.assistant_id is None
+
 
 # ---------------------------------------------------------------------------
 # Delete = total revocation

--- a/frontend/ai.client/src/app/schedules/models/schedule.model.ts
+++ b/frontend/ai.client/src/app/schedules/models/schedule.model.ts
@@ -73,6 +73,12 @@ export interface UpdateScheduleRequest {
   enabledTools?: string[] | null;
   deliverEmail?: boolean;
   state?: 'active' | 'paused';
+  // A bare null cannot clear assistantId/enabledTools (the backend reads null
+  // as "leave unchanged"), so clearing is an explicit intent. clearTools
+  // re-snapshots the caller's current RBAC-allowed tools; clearAssistant
+  // reverts to the default agent. Not combinable with the value field.
+  clearAssistant?: boolean;
+  clearTools?: boolean;
 }
 
 /** Response from GET /schedules. */

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
@@ -184,7 +184,7 @@ describe('ScheduleFormPage', () => {
       expect(request.assistantId).toBe('ast-1');
     });
 
-    it('clearing the assistant checkbox omits assistantId (documented gap: cannot actually detach)', async () => {
+    it('clearing the assistant checkbox sends clearAssistant instead of assistantId', async () => {
       component.ngOnInit();
       await Promise.resolve();
       await Promise.resolve();
@@ -193,10 +193,11 @@ describe('ScheduleFormPage', () => {
       await component.onSubmit();
 
       const [, request] = mockScheduleService.updateSchedule.mock.calls[0];
+      expect(request.clearAssistant).toBe(true);
       expect(request.assistantId).toBeUndefined();
     });
 
-    it('clearing the tools checkbox omits enabledTools from the PATCH', async () => {
+    it('clearing the tools checkbox sends clearTools instead of enabledTools', async () => {
       component.ngOnInit();
       await Promise.resolve();
       await Promise.resolve();
@@ -205,6 +206,7 @@ describe('ScheduleFormPage', () => {
       await component.onSubmit();
 
       const [, request] = mockScheduleService.updateSchedule.mock.calls[0];
+      expect(request.clearTools).toBe(true);
       expect(request.enabledTools).toBeUndefined();
       expect(component.selectedToolIds().size).toBe(0);
     });

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
@@ -65,13 +65,11 @@ function timezoneOptions(): string[] {
  *
  * Optional fields (assistant, tool selection) use explicit "clear"
  * checkboxes rather than relying on sending null: the backend's
- * `update_scheduled_prompt` only writes a field when the incoming value is
- * not None, so a bare `null` over the wire is silently ignored. The clear
- * checkboxes here are a client-side workaround — they still can't actually
- * detach an already-set field on an *edit*, because there is no
- * value/sentinel the backend currently accepts to mean "erase this". See
- * `buildUpdateRequest` for exactly where this bites, and the PR notes for
- * the suggested backend follow-up.
+ * `update_scheduled_prompt` reads a bare `null` as "leave unchanged", so a
+ * clear is signalled with the explicit `clearAssistant` / `clearTools`
+ * booleans instead. `clearAssistant` reverts to the default agent;
+ * `clearTools` re-snapshots the caller's current RBAC-allowed tools. See
+ * `buildUpdateRequest`.
  */
 @Component({
   selector: 'app-schedule-form-page',
@@ -270,14 +268,12 @@ export class ScheduleFormPage implements OnInit {
   }
 
   /**
-   * Builds the PATCH body for edit mode. KNOWN GAP: `assistantId` and
-   * `enabledTools` cannot be cleared this way — the backend only applies a
-   * field when it is not None (see UpdateScheduleRequest doc comment), so
-   * omitting the field (or sending null) both leave the stored value
-   * unchanged. The "clear" checkboxes are wired up so the UI intent is at
-   * least explicit and ready to send a real sentinel/clear signal the
-   * moment the backend supports one; until then this method sends the
-   * field only when there's a genuine non-empty value to set.
+   * Builds the PATCH body for edit mode. `assistantId` and `enabledTools`
+   * cannot be cleared with a bare null (the backend reads null as "leave
+   * unchanged"), so the "clear" checkboxes send an explicit `clearAssistant`
+   * / `clearTools` intent instead. A clear flag and a value are mutually
+   * exclusive (the backend rejects both), so each pair is either a clear, a
+   * set, or omitted.
    */
   private buildUpdateRequest(
     value: ReturnType<ScheduleFormPage['form']['getRawValue']>,
@@ -291,10 +287,14 @@ export class ScheduleFormPage implements OnInit {
       weekday: value.cadence === 'weekly' ? value.weekday : null,
       timezone: value.timezone!,
     };
-    if (!this.clearAssistant() && value.assistantId) {
+    if (this.clearAssistant()) {
+      request.clearAssistant = true;
+    } else if (value.assistantId) {
       request.assistantId = value.assistantId;
     }
-    if (!this.clearTools() && toolIds.length > 0) {
+    if (this.clearTools()) {
+      request.clearTools = true;
+    } else if (toolIds.length > 0) {
       request.enabledTools = toolIds;
     }
     return request;


### PR DESCRIPTION
PR-5a hardening for scheduled runs (follow-up to the #566/#567 lean-image fixes and #563 B1 CRUD). Two independent commits.

## 1. Lean-image import guard (test-only)
An AST test asserts the modules bundled into `Dockerfile.scheduled-runs` (`harness/`, `scheduled_prompts/`, `sessions_bff/`, `sessions/` + both lambda handlers) never import `agents`/`strands` — **top level or lazy** (a deferred import still crashes at call time in the lean image, as we saw live). This is the guard that would have caught the `ModuleNotFoundError: No module named 'agents'` that shipped in the first worker cut. Deliberately narrower than forbidding all `apis.shared → agents` (e.g. `quota.py` legitimately imports `agents` and is not in the lean image).

## 2. Clearable schedule fields (B1 gap)
`update_scheduled_prompt` skipped `None`, so a PATCH could never detach a schedule's assistant or reset its tool restriction — the SPA's clear checkboxes were inert (a bare null reads as "leave unchanged").

- **Service**: an `UNSET` sentinel distinguishes "omitted" (leave) from `None` (clear → `REMOVE` the attribute).
- **API**: `UpdateScheduleRequest` gains `clearAssistant`/`clearTools` booleans, rejected (422) if combined with a value. `clearAssistant` reverts to the default agent; `clearTools` re-snapshots the caller's current RBAC-allowed tools (mirrors creation — a schedule never stores an unresolved `None`).
- **SPA**: the existing clear checkboxes now send the flags; updated the two specs that asserted the old "documented gap".

## Verification
- Backend: 213 tests pass (scheduled_prompts service + routes incl. new clear/validator cases, import boundaries, all lambdas).
- Frontend: 46 schedule specs pass via `ng test`.

## Deferred (noted, not in this PR)
- Prod GA-gating check: confirm prod's `default` role grant before releasing scheduled runs to `main` (dev-ai's `default` has `*`, so it's effectively GA there).
- `apis/shared/quota.py` has the same `apis.shared → agents` coupling (not in the lean-image path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)