### PR TITLE
feat(sessions): mark-as-read/unread toggle + sidebar dot fixes

### DIFF
--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -24,6 +24,7 @@ from apis.shared.sessions.metadata import (
     list_user_sessions,
     get_session_metadata,
     mark_session_read,
+    mark_session_unread,
     remove_pending_interrupts,
     session_exists_for_other_user,
     set_interrupted_turn,
@@ -172,6 +173,26 @@ async def mark_session_read_endpoint(
     Requires session-cookie authentication. Returns 204 No Content.
     """
     await mark_session_read(session_id=session_id, user_id=current_user.user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{session_id}/unread", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_session_unread_endpoint(
+    session_id: str,
+    current_user: User = Depends(get_current_user_from_session)
+):
+    """
+    Mark a session as unread, setting the durable ``unread`` flag.
+
+    The manual counterpart to ``POST /{id}/read`` — lets a user re-flag a
+    conversation (e.g. "remind me to revisit this") so the sidebar dot
+    returns. Idempotent single-attribute write; ownership is enforced inside
+    ``mark_session_unread`` via the per-user GSI lookup, so a session
+    belonging to another user is silently ignored (no state change).
+
+    Requires session-cookie authentication. Returns 204 No Content.
+    """
+    await mark_session_unread(session_id=session_id, user_id=current_user.user_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -907,6 +907,16 @@ async def mark_session_read(session_id: str, user_id: str) -> None:
     await set_session_unread(session_id, user_id, False)
 
 
+async def mark_session_unread(session_id: str, user_id: str) -> None:
+    """Set the ``unread`` flag on a session (user marked it unread manually).
+
+    Thin wrapper over ``set_session_unread(..., True)`` — the unread verb the
+    app-api ``POST /sessions/{id}/unread`` endpoint calls. Ownership is enforced
+    inside ``set_session_unread`` via the per-user GSI lookup.
+    """
+    await set_session_unread(session_id, user_id, True)
+
+
 async def update_session_activity(
     session_id: str,
     user_id: str,

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -854,3 +854,30 @@ class TestMarkSessionRead:
         client = unauthenticated_client(app)
         resp = client.post("/sessions/sess-001/read")
         assert resp.status_code == 401
+
+
+class TestMarkSessionUnread:
+    """POST /sessions/{session_id}/unread sets the durable unread flag.
+
+    The manual counterpart to /read — lets a user re-flag a conversation so
+    the sidebar dot returns. Cookie-auth via get_current_user_from_session.
+    """
+
+    def test_returns_204_and_sets_unread(self, app, make_user, authenticated_client):
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        recorder = AsyncMock()
+        with patch(
+            "apis.app_api.sessions.routes.mark_session_unread",
+            recorder,
+        ):
+            resp = client.post("/sessions/sess-001/unread")
+
+        assert resp.status_code == 204
+        recorder.assert_awaited_once_with(session_id="sess-001", user_id=user.user_id)
+
+    def test_returns_401_for_unauthenticated(self, app, unauthenticated_client):
+        client = unauthenticated_client(app)
+        resp = client.post("/sessions/sess-001/unread")
+        assert resp.status_code == 401

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -530,6 +530,23 @@ class TestSessionUnread:
         assert (await get_session_metadata("s1", "u1")).unread is False
 
     @pytest.mark.asyncio
+    async def test_mark_unread_then_read_roundtrip(self, sessions_metadata_table):
+        """The manual mark_session_unread wrapper sets the flag; read clears it."""
+        from apis.shared.sessions.metadata import (
+            ensure_session_metadata_exists,
+            mark_session_unread,
+            mark_session_read,
+            get_session_metadata,
+        )
+        await ensure_session_metadata_exists("s1", "u1")
+
+        await mark_session_unread("s1", "u1")
+        assert (await get_session_metadata("s1", "u1")).unread is True
+
+        await mark_session_read("s1", "u1")
+        assert (await get_session_metadata("s1", "u1")).unread is False
+
+    @pytest.mark.asyncio
     async def test_survives_sk_rotation(self, sessions_metadata_table):
         """Unread set post-run must survive a later per-turn SK rotation."""
         from apis.shared.sessions.metadata import (

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.html
@@ -99,10 +99,15 @@
                                                      backgrounded response completed while the user was viewing
                                                      another conversation. Static blue (vs. the pulsing
                                                      secondary streaming dot) and, unlike the streaming dot, it
-                                                     fades on hover so the ellipsis menu can own the gutter.
-                                                     Cleared once the user opens the session. -->
+                                                     fades when the ellipsis menu would occupy the same gutter —
+                                                     on hover and when the trigger is keyboard-focused
+                                                     (focus-visible). Crucially NOT on plain focus-within: the
+                                                     CDK menu restores focus to the in-row trigger on close, and
+                                                     hiding the dot for that (mouse-driven) focus is what made a
+                                                     just-marked-unread dot stay invisible until the next
+                                                     interaction. Cleared once the user opens the session. -->
                                                 <span
-                                                    class="pointer-events-none absolute right-3 top-1/2 size-2 -translate-y-1/2 rounded-full bg-blue-500 transition-opacity group-hover:opacity-0 dark:bg-blue-400"
+                                                    class="pointer-events-none absolute right-3 top-1/2 size-2 -translate-y-1/2 rounded-full bg-blue-500 transition-opacity group-hover:opacity-0 group-has-[button:focus-visible]:opacity-0 dark:bg-blue-400"
                                                     aria-hidden="true"
                                                 ></span>
                                             }
@@ -112,7 +117,7 @@
                                                 [cdkMenuTriggerFor]="sessionMenu"
                                                 [cdkMenuPosition]="menuPositions"
                                                 [disabled]="deletingSessionId() === session.sessionId"
-                                                class="session-menu-trigger absolute right-1 top-1/2 -translate-y-1/2 flex size-7 items-center justify-center rounded-md text-gray-500 opacity-0 transition-opacity duration-150 ease-in hover:bg-gray-200 hover:text-gray-700 focus:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 group-hover:opacity-100 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
+                                                class="session-menu-trigger absolute right-1 top-1/2 -translate-y-1/2 flex size-7 items-center justify-center rounded-md text-gray-500 opacity-0 transition-opacity duration-150 ease-in hover:bg-gray-200 hover:text-gray-700 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 group-hover:opacity-100 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
                                                 [attr.aria-label]="'Options for conversation: ' + getSessionTitle(session)"
                                                 aria-haspopup="menu"
                                             >
@@ -161,6 +166,16 @@
                                                 >
                                                     <ng-icon name="heroCloudArrowUp" class="size-4" aria-hidden="true" />
                                                     <span>Save to…</span>
+                                                </button>
+                                                <button
+                                                    cdkMenuItem
+                                                    type="button"
+                                                    (click)="onToggleReadClick($event, session)"
+                                                    class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                                                    role="menuitem"
+                                                >
+                                                    <ng-icon [name]="shouldShowUnreadDot(session) ? 'heroEnvelopeOpen' : 'heroEnvelope'" class="size-4" aria-hidden="true" />
+                                                    <span>{{ shouldShowUnreadDot(session) ? 'Mark as read' : 'Mark as unread' }}</span>
                                                 </button>
                                                 <button
                                                     cdkMenuItem

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
@@ -34,6 +34,8 @@ describe('SessionList', () => {
       sessionsResource: { value: vi.fn().mockReturnValue(null), error: vi.fn().mockReturnValue(null), isPending: vi.fn().mockReturnValue(false) },
       isLocallyRead: vi.fn().mockReturnValue(false),
       markSessionRead: vi.fn().mockResolvedValue(undefined),
+      markSessionUnread: vi.fn().mockResolvedValue(undefined),
+      refreshSessions: vi.fn(),
     };
     mockSidenavService = { close: vi.fn() };
     mockToastService = { success: vi.fn(), error: vi.fn() };
@@ -135,6 +137,44 @@ describe('SessionList', () => {
 
     component['onSessionClick']({ ...mockSession, unread: true });
     expect(mockSessionService.markSessionRead).toHaveBeenCalledOnce();
+  });
+
+  it('marks a read session unread from the options menu and shows the dot optimistically', async () => {
+    const { ChatStateService } = await import('../../../../session/services/chat/chat-state.service');
+    const chatState = TestBed.inject(ChatStateService);
+    const markSpy = vi.spyOn(chatState, 'markSessionUnread');
+    const component = await createComponent();
+
+    // mockSession has no dot → the toggle marks it unread.
+    component['onToggleReadClick'](new Event('click'), mockSession);
+    // The mutation is deferred past the menu close (queueMicrotask).
+    await Promise.resolve();
+
+    expect(mockSessionService.markSessionUnread).toHaveBeenCalledWith(mockSession);
+    // Optimistic client-side flag surfaces the dot without waiting on the refetch.
+    expect(markSpy).toHaveBeenCalledWith(mockSession.sessionId);
+    expect(component['shouldShowUnreadDot'](mockSession)).toBe(true);
+    // markSessionUnread only refetches after its POST resolves, so the row is
+    // kicked to re-render synchronously — mirroring the mark-read branch.
+    expect(mockSessionService.refreshSessions).toHaveBeenCalled();
+    expect(mockSessionService.markSessionRead).not.toHaveBeenCalled();
+  });
+
+  it('marks an unread session read and clears the client-side dot', async () => {
+    const { ChatStateService } = await import('../../../../session/services/chat/chat-state.service');
+    const chatState = TestBed.inject(ChatStateService);
+    const clearSpy = vi.spyOn(chatState, 'clearSessionUnread');
+    const component = await createComponent();
+    const unreadSession = { ...mockSession, unread: true }; // server dot shows
+
+    component['onToggleReadClick'](new Event('click'), unreadSession);
+    await Promise.resolve();
+
+    expect(mockSessionService.markSessionRead).toHaveBeenCalledWith(unreadSession);
+    expect(clearSpy).toHaveBeenCalledWith(unreadSession.sessionId);
+    // markSessionRead skips the refetch, so the list is kicked to re-render.
+    expect(mockSessionService.refreshSessions).toHaveBeenCalled();
+    expect(mockSessionService.markSessionUnread).not.toHaveBeenCalled();
   });
 
   it('marks the title pending only for a titleless session that is streaming', async () => {

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -5,7 +5,7 @@ import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp } from '@ng-icons/heroicons/outline';
+import { heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp, heroEnvelope, heroEnvelopeOpen } from '@ng-icons/heroicons/outline';
 import { heroEllipsisHorizontalSolid } from '@ng-icons/heroicons/solid';
 import { SessionService } from '../../../../session/services/session/session.service';
 import { ChatStateService } from '../../../../session/services/chat/chat-state.service';
@@ -20,7 +20,7 @@ import { ConfirmationDialogComponent, ConfirmationDialogData } from '../../../co
 @Component({
   selector: 'app-session-list',
   imports: [RouterLink, RouterLinkActive, NgIcon, CdkMenuTrigger, CdkMenu, CdkMenuItem],
-  providers: [provideIcons({ heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroEllipsisHorizontalSolid, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp })],
+  providers: [provideIcons({ heroChatBubbleLeftRight, heroTrash, heroArrowPath, heroEllipsisHorizontalSolid, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp, heroEnvelope, heroEnvelopeOpen })],
   templateUrl: './session-list.html',
   styleUrl: './session-list.css',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -379,6 +379,46 @@ export class SessionList {
         sessionId: session.sessionId,
         ownerEmail: this.userService.currentUser()?.email ?? '',
       } as ShareModalData,
+    });
+  }
+
+  /**
+   * Toggles a session's unread state from the options menu, keyed on the
+   * currently visible dot. When unread, marks it read — clearing both the
+   * durable server flag and the transient client-side (background-stream)
+   * flag, so the dot vanishes without opening the conversation. Otherwise
+   * marks it unread ("remind me to revisit"), re-surfacing the server dot.
+   *
+   * @param event - Click event (stopped to prevent navigation)
+   * @param session - The session to toggle
+   */
+  protected onToggleReadClick(event: Event, session: SessionMetadata): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Defer past the CDK menu's synchronous close. Mutating unread state inside
+    // the menu-item click is swallowed by the overlay teardown's change-
+    // detection pass (zoneless), so the dot wouldn't update until the next
+    // interaction. Running after the menu closes — as the delete flow does via
+    // its confirmation dialog — lets the signal updates re-render the row.
+    queueMicrotask(() => {
+      if (this.shouldShowUnreadDot(session)) {
+        void this.sessionService.markSessionRead(session);
+        this.chatStateService.clearSessionUnread(session.sessionId);
+        // markSessionRead relies on the watermark (no refetch); sync the list
+        // row's server flag too so it's not left stale.
+        this.sessionService.refreshSessions();
+      } else {
+        // markSessionUnread only refetches the list AFTER its POST resolves, so
+        // the OnPush row wouldn't re-render to insert the dot until then. Kick a
+        // synchronous refresh here — exactly as the mark-read branch does — so
+        // the row re-evaluates right away; the dot reads true off the client
+        // signal immediately, even while the server flag is eventually
+        // consistent, and clears when the session is next opened.
+        void this.sessionService.markSessionUnread(session);
+        this.chatStateService.markSessionUnread(session.sessionId);
+        this.sessionService.refreshSessions();
+      }
     });
   }
 

--- a/frontend/ai.client/src/app/components/topnav/topnav.html
+++ b/frontend/ai.client/src/app/components/topnav/topnav.html
@@ -109,6 +109,16 @@
             <button
               cdkMenuItem
               type="button"
+              (click)="onToggleReadClick($event)"
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+            >
+              <ng-icon [name]="isCurrentUnread() ? 'heroEnvelopeOpen' : 'heroEnvelope'" class="size-4" aria-hidden="true" />
+              <span>{{ isCurrentUnread() ? 'Mark as read' : 'Mark as unread' }}</span>
+            </button>
+            <button
+              cdkMenuItem
+              type="button"
               (click)="onDeleteClick($event)"
               class="flex w-full items-center gap-2 px-3 py-2 text-sm/6 text-red-600 hover:bg-gray-50 focus:bg-gray-50 dark:text-red-400 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
               role="menuitem"

--- a/frontend/ai.client/src/app/components/topnav/topnav.spec.ts
+++ b/frontend/ai.client/src/app/components/topnav/topnav.spec.ts
@@ -21,10 +21,15 @@ describe('Topnav', () => {
     mockSessionService = {
       currentSession: signal({ sessionId: 'test-session', title: 'Test Session' }),
       sessionMetadataResource: { isLoading: metadataLoading },
+      markSessionRead: vi.fn(),
+      markSessionUnread: vi.fn(),
+      refreshSessions: vi.fn(),
     };
     loadingSessionIds = new Set<string>();
     mockChatStateService = {
       isSessionLoading: (id: string) => loadingSessionIds.has(id),
+      markSessionUnread: vi.fn(),
+      clearSessionUnread: vi.fn(),
     };
     mockSidenavService = { open: vi.fn() };
 
@@ -91,6 +96,33 @@ describe('Topnav', () => {
       const component = await createComponent();
       expect((component as any).titlePending()).toBe(false);
       expect((component as any).displayTitle()).toBe('Untitled Session');
+    });
+  });
+
+  describe('mark as read/unread toggle', () => {
+    it('marks a read session unread and surfaces the sidebar dot optimistically', async () => {
+      mockSessionService.currentSession.set({ sessionId: 'sess-1', title: 'T', unread: false });
+      const component = await createComponent();
+
+      expect((component as any).isCurrentUnread()).toBe(false);
+      (component as any).onToggleReadClick(new Event('click'));
+
+      expect(mockSessionService.markSessionUnread).toHaveBeenCalled();
+      expect(mockChatStateService.markSessionUnread).toHaveBeenCalledWith('sess-1');
+      expect(mockSessionService.markSessionRead).not.toHaveBeenCalled();
+    });
+
+    it('marks an unread session read, clears the client dot, and refreshes the sidebar', async () => {
+      mockSessionService.currentSession.set({ sessionId: 'sess-1', title: 'T', unread: true });
+      const component = await createComponent();
+
+      expect((component as any).isCurrentUnread()).toBe(true);
+      (component as any).onToggleReadClick(new Event('click'));
+
+      expect(mockSessionService.markSessionRead).toHaveBeenCalled();
+      expect(mockChatStateService.clearSessionUnread).toHaveBeenCalledWith('sess-1');
+      expect(mockSessionService.refreshSessions).toHaveBeenCalled();
+      expect(mockSessionService.markSessionUnread).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/ai.client/src/app/components/topnav/topnav.ts
+++ b/frontend/ai.client/src/app/components/topnav/topnav.ts
@@ -5,7 +5,7 @@ import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp } from '@ng-icons/heroicons/outline';
+import { heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp, heroEnvelope, heroEnvelopeOpen } from '@ng-icons/heroicons/outline';
 import { SessionService } from '../../session/services/session/session.service';
 import { ChatStateService } from '../../session/services/chat/chat-state.service';
 import { ShareModalComponent, ShareModalData } from '../../session/components/share-modal';
@@ -18,7 +18,7 @@ import { ConfirmationDialogComponent, ConfirmationDialogData } from '../confirma
 @Component({
   selector: 'app-topnav',
   imports: [NgIcon, CdkMenuTrigger, CdkMenu, CdkMenuItem],
-  providers: [provideIcons({ heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp })],
+  providers: [provideIcons({ heroChevronDown, heroTrash, heroPencilSquare, heroArrowUpOnSquare, heroCloudArrowUp, heroEnvelope, heroEnvelopeOpen })],
   templateUrl: './topnav.html',
   styleUrl: './topnav.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -188,6 +188,33 @@ export class Topnav {
     } else if (event.key === 'Escape') {
       event.preventDefault();
       this.onRenameCancel();
+    }
+  }
+
+  /** True when the active session currently carries the durable unread flag. */
+  protected readonly isCurrentUnread = computed(() => this.currentSession().unread === true);
+
+  /**
+   * Toggles the session's durable unread flag from the options menu. When
+   * unread, marks it read (clears the sidebar dot); otherwise marks it unread
+   * ("remind me to revisit"), which re-surfaces the dot.
+   */
+  protected onToggleReadClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const session = this.currentSession();
+    if (session.unread) {
+      void this.sessionService.markSessionRead(session);
+      this.chatStateService.clearSessionUnread(session.sessionId);
+      // markSessionRead relies on the watermark (no refetch); kick the sidebar
+      // list to re-render so its dot clears too, not just this header's menu.
+      this.sessionService.refreshSessions();
+    } else {
+      // markSessionUnread already refetches the list; the client-side flag
+      // surfaces the sidebar dot immediately (server flag is eventually
+      // consistent), and clears when the session is next opened.
+      void this.sessionService.markSessionUnread(session);
+      this.chatStateService.markSessionUnread(session.sessionId);
     }
   }
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -122,7 +122,14 @@ export class ChatStateService {
         return this.unreadSessionIds().has(sessionId);
     }
 
-    private markSessionUnread(sessionId: string): void {
+    /**
+     * Flags a session's client-side unread state. Set internally when a
+     * background stream finishes unwatched (see setChatLoading), and by the
+     * session list's "Mark as unread" action for an instant dot — the durable
+     * server flag lands async and the list query is eventually consistent, so
+     * this signal is what surfaces the dot immediately. Cleared on open.
+     */
+    markSessionUnread(sessionId: string): void {
         this.unreadSessionIds.update(set => {
             if (set.has(sessionId)) return set;
             const next = new Set(set);
@@ -131,7 +138,13 @@ export class ChatStateService {
         });
     }
 
-    private clearSessionUnread(sessionId: string): void {
+    /**
+     * Clears a session's client-side unread flag. Called internally when a
+     * session is opened (see setViewedSession), and by the session list's
+     * "Mark as read" action so a background-stream unread dot can be dismissed
+     * without opening the conversation.
+     */
+    clearSessionUnread(sessionId: string): void {
         this.unreadSessionIds.update(set => {
             if (!set.has(sessionId)) return set;
             const next = new Set(set);

--- a/frontend/ai.client/src/app/session/services/session/session.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.spec.ts
@@ -238,6 +238,39 @@ describe('SessionService', () => {
     });
   });
 
+  describe('markSessionRead / markSessionUnread', () => {
+    it('markSessionRead POSTs /read, sets a read watermark, and clears currentSession.unread', async () => {
+      service.currentSession.set({ ...mockSession, unread: true });
+
+      const promise = service.markSessionRead({ ...mockSession, unread: true });
+      const req = httpMock.expectOne('http://localhost:8000/sessions/test-session-id/read');
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+      await promise;
+
+      expect(service.isLocallyRead(mockSession)).toBe(true);
+      expect(service.currentSession().unread).toBe(false);
+    });
+
+    it('markSessionUnread POSTs /unread, lifts the read watermark, and sets currentSession.unread', async () => {
+      service.currentSession.set({ ...mockSession, unread: false });
+      // Seed a read watermark first so we can prove the unread path lifts it.
+      const readPromise = service.markSessionRead(mockSession);
+      httpMock.expectOne('http://localhost:8000/sessions/test-session-id/read').flush(null);
+      await readPromise;
+      expect(service.isLocallyRead(mockSession)).toBe(true);
+
+      const promise = service.markSessionUnread(mockSession);
+      const req = httpMock.expectOne('http://localhost:8000/sessions/test-session-id/unread');
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+      await promise;
+
+      expect(service.isLocallyRead(mockSession)).toBe(false);
+      expect(service.currentSession().unread).toBe(true);
+    });
+  });
+
   describe('hasCurrentSession', () => {
     it('should return true when sessionId is set', () => {
       service.currentSession.set({ ...mockSession, sessionId: 'test-id' });

--- a/frontend/ai.client/src/app/session/services/session/session.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/session.service.ts
@@ -930,6 +930,7 @@ export class SessionService {
       next.set(session.sessionId, session.lastMessageAt);
       return next;
     });
+    this.syncCurrentSessionUnread(session.sessionId, false);
 
     try {
       await firstValueFrom(
@@ -937,6 +938,43 @@ export class SessionService {
       );
     } catch (error) {
       console.error('Failed to mark session read:', error);
+    }
+  }
+
+  /**
+   * Marks a session as unread — the manual counterpart to `markSessionRead`.
+   * Lifts the local read-watermark (so the dot's server-side suppression is
+   * released), sets the durable flag via `POST /sessions/{id}/unread`, then
+   * refetches the list so the row carries `unread=true` and the sidebar dot
+   * returns. Best-effort — a failed POST leaves the flag clear, so the dot
+   * simply won't appear rather than being silently wrong.
+   */
+  async markSessionUnread(session: SessionMetadata): Promise<void> {
+    this.readWatermarks.update(watermarks => {
+      const next = new Map(watermarks);
+      next.delete(session.sessionId);
+      return next;
+    });
+    this.syncCurrentSessionUnread(session.sessionId, true);
+
+    try {
+      await firstValueFrom(
+        this.http.post<void>(`${this.baseUrl()}/${session.sessionId}/unread`, {})
+      );
+      // The dot reads off the list row's `unread` field — refetch so it flips.
+      this.refreshSessions();
+    } catch (error) {
+      console.error('Failed to mark session unread:', error);
+    }
+  }
+
+  /**
+   * Mirror an unread change onto `currentSession` when it's the active session,
+   * so a menu toggle keyed on `currentSession().unread` flips label instantly.
+   */
+  private syncCurrentSessionUnread(sessionId: string, unread: boolean): void {
+    if (this.currentSession().sessionId === sessionId) {
+      this.currentSession.update(current => ({ ...current, unread }));
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a **Mark as read / Mark as unread** toggle to the session options (`⋯`) menu in both the top nav and the sidebar session list, and fixes two sidebar-only bugs in that toggle.

- New backend `POST /sessions/{id}/unread` endpoint (`mark_session_unread`), the manual counterpart to the existing `/read` verb — idempotent single-attribute write, ownership enforced via the per-user GSI lookup.
- Frontend surfaces the unread dot instantly via the `ChatStateService` client signal while the durable server flag lands async (`markSessionUnread` / `clearSessionUnread` made public).

## Bug fixes

The sidebar's `⋯` trigger lives **inside** the row's `group`, so when the CDK menu closes and restores focus to it, `group-focus-within` was tripped. The top-nav toggle was never affected because its trigger sits outside the row.

- **Bug 1 — ellipsis stayed visible after a menu action.** The trigger's reveal moved from `:focus` / `group-focus-within` to **`:focus-visible`**, so mouse-restored focus no longer reveals it, while keyboard nav still does (a11y preserved).
- **Bug 2 — a freshly marked-unread dot didn't appear until the next browser interaction.** The dot was being hidden by `group-focus-within` on the restored trigger focus; scoped that to **`group-has-[button:focus-visible]`** so only a *keyboard*-focused trigger cedes the gutter. Also added a synchronous `refreshSessions()` to the mark-unread branch (mirroring mark-read) so the OnPush row re-renders immediately.

## Scope note

This PR is the self-contained **read/unread slice**. The broader Scheduled Runs / background-tasks work in the same working tree is intentionally left out.

## Testing

- Backend: `pytest tests/routes/test_sessions.py tests/shared/test_sessions_metadata.py` → **100 passed** (includes new `TestMarkSessionUnread`).
- Frontend: `ng test` for `session-list`, `topnav`, `session.service` specs → **50 passed**.
- The sidebar UX is behind login locally (`SKIP_AUTH=false`), so browser-preview verification wasn't possible; a manual test script is below.

### Manual test script
1. On a sidebar row with **no** unread dot: `⋯` → **Mark as unread** → dot appears immediately, `⋯` fades out.
2. Same row: `⋯` → **Mark as read** → dot clears immediately, `⋯` fades out.
3. Keyboard: Tab to the `⋯` button (appears with focus ring) → open → **Mark as unread** → focus returns to the visible trigger; dot shows after tabbing/Escaping away.
4. Confirm the top-nav toggle is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)