### PR TITLE
feat(memory): Memory Space sharing + optimistic manifest concurrency (A4)

### DIFF
--- a/backend/src/apis/app_api/memory_spaces/models.py
+++ b/backend/src/apis/app_api/memory_spaces/models.py
@@ -17,6 +17,7 @@ from apis.shared.memory.models import (
     MemorySpace,
     Role,
     ShareRole,
+    SpaceMember,
 )
 from apis.shared.memory.templates import TEMPLATES, SpaceTemplate
 
@@ -40,6 +41,15 @@ class UpsertEntryRequest(BaseModel):
 
 class UpdateIndexRequest(BaseModel):
     content: str = Field(..., description="The MEMORY.md index text")
+
+
+class ShareRequest(BaseModel):
+    email: str = Field(..., min_length=1, description="Grantee email")
+    permission: ShareRole = Field("viewer", description="viewer | editor")
+
+
+class UpdateShareRequest(BaseModel):
+    permission: ShareRole = Field(..., description="viewer | editor")
 
 
 # ---- responses ---------------------------------------------------------
@@ -135,6 +145,22 @@ class IndexContentResponse(BaseModel):
 
 class EntriesListResponse(BaseModel):
     entries: List[EntryRefResponse]
+
+
+class MemberResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    email: str
+    permission: ShareRole = "viewer"
+    created_at: str = Field("", alias="createdAt")
+
+    @classmethod
+    def from_member(cls, m: SpaceMember) -> "MemberResponse":
+        return cls(email=m.email, permission=m.permission, created_at=m.created_at)
+
+
+class MembersListResponse(BaseModel):
+    members: List[MemberResponse]
 
 
 def all_templates() -> List[TemplateResponse]:

