### PR TITLE
feat(memory): Memory Spaces data layer (PR-1)

### DIFF
--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -44,3 +44,20 @@ def scheduled_runs_enabled() -> bool:
     (``apis.shared.rbac.capabilities``) — two independent controls.
     """
     return os.environ.get("SCHEDULED_RUNS_ENABLED", "").strip().lower() != "false"
+
+
+def memory_spaces_enabled() -> bool:
+    """Whether the Memory Spaces feature is enabled for this environment.
+
+    Covers the user-owned/shareable markdown "second brain" surface (F5):
+    the app-api ``/memory/spaces`` CRUD, the runtime read/write tools, and
+    the SPA Memory panel. **Defaults off** (the ``SKILLS_ENABLED`` pattern):
+    set ``MEMORY_SPACES_ENABLED=true`` to turn it on. While off, the surfaces
+    are unmounted / hidden but all data and code remain intact. The feature
+    ships incrementally across several PRs, so it stays dark until complete.
+
+    Note this flag gates *feature existence* per environment; *who* can use it
+    will be an RBAC capability — two independent controls (mirroring
+    ``scheduled_runs_enabled``).
+    """
+    return os.environ.get("MEMORY_SPACES_ENABLED", "false").lower() == "true"

--- a/backend/src/apis/shared/memory/__init__.py
+++ b/backend/src/apis/shared/memory/__init__.py
@@ -1,0 +1,61 @@
+"""Memory Spaces — user-owned, shareable markdown "second brains" (F5).
+
+A shared-layer primitive (consumed by app-api and the agent runtime, never
+importing either) that stores named, per-owner, optionally-shared markdown
+wikis: an always-loaded ``MEMORY.md`` index plus typed entries fetched on
+demand. See ``docs/specs/user-markdown-memory.md``.
+
+PR-1 (this package) is the data layer only — models, S3 byte store, DynamoDB
+repository, and the permission-gated service. No routes, agent tools, or
+system-prompt wiring (those land in later PRs). Gated per environment by the
+``MEMORY_SPACES_ENABLED`` flag (default off; see ``apis.shared.feature_flags``).
+"""
+
+from .models import (
+    EntryType,
+    MemoryEntryRef,
+    MemoryIndex,
+    MemorySpace,
+    Role,
+    ShareRole,
+    SpaceMember,
+)
+from .repository import MemorySpaceRepository
+from .service import (
+    MemorySpaceError,
+    MemorySpaceNotFoundError,
+    MemorySpacePermissionError,
+    MemorySpaceService,
+)
+from .store import (
+    MemorySpaceStore,
+    MemorySpaceStoreError,
+    compute_content_hash,
+    content_key,
+    get_memory_space_store,
+)
+from .templates import TEMPLATES, SpaceTemplate, get_template, is_valid_template
+
+__all__ = [
+    "EntryType",
+    "MemoryEntryRef",
+    "MemoryIndex",
+    "MemorySpace",
+    "Role",
+    "ShareRole",
+    "SpaceMember",
+    "MemorySpaceRepository",
+    "MemorySpaceService",
+    "MemorySpaceError",
+    "MemorySpaceNotFoundError",
+    "MemorySpacePermissionError",
+    "MemorySpaceStore",
+    "MemorySpaceStoreError",
+    "compute_content_hash",
+    "content_key",
+    "get_memory_space_store",
+    "TEMPLATES",
+    "SpaceTemplate",
+    "get_template",
+    "is_valid_template",
+]

--- a/backend/src/apis/shared/memory/models.py
+++ b/backend/src/apis/shared/memory/models.py
@@ -1,0 +1,138 @@
+"""Pydantic models for the Memory Space primitive (PR-1, data layer).
+
+A **Memory Space** is a named, first-class, per-owner (optionally shared)
+markdown "second brain" that agents read and maintain. See
+``docs/specs/user-markdown-memory.md``.
+
+Storage shape (dedicated ``memory-spaces`` DynamoDB table, space-keyed so a
+shared space cannot live under one user's partition):
+
+  - ``PK=SPACE#{space_id}  SK=META``            → :class:`MemorySpace`
+  - ``PK=SPACE#{space_id}  SK=INDEX``           → :class:`MemoryIndex` (manifest)
+  - ``PK=SPACE#{space_id}  SK=MEMBER#{email}``  → :class:`SpaceMember`
+
+Two GSIs list a user's spaces (mirroring assistant sharing — owned and
+shared-in are separate indexes unioned in code):
+
+  - ``OwnerIndex``  ``GSI1PK=OWNER#{owner_id}   GSI1SK=SPACE#{space_id}``
+  - ``MemberIndex`` ``GSI2PK=MEMBER#{email}     GSI2SK=SPACE#{space_id}``
+
+Roles mirror assistant sharing: the owner is stored on the space row
+(``owner_id``); share records only ever carry ``viewer``/``editor``.
+
+The markdown bytes (``MEMORY.md`` and each entry) live in S3
+(``apis/shared/memory/store.py``); these rows carry only pointers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Full permission set: owner is implicit (stored on the space row); shares
+# only carry the two grantable roles.
+Role = Literal["owner", "editor", "viewer"]
+ShareRole = Literal["viewer", "editor"]
+
+# Entry kinds. ``entity`` = a mutable record keyed by subject (a person, a
+# project). ``episodic`` = an append-only dated record (a daily log, a brief).
+# ``fact`` = a flat distilled fact (the catch-all).
+EntryType = Literal["entity", "episodic", "fact"]
+
+
+class MemoryEntryRef(BaseModel):
+    """Manifest entry for one markdown file in a Memory Space.
+
+    The bytes live content-addressed in the ``memory-spaces`` S3 bucket
+    (``spaces/{space_id}/{content_hash}``); this lightweight ref lives in the
+    space's ``INDEX`` row. ``indexed`` copies a small allowlist of frontmatter
+    fields (e.g. ``status``, ``commitments.due``) so relational/temporal
+    queries ("who owes what") are a manifest lookup, not a full-corpus scan.
+
+    camelCase aliases round-trip the future API response (FastAPI serializes
+    by alias) while ``populate_by_name`` allows construction from snake_case.
+    DynamoDB (de)serialization is handled explicitly in the repository.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    slug: str = Field(..., description="Stable id within the space, e.g. 'jane-doe'")
+    entry_type: EntryType = Field(
+        "fact", alias="type", description="entity | episodic | fact"
+    )
+    description: str = Field(
+        "", description="One-line summary shown in the index catalog"
+    )
+    content_hash: str = Field(
+        ..., alias="contentHash", description="sha256 hex of the file bytes"
+    )
+    size: int = Field(..., description="Size of the file in bytes")
+    s3_key: str = Field(
+        ...,
+        alias="s3Key",
+        description="Object key in the memory-spaces bucket "
+        "(spaces/{space_id}/{content_hash})",
+    )
+    updated: str = Field("", description="ISO-8601 timestamp of the last write")
+    updated_by: str = Field(
+        "", alias="updatedBy", description="user_id of the last writer (attribution)"
+    )
+    indexed: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Allowlisted frontmatter fields copied out for querying",
+    )
+
+
+class MemoryIndex(BaseModel):
+    """The ``INDEX`` row: the machine manifest of a space's entries.
+
+    Distinct from the human-readable ``MEMORY.md`` index text (which lives in
+    S3 and is pointed to by :attr:`MemorySpace.index_s3_key`). ``version`` is a
+    monotonically-increasing counter reserved for optimistic-concurrency
+    control on shared spaces (PR-6); PR-1 writes it but does not yet gate on it.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    space_id: str = Field(..., alias="spaceId")
+    entries: List[MemoryEntryRef] = Field(default_factory=list)
+    version: int = Field(0, description="Optimistic-concurrency counter (PR-6)")
+
+
+class SpaceMember(BaseModel):
+    """A ``MEMBER#{email}`` row: one shared grant on a space.
+
+    Email-keyed (you invite by email before the grantee has necessarily
+    logged in), mirroring assistant ``ShareEntry``. The owner is NOT a member
+    row — ownership is stored on the space itself.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    email: str = Field(..., description="Grantee email (normalized lowercase)")
+    permission: ShareRole = Field("viewer", description="viewer | editor")
+    created_at: str = Field("", alias="createdAt")
+
+
+class MemorySpace(BaseModel):
+    """The ``META`` row: a Memory Space's identity + ownership + index pointer.
+
+    The entries manifest lives on the separate ``INDEX`` row (:class:`MemoryIndex`)
+    and shared grants on ``MEMBER#`` rows (:class:`SpaceMember`); this row is
+    what permission checks and space listings read.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    space_id: str = Field(..., alias="spaceId")
+    name: str = Field(..., description="User-facing space name")
+    template: str = Field("blank", description="Template id the space was seeded from")
+    owner_id: str = Field(..., alias="ownerId", description="user_id of the owner")
+    owner_email: str = Field("", alias="ownerEmail")
+    created_at: str = Field("", alias="createdAt")
+    updated_at: str = Field("", alias="updatedAt")
+    # Pointer to the MEMORY.md index text in S3 (content-addressed). Optional
+    # only transiently during creation; always set on a persisted space.
+    index_s3_key: Optional[str] = Field(None, alias="indexS3Key")
+    index_content_hash: Optional[str] = Field(None, alias="indexContentHash")

