### PR TITLE
feat(memory): Memory Spaces user surface — /memory/spaces CRUD (A2)

### DIFF
--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -184,6 +184,7 @@ from apis.app_api.chat.converse_routes import router as converse_router
 from apis.app_api.chat.proxy_routes import router as bff_chat_proxy_router
 from apis.app_api.mcp_apps.routes import router as mcp_apps_router
 from apis.app_api.memory.routes import router as memory_router
+from apis.app_api.memory_spaces.routes import router as memory_spaces_router
 from apis.app_api.tools.routes import router as tools_router
 from apis.app_api.files.routes import router as files_router
 from apis.app_api.assistants.routes import router as assistants_router
@@ -220,6 +221,7 @@ app.include_router(chat_router)  # Application-specific chat endpoints
 app.include_router(converse_router)  # Proxies to Inference API for cost accounting
 app.include_router(bff_chat_proxy_router)  # Cookie-authenticated SSE proxy (Phase 4, dormant until SPA cutover)
 app.include_router(mcp_apps_router)  # MCP Apps app-initiated tools/call proxy (PR #5; inert until host flag on)
+app.include_router(memory_spaces_router)  # Memory Spaces user surface (A2); 404s while flag off
 app.include_router(memory_router)  # AgentCore Memory access endpoints
 app.include_router(tools_router)  # Tool discovery and permissions
 app.include_router(files_router)  # File upload via pre-signed URLs

--- a/backend/src/apis/app_api/memory_spaces/__init__.py
+++ b/backend/src/apis/app_api/memory_spaces/__init__.py
@@ -1,0 +1,6 @@
+"""Memory Spaces user surface (app-api) — `/memory/spaces/*` CRUD (A2).
+
+The user-facing "own your data" surface over the Memory Space primitive
+(``apis.shared.memory``). Agent-consumption (tools, binding, prompt
+injection) is a separate workstream and does not live here.
+"""

