### PR TITLE
feat(agents): Agent Designer Phase 1 — AGENTS_API_ENABLED flag plumbing + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented in this file. Format follows 
 
 For narrative release notes written for operators and product owners, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+Agent Designer — Phase 1 (foundation). Evolves the assistant store in place into a primitive-agnostic **Agent** contract (governed `modelConfig` + uniform `bindings[]`) and adds a governed `/agents/*` surface, shipped dark behind a per-environment flag. Fully back-compatible: legacy Assistants read as Agents via a compat mapping and `/assistants/*` is unchanged.
+
+### ✨ Added
+
+- Agent contract in the shared assistant models: `AgentModelConfig` (governed single-select model; stored as `modelConfig`) and uniform `AgentBinding[]` (`knowledge_base` | `tool` | `skill` | `memory_space`), both optional and additive on the existing record (#591)
+- D2 compat mapping (`compat.py`): a legacy Assistant projects to an Agent with a `knowledge_base` binding synthesized on read (reffing the assistant id) and no fabricated model (#591)
+- Design-time `binding_validation` composing existing per-primitive RBAC (model access, memory `resolve_permission`) with inert shape-only checks for `tool`/`skill`; assistants `POST`/`PUT` validate and persist the new fields, with `modelConfig.params` floats round-tripped through DynamoDB `Decimal` (#591)
+- Governed `/agents/*` surface (draft/create/list/get/update/delete + shares) returning the Agent shape via `to_agent_view`; delegates to the same shared service + access gates as `/assistants` (#592)
+
+### 🏗️ Infrastructure
+
+- `AGENTS_API_ENABLED` app-api env var wired through CDK config (`CDK_AGENTS_API_ENABLED`, default off, mirroring `memorySpaces`); the `/agents/*` routes 404 until an environment opts in
+
 ## [1.0.4] - 2026-07-01
 
 IAM hotfix restoring AgentCore Memory. Both the App API task role and the AgentCore Runtime execution role were missing `bedrock-agentcore:GetMemory`, which `get_memory_strategies()` needs to resolve strategy IDs — breaking the memory dashboard (empty results) and long-term recall (retrieval silently disabled). Ships via the platform (CDK) pipeline; no migration.

--- a/docs/specs/agent-designer.md
+++ b/docs/specs/agent-designer.md
@@ -194,14 +194,28 @@ No big-bang: legacy ids and the compat mapping keep everything running throughou
 ## Phasing
 
 ```
-Phase 0  This spec — contracts, term map, AWS-federation decision            ← here
-Phase 1  Agent record + uniform binding model + compat mapping (back-compat)  ← memory binding DEFINED here
-Phase 2  Bindable-primitives catalog API (Registry-lite, RBAC-composed)       ← the palette
+Phase 0  This spec — contracts, term map, AWS-federation decision            ✅ done (#590)
+Phase 1  Agent record + uniform binding model + compat mapping (back-compat)  ✅ done (#591, #592, + flag plumbing)
+Phase 2  Bindable-primitives catalog API (Registry-lite, RBAC-composed)       ← the palette (next)
 Phase 3  Harness resolution: memory index injection + memory_* tools + model   ← Workstream B payoff (thin slice, D6)
 Phase 4  Agent Designer page (Agent Harness Editor)                            ← the headline UI, on P1–P2 contracts
 Phase 5  Assistant deprecation + migration
 Later    Federate AgentCore Registry / managed Harness as catalog+run backends (D1)
 ```
+
+**Phase 1 status (implemented).** The Agent contract (`modelConfig` + uniform `bindings[]`),
+the D2 compat mapping (legacy Assistant → Agent, KB binding synthesized on read), design-time
+`binding_validation` composing the existing per-primitive RBAC checks (D4), and the governed
+`/agents/*` surface (dark behind `AGENTS_API_ENABLED`, default off) all landed. Two Phase-1
+refinements vs this spec's sketch: (a) `knowledge_base` bindings are **synthesized on read but
+rejected on write** — the KB index isn't user-configurable and the agent id doesn't exist at
+create time, so an author-settable KB binding is meaningless until F4; (b) `modelConfig` is
+**optional in storage** (absent = resolve the model exactly as today) and required only at
+Designer write-time — no legacy assistant carries a model, so a "required singleton" invariant
+would force a fabricated backfill. `tool`/`skill` binding kinds are enum-valid but **inert**
+(stored, not resolved) until Phase 2/3. **The live Oliver dogfood (D6) is gated on Phase 3
+harness resolution + Memory Spaces being deployed to the target environment** — the binding is
+storable now but nothing consumes it at invocation yet.
 
 **Relationship to Workstream B (memory spec):** B's binding (`memorySpaces` declarative config) now
 lands as a `memory_space` **Binding** on the Agent's uniform model rather than a bespoke field. B1 =

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -51,6 +51,7 @@ export interface AppConfig {
   kbSync: KbSyncConfig;
   scheduledRuns: ScheduledRunsConfig;
   memorySpaces: MemorySpacesConfig;
+  agents: AgentsConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
   mcpSandbox: McpSandboxConfig;
@@ -165,6 +166,17 @@ export interface ScheduledRunsConfig {
  * MEMORY_SPACES_ENABLED env var on app-api and inference-api.
  */
 export interface MemorySpacesConfig {
+  enabled: boolean;
+}
+
+/**
+ * Agent Designer feature flag. Default OFF with an on switch — the governed
+ * `/agents/*` surface is opt-in per environment, enabled with
+ * CDK_AGENTS_API_ENABLED=true (or an `agents.enabled: true` cdk.json context).
+ * Sets the AGENTS_API_ENABLED env var on app-api. The feature ships
+ * incrementally, so it stays dark until complete; `/assistants/*` is unaffected.
+ */
+export interface AgentsConfig {
   enabled: boolean;
 }
 
@@ -325,6 +337,15 @@ export function loadConfig(scope: cdk.App): AppConfig {
       enabled: process.env.CDK_MEMORY_SPACES_ENABLED
         ? process.env.CDK_MEMORY_SPACES_ENABLED === 'true'
         : scope.node.tryGetContext('memorySpaces')?.enabled ?? false,
+    },
+    agents: {
+      // Default OFF with an on switch (same pattern as memorySpaces): opt-in per
+      // environment. The workflow forwards an EMPTY STRING when unset, so treat
+      // empty/unset as the default (off) and only the literal "true" as on. An
+      // `agents.enabled` cdk.json context can also force it on.
+      enabled: process.env.CDK_AGENTS_API_ENABLED
+        ? process.env.CDK_AGENTS_API_ENABLED === 'true'
+        : scope.node.tryGetContext('agents')?.enabled ?? false,
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -292,6 +292,10 @@ export function buildAppApiEnvironment(
     MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
     DYNAMODB_MEMORY_SPACES_TABLE_NAME: params.memorySpacesTableName,
     S3_MEMORY_SPACES_BUCKET_NAME: params.memorySpacesBucketName,
+    // Kill switch for the Agent Designer /agents surface (default off per env).
+    // Gates only whether the routes 404; the assistant store it reads is always
+    // present, so no extra table/bucket wiring is needed here.
+    AGENTS_API_ENABLED: config.agents.enabled ? 'true' : 'false',
     VOICE_TICKET_REPLAY_TABLE_NAME: params.voiceTicketReplayTableName,
     VOICE_TICKET_SIGNING_SECRET_ARN: params.voiceTicketSigningSecretArn,
   };

--- a/infrastructure/test/app-api-environment.test.ts
+++ b/infrastructure/test/app-api-environment.test.ts
@@ -40,4 +40,15 @@ describe('buildAppApiEnvironment — Memory Spaces', () => {
     );
     expect(on.MEMORY_SPACES_ENABLED).toBe('true');
   });
+
+  it('gates the /agents surface on AGENTS_API_ENABLED (default off)', () => {
+    const off = buildAppApiEnvironment(createMockConfig(), stubParams());
+    expect(off.AGENTS_API_ENABLED).toBe('false');
+
+    const on = buildAppApiEnvironment(
+      createMockConfig({ agents: { enabled: true } }),
+      stubParams(),
+    );
+    expect(on.AGENTS_API_ENABLED).toBe('true');
+  });
 });

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -54,6 +54,9 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     memorySpaces: {
       enabled: false,
     },
+    agents: {
+      enabled: false,
+    },
     fineTuning: {},
     artifacts: {
       retentionDays: 90,


### PR DESCRIPTION
## Agent Designer — Phase 1, PR-4 (deployability + docs)

Builds on #591 + #592. Completes Phase 1 by making the `/agents` surface **turn-on-able per environment**, and documents Phase-1 status. No application-logic change; no new AWS resources.

### What's here
- **CDK config plumbing** — `AgentsConfig { enabled }`, driven by `CDK_AGENTS_API_ENABLED` (default **off**, empty-string-safe) or an `agents.enabled` cdk.json context, **mirroring `memorySpaces` exactly**. Sets `AGENTS_API_ENABLED` on app-api. The flag only gates whether the `/agents/*` routes 404 — the assistant store they read is always present, so no table/bucket wiring is needed.
- **Infra tests** — default-off / opt-on assertion in `app-api-environment.test.ts`; `mock-config` default.
- **Docs** — `agent-designer.md` Phase-1 status (marks P0/P1 done, records the two refinements: KB synth-on-read/reject-on-write, and `modelConfig` optional-in-storage); `CHANGELOG.md` `[Unreleased]`.

### Deliberately NOT here — the live Oliver dogfood
D6's payoff (Oliver *reads* his bound Memory Space) is gated on two things not yet in place: **Phase 3 harness resolution** (nothing consumes a `memory_space` binding at invocation yet) and **Memory Spaces deployed to the target environment** (per the memory-spaces app-api wiring note). Shipping a seeded Oliver now would store a binding that can't resolve. It's the headline Phase-3 deliverable instead.

### Testing
`npx tsc --noEmit` clean; 67 infra tests pass (incl. the new `AGENTS_API_ENABLED` gate).

### Next
**Phase 2** (bindable-primitives catalog — the RBAC palette) or **Phase 3** (harness resolution — the memory dogfood payoff). Recommend Phase 3 to cash in D6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)