--- a/backend/src/apis/app_api/memory_spaces/routes.py
+++ b/backend/src/apis/app_api/memory_spaces/routes.py
@@ -33,6 +33,7 @@ from apis.shared.auth.models import User
 from apis.shared.feature_flags import memory_spaces_enabled
 from apis.shared.memory.models import EntryType
 from apis.shared.memory.service import (
+    MemorySpaceConcurrencyError,
     MemorySpaceError,
     MemorySpaceExport,
     MemorySpaceNotFoundError,
@@ -47,10 +48,14 @@ from apis.app_api.memory_spaces.models import (
     EntryContentResponse,
     EntryRefResponse,
     IndexContentResponse,
+    MemberResponse,
+    MembersListResponse,
+    ShareRequest,
     SpaceDetailResponse,
     SpaceSummaryResponse,
     SpacesListResponse,
     UpdateIndexRequest,
+    UpdateShareRequest,
     UpsertEntryRequest,
     all_templates,
 )
@@ -88,6 +93,8 @@ def _translate(e: Exception) -> HTTPException:
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     if isinstance(e, MemorySpacePermissionError):
         return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    if isinstance(e, MemorySpaceConcurrencyError):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     if isinstance(e, MemorySpaceError):
         return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     raise e
@@ -270,6 +277,73 @@ def delete_or_leave_space(
             svc.delete_space(space_id, user.user_id, user.email)
         else:
             svc.leave_space(space_id, user.user_id, user.email)
+    except MemorySpaceError as e:
+        raise _translate(e)
+
+
+# ---- sharing (A4) ------------------------------------------------------
+
+
+@router.get("/{space_id}/shares", response_model=MembersListResponse)
+def list_shares(
+    space_id: str, user: User = Depends(require_memory_spaces_user)
+) -> MembersListResponse:
+    """List a space's shared grants (editor+; the owner is implicit)."""
+    try:
+        members = _svc().list_members(space_id, user.user_id, user.email)
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return MembersListResponse(
+        members=[MemberResponse.from_member(m) for m in members]
+    )
+
+
+@router.post(
+    "/{space_id}/shares",
+    response_model=MemberResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def add_share(
+    space_id: str,
+    request: ShareRequest,
+    user: User = Depends(require_memory_spaces_user),
+) -> MemberResponse:
+    """Grant a user viewer/editor access to the space (owner only)."""
+    try:
+        member = _svc().share(
+            space_id, user.user_id, user.email, request.email, request.permission
+        )
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return MemberResponse.from_member(member)
+
+
+@router.patch("/{space_id}/shares/{email}", response_model=MemberResponse)
+def update_share(
+    space_id: str,
+    email: str,
+    request: UpdateShareRequest,
+    user: User = Depends(require_memory_spaces_user),
+) -> MemberResponse:
+    """Change an existing grant's role (owner only)."""
+    try:
+        member = _svc().update_share(
+            space_id, user.user_id, user.email, email, request.permission
+        )
+    except MemorySpaceError as e:
+        raise _translate(e)
+    return MemberResponse.from_member(member)
+
+
+@router.delete(
+    "/{space_id}/shares/{email}", status_code=status.HTTP_204_NO_CONTENT
+)
+def remove_share(
+    space_id: str, email: str, user: User = Depends(require_memory_spaces_user)
+) -> None:
+    """Revoke a user's grant (owner only). Idempotent."""
+    try:
+        _svc().revoke(space_id, user.user_id, user.email, email)
     except MemorySpaceError as e:
         raise _translate(e)
 

--- a/backend/src/apis/shared/memory/__init__.py
+++ b/backend/src/apis/shared/memory/__init__.py
@@ -22,6 +22,7 @@ from .models import (
 )
 from .repository import MemorySpaceRepository
 from .service import (
+    MemorySpaceConcurrencyError,
     MemorySpaceError,
     MemorySpaceExport,
     MemorySpaceNotFoundError,
@@ -48,6 +49,7 @@ __all__ = [
     "MemorySpaceRepository",
     "MemorySpaceService",
     "MemorySpaceExport",
+    "MemorySpaceConcurrencyError",
     "MemorySpaceError",
     "MemorySpaceNotFoundError",
     "MemorySpacePermissionError",

--- a/backend/src/apis/shared/memory/repository.py
+++ b/backend/src/apis/shared/memory/repository.py
@@ -23,13 +23,26 @@ from typing import Any, List, Optional
 try:  # boto3 is absent in some local-dev setups
     import boto3
     from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
 except ImportError:  # pragma: no cover - exercised only without boto3
     boto3 = None
     Key = None  # type: ignore[assignment]
+    ClientError = Exception  # type: ignore[assignment, misc]
 
 from .models import MemoryEntryRef, MemoryIndex, MemorySpace, SpaceMember
 
 logger = logging.getLogger(__name__)
+
+
+class OptimisticLockError(RuntimeError):
+    """A conditional manifest write failed because the row moved under us.
+
+    Raised by :meth:`MemorySpaceRepository.put_index` when a caller supplies an
+    ``expected_version`` that no longer matches the stored one. The service
+    translates this into a re-read-and-retry loop (and ultimately a
+    ``MemorySpaceConcurrencyError`` if it can't converge). Kept repository-local
+    so this layer stays free of the service's error taxonomy.
+    """
 
 _META_SK = "META"
 _INDEX_SK = "INDEX"
@@ -224,8 +237,36 @@ class MemorySpaceRepository:
             return MemoryIndex(space_id=space_id, entries=[], version=0)
         return self._item_to_index(item, space_id)
 
-    def put_index(self, index: MemoryIndex) -> None:
-        self._table.put_item(Item=self._index_to_item(index))
+    def put_index(
+        self, index: MemoryIndex, *, expected_version: Optional[int] = None
+    ) -> None:
+        """Persist the manifest row.
+
+        With ``expected_version`` the write is conditional on the stored
+        ``version`` still matching it — optimistic concurrency for shared
+        spaces. On a mismatch it raises :class:`OptimisticLockError` so the
+        service can re-read and retry. The ``attribute_not_exists`` branch
+        admits the very first write (``create_space`` seeds version 0, so this
+        is a safety net rather than the common path).
+        """
+        item = self._index_to_item(index)
+        if expected_version is None:
+            self._table.put_item(Item=item)
+            return
+        try:
+            self._table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(PK) OR #v = :expected",
+                ExpressionAttributeNames={"#v": "version"},
+                ExpressionAttributeValues={":expected": int(expected_version)},
+            )
+        except ClientError as e:  # narrow to the conditional-failure case
+            code = e.response.get("Error", {}).get("Code", "")
+            if code == "ConditionalCheckFailedException":
+                raise OptimisticLockError(
+                    f"manifest for space '{index.space_id}' changed concurrently"
+                ) from e
+            raise
 
     # ---- members -------------------------------------------------------
 

--- a/backend/src/apis/shared/memory/service.py
+++ b/backend/src/apis/shared/memory/service.py
@@ -20,7 +20,7 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 from .models import (
     EntryType,
@@ -31,13 +31,21 @@ from .models import (
     ShareRole,
     SpaceMember,
 )
-from .repository import MemorySpaceRepository
+from .repository import MemorySpaceRepository, OptimisticLockError
 from .store import MemorySpaceStore, compute_content_hash, get_memory_space_store
 from .templates import DEFAULT_TEMPLATE_ID, get_template, is_valid_template
 
 logger = logging.getLogger(__name__)
 
 _ROLE_RANK: Dict[str, int] = {"viewer": 1, "editor": 2, "owner": 3}
+
+# Bounded read-modify-retry attempts when a shared space's manifest is being
+# edited concurrently. Entry writes touch a single slug, so re-reading the
+# fresh manifest and re-applying the change is safe; only a sustained race
+# exhausts this and surfaces as a conflict.
+_MAX_MANIFEST_RETRIES = 5
+
+_T = TypeVar("_T")
 
 
 class MemorySpaceError(RuntimeError):
@@ -50,6 +58,14 @@ class MemorySpaceNotFoundError(MemorySpaceError):
 
 class MemorySpacePermissionError(MemorySpaceError):
     """The caller lacks the required role on the space."""
+
+
+class MemorySpaceConcurrencyError(MemorySpaceError):
+    """A shared space's manifest kept changing under a bounded retry loop.
+
+    Surfaced to the API layer as ``409 Conflict`` — the write is safe to retry
+    from a fresh read.
+    """
 
 
 @dataclass
@@ -308,6 +324,36 @@ class MemorySpaceService:
         self._touch(space_id)
         return member
 
+    def update_share(
+        self,
+        space_id: str,
+        actor_id: str,
+        actor_email: Optional[str],
+        grantee_email: str,
+        permission: ShareRole,
+    ) -> SpaceMember:
+        """Change an existing grant's role (owner only), preserving its origin.
+
+        Distinct from :meth:`share` (upsert-create) so a PATCH gets proper
+        not-found semantics and keeps the original ``created_at``.
+        """
+        self._require(space_id, actor_id, actor_email, "owner")
+        if permission not in ("viewer", "editor"):
+            raise MemorySpaceError(f"invalid share permission '{permission}'")
+        existing = self.repository.get_member(space_id, grantee_email)
+        if existing is None:
+            raise MemorySpaceNotFoundError(
+                f"'{grantee_email}' is not a member of memory space '{space_id}'"
+            )
+        member = SpaceMember(
+            email=grantee_email.strip().lower(),
+            permission=permission,
+            created_at=existing.created_at,
+        )
+        self.repository.put_member(space_id, member)
+        self._touch(space_id)
+        return member
+
     def revoke(
         self,
         space_id: str,
@@ -436,19 +482,20 @@ class MemorySpaceService:
             indexed=indexed or {},
         )
 
-        index = self.repository.get_index(space_id)
-        old = [e for e in index.entries if e.slug == slug]
-        kept = [e for e in index.entries if e.slug != slug]
-        kept.append(ref)
-        kept.sort(key=lambda e: e.slug)
-        index.entries = kept
-        index.version += 1
-        self.repository.put_index(index)
+        def apply(index: MemoryIndex) -> List[MemoryEntryRef]:
+            old = [e for e in index.entries if e.slug == slug]
+            kept = [e for e in index.entries if e.slug != slug]
+            kept.append(ref)
+            kept.sort(key=lambda e: e.slug)
+            index.entries = kept
+            return old
+
+        old, final_index = self._mutate_index(space_id, apply)
 
         # GC any object the replaced entry uniquely referenced.
         for prev in old:
             if prev.s3_key != s3_key and not self._key_in_use(
-                space_id, prev.s3_key, index=index
+                space_id, prev.s3_key, index=final_index
             ):
                 self.store.delete(prev.s3_key)
         return ref
@@ -462,20 +509,52 @@ class MemorySpaceService:
     ) -> None:
         """Remove an entry from the manifest (editor+) and GC its object."""
         self._require(space_id, user_id, user_email, "editor")
-        index = self.repository.get_index(space_id)
-        removed = [e for e in index.entries if e.slug == slug]
-        if not removed:
-            raise MemorySpaceNotFoundError(
-                f"entry '{slug}' not found in space '{space_id}'"
-            )
-        index.entries = [e for e in index.entries if e.slug != slug]
-        index.version += 1
-        self.repository.put_index(index)
+
+        def apply(index: MemoryIndex) -> List[MemoryEntryRef]:
+            removed = [e for e in index.entries if e.slug == slug]
+            if not removed:
+                raise MemorySpaceNotFoundError(
+                    f"entry '{slug}' not found in space '{space_id}'"
+                )
+            index.entries = [e for e in index.entries if e.slug != slug]
+            return removed
+
+        removed, final_index = self._mutate_index(space_id, apply)
         for prev in removed:
-            if not self._key_in_use(space_id, prev.s3_key, index=index):
+            if not self._key_in_use(space_id, prev.s3_key, index=final_index):
                 self.store.delete(prev.s3_key)
 
     # ---- helpers -------------------------------------------------------
+
+    def _mutate_index(
+        self, space_id: str, apply: Callable[[MemoryIndex], "_T"]
+    ) -> Tuple["_T", MemoryIndex]:
+        """Read-modify-conditional-write the manifest with bounded retry.
+
+        ``apply(index)`` mutates ``index.entries`` in place and returns any
+        value the caller needs afterward (e.g. the replaced refs to GC). The
+        helper bumps the version and persists conditionally on the version it
+        read; on a concurrent change it re-reads and re-applies, converging
+        because entry writes touch a single slug. Exhausting the retries raises
+        :class:`MemorySpaceConcurrencyError`. Returns ``(apply_result, final_index)``.
+        """
+        for attempt in range(_MAX_MANIFEST_RETRIES):
+            index = self.repository.get_index(space_id)
+            expected = index.version
+            result = apply(index)  # may raise (e.g. NotFound) — propagate as-is
+            index.version = expected + 1
+            try:
+                self.repository.put_index(index, expected_version=expected)
+            except OptimisticLockError:
+                if attempt + 1 >= _MAX_MANIFEST_RETRIES:
+                    raise MemorySpaceConcurrencyError(
+                        f"memory space '{space_id}' is being edited concurrently; "
+                        "retry the write"
+                    )
+                continue
+            return result, index
+        # Unreachable: the loop either returns or raises above.
+        raise MemorySpaceConcurrencyError(space_id)
 
     def _find_ref(self, space_id: str, slug: str) -> Optional[MemoryEntryRef]:
         for ref in self.repository.get_index(space_id).entries:

--- a/backend/tests/apis/app_api/test_memory_spaces_routes.py
+++ b/backend/tests/apis/app_api/test_memory_spaces_routes.py
@@ -248,6 +248,102 @@ class TestAccessControl:
         assert owner_client.get(f"/memory/spaces/{sid}").status_code == 200
 
 
+class TestSharing:
+    def _make_space(self, service, monkeypatch):
+        owner = _client(service, monkeypatch, user=OWNER)
+        sid = owner.post("/memory/spaces", json={"name": "Shared"}).json()["spaceId"]
+        return owner, sid
+
+    def test_owner_shares_lists_updates_revokes(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+
+        added = owner.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": STRANGER.email, "permission": "viewer"},
+        )
+        assert added.status_code == 201
+        assert added.json()["email"] == STRANGER.email
+        assert added.json()["permission"] == "viewer"
+
+        listed = owner.get(f"/memory/spaces/{sid}/shares").json()["members"]
+        assert [(m["email"], m["permission"]) for m in listed] == [
+            (STRANGER.email, "viewer")
+        ]
+        created_at = listed[0]["createdAt"]
+
+        upgraded = owner.patch(
+            f"/memory/spaces/{sid}/shares/{STRANGER.email}",
+            json={"permission": "editor"},
+        )
+        assert upgraded.status_code == 200
+        assert upgraded.json()["permission"] == "editor"
+        # PATCH preserves the original grant timestamp.
+        assert upgraded.json()["createdAt"] == created_at
+
+        assert (
+            owner.delete(f"/memory/spaces/{sid}/shares/{STRANGER.email}").status_code
+            == 204
+        )
+        assert owner.get(f"/memory/spaces/{sid}/shares").json()["members"] == []
+
+    def test_shared_member_gains_access(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+        owner.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": STRANGER.email, "permission": "editor"},
+        )
+        member = _client(service, monkeypatch, user=STRANGER)
+        # editor can now read and write entries
+        assert member.get(f"/memory/spaces/{sid}").status_code == 200
+        assert (
+            member.put(
+                f"/memory/spaces/{sid}/entries/note", json={"body": "hi"}
+            ).status_code
+            == 200
+        )
+
+    def test_non_owner_cannot_share(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+        owner.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": STRANGER.email, "permission": "editor"},
+        )
+        # an editor is not an owner — cannot manage grants
+        member = _client(service, monkeypatch, user=STRANGER)
+        r = member.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": "third@example.edu", "permission": "viewer"},
+        )
+        assert r.status_code == 403
+
+    def test_viewer_cannot_list_members(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+        owner.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": STRANGER.email, "permission": "viewer"},
+        )
+        member = _client(service, monkeypatch, user=STRANGER)
+        # listing members requires editor+
+        assert member.get(f"/memory/spaces/{sid}/shares").status_code == 403
+
+    def test_patch_unknown_member_404(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+        r = owner.patch(
+            f"/memory/spaces/{sid}/shares/nobody@example.edu",
+            json={"permission": "editor"},
+        )
+        assert r.status_code == 404
+
+    def test_share_rejects_owner_role(self, service, monkeypatch):
+        owner, sid = self._make_space(service, monkeypatch)
+        r = owner.post(
+            f"/memory/spaces/{sid}/shares",
+            json={"email": STRANGER.email, "permission": "owner"},
+        )
+        # "owner" is not a grantable ShareRole → 422 at the request model
+        assert r.status_code == 422
+
+
 class TestExport:
     def _seed(self, service, monkeypatch):
         client = _client(service, monkeypatch, user=OWNER)

--- a/backend/tests/shared/test_memory_spaces.py
+++ b/backend/tests/shared/test_memory_spaces.py
@@ -11,8 +11,9 @@ import pytest
 from moto import mock_aws
 
 from apis.shared.memory.models import MemoryIndex, MemorySpace, SpaceMember
-from apis.shared.memory.repository import MemorySpaceRepository
+from apis.shared.memory.repository import MemorySpaceRepository, OptimisticLockError
 from apis.shared.memory.service import (
+    MemorySpaceConcurrencyError,
     MemorySpaceNotFoundError,
     MemorySpacePermissionError,
     MemorySpaceService,
@@ -299,6 +300,31 @@ class TestSharing:
         _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
         assert role is None
 
+    def test_update_share_changes_role_preserving_origin(self, space, service):
+        created = service.share(
+            space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "viewer"
+        )
+        updated = service.update_share(
+            space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor"
+        )
+        assert updated.permission == "editor"
+        assert updated.created_at == created.created_at
+        _, role = service.resolve_permission(space.space_id, FRIEND, FRIEND_EMAIL)
+        assert role == "editor"
+
+    def test_update_share_unknown_member_raises(self, space, service):
+        with pytest.raises(MemorySpaceNotFoundError):
+            service.update_share(
+                space.space_id, OWNER, OWNER_EMAIL, STRANGER_EMAIL, "editor"
+            )
+
+    def test_update_share_requires_owner(self, space, service):
+        service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
+        with pytest.raises(MemorySpacePermissionError):
+            service.update_share(
+                space.space_id, FRIEND, FRIEND_EMAIL, FRIEND_EMAIL, "viewer"
+            )
+
     def test_member_can_leave(self, space, service):
         service.share(space.space_id, OWNER, OWNER_EMAIL, FRIEND_EMAIL, "editor")
         service.leave_space(space.space_id, FRIEND, FRIEND_EMAIL)
@@ -415,3 +441,48 @@ class TestIndexAndEntries:
             service.read_entry(space.space_id, FRIEND, FRIEND_EMAIL, "n")
             == "shared body"
         )
+
+
+# ==================== service: manifest concurrency (A4) ====================
+
+
+class TestManifestConcurrency:
+    def test_version_increments_per_write(self, space, service):
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "a", "1")
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "b", "2")
+        service.delete_entry(space.space_id, OWNER, OWNER_EMAIL, "a")
+        # three manifest mutations from the seeded version 0
+        assert service.repository.get_index(space.space_id).version == 3
+
+    def test_repository_rejects_stale_conditional_write(self, space, service):
+        service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "a", "1")  # -> v1
+        stale = service.repository.get_index(space.space_id)
+        # a writer that read v0 tries to commit against the now-v1 row
+        with pytest.raises(OptimisticLockError):
+            service.repository.put_index(stale, expected_version=0)
+
+    def test_write_retries_and_converges_on_transient_conflict(self, space, service):
+        real_put = service.repository.put_index
+        calls = {"n": 0}
+
+        def flaky(index, *, expected_version=None):
+            calls["n"] += 1
+            if calls["n"] == 1:  # first attempt loses the race, then converges
+                raise OptimisticLockError("transient")
+            return real_put(index, expected_version=expected_version)
+
+        service.repository.put_index = flaky
+        ref = service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "a", "1")
+        assert ref.slug == "a"
+        assert calls["n"] >= 2
+        assert [
+            e.slug for e in service.list_entries(space.space_id, OWNER, OWNER_EMAIL)
+        ] == ["a"]
+
+    def test_write_gives_up_after_max_retries(self, space, service):
+        def always_conflict(index, *, expected_version=None):
+            raise OptimisticLockError("perpetual")
+
+        service.repository.put_index = always_conflict
+        with pytest.raises(MemorySpaceConcurrencyError):
+            service.write_entry(space.space_id, OWNER, OWNER_EMAIL, "a", "1")