--- a/backend/src/apis/app_api/memory_spaces/models.py
+++ b/backend/src/apis/app_api/memory_spaces/models.py
@@ -1,0 +1,141 @@
+"""Request/response models for the Memory Spaces user surface (A2).
+
+The SPA consumes camelCase; FastAPI serializes by alias, so responses declare
+camelCase aliases with ``populate_by_name`` for snake_case construction —
+matching the assistants/schedules API models.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from apis.shared.memory.models import (
+    EntryType,
+    MemoryEntryRef,
+    MemorySpace,
+    Role,
+    ShareRole,
+)
+from apis.shared.memory.templates import TEMPLATES, SpaceTemplate
+
+
+# ---- requests ----------------------------------------------------------
+
+
+class CreateSpaceRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    template: str = Field("blank")
+
+
+class UpsertEntryRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    body: str = Field(..., description="The entry's markdown content")
+    entry_type: EntryType = Field("fact", alias="type")
+    description: str = Field("")
+    indexed: Dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateIndexRequest(BaseModel):
+    content: str = Field(..., description="The MEMORY.md index text")
+
+
+# ---- responses ---------------------------------------------------------
+
+
+class TemplateResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    template_id: str = Field(..., alias="templateId")
+    name: str
+    description: str
+
+    @classmethod
+    def from_template(cls, t: SpaceTemplate) -> "TemplateResponse":
+        return cls(template_id=t.template_id, name=t.name, description=t.description)
+
+
+class SpaceSummaryResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    space_id: str = Field(..., alias="spaceId")
+    name: str
+    template: str
+    role: Role
+    owner_id: str = Field(..., alias="ownerId")
+    created_at: str = Field("", alias="createdAt")
+    updated_at: str = Field("", alias="updatedAt")
+
+    @classmethod
+    def from_space(cls, space: MemorySpace, role: Role) -> "SpaceSummaryResponse":
+        return cls(
+            space_id=space.space_id,
+            name=space.name,
+            template=space.template,
+            role=role,
+            owner_id=space.owner_id,
+            created_at=space.created_at,
+            updated_at=space.updated_at,
+        )
+
+
+class SpacesListResponse(BaseModel):
+    spaces: List[SpaceSummaryResponse]
+    templates: List[TemplateResponse] = Field(default_factory=list)
+
+
+class EntryRefResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    slug: str
+    entry_type: EntryType = Field("fact", alias="type")
+    description: str = ""
+    size: int = 0
+    updated: str = ""
+    updated_by: str = Field("", alias="updatedBy")
+    indexed: Dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_ref(cls, r: MemoryEntryRef) -> "EntryRefResponse":
+        return cls(
+            slug=r.slug,
+            entry_type=r.entry_type,
+            description=r.description,
+            size=r.size,
+            updated=r.updated,
+            updated_by=r.updated_by,
+            indexed=r.indexed,
+        )
+
+
+class SpaceDetailResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    space_id: str = Field(..., alias="spaceId")
+    name: str
+    template: str
+    role: Role
+    owner_id: str = Field(..., alias="ownerId")
+    created_at: str = Field("", alias="createdAt")
+    updated_at: str = Field("", alias="updatedAt")
+    index: str = Field("", description="The MEMORY.md index text")
+    entries: List[EntryRefResponse] = Field(default_factory=list)
+
+
+class EntryContentResponse(BaseModel):
+    slug: str
+    content: str
+
+
+class IndexContentResponse(BaseModel):
+    content: str
+
+
+class EntriesListResponse(BaseModel):
+    entries: List[EntryRefResponse]
+
+
+def all_templates() -> List[TemplateResponse]:
+    return [TemplateResponse.from_template(t) for t in TEMPLATES.values()]

--- a/backend/src/apis/app_api/memory_spaces/routes.py
+++ b/backend/src/apis/app_api/memory_spaces/routes.py
@@ -1,0 +1,250 @@
+"""Memory Spaces user surface — CRUD over `/memory/spaces/*` (Workstream A2).
+
+The user-facing surface for the Memory Space primitive: a person creates,
+lists, reads, edits, and deletes their own (and shared-with-them) spaces,
+entries, and index. This is the "own your data" surface; the *agent*
+consumption of a space (tools, binding, prompt injection) is a separate
+workstream (Agent/Harness layer), not here.
+
+Gating: the router is mounted unconditionally but every route depends on
+``require_memory_spaces_user`` — a 404 when ``MEMORY_SPACES_ENABLED`` is off
+(the surface behaves as if unmounted). Auth is the standard SPA cookie
+dependency (``get_current_user_from_session``) per the CLAUDE.md app-api rule.
+Memory spaces are user-owned personal data (like sessions/assistants), so
+there is no cohort RBAC capability gate; access to a *specific* space is the
+identity-based ``resolve_permission`` check inside ``MemorySpaceService``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.feature_flags import memory_spaces_enabled
+from apis.shared.memory.models import EntryType
+from apis.shared.memory.service import (
+    MemorySpaceError,
+    MemorySpaceNotFoundError,
+    MemorySpacePermissionError,
+    MemorySpaceService,
+)
+
+from apis.app_api.memory_spaces.models import (
+    CreateSpaceRequest,
+    EntriesListResponse,
+    EntryContentResponse,
+    EntryRefResponse,
+    IndexContentResponse,
+    SpaceDetailResponse,
+    SpaceSummaryResponse,
+    SpacesListResponse,
+    UpdateIndexRequest,
+    UpsertEntryRequest,
+    all_templates,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/memory/spaces", tags=["memory-spaces"])
+
+_service: Optional[MemorySpaceService] = None
+
+
+def _svc() -> MemorySpaceService:
+    global _service
+    if _service is None:
+        _service = MemorySpaceService()
+    return _service
+
+
+async def require_memory_spaces_user(
+    user: User = Depends(get_current_user_from_session),
+) -> User:
+    """Cookie auth + the environment kill switch.
+
+    404 when ``MEMORY_SPACES_ENABLED`` is off, so the surface behaves as if
+    unmounted (mirrors the schedules/runs pattern).
+    """
+    if not memory_spaces_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return user
+
+
+def _translate(e: Exception) -> HTTPException:
+    """Map a service error to an HTTP status."""
+    if isinstance(e, MemorySpaceNotFoundError):
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    if isinstance(e, MemorySpacePermissionError):
+        return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    if isinstance(e, MemorySpaceError):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    raise e
+
+
+# ---- spaces ------------------------------------------------------------
+
+
+@router.get("", response_model=SpacesListResponse)
+def list_spaces(user: User = Depends(require_memory_spaces_user)) -> SpacesListResponse:
+    svc = _svc()
+    summaries = [
+        SpaceSummaryResponse.from_space(space, role)
+        for space, role in svc.list_spaces_for_user(user.user_id, user.email)
+    ]
+    return SpacesListResponse(spaces=summaries, templates=all_templates())
+
+
+@router.post("", response_model=SpaceSummaryResponse, status_code=status.HTTP_201_CREATED)
+def create_space(
+    request: CreateSpaceRequest,
+    user: User = Depends(require_memory_spaces_user),
+) -> SpaceSummaryResponse:
+    try:
+        space = _svc().create_space(
+            owner_id=user.user_id,
+            owner_email=user.email,
+            name=request.name,
+            template=request.template,
+        )
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return SpaceSummaryResponse.from_space(space, "owner")
+
+
+@router.get("/{space_id}", response_model=SpaceDetailResponse)
+def get_space(
+    space_id: str, user: User = Depends(require_memory_spaces_user)
+) -> SpaceDetailResponse:
+    svc = _svc()
+    try:
+        space, role = svc.resolve_permission(space_id, user.user_id, user.email)
+        if space is None:
+            raise MemorySpaceNotFoundError(f"Memory space '{space_id}' not found")
+        if role is None:
+            raise MemorySpacePermissionError(
+                f"'viewer' access required on memory space '{space_id}'"
+            )
+        index_text = svc.read_index(space_id, user.user_id, user.email)
+        entries = svc.list_entries(space_id, user.user_id, user.email)
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return SpaceDetailResponse(
+        space_id=space.space_id,
+        name=space.name,
+        template=space.template,
+        role=role,
+        owner_id=space.owner_id,
+        created_at=space.created_at,
+        updated_at=space.updated_at,
+        index=index_text,
+        entries=[EntryRefResponse.from_ref(r) for r in entries],
+    )
+
+
+@router.delete("/{space_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_or_leave_space(
+    space_id: str, user: User = Depends(require_memory_spaces_user)
+) -> None:
+    """Owner deletes the whole space; a member drops their own grant (leave)."""
+    svc = _svc()
+    try:
+        _, role = svc.resolve_permission(space_id, user.user_id, user.email)
+        if role == "owner":
+            svc.delete_space(space_id, user.user_id, user.email)
+        else:
+            svc.leave_space(space_id, user.user_id, user.email)
+    except MemorySpaceError as e:
+        raise _translate(e)
+
+
+# ---- index (MEMORY.md) -------------------------------------------------
+
+
+@router.get("/{space_id}/index", response_model=IndexContentResponse)
+def read_index(
+    space_id: str, user: User = Depends(require_memory_spaces_user)
+) -> IndexContentResponse:
+    try:
+        text = _svc().read_index(space_id, user.user_id, user.email)
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return IndexContentResponse(content=text)
+
+
+@router.put("/{space_id}/index", response_model=IndexContentResponse)
+def update_index(
+    space_id: str,
+    request: UpdateIndexRequest,
+    user: User = Depends(require_memory_spaces_user),
+) -> IndexContentResponse:
+    try:
+        _svc().update_index(space_id, user.user_id, user.email, request.content)
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return IndexContentResponse(content=request.content)
+
+
+# ---- entries -----------------------------------------------------------
+
+
+@router.get("/{space_id}/entries", response_model=EntriesListResponse)
+def list_entries(
+    space_id: str,
+    user: User = Depends(require_memory_spaces_user),
+    entry_type: Optional[EntryType] = Query(None, alias="type"),
+) -> EntriesListResponse:
+    try:
+        entries = _svc().list_entries(
+            space_id, user.user_id, user.email, entry_type=entry_type
+        )
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return EntriesListResponse(entries=[EntryRefResponse.from_ref(r) for r in entries])
+
+
+@router.get("/{space_id}/entries/{slug}", response_model=EntryContentResponse)
+def read_entry(
+    space_id: str, slug: str, user: User = Depends(require_memory_spaces_user)
+) -> EntryContentResponse:
+    try:
+        content = _svc().read_entry(space_id, user.user_id, user.email, slug)
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return EntryContentResponse(slug=slug, content=content)
+
+
+@router.put("/{space_id}/entries/{slug}", response_model=EntryRefResponse)
+def upsert_entry(
+    space_id: str,
+    slug: str,
+    request: UpsertEntryRequest,
+    user: User = Depends(require_memory_spaces_user),
+) -> EntryRefResponse:
+    try:
+        ref = _svc().write_entry(
+            space_id,
+            user.user_id,
+            user.email,
+            slug,
+            request.body,
+            entry_type=request.entry_type,
+            description=request.description,
+            indexed=request.indexed,
+        )
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return EntryRefResponse.from_ref(ref)
+
+
+@router.delete("/{space_id}/entries/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_entry(
+    space_id: str, slug: str, user: User = Depends(require_memory_spaces_user)
+) -> None:
+    try:
+        _svc().delete_entry(space_id, user.user_id, user.email, slug)
+    except MemorySpaceError as e:
+        raise _translate(e)

--- a/backend/src/apis/shared/memory/service.py
+++ b/backend/src/apis/shared/memory/service.py
@@ -174,18 +174,29 @@ class MemorySpaceService:
 
     def list_spaces_for_user(
         self, user_id: str, user_email: Optional[str] = None
-    ) -> List[MemorySpace]:
-        """List spaces the user owns plus spaces shared with them (deduped)."""
-        owned = self.repository.list_owned(user_id)
-        spaces: Dict[str, MemorySpace] = {s.space_id: s for s in owned}
+    ) -> List[Tuple[MemorySpace, Role]]:
+        """List ``(space, role)`` for spaces the user owns plus shared-in (deduped).
+
+        Owned spaces resolve to ``owner``; shared-in carry the member's actual
+        ``viewer``/``editor`` grant, so the SPA can render accurate affordances
+        without a follow-up call per space.
+        """
+        result: List[Tuple[MemorySpace, Role]] = []
+        seen: set[str] = set()
+        for s in self.repository.list_owned(user_id):
+            result.append((s, "owner"))
+            seen.add(s.space_id)
         if user_email:
             for space_id in self.repository.list_member_space_ids(user_email):
