### PR TITLE
feat(memory): Memory Spaces SPA panel — list/detail/create/share/export (A5)

### DIFF
--- a/docs/specs/user-markdown-memory.md
+++ b/docs/specs/user-markdown-memory.md
@@ -551,8 +551,13 @@ calls it.
   `OptimisticLockError`), and `write_entry`/`delete_entry` run a bounded read-modify-retry loop
   (`_mutate_index`) that converges on transient races and surfaces `MemorySpaceConcurrencyError`
   (→ 409) only on a sustained one. Access control is identity-based; no content gate.
-- **A5 — SPA Memory panel.** The Memory section: list, per-space view/edit/delete, create-from-
-  template, download `.zip`, share dialog (reuse the assistant-share component + `redesign-tokens`).
+- **A5 — SPA Memory panel.** ✅ The Memory section under `frontend/ai.client/src/app/memory-spaces/`:
+  a list page (owned + shared-in cards with role/template badges), a detail page (view/edit the
+  `MEMORY.md` index + entry list with view/edit/create/delete via a dialog), create-from-template
+  dialog, download `.zip` (blob → anchor), and a share dialog (add-by-email + per-row role + delta
+  save over the A4 endpoints). Signal facade + API service mirror the assistants/schedules pattern;
+  nav entry gated on a live `accessible$` probe (404 = kill switch off → hidden), redesign-tokens
+  throughout. Viewer = read-only. Facade spec green; dev build + tsc clean.
 - **A6 — Consolidation.** A maintenance job (scheduled per space, or on index-cap threshold) that
   merges duplicate entries, fixes stale ones, and prunes the index. Uses `MemorySpaceService`; runs
   on the shipped scheduler. Primitive-side corpus health, not a per-turn concern.

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -70,6 +70,16 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'memory-spaces/:id',
+        loadComponent: () => import('./memory-spaces/memory-space-detail.page').then(m => m.MemorySpaceDetailPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'memory-spaces',
+        loadComponent: () => import('./memory-spaces/memory-spaces.page').then(m => m.MemorySpacesPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'manage-sessions',
         loadComponent: () => import('./manage-sessions/manage-sessions.page').then(m => m.ManageSessionsPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -46,6 +46,22 @@
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
 
+        <!-- Memory Spaces (hidden until the accessibility probe resolves true — kill switch off = no entry) -->
+        @if (showMemorySpaces()) {
+            <a
+                routerLink="/memory-spaces"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Memory Spaces</span>
+            </a>
+        }
+
         <!-- Scheduled runs (system-admin only, plus the capability gate — hidden until the accessibility probe resolves true) -->
         @if (showSchedules() && isAdmin()) {
             <a

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -7,6 +7,7 @@ import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { ScheduleService } from '../../schedules/services/schedule.service';
+import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 
 describe('Sidenav', () => {
   let mockRouter: any;
@@ -15,6 +16,7 @@ describe('Sidenav', () => {
   let mockSidenavService: any;
   let mockUserService: any;
   let mockScheduleService: any;
+  let mockMemorySpaceService: any;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
@@ -39,6 +41,10 @@ describe('Sidenav', () => {
       accessible$: signal<boolean | null>(null),
       loadSchedules: vi.fn().mockResolvedValue(undefined),
     };
+    mockMemorySpaceService = {
+      accessible$: signal<boolean | null>(null),
+      loadSpaces: vi.fn().mockResolvedValue(undefined),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -48,6 +54,7 @@ describe('Sidenav', () => {
         { provide: SidenavService, useValue: mockSidenavService },
         { provide: UserService, useValue: mockUserService },
         { provide: ScheduleService, useValue: mockScheduleService },
+        { provide: MemorySpaceService, useValue: mockMemorySpaceService },
       ],
     });
   });
@@ -121,5 +128,30 @@ describe('Sidenav', () => {
     component.navigateToSchedules();
     expect(mockSidenavService.close).toHaveBeenCalled();
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/schedules']);
+  });
+
+  it('probes memory-space accessibility once a user is authenticated', async () => {
+    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
+    await createComponent();
+    expect(mockMemorySpaceService.loadSpaces).toHaveBeenCalled();
+  });
+
+  it('does not probe memory-space accessibility while unauthenticated', async () => {
+    mockUserService.currentUser.set(null);
+    await createComponent();
+    expect(mockMemorySpaceService.loadSpaces).not.toHaveBeenCalled();
+  });
+
+  it('hides the Memory Spaces nav entry until accessibility resolves true', async () => {
+    const component = await createComponent();
+
+    mockMemorySpaceService.accessible$.set(null);
+    expect(component.showMemorySpaces()).toBe(false);
+
+    mockMemorySpaceService.accessible$.set(false);
+    expect(component.showMemorySpaces()).toBe(false);
+
+    mockMemorySpaceService.accessible$.set(true);
+    expect(component.showMemorySpaces()).toBe(true);
   });
 });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -8,6 +8,7 @@ import { UserDropdownComponent } from '../topnav/components/user-dropdown.compon
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
 import { ScheduleService } from '../../schedules/services/schedule.service';
+import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 
 @Component({
   selector: 'app-sidenav',
@@ -20,6 +21,7 @@ export class Sidenav {
   private sessionService = inject(SessionService);
   private bffSession = inject(BffSessionService);
   private scheduleService = inject(ScheduleService);
+  private memorySpaceService = inject(MemorySpaceService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -50,12 +52,22 @@ export class Sidenav {
    */
   readonly showSchedules = computed(() => this.scheduleService.accessible$() === true);
 
+  /**
+   * Whether to show the "Memory Spaces" nav entry. Rides the spaces list call
+   * the same way `showSchedules` rides schedules: a successful (even empty)
+   * list means the `MEMORY_SPACES_ENABLED` kill switch is on; a 404 flips
+   * `accessible$` false and the entry stays hidden. `null` (unresolved) also
+   * hides it so it doesn't flash in before disappearing.
+   */
+  readonly showMemorySpaces = computed(() => this.memorySpaceService.accessible$() === true);
+
   constructor() {
-    // Kick off the accessibility probe once the user is authenticated —
+    // Kick off the accessibility probes once the user is authenticated —
     // mirrors UserService's own permissions-fetch gating.
     effect(() => {
       if (this.userService.currentUser()) {
         void this.scheduleService.loadSchedules();
+        void this.memorySpaceService.loadSpaces();
       }
     });
   }

--- a/frontend/ai.client/src/app/memory-spaces/components/create-space-dialog.component.ts
+++ b/frontend/ai.client/src/app/memory-spaces/components/create-space-dialog.component.ts
@@ -1,0 +1,175 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroCircleStack } from '@ng-icons/heroicons/outline';
+import { MemorySpaceSummary, SpaceTemplate } from '../models/memory-space.model';
+import { MemorySpaceService } from '../services/memory-space.service';
+
+export interface CreateSpaceDialogData {
+  templates: SpaceTemplate[];
+}
+
+/** The created space, or `undefined` if cancelled. */
+export type CreateSpaceDialogResult = MemorySpaceSummary | undefined;
+
+/**
+ * Create a Memory Space from a template. Collects a name + template choice,
+ * calls the service, and closes with the created space so the parent can
+ * navigate straight into it.
+ */
+@Component({
+  selector: 'app-create-space-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [provideIcons({ heroXMark, heroCircleStack })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative transform overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg sm:p-6 dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-space-title"
+        (click)="$event.stopPropagation()"
+      >
+        <div class="absolute top-3 right-3 hidden sm:block">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-label="Close dialog"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-2xl bg-blue-100 sm:mx-0 sm:size-10 dark:bg-blue-500/10">
+            <ng-icon name="heroCircleStack" class="size-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+          </div>
+          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 id="create-space-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+              New memory space
+            </h3>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              A named markdown "second brain" an agent reads and maintains.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-6">
+          <div>
+            <label for="space-name" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+              Name
+            </label>
+            <input
+              id="space-name"
+              type="text"
+              [ngModel]="name()"
+              (ngModelChange)="name.set($event)"
+              placeholder="e.g. Chief of Staff"
+              maxlength="200"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+            />
+          </div>
+
+          <fieldset>
+            <legend class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Template</legend>
+            <div class="mt-2 space-y-2" role="radiogroup" aria-label="Template">
+              @for (tmpl of data.templates; track tmpl.templateId) {
+                <button
+                  type="button"
+                  role="radio"
+                  [attr.aria-checked]="template() === tmpl.templateId"
+                  (click)="template.set(tmpl.templateId)"
+                  class="flex w-full flex-col items-start rounded-2xl border px-4 py-3 text-left transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 aria-checked:border-blue-500 aria-checked:bg-blue-50 dark:aria-checked:border-blue-400 dark:aria-checked:bg-blue-500/10 border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700/40"
+                >
+                  <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ tmpl.name }}</span>
+                  @if (tmpl.description) {
+                    <span class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">{{ tmpl.description }}</span>
+                  }
+                </button>
+              }
+            </div>
+          </fieldset>
+
+          @if (error()) {
+            <div class="rounded-2xl bg-red-50 px-3 py-2 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+              {{ error() }}
+            </div>
+          }
+        </div>
+
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="onCreate()"
+            [disabled]="saving() || !name().trim()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ saving() ? 'Creating…' : 'Create space' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+    .dialog-backdrop { animation: backdrop-fade-in 200ms ease-out; }
+    @keyframes backdrop-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    .dialog-panel { animation: dialog-fade-in-up 200ms ease-out; }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.95); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class CreateSpaceDialogComponent {
+  protected readonly dialogRef = inject<DialogRef<CreateSpaceDialogResult>>(DialogRef);
+  protected readonly data = inject<CreateSpaceDialogData>(DIALOG_DATA);
+  private readonly service = inject(MemorySpaceService);
+
+  protected readonly name = signal<string>('');
+  protected readonly template = signal<string>(this.data.templates[0]?.templateId ?? 'blank');
+  protected readonly saving = signal<boolean>(false);
+  protected readonly error = signal<string | null>(null);
+
+  protected async onCreate(): Promise<void> {
+    const name = this.name().trim();
+    if (!name) {
+      return;
+    }
+    this.saving.set(true);
+    this.error.set(null);
+    try {
+      const space = await this.service.createSpace({ name, template: this.template() });
+      this.dialogRef.close(space);
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to create space');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/components/entry-dialog.component.ts
+++ b/frontend/ai.client/src/app/memory-spaces/components/entry-dialog.component.ts
@@ -1,0 +1,235 @@
+import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroDocumentText, heroChevronDown } from '@ng-icons/heroicons/outline';
+import { EntryType } from '../models/memory-space.model';
+import { MemorySpaceService } from '../services/memory-space.service';
+
+export interface EntryDialogData {
+  spaceId: string;
+  /** Present in view/edit mode; absent to create a new entry. */
+  slug?: string;
+  /** Prefill for edit mode so the body/type/description show before the read resolves. */
+  type?: EntryType;
+  description?: string;
+  /** editor+ may write; a viewer opens read-only. */
+  canEdit: boolean;
+}
+
+export type EntryDialogResult = { action: 'saved' | 'deleted' } | undefined;
+
+/**
+ * View, edit, or create a single Memory Space entry (one markdown file).
+ * Editors get a slug/type/description/body form; viewers get a read-only body.
+ */
+@Component({
+  selector: 'app-entry-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [provideIcons({ heroXMark, heroDocumentText, heroChevronDown })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative transform overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-2xl sm:p-6 dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="entry-dialog-title"
+        (click)="$event.stopPropagation()"
+      >
+        <div class="absolute top-3 right-3 hidden sm:block">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-label="Close dialog"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-2xl bg-blue-100 sm:mx-0 sm:size-10 dark:bg-blue-500/10">
+            <ng-icon name="heroDocumentText" class="size-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+          </div>
+          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 id="entry-dialog-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+              {{ isCreate() ? 'New entry' : (canEdit ? 'Edit entry' : 'Entry') }}
+            </h3>
+            @if (!isCreate()) {
+              <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">{{ slug() }}</p>
+            }
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          @if (isCreate()) {
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <label for="entry-slug" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Slug</label>
+                <input
+                  id="entry-slug"
+                  type="text"
+                  [ngModel]="slug()"
+                  (ngModelChange)="slug.set($event)"
+                  placeholder="e.g. jane-doe"
+                  class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                />
+              </div>
+              <div>
+                <label for="entry-type" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Type</label>
+                <div class="relative mt-1 inline-flex w-full">
+                  <select
+                    id="entry-type"
+                    [ngModel]="type()"
+                    (ngModelChange)="type.set($event)"
+                    class="block w-full appearance-none rounded-2xl border border-gray-300 bg-white py-2 pl-3 pr-9 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  >
+                    <option value="fact">Fact</option>
+                    <option value="entity">Entity</option>
+                    <option value="episodic">Episodic</option>
+                  </select>
+                  <ng-icon name="heroChevronDown" class="pointer-events-none absolute right-3 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                </div>
+              </div>
+            </div>
+            <div>
+              <label for="entry-desc" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Description</label>
+              <input
+                id="entry-desc"
+                type="text"
+                [ngModel]="description()"
+                (ngModelChange)="description.set($event)"
+                placeholder="One-line summary shown in the index"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              />
+            </div>
+          }
+
+          <div>
+            <label for="entry-body" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Content</label>
+            @if (loading()) {
+              <div class="mt-1 h-48 animate-pulse rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"></div>
+            } @else {
+              <textarea
+                id="entry-body"
+                [ngModel]="body()"
+                (ngModelChange)="body.set($event)"
+                [readonly]="!canEdit"
+                rows="12"
+                class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 placeholder:text-gray-400 read-only:bg-gray-50 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:read-only:bg-gray-900/40"
+                placeholder="# Markdown body"
+              ></textarea>
+            }
+          </div>
+
+          @if (error()) {
+            <div class="rounded-2xl bg-red-50 px-3 py-2 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+              {{ error() }}
+            </div>
+          }
+        </div>
+
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            {{ canEdit ? 'Cancel' : 'Close' }}
+          </button>
+          @if (canEdit) {
+            <button
+              type="button"
+              (click)="onSave()"
+              [disabled]="saving() || !slug().trim()"
+              class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {{ saving() ? 'Saving…' : 'Save entry' }}
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+    .dialog-backdrop { animation: backdrop-fade-in 200ms ease-out; }
+    @keyframes backdrop-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    .dialog-panel { animation: dialog-fade-in-up 200ms ease-out; }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.95); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class EntryDialogComponent {
+  protected readonly dialogRef = inject<DialogRef<EntryDialogResult>>(DialogRef);
+  protected readonly data = inject<EntryDialogData>(DIALOG_DATA);
+  private readonly service = inject(MemorySpaceService);
+
+  protected readonly canEdit = this.data.canEdit;
+  protected readonly slug = signal<string>(this.data.slug ?? '');
+  protected readonly type = signal<EntryType>(this.data.type ?? 'fact');
+  protected readonly description = signal<string>(this.data.description ?? '');
+  protected readonly body = signal<string>('');
+  protected readonly loading = signal<boolean>(!!this.data.slug);
+  protected readonly saving = signal<boolean>(false);
+  protected readonly error = signal<string | null>(null);
+
+  protected readonly isCreate = computed<boolean>(() => !this.data.slug);
+
+  constructor() {
+    if (this.data.slug) {
+      void this.loadBody(this.data.slug);
+    }
+  }
+
+  private async loadBody(slug: string): Promise<void> {
+    this.loading.set(true);
+    try {
+      const entry = await this.service.readEntry(this.data.spaceId, slug);
+      this.body.set(entry.content);
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to load entry');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected async onSave(): Promise<void> {
+    const slug = this.slug().trim();
+    if (!slug) {
+      return;
+    }
+    this.saving.set(true);
+    this.error.set(null);
+    try {
+      await this.service.upsertEntry(this.data.spaceId, slug, {
+        body: this.body(),
+        type: this.type(),
+        description: this.description(),
+      });
+      this.dialogRef.close({ action: 'saved' });
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to save entry');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/components/share-space-dialog.component.ts
+++ b/frontend/ai.client/src/app/memory-spaces/components/share-space-dialog.component.ts
@@ -1,0 +1,328 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroXMark,
+  heroShare,
+  heroUserPlus,
+  heroTrash,
+  heroChevronDown,
+} from '@ng-icons/heroicons/outline';
+import { MemorySpaceSummary, ShareRole, SpaceMember } from '../models/memory-space.model';
+import { MemorySpaceService } from '../services/memory-space.service';
+
+export interface ShareSpaceDialogData {
+  space: MemorySpaceSummary;
+}
+
+export type ShareSpaceDialogResult = { action: 'shared' } | undefined;
+
+/** A working grant row (mirrors SpaceMember minus the server timestamp). */
+interface GrantRow {
+  email: string;
+  permission: ShareRole;
+}
+
+/**
+ * Share a Memory Space with other users by email (owner only). Mirrors the
+ * assistant share dialog's add-by-email + current-shares + delta-on-save
+ * ergonomics, over the `/memory/spaces/{id}/shares` endpoints. No visibility
+ * concept — a grant simply exists (identity-based access, no content gate).
+ */
+@Component({
+  selector: 'app-share-space-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [provideIcons({ heroXMark, heroShare, heroUserPlus, heroTrash, heroChevronDown })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative transform overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg sm:p-6 dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-space-title"
+        (click)="$event.stopPropagation()"
+      >
+        <div class="absolute top-3 right-3 hidden sm:block">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-label="Close dialog"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-2xl bg-blue-100 sm:mx-0 sm:size-10 dark:bg-blue-500/10">
+            <ng-icon name="heroShare" class="size-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+          </div>
+          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 id="share-space-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+              Share memory space
+            </h3>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">{{ data.space.name }}</p>
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-8">
+          <!-- Add people -->
+          <section class="space-y-3">
+            <div>
+              <label for="member-email" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Add people by email
+              </label>
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                Sharing includes current and future entries, including ones the agent writes later.
+              </p>
+            </div>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <input
+                id="member-email"
+                type="email"
+                [ngModel]="emailInput()"
+                (ngModelChange)="emailInput.set($event)"
+                (keydown.enter)="addEmail()"
+                placeholder="person@example.edu"
+                class="flex-1 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              />
+              <div class="relative inline-flex">
+                <label for="new-permission" class="sr-only">Permission for new people</label>
+                <select
+                  id="new-permission"
+                  [ngModel]="newPermission()"
+                  (ngModelChange)="newPermission.set($event)"
+                  class="h-full appearance-none rounded-2xl border border-gray-300 bg-white py-2 pl-3 pr-9 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                >
+                  <option value="viewer">Can view</option>
+                  <option value="editor">Can edit</option>
+                </select>
+                <ng-icon
+                  name="heroChevronDown"
+                  class="pointer-events-none absolute right-3 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+              </div>
+              <button
+                type="button"
+                (click)="addEmail()"
+                [disabled]="!emailInput().trim()"
+                class="inline-flex items-center justify-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+              >
+                <ng-icon name="heroUserPlus" class="size-4" aria-hidden="true" />
+                Add
+              </button>
+            </div>
+          </section>
+
+          <!-- Current shares -->
+          <section class="space-y-3 border-t border-gray-200 pt-6 dark:border-gray-700">
+            <div class="flex items-baseline justify-between">
+              <h4 class="text-base/7 font-semibold text-gray-900 dark:text-white">Shared with</h4>
+              @if (!loading()) {
+                <span class="text-xs/5 tabular-nums text-gray-500 dark:text-gray-400">{{ grants().length }}</span>
+              }
+            </div>
+
+            @if (loading()) {
+              <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+                <div class="h-3 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+              </div>
+            } @else if (grants().length === 0) {
+              <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-6 text-center dark:border-gray-700 dark:bg-gray-800">
+                <p class="text-sm/6 text-gray-500 dark:text-gray-400">Not shared with anyone yet.</p>
+              </div>
+            } @else {
+              <ul class="max-h-56 divide-y divide-gray-200 overflow-y-auto rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+                @for (grant of grants(); track grant.email) {
+                  <li class="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+                    <p class="min-w-0 flex-1 truncate text-sm/6 text-gray-900 dark:text-white">{{ grant.email }}</p>
+                    <div class="relative inline-flex shrink-0">
+                      <label class="sr-only" [attr.for]="'perm-' + grant.email">Permission for {{ grant.email }}</label>
+                      <select
+                        [id]="'perm-' + grant.email"
+                        [ngModel]="grant.permission"
+                        (ngModelChange)="setPermission(grant.email, $event)"
+                        class="appearance-none rounded-2xl border border-gray-300 bg-white py-1 pl-2.5 pr-8 text-xs/5 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                      >
+                        <option value="viewer">Can view</option>
+                        <option value="editor">Can edit</option>
+                      </select>
+                      <ng-icon
+                        name="heroChevronDown"
+                        class="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      (click)="removeEmail(grant.email)"
+                      class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                      [attr.aria-label]="'Remove ' + grant.email"
+                    >
+                      <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
+
+            @if (error()) {
+              <div class="rounded-2xl bg-red-50 px-3 py-2 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+                {{ error() }}
+              </div>
+            }
+          </section>
+        </div>
+
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="onSave()"
+            [disabled]="saving()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ saving() ? 'Saving…' : 'Save changes' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+    @custom-variant dark (&:where(.dark, .dark *));
+    .dialog-backdrop { animation: backdrop-fade-in 200ms ease-out; }
+    @keyframes backdrop-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    .dialog-panel { animation: dialog-fade-in-up 200ms ease-out; }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.95); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class ShareSpaceDialogComponent {
+  protected readonly dialogRef = inject<DialogRef<ShareSpaceDialogResult>>(DialogRef);
+  protected readonly data = inject<ShareSpaceDialogData>(DIALOG_DATA);
+  private readonly service = inject(MemorySpaceService);
+
+  protected readonly emailInput = signal<string>('');
+  protected readonly newPermission = signal<ShareRole>('viewer');
+  protected readonly grants = signal<GrantRow[]>([]);
+  protected readonly loading = signal<boolean>(true);
+  protected readonly saving = signal<boolean>(false);
+  protected readonly error = signal<string | null>(null);
+
+  /** Snapshot loaded from the API — diffed on save to compute the grant deltas. */
+  private initialGrants: GrantRow[] = [];
+
+  private static readonly EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  constructor() {
+    void this.loadShares();
+  }
+
+  protected async loadShares(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const response = await this.service.listShares(this.data.space.spaceId);
+      const rows = (response?.members ?? []).map((m: SpaceMember) => ({
+        email: m.email,
+        permission: m.permission,
+      }));
+      this.initialGrants = rows.map((r) => ({ ...r }));
+      this.grants.set(rows);
+    } catch {
+      // A viewer/editor without owner rights can't list — start empty and let
+      // Save surface any 403. Initial-load failure is not a user-facing error.
+      this.initialGrants = [];
+      this.grants.set([]);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected addEmail(): void {
+    const email = this.emailInput().trim().toLowerCase();
+    if (!email) {
+      return;
+    }
+    if (!ShareSpaceDialogComponent.EMAIL_RE.test(email)) {
+      this.flashError('Please enter a valid email address');
+      return;
+    }
+    if (this.grants().some((g) => g.email === email)) {
+      this.flashError('That person already has access');
+      return;
+    }
+    this.grants.update((current) => [...current, { email, permission: this.newPermission() }]);
+    this.emailInput.set('');
+  }
+
+  protected setPermission(email: string, permission: ShareRole): void {
+    this.grants.update((current) =>
+      current.map((g) => (g.email === email ? { ...g, permission } : g)),
+    );
+  }
+
+  protected removeEmail(email: string): void {
+    this.grants.update((current) => current.filter((g) => g.email !== email));
+  }
+
+  protected async onSave(): Promise<void> {
+    this.saving.set(true);
+    this.error.set(null);
+    const spaceId = this.data.space.spaceId;
+
+    try {
+      const initial = new Map(this.initialGrants.map((g) => [g.email, g.permission]));
+      const next = new Map(this.grants().map((g) => [g.email, g.permission]));
+
+      for (const [email, permission] of next) {
+        const previous = initial.get(email);
+        if (previous === undefined) {
+          await this.service.addShare(spaceId, { email, permission });
+        } else if (previous !== permission) {
+          await this.service.updateShare(spaceId, email, permission);
+        }
+      }
+      for (const [email] of initial) {
+        if (!next.has(email)) {
+          await this.service.removeShare(spaceId, email);
+        }
+      }
+      this.dialogRef.close({ action: 'shared' });
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to save shares');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+
+  private flashError(message: string): void {
+    this.error.set(message);
+    setTimeout(() => this.error.set(null), 3000);
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/memory-space-detail.page.html
+++ b/frontend/ai.client/src/app/memory-spaces/memory-space-detail.page.html
@@ -1,0 +1,183 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Back -->
+    <button
+      type="button"
+      (click)="goBack()"
+      class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-500 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+    >
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+      Memory Spaces
+    </button>
+
+    @if (loading()) {
+      <div class="mt-6 space-y-4" aria-hidden="true">
+        <div class="h-8 w-64 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+        <div class="h-48 animate-pulse rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"></div>
+      </div>
+      <span class="sr-only" role="status">Loading memory space…</span>
+    } @else if (error() && !space()) {
+      <div class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+        {{ error() }}
+      </div>
+    } @else if (space(); as sp) {
+      <!-- Header -->
+      <div class="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <h1 class="truncate text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+              {{ sp.name }}
+            </h1>
+            <span
+              class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium capitalize"
+              [class]="sp.role === 'owner'
+                ? 'bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+            >
+              {{ sp.role }}
+            </span>
+          </div>
+          @if (!canEdit()) {
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">You have read-only access to this space.</p>
+          }
+        </div>
+
+        <div class="flex items-center gap-1">
+          @if (isOwner()) {
+            <button
+              type="button"
+              (click)="onShare()"
+              class="flex size-9 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              aria-label="Share this space"
+            >
+              <ng-icon name="heroShare" class="size-5" aria-hidden="true" />
+            </button>
+          }
+          <button
+            type="button"
+            (click)="onDownload()"
+            [disabled]="exporting()"
+            class="flex size-9 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-label="Download this space as a zip"
+          >
+            <ng-icon name="heroArrowDownTray" class="size-5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            (click)="onDeleteOrLeave()"
+            class="flex size-9 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            [attr.aria-label]="isOwner() ? 'Delete this space' : 'Leave this space'"
+          >
+            <ng-icon name="heroTrash" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      @if (error()) {
+        <div class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+          {{ error() }}
+        </div>
+      }
+
+      <!-- Index (MEMORY.md) -->
+      <section class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Index (MEMORY.md)</h2>
+            <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
+              The always-loaded catalog of one-line pointers into this space.
+            </p>
+          </div>
+          @if (canEdit()) {
+            <button
+              type="button"
+              (click)="onSaveIndex()"
+              [disabled]="savingIndex()"
+              class="shrink-0 rounded-2xl bg-blue-600 px-3.5 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {{ savingIndex() ? 'Saving…' : 'Save index' }}
+            </button>
+          }
+        </div>
+        <textarea
+          [ngModel]="indexText()"
+          (ngModelChange)="indexText.set($event)"
+          [readonly]="!canEdit()"
+          rows="10"
+          class="mt-4 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 read-only:bg-gray-50 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:read-only:bg-gray-900/40"
+          aria-label="MEMORY.md index"
+        ></textarea>
+      </section>
+
+      <!-- Entries -->
+      <section class="mt-6">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+              Entries
+              <span class="ml-1 tabular-nums text-gray-400 dark:text-gray-500">{{ entries().length }}</span>
+            </h2>
+            <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
+              Typed markdown files fetched on demand.
+            </p>
+          </div>
+          @if (canEdit()) {
+            <button
+              type="button"
+              (click)="onNewEntry()"
+              class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-3.5 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+              New entry
+            </button>
+          }
+        </div>
+
+        @if (entries().length === 0) {
+          <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-sm/6 text-gray-500 dark:text-gray-400">No entries yet.</p>
+          </div>
+        } @else {
+          <ul class="mt-4 divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+            @for (entry of entries(); track entry.slug) {
+              <li
+                class="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                role="button"
+                tabindex="0"
+                (click)="onOpenEntry(entry)"
+                (keydown.enter)="onOpenEntry(entry)"
+              >
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">{{ entry.slug }}</p>
+                    <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium capitalize text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                      {{ entry.type }}
+                    </span>
+                  </div>
+                  @if (entry.description) {
+                    <p class="mt-0.5 truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ entry.description }}</p>
+                  }
+                </div>
+                <ng-icon
+                  [name]="canEdit() ? 'heroPencilSquare' : 'heroArrowDownTray'"
+                  class="size-4 shrink-0 text-gray-300 dark:text-gray-600"
+                  aria-hidden="true"
+                />
+                @if (canEdit()) {
+                  <button
+                    type="button"
+                    (click)="onDeleteEntry(entry, $event)"
+                    class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                    [attr.aria-label]="'Delete ' + entry.slug"
+                  >
+                    <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                  </button>
+                }
+              </li>
+            }
+          </ul>
+        }
+      </section>
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/memory-spaces/memory-space-detail.page.ts
+++ b/frontend/ai.client/src/app/memory-spaces/memory-space-detail.page.ts
@@ -1,0 +1,238 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal, computed } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroPlus,
+  heroShare,
+  heroArrowDownTray,
+  heroTrash,
+  heroPencilSquare,
+} from '@ng-icons/heroicons/outline';
+import { MemorySpaceService } from './services/memory-space.service';
+import { MemoryEntryRef, MemorySpaceDetail } from './models/memory-space.model';
+import { EntryDialogComponent, EntryDialogData, EntryDialogResult } from './components/entry-dialog.component';
+import {
+  ShareSpaceDialogComponent,
+  ShareSpaceDialogData,
+  ShareSpaceDialogResult,
+} from './components/share-space-dialog.component';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog/confirmation-dialog.component';
+
+/**
+ * Memory Space detail — view/edit the MEMORY.md index and the space's entries.
+ * Editors get editable fields; viewers get read-only. Owner-only actions
+ * (share) plus download/delete-or-leave live in the header.
+ */
+@Component({
+  selector: 'app-memory-space-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, NgIcon],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroPlus,
+      heroShare,
+      heroArrowDownTray,
+      heroTrash,
+      heroPencilSquare,
+    }),
+  ],
+  templateUrl: './memory-space-detail.page.html',
+})
+export class MemorySpaceDetailPage implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private dialog = inject(Dialog);
+  private service = inject(MemorySpaceService);
+
+  protected readonly space = signal<MemorySpaceDetail | null>(null);
+  protected readonly indexText = signal<string>('');
+  protected readonly loading = signal<boolean>(true);
+  protected readonly error = signal<string | null>(null);
+  protected readonly savingIndex = signal<boolean>(false);
+  protected readonly exporting = signal<boolean>(false);
+
+  protected readonly canEdit = computed<boolean>(() => {
+    const role = this.space()?.role;
+    return role === 'owner' || role === 'editor';
+  });
+  protected readonly isOwner = computed<boolean>(() => this.space()?.role === 'owner');
+  protected readonly entries = computed<MemoryEntryRef[]>(() => this.space()?.entries ?? []);
+
+  private get spaceId(): string {
+    return this.route.snapshot.paramMap.get('id') ?? '';
+  }
+
+  ngOnInit(): void {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const detail = await this.service.getSpace(this.spaceId);
+      this.space.set(detail);
+      this.indexText.set(detail.index);
+    } catch (err) {
+      const status = (err as { status?: number } | null)?.status;
+      this.error.set(
+        status === 404
+          ? 'This memory space no longer exists or you no longer have access.'
+          : err instanceof Error
+            ? err.message
+            : 'Failed to load memory space',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected goBack(): void {
+    void this.router.navigate(['/memory-spaces']);
+  }
+
+  protected async onSaveIndex(): Promise<void> {
+    if (!this.canEdit()) {
+      return;
+    }
+    this.savingIndex.set(true);
+    this.error.set(null);
+    try {
+      await this.service.updateIndex(this.spaceId, this.indexText());
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to save index');
+    } finally {
+      this.savingIndex.set(false);
+    }
+  }
+
+  protected async onNewEntry(): Promise<void> {
+    const dialogRef = this.dialog.open<EntryDialogResult>(EntryDialogComponent, {
+      data: { spaceId: this.spaceId, canEdit: true } as EntryDialogData,
+    });
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result?.action === 'saved') {
+      await this.load();
+    }
+  }
+
+  protected async onOpenEntry(entry: MemoryEntryRef): Promise<void> {
+    const dialogRef = this.dialog.open<EntryDialogResult>(EntryDialogComponent, {
+      data: {
+        spaceId: this.spaceId,
+        slug: entry.slug,
+        type: entry.type,
+        description: entry.description,
+        canEdit: this.canEdit(),
+      } as EntryDialogData,
+    });
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result?.action === 'saved') {
+      await this.load();
+    }
+  }
+
+  protected async onDeleteEntry(entry: MemoryEntryRef, event: Event): Promise<void> {
+    event.stopPropagation();
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: 'Delete entry',
+        message: `Delete "${entry.slug}"? This cannot be undone.`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (confirmed) {
+      try {
+        await this.service.deleteEntry(this.spaceId, entry.slug);
+        await this.load();
+      } catch (err) {
+        this.error.set(err instanceof Error ? err.message : 'Failed to delete entry');
+      }
+    }
+  }
+
+  protected async onShare(): Promise<void> {
+    const space = this.space();
+    if (!space) {
+      return;
+    }
+    const dialogRef = this.dialog.open<ShareSpaceDialogResult>(ShareSpaceDialogComponent, {
+      data: { space } as ShareSpaceDialogData,
+    });
+    await firstValueFrom(dialogRef.closed);
+  }
+
+  protected async onDownload(): Promise<void> {
+    const space = this.space();
+    if (!space) {
+      return;
+    }
+    this.exporting.set(true);
+    try {
+      const blob = await this.service.exportSpace(this.spaceId);
+      this.triggerDownload(blob, `${this.safeFileName(space.name)}.zip`);
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to export space');
+    } finally {
+      this.exporting.set(false);
+    }
+  }
+
+  protected async onDeleteOrLeave(): Promise<void> {
+    const space = this.space();
+    if (!space) {
+      return;
+    }
+    const isOwner = space.role === 'owner';
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: isOwner ? 'Delete memory space' : 'Leave memory space',
+        message: isOwner
+          ? `Permanently delete "${space.name}" and all its entries? This cannot be undone.`
+          : `Leave "${space.name}"? You'll lose access until the owner shares it again.`,
+        confirmText: isOwner ? 'Delete' : 'Leave',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (confirmed) {
+      try {
+        await this.service.deleteOrLeave(this.spaceId);
+        this.goBack();
+      } catch (err) {
+        this.error.set(err instanceof Error ? err.message : 'Failed to remove space');
+      }
+    }
+  }
+
+  private triggerDownload(blob: Blob, fileName: string): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  private safeFileName(name: string): string {
+    const cleaned = name.trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[-._]+|[-._]+$/g, '');
+    return cleaned || 'memory-space';
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/memory-spaces.page.html
+++ b/frontend/ai.client/src/app/memory-spaces/memory-spaces.page.html
@@ -1,0 +1,138 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+          Memory Spaces
+        </h1>
+        <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+          Named markdown "second brains" your agents read and maintain over time.
+        </p>
+      </div>
+      @if (accessible() !== false) {
+        <button
+          type="button"
+          (click)="onCreate()"
+          class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+          New space
+        </button>
+      }
+    </div>
+
+    <!-- Feature unavailable (kill switch off) -->
+    @if (accessible() === false) {
+      <div class="mt-10 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800">
+        <ng-icon name="heroCircleStack" class="mx-auto size-8 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+        <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">
+          Memory Spaces isn't enabled for your environment yet.
+        </p>
+      </div>
+    } @else {
+      <!-- Error -->
+      @if (error()) {
+        <div class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400" role="alert">
+          {{ error() }}
+        </div>
+      }
+
+      <!-- Loading -->
+      @if (loading() && spaces().length === 0) {
+        <div class="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+          @for (row of [0, 1, 2]; track row) {
+            <div class="h-40 animate-pulse rounded-xl border border-gray-200/80 bg-white dark:border-gray-700/60 dark:bg-gray-800/80"></div>
+          }
+        </div>
+        <span class="sr-only" role="status">Loading memory spaces…</span>
+      } @else if (spaces().length === 0) {
+        <!-- Empty -->
+        <div class="mt-10 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800">
+          <ng-icon name="heroCircleStack" class="mx-auto size-8 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+          <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">No memory spaces yet</h2>
+          <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+            Create one from a template to give an agent a persistent, editable knowledge base.
+          </p>
+          <button
+            type="button"
+            (click)="onCreate()"
+            class="mt-5 inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+            New space
+          </button>
+        </div>
+      } @else {
+        <!-- Grid -->
+        <div class="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          @for (space of spaces(); track space.spaceId) {
+            <div
+              class="group relative flex h-full cursor-pointer flex-col rounded-xl border border-gray-200/80 bg-white p-5 transition-all duration-300 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-lg dark:border-gray-700/60 dark:bg-gray-800/80 dark:hover:border-gray-600 dark:hover:shadow-black/20"
+              role="button"
+              tabindex="0"
+              (click)="openSpace(space)"
+              (keydown.enter)="openSpace(space)"
+              (keydown.space)="openSpace(space)"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <h3 class="min-w-0 flex-1 truncate text-base/7 font-semibold text-gray-900 dark:text-white">
+                  {{ space.name }}
+                </h3>
+                <span
+                  class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium capitalize"
+                  [class]="space.role === 'owner'
+                    ? 'bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-300'
+                    : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+                >
+                  {{ space.role }}
+                </span>
+              </div>
+
+              <div class="mt-2">
+                <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                  {{ templateLabel(space.template) }}
+                </span>
+              </div>
+
+              <!-- Actions -->
+              <div class="mt-auto flex items-center gap-1 pt-5">
+                @if (space.role === 'owner') {
+                  <button
+                    type="button"
+                    (click)="onShare(space, $event)"
+                    class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                    [attr.aria-label]="'Share ' + space.name"
+                  >
+                    <ng-icon name="heroShare" class="size-4" aria-hidden="true" />
+                  </button>
+                }
+                <button
+                  type="button"
+                  (click)="onDownload(space, $event)"
+                  [disabled]="exportingId() === space.spaceId"
+                  class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                  [attr.aria-label]="'Download ' + space.name + ' as a zip'"
+                >
+                  <ng-icon name="heroArrowDownTray" class="size-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  (click)="onDeleteOrLeave(space, $event)"
+                  class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                  [attr.aria-label]="(space.role === 'owner' ? 'Delete ' : 'Leave ') + space.name"
+                >
+                  <ng-icon
+                    [name]="space.role === 'owner' ? 'heroTrash' : 'heroArrowRightStartOnRectangle'"
+                    class="size-4"
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/memory-spaces/memory-spaces.page.ts
+++ b/frontend/ai.client/src/app/memory-spaces/memory-spaces.page.ts
@@ -1,0 +1,160 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroPlus,
+  heroCircleStack,
+  heroShare,
+  heroArrowDownTray,
+  heroTrash,
+  heroArrowRightStartOnRectangle,
+} from '@ng-icons/heroicons/outline';
+import { MemorySpaceService } from './services/memory-space.service';
+import { MemorySpaceSummary } from './models/memory-space.model';
+import {
+  CreateSpaceDialogComponent,
+  CreateSpaceDialogData,
+  CreateSpaceDialogResult,
+} from './components/create-space-dialog.component';
+import {
+  ShareSpaceDialogComponent,
+  ShareSpaceDialogData,
+  ShareSpaceDialogResult,
+} from './components/share-space-dialog.component';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog/confirmation-dialog.component';
+
+/**
+ * Memory Spaces list page — the "own your data" surface. Lists a user's owned
+ * and shared-in spaces, creates from a template, and per space: open (detail),
+ * share (owner), download `.zip`, delete/leave. The whole feature 404s while
+ * the backend kill switch is off; the facade's `accessible$` drives a graceful
+ * "unavailable" state rather than an error.
+ */
+@Component({
+  selector: 'app-memory-spaces',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [
+    provideIcons({
+      heroPlus,
+      heroCircleStack,
+      heroShare,
+      heroArrowDownTray,
+      heroTrash,
+      heroArrowRightStartOnRectangle,
+    }),
+  ],
+  templateUrl: './memory-spaces.page.html',
+})
+export class MemorySpacesPage implements OnInit {
+  private router = inject(Router);
+  private dialog = inject(Dialog);
+  protected readonly service = inject(MemorySpaceService);
+
+  readonly spaces = this.service.spaces$;
+  readonly loading = this.service.loading$;
+  readonly error = this.service.error$;
+  readonly accessible = this.service.accessible$;
+
+  /** Space id currently exporting, so its button can show progress. */
+  protected readonly exportingId = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.service.loadSpaces();
+  }
+
+  protected openSpace(space: MemorySpaceSummary): void {
+    void this.router.navigate(['/memory-spaces', space.spaceId]);
+  }
+
+  /** Friendly template name for the card badge, falling back to the raw id. */
+  protected templateLabel(templateId: string): string {
+    const match = this.service.templates$().find((t) => t.templateId === templateId);
+    if (match) {
+      return match.name;
+    }
+    return templateId
+      .split('-')
+      .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+      .join(' ');
+  }
+
+  protected async onCreate(): Promise<void> {
+    const dialogRef = this.dialog.open<CreateSpaceDialogResult>(CreateSpaceDialogComponent, {
+      data: { templates: this.service.templates$() } as CreateSpaceDialogData,
+    });
+    const created = await firstValueFrom(dialogRef.closed);
+    if (created) {
+      void this.router.navigate(['/memory-spaces', created.spaceId]);
+    }
+  }
+
+  protected async onShare(space: MemorySpaceSummary, event: Event): Promise<void> {
+    event.stopPropagation();
+    const dialogRef = this.dialog.open<ShareSpaceDialogResult>(ShareSpaceDialogComponent, {
+      data: { space } as ShareSpaceDialogData,
+    });
+    await firstValueFrom(dialogRef.closed);
+  }
+
+  protected async onDownload(space: MemorySpaceSummary, event: Event): Promise<void> {
+    event.stopPropagation();
+    this.exportingId.set(space.spaceId);
+    try {
+      const blob = await this.service.exportSpace(space.spaceId);
+      this.triggerDownload(blob, `${this.safeFileName(space.name)}.zip`);
+    } catch (err) {
+      console.error('Failed to export memory space:', err);
+    } finally {
+      this.exportingId.set(null);
+    }
+  }
+
+  protected async onDeleteOrLeave(space: MemorySpaceSummary, event: Event): Promise<void> {
+    event.stopPropagation();
+    const isOwner = space.role === 'owner';
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: isOwner ? 'Delete memory space' : 'Leave memory space',
+        message: isOwner
+          ? `Permanently delete "${space.name}" and all its entries? This cannot be undone.`
+          : `Leave "${space.name}"? You'll lose access until the owner shares it again.`,
+        confirmText: isOwner ? 'Delete' : 'Leave',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (confirmed) {
+      try {
+        await this.service.deleteOrLeave(space.spaceId);
+      } catch (err) {
+        console.error('Failed to remove memory space:', err);
+      }
+    }
+  }
+
+  private triggerDownload(blob: Blob, fileName: string): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  private safeFileName(name: string): string {
+    const cleaned = name.trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^[-._]+|[-._]+$/g, '');
+    return cleaned || 'memory-space';
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/models/memory-space.model.ts
+++ b/frontend/ai.client/src/app/memory-spaces/models/memory-space.model.ts
@@ -1,0 +1,95 @@
+/**
+ * Memory Spaces — user-owned, shareable markdown "second brains" (F5, A5 SPA surface).
+ *
+ * These interfaces mirror the app-api response models under
+ * `apis/app_api/memory_spaces/` (which serialize camelCase). Keep them in
+ * lockstep with that backend contract — a breaking change to either side must
+ * update both in the same PR.
+ */
+
+/** Full role set on a space. `owner` is implicit (stored on the space). */
+export type MemoryRole = 'owner' | 'editor' | 'viewer';
+
+/** The two grantable roles (a share is never `owner`). */
+export type ShareRole = 'viewer' | 'editor';
+
+/** Entry kinds: mutable entity, append-only episodic, flat fact. */
+export type EntryType = 'entity' | 'episodic' | 'fact';
+
+/** A template a space can be seeded from (Blank / Chief of Staff / Research Notebook). */
+export interface SpaceTemplate {
+  templateId: string;
+  name: string;
+  description: string;
+}
+
+/** A space as it appears in the list (no index/entries body). */
+export interface MemorySpaceSummary {
+  spaceId: string;
+  name: string;
+  template: string;
+  role: MemoryRole;
+  ownerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** GET /memory/spaces */
+export interface SpacesListResponse {
+  spaces: MemorySpaceSummary[];
+  templates: SpaceTemplate[];
+}
+
+/** A manifest entry ref (the catalog row; the body is fetched on demand). */
+export interface MemoryEntryRef {
+  slug: string;
+  type: EntryType;
+  description: string;
+  size: number;
+  updated: string;
+  updatedBy: string;
+  indexed: Record<string, unknown>;
+}
+
+/** GET /memory/spaces/{id} — summary + the MEMORY.md index text + entry refs. */
+export interface MemorySpaceDetail extends MemorySpaceSummary {
+  index: string;
+  entries: MemoryEntryRef[];
+}
+
+/** GET /memory/spaces/{id}/entries/{slug} */
+export interface EntryContent {
+  slug: string;
+  content: string;
+}
+
+/** One shared grant on a space. */
+export interface SpaceMember {
+  email: string;
+  permission: ShareRole;
+  createdAt: string;
+}
+
+/** GET /memory/spaces/{id}/shares */
+export interface MembersListResponse {
+  members: SpaceMember[];
+}
+
+// ---- requests ----------------------------------------------------------
+
+export interface CreateSpaceRequest {
+  name: string;
+  template: string;
+}
+
+export interface UpsertEntryRequest {
+  body: string;
+  type?: EntryType;
+  description?: string;
+  indexed?: Record<string, unknown>;
+}
+
+export interface ShareRequest {
+  email: string;
+  permission: ShareRole;
+}

--- a/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.ts
+++ b/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, inject, computed } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import {
+  CreateSpaceRequest,
+  EntryContent,
+  EntryType,
+  MembersListResponse,
+  MemoryEntryRef,
+  MemorySpaceDetail,
+  MemorySpaceSummary,
+  ShareRequest,
+  ShareRole,
+  SpaceMember,
+  SpacesListResponse,
+  UpsertEntryRequest,
+} from '../models/memory-space.model';
+
+/**
+ * HTTP surface for the Memory Spaces user API (`/memory/spaces/*`).
+ *
+ * Thin and untyped-error by design (mirrors AssistantApiService): returns raw
+ * Observables and leaves state, error translation, and cache upkeep to
+ * MemorySpaceService. The whole surface 404s while `MEMORY_SPACES_ENABLED` is
+ * off on the backend — the facade treats that as "feature unavailable".
+ */
+@Injectable({ providedIn: 'root' })
+export class MemorySpaceApiService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/memory/spaces`);
+
+  // ---- spaces ----------------------------------------------------------
+
+  list(): Observable<SpacesListResponse> {
+    return this.http.get<SpacesListResponse>(this.baseUrl());
+  }
+
+  create(request: CreateSpaceRequest): Observable<MemorySpaceSummary> {
+    return this.http.post<MemorySpaceSummary>(this.baseUrl(), request);
+  }
+
+  get(spaceId: string): Observable<MemorySpaceDetail> {
+    return this.http.get<MemorySpaceDetail>(`${this.baseUrl()}/${spaceId}`);
+  }
+
+  /** Owner deletes the space; a member drops their own grant (leave). */
+  remove(spaceId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl()}/${spaceId}`);
+  }
+
+  /** The whole space as a `.zip` of raw markdown (viewer+). */
+  export(spaceId: string): Observable<Blob> {
+    return this.http.get(`${this.baseUrl()}/${spaceId}/export`, {
+      responseType: 'blob',
+    });
+  }
+
+  // ---- index (MEMORY.md) ----------------------------------------------
+
+  updateIndex(spaceId: string, content: string): Observable<{ content: string }> {
+    return this.http.put<{ content: string }>(
+      `${this.baseUrl()}/${spaceId}/index`,
+      { content },
+    );
+  }
+
+  // ---- entries ---------------------------------------------------------
+
+  readEntry(spaceId: string, slug: string): Observable<EntryContent> {
+    return this.http.get<EntryContent>(
+      `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
+    );
+  }
+
+  upsertEntry(
+    spaceId: string,
+    slug: string,
+    request: UpsertEntryRequest,
+  ): Observable<MemoryEntryRef> {
+    return this.http.put<MemoryEntryRef>(
+      `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
+      request,
+    );
+  }
+
+  deleteEntry(spaceId: string, slug: string): Observable<void> {
+    return this.http.delete<void>(
+      `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
+    );
+  }
+
+  listEntries(spaceId: string, type?: EntryType): Observable<{ entries: MemoryEntryRef[] }> {
+    let params = new HttpParams();
+    if (type) {
+      params = params.set('type', type);
+    }
+    return this.http.get<{ entries: MemoryEntryRef[] }>(
+      `${this.baseUrl()}/${spaceId}/entries`,
+      { params },
+    );
+  }
+
+  // ---- sharing ---------------------------------------------------------
+
+  listShares(spaceId: string): Observable<MembersListResponse> {
+    return this.http.get<MembersListResponse>(`${this.baseUrl()}/${spaceId}/shares`);
+  }
+
+  addShare(spaceId: string, request: ShareRequest): Observable<SpaceMember> {
+    return this.http.post<SpaceMember>(`${this.baseUrl()}/${spaceId}/shares`, request);
+  }
+
+  updateShare(
+    spaceId: string,
+    email: string,
+    permission: ShareRole,
+  ): Observable<SpaceMember> {
+    return this.http.patch<SpaceMember>(
+      `${this.baseUrl()}/${spaceId}/shares/${encodeURIComponent(email)}`,
+      { permission },
+    );
+  }
+
+  removeShare(spaceId: string, email: string): Observable<void> {
+    return this.http.delete<void>(
+      `${this.baseUrl()}/${spaceId}/shares/${encodeURIComponent(email)}`,
+    );
+  }
+}

--- a/frontend/ai.client/src/app/memory-spaces/services/memory-space.service.spec.ts
+++ b/frontend/ai.client/src/app/memory-spaces/services/memory-space.service.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { MemorySpaceService } from './memory-space.service';
+import { MemorySpaceApiService } from './memory-space-api.service';
+import { MemorySpaceSummary, SpaceTemplate } from '../models/memory-space.model';
+
+function stubSpace(overrides: Partial<MemorySpaceSummary> = {}): MemorySpaceSummary {
+  return {
+    spaceId: 'spc_abc123',
+    name: 'My Brain',
+    template: 'chief-of-staff',
+    role: 'owner',
+    ownerId: 'user-1',
+    createdAt: '2026-07-07T00:00:00Z',
+    updatedAt: '2026-07-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const TEMPLATES: SpaceTemplate[] = [
+  { templateId: 'blank', name: 'Blank', description: 'An empty wiki' },
+];
+
+describe('MemorySpaceService', () => {
+  let service: MemorySpaceService;
+  let mockApi: {
+    list: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    export: ReturnType<typeof vi.fn>;
+    updateIndex: ReturnType<typeof vi.fn>;
+    readEntry: ReturnType<typeof vi.fn>;
+    upsertEntry: ReturnType<typeof vi.fn>;
+    deleteEntry: ReturnType<typeof vi.fn>;
+    listShares: ReturnType<typeof vi.fn>;
+    addShare: ReturnType<typeof vi.fn>;
+    updateShare: ReturnType<typeof vi.fn>;
+    removeShare: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockApi = {
+      list: vi.fn(),
+      create: vi.fn(),
+      get: vi.fn(),
+      remove: vi.fn(),
+      export: vi.fn(),
+      updateIndex: vi.fn(),
+      readEntry: vi.fn(),
+      upsertEntry: vi.fn(),
+      deleteEntry: vi.fn(),
+      listShares: vi.fn(),
+      addShare: vi.fn(),
+      updateShare: vi.fn(),
+      removeShare: vi.fn(),
+    };
+    TestBed.configureTestingModule({
+      providers: [MemorySpaceService, { provide: MemorySpaceApiService, useValue: mockApi }],
+    });
+    service = TestBed.inject(MemorySpaceService);
+  });
+
+  it('loads spaces and templates and marks the feature accessible', async () => {
+    const space = stubSpace();
+    mockApi.list.mockReturnValue(of({ spaces: [space], templates: TEMPLATES }));
+
+    await service.loadSpaces();
+
+    expect(service.spaces$()).toEqual([space]);
+    expect(service.templates$()).toEqual(TEMPLATES);
+    expect(service.accessible$()).toBe(true);
+    expect(service.loading$()).toBe(false);
+  });
+
+  it('marks the feature inaccessible on a 404 (kill switch off) without an error', async () => {
+    mockApi.list.mockReturnValue(throwError(() => ({ status: 404 })));
+
+    await service.loadSpaces();
+
+    expect(service.accessible$()).toBe(false);
+    expect(service.spaces$()).toEqual([]);
+    expect(service.error$()).toBeNull();
+  });
+
+  it('surfaces a real error for non-gating failures', async () => {
+    mockApi.list.mockReturnValue(throwError(() => new Error('network blip')));
+
+    await expect(service.loadSpaces()).rejects.toThrow('network blip');
+    expect(service.error$()).toBe('network blip');
+    // accessible stays null (unresolved) so the nav entry doesn't flash in
+    expect(service.accessible$()).toBeNull();
+  });
+
+  it('appends a created space to local state', async () => {
+    mockApi.list.mockReturnValue(of({ spaces: [], templates: TEMPLATES }));
+    await service.loadSpaces();
+
+    const created = stubSpace({ spaceId: 'spc_new', name: 'Research' });
+    mockApi.create.mockReturnValue(of(created));
+
+    const result = await service.createSpace({ name: 'Research', template: 'blank' });
+
+    expect(result).toEqual(created);
+    expect(service.spaces$()).toContain(created);
+  });
+
+  it('removes a space from local state on delete/leave', async () => {
+    const space = stubSpace();
+    mockApi.list.mockReturnValue(of({ spaces: [space], templates: [] }));
+    await service.loadSpaces();
+
+    mockApi.remove.mockReturnValue(of(undefined));
+    await service.deleteOrLeave(space.spaceId);
+
+    expect(service.spaces$()).toEqual([]);
+  });
+
+  it('returns the export blob', async () => {
+    const blob = new Blob(['zip-bytes'], { type: 'application/zip' });
+    mockApi.export.mockReturnValue(of(blob));
+
+    const result = await service.exportSpace('spc_abc123');
+
+    expect(result).toBe(blob);
+    expect(mockApi.export).toHaveBeenCalledWith('spc_abc123');
+  });
+
+  it('delegates share operations to the api', async () => {
+    mockApi.addShare.mockReturnValue(of({ email: 'a@b.edu', permission: 'viewer', createdAt: '' }));
+    mockApi.updateShare.mockReturnValue(of({ email: 'a@b.edu', permission: 'editor', createdAt: '' }));
+    mockApi.removeShare.mockReturnValue(of(undefined));
+
+    await service.addShare('spc_1', { email: 'a@b.edu', permission: 'viewer' });
+    await service.updateShare('spc_1', 'a@b.edu', 'editor');
+    await service.removeShare('spc_1', 'a@b.edu');
+
+    expect(mockApi.addShare).toHaveBeenCalledWith('spc_1', { email: 'a@b.edu', permission: 'viewer' });
+    expect(mockApi.updateShare).toHaveBeenCalledWith('spc_1', 'a@b.edu', 'editor');
+    expect(mockApi.removeShare).toHaveBeenCalledWith('spc_1', 'a@b.edu');
+  });
+});

--- a/frontend/ai.client/src/app/memory-spaces/services/memory-space.service.ts
+++ b/frontend/ai.client/src/app/memory-spaces/services/memory-space.service.ts
@@ -1,0 +1,141 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  CreateSpaceRequest,
+  EntryContent,
+  MembersListResponse,
+  MemoryEntryRef,
+  MemorySpaceDetail,
+  MemorySpaceSummary,
+  ShareRequest,
+  ShareRole,
+  SpaceMember,
+  SpaceTemplate,
+  UpsertEntryRequest,
+} from '../models/memory-space.model';
+import { MemorySpaceApiService } from './memory-space-api.service';
+
+/**
+ * Signal-based state for the Memory Spaces feature. Mirrors the assistants /
+ * schedules facades: private mutable signals, readonly public views, and async
+ * methods that round-trip through the API service and keep local state in sync.
+ *
+ * `accessible$` rides the list call the same way ScheduleService does: a
+ * successful (even empty) list means the caller can use the feature and the
+ * `MEMORY_SPACES_ENABLED` kill switch is on; a 404 flips it false so the nav
+ * entry and page hide gracefully instead of showing an error.
+ */
+@Injectable({ providedIn: 'root' })
+export class MemorySpaceService {
+  private apiService = inject(MemorySpaceApiService);
+
+  private spaces = signal<MemorySpaceSummary[]>([]);
+  private templates = signal<SpaceTemplate[]>([]);
+  private loading = signal<boolean>(false);
+  private error = signal<string | null>(null);
+  private accessible = signal<boolean | null>(null);
+
+  readonly spaces$ = this.spaces.asReadonly();
+  readonly templates$ = this.templates.asReadonly();
+  readonly loading$ = this.loading.asReadonly();
+  readonly error$ = this.error.asReadonly();
+  readonly accessible$ = this.accessible.asReadonly();
+
+  async loadSpaces(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const response = await firstValueFrom(this.apiService.list());
+      this.spaces.set(response?.spaces ?? []);
+      this.templates.set(response?.templates ?? []);
+      this.accessible.set(true);
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 404) {
+        // Kill switch off — fail gracefully rather than surfacing an error.
+        this.accessible.set(false);
+        this.spaces.set([]);
+        this.templates.set([]);
+        return;
+      }
+      this.error.set(err instanceof Error ? err.message : 'Failed to load memory spaces');
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async createSpace(request: CreateSpaceRequest): Promise<MemorySpaceSummary> {
+    this.error.set(null);
+    try {
+      const space = await firstValueFrom(this.apiService.create(request));
+      this.spaces.update((current) => [...current, space]);
+      return space;
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to create memory space');
+      throw err;
+    }
+  }
+
+  getSpace(spaceId: string): Promise<MemorySpaceDetail> {
+    return firstValueFrom(this.apiService.get(spaceId));
+  }
+
+  /** Owner deletes the whole space; a member drops their own grant (leave). */
+  async deleteOrLeave(spaceId: string): Promise<void> {
+    this.error.set(null);
+    try {
+      await firstValueFrom(this.apiService.remove(spaceId));
+      this.spaces.update((current) => current.filter((s) => s.spaceId !== spaceId));
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to remove memory space');
+      throw err;
+    }
+  }
+
+  /** Fetch the `.zip` export blob for a space. */
+  exportSpace(spaceId: string): Promise<Blob> {
+    return firstValueFrom(this.apiService.export(spaceId));
+  }
+
+  // ---- index (MEMORY.md) + entries ------------------------------------
+
+  updateIndex(spaceId: string, content: string): Promise<{ content: string }> {
+    return firstValueFrom(this.apiService.updateIndex(spaceId, content));
+  }
+
+  readEntry(spaceId: string, slug: string): Promise<EntryContent> {
+    return firstValueFrom(this.apiService.readEntry(spaceId, slug));
+  }
+
+  upsertEntry(
+    spaceId: string,
+    slug: string,
+    request: UpsertEntryRequest,
+  ): Promise<MemoryEntryRef> {
+    return firstValueFrom(this.apiService.upsertEntry(spaceId, slug, request));
+  }
+
+  deleteEntry(spaceId: string, slug: string): Promise<void> {
+    return firstValueFrom(this.apiService.deleteEntry(spaceId, slug));
+  }
+
+  // ---- sharing ---------------------------------------------------------
+
+  listShares(spaceId: string): Promise<MembersListResponse> {
+    return firstValueFrom(this.apiService.listShares(spaceId));
+  }
+
+  addShare(spaceId: string, request: ShareRequest): Promise<SpaceMember> {
+    return firstValueFrom(this.apiService.addShare(spaceId, request));
+  }
+
+  updateShare(spaceId: string, email: string, permission: ShareRole): Promise<SpaceMember> {
+    return firstValueFrom(this.apiService.updateShare(spaceId, email, permission));
+  }
+
+  removeShare(spaceId: string, email: string): Promise<void> {
+    return firstValueFrom(this.apiService.removeShare(spaceId, email));
+  }
+}


### PR DESCRIPTION
## What

Workstream A5 — the user-facing **Memory** surface for the Memory Space primitive. This is the SPA that makes A2–A4 visible: a person can see, create, edit, share, download, and delete their spaces. New feature area at `frontend/ai.client/src/app/memory-spaces/`.

### Screens

- **List page** (`/memory-spaces`) — owned + shared-in spaces as cards with role and template badges. Per card: open, share (owner only), download `.zip`, delete (owner) / leave (member). Handles empty, loading, error, and feature-unavailable states.
- **Detail page** (`/memory-spaces/:id`) — view/edit the `MEMORY.md` index (editor+), and the entry list. Entries open in a dialog to **view** (viewer) or **edit/create** (editor+); per-entry delete. Header carries share / download / delete-or-leave.
- **Create-from-template dialog** — name + template picker, creates and navigates in.
- **Share dialog** — add-by-email + per-row role select + remove, **delta-on-save** over the A4 `/shares` endpoints (add → POST, role change → PATCH, remove → DELETE). Mirrors the assistant share dialog's ergonomics; no visibility concept (identity-based access). Fails soft for non-owners.

## How

- **Signal facade** (`MemorySpaceService`) + thin **API service** (`MemorySpaceApiService`) mirror the assistants/schedules pattern: private mutable signals, readonly views, `firstValueFrom` async methods, local-cache upkeep after mutations.
- **Nav gating** — the sidebar entry rides a live `accessible$` probe exactly like `showSchedules`: a successful (even empty) list means `MEMORY_SPACES_ENABLED` is on; a **404 hides the entry** so a disabled environment shows nothing rather than a dead link. The probe fires once on auth (sidenav `effect`).
- **Viewer = read-only** throughout (index textarea `readonly`, no edit/create/delete affordances, entry dialog in view mode).
- **Download** streams the A3 `.zip` blob to an anchor with a sanitized filename.
- Routing under `authGuard`; `@angular/cdk/dialog` + redesign-tokens (`rounded-2xl`, `text-sm/6`, `bg-blue-600`) per `frontend/.claude/CLAUDE.md`.

## Backend

None — all endpoints already shipped in A2–A4. Frontend-only PR.

## Verification

- `npx tsc --noEmit` clean.
- `ng build --configuration development` clean — all new templates compile under Angular's strict template checker (`memory-space-detail-page` and friends emit).
- New facade spec (7 tests, `ng test`) green: load + accessible-true, 404 → inaccessible-no-error, real-error surfaces, create/delete cache upkeep, export blob, share delegation.
- Existing sidenav specs still green (18) after the added service injection.

**Not browser-verified**: the feature needs the full authenticated backend (app-api + DynamoDB + S3 + Cognito) with the flag on, which isn't stood up in a headless session. Manual test script below.

### Manual test script (reviewer, in a deployed/local env with `MEMORY_SPACES_ENABLED=true`)

1. Sign in → confirm **Memory Spaces** appears in the sidebar. Flip the flag off → entry disappears (page 404s).
2. **New space** → pick "Chief of Staff" → lands on the detail page seeded with a `MEMORY.md`.
3. Edit the index → **Save index** → reload → change persisted.
4. **New entry** (slug/type/description/body) → appears in the list; open it → edit → save; delete it → gone.
5. Back to list → **Download** → a `.zip` named after the space downloads; unzip → `MEMORY.md` + `entries/<type>/*.md` + `metadata.json`.
6. **Share** (owner) → add an email as viewer → save; reopen → change to editor; remove → save.
7. As the shared-in **viewer**: space shows role "viewer", index/entries read-only, no share button; **Leave** (not Delete) removes it from your list only.

## Spec

`docs/specs/user-markdown-memory.md` — A5 marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)