--- a/backend/src/apis/shared/memory/repository.py
+++ b/backend/src/apis/shared/memory/repository.py
@@ -1,0 +1,261 @@
+"""DynamoDB repository for Memory Spaces (PR-1, data layer).
+
+Owns the row shapes on the dedicated ``memory-spaces`` table and all
+(de)serialization between DynamoDB items (camelCase, ``Decimal`` numbers) and
+the Pydantic models. No access control lives here — that is the service's job
+(``resolve_permission``); the repository is a thin, permission-agnostic CRUD
+layer, matching how ``apis/shared`` repositories are structured elsewhere.
+
+Row shapes (see ``models.py``):
+
+  - ``PK=SPACE#{id}  SK=META``            + ``GSI1PK=OWNER#{owner_id}``
+  - ``PK=SPACE#{id}  SK=INDEX``
+  - ``PK=SPACE#{id}  SK=MEMBER#{email}``  + ``GSI2PK=MEMBER#{email}``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal
+from typing import Any, List, Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from boto3.dynamodb.conditions import Key
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    Key = None  # type: ignore[assignment]
+
+from .models import MemoryEntryRef, MemoryIndex, MemorySpace, SpaceMember
+
+logger = logging.getLogger(__name__)
+
+_META_SK = "META"
+_INDEX_SK = "INDEX"
+_MEMBER_SK_PREFIX = "MEMBER#"
+
+OWNER_INDEX = "OwnerIndex"
+MEMBER_INDEX = "MemberIndex"
+
+
+def _space_pk(space_id: str) -> str:
+    return f"SPACE#{space_id}"
+
+
+def _member_sk(email: str) -> str:
+    return f"{_MEMBER_SK_PREFIX}{email.strip().lower()}"
+
+
+def _to_dynamo(obj: Any) -> Any:
+    """Recursively convert floats to Decimal for DynamoDB writes."""
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: _to_dynamo(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_dynamo(v) for v in obj]
+    return obj
+
+
+def _from_dynamo(obj: Any) -> Any:
+    """Recursively convert Decimal to int/float for JSON-friendly reads."""
+    if isinstance(obj, Decimal):
+        # Whole numbers come back as int (sizes, counts); keep fractions float.
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    if isinstance(obj, dict):
+        return {k: _from_dynamo(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_from_dynamo(v) for v in obj]
+    return obj
+
+
+class MemorySpaceRepository:
+    """CRUD for the ``memory-spaces`` single table (META / INDEX / MEMBER rows)."""
+
+    def __init__(self, table_name: Optional[str] = None):
+        self.table_name = table_name or os.environ.get(
+            "DYNAMODB_MEMORY_SPACES_TABLE_NAME", "memory-spaces"
+        )
+        self._dynamodb = boto3.resource("dynamodb")
+        self._table = self._dynamodb.Table(self.table_name)
+
+    # ---- serialization -------------------------------------------------
+
+    @staticmethod
+    def _space_to_item(space: MemorySpace) -> dict:
+        item = {
+            "PK": _space_pk(space.space_id),
+            "SK": _META_SK,
+            "GSI1PK": f"OWNER#{space.owner_id}",
+            "GSI1SK": _space_pk(space.space_id),
+            "spaceId": space.space_id,
+            "name": space.name,
+            "template": space.template,
+            "ownerId": space.owner_id,
+            "ownerEmail": space.owner_email,
+            "createdAt": space.created_at,
+            "updatedAt": space.updated_at,
+        }
+        if space.index_s3_key is not None:
+            item["indexS3Key"] = space.index_s3_key
+        if space.index_content_hash is not None:
+            item["indexContentHash"] = space.index_content_hash
+        return item
+
+    @staticmethod
+    def _item_to_space(item: dict) -> MemorySpace:
+        return MemorySpace(
+            space_id=item.get("spaceId", ""),
+            name=item.get("name", ""),
+            template=item.get("template", "blank"),
+            owner_id=item.get("ownerId", ""),
+            owner_email=item.get("ownerEmail", ""),
+            created_at=item.get("createdAt", ""),
+            updated_at=item.get("updatedAt", ""),
+            index_s3_key=item.get("indexS3Key"),
+            index_content_hash=item.get("indexContentHash"),
+        )
+
+    @staticmethod
+    def _index_to_item(index: MemoryIndex) -> dict:
+        entries = [
+            {
+                "slug": r.slug,
+                "type": r.entry_type,
+                "description": r.description,
+                "contentHash": r.content_hash,
+                "size": int(r.size),
+                "s3Key": r.s3_key,
+                "updated": r.updated,
+                "updatedBy": r.updated_by,
+                "indexed": _to_dynamo(r.indexed),
+            }
+            for r in index.entries
+        ]
+        return {
+            "PK": _space_pk(index.space_id),
+            "SK": _INDEX_SK,
+            "spaceId": index.space_id,
+            "entries": entries,
+            "version": int(index.version),
+        }
+
+    @staticmethod
+    def _item_to_index(item: dict, space_id: str) -> MemoryIndex:
+        entries = [
+            MemoryEntryRef(
+                slug=r.get("slug", ""),
+                entry_type=r.get("type", "fact"),
+                description=r.get("description", ""),
+                content_hash=r.get("contentHash", ""),
+                size=int(r.get("size", 0)),
+                s3_key=r.get("s3Key", ""),
+                updated=r.get("updated", ""),
+                updated_by=r.get("updatedBy", ""),
+                indexed=_from_dynamo(r.get("indexed") or {}),
+            )
+            for r in (item.get("entries") or [])
+        ]
+        return MemoryIndex(
+            space_id=space_id,
+            entries=entries,
+            version=int(item.get("version", 0)),
+        )
+
+    @staticmethod
+    def _member_to_item(space_id: str, member: SpaceMember) -> dict:
+        email = member.email.strip().lower()
+        return {
+            "PK": _space_pk(space_id),
+            "SK": _member_sk(email),
+            "GSI2PK": f"MEMBER#{email}",
+            "GSI2SK": _space_pk(space_id),
+            "spaceId": space_id,
+            "email": email,
+            "permission": member.permission,
+            "createdAt": member.created_at,
+        }
+
+    @staticmethod
+    def _item_to_member(item: dict) -> SpaceMember:
+        return SpaceMember(
+            email=item.get("email", ""),
+            permission=item.get("permission", "viewer"),
+            created_at=item.get("createdAt", ""),
+        )
+
+    # ---- space META ----------------------------------------------------
+
+    def put_space(self, space: MemorySpace) -> None:
+        self._table.put_item(Item=self._space_to_item(space))
+
+    def get_space(self, space_id: str) -> Optional[MemorySpace]:
+        resp = self._table.get_item(
+            Key={"PK": _space_pk(space_id), "SK": _META_SK}
+        )
+        item = resp.get("Item")
+        return self._item_to_space(item) if item else None
+
+    def list_owned(self, owner_id: str) -> List[MemorySpace]:
+        resp = self._table.query(
+            IndexName=OWNER_INDEX,
+            KeyConditionExpression=Key("GSI1PK").eq(f"OWNER#{owner_id}"),
+        )
+        return [self._item_to_space(i) for i in resp.get("Items", [])]
+
+    def delete_space(self, space_id: str) -> None:
+        """Delete every row for a space (META + INDEX + all MEMBER rows)."""
+        resp = self._table.query(
+            KeyConditionExpression=Key("PK").eq(_space_pk(space_id))
+        )
+        with self._table.batch_writer() as batch:
+            for item in resp.get("Items", []):
+                batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
+
+    # ---- index manifest ------------------------------------------------
+
+    def get_index(self, space_id: str) -> MemoryIndex:
+        resp = self._table.get_item(
+            Key={"PK": _space_pk(space_id), "SK": _INDEX_SK}
+        )
+        item = resp.get("Item")
+        if not item:
+            return MemoryIndex(space_id=space_id, entries=[], version=0)
+        return self._item_to_index(item, space_id)
+
+    def put_index(self, index: MemoryIndex) -> None:
+        self._table.put_item(Item=self._index_to_item(index))
+
+    # ---- members -------------------------------------------------------
+
+    def put_member(self, space_id: str, member: SpaceMember) -> None:
+        self._table.put_item(Item=self._member_to_item(space_id, member))
+
+    def get_member(self, space_id: str, email: str) -> Optional[SpaceMember]:
+        resp = self._table.get_item(
+            Key={"PK": _space_pk(space_id), "SK": _member_sk(email)}
+        )
+        item = resp.get("Item")
+        return self._item_to_member(item) if item else None
+
+    def delete_member(self, space_id: str, email: str) -> None:
+        self._table.delete_item(
+            Key={"PK": _space_pk(space_id), "SK": _member_sk(email)}
+        )
+
+    def list_members(self, space_id: str) -> List[SpaceMember]:
+        resp = self._table.query(
+            KeyConditionExpression=Key("PK").eq(_space_pk(space_id))
+            & Key("SK").begins_with(_MEMBER_SK_PREFIX)
+        )
+        return [self._item_to_member(i) for i in resp.get("Items", [])]
+
+    def list_member_space_ids(self, email: str) -> List[str]:
+        """Return the space_ids a user (by email) has been granted access to."""
+        normalized = email.strip().lower()
+        resp = self._table.query(
+            IndexName=MEMBER_INDEX,
+            KeyConditionExpression=Key("GSI2PK").eq(f"MEMBER#{normalized}"),
+        )
+        return [i.get("spaceId", "") for i in resp.get("Items", []) if i.get("spaceId")]

--- a/backend/src/apis/shared/memory/service.py
+++ b/backend/src/apis/shared/memory/service.py
@@ -1,0 +1,427 @@
+"""Service layer for Memory Spaces (PR-1, data layer).
+
+Owns space lifecycle, permission resolution, sharing, and entry/index I/O —
+composing the DynamoDB repository (``repository.py``) with the S3 byte store
+(``store.py``). This is the data-layer API that the runtime read/write path
+(PR-2/PR-4) and the app-api user surface (PR-5) call; PR-1 adds no routes,
+tools, or system-prompt wiring.
+
+**Access control is identity-based and enforced here**, at the one chokepoint
+``resolve_permission`` — mirroring ``resolve_assistant_permission``. The owner
+is stored on the space; shared grants are ``viewer``/``editor`` member rows.
+Every read requires ``viewer+``; every write requires ``editor+``; sharing and
+deletion require ``owner``. There is no content inspection — governance is the
+grant, consistent with how the platform treats every other shared entity.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from .models import (
+    EntryType,
+    MemoryEntryRef,
+    MemoryIndex,
+    MemorySpace,
+    Role,
+    ShareRole,
+    SpaceMember,
+)
+from .repository import MemorySpaceRepository
+from .store import MemorySpaceStore, compute_content_hash, get_memory_space_store
+from .templates import DEFAULT_TEMPLATE_ID, get_template, is_valid_template
+
+logger = logging.getLogger(__name__)
+
+_ROLE_RANK: Dict[str, int] = {"viewer": 1, "editor": 2, "owner": 3}
+
+
+class MemorySpaceError(RuntimeError):
+    """Base class for memory-space service errors (translated by the API layer)."""
+
+
+class MemorySpaceNotFoundError(MemorySpaceError):
+    """The space does not exist (or the caller may not even know it does)."""
+
+
+class MemorySpacePermissionError(MemorySpaceError):
+    """The caller lacks the required role on the space."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_space_id() -> str:
+    return f"spc_{uuid.uuid4().hex}"
+
+
+def _get_nested(data: Dict[str, Any], dotted: str) -> Any:
+    """Resolve a dotted key (``commitments.due``) against a nested dict."""
+    cur: Any = data
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+class MemorySpaceService:
+    """Lifecycle + permission + I/O for Memory Spaces."""
+
+    def __init__(
+        self,
+        repository: Optional[MemorySpaceRepository] = None,
+        store: Optional[MemorySpaceStore] = None,
+    ) -> None:
+        self.repository = repository or MemorySpaceRepository()
+        self.store = store or get_memory_space_store()
+
+    # ---- permission ----------------------------------------------------
+
+    def resolve_permission(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> Tuple[Optional[MemorySpace], Optional[Role]]:
+        """Resolve the caller's role on a space.
+
+        Returns ``(space, role)`` where role is ``owner``/``editor``/``viewer``,
+        or ``(space, None)`` if the caller has no grant, or ``(None, None)`` if
+        the space does not exist. Mirrors ``resolve_assistant_permission``.
+        """
+        space = self.repository.get_space(space_id)
+        if space is None:
+            return None, None
+        if space.owner_id == user_id:
+            return space, "owner"
+        if user_email:
+            member = self.repository.get_member(space_id, user_email)
+            if member is not None:
+                return space, member.permission
+        return space, None
+
+    def _require(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str],
+        min_role: Role,
+    ) -> Tuple[MemorySpace, Role]:
+        space, role = self.resolve_permission(space_id, user_id, user_email)
+        if space is None:
+            raise MemorySpaceNotFoundError(f"Memory space '{space_id}' not found")
+        if role is None or _ROLE_RANK[role] < _ROLE_RANK[min_role]:
+            raise MemorySpacePermissionError(
+                f"'{min_role}' access required on memory space '{space_id}'"
+            )
+        return space, role
+
+    # ---- lifecycle -----------------------------------------------------
+
+    def create_space(
+        self,
+        owner_id: str,
+        owner_email: str,
+        name: str,
+        template: str = DEFAULT_TEMPLATE_ID,
+    ) -> MemorySpace:
+        """Create a space seeded from a template; returns the persisted space."""
+        if not owner_id:
+            raise MemorySpaceError("owner_id is required to create a space")
+        if not name or not name.strip():
+            raise MemorySpaceError("a memory space name is required")
+        if not is_valid_template(template):
+            raise MemorySpaceError(f"unknown template '{template}'")
+
+        tmpl = get_template(template)
+        space_id = _new_space_id()
+        now = _now_iso()
+
+        # Seed the human-readable MEMORY.md index in S3.
+        index_bytes = tmpl.starter_index.encode("utf-8")
+        index_key = self.store.put(
+            space_id=space_id, content=index_bytes, content_type="text/markdown"
+        )
+
+        space = MemorySpace(
+            space_id=space_id,
+            name=name.strip(),
+            template=template,
+            owner_id=owner_id,
+            owner_email=(owner_email or "").strip().lower(),
+            created_at=now,
+            updated_at=now,
+            index_s3_key=index_key,
+            index_content_hash=compute_content_hash(index_bytes),
+        )
+        self.repository.put_space(space)
+        self.repository.put_index(MemoryIndex(space_id=space_id, entries=[], version=0))
+        logger.info(
+            "memory-spaces: created space=%s owner=%s template=%s",
+            space_id,
+            owner_id,
+            template,
+        )
+        return space
+
+    def get_space(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> MemorySpace:
+        space, _ = self._require(space_id, user_id, user_email, "viewer")
+        return space
+
+    def list_spaces_for_user(
+        self, user_id: str, user_email: Optional[str] = None
+    ) -> List[MemorySpace]:
+        """List spaces the user owns plus spaces shared with them (deduped)."""
+        owned = self.repository.list_owned(user_id)
+        spaces: Dict[str, MemorySpace] = {s.space_id: s for s in owned}
+        if user_email:
+            for space_id in self.repository.list_member_space_ids(user_email):
+                if space_id in spaces:
+                    continue
+                shared = self.repository.get_space(space_id)
+                if shared is not None:
+                    spaces[space_id] = shared
+        return sorted(spaces.values(), key=lambda s: s.created_at)
+
+    def delete_space(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> None:
+        """Delete a space (owner only): all rows + best-effort S3 objects."""
+        space, _ = self._require(space_id, user_id, user_email, "owner")
+        # Best-effort purge of the byte objects (dedup-aware deletion is a v1
+        # concern per the spec's data-governance section; content-addressed
+        # objects unreferenced after row deletion are the only residue).
+        index = self.repository.get_index(space_id)
+        for ref in index.entries:
+            self.store.delete(ref.s3_key)
+        if space.index_s3_key:
+            self.store.delete(space.index_s3_key)
+        self.repository.delete_space(space_id)
+        logger.info("memory-spaces: deleted space=%s by user=%s", space_id, user_id)
+
+    # ---- sharing -------------------------------------------------------
+
+    def share(
+        self,
+        space_id: str,
+        actor_id: str,
+        actor_email: Optional[str],
+        grantee_email: str,
+        permission: ShareRole = "viewer",
+    ) -> SpaceMember:
+        """Grant ``grantee_email`` a role on the space (owner only)."""
+        self._require(space_id, actor_id, actor_email, "owner")
+        if permission not in ("viewer", "editor"):
+            raise MemorySpaceError(f"invalid share permission '{permission}'")
+        member = SpaceMember(
+            email=grantee_email.strip().lower(),
+            permission=permission,
+            created_at=_now_iso(),
+        )
+        self.repository.put_member(space_id, member)
+        self._touch(space_id)
+        return member
+
+    def revoke(
+        self,
+        space_id: str,
+        actor_id: str,
+        actor_email: Optional[str],
+        grantee_email: str,
+    ) -> None:
+        """Remove a grant (owner only)."""
+        self._require(space_id, actor_id, actor_email, "owner")
+        self.repository.delete_member(space_id, grantee_email)
+        self._touch(space_id)
+
+    def list_members(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> List[SpaceMember]:
+        """List a space's shared grants (owner or editor)."""
+        self._require(space_id, user_id, user_email, "editor")
+        return self.repository.list_members(space_id)
+
+    # ---- index (MEMORY.md) ---------------------------------------------
+
+    def read_index(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> str:
+        space, _ = self._require(space_id, user_id, user_email, "viewer")
+        if not space.index_s3_key:
+            return ""
+        return self.store.get(space.index_s3_key).decode("utf-8")
+
+    def update_index(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str],
+        body: str,
+    ) -> MemorySpace:
+        """Replace the MEMORY.md index text (editor+)."""
+        space, _ = self._require(space_id, user_id, user_email, "editor")
+        content = body.encode("utf-8")
+        old_key = space.index_s3_key
+        new_key = self.store.put(
+            space_id=space_id, content=content, content_type="text/markdown"
+        )
+        space.index_s3_key = new_key
+        space.index_content_hash = compute_content_hash(content)
+        space.updated_at = _now_iso()
+        self.repository.put_space(space)
+        if old_key and old_key != new_key and not self._key_in_use(space_id, old_key):
+            self.store.delete(old_key)
+        return space
+
+    # ---- entries -------------------------------------------------------
+
+    def list_entries(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str] = None,
+        *,
+        entry_type: Optional[EntryType] = None,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> List[MemoryEntryRef]:
+        """List manifest entries, optionally filtered by type and indexed fields.
+
+        ``where`` matches dotted keys against each entry's ``indexed`` map by
+        exact equality (operator queries like ``"<7d"`` are PR-2). This is the
+        "who owes what" path — a manifest scan, never a body load.
+        """
+        self._require(space_id, user_id, user_email, "viewer")
+        entries = self.repository.get_index(space_id).entries
+        if entry_type is not None:
+            entries = [e for e in entries if e.entry_type == entry_type]
+        if where:
+            entries = [
+                e
+                for e in entries
+                if all(_get_nested(e.indexed, k) == v for k, v in where.items())
+            ]
+        return entries
+
+    def read_entry(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str],
+        slug: str,
+    ) -> str:
+        self._require(space_id, user_id, user_email, "viewer")
+        ref = self._find_ref(space_id, slug)
+        if ref is None:
+            raise MemorySpaceNotFoundError(
+                f"entry '{slug}' not found in space '{space_id}'"
+            )
+        return self.store.get(ref.s3_key).decode("utf-8")
+
+    def write_entry(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str],
+        slug: str,
+        body: str,
+        *,
+        entry_type: EntryType = "fact",
+        description: str = "",
+        indexed: Optional[Dict[str, Any]] = None,
+    ) -> MemoryEntryRef:
+        """Create or replace an entry (editor+); updates the manifest."""
+        self._require(space_id, user_id, user_email, "editor")
+        if not slug or not slug.strip():
+            raise MemorySpaceError("an entry slug is required")
+
+        content = body.encode("utf-8")
+        s3_key = self.store.put(
+            space_id=space_id, content=content, content_type="text/markdown"
+        )
+        ref = MemoryEntryRef(
+            slug=slug,
+            entry_type=entry_type,
+            description=description,
+            content_hash=compute_content_hash(content),
+            size=len(content),
+            s3_key=s3_key,
+            updated=_now_iso(),
+            updated_by=user_id,
+            indexed=indexed or {},
+        )
+
+        index = self.repository.get_index(space_id)
+        old = [e for e in index.entries if e.slug == slug]
+        kept = [e for e in index.entries if e.slug != slug]
+        kept.append(ref)
+        kept.sort(key=lambda e: e.slug)
+        index.entries = kept
+        index.version += 1
+        self.repository.put_index(index)
+
+        # GC any object the replaced entry uniquely referenced.
+        for prev in old:
+            if prev.s3_key != s3_key and not self._key_in_use(
+                space_id, prev.s3_key, index=index
+            ):
+                self.store.delete(prev.s3_key)
+        return ref
+
+    def delete_entry(
+        self,
+        space_id: str,
+        user_id: str,
+        user_email: Optional[str],
+        slug: str,
+    ) -> None:
+        """Remove an entry from the manifest (editor+) and GC its object."""
+        self._require(space_id, user_id, user_email, "editor")
+        index = self.repository.get_index(space_id)
+        removed = [e for e in index.entries if e.slug == slug]
+        if not removed:
+            raise MemorySpaceNotFoundError(
+                f"entry '{slug}' not found in space '{space_id}'"
+            )
+        index.entries = [e for e in index.entries if e.slug != slug]
+        index.version += 1
+        self.repository.put_index(index)
+        for prev in removed:
+            if not self._key_in_use(space_id, prev.s3_key, index=index):
+                self.store.delete(prev.s3_key)
+
+    # ---- helpers -------------------------------------------------------
+
+    def _find_ref(self, space_id: str, slug: str) -> Optional[MemoryEntryRef]:
+        for ref in self.repository.get_index(space_id).entries:
+            if ref.slug == slug:
+                return ref
+        return None
+
+    def _key_in_use(
+        self,
+        space_id: str,
+        s3_key: str,
+        *,
+        index: Optional[MemoryIndex] = None,
+    ) -> bool:
+        """True if any entry or the space index still references ``s3_key``.
+
+        Objects are content-addressed, so identical content under different
+        slugs shares one object — never delete a key another ref still points
+        at.
+        """
+        idx = index if index is not None else self.repository.get_index(space_id)
+        if any(e.s3_key == s3_key for e in idx.entries):
+            return True
+        space = self.repository.get_space(space_id)
+        return bool(space and space.index_s3_key == s3_key)
+
+    def _touch(self, space_id: str) -> None:
+        space = self.repository.get_space(space_id)
+        if space is not None:
+            space.updated_at = _now_iso()
+            self.repository.put_space(space)