--- a/docs/specs/user-markdown-memory.md
+++ b/docs/specs/user-markdown-memory.md
@@ -545,8 +545,12 @@ calls it.
   `MemorySpaceService.export_space` gathers the corpus (viewer+, members only for editor+); the
   route builds the zip in a `SpooledTemporaryFile` (spills to disk so a large space never pins
   memory) and streams it. Archive path components are sanitized against zip-slip. Route tests.
-- **A4 — Sharing.** Membership API (`POST|PATCH|DELETE .../shares`) over the `MEMBER#` rows +
-  shared concurrency (optimistic manifest). Access control is identity-based; no content gate.
+- **A4 — Sharing.** ✅ Membership API (`GET|POST|PATCH|DELETE .../shares`) over the `MEMBER#` rows
+  (owner grants/updates/revokes viewer|editor; editor+ lists) + shared concurrency: the manifest
+  `INDEX` row now takes a **conditional write** on `version` (`put_index(expected_version=…)` →
+  `OptimisticLockError`), and `write_entry`/`delete_entry` run a bounded read-modify-retry loop
+  (`_mutate_index`) that converges on transient races and surfaces `MemorySpaceConcurrencyError`
+  (→ 409) only on a sustained one. Access control is identity-based; no content gate.
 - **A5 — SPA Memory panel.** The Memory section: list, per-space view/edit/delete, create-from-
   template, download `.zip`, share dialog (reuse the assistant-share component + `redesign-tokens`).
 - **A6 — Consolidation.** A maintenance job (scheduled per space, or on index-cap threshold) that


