### PR TITLE
feat(schedules): interval cadence + "Run now" with background-task toasts

### DIFF
--- a/backend/src/apis/app_api/schedules/models.py
+++ b/backend/src/apis/app_api/schedules/models.py
@@ -4,7 +4,13 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from apis.shared.scheduled_prompts.models import ScheduleCadence, ScheduledPrompt, ScheduledPromptState
+from apis.shared.scheduled_prompts.models import (
+    IntervalUnit,
+    ScheduleCadence,
+    ScheduledPrompt,
+    ScheduledPromptState,
+)
+from apis.shared.scheduled_prompts.service import MIN_INTERVAL_MINUTES, interval_to_minutes
 
 _MAX_PROMPT_CHARS = 20_000
 
@@ -19,6 +25,8 @@ class CreateScheduleRequest(BaseModel):
     cadence: ScheduleCadence
     hour_local: int = Field(..., alias="hourLocal", ge=0, le=23)
     weekday: Optional[int] = Field(None, ge=0, le=6)
+    interval_value: Optional[int] = Field(None, alias="intervalValue", ge=1)
+    interval_unit: Optional[IntervalUnit] = Field(None, alias="intervalUnit")
     timezone: str = Field(..., min_length=1, max_length=64)
     assistant_id: Optional[str] = Field(None, alias="assistantId")
     # None = snapshot "all RBAC-allowed at creation" (resolved by the route,
@@ -28,9 +36,14 @@ class CreateScheduleRequest(BaseModel):
     deliver_email: bool = Field(False, alias="deliverEmail")
 
     @model_validator(mode="after")
-    def _weekly_requires_weekday(self) -> "CreateScheduleRequest":
+    def _validate_cadence_fields(self) -> "CreateScheduleRequest":
         if self.cadence == "weekly" and self.weekday is None:
             raise ValueError("weekday is required when cadence is 'weekly'")
+        if self.cadence == "interval":
+            if self.interval_value is None or self.interval_unit is None:
+                raise ValueError("intervalValue and intervalUnit are required when cadence is 'interval'")
+            if interval_to_minutes(self.interval_value, self.interval_unit) < MIN_INTERVAL_MINUTES:
+                raise ValueError(f"interval must be at least {MIN_INTERVAL_MINUTES} minutes")
         return self
 
 
@@ -49,6 +62,8 @@ class UpdateScheduleRequest(BaseModel):
     cadence: Optional[ScheduleCadence] = None
     hour_local: Optional[int] = Field(None, alias="hourLocal", ge=0, le=23)
     weekday: Optional[int] = Field(None, ge=0, le=6)
+    interval_value: Optional[int] = Field(None, alias="intervalValue", ge=1)
+    interval_unit: Optional[IntervalUnit] = Field(None, alias="intervalUnit")
     timezone: Optional[str] = Field(None, min_length=1, max_length=64)
     assistant_id: Optional[str] = Field(None, alias="assistantId")
     enabled_tools: Optional[List[str]] = Field(None, alias="enabledTools")
@@ -82,6 +97,8 @@ class ScheduledPromptResponse(BaseModel):
     cadence: ScheduleCadence
     hour_local: int = Field(..., alias="hourLocal")
     weekday: Optional[int] = None
+    interval_value: Optional[int] = Field(None, alias="intervalValue")
+    interval_unit: Optional[IntervalUnit] = Field(None, alias="intervalUnit")
     timezone: str
     state: ScheduledPromptState
     state_reason: Optional[str] = Field(None, alias="stateReason")
@@ -107,6 +124,8 @@ class ScheduledPromptResponse(BaseModel):
             cadence=schedule.cadence,
             hour_local=schedule.hour_local,
             weekday=schedule.weekday,
+            interval_value=schedule.interval_value,
+            interval_unit=schedule.interval_unit,
             timezone=schedule.timezone,
             state=schedule.state,
             state_reason=schedule.state_reason,

--- a/backend/src/apis/app_api/schedules/routes.py
+++ b/backend/src/apis/app_api/schedules/routes.py
@@ -30,10 +30,12 @@ from apis.shared.feature_flags import scheduled_runs_enabled
 from apis.shared.rbac.capabilities import SCHEDULED_RUNS_CAPABILITY, user_has_capability
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.scheduled_prompts.service import (
+    MIN_INTERVAL_MINUTES,
     UNSET,
     ScheduledPromptLimitExceeded,
     compute_next_run_at,
     create_scheduled_prompt,
+    interval_to_minutes,
     delete_scheduled_prompt,
     get_scheduled_prompt,
     list_scheduled_prompts,
@@ -118,6 +120,8 @@ async def create_schedule(
             hour_local=request.hour_local,
             timezone_name=request.timezone,
             weekday=request.weekday,
+            interval_value=request.interval_value,
+            interval_unit=request.interval_unit,
             assistant_id=request.assistant_id,
             enabled_tools=enabled_tools,
             deliver_email=request.deliver_email,
@@ -173,6 +177,24 @@ async def update_schedule(
             detail="weekday is required when cadence is 'weekly'",
         )
 
+    effective_interval_value = (
+        request.interval_value if request.interval_value is not None else schedule.interval_value
+    )
+    effective_interval_unit = (
+        request.interval_unit if request.interval_unit is not None else schedule.interval_unit
+    )
+    if effective_cadence == "interval":
+        if effective_interval_value is None or effective_interval_unit is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="intervalValue and intervalUnit are required when cadence is 'interval'",
+            )
+        if interval_to_minutes(effective_interval_value, effective_interval_unit) < MIN_INTERVAL_MINUTES:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"interval must be at least {MIN_INTERVAL_MINUTES} minutes",
+            )
+
     # Clear intent is explicit — a bare null means "leave unchanged", so the
     # service uses the UNSET sentinel for "untouched". Clearing the assistant
     # reverts to the default agent; clearing tools re-snapshots the caller's