--- a/backend/src/apis/shared/memory/store.py
+++ b/backend/src/apis/shared/memory/store.py
@@ -1,0 +1,213 @@
+"""S3-backed store for a Memory Space's markdown bytes (PR-1).
+
+A Memory Space is a per-owner (optionally shared) markdown "second brain":
+an always-loaded index (``MEMORY.md``) plus a set of typed entry files. The
+bytes are too large / too many to inline in DynamoDB (400 KB item limit), so
+they live in the ``memory-spaces`` S3 bucket and the DynamoDB rows carry only
+lightweight manifests (``MemoryEntryRef``) plus a pointer to the index object.
+
+This store is a faithful sibling of ``apis/shared/skills/resource_store.py``
+(the skills reference-file / progressive-disclosure mechanism the Memory
+Spaces spec re-scopes from per-skill to per-space):
+
+  - Objects are **content-addressed**: the key is
+    ``spaces/{space_id}/{content_hash}`` where ``content_hash`` is the sha256
+    hex of the bytes. Identical content within a space dedupes to one object,
+    and every write produces an immutable object — a new edit is a new object
+    plus a manifest-pointer swap, which keeps concurrency clean (PR-6) and
+    makes the readable-path export (spec §9) a pure function of the manifest.
+  - The manifest / index pointer references objects by key; the bytes never
+    travel through DynamoDB.
+
+Boundary: this module lives under ``apis/shared/memory/`` and is import-clean
+(it never imports ``app_api``/``inference_api``). The user-facing CRUD path
+(app-api, PR-5) and the runtime read/write path (inference-api, PR-2/PR-4)
+both reach it through ``apis.shared``.
+
+Configuration: the bucket name comes from ``S3_MEMORY_SPACES_BUCKET_NAME``
+(set on both compute roles by the CDK ``MemorySpacesConstruct`` wiring). When
+boto3 or the bucket name is absent (local dev without AWS), the store is
+``enabled == False`` and every operation raises ``MemorySpaceStoreError`` so a
+misconfigured write surfaces loudly rather than silently "succeeding" with no
+bytes persisted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# AWS-managed (SSE-S3 / AES256) encryption, matching the bucket default and
+# the skills/artifacts/file-upload buckets.
+_SSE_ALGORITHM = "AES256"
+
+
+class MemorySpaceStoreError(RuntimeError):
+    """Raised when the store is asked to do work it cannot complete.
+
+    Covers both "storage not configured" (no bucket / no boto3) and an
+    unexpected S3 failure, so callers have one error type to translate.
+    """
+
+
+def content_key(space_id: str, content_hash: str) -> str:
+    """Return the content-addressed object key for a space's markdown file."""
+    return f"spaces/{space_id}/{content_hash}"
+
+
+def compute_content_hash(content: bytes) -> str:
+    """Return the sha256 hex digest used as the content address."""
+    return hashlib.sha256(content).hexdigest()
+
+
+class MemorySpaceStore:
+    """Put / get / delete a Memory Space's markdown bytes in S3."""
+
+    def __init__(
+        self,
+        bucket_name: Optional[str] = None,
+        s3_client: Optional[object] = None,
+    ) -> None:
+        self.bucket_name = bucket_name or os.environ.get(
+            "S3_MEMORY_SPACES_BUCKET_NAME"
+        )
+        # Allow an explicit client (tests inject a moto client); otherwise it
+        # is created lazily on first use so importing the module never needs
+        # AWS creds.
+        self._s3 = s3_client
+
+    @property
+    def enabled(self) -> bool:
+        """True when a bucket is configured and boto3 is importable."""
+        return bool(self.bucket_name) and boto3 is not None
+
+    def _client(self):
+        if self._s3 is None:
+            if boto3 is None:  # pragma: no cover - import-guarded above
+                raise MemorySpaceStoreError(
+                    "memory space storage unavailable: boto3 is not installed"
+                )
+            self._s3 = boto3.client("s3")
+        return self._s3
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise MemorySpaceStoreError(
+                "memory space storage is not configured "
+                "(S3_MEMORY_SPACES_BUCKET_NAME is unset)"
+            )
+
+    def put(self, *, space_id: str, content: bytes, content_type: str) -> str:
+        """Persist markdown bytes content-addressed; return the object key.
+
+        Computes the sha256 of ``content``, derives the
+        ``spaces/{space_id}/{content_hash}`` key, and uploads. If an object
+        already exists at that key (same content), the upload is skipped
+        (dedupe) — the key is returned either way.
+        """
+        self._require_enabled()
+        digest = compute_content_hash(content)
+        key = content_key(space_id, digest)
+        client = self._client()
+
+        if self._object_exists(key):
+            logger.info(
+                "memory-spaces: dedupe hit for space=%s key=%s (%d bytes)",
+                space_id,
+                key,
+                len(content),
+            )
+            return key
+
+        try:
+            client.put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=content,
+                ContentType=content_type or "text/markdown",
+                ServerSideEncryption=_SSE_ALGORITHM,
+            )
+        except ClientError as e:  # pragma: no cover - network/permission path
+            logger.error(
+                "memory-spaces: put failed for space=%s key=%s: %s",
+                space_id,
+                key,
+                e,
+            )
+            raise MemorySpaceStoreError(
+                f"failed to store memory bytes for space '{space_id}'"
+            ) from e
+
+        logger.info(
+            "memory-spaces: stored space=%s key=%s (%d bytes)",
+            space_id,
+            key,
+            len(content),
+        )
+        return key
+
+    def get(self, s3_key: str) -> bytes:
+        """Return the bytes for an object key. Raises if missing/unavailable."""
+        self._require_enabled()
+        client = self._client()
+        try:
+            response = client.get_object(Bucket=self.bucket_name, Key=s3_key)
+            return response["Body"].read()
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "404"):
+                raise MemorySpaceStoreError(
+                    f"memory file not found at key '{s3_key}'"
+                ) from e
+            logger.error("memory-spaces: get failed for key=%s: %s", s3_key, e)
+            raise MemorySpaceStoreError(
+                f"failed to read memory file at key '{s3_key}'"
+            ) from e
+
+    def delete(self, s3_key: str) -> None:
+        """Delete an object key. Best-effort — never raises on the storage
+        miss path (deleting an already-absent object is a no-op in S3)."""
+        if not self.enabled:
+            return
+        client = self._client()
+        try:
+            client.delete_object(Bucket=self.bucket_name, Key=s3_key)
+        except ClientError:  # pragma: no cover - best-effort cleanup
+            logger.warning(
+                "memory-spaces: delete failed for key=%s", s3_key, exc_info=True
+            )
+
+    def _object_exists(self, key: str) -> bool:
+        client = self._client()
+        try:
+            client.head_object(Bucket=self.bucket_name, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            # Any other error (permissions, throttling) is real — surface it
+            # rather than masquerading as "absent" and double-uploading.
+            raise
+
+
+_store: Optional[MemorySpaceStore] = None
+
+
+def get_memory_space_store() -> MemorySpaceStore:
+    """Get or create the process-global memory-space store."""
+    global _store
+    if _store is None:
+        _store = MemorySpaceStore()
+    return _store

--- a/backend/src/apis/shared/memory/templates.py
+++ b/backend/src/apis/shared/memory/templates.py
@@ -1,0 +1,109 @@
+"""Space templates — presets that seed a new Memory Space (PR-1).
+
+A template supplies the starter ``MEMORY.md`` index text, the entry types the
+space uses, and the ``always_load`` rule (which entries hydrate at an agent's
+wake-up). Templates keep the Oliver-class ergonomics without hardcoding any
+one use case: "Oliver" is the ``chief-of-staff`` template + a bound agent.
+
+PR-1 ships the registry and starter index text. Richer template seeding
+(pre-created example entries, per-type frontmatter scaffolds) can be layered
+in PR-2 when the read path lands; the shape here is deliberately minimal.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+from .models import EntryType
+
+
+class SpaceTemplate(BaseModel):
+    """A preset for creating a Memory Space."""
+
+    template_id: str
+    name: str
+    description: str
+    entry_types: List[EntryType] = Field(default_factory=list)
+    # Entries hydrated at wake-up. ``MEMORY.md`` is the index; ``latest:{type}``
+    # resolves to the most-recent entry of that type (the Oliver rule).
+    always_load: List[str] = Field(default_factory=lambda: ["MEMORY.md"])
+    starter_index: str = "# Memory\n"
+
+
+_BLANK = SpaceTemplate(
+    template_id="blank",
+    name="Blank Wiki",
+    description="An empty space. Start from scratch.",
+    entry_types=["entity", "episodic", "fact"],
+    always_load=["MEMORY.md"],
+    starter_index=(
+        "# Memory\n\n"
+        "This is your memory index. One-line pointers to the things worth "
+        "remembering go here; the details live in linked entries.\n"
+    ),
+)
+
+_CHIEF_OF_STAFF = SpaceTemplate(
+    template_id="chief-of-staff",
+    name="Chief of Staff",
+    description=(
+        "An institutional-memory space for a chief-of-staff-style assistant: "
+        "people, projects, and commitments, with a daily log and periodic "
+        "briefs."
+    ),
+    entry_types=["entity", "episodic", "fact"],
+    always_load=["MEMORY.md", "latest:episodic/daily", "latest:episodic/brief"],
+    starter_index=(
+        "# Memory\n\n"
+        "## Strategic priorities\n"
+        "_What matters most right now. Everything maps back to these._\n\n"
+        "## Key people\n"
+        "_Pointers to `people/` entries — role, what they care about, what's "
+        "owed in both directions._\n\n"
+        "## Active projects\n"
+        "_Pointers to `projects/` entries — status and stakeholders._\n\n"
+        "## Open commitments\n"
+        "_Who owes what, and by when. The commitments sections in each person "
+        "entry are the CRM._\n"
+    ),
+)
+
+_RESEARCH_NOTEBOOK = SpaceTemplate(
+    template_id="research-notebook",
+    name="Research Notebook",
+    description=(
+        "A space for research work: papers, threads of inquiry, and open "
+        "questions, with a running log."
+    ),
+    entry_types=["entity", "episodic", "fact"],
+    always_load=["MEMORY.md", "latest:episodic/log"],
+    starter_index=(
+        "# Memory\n\n"
+        "## Threads of inquiry\n"
+        "_Active lines of research — pointers to their entries._\n\n"
+        "## Papers & sources\n"
+        "_Key references worth remembering._\n\n"
+        "## Open questions\n"
+        "_What we don't yet know and want to resolve._\n"
+    ),
+)
+
+
+TEMPLATES: Dict[str, SpaceTemplate] = {
+    t.template_id: t
+    for t in (_BLANK, _CHIEF_OF_STAFF, _RESEARCH_NOTEBOOK)
+}
+
+DEFAULT_TEMPLATE_ID = "blank"
+
+
+def get_template(template_id: str) -> SpaceTemplate:
+    """Return a template by id, or raise ``KeyError`` if unknown."""
+    return TEMPLATES[template_id]
+
+
+def is_valid_template(template_id: str) -> bool:
+    """True when ``template_id`` names a known template."""
+    return template_id in TEMPLATES

--- a/backend/tests/shared/test_memory_spaces.py
+++ b/backend/tests/shared/test_memory_spaces.py
@@ -1,0 +1,399 @@
+"""Tests for the Memory Spaces repository + service (PR-1, data layer).
+
+moto-backed DynamoDB (with the OwnerIndex/MemberIndex GSIs) + S3. Exercises
+row (de)serialization, GSI listings, and the full permission-gated service
+API: create/get/list/delete, share/revoke, index + entry I/O, and the
+role-gating (viewer reads, editor writes, owner shares/deletes).
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.memory.models import MemoryIndex, MemorySpace, SpaceMember
+from apis.shared.memory.repository import MemorySpaceRepository
+from apis.shared.memory.service import (
+    MemorySpaceNotFoundError,
+    MemorySpacePermissionError,
+    MemorySpaceService,
+)
+from apis.shared.memory.store import MemorySpaceStore
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-memory-spaces"
+TABLE = "test-memory-spaces"
+
+OWNER = "user-owner"
+OWNER_EMAIL = "owner@example.edu"
+FRIEND = "user-friend"
+FRIEND_EMAIL = "friend@example.edu"
+STRANGER = "user-stranger"
+STRANGER_EMAIL = "stranger@example.edu"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def table(aws_env):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "OwnerIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "MemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
+    return MemorySpaceRepository(table_name=TABLE)
+
+
+@pytest.fixture()
+def store(aws_env):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return MemorySpaceStore(bucket_name=BUCKET, s3_client=client)
+
+
+@pytest.fixture()
+def service(table, store):
+    return MemorySpaceService(repository=table, store=store)
+
+
+@pytest.fixture()
+def space(service):
+    return service.create_space(OWNER, OWNER_EMAIL, "My Brain", template="blank")
+
+
+# ============================ repository ============================
+
+
+class TestRepository:
+    def test_space_round_trip(self, table):
+        s = MemorySpace(
+            space_id="spc_1",
+            name="X",
+            template="blank",
+            owner_id=OWNER,
+            owner_email=OWNER_EMAIL,
+            created_at="t0",
+            updated_at="t0",
+            index_s3_key="spaces/spc_1/abc",
+            index_content_hash="abc",
+        )
+        table.put_space(s)
+        got = table.get_space("spc_1")
+        assert got is not None
+        assert got.name == "X"
+        assert got.owner_id == OWNER
+        assert got.index_s3_key == "spaces/spc_1/abc"
+
+    def test_get_missing_space_returns_none(self, table):
+        assert table.get_space("nope") is None
+
+    def test_list_owned_via_gsi(self, table):
+        for i in range(3):
+            table.put_space(
+                MemorySpace(
+                    space_id=f"spc_{i}",
+                    name=f"S{i}",
+                    owner_id=OWNER,
+                    created_at=f"t{i}",
+                    updated_at=f"t{i}",
+                )
+            )
+        table.put_space(
+            MemorySpace(space_id="other", name="O", owner_id="someone-else")
+        )
+        owned = table.list_owned(OWNER)
+        assert {s.space_id for s in owned} == {"spc_0", "spc_1", "spc_2"}
+
+    def test_index_default_empty(self, table):
+        idx = table.get_index("spc_new")
+        assert idx.entries == []
+        assert idx.version == 0
+
+    def test_index_round_trip_with_indexed_numbers(self, table):
+        idx = MemoryIndex(space_id="spc_1", version=2)
+        from apis.shared.memory.models import MemoryEntryRef
+
+        idx.entries.append(
+            MemoryEntryRef(
+                slug="jane",
+                entry_type="entity",
+                description="VP",
+                content_hash="h",
+                size=123,
+                s3_key="spaces/spc_1/h",
+                updated="t",
+                updated_by=OWNER,
+                indexed={"open": True, "count": 3, "ratio": 0.5},
+            )
+        )
+        table.put_index(idx)
+        got = table.get_index("spc_1")
+        assert got.version == 2
+        assert len(got.entries) == 1
+        e = got.entries[0]
+        assert e.size == 123 and isinstance(e.size, int)
+        assert e.indexed == {"open": True, "count": 3, "ratio": 0.5}
+
+    def test_member_round_trip_and_listing(self, table):
+        table.put_member("spc_1", SpaceMember(email=FRIEND_EMAIL, permission="editor"))
+        got = table.get_member("spc_1", FRIEND_EMAIL)
+        assert got is not None and got.permission == "editor"
+        assert [m.email for m in table.list_members("spc_1")] == [FRIEND_EMAIL]
+        assert table.list_member_space_ids(FRIEND_EMAIL) == ["spc_1"]
+
+    def test_member_email_normalized(self, table):
+        table.put_member("spc_1", SpaceMember(email="MiXeD@Example.EDU"))
+        assert table.get_member("spc_1", "mixed@example.edu") is not None
+
+    def test_delete_member(self, table):
+        table.put_member("spc_1", SpaceMember(email=FRIEND_EMAIL))
+        table.delete_member("spc_1", FRIEND_EMAIL)
+        assert table.get_member("spc_1", FRIEND_EMAIL) is None
+
+    def test_delete_space_removes_all_rows(self, table):
+        table.put_space(MemorySpace(space_id="spc_1", name="X", owner_id=OWNER))
+        table.put_index(MemoryIndex(space_id="spc_1"))
+        table.put_member("spc_1", SpaceMember(email=FRIEND_EMAIL))
+        table.delete_space("spc_1")
+        assert table.get_space("spc_1") is None
+        assert table.get_member("spc_1", FRIEND_EMAIL) is None
+        assert table.get_index("spc_1").entries == []
+
+
+# ============================ service: lifecycle ============================
+
+
+class TestCreateAndList:
+    def test_create_seeds_index_and_rows(self, service):
+        s = service.create_space(OWNER, OWNER_EMAIL, "Brain", template="chief-of-staff")
+        assert s.space_id.startswith("spc_")
+        assert s.template == "chief-of-staff"
+        assert s.index_s3_key
+        # index text is seeded from the template
+        text = service.read_index(s.space_id, OWNER, OWNER_EMAIL)
+        assert "Strategic priorities" in text
+
+    def test_create_rejects_unknown_template(self, service):
+        with pytest.raises(Exception):
+            service.create_space(OWNER, OWNER_EMAIL, "X", template="does-not-exist")
+
+    def test_create_rejects_blank_name(self, service):
+        with pytest.raises(Exception):
+            service.create_space(OWNER, OWNER_EMAIL, "   ", template="blank")
+
+    def test_list_owned_and_shared(self, service):
+        a = service.create_space(OWNER, OWNER_EMAIL, "A")
+        b = service.create_space(OWNER, OWNER_EMAIL, "B")
+        # a third space owned by someone else, shared with FRIEND
+        other = service.create_space(STRANGER, STRANGER_EMAIL, "Shared")
+        service.share(other.space_id, STRANGER, STRANGER_EMAIL, FRIEND_EMAIL, "viewer")
+
+        owner_spaces = {s.space_id for s in service.list_spaces_for_user(OWNER, OWNER_EMAIL)}
+        assert owner_spaces == {a.space_id, b.space_id}
+
+        friend_spaces = {
+            s.space_id for s in service.list_spaces_for_user(FRIEND, FRIEND_EMAIL)
+        }
+        assert friend_spaces == {other.space_id}
+
+    def test_delete_space_owner_only(self, space, service):
+        with pytest.raises(MemorySpacePermissionError):
+            service.delete_space(space.space_id, STRANGER, STRANGER_EMAIL)
+        service.delete_space(space.space_id, OWNER, OWNER_EMAIL)
+        with pytest.raises(MemorySpaceNotFoundError):
+            service.get_space(space.space_id, OWNER, OWNER_EMAIL)
+
+
+# ============================ service: permissions ============================
+
+
+class TestPermissions:
+    def test_owner_resolves(self, space, service):
+        _, role = service.resolve_permission(space.space_id, OWNER, OWNER_EMAIL)
+        assert role == "owner"
+
+    def test_member_resolves(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
+        _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
+        assert role == "editor"
+
+    def test_stranger_has_no_role(self, space, service):
+        s, role = service.resolve_permission(space.space_id, STRANGER, STRANGER_EMAIL)
+        assert s is not None and role is None
+
+    def test_missing_space_resolves_none(self, service):
+        s, role = service.resolve_permission("nope", OWNER, OWNER_EMAIL)
+        assert s is None and role is None
+
+    def test_get_space_denied_for_stranger(self, space, service):
+        with pytest.raises(MemorySpacePermissionError):
+            service.get_space(space.space_id, STRANGER, STRANGER_EMAIL)
+
+    def test_get_missing_space_raises_not_found(self, service):
+        with pytest.raises(MemorySpaceNotFoundError):
+            service.get_space("nope", OWNER, OWNER_EMAIL)
+
+
+# ============================ service: sharing ============================
+
+
+class TestSharing:
+    def test_share_requires_owner(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer")
+        # an editor cannot re-share
+        with pytest.raises(MemorySpacePermissionError):
+            service.share(space.space_id, FRIEND, FRIEND_EMAIL, STRANGER_EMAIL, "viewer")
+
+    def test_list_members_editor_ok_viewer_denied(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
+        service.share(space.space_id, OWNER, OWNER_EMAIL, STRANGER_EMAIL, "viewer")
+        assert len(service.list_members(space.space_id, OWNER, OWNER_EMAIL)) == 2
+        # editor may view members
+        assert len(service.list_members(space.space_id, FRIEND, FRIEND_EMAIL)) == 2
+        # viewer may not
+        with pytest.raises(MemorySpacePermissionError):
+            service.list_members(space.space_id, STRANGER, STRANGER_EMAIL)
+
+    def test_revoke(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer")
+        service.revoke(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL)
+        _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
+        assert role is None
+
+
+# ============================ service: index + entries ============================
+
+
+class TestIndexAndEntries:
+    def test_update_and_read_index(self, space, service):
+        service.update_index(space.space_id, OWNER, OWNER_EMAIL, "# New index\n")
+        assert service.read_index(space.space_id, OWNER, OWNER_EMAIL) == "# New index\n"
+
+    def test_update_index_requires_editor(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer")
+        with pytest.raises(MemorySpacePermissionError):
+            service.update_index(space.space_id, FRIEND, FRIEND_EMAIL, "nope")
+
+    def test_write_and_read_entry(self, space, service):
+        ref = service.write_entry(
+            space.space_id,
+            OWNER,
+            OWNER_EMAIL,
+            "jane-doe",
+            "# Jane\nVP Research",
+            entry_type="entity",
+            description="VP Research",
+            indexed={"status": "active"},
+        )
+        assert ref.slug == "jane-doe"
+        assert ref.updated_by == OWNER
+        body = service.read_entry(space.space_id, OWNER, OWNER_EMAIL, "jane-doe")
+        assert "VP Research" in body
+
+    def test_write_entry_requires_editor(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer")
+        with pytest.raises(MemorySpacePermissionError):
+            service.write_entry(space.space_id, FRIEND, FRIEND_EMAIL, "x", "body")
+
+    def test_editor_can_write(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
+        ref = service.write_entry(space.space_id, FRIEND, FRIEND_EMAIL, "note", "hi")
+        assert ref.updated_by == FRIEND
+
+    def test_write_replaces_same_slug_and_gcs_old(self, space, service):
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "n", "v1")
+        old_ref = service._find_ref(space.space_id, "n")
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "n", "v2")
+        # manifest has a single entry with the new content
+        entries = service.list_entries(space.space_id, OWNER, OWNER_EMAIL)
+        assert len(entries) == 1
+        assert service.read_entry(space.space_id, OWNER, OWNER_EMAIL, "n") == "v2"
+        # old content-addressed object was garbage collected
+        from apis.shared.memory.store import MemorySpaceStoreError
+
+        with pytest.raises(MemorySpaceStoreError):
+            service.store.get(old_ref.s3_key)
+
+    def test_list_entries_filter_by_type_and_where(self, space, service):
+        service.write_entry(
+            space.space_id, OWNER, OWNER_EMAIL, "p1", "b",
+            entry_type="entity", indexed={"open": True},
+        )
+        service.write_entry(
+            space.space_id, OWNER, OWNER_EMAIL, "p2", "b",
+            entry_type="entity", indexed={"open": False},
+        )
+        service.write_entry(
+            space.space_id, OWNER, OWNER_EMAIL, "f1", "b", entry_type="fact"
+        )
+        entities = service.list_entries(
+            space.space_id, OWNER, OWNER_EMAIL, entry_type="entity"
+        )
+        assert {e.slug for e in entities} == {"p1", "p2"}
+        open_ones = service.list_entries(
+            space.space_id, OWNER, OWNER_EMAIL, where={"open": True}
+        )
+        assert {e.slug for e in open_ones} == {"p1"}
+
+    def test_read_missing_entry_raises(self, space, service):
+        with pytest.raises(MemorySpaceNotFoundError):
+            service.read_entry(space.space_id, OWNER, OWNER_EMAIL, "ghost")
+
+    def test_delete_entry(self, space, service):
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "n", "v")
+        ref = service._find_ref(space.space_id, "n")
+        service.delete_entry(space.space_id, OWNER, OWNER_EMAIL, "n")
+        assert service.list_entries(space.space_id, OWNER, OWNER_EMAIL) == []
+        from apis.shared.memory.store import MemorySpaceStoreError
+
+        with pytest.raises(MemorySpaceStoreError):
+            service.store.get(ref.s3_key)
+
+    def test_delete_missing_entry_raises(self, space, service):
+        with pytest.raises(MemorySpaceNotFoundError):
+            service.delete_entry(space.space_id, OWNER, OWNER_EMAIL, "ghost")
+
+    def test_viewer_can_read_entry(self, space, service):
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "n", "shared body")
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer")
+        assert (
+            service.read_entry(space.space_id, FRIEND, FRIEND_EMAIL, "n")
+            == "shared body"
+        )

--- a/backend/tests/shared/test_memory_store.py
+++ b/backend/tests/shared/test_memory_store.py
@@ -1,0 +1,121 @@
+"""Tests for the S3-backed Memory Space byte store (PR-1).
+
+moto-backed: exercises content-hash keying, dedupe (no second put for
+identical bytes), get/delete round-trip, and the not-configured guard.
+Mirrors ``test_skills_resource_store.py``.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.memory.store import (
+    MemorySpaceStore,
+    MemorySpaceStoreError,
+    compute_content_hash,
+    content_key,
+    get_memory_space_store,
+)
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-memory-spaces"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def s3_client(aws_env):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+@pytest.fixture()
+def store(s3_client):
+    return MemorySpaceStore(bucket_name=BUCKET, s3_client=s3_client)
+
+
+class TestContentKey:
+    def test_key_is_content_addressed(self):
+        digest = compute_content_hash(b"# Memory")
+        assert content_key("spc_abc", digest) == f"spaces/spc_abc/{digest}"
+
+    def test_hash_is_stable_and_distinct(self):
+        assert compute_content_hash(b"a") == compute_content_hash(b"a")
+        assert compute_content_hash(b"a") != compute_content_hash(b"b")
+
+
+class TestPutGetDelete:
+    def test_put_returns_content_addressed_key(self, store):
+        key = store.put(
+            space_id="spc_abc", content=b"# Memory", content_type="text/markdown"
+        )
+        assert key == content_key("spc_abc", compute_content_hash(b"# Memory"))
+
+    def test_get_round_trip(self, store):
+        key = store.put(
+            space_id="spc_abc", content=b"hello", content_type="text/markdown"
+        )
+        assert store.get(key) == b"hello"
+
+    def test_put_is_idempotent_dedupe(self, store, s3_client):
+        k1 = store.put(space_id="s", content=b"same", content_type="text/markdown")
+        k2 = store.put(space_id="s", content=b"same", content_type="text/markdown")
+        assert k1 == k2
+        listed = s3_client.list_objects_v2(Bucket=BUCKET).get("Contents", [])
+        assert len(listed) == 1
+
+    def test_different_content_distinct_keys(self, store):
+        k1 = store.put(space_id="s", content=b"one", content_type="text/markdown")
+        k2 = store.put(space_id="s", content=b"two", content_type="text/markdown")
+        assert k1 != k2
+
+    def test_get_missing_raises(self, store):
+        with pytest.raises(MemorySpaceStoreError):
+            store.get("spaces/s/deadbeef")
+
+    def test_delete_round_trip(self, store):
+        key = store.put(space_id="s", content=b"bye", content_type="text/markdown")
+        store.delete(key)
+        with pytest.raises(MemorySpaceStoreError):
+            store.get(key)
+
+    def test_delete_absent_is_noop(self, store):
+        # Best-effort: deleting a missing key does not raise.
+        store.delete("spaces/s/missing")
+
+
+class TestNotConfigured:
+    def test_disabled_when_no_bucket(self, monkeypatch):
+        monkeypatch.delenv("S3_MEMORY_SPACES_BUCKET_NAME", raising=False)
+        store = MemorySpaceStore(bucket_name=None)
+        assert store.enabled is False
+
+    def test_put_raises_when_not_configured(self, monkeypatch):
+        monkeypatch.delenv("S3_MEMORY_SPACES_BUCKET_NAME", raising=False)
+        store = MemorySpaceStore(bucket_name=None)
+        with pytest.raises(MemorySpaceStoreError):
+            store.put(space_id="s", content=b"x", content_type="text/markdown")
+
+    def test_delete_when_disabled_is_noop(self, monkeypatch):
+        monkeypatch.delenv("S3_MEMORY_SPACES_BUCKET_NAME", raising=False)
+        MemorySpaceStore(bucket_name=None).delete("spaces/s/x")
+
+
+def test_global_store_singleton(monkeypatch):
+    monkeypatch.setenv("S3_MEMORY_SPACES_BUCKET_NAME", "b")
+    import apis.shared.memory.store as store_mod
+
+    store_mod._store = None  # reset the process-global for a clean read
+    a = get_memory_space_store()
+    b = get_memory_space_store()
+    assert a is b
+    store_mod._store = None

--- a/docs/specs/user-markdown-memory.md
+++ b/docs/specs/user-markdown-memory.md
@@ -218,11 +218,22 @@ S3 (content-addressed, one bucket):
 ```
 
 ```
-DynamoDB (single-table, existing platform table):
-  PK=SPACE#{space_id}  SK=META                     # space name, template, owner_id, created, flags
+DynamoDB (dedicated `memory-spaces` table — the project uses per-domain tables,
+not one global table; a dedicated table avoids GSI-number collisions and lets the
+MemorySpacesConstruct own both the bucket and the table):
+  PK=SPACE#{space_id}  SK=META                     # space name, template, owner_id, created, index pointer
   PK=SPACE#{space_id}  SK=INDEX                     # manifest: [{slug,type,description,content_hash,size,updated,updated_by,indexed:{...}}]
-  PK=SPACE#{space_id}  SK=MEMBER#{user_id}          # role: owner|editor|viewer, granted_by, granted_at
-        GSI (UserSpacesIndex): PK=USER#{user_id}  SK=SPACE#{space_id}   # list a user's owned + shared-in spaces
+  PK=SPACE#{space_id}  SK=MEMBER#{email}            # role: viewer|editor (owner lives on the META row)
+```
+
+Owned vs. shared-in are listed via **two GSIs** unioned in code — mirroring
+assistant sharing (owner index + share-by-email index), rather than one combined
+index (the proven pattern; a single `USER#`-keyed index can't cover both an
+`owner_id` and an invited-by-`email` grant):
+
+```
+  OwnerIndex   GSI1PK=OWNER#{owner_id}   GSI1SK=SPACE#{space_id}   # list owned spaces
+  MemberIndex  GSI2PK=MEMBER#{email}     GSI2SK=SPACE#{space_id}   # list shared-in spaces
 ```
 
 Each entry file carries frontmatter (mirrors the coding-agent memory shape; adds type + author):
@@ -367,8 +378,10 @@ S3 bucket (encryption **matching the platform's sessions/artifacts standard** �
 special-case memory), block public access, enforce SSL, **no auto-expiry** (memory is durable;
 deletion is explicit/user-driven — see [Data governance](#data-governance-proportionate--not-a-special-category) on the dedup-aware purge). Thread the bucket to compute roles via
 `PlatformComputeRefs` (typed ref, not SSM), per the construct rules. Read+write grant to
-inference-api runtime role and app-api role. The manifest/membership rows reuse the existing
-single-table DynamoDB with the new `UserSpacesIndex` GSI.
+inference-api runtime role and app-api role. The **same construct also owns a dedicated
+`memory-spaces` DynamoDB table** (PK/SK, PAY_PER_REQUEST, PITR) with the `OwnerIndex` +
+`MemberIndex` GSIs — a per-domain table (the project's actual pattern) rather than a GSI grafted
+onto `sessions-metadata`, threaded to both roles as `DYNAMODB_MEMORY_SPACES_TABLE_NAME`.
 
 ### 8. User-facing surface (app-api + SPA)
 
@@ -502,10 +515,12 @@ sentence, not a gate.
 
 ## Phasing (proposed PRs)
 
-- **PR-1 — Data layer.** `apis/shared/memory/` (`MemorySpaceStore` + `MemorySpaceService` +
-  `MemoryEntryRef`/`MemorySpace` models + manifest/membership repo, space-keyed, `resolve_permission`).
-  `MemorySpacesConstruct` (CDK) + `UserSpacesIndex` GSI. Unit tests. No runtime wiring. Flag
-  `MEMORY_SPACES_ENABLED` added, default off.
+- **PR-1 — Data layer.** ✅ `apis/shared/memory/` (`MemorySpaceStore` + `MemorySpaceService` +
+  `MemoryEntryRef`/`MemorySpace`/`MemoryIndex`/`SpaceMember` models + space-keyed repo +
+  `resolve_permission` + Blank/Chief-of-Staff/Research-Notebook templates).
+  `MemorySpacesConstruct` (CDK) = the S3 bucket + a dedicated `memory-spaces` table with
+  `OwnerIndex`/`MemberIndex` GSIs, wired to both compute roles (readwrite). Unit tests (moto).
+  No runtime wiring. Flag `MEMORY_SPACES_ENABLED` added, default off.
 - **PR-2 — Templates + read path.** Space templates (Chief of Staff / Research Notebook / Blank).
   Index injection (strategy A) + `memory_read` + `memory_query` tools + `memory` partition in
   `contextBreakdown`. Gated by the flag.

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -50,6 +50,7 @@ export interface AppConfig {
   ragIngestion: RagIngestionConfig;
   kbSync: KbSyncConfig;
   scheduledRuns: ScheduledRunsConfig;
+  memorySpaces: MemorySpacesConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
   mcpSandbox: McpSandboxConfig;
@@ -154,6 +155,16 @@ export interface KbSyncConfig {
  * surface is governed separately by the `scheduled-runs` RBAC capability.
  */
 export interface ScheduledRunsConfig {
+  enabled: boolean;
+}
+
+/**
+ * Memory Spaces feature flag. Default OFF with an on switch — the feature
+ * is opt-in per environment, enabled with CDK_MEMORY_SPACES_ENABLED=true
+ * (or a `memorySpaces.enabled: true` cdk.json context). Sets the
+ * MEMORY_SPACES_ENABLED env var on app-api and inference-api.
+ */
+export interface MemorySpacesConfig {
   enabled: boolean;
 }
 
@@ -303,6 +314,17 @@ export function loadConfig(scope: cdk.App): AppConfig {
       enabled: process.env.CDK_SCHEDULED_RUNS_ENABLED
         ? process.env.CDK_SCHEDULED_RUNS_ENABLED !== 'false'
         : scope.node.tryGetContext('scheduledRuns')?.enabled ?? true,
+    },
+    memorySpaces: {
+      // Default OFF with an on switch: the feature is opt-in per
+      // environment, enabled only when explicitly turned on. The workflow
+      // forwards an EMPTY STRING when the variable is unset, so treat
+      // empty/unset as "use the default (off)" and only the literal "true"
+      // as the on switch. A `memorySpaces.enabled` cdk.json context can
+      // also force it on.
+      enabled: process.env.CDK_MEMORY_SPACES_ENABLED
+        ? process.env.CDK_MEMORY_SPACES_ENABLED === 'true'
+        : scope.node.tryGetContext('memorySpaces')?.enabled ?? false,
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -277,6 +277,8 @@ export function buildAppApiEnvironment(
     // (scheduled-runs PR-1). Cohort access is RBAC (`scheduled-runs`
     // capability); this only gates feature existence per environment.
     SCHEDULED_RUNS_ENABLED: config.scheduledRuns.enabled ? 'true' : 'false',
+    // Kill switch for the Memory Spaces feature (default off per env).
+    MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
     VOICE_TICKET_REPLAY_TABLE_NAME: params.voiceTicketReplayTableName,
     VOICE_TICKET_SIGNING_SECRET_ARN: params.voiceTicketSigningSecretArn,
   };

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -326,6 +326,29 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Memory Spaces (S3 + DynamoDB) ──
+  // app-api is a readwriter of memory-space content and metadata
+  // (apis/shared/memory/*). Sourced from typed refs.
+  const memorySpacesBucketArn = props.refs.memorySpacesBucket.bucketArn;
+  const memorySpacesTableArn = props.refs.memorySpacesTable.tableArn;
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'MemorySpacesBucketReadWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+      resources: [memorySpacesBucketArn, `${memorySpacesBucketArn}/*`],
+    }),
+  );
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'MemorySpacesTableReadWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DeleteItem',
+                'dynamodb:Query', 'dynamodb:BatchWriteItem'],
+      resources: [memorySpacesTableArn, `${memorySpacesTableArn}/index/*`],
+    }),
+  );
+
   // ── Fine-tuning ──
   // Sourced from typed PlatformStack refs.
   const ftJobsTableArn = props.refs.fineTuningJobsTable.tableArn;

--- a/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
@@ -184,6 +184,10 @@ export class AppApiServiceConstruct extends Construct {
     // apis/shared/skills/resource_store.py via S3_SKILL_RESOURCES_BUCKET_NAME.
     environment['S3_SKILL_RESOURCES_BUCKET_NAME'] = props.refs.skillResourcesBucket.bucketName;
 
+    // Memory Spaces storage. Read by apis/shared/memory/* via these env vars.
+    environment['S3_MEMORY_SPACES_BUCKET_NAME'] = props.refs.memorySpacesBucket.bucketName;
+    environment['DYNAMODB_MEMORY_SPACES_TABLE_NAME'] = props.refs.memorySpacesTable.tableName;
+
     // Fine-tuning env vars (always-on). Names verified against
     // backend/src/apis/app_api/fine_tuning/* to match the exact env
     // var names Python reads via os.environ.get(...).

--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -341,6 +341,12 @@ export class InferenceAgentCoreConstruct extends Construct {
         // files at dispatch time; no code consumes it yet.
         S3_SKILL_RESOURCES_BUCKET_NAME: props.refs.skillResourcesBucket.bucketName,
 
+        // Memory Spaces storage. The runtime writes memory in a later PR
+        // (readwrite grant below); read by apis/shared/memory/*.
+        S3_MEMORY_SPACES_BUCKET_NAME: props.refs.memorySpacesBucket.bucketName,
+        DYNAMODB_MEMORY_SPACES_TABLE_NAME: props.refs.memorySpacesTable.tableName,
+        MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
+
         // Authentication
         ENABLE_QUOTA_ENFORCEMENT: 'true',
 

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -257,6 +257,25 @@ export function createRuntimeExecutionRole(
     resources: [skillResourcesBucketArn, `${skillResourcesBucketArn}/*`],
   }));
 
+  // ── Memory Spaces (S3 + DynamoDB, readwrite) ──
+  // The runtime writes memory in a later PR; provisioned readwrite now so
+  // that PR needs no infra change (apis/shared/memory/*).
+  const memorySpacesBucketArn = refs.memorySpacesBucket.bucketArn;
+  const memorySpacesTableArn = refs.memorySpacesTable.tableArn;
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'MemorySpacesBucketReadWrite',
+    effect: iam.Effect.ALLOW,
+    actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+    resources: [memorySpacesBucketArn, `${memorySpacesBucketArn}/*`],
+  }));
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'MemorySpacesTableReadWrite',
+    effect: iam.Effect.ALLOW,
+    actions: ['dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:DeleteItem',
+              'dynamodb:Query', 'dynamodb:BatchWriteItem'],
+    resources: [memorySpacesTableArn, `${memorySpacesTableArn}/index/*`],
+  }));
+
   // ── S3 Vectors (RAG query) ──
   const vectorBucketName = refs.ragVectorBucketName;
   const vectorIndexName = refs.ragVectorIndexName;

--- a/infrastructure/lib/constructs/memory/memory-spaces-construct.ts
+++ b/infrastructure/lib/constructs/memory/memory-spaces-construct.ts
@@ -1,0 +1,92 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+import {
+  AppConfig,
+  getAutoDeleteObjects,
+  getRemovalPolicy,
+  getResourceName,
+} from '../../config';
+
+export interface MemorySpacesConstructProps {
+  config: AppConfig;
+}
+
+/**
+ * MemorySpacesConstruct — storage backing the "Memory Spaces" feature.
+ *
+ * Two resources, one construct:
+ *   - S3 content bucket for memory-space files (mirrors the skill
+ *     reference-file bucket: private, bytes-only, fetched server-side).
+ *   - DynamoDB single-table (PK/SK) with two GSIs — OwnerIndex (GSI1) and
+ *     MemberIndex (GSI2) — for owner/member reverse lookups.
+ *
+ * Private — the bucket is only ever read/written server-side by app-api
+ * and the inference-api runtime. No CORS; never loaded cross-origin.
+ *
+ * Lifecycle:
+ *   - Failed multipart uploads aborted after 7 days.
+ *   (No expiration rule: memory-space files persist for the life of the
+ *   space and are removed explicitly by the delete path.)
+ *
+ * The bucket/table are threaded to the compute roles via
+ * `PlatformComputeRefs.memorySpacesBucket` / `.memorySpacesTable` (typed
+ * refs, not SSM) — see the CLAUDE.md File Creation Rules.
+ */
+export class MemorySpacesConstruct extends Construct {
+  public readonly bucket: s3.Bucket;
+  public readonly table: dynamodb.Table;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: MemorySpacesConstructProps,
+  ) {
+    super(scope, id);
+
+    const { config } = props;
+
+    this.bucket = new s3.Bucket(this, 'MemorySpacesBucket', {
+      bucketName: getResourceName(config, 'memory-spaces'),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      lifecycleRules: [
+        {
+          id: 'abort-stale-multipart',
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(7),
+        },
+      ],
+      removalPolicy: getRemovalPolicy(config),
+      autoDeleteObjects: getAutoDeleteObjects(config),
+    });
+
+    this.table = new dynamodb.Table(this, 'MemorySpacesTable', {
+      tableName: getResourceName(config, 'memory-spaces'),
+      partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: getRemovalPolicy(config),
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // OwnerIndex — reverse lookup of memory spaces by owner.
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'OwnerIndex',
+      partitionKey: { name: 'GSI1PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI1SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // MemberIndex — reverse lookup of memory spaces by member.
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'MemberIndex',
+      partitionKey: { name: 'GSI2PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI2SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+  }
+}

--- a/infrastructure/lib/constructs/platform-compute-refs.ts
+++ b/infrastructure/lib/constructs/platform-compute-refs.ts
@@ -97,6 +97,10 @@ export interface PlatformComputeRefs {
   // ── Skills (admin-managed) — S3-backed reference files (PR-4)
   skillResourcesBucket: s3.IBucket;
 
+  // ── Memory Spaces — S3 content bucket + DynamoDB single-table
+  memorySpacesBucket: s3.IBucket;
+  memorySpacesTable: dynamodb.ITable;
+
   // ── Fine-tuning
   fineTuningJobsTable: dynamodb.ITable;
   fineTuningAccessTable: dynamodb.ITable;

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -53,6 +53,7 @@ import { ArtifactsDataConstruct } from './constructs/artifacts/artifacts-data-co
 import { ArtifactRenderLambdaConstruct } from './constructs/artifacts/artifact-render-lambda-construct';
 import { ArtifactsDistributionConstruct } from './constructs/artifacts/artifacts-distribution-construct';
 import { SkillResourcesConstruct } from './constructs/skills/skill-resources-construct';
+import { MemorySpacesConstruct } from './constructs/memory/memory-spaces-construct';
 
 // AgentCore (Memory, Code Interpreter, Browser, Gateway).
 // Pure infrastructure — no code, no out-of-band updates needed.
@@ -203,6 +204,10 @@ export class PlatformStack extends cdk.Stack {
 
   // ── Skills (admin-managed) — S3-backed reference files (PR-4)
   public readonly skillResourcesBucket: s3.IBucket;
+
+  // ── Memory Spaces — S3 content bucket + DynamoDB single-table
+  public readonly memorySpacesBucket: s3.IBucket;
+  public readonly memorySpacesTable: dynamodb.ITable;
 
   // ── Fine-tuning
   public readonly fineTuningJobsTable: dynamodb.ITable;
@@ -437,6 +442,19 @@ export class PlatformStack extends cdk.Stack {
       { config },
     ).bucket;
 
+    // ============================================================
+    // Memory Spaces — S3 content bucket + DynamoDB single-table.
+    // Threaded to the compute roles via PlatformComputeRefs
+    // .memorySpacesBucket / .memorySpacesTable below.
+    // ============================================================
+    const memorySpaces = new MemorySpacesConstruct(
+      this,
+      'MemorySpaces',
+      { config },
+    );
+    this.memorySpacesBucket = memorySpaces.bucket;
+    this.memorySpacesTable = memorySpaces.table;
+
     const artifactsDomainName = config.domainName!;
     this.artifactsFrameAncestors = [
       `https://${artifactsDomainName}`,
@@ -663,6 +681,8 @@ export class PlatformStack extends cdk.Stack {
       artifactRenderTokenSecret: this.artifactRenderTokenSecret,
       artifactsOriginUrl: this.artifactsOriginUrl,
       skillResourcesBucket: this.skillResourcesBucket,
+      memorySpacesBucket: this.memorySpacesBucket,
+      memorySpacesTable: this.memorySpacesTable,
       fineTuningJobsTable: this.fineTuningJobsTable,
       fineTuningAccessTable: this.fineTuningAccessTable,
       fineTuningDataBucket: this.fineTuningDataBucket,

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -51,6 +51,9 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     scheduledRuns: {
       enabled: false,
     },
+    memorySpaces: {
+      enabled: false,
+    },
     fineTuning: {},
     artifacts: {
       retentionDays: 90,

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -101,21 +101,23 @@ describe('PlatformStack', () => {
 
   describe('DynamoDB tables', () => {
     it('creates all shared tables', () => {
-      // 24 tables. Was 23 — the system-prompts table was added for
-      // admin-managed Conversation Modes (custom system prompt catalog).
-      // Previously was 24 before the standalone "assistants" table
-      // was decommissioned (the python app uses rag-assistants for
-      // both assistant config and document metadata via
+      // 25 tables. Was 24 — the memory-spaces table was added for the
+      // Memory Spaces feature. Prior note: the system-prompts table was
+      // added for admin-managed Conversation Modes (custom system prompt
+      // catalog); previously 24 before the standalone "assistants" table
+      // was decommissioned (the python app uses rag-assistants for both
+      // assistant config and document metadata via
       // DYNAMODB_ASSISTANTS_TABLE_NAME).
-      template.resourceCountIs('AWS::DynamoDB::Table', 24);
+      template.resourceCountIs('AWS::DynamoDB::Table', 25);
     });
   });
 
   describe('S3 buckets', () => {
     it('creates all data buckets', () => {
       // file-uploads, SPA static, mcp-sandbox, rag-documents, fine-tuning-data,
-      // artifacts-content, skill-resources (admin-managed Skills reference files)
-      template.resourceCountIs('AWS::S3::Bucket', 7);
+      // artifacts-content, skill-resources (admin-managed Skills reference files),
+      // memory-spaces (Memory Spaces feature content bucket)
+      template.resourceCountIs('AWS::S3::Bucket', 8);
     });
   });
 


### PR DESCRIPTION
First buildout PR for the **Memory Spaces** primitive (F5) — the data layer only. No routes, agent tools, or system-prompt wiring; gated per-environment by `MEMORY_SPACES_ENABLED` (**default off**). Spec: [docs/specs/user-markdown-memory.md](docs/specs/user-markdown-memory.md).

## Backend (`apis/shared/memory/`)
- **`store.py`** — `MemorySpaceStore`: S3 content-addressed byte store (a faithful sibling of the skills reference-file store — lazy boto3, `spaces/{id}/{sha256}` keys, dedupe, loud-on-missing).
- **`models.py`** — `MemorySpace` (META) / `MemoryIndex` (manifest) / `MemoryEntryRef` (entity/episodic/fact) / `SpaceMember`; Pydantic v2, camelCase aliases.
- **`templates.py`** — Blank / Chief-of-Staff / Research-Notebook presets (starter `MEMORY.md` + entry types + `alwaysLoad`).
- **`repository.py`** — dedicated `memory-spaces` table CRUD; `META`/`INDEX`/`MEMBER#{email}` rows; `OwnerIndex` + `MemberIndex` GSIs; Decimal↔native handling.
- **`service.py`** — permission-gated lifecycle + sharing + entry/index I/O. **`resolve_permission` is the single chokepoint** (mirrors `resolve_assistant_permission`): viewer reads, editor writes, owner shares/deletes. Content-addressed writes with GC-on-replace.
- **`feature_flags.py`** — `memory_spaces_enabled()` (default off, `SKILLS_ENABLED` pattern).
- **47 moto-backed tests** (store + repository + full service API incl. role gating, sharing, indexed-field queries, GC). Import-boundary test green (package never imports `app_api`/`inference_api`).

## Infrastructure
- **`MemorySpacesConstruct`** — the S3 bucket **plus** a dedicated `memory-spaces` DynamoDB table (PK/SK, PAY_PER_REQUEST, PITR) with `OwnerIndex`/`MemberIndex` GSIs.
- Threaded via `PlatformComputeRefs` to **both** compute roles (readwrite S3 + DynamoDB incl. `/index/*`); env vars `S3_MEMORY_SPACES_BUCKET_NAME` / `DYNAMODB_MEMORY_SPACES_TABLE_NAME` / `MEMORY_SPACES_ENABLED`.
- `config.ts` flag **default-off**; resource-count assertions bumped (buckets 7→8, tables 24→25).
- `tsc --noEmit` clean; **429 jest tests pass**.

## Design decisions (spec updated to match)
- **Dedicated `memory-spaces` table**, not a GSI on `sessions-metadata` — the project uses per-domain tables, and this lets one construct own bucket + table and avoids GSI-number collisions.
- **Two GSIs (owner + member-by-email) unioned in code**, not one `USER#`-keyed index — mirrors the proven assistant-sharing pattern (an invited grant is keyed by email before the grantee has logged in).
- Sharing is **identity-based only** — no content inspection, per the governance decision.

## Verification
- Backend: `uv run pytest tests/shared/test_memory_store.py tests/shared/test_memory_spaces.py tests/architecture` → 54 passing.
- Infra: `npx tsc --noEmit` clean; `npx jest` → 429 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)