### PR TITLE
feat(agents): Agent Designer Phase 1 — /agents surface (dark)

### DIFF
--- a/backend/src/apis/app_api/agents/routes.py
+++ b/backend/src/apis/app_api/agents/routes.py
@@ -1,0 +1,321 @@
+"""Agent Designer — the ``/agents/*`` surface (Phase 1, PR-3).
+
+A thin alias over the evolved assistant store: the same ``apis.shared.assistants``
+service functions and the same identity-based access gates as ``/assistants/*``, but
+returning the **Agent** shape (``compat.to_agent_view`` → ``AgentResponse``) so callers
+see ``modelConfig`` + ``bindings``. Legacy ids are valid unchanged (agentId == assistantId).
+
+Gating: the router is mounted unconditionally but every route depends on
+``require_agents_enabled`` — a 404 when ``AGENTS_API_ENABLED`` is off, so the surface
+behaves as if unmounted while the feature ships incrementally. Auth is the standard SPA
+cookie dependency per the CLAUDE.md app-api rule.
+
+Deliberately excluded in Phase 1: ``test-chat`` (the only reason the assistants router is
+on the architecture import-boundary allow-list — aliasing it would force a second
+exception) and document sub-routes. Those stay on ``/assistants/*``. ``GET /agents`` lists
+the caller's own + shared-with-them agents; ``include_public``/pagination parity is a
+Phase-4 concern when the Designer consumes it.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.app_api.agents.services.binding_validation import (
+    BindingValidationError,
+    validate_agent_write,
+)
+from apis.shared.assistants.compat import to_agent_view
+from apis.shared.assistants.models import (
+    AgentResponse,
+    AgentSharesResponse,
+    AgentsListResponse,
+    CreateAssistantDraftRequest,
+    CreateAssistantRequest,
+    ShareAssistantRequest,
+    ShareEntry,
+    UnshareAssistantRequest,
+    UpdateAssistantRequest,
+    UpdateSharePermissionRequest,
+)
+from apis.shared.assistants.service import (
+    assistant_exists,
+    create_assistant,
+    create_assistant_draft,
+    delete_assistant,
+    get_assistant_with_access_check,
+    list_assistant_shares,
+    list_shared_with_user,
+    list_user_assistants,
+    resolve_assistant_permission,
+    share_assistant,
+    unshare_assistant,
+    update_assistant,
+    update_share_permission,
+)
+from apis.shared.auth.dependencies import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.feature_flags import agents_enabled
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+async def require_agents_enabled(
+    user: User = Depends(get_current_user_from_session),
+) -> User:
+    """Cookie auth + the environment kill switch.
+
+    404 when ``AGENTS_API_ENABLED`` is off, so the surface behaves as if unmounted
+    (mirrors the memory-spaces / schedules pattern).
+    """
+    if not agents_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return user
+
+
+def _agent_response(assistant, *, permission: Optional[str] = None,
+                    is_shared_with_me: Optional[bool] = None) -> AgentResponse:
+    """Project an Assistant into the Agent read-shape, layering share metadata."""
+    view = to_agent_view(assistant)
+    if permission is not None:
+        view["userPermission"] = permission
+    if is_shared_with_me is not None:
+        view["isSharedWithMe"] = is_shared_with_me
+        view["firstInteracted"] = getattr(assistant, "first_interacted", None)
+    return AgentResponse.model_validate(view)
+
+
+def _shares_response(agent_id: str, shares: list) -> AgentSharesResponse:
+    return AgentSharesResponse(
+        agent_id=agent_id,
+        shared_with=[ShareEntry.model_validate(s) for s in shares],
+    )
+
+
+# --------------------------------------------------------------------------- CRUD
+@router.post("/draft", response_model=AgentResponse, response_model_exclude_none=True)
+async def create_agent_draft_endpoint(
+    request: CreateAssistantDraftRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Create a draft Agent with an auto-generated id (status=DRAFT)."""
+    try:
+        assistant = await create_assistant_draft(
+            owner_id=current_user.user_id, owner_name=current_user.name, name=request.name
+        )
+        return _agent_response(assistant, permission="owner")
+    except Exception as e:
+        logger.error(f"Error creating draft agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to create draft agent: {str(e)}")
+
+
+@router.post("", response_model=AgentResponse, response_model_exclude_none=True)
+async def create_agent_endpoint(
+    request: CreateAssistantRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Create a complete Agent (status=COMPLETE) with optional bindings + modelConfig."""
+    try:
+        await validate_agent_write(
+            current_user, bindings=request.bindings, model_settings=request.model_settings
+        )
+    except BindingValidationError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    try:
+        assistant = await create_assistant(
+            owner_id=current_user.user_id,
+            owner_name=current_user.name,
+            name=request.name,
+            description=request.description,
+            instructions=request.instructions,
+            visibility=request.visibility,
+            tags=request.tags,
+            starters=request.starters,
+            emoji=request.emoji,
+            bindings=request.bindings,
+            model_settings=request.model_settings,
+        )
+        return _agent_response(assistant, permission="owner")
+    except Exception as e:
+        logger.error(f"Error creating agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to create agent: {str(e)}")
+
+
+@router.get("", response_model=AgentsListResponse, response_model_exclude_none=True)
+async def list_agents_endpoint(
+    include_drafts: bool = False, current_user: User = Depends(require_agents_enabled)
+):
+    """List the caller's own Agents plus those shared with them (most-recent first)."""
+    try:
+        owned, _ = await list_user_assistants(
+            owner_id=current_user.user_id, include_drafts=include_drafts, include_public=False
+        )
+        owned_ids = {a.assistant_id for a in owned}
+        shared = [a for a in await list_shared_with_user(current_user.email) if a.assistant_id not in owned_ids]
+
+        agents = [_agent_response(a, permission="owner", is_shared_with_me=False) for a in owned]
+        agents += [
+            _agent_response(a, permission=getattr(a, "user_permission", None), is_shared_with_me=True)
+            for a in shared
+        ]
+        agents.sort(key=lambda a: a.created_at, reverse=True)
+        return AgentsListResponse(agents=agents, next_token=None)
+    except Exception as e:
+        logger.error(f"Error listing agents: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list agents: {str(e)}")
+
+
+@router.get("/{agent_id}", response_model=AgentResponse, response_model_exclude_none=True)
+async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require_agents_enabled)):
+    """Retrieve an Agent by id with visibility-based access control."""
+    try:
+        if not await assistant_exists(agent_id):
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        assistant, permission = await get_assistant_with_access_check(
+            assistant_id=agent_id, user_id=current_user.user_id, user_email=current_user.email
+        )
+        if not assistant:
+            raise HTTPException(status_code=403, detail="Access denied: you do not have permission to access this agent")
+        return _agent_response(assistant, permission=permission)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve agent: {str(e)}")
+
+
+@router.put("/{agent_id}", response_model=AgentResponse, response_model_exclude_none=True)
+async def update_agent_endpoint(
+    agent_id: str, request: UpdateAssistantRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Update an Agent (owner or editor); visibility changes are owner-only."""
+    try:
+        assistant, permission = await resolve_assistant_permission(
+            assistant_id=agent_id, user_id=current_user.user_id, user_email=current_user.email
+        )
+        if not assistant:
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        if permission not in ("owner", "editor"):
+            raise HTTPException(status_code=403, detail="You do not have permission to edit this agent")
+        if permission == "editor" and request.visibility is not None and request.visibility != assistant.visibility:
+            raise HTTPException(status_code=400, detail="Only the owner can change agent visibility")
+
+        try:
+            await validate_agent_write(
+                current_user, bindings=request.bindings, model_settings=request.model_settings
+            )
+        except BindingValidationError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.message)
+
+        updated = await update_assistant(
+            assistant_id=agent_id,
+            owner_id=assistant.owner_id,
+            name=request.name,
+            description=request.description,
+            instructions=request.instructions,
+            visibility=request.visibility,
+            tags=request.tags,
+            starters=request.starters,
+            emoji=request.emoji,
+            status=request.status,
+            image_url=request.image_url,
+            bindings=request.bindings,
+            model_settings=request.model_settings,
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        return _agent_response(updated, permission=permission)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update agent: {str(e)}")
+
+
+@router.delete("/{agent_id}", status_code=204)
+async def delete_agent_endpoint(agent_id: str, current_user: User = Depends(require_agents_enabled)):
+    """Delete an Agent (owner only)."""
+    try:
+        deleted = await delete_assistant(agent_id, current_user.user_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to delete agent: {str(e)}")
+
+
+# --------------------------------------------------------------------------- shares
+# The share mutations return a bool (False → not owned / not found); we then read the
+# updated list. Mirrors the /assistants/{id}/shares handlers exactly (same records).
+@router.post("/{agent_id}/shares", response_model=AgentSharesResponse)
+async def share_agent_endpoint(
+    agent_id: str, request: ShareAssistantRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Share an Agent with emails at a permission level (owner only)."""
+    user_id = current_user.user_id
+    try:
+        if not await share_assistant(agent_id, user_id, request.emails, request.permission):
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        return _shares_response(agent_id, await list_assistant_shares(agent_id, user_id))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error sharing agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to share agent: {str(e)}")
+
+
+@router.delete("/{agent_id}/shares", response_model=AgentSharesResponse)
+async def unshare_agent_endpoint(
+    agent_id: str, request: UnshareAssistantRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Remove shares from an Agent (owner only)."""
+    user_id = current_user.user_id
+    try:
+        if not await unshare_assistant(agent_id, user_id, request.emails):
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        return _shares_response(agent_id, await list_assistant_shares(agent_id, user_id))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error unsharing agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to modify shares for agent: {str(e)}")
+
+
+@router.patch("/{agent_id}/shares", response_model=AgentSharesResponse)
+async def update_agent_share_endpoint(
+    agent_id: str, request: UpdateSharePermissionRequest, current_user: User = Depends(require_agents_enabled)
+):
+    """Change an existing share's permission level (owner only)."""
+    user_id = current_user.user_id
+    try:
+        if not await update_share_permission(agent_id, user_id, request.email, request.permission):
+            raise HTTPException(status_code=404, detail="Agent or share record not found")
+        return _shares_response(agent_id, await list_assistant_shares(agent_id, user_id))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating agent share permission: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update share permission: {str(e)}")
+
+
+@router.get("/{agent_id}/shares", response_model=AgentSharesResponse)
+async def get_agent_shares_endpoint(agent_id: str, current_user: User = Depends(require_agents_enabled)):
+    """List an Agent's share records (owners and editors may read)."""
+    try:
+        assistant, permission = await resolve_assistant_permission(
+            assistant_id=agent_id, user_id=current_user.user_id, user_email=current_user.email
+        )
+        if not assistant:
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        if permission not in ("owner", "editor"):
+            raise HTTPException(status_code=403, detail="You do not have permission to view shares for this agent")
+        return _shares_response(agent_id, await list_assistant_shares(agent_id, assistant.owner_id))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting agent shares: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get agent shares: {str(e)}")

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -188,6 +188,7 @@ from apis.app_api.memory_spaces.routes import router as memory_spaces_router
 from apis.app_api.tools.routes import router as tools_router
 from apis.app_api.files.routes import router as files_router
 from apis.app_api.assistants.routes import router as assistants_router
+from apis.app_api.agents.routes import router as agents_router
 from apis.app_api.documents.routes import router as documents_router
 from apis.app_api.users.routes import router as users_router
 from apis.app_api.user_settings.routes import router as user_settings_router
@@ -212,6 +213,7 @@ app.include_router(api_keys_router)
 app.include_router(sessions_router)
 app.include_router(admin_router)
 app.include_router(assistants_router)
+app.include_router(agents_router)  # Agent Designer /agents surface; 404s while AGENTS_API_ENABLED off
 app.include_router(documents_router)
 app.include_router(users_router)
 app.include_router(user_settings_router)

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -169,6 +169,57 @@ class AssistantsListResponse(BaseModel):
     next_token: Optional[str] = Field(None, alias="nextToken", description="Pagination token for next page")
 
 
+class AgentResponse(BaseModel):
+    """Agent read-shape (D3) — the projection served by the ``/agents/*`` surface.
+
+    Consumes ``compat.to_agent_view`` output directly. ``agentId`` aliases the
+    assistant id (legacy ids remain valid). Unlike ``AssistantResponse`` this carries
+    ``modelConfig`` + ``bindings`` — the whole point of the Agent surface.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier (== legacy assistant id)")
+    owner_name: str = Field(..., alias="ownerName", description="Owner display name")
+    name: str = Field(..., description="Agent display name")
+    description: str = Field(..., description="Short summary")
+    instructions: str = Field(..., description="System prompt")
+    model_settings: Optional[AgentModelConfig] = Field(None, alias="modelConfig", description="Governed single-select model")
+    bindings: List[AgentBinding] = Field(default_factory=list, description="Resolved bindings (legacy KB synthesized)")
+    visibility: Literal["PRIVATE", "PUBLIC", "SHARED"] = Field(..., description="Access control")
+    tags: Optional[List[str]] = Field(default_factory=list, description="Search keywords")
+    starters: Optional[List[str]] = Field(default_factory=list, description="Conversation starter prompts")
+    emoji: Optional[str] = Field(None, description="Single emoji character for agent avatar")
+    image_url: Optional[str] = Field(None, alias="imageUrl", description="URL to agent avatar/image")
+    usage_count: int = Field(..., alias="usageCount", description="Usage count")
+    status: Literal["DRAFT", "COMPLETE"] = Field(..., description="Lifecycle status")
+    created_at: str = Field(..., alias="createdAt", description="ISO 8601 creation timestamp")
+    updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 update timestamp")
+
+    # Share metadata (parity with AssistantResponse; set post-projection)
+    first_interacted: Optional[bool] = Field(None, alias="firstInteracted")
+    is_shared_with_me: Optional[bool] = Field(None, alias="isSharedWithMe")
+    user_permission: Optional[Literal["owner", "editor", "viewer"]] = Field(None, alias="userPermission")
+
+
+class AgentsListResponse(BaseModel):
+    """Response for listing Agents."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agents: List[AgentResponse] = Field(..., description="Agents visible to the caller")
+    next_token: Optional[str] = Field(None, alias="nextToken", description="Pagination token for next page")
+
+
+class AgentSharesResponse(BaseModel):
+    """Share records for an Agent (agentId == assistantId; same underlying records)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    shared_with: List["ShareEntry"] = Field(..., alias="sharedWith", description="Share records (email + permission)")
+
+
 class AssistantTestChatRequest(BaseModel):
     """Request body for testing assistant chat with RAG"""
 

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -61,3 +61,19 @@ def memory_spaces_enabled() -> bool:
     ``scheduled_runs_enabled``).
     """
     return os.environ.get("MEMORY_SPACES_ENABLED", "false").lower() == "true"
+
+
+def agents_enabled() -> bool:
+    """Whether the Agent Designer surface is enabled for this environment.
+
+    Gates the ``/agents/*`` alias router (the governed Agent read/write surface over
+    the evolved assistant store). **Defaults off** (the ``MEMORY_SPACES_ENABLED``
+    pattern): set ``AGENTS_API_ENABLED=true`` to turn it on. The feature ships
+    incrementally across several PRs (contract → surface → resolution → Designer UI),
+    so it stays dark until complete — the assistant store and its ``/assistants/*``
+    surface are unaffected while off.
+
+    Gates *feature existence* per environment; *who* may use a specific agent is the
+    identity-based access check already enforced by the assistant service.
+    """
+    return os.environ.get("AGENTS_API_ENABLED", "false").lower() == "true"

--- a/backend/tests/routes/test_agents.py
+++ b/backend/tests/routes/test_agents.py
@@ -1,0 +1,195 @@
+"""Tests for the /agents alias surface (Agent Designer Phase 1, PR-3).
+
+Covers the AGENTS_API_ENABLED 404-gate, the Agent projection (agentId + bindings +
+modelConfig), and CRUD/shares parity with /assistants. Services are patched in the
+agents routes module namespace.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.agents.routes import router
+from apis.shared.assistants.models import AgentBinding, AgentModelConfig, Assistant
+from tests.routes.conftest import mock_auth_user
+
+ROUTES_MODULE = "apis.app_api.agents.routes"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-001",
+        ownerName="Test User",
+        name="My Agent",
+        description="A helpful agent",
+        instructions="You are helpful.",
+        vectorIndexId="idx-001",
+        visibility="PRIVATE",
+        tags=["test"],
+        starters=["Hi"],
+        emoji="🤖",
+        usageCount=0,
+        createdAt="2024-01-01T00:00:00Z",
+        updatedAt="2024-01-01T00:00:00Z",
+        status="COMPLETE",
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+@pytest.fixture
+def _flag_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+
+
+# --------------------------------------------------------------------------- gate
+class TestFeatureGate:
+    def test_404_when_flag_off(self, app, make_user, monkeypatch):
+        monkeypatch.setenv("AGENTS_API_ENABLED", "false")
+        mock_auth_user(app, make_user())  # auth passes; the gate itself 404s
+        with patch(f"{ROUTES_MODULE}.list_user_assistants", new_callable=AsyncMock, return_value=([], None)):
+            resp = TestClient(app).get("/agents")
+        assert resp.status_code == 404
+
+    def test_available_when_flag_on(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.list_user_assistants", new_callable=AsyncMock, return_value=([], None)), patch(
+            f"{ROUTES_MODULE}.list_shared_with_user", new_callable=AsyncMock, return_value=[]
+        ):
+            resp = TestClient(app).get("/agents")
+        assert resp.status_code == 200
+        assert resp.json()["agents"] == []
+
+
+# --------------------------------------------------------------------------- projection
+class TestAgentProjection:
+    def test_list_projects_agent_id_and_synthesizes_kb_binding(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{ROUTES_MODULE}.list_user_assistants", new_callable=AsyncMock, return_value=([_make_assistant()], None)
+        ), patch(f"{ROUTES_MODULE}.list_shared_with_user", new_callable=AsyncMock, return_value=[]):
+            resp = TestClient(app).get("/agents")
+        assert resp.status_code == 200
+        agent = resp.json()["agents"][0]
+        assert agent["agentId"] == "ast-001"
+        assert "assistantId" not in agent
+        # Legacy row → compat synthesizes a knowledge_base binding reffing the id.
+        assert agent["bindings"] == [
+            {"kind": "knowledge_base", "ref": "ast-001", "config": {"vectorIndexId": "idx-001"}}
+        ]
+
+    def test_get_exposes_bindings_and_modelconfig(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        agent = _make_assistant(
+            bindings=[AgentBinding(kind="memory_space", ref="spc_1", config={"access": "readwrite"})],
+            model_settings=AgentModelConfig(model_id="m1", params={"temperature": 0.7}),
+        )
+        with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check", new_callable=AsyncMock, return_value=(agent, "owner")
+        ):
+            resp = TestClient(app).get("/agents/ast-001")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["modelConfig"] == {"modelId": "m1", "params": {"temperature": 0.7}}
+        assert body["bindings"][0]["kind"] == "memory_space"
+        assert body["userPermission"] == "owner"
+
+    def test_get_404_when_missing(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=False):
+            resp = TestClient(app).get("/agents/ghost")
+        assert resp.status_code == 404
+
+    def test_get_403_when_access_denied(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check", new_callable=AsyncMock, return_value=(None, None)
+        ):
+            resp = TestClient(app).get("/agents/ast-001")
+        assert resp.status_code == 403
+
+
+# --------------------------------------------------------------------------- writes
+class TestAgentWrites:
+    def test_create_validates_then_persists(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        created = _make_assistant()
+        with patch(f"{ROUTES_MODULE}.validate_agent_write", new_callable=AsyncMock) as v, patch(
+            f"{ROUTES_MODULE}.create_assistant", new_callable=AsyncMock, return_value=created
+        ):
+            resp = TestClient(app).post(
+                "/agents", json={"name": "My Agent", "description": "d", "instructions": "i"}
+            )
+        assert resp.status_code == 200
+        assert resp.json()["agentId"] == "ast-001"
+        v.assert_awaited_once()
+
+    def test_create_surfaces_validation_403(self, app, make_user, _flag_on):
+        from apis.app_api.agents.services.binding_validation import BindingValidationError
+
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{ROUTES_MODULE}.validate_agent_write",
+            new_callable=AsyncMock,
+            side_effect=BindingValidationError("no access to model 'm1'", status_code=403),
+        ):
+            resp = TestClient(app).post(
+                "/agents",
+                json={"name": "X", "description": "d", "instructions": "i", "modelConfig": {"modelId": "m1"}},
+            )
+        assert resp.status_code == 403
+        assert "no access" in resp.json()["detail"]
+
+    def test_update_gates_on_permission(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        existing = _make_assistant()
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(existing, "viewer"),
+        ):
+            resp = TestClient(app).put("/agents/ast-001", json={"name": "New"})
+        assert resp.status_code == 403
+
+    def test_delete_204(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.delete_assistant", new_callable=AsyncMock, return_value=True):
+            resp = TestClient(app).delete("/agents/ast-001")
+        assert resp.status_code == 204
+
+
+# --------------------------------------------------------------------------- shares
+class TestAgentShares:
+    def test_get_shares_projects_agent_id(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        existing = _make_assistant()
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(existing, "owner"),
+        ), patch(
+            f"{ROUTES_MODULE}.list_assistant_shares",
+            new_callable=AsyncMock,
+            return_value=[{"email": "bob@x.edu", "permission": "viewer"}],
+        ):
+            resp = TestClient(app).get("/agents/ast-001/shares")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agentId"] == "ast-001"
+        assert body["sharedWith"] == [{"email": "bob@x.edu", "permission": "viewer"}]
+
+    def test_share_404_when_not_owned(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.share_assistant", new_callable=AsyncMock, return_value=False):
+            resp = TestClient(app).post("/agents/ast-001/shares", json={"emails": ["b@x.edu"], "permission": "viewer"})
+        assert resp.status_code == 404


### PR DESCRIPTION
## Agent Designer — Phase 1, PR-3 (the `/agents` surface, dark)

Builds on #591. Adds the governed **Agent** read/write surface — a thin alias over the evolved assistant store returning the Agent shape (`modelConfig` + `bindings`) via `compat.to_agent_view`. **Deploys dark:** the whole surface 404s until `AGENTS_API_ENABLED=true`, and `/assistants/*` is completely unaffected.

### What's here
- **`feature_flags.agents_enabled()`** — `AGENTS_API_ENABLED`, **default off** (the `MEMORY_SPACES_ENABLED` incremental-build pattern). `require_agents_enabled` 404-gates every route.
- **`app_api/agents/routes.py`** — `draft`, `create`, `list`, `get`, `update`, `delete`, and the 4 `shares` endpoints. Each delegates to the **same** `apis.shared.assistants` service functions and identity-based access gates as `/assistants`, then reprojects to `AgentResponse`. `create`/`update` run the PR-2 `binding_validation`.
- **`AgentResponse` / `AgentsListResponse` / `AgentSharesResponse`** — `agentId == assistantId`; legacy ids valid unchanged.
- **`main.py`** mounts the router.

### Scope decisions
- **`test-chat` + document sub-routes excluded.** `test-chat` is the sole reason the assistants router is on the architecture import-boundary allow-list; aliasing it would force a second exception. Those stay on `/assistants/*`.
- **`GET /agents` = owner + shared-with-me.** `include_public`/pagination parity is deferred to the Phase-4 Designer that will actually consume the list. The detail `GET` carries full bindings, which is what matters now.

### Testing
47 tests pass (12 new agent-route tests: 404-gate, `agentId`/bindings/`modelConfig` projection, CRUD permission gating, shares) + `/assistants` regression + the architecture import-boundary gate. App boots with all 4 route groups mounted.

### Next
- **PR-4:** dogfood — make **Oliver** a real Agent with a `memory_space` binding (flip the flag in dev, create the record, docs). Its binding goes live when Phase 3 harness resolution lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)