### PR TITLE
feat(agents): Agent Designer Phase 3 — harness resolution (model + read-only memory)

### DIFF
--- a/backend/src/apis/inference_api/chat/agent_binding_resolver.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_resolver.py
@@ -21,12 +21,17 @@ Phase 3 lands incrementally:
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from apis.shared.assistants.models import Assistant
 from apis.shared.auth.models import User
+from apis.shared.feature_flags import memory_spaces_enabled
+from apis.shared.memory.service import MemorySpaceService
 from apis.shared.rbac.service import get_app_role_service
+
+_ROLE_RANK = {"viewer": 1, "editor": 2, "owner": 3}
 
 
 class AgentBindingBlockedError(Exception):
@@ -50,14 +55,33 @@ class ResolvedModel:
 
 
 @dataclass
+class ResolvedMemoryBinding:
+    """A ``memory_space`` binding resolved for the invoking user.
+
+    ``role``/``access`` decide what the Harness may do: ``access`` is the *authored*
+    intent (``read``|``readwrite``), ``role`` is the invoker's actual grant. A
+    ``readwrite`` binding requires the invoker to be ``editor+`` (else the resolver
+    blocks — no silent read-only downgrade, D5). ``always_load`` drives prompt injection.
+    """
+
+    space_id: str
+    space_name: str
+    role: str
+    access: str
+    always_load: Optional[List[str]] = None
+
+
+@dataclass
 class AgentInvocationPlan:
     """What the Harness should apply for this turn after resolving the Agent.
 
     ``model_override`` is ``None`` when the Agent pins no model — the caller then
-    resolves the model exactly as today. (Memory resolution lands in a later PR.)
+    resolves the model exactly as today. ``memory`` is ``None`` when the Agent binds no
+    Memory Space.
     """
 
     model_override: Optional[ResolvedModel] = None
+    memory: Optional[ResolvedMemoryBinding] = None
 
 
 async def resolve_agent_invocation(assistant: Assistant, invoker: User) -> AgentInvocationPlan:
@@ -84,4 +108,52 @@ async def resolve_agent_invocation(assistant: Assistant, invoker: User) -> Agent
             params=model_settings.params,
         )
 
+    plan.memory = await _resolve_memory(assistant, invoker)
     return plan
+
+
+async def _resolve_memory(assistant: Assistant, invoker: User) -> Optional[ResolvedMemoryBinding]:
+    """Resolve the Agent's ``memory_space`` binding for ``invoker`` (D5); raise on block.
+
+    v1 supports one Memory Space per Agent (Phase-1 UI writes at most one); any extras are
+    ignored. Reads permission via ``MemorySpaceService`` (the same identity-based
+    ``resolve_permission`` the app-api surface uses — D4), wrapped in a thread since it's
+    sync boto3.
+    """
+    memory_bindings = [b for b in (assistant.bindings or []) if b.kind == "memory_space"]
+    if not memory_bindings:
+        return None
+
+    if not memory_spaces_enabled():
+        # Design-time validation refuses to create these while the flag is off, so
+        # hitting this means environment drift — block rather than silently drop (D5).
+        raise AgentBindingBlockedError(
+            "This agent uses Memory, which isn't enabled in this environment."
+        )
+
+    binding = memory_bindings[0]
+    access = (binding.config or {}).get("access", "read")
+
+    service = MemorySpaceService()
+    space, role = await asyncio.to_thread(
+        service.resolve_permission, binding.ref, invoker.user_id, invoker.email
+    )
+    if space is None:
+        raise AgentBindingBlockedError(
+            "This agent's Memory Space no longer exists. Ask its owner to reconnect it."
+        )
+
+    required = "editor" if access == "readwrite" else "viewer"
+    if role is None or _ROLE_RANK[role] < _ROLE_RANK[required]:
+        raise AgentBindingBlockedError(
+            f"This agent needs **{required}** access to its Memory Space "
+            f'"{space.name}", which your account doesn\'t have.'
+        )
+
+    return ResolvedMemoryBinding(
+        space_id=binding.ref,
+        space_name=space.name,
+        role=role,
+        access=access,
+        always_load=(binding.config or {}).get("alwaysLoad"),
+    )