### PR DESCRIPTION
## What

Workstream A4 — the **sharing** leg of Memory Spaces, plus the concurrency guarantee that makes multi-editor spaces safe.

### Sharing surface (`/memory/spaces/{id}/shares`)

Thin app-api routes over the grant methods that already shipped in A1:

| Method | Path | Who | Purpose |
|---|---|---|---|
| `GET` | `/shares` | editor+ | list grants |
| `POST` | `/shares` | owner | grant `viewer`\|`editor` |
| `PATCH` | `/shares/{email}` | owner | change a grant's role |
| `DELETE` | `/shares/{email}` | owner | revoke (idempotent) |

New `MemorySpaceService.update_share` backs PATCH — distinct from `share`'s upsert so it gets proper not-found (404) semantics and preserves the grant's original `createdAt`.

### Optimistic manifest concurrency (the real design content)

Sharing means multiple editors, so the manifest `INDEX` row needed a concurrency guard (the spec's "optimistic manifest"). `MemoryIndex.version` was written since A1 but never enforced — now it is:

- `MemorySpaceRepository.put_index(expected_version=…)` does a **conditional DynamoDB write** on `version`, raising the repository-local `OptimisticLockError` on a mismatch.
- `write_entry` / `delete_entry` route through a new `_mutate_index` helper: a **bounded read-modify-conditional-write retry loop**. Because an entry write only touches a single slug, re-reading the fresh manifest and re-applying is safe — it converges on transient races and surfaces `MemorySpaceConcurrencyError` (→ **409**) only on a sustained one.

**Single-writer behavior is unchanged** — the retry loop is transparent when there's no contention.

## Why

A4 completes the sharing model of the primitive (unblocks the A5 SPA share dialog) and is the capability behind "Oliver, shared `viewer` with a delegate." The optimistic-manifest piece is what lets two editors of a shared space work without clobbering each other's index.

## Reviewer notes

- `OptimisticLockError` lives in `repository.py` (not the service error taxonomy) so the repository stays permission-agnostic and import-clean; the service catches it and raises the API-facing `MemorySpaceConcurrencyError`.
- The conditional uses `attribute_not_exists(PK) OR #v = :expected` — the `attribute_not_exists` branch is a safety net (`create_space` seeds `version: 0`, so the first write already matches).
- `revoke` stays idempotent (DynamoDB delete of an absent row is a no-op) — DELETE returns 204 whether or not the grant existed.
- No CDK / infra changes. Rides the existing `MEMORY_SPACES_ENABLED` flag (default off).

## Tests

- **6 route tests**: share CRUD round-trip (create→list→PATCH-upgrade→revoke, timestamp preserved), shared member gains read+write, non-owner can't share (403), viewer can't list members (403), PATCH unknown member (404), `owner` role rejected at the request model (422).
- **7 service tests**: `update_share` role change / origin preservation / owner gate; version increments per mutation; stale conditional write rejected; retry converges on a transient conflict; gives up after max retries → `MemorySpaceConcurrencyError`.

76 memory + import-boundary tests green.

## Spec

`docs/specs/user-markdown-memory.md` — A4 marked ✅ with the concurrency mechanism described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)