### PR TITLE
feat(sidenav): gate Scheduled Runs nav entry to system_admin

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -46,8 +46,8 @@
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
 
-        <!-- Scheduled runs (capability-gated — hidden until the accessibility probe resolves true) -->
-        @if (showSchedules()) {
+        <!-- Scheduled runs (system-admin only, plus the capability gate — hidden until the accessibility probe resolves true) -->
+        @if (showSchedules() && isAdmin()) {
             <a
                 routerLink="/schedules"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"


### PR DESCRIPTION
## What

Hides the **Scheduled Runs** sidenav entry from everyone except users with the `system_admin` AppRole, while the scheduled-runs feature is still maturing.

The existing capability gate `@if (showSchedules())` becomes `@if (showSchedules() && isAdmin())` — a one-line template change in `sidenav.html` that mirrors the established admin-dashboard nav pattern (`@if (isAdmin())`). `isAdmin` (`appRoles().includes('system_admin')`) was already injected into the component from `UserService`, so no TypeScript change was required. `showSchedules()` keeps its accessibility-probe behavior unchanged.

## Why

We want the menu option visible only to system admins for now. Per the request, this is a **menu-visibility hide**, not a hard access control.

## Reviewer notes

- ⚠️ **Visibility only, not a route guard.** `/schedules` is still reachable by direct URL for anyone the backend capability probe allows; this PR only removes the nav affordance. If a hard gate is wanted later, the existing `admin.guard.ts` (also keyed on `system_admin`) can be attached to the schedules route in a follow-up.
- The mirrored admin-dashboard pattern is itself template-only and untested at the DOM level; this change follows suit. Existing sidenav spec (method/computed-based, not DOM-rendered) is unaffected — **8/8 pass** via `ng test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)