--- a/backend/src/apis/inference_api/chat/agent_binding_resolver.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_resolver.py
@@ -1,0 +1,87 @@
+"""Agent Designer Phase 3 — run-time binding resolution (the Harness side).
+
+At invocation the Harness re-resolves an Agent's ``modelConfig`` + ``bindings`` against
+the **invoking** user (D5), not the author — an Agent is shared but its capabilities are
+gated per user. v1 policy is **block-with-message**: if the invoker lacks a required
+capability the turn raises ``AgentBindingBlockedError`` and the route streams a
+conversational error (SSE ``stream_error``) rather than silently downgrading.
+
+This module lives in inference-api and may import only ``apis.shared`` (never
+``apis.app_api`` — the design-time ``binding_validation`` there is a different concern and
+would break the import boundary). It reuses the harness's existing per-primitive access
+checks; it invents no new RBAC (D4).
+
+Phase 3 lands incrementally:
+- **PR-A (here):** ``modelConfig`` → ``model_override``, reusing the exact
+  ``AppRoleService.can_access_model`` gate the harness already enforces (R2). Absent
+  ``modelConfig`` ⇒ no override ⇒ today's model-resolution chain is untouched.
+- **Later:** ``memory_space`` bindings → index injection + ``memory_*`` tools (PR-C+).
+  ``knowledge_base`` stays with the existing RAG path; ``tool``/``skill`` are inert.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from apis.shared.assistants.models import Assistant
+from apis.shared.auth.models import User
+from apis.shared.rbac.service import get_app_role_service
+
+
+class AgentBindingBlockedError(Exception):
+    """The invoking user lacks a capability the Agent requires (D5 block-with-message).
+
+    ``message`` is markdown shown to the user as the assistant turn.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+@dataclass
+class ResolvedModel:
+    """A governed model selection resolved for the invoking user."""
+
+    model_id: str
+    provider: Optional[str] = None
+    params: Optional[dict] = None
+
+
+@dataclass
+class AgentInvocationPlan:
+    """What the Harness should apply for this turn after resolving the Agent.
+
+    ``model_override`` is ``None`` when the Agent pins no model — the caller then
+    resolves the model exactly as today. (Memory resolution lands in a later PR.)
+    """
+
+    model_override: Optional[ResolvedModel] = None
+
+
+async def resolve_agent_invocation(assistant: Assistant, invoker: User) -> AgentInvocationPlan:
+    """Resolve an Agent's governed capabilities for ``invoker``; raise on a block (D5).
+
+    PR-A resolves only ``modelConfig``. The model is access-checked against the invoker
+    with the same ``AppRoleService.can_access_model`` the harness uses elsewhere (R2), so
+    an author cannot compose a model the invoker is later blocked on at model-resolution
+    time.
+    """
+    plan = AgentInvocationPlan()
+
+    model_settings = assistant.model_settings
+    if model_settings is not None:
+        app_role_service = get_app_role_service()
+        if not await app_role_service.can_access_model(invoker, model_settings.model_id):
+            raise AgentBindingBlockedError(
+                f"This agent runs on **{model_settings.model_id}**, which isn't available "
+                "to your account. Ask an administrator for access, or use a different agent."
+            )
+        plan.model_override = ResolvedModel(
+            model_id=model_settings.model_id,
+            provider=model_settings.provider,
+            params=model_settings.params,
+        )
+
+    return plan

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1138,10 +1138,11 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     context_chunks = None
     augmented_message = input_data.message
     system_prompt = input_data.system_prompt  # Start with provided system prompt
-    # Agent Designer Phase 3: governed model override resolved per invoking user
-    # (D5). None ⇒ the model resolves exactly as today. Set in the assistant block
-    # below, consumed at model resolution; stays None on resume/continuation.
+    # Agent Designer Phase 3: governed capabilities resolved per invoking user
+    # (D5). None ⇒ resolve exactly as today. Set in the assistant block below,
+    # consumed at model resolution / prompt assembly; None on resume/continuation.
     agent_model_override = None
