### PR TITLE
fix(app-api): grant bedrock:ListFoundationModels to task role

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -439,6 +439,22 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Bedrock control-plane model browsing ──
+  // GET /admin/bedrock/models calls the Bedrock control plane's
+  // ListFoundationModels (apis/app_api/admin/routes.py). These are
+  // account-level list/read actions that do NOT support resource-level
+  // permissions, so they must be granted on `*`. Without this, the deployed
+  // task role gets AccessDeniedException and the endpoint 502s (works locally
+  // only because local dev runs with the developer's broader AWS credentials).
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'BedrockListFoundationModels',
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock:ListFoundationModels', 'bedrock:GetFoundationModel'],
+      resources: ['*'],
+    }),
+  );
+
   // ── Bedrock Mantle model browsing ──
   // GET /admin/mantle/models authenticates against the OpenAI-compatible
   // Bedrock Mantle endpoint with a short-term bearer token presigned by this


### PR DESCRIPTION
## Problem

`GET /admin/bedrock/models` returns **502 Bad Gateway** (`{"detail":"Upstream service error."}`) in deployed environments (e.g. dev-ai / `alpha`), but works when running the app locally.

## Root cause

The endpoint calls the Bedrock **control plane** `ListFoundationModels` (`backend/src/apis/app_api/admin/routes.py`), but the App API Fargate task role only granted `bedrock:InvokeModel`. In a deployed environment the call raises `AccessDeniedException` — a botocore `ClientError` — which the app-wide AWS-error handler (`apis/shared/security/error_handler.py`) deliberately maps to a generic **502** without echoing the AWS message.

It only worked locally because local dev runs under the developer's own (broader) AWS credentials rather than the task role.

## Fix

Add a `BedrockListFoundationModels` statement to the App API task-role grants (`infrastructure/lib/constructs/app-api/app-api-iam-grants.ts`) for `bedrock:ListFoundationModels` and `bedrock:GetFoundationModel`. These are account-level list/read actions with no resource-level permission support, so they're granted on `*`.

## Deploy note

This is an IAM/CDK change — it needs a **`platform.yml` (CDK) deploy** to the affected environment(s) to take effect; a `backend.yml`-only code push won't apply it. The same gap exists in prod (`beta`) once that admin view is loaded there, so it should ride the release through to `main` as well.

## Testing

- `npx tsc --noEmit` passes in `infrastructure/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)