### PR TITLE
feat(sessions): unread indicator for scheduled-run deliveries

### DIFF
--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -23,6 +23,7 @@ from apis.shared.sessions.messages import get_messages
 from apis.shared.sessions.metadata import (
     list_user_sessions,
     get_session_metadata,
+    mark_session_read,
     remove_pending_interrupts,
     session_exists_for_other_user,
     set_interrupted_turn,
@@ -152,6 +153,26 @@ async def get_session_metadata_endpoint(
             status_code=500,
             detail=f"Failed to retrieve session metadata: {str(e)}"
         )
+
+
+@router.post("/{session_id}/read", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_session_read_endpoint(
+    session_id: str,
+    current_user: User = Depends(get_current_user_from_session)
+):
+    """
+    Mark a session as read, clearing the durable ``unread`` flag.
+
+    Called by the SPA when the user opens a session that a scheduled
+    (unattended) run left unread. Idempotent single-attribute write — a
+    no-op if the session is already read or doesn't exist. Ownership is
+    enforced inside ``mark_session_read`` via the GSI lookup, so a session
+    belonging to another user is silently ignored (no state change).
+
+    Requires session-cookie authentication. Returns 204 No Content.
+    """
+    await mark_session_read(session_id=session_id, user_id=current_user.user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.put("/{session_id}/metadata", response_model=SessionMetadataResponse, response_model_exclude_none=True)

--- a/backend/src/apis/shared/harness/runner.py
+++ b/backend/src/apis/shared/harness/runner.py
@@ -232,6 +232,7 @@ async def run_agent_headless(
     try:
         from apis.shared.sessions.metadata import (
             ensure_session_metadata_exists,
+            set_session_unread,
             update_session_title,
         )
 
@@ -239,6 +240,15 @@ async def run_agent_headless(
         if title:
             await update_session_title(session_id, user_id, title)
             result.title = title
+
+        # A scheduled (unattended) run produced a response the user wasn't
+        # watching — flag the session unread so the sidebar shows a dot until
+        # they open it. Runs *after* the SK-rotating writes above, on the row's
+        # final SK. Gated on a successful completion (no dot for a failed or
+        # consent-blocked run) and on the unattended trigger (attended "Run
+        # now" / manual invocations don't mark unread — the user is present).
+        if trigger == "schedule" and result.status == "completed":
+            await set_session_unread(session_id, user_id, True)
     except Exception:
         logger.error(
             "Headless run %s: result delivery failed", run_id, exc_info=True

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -851,6 +851,62 @@ async def update_session_title(session_id: str, user_id: str, title: str) -> Non
         logger.error(f"update_session_title failed: {e}", exc_info=True)
 
 
+async def set_session_unread(session_id: str, user_id: str, unread: bool) -> None:
+    """Set (or clear) the durable ``unread`` flag on the session row.
+
+    Targeted ``UpdateExpression`` on the current SK — mirrors
+    ``update_session_title`` so it can run concurrently with the full-row
+    merge without clobbering ``messageCount`` / ``lastMessageAt`` / ``title``.
+    ``unread`` is NOT part of the SK, so no SK rotation is needed. Looks up the
+    current SK via the GSI because the SK contains a timestamp.
+
+    Set ``True`` from the unattended-run delivery path (a scheduled run the user
+    didn't witness); cleared via ``mark_session_read`` when they open it.
+
+    No-op when the session row doesn't exist (preview sessions, sessions
+    deleted mid-turn) — best-effort, never raises.
+    """
+    if is_preview_session(session_id):
+        return
+
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table:
+        raise RuntimeError("DYNAMODB_SESSIONS_METADATA_TABLE_NAME environment variable is required")
+
+    try:
+        import boto3
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        existing = await _get_session_by_gsi(session_id, user_id, table)
+        if not existing:
+            logger.info(f"set_session_unread: session {session_id} not found, skipping")
+            return
+        sk = existing.get("SK")
+        if not sk:
+            logger.warning(f"set_session_unread: session {session_id} has no SK")
+            return
+
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": sk},
+            UpdateExpression="SET unread = :u",
+            ExpressionAttributeValues={":u": unread},
+        )
+        logger.info(f"💾 Set unread={unread} for session {session_id}")
+    except Exception as e:
+        logger.error(f"set_session_unread failed: {e}", exc_info=True)
+
+
+async def mark_session_read(session_id: str, user_id: str) -> None:
+    """Clear the ``unread`` flag on a session (user opened it).
+
+    Thin wrapper over ``set_session_unread(..., False)`` — the read verb the
+    app-api ``POST /sessions/{id}/read`` endpoint calls.
+    """
+    await set_session_unread(session_id, user_id, False)
+
+
 async def update_session_activity(
     session_id: str,
     user_id: str,

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -283,6 +283,16 @@ class SessionMetadata(BaseModel):
         description="Receipts for conversation exports to connected apps, newest appended last",
     )
 
+    # Durable "unread" flag: set when an UNATTENDED run (scheduled / headless)
+    # completes in this session, since the user by definition wasn't watching.
+    # Interactive turns never set it (the client tracks same-tab unread state).
+    # Cleared server-side when the user opens the session (mark_session_read),
+    # so the dot survives reload and reaches other devices. Not part of the SK.
+    unread: Optional[bool] = Field(
+        False,
+        description="True when an unattended (scheduled) run left a response the user hasn't opened yet",
+    )
+
 
 class UpdateSessionMetadataRequest(BaseModel):
     """Request body for updating session metadata"""
@@ -374,6 +384,10 @@ class SessionMetadataResponse(BaseModel):
         default=None,
         alias="exportReceipts",
         description="Receipts for conversation exports to connected apps, newest appended last; lets the UI restore a 'Saved · Open' affordance after a reload",
+    )
+    unread: Optional[bool] = Field(
+        False,
+        description="True when an unattended (scheduled) run left a response the user hasn't opened yet; drives the blue unread dot in the session list",
     )
 
 

--- a/backend/tests/apis/shared/test_harness_runner.py
+++ b/backend/tests/apis/shared/test_harness_runner.py
@@ -67,7 +67,7 @@ _HAPPY_STREAM = _sse(
 @pytest.fixture
 def delivery_spy(monkeypatch):
     """Spy the runner's delivery calls (imported lazily from sessions.metadata)."""
-    calls = {"ensure": [], "title": []}
+    calls = {"ensure": [], "title": [], "unread": []}
 
     async def fake_ensure(session_id, user_id):
         calls["ensure"].append((session_id, user_id))
@@ -76,8 +76,12 @@ def delivery_spy(monkeypatch):
     async def fake_title(session_id, user_id, title):
         calls["title"].append((session_id, user_id, title))
 
+    async def fake_unread(session_id, user_id, unread):
+        calls["unread"].append((session_id, user_id, unread))
+
     monkeypatch.setattr(sessions_metadata, "ensure_session_metadata_exists", fake_ensure)
     monkeypatch.setattr(sessions_metadata, "update_session_title", fake_title)
+    monkeypatch.setattr(sessions_metadata, "set_session_unread", fake_unread)
     return calls
 
 
@@ -178,6 +182,54 @@ async def test_happy_path_completes_and_delivers(monkeypatch, delivery_spy):
     # Delivery: idempotent session ensure + explicit title override.
     assert delivery_spy["ensure"] == [(result.session_id, "user-1")]
     assert delivery_spy["title"] == [(result.session_id, "user-1", "My Briefing")]
+    # Attended trigger ("run_now") — the user is present, so no unread flag.
+    assert delivery_spy["unread"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduled_completion_marks_session_unread(monkeypatch, delivery_spy):
+    """An unattended (schedule) run flags the session unread on completion."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_HAPPY_STREAM,
+        )
+
+    _mock_http(monkeypatch, handler)
+
+    result = await run_agent_headless(
+        user_id="user-1",
+        prompt="daily briefing",
+        auth=SpyBearerAuth("bearer-xyz"),
+        trigger="schedule",
+        invocations_base_url="http://localhost:8001",
+        governance=GovernanceFloor(audit=RecordingAudit()),
+    )
+
+    assert result.status == "completed"
+    assert delivery_spy["unread"] == [(result.session_id, "user-1", True)]
+
+
+@pytest.mark.asyncio
+async def test_scheduled_error_does_not_mark_unread(monkeypatch, delivery_spy):
+    """A failed schedule run leaves no unread dot (nothing worth reading)."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"message": "OAuth authorization failed"})
+
+    _mock_http(monkeypatch, handler)
+
+    result = await run_agent_headless(
+        user_id="user-1",
+        prompt="daily briefing",
+        auth=SpyBearerAuth("bearer-xyz"),
+        trigger="schedule",
+        invocations_base_url="http://localhost:8001",
+        governance=GovernanceFloor(audit=RecordingAudit()),
+    )
+
+    assert result.status != "completed"
+    assert delivery_spy["unread"] == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -826,3 +826,31 @@ class TestSignalTurnInterrupted:
             json={"reason": "user_stopped"},
         )
         assert resp.status_code == 401
+
+
+class TestMarkSessionRead:
+    """POST /sessions/{session_id}/read clears the durable unread flag.
+
+    Called by the SPA when the user opens a session that a scheduled
+    (unattended) run left unread. Cookie-auth via
+    get_current_user_from_session per the app-api auth rule.
+    """
+
+    def test_returns_204_and_clears_unread(self, app, make_user, authenticated_client):
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        recorder = AsyncMock()
+        with patch(
+            "apis.app_api.sessions.routes.mark_session_read",
+            recorder,
+        ):
+            resp = client.post("/sessions/sess-001/read")
+
+        assert resp.status_code == 204
+        recorder.assert_awaited_once_with(session_id="sess-001", user_id=user.user_id)
+
+    def test_returns_401_for_unauthenticated(self, app, unauthenticated_client):
+        client = unauthenticated_client(app)
+        resp = client.post("/sessions/sess-001/read")
+        assert resp.status_code == 401

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -509,6 +509,67 @@ class TestUpdateSessionActivity:
         assert items == []
 
 
+class TestSessionUnread:
+    """Durable unread flag set by unattended (scheduled) runs, cleared on open."""
+
+    @pytest.mark.asyncio
+    async def test_set_then_mark_read(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            ensure_session_metadata_exists,
+            set_session_unread,
+            mark_session_read,
+            get_session_metadata,
+        )
+        await ensure_session_metadata_exists("s1", "u1")
+        assert (await get_session_metadata("s1", "u1")).unread is False
+
+        await set_session_unread("s1", "u1", True)
+        assert (await get_session_metadata("s1", "u1")).unread is True
+
+        await mark_session_read("s1", "u1")
+        assert (await get_session_metadata("s1", "u1")).unread is False
+
+    @pytest.mark.asyncio
+    async def test_survives_sk_rotation(self, sessions_metadata_table):
+        """Unread set post-run must survive a later per-turn SK rotation."""
+        from apis.shared.sessions.metadata import (
+            ensure_session_metadata_exists,
+            set_session_unread,
+            update_session_activity,
+            get_session_metadata,
+        )
+        await ensure_session_metadata_exists("s1", "u1")
+        await set_session_unread("s1", "u1", True)
+        await update_session_activity(session_id="s1", user_id="u1", last_model="claude-3")
+        assert (await get_session_metadata("s1", "u1")).unread is True
+
+    @pytest.mark.asyncio
+    async def test_noop_when_session_missing(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import set_session_unread
+        # No row exists — best-effort, must not raise or create a row.
+        await set_session_unread("ghost", "u1", True)
+        assert sessions_metadata_table.scan()["Items"] == []
+
+    @pytest.mark.asyncio
+    async def test_noop_for_preview_session(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import set_session_unread
+        await set_session_unread("preview-abc", "u1", True)
+        assert sessions_metadata_table.scan()["Items"] == []
+
+    @pytest.mark.asyncio
+    async def test_user_isolation(self, sessions_metadata_table):
+        """A set for one user must not flip another user's same-id session."""
+        from apis.shared.sessions.metadata import (
+            ensure_session_metadata_exists,
+            set_session_unread,
+            get_session_metadata,
+        )
+        await ensure_session_metadata_exists("s1", "u1")
+        # Wrong owner → GSI ownership check returns None → no-op.
+        await set_session_unread("s1", "other-user", True)
+        assert (await get_session_metadata("s1", "u1")).unread is False
+
+
 class TestEnsureSessionMetadataExists:
     @pytest.mark.asyncio
     async def test_repeated_calls_do_not_create_duplicates(self, sessions_metadata_table):

--- a/frontend/ai.client/src/app/app.ts
+++ b/frontend/ai.client/src/app/app.ts
@@ -7,6 +7,7 @@ import { SidenavService } from './services/sidenav/sidenav.service';
 import { HeaderService } from './services/header/header.service';
 import { TooltipDirective } from './components/tooltip/tooltip.directive';
 import { SessionService } from './auth/session.service';
+import { SessionService as SessionListService } from './session/services/session/session.service';
 import { ArtifactStateService } from './session/services/artifacts/artifact-state.service';
 
 @Component({
@@ -27,6 +28,7 @@ export class App {
   protected headerService = inject(HeaderService);
   private router = inject(Router);
   private session = inject(SessionService);
+  private sessionList = inject(SessionListService);
   private artifactState = inject(ArtifactStateService);
 
   /** True while an artifact pane is docked — content reserves right-side
@@ -52,6 +54,9 @@ export class App {
       const handler = () => {
         if (document.visibilityState === 'visible') {
           this.session.recheck();
+          // Surface unread dots from scheduled (server-side) runs that finished
+          // while the tab was backgrounded — refetch the list on return, no poll.
+          this.sessionList.refreshSessions();
         }
       };
       document.addEventListener('visibilitychange', handler);

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
@@ -78,6 +78,8 @@
                                             }
                                             @if (isSessionStreaming(session.sessionId)) {
                                                 <span class="sr-only">(response in progress)</span>
+                                            } @else if (shouldShowUnreadDot(session)) {
+                                                <span class="sr-only">(unread)</span>
                                             }
                                         </a>
                                         @if (isSessionStreaming(session.sessionId)) {
@@ -92,6 +94,18 @@
                                                 aria-hidden="true"
                                             ></span>
                                         } @else {
+                                            @if (shouldShowUnreadDot(session)) {
+                                                <!-- Unread dot: an unattended (scheduled) run finished, or a
+                                                     backgrounded response completed while the user was viewing
+                                                     another conversation. Static blue (vs. the pulsing
+                                                     secondary streaming dot) and, unlike the streaming dot, it
+                                                     fades on hover so the ellipsis menu can own the gutter.
+                                                     Cleared once the user opens the session. -->
+                                                <span
+                                                    class="pointer-events-none absolute right-3 top-1/2 size-2 -translate-y-1/2 rounded-full bg-blue-500 transition-opacity group-hover:opacity-0 dark:bg-blue-400"
+                                                    aria-hidden="true"
+                                                ></span>
+                                            }
                                             <!-- Ellipsis menu button - visible on hover with fade-in animation -->
                                             <button
                                                 type="button"

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
@@ -32,6 +32,8 @@ describe('SessionList', () => {
       currentSession: signal(mockSession),
       deleteSession: vi.fn().mockResolvedValue(undefined),
       sessionsResource: { value: vi.fn().mockReturnValue(null), error: vi.fn().mockReturnValue(null), isPending: vi.fn().mockReturnValue(false) },
+      isLocallyRead: vi.fn().mockReturnValue(false),
+      markSessionRead: vi.fn().mockResolvedValue(undefined),
     };
     mockSidenavService = { close: vi.fn() };
     mockToastService = { success: vi.fn(), error: vi.fn() };
@@ -93,6 +95,46 @@ describe('SessionList', () => {
 
     chatState.setChatLoading('test-session', false);
     expect(component['isSessionStreaming']('test-session')).toBe(false);
+  });
+
+  it('shows the unread dot for a server-unread session and suppresses it once locally read', async () => {
+    const component = await createComponent();
+    const unreadSession = { ...mockSession, unread: true };
+
+    // Server flag set, not yet locally read → dot shows.
+    expect(component['shouldShowUnreadDot'](unreadSession)).toBe(true);
+
+    // User opened it: local read-watermark suppresses the dot before the
+    // server round-trips.
+    mockSessionService.isLocallyRead.mockReturnValue(true);
+    expect(component['shouldShowUnreadDot'](unreadSession)).toBe(false);
+
+    // A session with no server flag and no client signal shows nothing.
+    mockSessionService.isLocallyRead.mockReturnValue(false);
+    expect(component['shouldShowUnreadDot'](mockSession)).toBe(false);
+  });
+
+  it('ORs the client-side interactive unread signal into the dot', async () => {
+    const { ChatStateService } = await import('../../../../session/services/chat/chat-state.service');
+    const chatState = TestBed.inject(ChatStateService);
+    const component = await createComponent();
+
+    // No server flag, but a stream finished in this tab while viewing elsewhere.
+    chatState.setViewedSession('other');
+    chatState.setChatLoading('test-session', true);
+    chatState.setChatLoading('test-session', false);
+
+    expect(component['shouldShowUnreadDot'](mockSession)).toBe(true);
+  });
+
+  it('marks a server-unread session read on open, but not a read one', async () => {
+    const component = await createComponent();
+
+    component['onSessionClick'](mockSession);
+    expect(mockSessionService.markSessionRead).not.toHaveBeenCalled();
+
+    component['onSessionClick']({ ...mockSession, unread: true });
+    expect(mockSessionService.markSessionRead).toHaveBeenCalledOnce();
   });
 
   it('marks the title pending only for a titleless session that is streaming', async () => {

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -184,6 +184,25 @@ export class SessionList {
   }
 
   /**
+   * Whether this conversation should show the blue unread dot (distinct from
+   * the pulsing secondary streaming dot). Unread has two sources, ORed here:
+   *
+   *  - **Server** (`session.unread`): a scheduled/unattended run left a
+   *    response the user hasn't opened — durable, survives reload, cross-device.
+   *    Suppressed by `isLocallyRead` the instant the user opens it, so the dot
+   *    vanishes before `POST /read` round-trips.
+   *  - **Client** (`ChatStateService`): a stream finished in this tab while the
+   *    user was viewing a different session — ephemeral, cleared on view.
+   *
+   * Signal-backed (client signal + resource-driven `session.unread`), so the
+   * OnPush row updates when either source changes.
+   */
+  protected shouldShowUnreadDot(session: SessionMetadata): boolean {
+    const serverUnread = session.unread === true && !this.sessionService.isLocallyRead(session);
+    return serverUnread || this.chatStateService.isSessionUnread(session.sessionId);
+  }
+
+  /**
    * Gets the queryParams for a session's routerLink. When the session has
    * an assistant attached in preferences, we include it in the URL so the
    * session page can load the assistant without a second round-trip. Keeping
@@ -261,6 +280,12 @@ export class SessionList {
    */
   protected onSessionClick(session: SessionMetadata): void {
     this.sessionService.currentSession.set(session);
+    // Opening a session with a durable (scheduled-run) unread flag clears it
+    // server-side and suppresses the dot locally right away. The client-side
+    // interactive unread signal is cleared separately via setViewedSession.
+    if (session.unread) {
+      this.sessionService.markSessionRead(session);
+    }
     this.sidenavService.close();
   }
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.spec.ts
@@ -60,6 +60,42 @@ describe('ChatStateService', () => {
     });
   });
 
+  describe('unread tracking', () => {
+    it('flags a session unread when its response finishes while unviewed', () => {
+      service.setViewedSession('a');
+
+      service.setChatLoading('b', true);
+      expect(service.isSessionUnread('b')).toBe(false);
+
+      service.setChatLoading('b', false);
+      expect(service.isSessionUnread('b')).toBe(true);
+    });
+
+    it('does not flag the currently-viewed session when its response finishes', () => {
+      service.setViewedSession('a');
+      service.setChatLoading('a', true);
+      service.setChatLoading('a', false);
+      expect(service.isSessionUnread('a')).toBe(false);
+    });
+
+    it('only flags on a true→false transition, not an idempotent stop', () => {
+      service.setViewedSession('a');
+      // No prior loading=true, so this is not a "finished" transition.
+      service.setChatLoading('b', false);
+      expect(service.isSessionUnread('b')).toBe(false);
+    });
+
+    it('clears the unread flag when the user opens the session', () => {
+      service.setViewedSession('a');
+      service.setChatLoading('b', true);
+      service.setChatLoading('b', false);
+      expect(service.isSessionUnread('b')).toBe(true);
+
+      service.setViewedSession('b');
+      expect(service.isSessionUnread('b')).toBe(false);
+    });
+  });
+
   describe('setLastTurnContinuable', () => {
     it('toggles the continuable flag per session', () => {
       service.setViewedSession('a');

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -45,6 +45,14 @@ export class ChatStateService {
     private readonly viewedSessionIdSignal = signal<string | null>(null);
     readonly viewedSessionId: Signal<string | null> = this.viewedSessionIdSignal.asReadonly();
 
+    /**
+     * Sessions whose most recent response finished while the user was looking
+     * somewhere else — "unread" until they open the conversation. Held as a
+     * signal so the OnPush session-list rows re-render when a background stream
+     * completes (dot appears) or the user navigates in (dot clears).
+     */
+    private readonly unreadSessionIds = signal<ReadonlySet<string>>(new Set());
+
     readonly isChatLoading = computed(() => this.viewedState()?.loading() ?? false);
     readonly currentStopReason = computed(() => this.viewedState()?.stopReason() ?? null);
     readonly lastTurnContinuable = computed(() => this.viewedState()?.lastTurnContinuable() ?? false);
@@ -73,21 +81,63 @@ export class ChatStateService {
     private readonly scrollToLastUserSignal = signal(0);
     readonly scrollToLastUserTick: Signal<number> = this.scrollToLastUserSignal.asReadonly();
 
-    /** Point the viewed-session facades at a (possibly null) session. */
+    /**
+     * Point the viewed-session facades at a (possibly null) session. Opening a
+     * session also clears its unread flag — the user has now seen whatever
+     * response finished while they were away.
+     */
     setViewedSession(sessionId: string | null): void {
         this.viewedSessionIdSignal.set(sessionId);
+        if (sessionId) {
+            this.clearSessionUnread(sessionId);
+        }
     }
 
     /**
-     * Sets the chat loading state for a session.
+     * Sets the chat loading state for a session. When a response *finishes*
+     * (loading true→false) in a session the user isn't currently viewing, that
+     * conversation is flagged unread so the session list can surface a dot.
      */
     setChatLoading(sessionId: string, loading: boolean): void {
-        this.stateFor(sessionId).loading.set(loading);
+        const state = this.stateFor(sessionId);
+        const wasLoading = state.loading();
+        state.loading.set(loading);
+
+        if (wasLoading && !loading && sessionId !== this.viewedSessionIdSignal()) {
+            this.markSessionUnread(sessionId);
+        }
     }
 
     /** Whether a specific session is currently streaming (loading). */
     isSessionLoading(sessionId: string): boolean {
         return this.states().get(sessionId)?.loading() ?? false;
+    }
+
+    /**
+     * Whether a session has an unread response — one that finished streaming
+     * while the user was looking at a different conversation. Cleared when the
+     * user opens the session (see setViewedSession).
+     */
+    isSessionUnread(sessionId: string): boolean {
+        return this.unreadSessionIds().has(sessionId);
+    }
+
+    private markSessionUnread(sessionId: string): void {
+        this.unreadSessionIds.update(set => {
+            if (set.has(sessionId)) return set;
+            const next = new Set(set);
+            next.add(sessionId);
+            return next;
+        });
+    }
+
+    private clearSessionUnread(sessionId: string): void {
+        this.unreadSessionIds.update(set => {
+            if (!set.has(sessionId)) return set;
+            const next = new Set(set);
+            next.delete(sessionId);
+            return next;
+        });
     }
 
     /**

--- a/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
@@ -60,6 +60,13 @@ export interface SessionMetadata {
   lastTurnInterruptReason?: 'user_stopped' | 'connection_lost' | 'unknown';
   /** ISO 8601 timestamp when the interruption was detected. */
   lastTurnInterruptedAt?: string;
+  /** True when an unattended (scheduled) run left a response the user hasn't
+   *  opened yet. Server-persisted, so the unread dot survives reload and
+   *  reaches other devices; cleared server-side via POST /sessions/{id}/read
+   *  when the user opens the session. Distinct from the ephemeral, in-tab
+   *  unread state ChatStateService tracks for interactive background
+   *  completions — the session list ORs the two. */
+  unread?: boolean;
 }
 
 // Request model for updating session metadata

--- a/frontend/ai.client/src/app/session/services/session/session.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.ts
@@ -176,6 +176,16 @@ export class SessionService {
   private localSessionsCache = signal<SessionMetadata[]>([]);
 
   /**
+   * Optimistic read-watermark: sessionId → the `lastMessageAt` the user has
+   * locally acknowledged as read. Suppresses the server-driven `unread` dot
+   * the instant a session is opened, before `POST /read` round-trips and the
+   * next list refetch reflects `unread=false`. Keyed by `lastMessageAt` (not a
+   * bare id) so a *later* scheduled run — which advances `lastMessageAt` —
+   * correctly re-surfaces the dot instead of being permanently suppressed.
+   */
+  private readonly readWatermarks = signal<ReadonlyMap<string, string>>(new Map());
+
+  /**
    * Signal for the session ID used by the session metadata resource.
    * Update this signal to trigger a refetch with new session ID.
    * Set to null to disable the resource.
@@ -885,6 +895,49 @@ export class SessionService {
    */
   clearSessionCache(): void {
     this.localSessionsCache.set([]);
+  }
+
+  /**
+   * Reloads the session list from the API if loading is enabled. Called when
+   * the tab regains focus so a session that a scheduled (server-side) run left
+   * `unread` surfaces its dot without polling. No-op before auth is ready.
+   */
+  refreshSessions(): void {
+    if (this.sessionsRequest()) {
+      this.sessionsResource.reload();
+    }
+  }
+
+  /**
+   * Whether the session's current activity has been locally acknowledged as
+   * read (see `readWatermarks`). The session list uses this to suppress the
+   * server `unread` dot immediately on open, before the server round-trips.
+   */
+  isLocallyRead(session: SessionMetadata): boolean {
+    return this.readWatermarks().get(session.sessionId) === session.lastMessageAt;
+  }
+
+  /**
+   * Marks a session as read: clears the durable server-side `unread` flag via
+   * `POST /sessions/{id}/read`, and optimistically suppresses the dot locally
+   * (keyed to the activity being acknowledged) so it vanishes instantly.
+   * Best-effort — a failed POST leaves the durable flag set, so the dot simply
+   * re-appears on the next list load rather than being silently lost.
+   */
+  async markSessionRead(session: SessionMetadata): Promise<void> {
+    this.readWatermarks.update(watermarks => {
+      const next = new Map(watermarks);
+      next.set(session.sessionId, session.lastMessageAt);
+      return next;
+    });
+
+    try {
+      await firstValueFrom(
+        this.http.post<void>(`${this.baseUrl()}/${session.sessionId}/read`, {})
+      );
+    } catch (error) {
+      console.error('Failed to mark session read:', error);
+    }
   }
 
   constructor() {


### PR DESCRIPTION
Surfaces scheduled-run results the user hasn't seen — the sidebar shows an unread dot on a session a scheduled (unattended) run delivered, until they open it. Natural UX follow-on to the scheduled-runs engine.

## Behavior
- **Backend** — `set_session_unread` / `mark_session_read` (`sessions/metadata.py`): a targeted single-attribute `UpdateExpression` on the row's current SK (GSI-resolved), concurrent-safe with the title/activity writes, preview-session-guarded, best-effort. `run_agent_headless` marks the session unread **only** on a `completed` run with `trigger == "schedule"` — attended "Run now" and failed/consent-blocked runs never set the dot.
- **API** — `POST /sessions/{id}/read` clears the durable flag when the user opens the session (idempotent, ownership-enforced via the GSI lookup, 204).
- **SPA** — durable server-persisted `unread` on `SessionMetadata` (survives reload, reaches other devices) **ORed** with `ChatStateService`'s ephemeral in-tab unread for interactive background completions; `session-list` renders the dot.

## Verification
- Backend: 108 tests pass (`test_harness_runner`, `test_sessions`, `test_sessions_metadata`).
- Frontend: 25 specs pass (`session-list`, `chat-state.service`) via `ng test`.

Depends on the `is_preview_session` leaf from #567 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)