+    agent_memory = None
 
     logger.info(
         "Invocation request - processing with assistant context"
@@ -1266,6 +1267,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             try:
                 agent_plan = await resolve_agent_invocation(assistant, current_user)
                 agent_model_override = agent_plan.model_override
+                agent_memory = agent_plan.memory
             except AgentBindingBlockedError as block:
                 blocked_event = ConversationalErrorEvent(
                     code=ErrorCode.FORBIDDEN, message=block.message, recoverable=False
@@ -1347,6 +1349,31 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             logger.info(
                 "Assistant has no instructions - using fallback system prompt"
             )
+
+        # 5b. Agent Designer Phase 3: inject the bound Memory Space content (read-only)
+        # after instructions, in either branch. Hydration re-reads via the invoker
+        # (MemorySpaceService re-checks viewer+ internally). Empty for a fresh space.
+        if agent_memory is not None:
+            from apis.shared.memory.hydration import render_memory_block, resolve_always_load
+            from apis.shared.memory.service import MemorySpaceService
+
+            try:
+                fragments = await asyncio.to_thread(
+                    resolve_always_load,
+                    MemorySpaceService(),
+                    agent_memory.space_id,
+                    user_id,
+                    current_user.email,
+                    agent_memory.always_load,
+                )
+                memory_block = render_memory_block(agent_memory.space_name, fragments)
+                if memory_block:
+                    system_prompt = f"{system_prompt}\n\n{memory_block}" if system_prompt else memory_block
+                    logger.info("Injected bound Memory Space content into system prompt")
+            except Exception:
+                # Never fail a turn on a memory-read hiccup — the permission was already
+                # resolved; injection is best-effort context.
+                logger.error("Failed to hydrate bound Memory Space; continuing", exc_info=True)
 
         # 6. Save assistant_id to session preferences (persist for future loads)
         # Skip persistence for preview sessions

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -26,7 +26,7 @@ from apis.shared.errors import (
     ErrorCode,
     build_conversational_error_event,
 )
-from apis.shared.feature_flags import skills_enabled
+from apis.shared.feature_flags import agents_enabled, skills_enabled
 from apis.shared.files.file_resolver import get_file_resolver
 from apis.shared.models.managed_models import list_managed_models
 from apis.shared.platform_settings.models import DEFAULT_CHAT_MODE, ChatModeSettings
@@ -41,6 +41,10 @@ from apis.shared.quota import (
 )
 
 from apis.shared.rbac.service import get_app_role_service
+from apis.inference_api.chat.agent_binding_resolver import (
+    AgentBindingBlockedError,
+    resolve_agent_invocation,
+)
 from apis.shared.sessions.metadata import ensure_session_metadata_exists
 from apis.shared.user_settings.repository import UserSettingsRepository
 
@@ -1134,6 +1138,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     context_chunks = None
     augmented_message = input_data.message
     system_prompt = input_data.system_prompt  # Start with provided system prompt
+    # Agent Designer Phase 3: governed model override resolved per invoking user
+    # (D5). None ⇒ the model resolves exactly as today. Set in the assistant block
+    # below, consumed at model resolution; stays None on resume/continuation.
+    agent_model_override = None
 
     logger.info(
         "Invocation request - processing with assistant context"
@@ -1250,6 +1258,30 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 await resume_inactive_policies(input_data.rag_assistant_id)
         except Exception as bump_err:
             logger.warning(f"lastUsedAt bump failed for assistant {input_data.rag_assistant_id}: {bump_err}")
+
+        # 2b. Agent Designer Phase 3 — resolve the Agent's governed capabilities
+        # for the INVOKING user (D5), before the expensive KB search. v1 blocks
+        # with a conversational message when the invoker lacks a required model.
+        if agents_enabled():
+            try:
+                agent_plan = await resolve_agent_invocation(assistant, current_user)
+                agent_model_override = agent_plan.model_override
+            except AgentBindingBlockedError as block:
+                blocked_event = ConversationalErrorEvent(
+                    code=ErrorCode.FORBIDDEN, message=block.message, recoverable=False
+                )
+                return StreamingResponse(
+                    stream_conversational_message(
+                        message=block.message,
+                        stop_reason="error",
+                        metadata_event=blocked_event,
+                        session_id=input_data.session_id,
+                        user_id=user_id,
+                        user_input=input_data.message,
+                    ),
+                    media_type="text/event-stream",
+                    headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no", "X-Session-ID": input_data.session_id},
+                )
 
         # 3. Search assistant knowledge base
         logger.info("Starting knowledge base search for assistant...")
@@ -1486,6 +1518,12 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             # saved preference is silently ignored at chat time (#161).
             effective_model_id = input_data.model_id
             effective_provider = input_data.provider
+            if agent_model_override is not None:
+                # The Agent's governed modelConfig wins over the request / user-default
+                # chain. Already access-checked against the invoker in the resolver (R2),
+                # so the earlier request-only gate at the top doesn't leave a hole.
+                effective_model_id = agent_model_override.model_id
+                effective_provider = agent_model_override.provider or effective_provider
             if not effective_model_id:
                 user_default_id, user_default_provider = await _resolve_user_default_model(user_id)
                 if user_default_id:
@@ -1503,6 +1541,12 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                         logger.info(
                             "User default model exists but RBAC denies access; falling back to system default"
                         )
+
+            # Agent-authored params sit as defaults BENEATH explicit request params,
+            # then flow through _resolve_model_settings' admin bounds/locks like any
+            # other request params — an author can't smuggle out-of-bounds values.
+            if agent_model_override is not None and agent_model_override.params:
+                request_inference_params = {**agent_model_override.params, **request_inference_params}
 
             # Single registry lookup resolves caching + inference params +
             # the Mantle endpoint path, merging admin defaults with request

--- a/backend/src/apis/shared/memory/hydration.py
+++ b/backend/src/apis/shared/memory/hydration.py
@@ -1,0 +1,147 @@
+"""Agent Designer Phase 3 — Memory-Space content hydration for prompt injection.
+
+Resolves a ``memory_space`` binding's ``config.alwaysLoad`` list into concrete text
+fragments to inject into an Agent's system prompt at invocation. Lives in ``apis.shared``
+so both the Harness (inference-api) and any future app-api preview/"context breakdown"
+surface can reuse it.
+
+``alwaysLoad`` addressing scheme (see ``templates.py`` / the memory spec):
+- ``"MEMORY.md"``            → the space index text (``read_index``).
+- ``"latest:<type>/<prefix>"`` → the most-recently-updated manifest entry whose
+  ``entry_type`` matches ``<type>`` and whose slug starts with ``<prefix>`` (e.g.
+  ``latest:episodic/daily``). If ``<type>`` isn't a valid ``EntryType`` the whole
+  remainder is treated as a slug prefix with no type filter.
+- any other string          → an exact entry slug (``read_entry``).
+
+A missing entry is skipped (an empty space, or an entry deleted since the binding was
+authored, must never fail the turn). Injection is budget-capped: over-budget fragments are
+truncated with a marker so the model knows to fetch the rest via a ``memory_read`` tool.
+All reads run through ``MemorySpaceService``, which re-checks the caller's ``viewer+`` grant
+internally — so hydration cannot leak a space the invoker can't read.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+from apis.shared.memory.service import MemorySpaceNotFoundError, MemorySpaceService
+
+_VALID_ENTRY_TYPES = {"entity", "episodic", "fact"}
+DEFAULT_ALWAYS_LOAD = ["MEMORY.md"]
+
+# Total injected memory budget (bytes). ~24 KB ≈ 6k tokens — headroom over the
+# documented steady state (~200 entries ≈ 4k tokens). Override per environment.
+_DEFAULT_MAX_TOTAL_BYTES = 24_000
+_TRUNCATION_MARKER = "\n…[truncated — use memory_read to fetch the full entry]"
+
+
+@dataclass
+class LoadedFragment:
+    """One resolved piece of memory to inject: a human label + its text."""
+
+    label: str
+    text: str
+
+
+def _max_total_bytes() -> int:
+    raw = os.environ.get("MEMORY_INJECTION_MAX_BYTES")
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_MAX_TOTAL_BYTES
+
+
+def _resolve_latest(
+    service: MemorySpaceService, space_id: str, user_id: str, user_email: Optional[str], rest: str
+) -> Optional[tuple]:
+    """Resolve a ``latest:<type>/<prefix>`` spec → (slug, text) or None."""
+    if "/" in rest:
+        type_part, prefix = rest.split("/", 1)
+    else:
+        type_part, prefix = rest, ""
+    entry_type = type_part if type_part in _VALID_ENTRY_TYPES else None
+    # If the first segment isn't a valid type, treat the whole remainder as a slug prefix.
+    if entry_type is None:
+        prefix = rest
+
+    entries = service.list_entries(space_id, user_id, user_email, entry_type=entry_type)
+    if prefix:
+        entries = [e for e in entries if e.slug.startswith(prefix)]
+    if not entries:
+        return None
+    latest = max(entries, key=lambda e: e.updated)
+    return latest.slug, service.read_entry(space_id, user_id, user_email, latest.slug)
+
+
+def resolve_always_load(
+    service: MemorySpaceService,
+    space_id: str,
+    user_id: str,
+    user_email: Optional[str],
+    always_load: Optional[List[str]],
+    *,
+    max_total_bytes: Optional[int] = None,
+) -> List[LoadedFragment]:
+    """Resolve ``always_load`` specs into injectable fragments, within a byte budget.
+
+    Synchronous (``MemorySpaceService`` is sync boto3) — callers on the event loop wrap
+    this in ``asyncio.to_thread``. Never raises for a missing entry; a genuinely broken
+    read (permission revoked mid-turn, store error) propagates.
+    """
+    specs = always_load if always_load else DEFAULT_ALWAYS_LOAD
+    budget = _max_total_bytes() if max_total_bytes is None else max_total_bytes
+
+    fragments: List[LoadedFragment] = []
+    used = 0
+    for spec in specs:
+        if used >= budget:
+            break
+        try:
+            if spec == "MEMORY.md":
+                text, label = service.read_index(space_id, user_id, user_email), "MEMORY.md"
+            elif spec.startswith("latest:"):
+                resolved = _resolve_latest(service, space_id, user_id, user_email, spec[len("latest:"):])
+                if resolved is None:
+                    continue
+                slug, text = resolved
+                label = f"{spec} → {slug}"
+            else:
+                text, label = service.read_entry(space_id, user_id, user_email, spec), spec
+        except MemorySpaceNotFoundError:
+            # Entry/index deleted since the binding was authored — skip, don't fail.
+            continue
+
+        if not text:
+            continue
+
+        encoded = text.encode("utf-8")
+        remaining = budget - used
+        if len(encoded) > remaining:
+            text = encoded[:remaining].decode("utf-8", errors="ignore") + _TRUNCATION_MARKER
+            used = budget
+        else:
+            used += len(encoded)
+        fragments.append(LoadedFragment(label=label, text=text))
+
+    return fragments
+
+
+def render_memory_block(space_name: str, fragments: List[LoadedFragment]) -> str:
+    """Render resolved fragments into a delimited system-prompt block.
+
+    Empty when there are no fragments (a fresh space injects nothing).
+    """
+    if not fragments:
+        return ""
+    parts = [
+        f'## Bound Memory — "{space_name}"',
+        "This is your persistent memory for this agent. Fetch more with `memory_read` / "
+        "list with `memory_list`.",
+    ]
+    for frag in fragments:
+        parts.append(f"### {frag.label}\n{frag.text}")
+    return "\n\n".join(parts)

--- a/backend/tests/apis/inference_api/test_agent_binding_resolver.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_resolver.py
@@ -5,6 +5,7 @@ harness's AppRoleService.can_access_model gate (mocked here). Verifies: pinned+a
 model_override; pinned+denied → block; no modelConfig → empty plan (today's behavior).
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,7 +14,7 @@ from apis.inference_api.chat.agent_binding_resolver import (
     AgentBindingBlockedError,
     resolve_agent_invocation,
 )
-from apis.shared.assistants.models import AgentModelConfig, Assistant
+from apis.shared.assistants.models import AgentBinding, AgentModelConfig, Assistant
 from apis.shared.auth.models import User
 
 MODULE = "apis.inference_api.chat.agent_binding_resolver"
@@ -23,7 +24,7 @@ def _user() -> User:
     return User(email="bob@x.edu", user_id="u-bob", name="Bob", roles=[])
 
 
-def _assistant(model_settings=None) -> Assistant:
+def _assistant(model_settings=None, bindings=None) -> Assistant:
     return Assistant(
         assistantId="ast-1",
         ownerId="u-alice",
@@ -37,7 +38,23 @@ def _assistant(model_settings=None) -> Assistant:
         updatedAt="t",
         status="COMPLETE",
         model_settings=model_settings,
+        bindings=bindings,
     )
+
+
+def _patch_memory(monkeypatch, *, enabled=True, space=None, role=None):
+    monkeypatch.setattr(f"{MODULE}.memory_spaces_enabled", lambda: enabled)
+    svc = MagicMock()
+    svc.resolve_permission = MagicMock(return_value=(space, role))
+    monkeypatch.setattr(f"{MODULE}.MemorySpaceService", lambda: svc)
+    return svc
+
+
+def _mem_binding(access="read", ref="spc_1", always_load=None):
+    config = {"access": access}
+    if always_load is not None:
+        config["alwaysLoad"] = always_load
+    return AgentBinding(kind="memory_space", ref=ref, config=config)
 
 
 def _patch_access(monkeypatch, allowed: bool) -> MagicMock:
@@ -82,3 +99,63 @@ class TestModelResolution:
         _patch_access(monkeypatch, False)
         plan = await resolve_agent_invocation(_assistant(model_settings=None), _user())
         assert plan.model_override is None
+
+
+class TestMemoryResolution:
+    _SPACE = SimpleNamespace(name="Oliver's Brain", space_id="spc_1")
+
+    @pytest.mark.asyncio
+    async def test_no_binding_is_none(self, monkeypatch):
+        svc = _patch_memory(monkeypatch)
+        plan = await resolve_agent_invocation(_assistant(bindings=[]), _user())
+        assert plan.memory is None
+        svc.resolve_permission.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_blocks(self, monkeypatch):
+        _patch_memory(monkeypatch, enabled=False)
+        with pytest.raises(AgentBindingBlockedError):
+            await resolve_agent_invocation(_assistant(bindings=[_mem_binding()]), _user())
+
+    @pytest.mark.asyncio
+    async def test_missing_space_blocks(self, monkeypatch):
+        _patch_memory(monkeypatch, space=None, role=None)
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(_assistant(bindings=[_mem_binding()]), _user())
+        assert "no longer exists" in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_read_viewer_resolves(self, monkeypatch):
+        _patch_memory(monkeypatch, space=self._SPACE, role="viewer")
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_mem_binding(access="read", always_load=["MEMORY.md"])]), _user()
+        )
+        assert plan.memory.space_id == "spc_1"
+        assert plan.memory.space_name == "Oliver's Brain"
+        assert plan.memory.access == "read" and plan.memory.role == "viewer"
+        assert plan.memory.always_load == ["MEMORY.md"]
+
+    @pytest.mark.asyncio
+    async def test_readwrite_requires_editor(self, monkeypatch):
+        _patch_memory(monkeypatch, space=self._SPACE, role="viewer")
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(
+                _assistant(bindings=[_mem_binding(access="readwrite")]), _user()
+            )
+        assert "editor" in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_readwrite_editor_resolves(self, monkeypatch):
+        _patch_memory(monkeypatch, space=self._SPACE, role="editor")
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_mem_binding(access="readwrite")]), _user()
+        )
+        assert plan.memory.access == "readwrite" and plan.memory.role == "editor"
+
+    @pytest.mark.asyncio
+    async def test_permission_checked_against_invoker(self, monkeypatch):
+        svc = _patch_memory(monkeypatch, space=self._SPACE, role="viewer")
+        await resolve_agent_invocation(_assistant(bindings=[_mem_binding()]), _user())
+        # resolve_permission(space_id, user_id, user_email) — invoker's identity.
+        args = svc.resolve_permission.call_args.args
+        assert args[0] == "spc_1" and args[1] == "u-bob" and args[2] == "bob@x.edu"

--- a/backend/tests/apis/inference_api/test_agent_binding_resolver.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_resolver.py
@@ -1,0 +1,84 @@
+"""Agent Designer Phase 3 (PR-A) — run-time model resolution + D5 block.
+
+The resolver re-checks the Agent's modelConfig against the INVOKING user, reusing the
+harness's AppRoleService.can_access_model gate (mocked here). Verifies: pinned+allowed →
+model_override; pinned+denied → block; no modelConfig → empty plan (today's behavior).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.inference_api.chat.agent_binding_resolver import (
+    AgentBindingBlockedError,
+    resolve_agent_invocation,
+)
+from apis.shared.assistants.models import AgentModelConfig, Assistant
+from apis.shared.auth.models import User
+
+MODULE = "apis.inference_api.chat.agent_binding_resolver"
+
+
+def _user() -> User:
+    return User(email="bob@x.edu", user_id="u-bob", name="Bob", roles=[])
+
+
+def _assistant(model_settings=None) -> Assistant:
+    return Assistant(
+        assistantId="ast-1",
+        ownerId="u-alice",
+        ownerName="Alice",
+        name="Oliver",
+        description="d",
+        instructions="i",
+        vectorIndexId="idx",
+        visibility="SHARED",
+        createdAt="t",
+        updatedAt="t",
+        status="COMPLETE",
+        model_settings=model_settings,
+    )
+
+
+def _patch_access(monkeypatch, allowed: bool) -> MagicMock:
+    svc = MagicMock()
+    svc.can_access_model = AsyncMock(return_value=allowed)
+    monkeypatch.setattr(f"{MODULE}.get_app_role_service", lambda: svc)
+    return svc
+
+
+class TestModelResolution:
+    @pytest.mark.asyncio
+    async def test_no_modelconfig_is_empty_plan(self, monkeypatch):
+        svc = _patch_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(_assistant(model_settings=None), _user())
+        assert plan.model_override is None
+        # No modelConfig ⇒ we must not even consult model RBAC (today's behavior).
+        svc.can_access_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allowed_model_sets_override(self, monkeypatch):
+        _patch_access(monkeypatch, True)
+        cfg = AgentModelConfig(model_id="us.anthropic.opus", provider="bedrock", params={"temperature": 0.5})
+        plan = await resolve_agent_invocation(_assistant(model_settings=cfg), _user())
+        assert plan.model_override.model_id == "us.anthropic.opus"
+        assert plan.model_override.provider == "bedrock"
+        assert plan.model_override.params == {"temperature": 0.5}
+
+    @pytest.mark.asyncio
+    async def test_denied_model_blocks_with_message(self, monkeypatch):
+        svc = _patch_access(monkeypatch, False)
+        cfg = AgentModelConfig(model_id="us.anthropic.opus")
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(_assistant(model_settings=cfg), _user())
+        # The block message names the model and is invoker-facing markdown (D5).
+        assert "us.anthropic.opus" in ei.value.message
+        # Checked against the INVOKING user, not the author.
+        assert svc.can_access_model.await_args.args[0].user_id == "u-bob"
+
+    @pytest.mark.asyncio
+    async def test_legacy_assistant_never_blocks(self, monkeypatch):
+        # A legacy row (no model_settings) resolves to an empty plan regardless.
+        _patch_access(monkeypatch, False)
+        plan = await resolve_agent_invocation(_assistant(model_settings=None), _user())
+        assert plan.model_override is None

--- a/backend/tests/shared/test_memory_hydration.py
+++ b/backend/tests/shared/test_memory_hydration.py
@@ -1,0 +1,117 @@
+"""Agent Designer Phase 3 (PR-B) — Memory-Space hydration helper.
+
+Resolves alwaysLoad specs against a fake MemorySpaceService: MEMORY.md, the
+latest:<type>/<prefix> scheme, bare slugs, missing-entry skip, default, budget cap.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from apis.shared.memory.hydration import (
+    DEFAULT_ALWAYS_LOAD,
+    render_memory_block,
+    resolve_always_load,
+)
+from apis.shared.memory.service import MemorySpaceNotFoundError
+
+
+@dataclass
+class _Ref:
+    slug: str
+    entry_type: str
+    updated: str
+
+
+class _FakeService:
+    """Minimal MemorySpaceService stand-in; filters like the real list_entries."""
+
+    def __init__(self, index="", entries=None, bodies=None):
+        self._index = index
+        self._entries = entries or []
+        self._bodies = bodies or {}
+
+    def read_index(self, space_id, user_id, user_email=None):
+        return self._index
+
+    def list_entries(self, space_id, user_id, user_email=None, *, entry_type=None, where=None):
+        return [e for e in self._entries if entry_type is None or e.entry_type == entry_type]
+
+    def read_entry(self, space_id, user_id, user_email, slug):
+        if slug not in self._bodies:
+            raise MemorySpaceNotFoundError(f"entry '{slug}' not found")
+        return self._bodies[slug]
+
+
+def _resolve(service, always_load, **kw):
+    return resolve_always_load(service, "spc_1", "u1", "u1@x.edu", always_load, **kw)
+
+
+class TestHydration:
+    def test_default_is_memory_md(self):
+        frags = _resolve(_FakeService(index="# Index"), None)
+        assert DEFAULT_ALWAYS_LOAD == ["MEMORY.md"]
+        assert [f.label for f in frags] == ["MEMORY.md"]
+        assert frags[0].text == "# Index"
+
+    def test_empty_index_skipped(self):
+        assert _resolve(_FakeService(index=""), ["MEMORY.md"]) == []
+
+    def test_latest_picks_most_recent_matching_type_and_prefix(self):
+        svc = _FakeService(
+            entries=[
+                _Ref("daily-2026-07-05", "episodic", "2026-07-05"),
+                _Ref("daily-2026-07-07", "episodic", "2026-07-07"),
+                _Ref("weekly-2026-07-01", "episodic", "2026-07-01"),
+                _Ref("daily-note", "fact", "2026-07-09"),  # wrong type, ignored
+            ],
+            bodies={"daily-2026-07-07": "latest daily"},
+        )
+        frags = _resolve(svc, ["latest:episodic/daily"])
+        assert len(frags) == 1
+        assert frags[0].label == "latest:episodic/daily → daily-2026-07-07"
+        assert frags[0].text == "latest daily"
+
+    def test_latest_with_invalid_type_treats_whole_as_slug_prefix(self):
+        svc = _FakeService(
+            entries=[_Ref("proj-x", "fact", "2026-07-07")],
+            bodies={"proj-x": "project x"},
+        )
+        frags = _resolve(svc, ["latest:proj"])
+        assert frags[0].text == "project x"
+
+    def test_latest_no_match_skipped(self):
+        assert _resolve(_FakeService(entries=[]), ["latest:episodic/daily"]) == []
+
+    def test_bare_slug_reads_entry(self):
+        svc = _FakeService(bodies={"jane-doe": "Jane's profile"})
+        frags = _resolve(svc, ["jane-doe"])
+        assert frags[0].label == "jane-doe" and frags[0].text == "Jane's profile"
+
+    def test_missing_slug_is_skipped_not_raised(self):
+        assert _resolve(_FakeService(bodies={}), ["ghost"]) == []
+
+    def test_budget_truncates_with_marker(self):
+        svc = _FakeService(index="A" * 500)
+        frags = _resolve(svc, ["MEMORY.md"], max_total_bytes=100)
+        assert frags[0].text.startswith("A" * 100)
+        assert "truncated" in frags[0].text
+
+    def test_budget_stops_further_fragments(self):
+        svc = _FakeService(index="A" * 100, bodies={"e": "B" * 100})
+        frags = _resolve(svc, ["MEMORY.md", "e"], max_total_bytes=100)
+        # First fragment exhausts the budget; the second is not loaded.
+        assert [f.label for f in frags] == ["MEMORY.md"]
+
+
+class TestRenderBlock:
+    def test_empty_when_no_fragments(self):
+        assert render_memory_block("Oliver's Brain", []) == ""
+
+    def test_renders_labeled_sections(self):
+        svc = _FakeService(index="# Index", bodies={"jane": "profile"})
+        frags = _resolve(svc, ["MEMORY.md", "jane"])
+        block = render_memory_block("Oliver's Brain", frags)
+        assert 'Bound Memory — "Oliver\'s Brain"' in block
+        assert "### MEMORY.md" in block and "# Index" in block
+        assert "### jane" in block and "profile" in block

--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -347,6 +347,12 @@ export class InferenceAgentCoreConstruct extends Construct {
         DYNAMODB_MEMORY_SPACES_TABLE_NAME: props.refs.memorySpacesTable.tableName,
         MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
 
+        // Agent Designer harness resolution (Phase 3): the runtime resolves an
+        // Agent's bindings + modelConfig at invocation. Gates that resolution;
+        // default off, mirrors the app-api flag. Without it the harness ignores
+        // bindings entirely (today's behavior).
+        AGENTS_API_ENABLED: config.agents.enabled ? 'true' : 'false',
+
         // Authentication
         ENABLE_QUOTA_ENFORCEMENT: 'true',
 


### PR DESCRIPTION
## Agent Designer — Phase 3: harness resolution (model select + read-only memory injection)

The D6 read-side payoff. The Harness (inference-api) now resolves an Agent's governed `modelConfig` **and** its `memory_space` binding **against the invoking user** at invocation (D5). Dark by default (`AGENTS_API_ENABLED` off everywhere) and **byte-identical to today when an Agent has no modelConfig / no bindings**. Write tools (`memory_write`) are a deliberate follow-up.

Four commits:

- **PR-0** — thread `AGENTS_API_ENABLED` to the inference runtime construct (the resolver runs there).
- **PR-A** — `agent_binding_resolver.py`: model selection re-checked against the invoker via the harness's own `AppRoleService.can_access_model` (R2); block-with-message via `stream_conversational_message` + `stream_error` (D5, not HTTP 403). Override wins at model resolution; agent params sit beneath request params through the managed-model bounds/locks.
- **PR-B** — shared `memory/hydration.py`: resolves `alwaysLoad` specs (`MEMORY.md`, the new `latest:<type>/<prefix>` scheme, bare slugs), byte-budgeted with a truncation marker; skips missing entries.
- **PR-C** — resolver learns `memory_space`: grant re-check via `MemorySpaceService.resolve_permission` (D4), blocks on flag-off / missing-space / `readwrite`+below-editor (no silent downgrade). `routes.py` injects the hydrated block into the system prompt after instructions; best-effort so a memory hiccup never fails a turn.

### Safety
- Per-invoker: an Agent is shared but every gated capability re-resolves against the caller; a memory read runs through `MemorySpaceService`, which re-checks `viewer+` internally, so nothing leaks.
- Import-boundary clean: the resolver + hydration import `apis.shared` only (the app-api design-time validator is a separate concern).

### Testing
11 resolver unit tests (model gate + full memory grant matrix, incl. invoker-identity assertion) + 11 hydration tests + **57 existing inference/chat tests unchanged** + architecture boundary gate. `routes.py` imports clean.

### Next
`memory_list` / `memory_read` / `memory_write` tools scoped to the bound space (separate PR) — then **Oliver reads and writes his Memory Space** (D6 dogfood; also needs Memory Spaces deployed to the target env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)