@@ -201,6 +223,8 @@ async def update_schedule(
         cadence=request.cadence,
         hour_local=request.hour_local,
         weekday=request.weekday,
+        interval_value=request.interval_value,
+        interval_unit=request.interval_unit,
         timezone_name=request.timezone,
         assistant_id=assistant_arg,
         enabled_tools=tools_arg,
@@ -210,7 +234,11 @@ async def update_schedule(
     if request.state is not None and request.state != schedule.state:
         if request.state == "active":
             next_run_at = compute_next_run_at(
-                schedule.cadence, schedule.hour_local, schedule.timezone, weekday=schedule.weekday
+                schedule.cadence,
+                schedule.hour_local,
+                schedule.timezone,
+                weekday=schedule.weekday,
+                interval_minutes=interval_to_minutes(schedule.interval_value, schedule.interval_unit),
             )
             await set_schedule_state(user.user_id, schedule_id, "active", next_run_at=next_run_at)
         else:
@@ -247,7 +275,11 @@ async def resume_schedule(
         return ScheduledPromptResponse.from_schedule(schedule)
 
     next_run_at = compute_next_run_at(
-        schedule.cadence, schedule.hour_local, schedule.timezone, weekday=schedule.weekday
+        schedule.cadence,
+        schedule.hour_local,
+        schedule.timezone,
+        weekday=schedule.weekday,
+        interval_minutes=interval_to_minutes(schedule.interval_value, schedule.interval_unit),
     )
     await set_schedule_state(user.user_id, schedule_id, "active", next_run_at=next_run_at)
     schedule = await get_scheduled_prompt(user.user_id, schedule_id)

--- a/backend/src/apis/shared/harness/runner.py
+++ b/backend/src/apis/shared/harness/runner.py
@@ -241,13 +241,16 @@ async def run_agent_headless(
             await update_session_title(session_id, user_id, title)
             result.title = title
 
-        # A scheduled (unattended) run produced a response the user wasn't
-        # watching — flag the session unread so the sidebar shows a dot until
-        # they open it. Runs *after* the SK-rotating writes above, on the row's
-        # final SK. Gated on a successful completion (no dot for a failed or
-        # consent-blocked run) and on the unattended trigger (attended "Run
-        # now" / manual invocations don't mark unread — the user is present).
-        if trigger == "schedule" and result.status == "completed":
+        # A background run produced a response the user wasn't watching — flag
+        # the session unread so the sidebar shows a dot until they open it. Runs
+        # *after* the SK-rotating writes above, on the row's final SK. Gated on a
+        # successful completion (no dot for a failed or consent-blocked run) and
+        # on the background triggers: "schedule" (unattended) and "run_now",
+        # which is now fire-and-forget — the SPA hands the run to a background
+        # tracker and the user keeps working elsewhere, so the result arrives
+        # asynchronously in the sidebar just like a scheduled run. "manual" (the
+        # default, used where a caller drains the result itself) stays excluded.
+        if trigger in ("schedule", "run_now") and result.status == "completed":
             await set_session_unread(session_id, user_id, True)
     except Exception:
         logger.error(

--- a/backend/src/apis/shared/scheduled_prompts/models.py
+++ b/backend/src/apis/shared/scheduled_prompts/models.py
@@ -19,7 +19,8 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-ScheduleCadence = Literal["daily", "weekday", "weekly"]
+ScheduleCadence = Literal["daily", "weekday", "weekly", "interval"]
+IntervalUnit = Literal["minutes", "hours"]
 ScheduledPromptState = Literal["active", "paused", "paused_error"]
 
 #: Sentinel partition key for the sparse due index. Single logical partition
@@ -40,9 +41,18 @@ class ScheduledPrompt(BaseModel):
     label: str = Field(..., min_length=1, max_length=200, description="Human-readable schedule name, e.g. 'Morning Briefing'")
     prompt_text: str = Field(..., alias="promptText", min_length=1, max_length=20_000, description="The prompt to run")
     cadence: ScheduleCadence = Field(..., description="Re-run cadence (bounded enum — no cron)")
-    hour_local: int = Field(..., alias="hourLocal", ge=0, le=23, description="Local hour of day to run, 0-23")
+    hour_local: int = Field(..., alias="hourLocal", ge=0, le=23, description="Local hour of day to run, 0-23; ignored for 'interval'")
     weekday: Optional[int] = Field(
         None, ge=0, le=6, description="0=Monday..6=Sunday; required when cadence == 'weekly'"
+    )
+    # Custom "every N" cadence: interpreted as a fixed delta from the previous
+    # fire (no wall-clock anchor). Stored as value + unit so the UI can render
+    # "every 6 hours" losslessly; the engine converts to minutes on demand.
+    interval_value: Optional[int] = Field(
+        None, alias="intervalValue", ge=1, description="Magnitude of the custom interval; required when cadence == 'interval'"
+    )
+    interval_unit: Optional["IntervalUnit"] = Field(
+        None, alias="intervalUnit", description="Unit for interval_value ('minutes'|'hours'); required when cadence == 'interval'"
     )
     timezone: str = Field(..., description="IANA timezone, e.g. 'America/Boise'")
     state: ScheduledPromptState = Field("active", description="Lifecycle state; only 'active' schedules appear in DueScheduleIndex")

--- a/backend/src/apis/shared/scheduled_prompts/service.py
+++ b/backend/src/apis/shared/scheduled_prompts/service.py
@@ -21,9 +21,14 @@ from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional, Union
 from zoneinfo import ZoneInfo
 
-from .models import DUE_INDEX_PK, ScheduleCadence, ScheduledPrompt, ScheduledPromptState
+from .models import DUE_INDEX_PK, IntervalUnit, ScheduleCadence, ScheduledPrompt, ScheduledPromptState
 
 logger = logging.getLogger(__name__)
+
+#: Floor for the custom "every N" cadence. Below this a schedule fires faster
+#: than the runaway guard (``max_runs_per_day``) tolerates and just self-pauses;
+#: 15 minutes keeps the smallest interval useful without inviting a hot loop.
+MIN_INTERVAL_MINUTES = 15
 
 
 class _Unset:
@@ -97,12 +102,25 @@ def max_schedules_per_user() -> int:
     return int(os.environ.get("SCHEDULED_RUNS_MAX_PER_USER", DEFAULT_MAX_SCHEDULES_PER_USER))
 
 
+def interval_to_minutes(value: Optional[int], unit: Optional[IntervalUnit]) -> Optional[int]:
+    """Canonicalize an interval value+unit to whole minutes.
+
+    Returns ``None`` when either half is missing so callers can pass a
+    schedule's interval fields through unconditionally (a non-interval
+    schedule carries ``None`` for both).
+    """
+    if value is None or unit is None:
+        return None
+    return value * 60 if unit == "hours" else value
+
+
 def compute_next_run_at(
     cadence: ScheduleCadence,
     hour_local: int,
     timezone_name: str,
     weekday: Optional[int] = None,
     from_time: Optional[datetime] = None,
+    interval_minutes: Optional[int] = None,
 ) -> str:
     """Compute the next due timestamp (ISO 8601 UTC) for a cadence.
 
@@ -112,8 +130,16 @@ def compute_next_run_at(
     at 9:05am local for "daily at 9am" fires tomorrow, not immediately.
 
     ``weekday`` is 0=Monday..6=Sunday (``datetime.weekday()`` convention) and
-    is required for cadence == "weekly"; ignored otherwise.
+    is required for cadence == "weekly"; ignored otherwise. ``interval_minutes``
+    is required for cadence == "interval" (a plain delta from ``from_time`` —
+    no wall-clock or timezone anchor); ignored otherwise.
     """
+    if cadence == "interval":
+        if interval_minutes is None or interval_minutes <= 0:
+            raise ValueError("interval_minutes is required and must be positive when cadence == 'interval'")
+        base_utc = (from_time or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        return _iso(base_utc + timedelta(minutes=interval_minutes))
+
     tz = ZoneInfo(timezone_name)
     base = (from_time or datetime.now(timezone.utc)).astimezone(tz)
 
@@ -148,6 +174,8 @@ async def create_scheduled_prompt(
     hour_local: int,
     timezone_name: str,
     weekday: Optional[int] = None,
+    interval_value: Optional[int] = None,
+    interval_unit: Optional[IntervalUnit] = None,
     assistant_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     deliver_email: bool = False,
@@ -166,7 +194,13 @@ async def create_scheduled_prompt(
         )
 
     now = _get_current_timestamp()
-    next_run_at = compute_next_run_at(cadence, hour_local, timezone_name, weekday=weekday)
+    next_run_at = compute_next_run_at(
+        cadence,
+        hour_local,
+        timezone_name,
+        weekday=weekday,
+        interval_minutes=interval_to_minutes(interval_value, interval_unit),
+    )
     schedule = ScheduledPrompt(
         schedule_id=_generate_schedule_id(),
         user_id=user_id,
@@ -176,6 +210,8 @@ async def create_scheduled_prompt(
         cadence=cadence,
         hour_local=hour_local,
         weekday=weekday,
+        interval_value=interval_value,
+        interval_unit=interval_unit,
         timezone=timezone_name,
         state="active",
         next_run_at=next_run_at,
@@ -404,6 +440,8 @@ async def update_scheduled_prompt(
     cadence: Optional[ScheduleCadence] = None,
     hour_local: Optional[int] = None,
     weekday: Optional[int] = None,
+    interval_value: Optional[int] = None,
+    interval_unit: Optional[IntervalUnit] = None,
     timezone_name: Optional[str] = None,
     assistant_id: Union[str, None, _Unset] = UNSET,
     enabled_tools: Union[List[str], None, _Unset] = UNSET,
@@ -431,12 +469,16 @@ async def update_scheduled_prompt(
     new_cadence = cadence if cadence is not None else schedule.cadence
     new_hour_local = hour_local if hour_local is not None else schedule.hour_local
     new_weekday = weekday if weekday is not None else schedule.weekday
+    new_interval_value = interval_value if interval_value is not None else schedule.interval_value
+    new_interval_unit = interval_unit if interval_unit is not None else schedule.interval_unit
     new_timezone = timezone_name if timezone_name is not None else schedule.timezone
 
     cadence_changed = (
         new_cadence != schedule.cadence
         or new_hour_local != schedule.hour_local
         or new_weekday != schedule.weekday
+        or new_interval_value != schedule.interval_value
+        or new_interval_unit != schedule.interval_unit
         or new_timezone != schedule.timezone
     )
 
@@ -453,9 +495,21 @@ async def update_scheduled_prompt(
         if new_weekday is not None:
             set_parts.append("weekday = :weekday")
             values[":weekday"] = new_weekday
+        if new_interval_value is not None:
+            set_parts.append("intervalValue = :interval_value")
+            values[":interval_value"] = new_interval_value
+        if new_interval_unit is not None:
+            set_parts.append("intervalUnit = :interval_unit")
+            values[":interval_unit"] = new_interval_unit
 
         if schedule.state == "active":
-            next_run_at = compute_next_run_at(new_cadence, new_hour_local, new_timezone, weekday=new_weekday)
+            next_run_at = compute_next_run_at(
+                new_cadence,
+                new_hour_local,
+                new_timezone,
+                weekday=new_weekday,
+                interval_minutes=interval_to_minutes(new_interval_value, new_interval_unit),
+            )
             set_parts += ["nextRunAt = :next", "GSI3_PK = :gsipk", "GSI3_SK = :gsisk"]
             values[":next"] = next_run_at
             values[":gsipk"] = DUE_INDEX_PK

--- a/backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py
+++ b/backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py
@@ -97,7 +97,7 @@ def _next_run_at(schedule: ScheduledPrompt, now: datetime) -> str:
     (`compute_next_run_at`) so a daily/weekday/weekly schedule advances
     correctly — no cron strings, no engine-side interval table.
     """
-    from apis.shared.scheduled_prompts.service import compute_next_run_at
+    from apis.shared.scheduled_prompts.service import compute_next_run_at, interval_to_minutes
 
     try:
         return compute_next_run_at(
@@ -106,6 +106,7 @@ def _next_run_at(schedule: ScheduledPrompt, now: datetime) -> str:
             schedule.timezone,
             weekday=schedule.weekday,
             from_time=now,
+            interval_minutes=interval_to_minutes(schedule.interval_value, schedule.interval_unit),
         )
     except Exception as e:
         # Defensive fallback — should never trigger for a valid schedule,

--- a/backend/tests/apis/shared/test_harness_runner.py
+++ b/backend/tests/apis/shared/test_harness_runner.py
@@ -182,8 +182,10 @@ async def test_happy_path_completes_and_delivers(monkeypatch, delivery_spy):
     # Delivery: idempotent session ensure + explicit title override.
     assert delivery_spy["ensure"] == [(result.session_id, "user-1")]
     assert delivery_spy["title"] == [(result.session_id, "user-1", "My Briefing")]
-    # Attended trigger ("run_now") — the user is present, so no unread flag.
-    assert delivery_spy["unread"] == []
+    # "run_now" is a background/fire-and-forget surface — the user isn't
+    # watching the stream, so a completed run flags the session unread (a
+    # sidebar dot until they open it), same as a scheduled run.
+    assert delivery_spy["unread"] == [(result.session_id, "user-1", True)]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routes/test_schedules_routes.py
+++ b/backend/tests/routes/test_schedules_routes.py
@@ -262,6 +262,66 @@ class TestCreateSchedule:
         )
         assert response.status_code == 422
 
+    def test_interval_happy_path(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        created = _make_schedule(cadence="interval", intervalValue=6, intervalUnit="hours", weekday=None)
+        create_mock = AsyncMock(return_value=created)
+        monkeypatch.setattr(schedules_routes, "create_scheduled_prompt", create_mock)
+
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Every 6 hours",
+                "promptText": "Check in",
+                "cadence": "interval",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+                "intervalValue": 6,
+                "intervalUnit": "hours",
+            },
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["cadence"] == "interval"
+        assert body["intervalValue"] == 6
+        assert body["intervalUnit"] == "hours"
+
+        (call,) = create_mock.call_args_list
+        assert call.kwargs["interval_value"] == 6
+        assert call.kwargs["interval_unit"] == "hours"
+
+    def test_interval_without_value_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Interval",
+                "promptText": "Go",
+                "cadence": "interval",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+                "intervalUnit": "hours",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_interval_below_floor_is_422(self, monkeypatch):
+        client = _make_client(monkeypatch)
+        response = client.post(
+            "/schedules",
+            json={
+                "label": "Too frequent",
+                "promptText": "Go",
+                "cadence": "interval",
+                "hourLocal": 9,
+                "timezone": "America/Boise",
+                "intervalValue": 5,
+                "intervalUnit": "minutes",
+            },
+        )
+        assert response.status_code == 422
+
     def test_over_cap_is_400(self, monkeypatch):
         client = _make_client(monkeypatch)
         monkeypatch.setattr(

--- a/backend/tests/shared/test_scheduled_prompts.py
+++ b/backend/tests/shared/test_scheduled_prompts.py
@@ -22,6 +22,7 @@ from apis.shared.scheduled_prompts.service import (
     create_scheduled_prompt,
     delete_scheduled_prompt,
     get_scheduled_prompt,
+    interval_to_minutes,
     list_due_schedules,
     list_scheduled_prompts,
     max_schedules_per_user,
@@ -122,6 +123,41 @@ class TestComputeNextRunAt:
         with pytest.raises(ValueError, match="Unknown cadence"):
             compute_next_run_at("monthly", 9, "America/Boise")  # type: ignore[arg-type]
 
+    def test_interval_adds_a_plain_delta_from_now(self):
+        # "every 90 minutes" is a fixed delta off from_time — no hour/tz anchor.
+        from_time = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)
+        result = compute_next_run_at(
+            "interval", 9, "America/Boise", from_time=from_time, interval_minutes=90
+        )
+        expected = datetime(2026, 7, 5, 13, 30, tzinfo=timezone.utc)
+        assert result == expected.isoformat().replace("+00:00", "Z")
+
+    def test_interval_ignores_hour_and_timezone(self):
+        # hour_local/timezone are meaningless for interval; two different zones
+        # produce the same UTC delta.
+        from_time = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)
+        a = compute_next_run_at("interval", 3, "America/Boise", from_time=from_time, interval_minutes=360)
+        b = compute_next_run_at("interval", 21, "Asia/Tokyo", from_time=from_time, interval_minutes=360)
+        assert a == b == "2026-07-05T18:00:00Z"
+
+    def test_interval_requires_positive_minutes(self):
+        with pytest.raises(ValueError, match="interval_minutes is required"):
+            compute_next_run_at("interval", 9, "America/Boise")
+        with pytest.raises(ValueError, match="interval_minutes is required"):
+            compute_next_run_at("interval", 9, "America/Boise", interval_minutes=0)
+
+
+class TestIntervalToMinutes:
+    def test_hours_convert(self):
+        assert interval_to_minutes(6, "hours") == 360
+
+    def test_minutes_passthrough(self):
+        assert interval_to_minutes(45, "minutes") == 45
+
+    def test_missing_half_is_none(self):
+        assert interval_to_minutes(None, "hours") is None
+        assert interval_to_minutes(6, None) is None
+
     def test_different_timezone_produces_different_utc_time(self):
         from_time = datetime(2026, 7, 5, 0, 0, tzinfo=timezone.utc)
         boise = compute_next_run_at("daily", 9, "America/Boise", from_time=from_time)
@@ -178,6 +214,18 @@ class TestCreateAndGet:
     async def test_weekly_requires_weekday_at_creation(self, sessions_metadata_table):
         with pytest.raises(ValueError):
             await _make_schedule(cadence="weekly", weekday=None)
+
+    async def test_interval_persists_value_and_unit(self, sessions_metadata_table):
+        schedule = await _make_schedule(
+            cadence="interval", interval_value=6, interval_unit="hours"
+        )
+        assert schedule.cadence == "interval"
+        assert schedule.next_run_at is not None
+
+        fetched = await get_scheduled_prompt(USER_ID, schedule.schedule_id)
+        assert fetched is not None
+        assert fetched.interval_value == 6
+        assert fetched.interval_unit == "hours"
 
     async def test_per_user_cap_enforced(self, sessions_metadata_table, monkeypatch):
         monkeypatch.setenv("SCHEDULED_RUNS_MAX_PER_USER", "2")

--- a/frontend/ai.client/src/app/app.html
+++ b/frontend/ai.client/src/app/app.html
@@ -122,3 +122,6 @@
 
   <!-- Global toast notifications -->
   <app-toast />
+
+  <!-- Persistent background-task toasts (headless runs, etc.) -->
+  <app-background-task-toasts />

--- a/frontend/ai.client/src/app/app.ts
+++ b/frontend/ai.client/src/app/app.ts
@@ -3,6 +3,7 @@ import { Router, RouterOutlet } from '@angular/router';
 import { Sidenav } from './components/sidenav/sidenav';
 import { ErrorToastComponent } from './components/error-toast/error-toast.component';
 import { ToastComponent } from './components/toast';
+import { BackgroundTaskToastsComponent } from './components/background-task-toasts/background-task-toasts.component';
 import { SidenavService } from './services/sidenav/sidenav.service';
 import { HeaderService } from './services/header/header.service';
 import { TooltipDirective } from './components/tooltip/tooltip.directive';
@@ -17,6 +18,7 @@ import { ArtifactStateService } from './session/services/artifacts/artifact-stat
     Sidenav,
     ErrorToastComponent,
     ToastComponent,
+    BackgroundTaskToastsComponent,
     TooltipDirective
   ],
   templateUrl: './app.html',

--- a/frontend/ai.client/src/app/components/background-task-toasts/background-task-toasts.component.spec.ts
+++ b/frontend/ai.client/src/app/components/background-task-toasts/background-task-toasts.component.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { BackgroundTaskToastsComponent } from './background-task-toasts.component';
+import { BackgroundTaskService } from '../../services/background-tasks/background-task.service';
+
+describe('BackgroundTaskToastsComponent', () => {
+  let fixture: ComponentFixture<BackgroundTaskToastsComponent>;
+  let tasks: BackgroundTaskService;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [BackgroundTaskToastsComponent],
+      providers: [provideRouter([{ path: 's/:id', children: [] }]), BackgroundTaskService],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackgroundTaskToastsComponent);
+    tasks = TestBed.inject(BackgroundTaskService);
+    fixture.detectChanges();
+  });
+
+  it('renders a toast per task with its title', () => {
+    tasks.start('Running "Briefing"', 'Working…');
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Running "Briefing"');
+    expect(text).toContain('Working…');
+  });
+
+  it('shows a View button only once a route is attached', () => {
+    const id = tasks.start('Run');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button[aria-label="Dismiss"]')).toBeTruthy();
+
+    tasks.complete(id, { route: ['/s', 'sess-1'], viewLabel: 'View result' });
+    fixture.detectChanges();
+    expect((fixture.nativeElement.textContent as string)).toContain('View result');
+  });
+
+  it('View navigates to the route and dismisses the toast', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const id = tasks.start('Run');
+    tasks.complete(id, { route: ['/s', 'sess-1'] });
+    fixture.detectChanges();
+
+    clickView();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/s', 'sess-1']);
+    expect(tasks.tasks().length).toBe(0);
+  });
+
+  it('View runs a custom onView handler instead of route navigation, then dismisses', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const onView = vi.fn();
+    const id = tasks.start('Run');
+    tasks.complete(id, { route: ['/s', 'sess-1'], onView });
+    fixture.detectChanges();
+
+    clickView();
+
+    expect(onView).toHaveBeenCalled();
+    expect(navigateSpy).not.toHaveBeenCalled();
+    expect(tasks.tasks().length).toBe(0);
+  });
+
+  function clickView(): void {
+    const viewBtn = Array.from(fixture.nativeElement.querySelectorAll('button')).find((b) =>
+      (b as HTMLButtonElement).textContent?.includes('View'),
+    ) as HTMLButtonElement;
+    viewBtn.click();
+  }
+});

--- a/frontend/ai.client/src/app/components/background-task-toasts/background-task-toasts.component.ts
+++ b/frontend/ai.client/src/app/components/background-task-toasts/background-task-toasts.component.ts
@@ -1,0 +1,184 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowRight,
+  heroCheckCircle,
+  heroExclamationTriangle,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import { BackgroundTask, BackgroundTaskService } from '../../services/background-tasks/background-task.service';
+
+/**
+ * Shell-level stack of persistent background-task toasts (top-right). Mounted
+ * once in the app shell so it survives navigation between views — a headless
+ * "Run now" kicked off on the schedules form keeps reporting here after the
+ * user moves elsewhere.
+ *
+ * Unobtrusive but always visible: our signature pulsing dot while processing,
+ * a check/warning when settled, and a "View" button that links to the result
+ * (e.g. the session-detail conversation). Native `animate.enter` /
+ * `animate.leave` (Angular 21) give it polished entry/exit animations.
+ */
+@Component({
+  selector: 'app-background-task-toasts',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({ heroArrowRight, heroCheckCircle, heroExclamationTriangle, heroXMark }),
+  ],
+  host: { class: 'contents' },
+  template: `
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      class="pointer-events-none fixed right-4 top-4 z-50 flex max-w-[calc(100vw-2rem)] flex-col items-end gap-3"
+    >
+      @for (task of taskService.tasks(); track task.id) {
+        <div
+          role="status"
+          animate.enter="bg-toast-enter"
+          animate.leave="bg-toast-leave"
+          class="bg-toast pointer-events-auto w-72 max-w-full overflow-hidden rounded-xl bg-white/90 shadow-lg ring-1 ring-black/5 backdrop-blur-md dark:bg-gray-800/90 dark:ring-white/10"
+        >
+          <div class="flex items-center gap-2.5 px-3 py-2.5">
+            <!-- Status glyph -->
+            <div class="flex size-4 shrink-0 items-center justify-center">
+              @switch (task.status) {
+                @case ('processing') {
+                  <span class="bg-toast-dot" aria-hidden="true"></span>
+                }
+                @case ('completed') {
+                  <ng-icon name="heroCheckCircle" class="size-4 text-green-500 dark:text-green-400" aria-hidden="true" />
+                }
+                @case ('error') {
+                  <ng-icon name="heroExclamationTriangle" class="size-4 text-amber-500 dark:text-amber-400" aria-hidden="true" />
+                }
+              }
+            </div>
+
+            <!-- Content -->
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ task.title }}</p>
+              @if (task.detail) {
+                <p class="truncate text-xs text-gray-500 dark:text-gray-400">{{ task.detail }}</p>
+              }
+              @if (task.route) {
+                <button
+                  type="button"
+                  (click)="view(task)"
+                  class="mt-1 inline-flex items-center gap-1 text-xs font-semibold text-blue-600 hover:text-blue-700 focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  {{ task.viewLabel ?? 'View' }}
+                  <ng-icon name="heroArrowRight" class="size-4" aria-hidden="true" />
+                </button>
+              }
+            </div>
+
+            <!-- Dismiss -->
+            <button
+              type="button"
+              (click)="dismiss(task.id)"
+              class="-m-1 shrink-0 self-start rounded-md p-1 text-gray-400 hover:text-gray-600 focus:outline-2 focus:outline-offset-2 focus:outline-gray-400 dark:text-gray-500 dark:hover:text-gray-300"
+              aria-label="Dismiss"
+            >
+              <ng-icon name="heroXMark" class="size-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .bg-toast-enter {
+      animation: bg-toast-in 260ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .bg-toast-leave {
+      animation: bg-toast-out 200ms ease-in forwards;
+    }
+
+    @keyframes bg-toast-in {
+      from { opacity: 0; transform: translateX(1rem) scale(0.98); }
+      to { opacity: 1; transform: translateX(0) scale(1); }
+    }
+    @keyframes bg-toast-out {
+      from { opacity: 1; transform: translateX(0) scale(1); }
+      to { opacity: 0; transform: translateX(1rem) scale(0.98); }
+    }
+
+    /* Signature pulsing dot — ring + core, matching PulsatingLoaderComponent */
+    .bg-toast-dot {
+      position: relative;
+      display: block;
+      width: 7px;
+      height: 7px;
+      flex-shrink: 0;
+    }
+    .bg-toast-dot::before {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 300%;
+      height: 300%;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
+      background-color: var(--color-blue-500);
+      animation: bg-toast-pulse-ring 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+    }
+    .bg-toast-dot::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: 50%;
+      background-color: var(--color-blue-500);
+      animation: bg-toast-pulse-dot 1.25s cubic-bezier(0.455, 0.03, 0.515, 0.955) -0.4s infinite;
+    }
+    :host-context(.dark) .bg-toast-dot::before,
+    :host-context(.dark) .bg-toast-dot::after {
+      background-color: var(--color-blue-400);
+    }
+
+    @keyframes bg-toast-pulse-ring {
+      0% { transform: translate(-50%, -50%) scale(0.33); }
+      80%, 100% { opacity: 0; }
+    }
+    @keyframes bg-toast-pulse-dot {
+      0% { transform: scale(0.8); }
+      50% { transform: scale(1); }
+      100% { transform: scale(0.8); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .bg-toast-enter,
+      .bg-toast-leave,
+      .bg-toast-dot::before,
+      .bg-toast-dot::after {
+        animation: none;
+      }
+    }
+  `,
+})
+export class BackgroundTaskToastsComponent {
+  protected readonly taskService = inject(BackgroundTaskService);
+  private readonly router = inject(Router);
+
+  protected view(task: BackgroundTask): void {
+    if (task.onView) {
+      task.onView();
+    } else if (task.route) {
+      this.router.navigate(task.route);
+    }
+    this.taskService.dismiss(task.id);
+  }
+
+  protected dismiss(id: string): void {
+    this.taskService.dismiss(id);
+  }
+}

--- a/frontend/ai.client/src/app/schedules/models/schedule.model.ts
+++ b/frontend/ai.client/src/app/schedules/models/schedule.model.ts
@@ -7,8 +7,12 @@
  * docs/specs/scheduled-agent-runs.md §3.
  */
 
-export type ScheduleCadence = 'daily' | 'weekday' | 'weekly';
+export type ScheduleCadence = 'daily' | 'weekday' | 'weekly' | 'interval';
+export type IntervalUnit = 'minutes' | 'hours';
 export type ScheduledPromptState = 'active' | 'paused' | 'paused_error';
+
+/** Floor for the custom "every N" cadence (mirrors backend MIN_INTERVAL_MINUTES). */
+export const MIN_INTERVAL_MINUTES = 15;
 
 /** Public view of a scheduled prompt (backend ScheduledPromptResponse). */
 export interface ScheduledPrompt {
@@ -19,6 +23,8 @@ export interface ScheduledPrompt {
   cadence: ScheduleCadence;
   hourLocal: number;
   weekday?: number | null;
+  intervalValue?: number | null;
+  intervalUnit?: IntervalUnit | null;
   timezone: string;
   state: ScheduledPromptState;
   stateReason?: string | null;
@@ -42,6 +48,8 @@ export interface CreateScheduleRequest {
   cadence: ScheduleCadence;
   hourLocal: number;
   weekday?: number | null;
+  intervalValue?: number | null;
+  intervalUnit?: IntervalUnit | null;
   timezone: string;
   assistantId?: string | null;
   enabledTools?: string[] | null;
@@ -68,6 +76,8 @@ export interface UpdateScheduleRequest {
   cadence?: ScheduleCadence;
   hourLocal?: number;
   weekday?: number | null;
+  intervalValue?: number | null;
+  intervalUnit?: IntervalUnit | null;
   timezone?: string;
   assistantId?: string | null;
   enabledTools?: string[] | null;
@@ -84,4 +94,26 @@ export interface UpdateScheduleRequest {
 /** Response from GET /schedules. */
 export interface ScheduledPromptsListResponse {
   schedules: ScheduledPrompt[];
+}
+
+/**
+ * Request body for POST /runs/now — fire one attended agent turn immediately
+ * through the headless harness (the "Run now" button). Distinct surface from
+ * schedules: it does not create a saved schedule, it just executes once.
+ */
+export interface RunNowRequest {
+  prompt: string;
+  title?: string | null;
+  enabledTools?: string[] | null;
+}
+
+/** Response from POST /runs/now. The run also lands as a session. */
+export interface RunNowResponse {
+  runId: string;
+  sessionId: string;
+  status: string;
+  finalMessage: string;
+  stopReason?: string | null;
+  error?: string | null;
+  title?: string | null;
 }

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
@@ -8,12 +8,30 @@
         <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
         Back to schedules
       </a>
-      <h1 class="mt-3 text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
-        {{ mode() === 'create' ? 'New scheduled run' : 'Edit scheduled run' }}
-      </h1>
-      <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
-        Run a prompt automatically on a cadence you choose. Results land in your conversation list.
-      </p>
+      <div class="mt-3 flex items-start justify-between gap-4">
+        <div class="min-w-0">
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+            {{ mode() === 'create' ? 'New scheduled run' : 'Edit scheduled run' }}
+          </h1>
+          <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+            Run a prompt automatically on a cadence you choose. Results land in your conversation list.
+          </p>
+        </div>
+
+        @if (!loadingSchedule() && !loadError()) {
+          <div class="flex shrink-0 flex-col items-end gap-1">
+            <button
+              type="button"
+              (click)="runNow()"
+              [disabled]="saving()"
+              class="inline-flex items-center justify-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              Run now
+            </button>
+            <span class="text-xs/5 text-gray-500 dark:text-gray-400">Runs once now — doesn’t create a schedule</span>
+          </div>
+        }
+      </div>
     </div>
 
     @if (loadingSchedule()) {
@@ -67,7 +85,7 @@
         <section class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
           <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">When it runs</h2>
           <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-            A bounded cadence — daily, weekdays, or a specific day each week. No custom cron.
+            Daily, weekdays, a specific day each week, or a custom interval.
           </p>
 
           <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -83,6 +101,7 @@
                 <option value="daily">Every day</option>
                 <option value="weekday">Every weekday</option>
                 <option value="weekly">Weekly on a day</option>
+                <option value="interval">Custom interval</option>
               </select>
             </div>
 
@@ -103,36 +122,77 @@
               </div>
             }
 
-            <div>
-              <label for="hourLocal" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                Time of day
+            @if (isInterval()) {
+              <div>
+                <label for="intervalValue" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                  Every
+                </label>
+                <input
+                  id="intervalValue"
+                  type="number"
+                  min="1"
+                  formControlName="intervalValue"
+                  class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                />
+              </div>
+              <div>
+                <label for="intervalUnit" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                  Unit
+                </label>
+                <select
+                  id="intervalUnit"
+                  formControlName="intervalUnit"
+                  class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                >
+                  @for (unit of intervalUnitOptions; track unit) {
+                    <option [value]="unit">{{ unit }}</option>
+                  }
+                </select>
+              </div>
+            } @else {
+              <div>
+                <label for="hourLocal" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                  Time of day
+                </label>
+                <select
+                  id="hourLocal"
+                  formControlName="hourLocal"
+                  class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                >
+                  @for (hour of hourOptions; track hour.value) {
+                    <option [value]="hour.value">{{ hour.label }}</option>
+                  }
+                </select>
+              </div>
+            }
+          </div>
+
+          @if (isInterval()) {
+            @if (form.controls.intervalValue.touched && form.controls.intervalValue.errors?.['min']) {
+              <p class="mt-2 text-xs/5 text-red-600 dark:text-red-400">
+                Interval must be at least {{ minIntervalMinutes }} minutes.
+              </p>
+            }
+            <p class="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
+              Runs on a fixed interval from the previous run — no fixed clock time. Minimum
+              {{ minIntervalMinutes }} minutes between runs.
+            </p>
+          } @else {
+            <div class="mt-4">
+              <label for="timezone" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Timezone
               </label>
               <select
-                id="hourLocal"
-                formControlName="hourLocal"
-                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                id="timezone"
+                formControlName="timezone"
+                class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
               >
-                @for (hour of hourOptions; track hour.value) {
-                  <option [value]="hour.value">{{ hour.label }}</option>
+                @for (tz of timezoneOptions; track tz) {
+                  <option [value]="tz">{{ tz }}</option>
                 }
               </select>
             </div>
-          </div>
-
-          <div class="mt-4">
-            <label for="timezone" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
-              Timezone
-            </label>
-            <select
-              id="timezone"
-              formControlName="timezone"
-              class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-            >
-              @for (tz of timezoneOptions; track tz) {
-                <option [value]="tz">{{ tz }}</option>
-              }
-            </select>
-          </div>
+          }
         </section>
 
         <!-- Target config -->

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { provideRouter, ActivatedRoute } from '@angular/router';
+import { provideRouter, ActivatedRoute, Router } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
 import { signal } from '@angular/core';
 import { ScheduleFormPage } from './schedule-form.page';
 import { ScheduleService } from '../services/schedule.service';
+import { RunNowService } from '../services/run-now.service';
 import { AssistantService } from '../../assistants/services/assistant.service';
 import { ToolService } from '../../services/tool/tool.service';
 import { ToastService } from '../../services/toast/toast.service';
@@ -58,12 +59,17 @@ describe('ScheduleFormPage', () => {
     loadTools: vi.fn().mockResolvedValue(undefined),
   };
 
-  const mockToast = { success: vi.fn(), error: vi.fn() };
+  const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
+
+  const mockRunNow = {
+    run: vi.fn().mockReturnValue('bgtask-1'),
+  };
 
   function configure(routeParams: Record<string, string> = {}) {
     TestBed.resetTestingModule();
     vi.clearAllMocks();
     mockScheduleService.getSchedule.mockResolvedValue(undefined);
+    mockRunNow.run.mockReturnValue('bgtask-1');
 
     TestBed.configureTestingModule({
       imports: [ReactiveFormsModule],
@@ -74,6 +80,7 @@ describe('ScheduleFormPage', () => {
         // rejection after the test body, failing the whole vitest process.
         provideRouter([{ path: 'schedules', children: [] }]),
         { provide: ScheduleService, useValue: mockScheduleService },
+        { provide: RunNowService, useValue: mockRunNow },
         { provide: AssistantService, useValue: mockAssistantService },
         { provide: ToolService, useValue: mockToolService },
         { provide: ToastService, useValue: mockToast },
@@ -154,6 +161,75 @@ describe('ScheduleFormPage', () => {
 
       expect(mockScheduleService.createSchedule).not.toHaveBeenCalled();
       expect(component.form.controls.weekday.errors).toEqual({ required: true });
+    });
+
+    it('defaults the interval to every 6 hours the first time interval is chosen', () => {
+      expect(component.isInterval()).toBe(false);
+      component.form.controls.cadence.setValue('interval');
+      expect(component.isInterval()).toBe(true);
+      expect(component.form.controls.intervalValue.value).toBe(6);
+      expect(component.form.controls.intervalUnit.value).toBe('hours');
+    });
+
+    it('creates an interval schedule with value and unit', async () => {
+      component.form.patchValue({
+        label: 'Every 6h',
+        promptText: 'Check in',
+        cadence: 'interval',
+        intervalValue: 6,
+        intervalUnit: 'hours',
+      });
+
+      await component.onSubmit();
+
+      expect(mockScheduleService.createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cadence: 'interval',
+          intervalValue: 6,
+          intervalUnit: 'hours',
+        }),
+      );
+    });
+
+    it('rejects an interval below the minimum floor', async () => {
+      component.form.patchValue({
+        label: 'Too frequent',
+        promptText: 'Check in',
+        cadence: 'interval',
+        intervalValue: 5,
+        intervalUnit: 'minutes',
+      });
+
+      await component.onSubmit();
+
+      expect(mockScheduleService.createSchedule).not.toHaveBeenCalled();
+      expect(component.form.controls.intervalValue.errors).toEqual({ min: true });
+    });
+
+    it('run now hands the prompt to the background runner without saving or navigating', () => {
+      const router = TestBed.inject(Router);
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      component.form.patchValue({ label: 'Test', promptText: 'Do the thing' });
+      component.toggleTool('class_search');
+
+      component.runNow();
+
+      expect(mockRunNow.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'Do the thing',
+          title: 'Test',
+          enabledTools: ['class_search'],
+        }),
+      );
+      expect(mockScheduleService.createSchedule).not.toHaveBeenCalled();
+      // The view must not change — tracking happens in the corner toast.
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it('run now requires a prompt', () => {
+      component.runNow();
+      expect(mockRunNow.run).not.toHaveBeenCalled();
+      expect(component.form.controls.promptText.errors).toEqual({ required: true });
     });
   });
 

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
@@ -11,10 +11,18 @@ import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angu
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft } from '@ng-icons/heroicons/outline';
 import { ScheduleService } from '../services/schedule.service';
+import { RunNowService } from '../services/run-now.service';
 import { AssistantService } from '../../assistants/services/assistant.service';
 import { Assistant } from '../../assistants/models/assistant.model';
 import { ToolService } from '../../services/tool/tool.service';
-import { CreateScheduleRequest, ScheduleCadence, UpdateScheduleRequest } from '../models/schedule.model';
+import {
+  CreateScheduleRequest,
+  IntervalUnit,
+  MIN_INTERVAL_MINUTES,
+  RunNowRequest,
+  ScheduleCadence,
+  UpdateScheduleRequest,
+} from '../models/schedule.model';
 import { ToastService } from '../../services/toast/toast.service';
 
 const WEEKDAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -83,6 +91,7 @@ export class ScheduleFormPage implements OnInit {
   private readonly router = inject(Router);
   private readonly fb = inject(FormBuilder);
   private readonly scheduleService = inject(ScheduleService);
+  private readonly runNowService = inject(RunNowService);
   private readonly assistantService = inject(AssistantService);
   private readonly toolService = inject(ToolService);
   private readonly toast = inject(ToastService);
@@ -92,6 +101,9 @@ export class ScheduleFormPage implements OnInit {
   readonly saving = signal(false);
   readonly loadError = signal<string | null>(null);
   readonly loadingSchedule = signal(false);
+
+  readonly minIntervalMinutes = MIN_INTERVAL_MINUTES;
+  readonly intervalUnitOptions: IntervalUnit[] = ['minutes', 'hours'];
 
   readonly assistants = this.assistantService.assistants$;
   readonly tools = this.toolService.tools;
@@ -116,11 +128,15 @@ export class ScheduleFormPage implements OnInit {
     cadence: ['daily' as ScheduleCadence, [Validators.required]],
     hourLocal: [7, [Validators.required]],
     weekday: new FormControl<number | null>(null),
+    intervalValue: new FormControl<number | null>(null),
+    intervalUnit: ['hours' as IntervalUnit, [Validators.required]],
     timezone: [this.guessTimezone(), [Validators.required]],
     assistantId: new FormControl<string | null>(null),
   });
 
-  readonly isWeekly = computed(() => this.form.controls.cadence.value === 'weekly');
+  private readonly cadenceValue = signal<ScheduleCadence>('daily');
+  readonly isWeekly = computed(() => this.cadenceValue() === 'weekly');
+  readonly isInterval = computed(() => this.cadenceValue() === 'interval');
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('scheduleId');
@@ -135,10 +151,19 @@ export class ScheduleFormPage implements OnInit {
       void this.loadSchedule(id);
     }
 
-    // "weekly" requires a weekday — default to Monday the first time it's chosen.
+    // Keep the cadence-driven signals in sync (form values aren't signals, so
+    // the isWeekly/isInterval computeds read this instead of the control).
+    this.cadenceValue.set(this.form.controls.cadence.value ?? 'daily');
     this.form.controls.cadence.valueChanges.subscribe((cadence) => {
+      this.cadenceValue.set(cadence ?? 'daily');
+      // "weekly" requires a weekday — default to Monday the first time it's chosen.
       if (cadence === 'weekly' && this.form.controls.weekday.value === null) {
         this.form.controls.weekday.setValue(1);
+      }
+      // "interval" needs a magnitude — default to every 6 hours the first time.
+      if (cadence === 'interval' && this.form.controls.intervalValue.value === null) {
+        this.form.controls.intervalValue.setValue(6);
+        this.form.controls.intervalUnit.setValue('hours');
       }
     });
   }
@@ -158,9 +183,12 @@ export class ScheduleFormPage implements OnInit {
         cadence: schedule.cadence,
         hourLocal: schedule.hourLocal,
         weekday: schedule.weekday ?? null,
+        intervalValue: schedule.intervalValue ?? null,
+        intervalUnit: schedule.intervalUnit ?? 'hours',
         timezone: schedule.timezone,
         assistantId: schedule.assistantId ?? null,
       });
+      this.cadenceValue.set(schedule.cadence);
       this.selectedToolIds.set(new Set(schedule.enabledTools ?? []));
     } catch {
       this.loadError.set('Failed to load this schedule.');
@@ -236,6 +264,11 @@ export class ScheduleFormPage implements OnInit {
       this.form.controls.weekday.setErrors({ required: true });
       return;
     }
+    if (value.cadence === 'interval' && !this.isIntervalValid(value.intervalValue, value.intervalUnit)) {
+      this.form.controls.intervalValue.setErrors({ min: true });
+      this.form.controls.intervalValue.markAsTouched();
+      return;
+    }
 
     this.saving.set(true);
     try {
@@ -247,6 +280,8 @@ export class ScheduleFormPage implements OnInit {
           cadence: value.cadence!,
           hourLocal: value.hourLocal!,
           weekday: value.cadence === 'weekly' ? value.weekday : null,
+          intervalValue: value.cadence === 'interval' ? value.intervalValue : null,
+          intervalUnit: value.cadence === 'interval' ? value.intervalUnit : null,
           timezone: value.timezone!,
           assistantId: value.assistantId ?? null,
           enabledTools: toolIds.length > 0 ? toolIds : null,
@@ -285,6 +320,8 @@ export class ScheduleFormPage implements OnInit {
       cadence: value.cadence!,
       hourLocal: value.hourLocal!,
       weekday: value.cadence === 'weekly' ? value.weekday : null,
+      intervalValue: value.cadence === 'interval' ? value.intervalValue : null,
+      intervalUnit: value.cadence === 'interval' ? value.intervalUnit : null,
       timezone: value.timezone!,
     };
     if (this.clearAssistant()) {
@@ -298,6 +335,39 @@ export class ScheduleFormPage implements OnInit {
       request.enabledTools = toolIds;
     }
     return request;
+  }
+
+  /** True when value+unit clear the backend's minimum-interval floor. */
+  private isIntervalValid(value: number | null, unit: IntervalUnit | null): boolean {
+    if (value === null || value < 1 || unit === null) {
+      return false;
+    }
+    const minutes = unit === 'hours' ? value * 60 : value;
+    return minutes >= this.minIntervalMinutes;
+  }
+
+  /**
+   * Fire the prompt once immediately via POST /runs/now — the attended test
+   * surface. Does NOT save a schedule and does NOT change the view: the run is
+   * handed to `RunNowService`, which tracks it as a persistent background-task
+   * toast and, when it finishes, links to the session-detail conversation
+   * where the result renders with full formatting. Only the prompt is required.
+   */
+  runNow(): void {
+    const promptText = this.form.controls.promptText.value?.trim();
+    if (!promptText) {
+      this.form.controls.promptText.setErrors({ required: true });
+      this.form.controls.promptText.markAsTouched();
+      return;
+    }
+
+    const toolIds = Array.from(this.selectedToolIds());
+    const request: RunNowRequest = {
+      prompt: promptText,
+      title: this.form.controls.label.value?.trim() || null,
+      enabledTools: toolIds.length > 0 ? toolIds : null,
+    };
+    this.runNowService.run(request);
   }
 
   onCancel(): void {

--- a/frontend/ai.client/src/app/schedules/schedules.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedules.page.ts
@@ -171,6 +171,12 @@ export class SchedulesPage implements OnInit {
           : '';
         return `Every ${day} at ${time}`;
       }
+      case 'interval': {
+        const value = schedule.intervalValue ?? 0;
+        const unit = schedule.intervalUnit ?? 'hours';
+        const singular = value === 1 ? unit.replace(/s$/, '') : unit;
+        return value === 1 ? `Every ${singular}` : `Every ${value} ${singular}`;
+      }
       default:
         return time;
     }

--- a/frontend/ai.client/src/app/schedules/services/run-api.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/run-api.service.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { RunApiService } from './run-api.service';
+import { ConfigService } from '../../services/config.service';
+import { RunNowResponse } from '../models/schedule.model';
+
+const BASE = 'http://localhost:8000/runs';
+
+function stubRunResponse(overrides: Partial<RunNowResponse> = {}): RunNowResponse {
+  return {
+    runId: 'run-1',
+    sessionId: 'sess-1',
+    status: 'completed',
+    finalMessage: 'done',
+    stopReason: null,
+    error: null,
+    title: null,
+    ...overrides,
+  };
+}
+
+describe('RunApiService', () => {
+  let service: RunApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        RunApiService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(RunApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('POSTs to /runs/now with the prompt payload', async () => {
+    const result = stubRunResponse();
+    const promise = firstValueFrom(service.runNow({ prompt: 'Do the thing', title: 'Test' }));
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/now`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ prompt: 'Do the thing', title: 'Test' });
+      req.flush(result);
+    });
+
+    expect(await promise).toEqual(result);
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/run-api.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/run-api.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import { RunNowRequest, RunNowResponse } from '../models/schedule.model';
+
+/**
+ * Thin HTTP layer over `/runs/*` (app-api, cookie-authed). The "Run now"
+ * surface fires one attended agent turn through the exact headless machinery
+ * a scheduled run will use — it does not create a saved schedule. Synchronous
+ * from the caller's perspective (the response is the full run result once the
+ * turn drains, bounded by the harness's 300s budget).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class RunApiService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/runs`);
+
+  runNow(request: RunNowRequest): Observable<RunNowResponse> {
+    return this.http.post<RunNowResponse>(`${this.baseUrl()}/now`, request);
+  }
+}

--- a/frontend/ai.client/src/app/schedules/services/run-now.service.spec.ts
+++ b/frontend/ai.client/src/app/schedules/services/run-now.service.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { RunNowService } from './run-now.service';
+import { RunApiService } from './run-api.service';
+import { BackgroundTaskService } from '../../services/background-tasks/background-task.service';
+import { SessionService as SessionListService } from '../../session/services/session/session.service';
+import { SessionMetadata } from '../../session/services/models/session-metadata.model';
+import { RunNowResponse } from '../models/schedule.model';
+
+const EMPTY_SESSION: SessionMetadata = {
+  sessionId: '',
+  userId: '',
+  title: '',
+  status: 'active',
+  createdAt: '',
+  lastMessageAt: '',
+  messageCount: 0,
+};
+
+function response(overrides: Partial<RunNowResponse> = {}): RunNowResponse {
+  return {
+    runId: 'run-1',
+    sessionId: 'sess-1',
+    status: 'completed',
+    finalMessage: 'done',
+    stopReason: null,
+    error: null,
+    title: null,
+    ...overrides,
+  };
+}
+
+describe('RunNowService', () => {
+  let service: RunNowService;
+  let tasks: BackgroundTaskService;
+  const mockRunApi = { runNow: vi.fn() };
+  const mockSessions = { refreshSessions: vi.fn(), currentSession: signal<SessionMetadata>(EMPTY_SESSION) };
+  const mockRouter = { navigate: vi.fn() };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+    mockSessions.currentSession.set(EMPTY_SESSION);
+    TestBed.configureTestingModule({
+      providers: [
+        RunNowService,
+        BackgroundTaskService,
+        { provide: RunApiService, useValue: mockRunApi },
+        { provide: SessionListService, useValue: mockSessions },
+        { provide: Router, useValue: mockRouter },
+      ],
+    });
+    service = TestBed.inject(RunNowService);
+    tasks = TestBed.inject(BackgroundTaskService);
+  });
+
+  it('registers a processing task immediately and fires the request', () => {
+    mockRunApi.runNow.mockReturnValue(of(response()));
+    service.run({ prompt: 'Go', title: 'My run' });
+
+    expect(mockRunApi.runNow).toHaveBeenCalledWith({ prompt: 'Go', title: 'My run' });
+    const [task] = tasks.tasks();
+    expect(task.title).toContain('My run');
+  });
+
+  it('completes the task with a session-detail route on success and refreshes the sidebar list', () => {
+    mockRunApi.runNow.mockReturnValue(of(response({ sessionId: 'sess-9' })));
+    service.run({ prompt: 'Go' });
+
+    const [task] = tasks.tasks();
+    expect(task.status).toBe('completed');
+    expect(task.route).toEqual(['/s', 'sess-9']);
+    expect(mockSessions.refreshSessions).toHaveBeenCalled();
+  });
+
+  it('onView optimistically seeds the header title before navigating', () => {
+    mockRunApi.runNow.mockReturnValue(of(response({ sessionId: 'sess-9', title: 'My Briefing' })));
+    service.run({ prompt: 'Go', title: 'My Briefing' });
+
+    const [task] = tasks.tasks();
+    task.onView?.();
+
+    // Header title reflects the run's session immediately (not the previous one).
+    expect(mockSessions.currentSession().sessionId).toBe('sess-9');
+    expect(mockSessions.currentSession().title).toBe('My Briefing');
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/s', 'sess-9']);
+  });
+
+  it('fails the task but keeps a route when a run errors with a session', () => {
+    mockRunApi.runNow.mockReturnValue(of(response({ status: 'error', error: 'boom', sessionId: 'sess-3' })));
+    service.run({ prompt: 'Go' });
+
+    const [task] = tasks.tasks();
+    expect(task.status).toBe('error');
+    expect(task.detail).toBe('boom');
+    expect(task.route).toEqual(['/s', 'sess-3']);
+  });
+
+  it('marks oauth_required as an error needing account connection', () => {
+    mockRunApi.runNow.mockReturnValue(of(response({ status: 'oauth_required' })));
+    service.run({ prompt: 'Go' });
+
+    const [task] = tasks.tasks();
+    expect(task.status).toBe('error');
+    expect(task.detail).toContain('connect an account');
+  });
+
+  it('fails the task on a transport error', () => {
+    mockRunApi.runNow.mockReturnValue(throwError(() => new Error('network down')));
+    service.run({ prompt: 'Go' });
+
+    const [task] = tasks.tasks();
+    expect(task.status).toBe('error');
+    expect(task.detail).toBe('network down');
+    expect(task.route).toBeNull();
+    expect(mockSessions.refreshSessions).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/schedules/services/run-now.service.ts
+++ b/frontend/ai.client/src/app/schedules/services/run-now.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { BackgroundTaskService } from '../../services/background-tasks/background-task.service';
+import { SessionService as SessionListService } from '../../session/services/session/session.service';
+import { RunNowRequest, RunNowResponse } from '../models/schedule.model';
+import { RunApiService } from './run-api.service';
+
+/**
+ * Fires a headless "Run now" and tracks it as a persistent background task.
+ *
+ * Fire-and-forget from the caller's view: `run()` returns immediately and the
+ * corner toast reports progress. The `/runs/now` request is subscribed here in
+ * a root service (not the component) so it — and the toast resolution — survive
+ * the originating form being destroyed on navigation. When the run finishes,
+ * the task gets a "View" route to the session-detail conversation, where the
+ * result renders with full formatting.
+ */
+@Injectable({ providedIn: 'root' })
+export class RunNowService {
+  private readonly runApi = inject(RunApiService);
+  private readonly tasks = inject(BackgroundTaskService);
+  private readonly sessions = inject(SessionListService);
+  private readonly router = inject(Router);
+
+  /** Start a headless run in the background. Returns the task id. */
+  run(request: RunNowRequest): string {
+    const label = request.title?.trim() || 'your prompt';
+    const taskId = this.tasks.start(`Running "${label}"`, 'The agent is working…');
+
+    this.runApi.runNow(request).subscribe({
+      next: (result) => {
+        const route = result.sessionId ? ['/s', result.sessionId] : null;
+        // The run materializes as a real session server-side. Refresh the
+        // sidebar list so it appears like any other conversation (with its
+        // server-generated title + unread dot), not just behind the toast link.
+        if (result.sessionId) {
+          this.sessions.refreshSessions();
+        }
+        if (result.status === 'completed') {
+          this.tasks.complete(taskId, {
+            detail: 'Run finished — added to your conversations',
+            route,
+            viewLabel: 'View result',
+            onView: () => this.openResult(result),
+          });
+        } else if (result.status === 'oauth_required') {
+          this.tasks.fail(taskId, 'A tool needs you to connect an account first.', route);
+        } else {
+          this.tasks.fail(taskId, result.error ?? `Run ${result.status}.`, route);
+        }
+      },
+      error: (err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Run failed.';
+        this.tasks.fail(taskId, message);
+      },
+    });
+
+    return taskId;
+  }
+
+  /**
+   * Open a finished run's conversation. Optimistically seeds `currentSession`
+   * with the id + known title *before* routing so the session-detail top-nav
+   * shows the right title immediately, instead of lingering on the previously
+   * viewed conversation's title until the metadata fetch resolves. The
+   * ConversationPage's metadata load then reconciles the full record. Mirrors
+   * `SessionListComponent.onSessionClick`.
+   */
+  private openResult(result: RunNowResponse): void {
+    // Minimal optimistic record — the ConversationPage metadata fetch fills in
+    // the authoritative timestamps/counts moments later.
+    this.sessions.currentSession.set({
+      sessionId: result.sessionId,
+      userId: '',
+      title: result.title ?? '',
+      status: 'active',
+      createdAt: '',
+      lastMessageAt: '',
+      messageCount: 0,
+    });
+    this.router.navigate(['/s', result.sessionId]);
+  }
+}

--- a/frontend/ai.client/src/app/services/background-tasks/background-task.service.spec.ts
+++ b/frontend/ai.client/src/app/services/background-tasks/background-task.service.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { BackgroundTaskService } from './background-task.service';
+
+describe('BackgroundTaskService', () => {
+  let service: BackgroundTaskService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ providers: [BackgroundTaskService] });
+    service = TestBed.inject(BackgroundTaskService);
+  });
+
+  it('starts a processing task and returns its id', () => {
+    const id = service.start('Running "X"', 'Working…');
+    const [task] = service.tasks();
+    expect(task.id).toBe(id);
+    expect(task.status).toBe('processing');
+    expect(task.title).toBe('Running "X"');
+    expect(task.detail).toBe('Working…');
+    expect(task.route).toBeNull();
+  });
+
+  it('completes a task with a view route and detail', () => {
+    const id = service.start('Run');
+    service.complete(id, { detail: 'Done', route: ['/s', 'sess-1'], viewLabel: 'View result' });
+    const [task] = service.tasks();
+    expect(task.status).toBe('completed');
+    expect(task.detail).toBe('Done');
+    expect(task.route).toEqual(['/s', 'sess-1']);
+    expect(task.viewLabel).toBe('View result');
+  });
+
+  it('fails a task, optionally keeping a route to a partial session', () => {
+    const id = service.start('Run');
+    service.fail(id, 'It broke', ['/s', 'sess-2']);
+    const [task] = service.tasks();
+    expect(task.status).toBe('error');
+    expect(task.detail).toBe('It broke');
+    expect(task.route).toEqual(['/s', 'sess-2']);
+  });
+
+  it('dismisses a task by id and leaves others intact', () => {
+    const a = service.start('A');
+    const b = service.start('B');
+    service.dismiss(a);
+    expect(service.tasks().map((t) => t.id)).toEqual([b]);
+  });
+
+  it('only patches the targeted task', () => {
+    const a = service.start('A');
+    const b = service.start('B');
+    service.complete(a, { detail: 'done' });
+    const byId = Object.fromEntries(service.tasks().map((t) => [t.id, t.status]));
+    expect(byId[a]).toBe('completed');
+    expect(byId[b]).toBe('processing');
+  });
+});

--- a/frontend/ai.client/src/app/services/background-tasks/background-task.service.ts
+++ b/frontend/ai.client/src/app/services/background-tasks/background-task.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, signal } from '@angular/core';
+
+/** Lifecycle of a tracked background task. */
+export type BackgroundTaskStatus = 'processing' | 'completed' | 'error';
+
+/**
+ * A long-running, out-of-band process surfaced to the user as a persistent
+ * corner toast (e.g. a headless "Run now", an export, an ingestion job). The
+ * toast lives at the app-shell level so it survives navigation between views.
+ */
+export interface BackgroundTask {
+  id: string;
+  /** Short headline, e.g. `Running "Morning Briefing"`. */
+  title: string;
+  /** Optional one-line status detail (e.g. "The agent is working…"). */
+  detail?: string | null;
+  status: BackgroundTaskStatus;
+  /**
+   * Router commands for a "View" action. When set, the toast shows a button
+   * that navigates here — e.g. `['/s', sessionId]` to open a headless run's
+   * conversation in the session-detail view. Reusable for any result target.
+   */
+  route?: string[] | null;
+  /** Label for the view button; defaults to "View". */
+  viewLabel?: string;
+  /**
+   * Optional custom handler for the "View" button. When set, the toast runs
+   * this instead of navigating to `route` — lets a consumer do side work
+   * first (e.g. optimistically seed the session header title before routing,
+   * mirroring a sidebar click). `route` is still used to *show* the button.
+   */
+  onView?: () => void;
+  createdAt: number;
+}
+
+/**
+ * Tracks background tasks and exposes them as a signal for a shell-level toast
+ * stack. Deliberately generic — "Run now" is the first consumer, but exports,
+ * ingestion jobs, and other headless work can register here too.
+ *
+ * A root service (not a component) owns task lifecycle so the tracking — and
+ * any subscription that resolves it — survives the originating component being
+ * destroyed on navigation.
+ */
+@Injectable({ providedIn: 'root' })
+export class BackgroundTaskService {
+  private tasksSignal = signal<BackgroundTask[]>([]);
+
+  /** Readonly signal of the current tasks, oldest first. */
+  readonly tasks = this.tasksSignal.asReadonly();
+
+  /** Register a new in-progress task; returns its id for later resolution. */
+  start(title: string, detail?: string): string {
+    const id = this.generateId();
+    this.tasksSignal.update((tasks) => [
+      ...tasks,
+      { id, title, detail: detail ?? null, status: 'processing', route: null, createdAt: Date.now() },
+    ]);
+    return id;
+  }
+
+  /** Mark a task finished, optionally attaching a "View" route + detail. */
+  complete(
+    id: string,
+    patch: { detail?: string; route?: string[] | null; viewLabel?: string; onView?: () => void } = {},
+  ): void {
+    this.patch(id, { status: 'completed', ...patch });
+  }
+
+  /** Mark a task failed. A route may still be attached (a failed run can
+   *  materialize a partial session worth viewing). */
+  fail(id: string, detail: string, route?: string[] | null): void {
+    this.patch(id, { status: 'error', detail, route: route ?? null });
+  }
+
+  /** Remove a task from the stack. */
+  dismiss(id: string): void {
+    this.tasksSignal.update((tasks) => tasks.filter((t) => t.id !== id));
+  }
+
+  private patch(id: string, changes: Partial<BackgroundTask>): void {
+    this.tasksSignal.update((tasks) => tasks.map((t) => (t.id === id ? { ...t, ...changes } : t)));
+  }
+
+  private generateId(): string {
+    return `bgtask-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+}


### PR DESCRIPTION
## Summary

Two additions to the **Scheduled Runs** feature, both gated behind the existing `SCHEDULED_RUNS_ENABLED` + RBAC runtime checks:

### 1. Interval cadence
Schedules can now run every _N_ minutes/hours, alongside the existing daily/weekly cadences.
- `interval_value` / `interval_unit` added to the scheduled-prompt model and API.
- `MIN_INTERVAL_MINUTES` floor enforced on create / update / resume (422 below it).
- `interval_to_minutes()` feeds `compute_next_run_at`.
- Schedule form gains the interval option with matching client + server validation.

### 2. "Run now"
Run a schedule's prompt headlessly on demand from the schedule form.
- `RunNowService` fires `POST /runs/now` (the app-api endpoint already on `develop` from scheduled-runs PR-1) as fire-and-forget.
- Progress is reported through a new app-wide toast system: `BackgroundTaskService` (signal-backed task list) rendered by `BackgroundTaskToastsComponent`, mounted in `app.html`.
- On completion the run materializes as a real session; the session list refreshes and the toast offers a **View** affordance.

## Scope note

This is the second of two PRs carved from one working tree. The **mark-as-read/unread** slice is in #577. This PR contains only the interval-cadence + Run-now work; there is no overlap.

## Testing

- Backend: `pytest tests/routes/test_schedules_routes.py tests/shared/test_scheduled_prompts.py tests/apis/shared/test_harness_runner.py` → **100 passed**.
- Frontend: `ng test` for `schedule-form`, `run-api.service`, `run-now.service`, `background-task.service`, `background-task-toasts.component` → **30 passed**.
- The schedules UI is behind login locally (`SKIP_AUTH=false`), so browser-preview verification wasn't possible; the specs cover the service + component logic.

## Note

I did not author this code — it was in-progress in the working tree. It builds and its tests pass, but please confirm it's feature-complete before merging (e.g. the interval UI wiring and any RBAC/flag interplay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)