-                if space_id in spaces:
+                if space_id in seen:
                     continue
                 shared = self.repository.get_space(space_id)
-                if shared is not None:
-                    spaces[space_id] = shared
-        return sorted(spaces.values(), key=lambda s: s.created_at)
+                if shared is None:
+                    continue
+                member = self.repository.get_member(space_id, user_email)
+                result.append((shared, member.permission if member else "viewer"))
+                seen.add(space_id)
+        return sorted(result, key=lambda t: t[0].created_at)
 
     def delete_space(
         self, space_id: str, user_id: str, user_email: Optional[str] = None
@@ -202,6 +213,29 @@ class MemorySpaceService:
             self.store.delete(space.index_s3_key)
         self.repository.delete_space(space_id)
         logger.info("memory-spaces: deleted space=%s by user=%s", space_id, user_id)
+
+    def leave_space(
+        self, space_id: str, user_id: str, user_email: Optional[str] = None
+    ) -> None:
+        """Drop the caller's own grant on a space shared with them.
+
+        A member removes *their own* access — no owner action required (the
+        "forget-me on a shared-in space = leave" case from the governance
+        section). The owner cannot leave; they delete the space instead.
+        """
+        space, role = self.resolve_permission(space_id, user_id, user_email)
+        if space is None:
+            raise MemorySpaceNotFoundError(f"Memory space '{space_id}' not found")
+        if role == "owner":
+            raise MemorySpaceError(
+                "the owner cannot leave a space; delete it instead"
+            )
+        if role is None or not user_email:
+            raise MemorySpacePermissionError(
+                f"you are not a member of memory space '{space_id}'"
+            )
+        self.repository.delete_member(space_id, user_email)
+        logger.info("memory-spaces: user=%s left space=%s", user_id, space_id)
 
     # ---- sharing -------------------------------------------------------
 

--- a/backend/tests/apis/app_api/test_memory_spaces_routes.py
+++ b/backend/tests/apis/app_api/test_memory_spaces_routes.py
@@ -1,0 +1,238 @@
+"""Route tests for the Memory Spaces user surface (`/memory/spaces/*`, A2).
+
+Pins the flag gate (404 while off), CRUD happy paths, and identity-based
+access (403 for a non-member, 404 for a missing space). Backed by a REAL
+`MemorySpaceService` on moto (DynamoDB + S3), so the routes are exercised
+end-to-end through the shared service.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.memory.repository import MemorySpaceRepository
+from apis.shared.memory.service import MemorySpaceService
+from apis.shared.memory.store import MemorySpaceStore
+
+from apis.app_api.memory_spaces import routes as mem_routes
+
+REGION = "us-east-1"
+BUCKET = "test-memory-spaces"
+TABLE = "test-memory-spaces"
+
+OWNER = User(user_id="user-owner", email="owner@example.edu", name="O", roles=["default"])
+STRANGER = User(
+    user_id="user-stranger", email="stranger@example.edu", name="S", roles=["default"]
+)
+
+
+def _make_table():
+    ddb = boto3.client("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "OwnerIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "MemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
+    return MemorySpaceRepository(table_name=TABLE)
+
+
+@pytest.fixture()
+def env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("MEMORY_SPACES_ENABLED", "true")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def service(env):
+    repo = _make_table()
+    s3 = boto3.client("s3", region_name=REGION)
+    s3.create_bucket(Bucket=BUCKET)
+    return MemorySpaceService(
+        repository=repo, store=MemorySpaceStore(bucket_name=BUCKET, s3_client=s3)
+    )
+
+
+def _client(service, monkeypatch, user: User = OWNER, authed: bool = True):
+    monkeypatch.setattr(mem_routes, "_service", service)
+    app = FastAPI()
+    app.include_router(mem_routes.router)
+    if authed:
+        app.dependency_overrides[get_current_user_from_session] = lambda: user
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestFlagGate:
+    def test_404_when_flag_off(self, service, monkeypatch):
+        monkeypatch.setenv("MEMORY_SPACES_ENABLED", "false")
+        client = _client(service, monkeypatch)
+        assert client.get("/memory/spaces").status_code == 404
+
+
+class TestSpaceCrud:
+    def test_create_list_get(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+
+        resp = client.post(
+            "/memory/spaces", json={"name": "My Brain", "template": "chief-of-staff"}
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "My Brain"
+        assert body["role"] == "owner"
+        space_id = body["spaceId"]
+
+        listed = client.get("/memory/spaces").json()
+        assert {s["spaceId"] for s in listed["spaces"]} == {space_id}
+        assert any(t["templateId"] == "chief-of-staff" for t in listed["templates"])
+
+        detail = client.get(f"/memory/spaces/{space_id}").json()
+        assert detail["role"] == "owner"
+        assert "Strategic priorities" in detail["index"]
+        assert detail["entries"] == []
+
+    def test_create_rejects_unknown_template(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+        resp = client.post("/memory/spaces", json={"name": "X", "template": "nope"})
+        assert resp.status_code == 400
+
+    def test_create_rejects_blank_name(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+        resp = client.post("/memory/spaces", json={"name": "   "})
+        assert resp.status_code in (400, 422)
+
+    def test_get_missing_space_404(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+        assert client.get("/memory/spaces/spc_missing").status_code == 404
+
+    def test_owner_deletes(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+        sid = client.post("/memory/spaces", json={"name": "X"}).json()["spaceId"]
+        assert client.delete(f"/memory/spaces/{sid}").status_code == 204
+        assert client.get(f"/memory/spaces/{sid}").status_code == 404
+
+
+class TestIndexAndEntries:
+    def _make_space(self, service, monkeypatch):
+        client = _client(service, monkeypatch)
+        sid = client.post("/memory/spaces", json={"name": "X"}).json()["spaceId"]
+        return client, sid
+
+    def test_index_read_update(self, service, monkeypatch):
+        client, sid = self._make_space(service, monkeypatch)
+        r = client.put(f"/memory/spaces/{sid}/index", json={"content": "# New\n"})
+        assert r.status_code == 200
+        assert client.get(f"/memory/spaces/{sid}/index").json()["content"] == "# New\n"
+
+    def test_entry_upsert_read_list_delete(self, service, monkeypatch):
+        client, sid = self._make_space(service, monkeypatch)
+
+        up = client.put(
+            f"/memory/spaces/{sid}/entries/jane-doe",
+            json={
+                "body": "# Jane\nVP Research",
+                "type": "entity",
+                "description": "VP Research",
+                "indexed": {"status": "active"},
+            },
+        )
+        assert up.status_code == 200
+        assert up.json()["slug"] == "jane-doe"
+        assert up.json()["type"] == "entity"
+
+        got = client.get(f"/memory/spaces/{sid}/entries/jane-doe").json()
+        assert "VP Research" in got["content"]
+
+        listed = client.get(f"/memory/spaces/{sid}/entries").json()["entries"]
+        assert [e["slug"] for e in listed] == ["jane-doe"]
+
+        typed = client.get(f"/memory/spaces/{sid}/entries?type=fact").json()["entries"]
+        assert typed == []
+
+        assert client.delete(f"/memory/spaces/{sid}/entries/jane-doe").status_code == 204
+        assert client.get(f"/memory/spaces/{sid}/entries/jane-doe").status_code == 404
+
+
+class TestAccessControl:
+    def test_stranger_cannot_read_space(self, service, monkeypatch):
+        owner_client = _client(service, monkeypatch, user=OWNER)
+        sid = owner_client.post("/memory/spaces", json={"name": "Private"}).json()[
+            "spaceId"
+        ]
+        stranger_client = _client(service, monkeypatch, user=STRANGER)
+        assert stranger_client.get(f"/memory/spaces/{sid}").status_code == 403
+
+    def test_stranger_cannot_write_entry(self, service, monkeypatch):
+        owner_client = _client(service, monkeypatch, user=OWNER)
+        sid = owner_client.post("/memory/spaces", json={"name": "P"}).json()["spaceId"]
+        stranger_client = _client(service, monkeypatch, user=STRANGER)
+        r = stranger_client.put(
+            f"/memory/spaces/{sid}/entries/x", json={"body": "hi"}
+        )
+        assert r.status_code == 403
+
+    def test_stranger_space_not_in_their_list(self, service, monkeypatch):
+        owner_client = _client(service, monkeypatch, user=OWNER)
+        owner_client.post("/memory/spaces", json={"name": "P"})
+        stranger_client = _client(service, monkeypatch, user=STRANGER)
+        assert stranger_client.get("/memory/spaces").json()["spaces"] == []
+
+    def test_member_leaves_via_delete(self, service, monkeypatch):
+        owner_client = _client(service, monkeypatch, user=OWNER)
+        sid = owner_client.post("/memory/spaces", json={"name": "Shared"}).json()[
+            "spaceId"
+        ]
+        # share directly through the service (sharing endpoints land in A4)
+        service.share(sid, OWNER.user_id, OWNER.email, STRANGER.email, "viewer")
+        member_client = _client(service, monkeypatch, user=STRANGER)
+        listed = member_client.get("/memory/spaces").json()["spaces"]
+        assert {s["spaceId"] for s in listed} == {sid}
+        # the list reports the member's actual grant, not a placeholder
+        assert listed[0]["role"] == "viewer"
+        # member DELETE = leave, not destroy
+        assert member_client.delete(f"/memory/spaces/{sid}").status_code == 204
+        assert member_client.get(f"/memory/spaces/{sid}").status_code == 403
+        # the space still exists for the owner
+        assert owner_client.get(f"/memory/spaces/{sid}").status_code == 200

--- a/backend/tests/shared/test_memory_spaces.py
+++ b/backend/tests/shared/test_memory_spaces.py
@@ -225,13 +225,15 @@ class TestCreateAndList:
         other = service.create_space(STRANGER, STRANGER_EMAIL, "Shared")
         service.share(other.space_id, STRANGER, STRANGER_EMAIL, FRIEND_EMAIL, "viewer")
 
-        owner_spaces = {s.space_id for s in service.list_spaces_for_user(OWNER, OWNER_EMAIL)}
+        owner_spaces = {
+            s.space_id for s, _ in service.list_spaces_for_user(OWNER, OWNER_EMAIL)
+        }
         assert owner_spaces == {a.space_id, b.space_id}
 
-        friend_spaces = {
-            s.space_id for s in service.list_spaces_for_user(FRIEND, FRIEND_EMAIL)
-        }
-        assert friend_spaces == {other.space_id}
+        friend = service.list_spaces_for_user(FRIEND, FRIEND_EMAIL)
+        assert {s.space_id for s, _ in friend} == {other.space_id}
+        # shared-in space carries the member's actual grant, not a placeholder
+        assert friend[0][1] == "viewer"
 
     def test_delete_space_owner_only(self, space, service):
         with pytest.raises(MemorySpacePermissionError):
@@ -296,6 +298,22 @@ class TestSharing:
         service.revoke(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL)
         _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
         assert role is None
+
+    def test_member_can_leave(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
+        service.leave_space(space.space_id, FRIEND, FRIEND_EMAIL)
+        _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
+        assert role is None
+        # the space itself still exists for the owner
+        assert service.get_space(space.space_id, OWNER, OWNER_EMAIL) is not None
+
+    def test_owner_cannot_leave(self, space, service):
+        with pytest.raises(Exception):
+            service.leave_space(space.space_id, OWNER, OWNER_EMAIL)
+
+    def test_non_member_cannot_leave(self, space, service):
+        with pytest.raises(MemorySpacePermissionError):
+            service.leave_space(space.space_id, STRANGER, STRANGER_EMAIL)
 
 
 # ============================ service: index + entries ============================


### PR DESCRIPTION
**Workstream A2** of the re-sliced [Memory Spaces epic](docs/specs/user-markdown-memory.md) — the user-facing "own your data" surface over the primitive from #582. No agent-consumption here (tools / binding / prompt injection are the separate Agent/Harness workstream).

## app-api (`apis/app_api/memory_spaces/`)
`/memory/spaces` CRUD over `MemorySpaceService`:
- `GET /memory/spaces` — list owned + shared-in (with `templates` and the caller's **accurate per-space role**)
- `POST /memory/spaces` — create from a template
- `GET /memory/spaces/{id}` — space + `MEMORY.md` text + entry manifest + role
- `DELETE /memory/spaces/{id}` — owner deletes; a member **leaves** (drops own grant)
- `GET|PUT /memory/spaces/{id}/index` — read/update `MEMORY.md`
- `GET /memory/spaces/{id}/entries[?type=]`, `GET|PUT|DELETE .../entries/{slug}` — entry read/list/upsert/delete

Details:
- **Gated** by `require_memory_spaces_user`: **404 while `MEMORY_SPACES_ENABLED` off** (surface behaves as unmounted); cookie auth via `get_current_user_from_session` per the CLAUDE.md app-api rule.
- Errors translated `NotFound→404`, `Permission→403`, `Error→400`.
- Sync handlers (FastAPI threadpools the sync boto3 service).
- Mounted **before** the existing `/memory` (AgentCore Memory) router; paths are non-overlapping (`/memory/spaces` vs the one-segment `/memory/{record_id}`).

## Shared service additions
- **`leave_space()`** — a member drops their own grant (the shared-in "forget-me = leave" case); the owner cannot leave (deletes instead).
- **`list_spaces_for_user()` now returns `(space, role)`** so shared-in spaces carry the member's real viewer/editor grant instead of a placeholder (the new route is the only consumer).

## Tests
12 route tests (moto-backed **real** service — flag gate, CRUD, 403/404, member-leaves-via-delete, accurate shared role) + `leave_space` service tests. Full memory suite + import boundaries green — **69 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)