### PR TITLE
chore(memory): default Memory Spaces ON with a kill switch

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -102,6 +102,16 @@ jobs:
       # (on). Set the `CDK_SCHEDULED_RUNS_ENABLED` variable to "false" in
       # an environment only to dark-stop the feature there.
       CDK_SCHEDULED_RUNS_ENABLED: ${{ vars.CDK_SCHEDULED_RUNS_ENABLED }}
+      # Memory Spaces (user-owned markdown "second brain" + agent binding).
+      # Default ON with a kill switch: unset resolves to empty string, which
+      # config.ts treats as the default (on). Set the `CDK_MEMORY_SPACES_ENABLED`
+      # variable to "false" in an environment only to dark-stop the feature there.
+      CDK_MEMORY_SPACES_ENABLED: ${{ vars.CDK_MEMORY_SPACES_ENABLED }}
+      # Agent Designer /agents surface. Default OFF (opt-in) until the Phase-4
+      # Designer UI ships — a headless API helps no forker. Set the
+      # `CDK_AGENTS_API_ENABLED` variable to "true" in an environment (e.g. dev)
+      # to enable it there for dogfooding.
+      CDK_AGENTS_API_ENABLED: ${{ vars.CDK_AGENTS_API_ENABLED }}
       # Secrets
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -160,10 +160,12 @@ export interface ScheduledRunsConfig {
 }
 
 /**
- * Memory Spaces feature flag. Default OFF with an on switch — the feature
- * is opt-in per environment, enabled with CDK_MEMORY_SPACES_ENABLED=true
- * (or a `memorySpaces.enabled: true` cdk.json context). Sets the
- * MEMORY_SPACES_ENABLED env var on app-api and inference-api.
+ * Memory Spaces feature flag. Default ON with a kill switch — the feature is
+ * complete and ships enabled for every deployer (opt-out), disabled per
+ * environment with CDK_MEMORY_SPACES_ENABLED=false (or a
+ * `memorySpaces.enabled: false` cdk.json context). Sets the
+ * MEMORY_SPACES_ENABLED env var on app-api and inference-api. The table + bucket
+ * are provisioned unconditionally, so this only gates route mounting at runtime.
  */
 export interface MemorySpacesConfig {
   enabled: boolean;
@@ -328,15 +330,16 @@ export function loadConfig(scope: cdk.App): AppConfig {
         : scope.node.tryGetContext('scheduledRuns')?.enabled ?? true,
     },
     memorySpaces: {
-      // Default OFF with an on switch: the feature is opt-in per
-      // environment, enabled only when explicitly turned on. The workflow
-      // forwards an EMPTY STRING when the variable is unset, so treat
-      // empty/unset as "use the default (off)" and only the literal "true"
-      // as the on switch. A `memorySpaces.enabled` cdk.json context can
-      // also force it on.
+      // Default ON with a kill switch: Memory Spaces is a complete feature and
+      // ships enabled for every deployer (opt-out, not opt-in — matches kbSync /
+      // scheduledRuns). The table + bucket are provisioned unconditionally, so this
+      // only toggles the runtime MEMORY_SPACES_ENABLED env var. The workflow forwards
+      // an EMPTY STRING when the variable is unset, so treat empty/unset as the
+      // default (on) and only the literal "false" as the kill switch. A
+      // `memorySpaces.enabled: false` cdk.json context can also disable it.
       enabled: process.env.CDK_MEMORY_SPACES_ENABLED
-        ? process.env.CDK_MEMORY_SPACES_ENABLED === 'true'
-        : scope.node.tryGetContext('memorySpaces')?.enabled ?? false,
+        ? process.env.CDK_MEMORY_SPACES_ENABLED !== 'false'
+        : scope.node.tryGetContext('memorySpaces')?.enabled ?? true,
     },
     agents: {
       // Default OFF with an on switch (same pattern as memorySpaces): opt-in per

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -283,7 +283,7 @@ export function buildAppApiEnvironment(
     // (scheduled-runs PR-1). Cohort access is RBAC (`scheduled-runs`
     // capability); this only gates feature existence per environment.
     SCHEDULED_RUNS_ENABLED: config.scheduledRuns.enabled ? 'true' : 'false',
-    // Kill switch for the Memory Spaces feature (default off per env).
+    // Memory Spaces feature (default ON with a kill switch per env).
     // The table/bucket names are always wired (the service reads them lazily);
     // only MEMORY_SPACES_ENABLED gates whether the routes are mounted. Without
     // these two, app-api falls back to the default "memory-spaces" name and

--- a/infrastructure/test/config.test.ts
+++ b/infrastructure/test/config.test.ts
@@ -385,6 +385,44 @@ describe('RAG Ingestion Configuration', () => {
   });
 
   // ============================================================
+  // Memory Spaces feature flag — default ON with a kill switch
+  // (complete feature; ships enabled for forkers, empty var must not disable)
+  // ============================================================
+
+  describe('Memory Spaces feature flag', () => {
+    test('defaults to enabled when CDK_MEMORY_SPACES_ENABLED is unset', () => {
+      delete process.env.CDK_MEMORY_SPACES_ENABLED;
+
+      expect(loadConfig(app).memorySpaces.enabled).toBe(true);
+    });
+
+    test('treats empty string (unset GitHub Actions variable) as enabled', () => {
+      process.env.CDK_MEMORY_SPACES_ENABLED = '';
+
+      expect(loadConfig(app).memorySpaces.enabled).toBe(true);
+    });
+
+    test('CDK_MEMORY_SPACES_ENABLED="false" is the kill switch', () => {
+      process.env.CDK_MEMORY_SPACES_ENABLED = 'false';
+
+      expect(loadConfig(app).memorySpaces.enabled).toBe(false);
+    });
+
+    test('CDK_MEMORY_SPACES_ENABLED="true" stays enabled', () => {
+      process.env.CDK_MEMORY_SPACES_ENABLED = 'true';
+
+      expect(loadConfig(app).memorySpaces.enabled).toBe(true);
+    });
+
+    test('cdk.json context memorySpaces.enabled=false disables when env is unset', () => {
+      delete process.env.CDK_MEMORY_SPACES_ENABLED;
+      app.node.setContext('memorySpaces', { enabled: false });
+
+      expect(loadConfig(app).memorySpaces.enabled).toBe(false);
+    });
+  });
+
+  // ============================================================
   // Configuration Validation Tests
   // ============================================================
 


### PR DESCRIPTION
## Default Memory Spaces ON for every deployer (opt-out, not opt-in)

Memory Spaces is a complete feature (CRUD + SPA panel + the agent binding that Phase 3 consumes), so a forker of this repo should get it working out of the box rather than having to discover a flag. This flips it to **default ON with a kill switch**, matching the `kbSync` / `scheduledRuns` convention.

**Zero new infra footprint:** the DynamoDB table + S3 bucket are already provisioned *unconditionally* in `PlatformStack` — the flag only toggles the runtime `MEMORY_SPACES_ENABLED` env var (route mounting). So this is a pure default flip.

### Changes
- **`config.ts`** — `memorySpaces.enabled` defaults `true`; empty/unset workflow var = on, only the literal `"false"` disables (the empty-string-safe ternary used by kbSync/scheduledRuns). Interface + block docs updated.
- **`platform.yml`** — forward `CDK_MEMORY_SPACES_ENABLED` (the kill switch) and `CDK_AGENTS_API_ENABLED` (so an environment can enable the still-off `/agents` surface for dogfooding without a code change).
- **`app-api-environment.ts`** — comment reflects default-on.
- **`config.test.ts`** — 5 tests locking default-on / empty-var-safe / kill switch / context override.

### Deliberately NOT flipped: Agent Designer
`AGENTS_API_ENABLED` stays **default off** until the Phase-4 Designer UI ships — a headless `/agents` API with no UI helps no forker. Dev-ai enables it per-environment via the newly-forwarded `CDK_AGENTS_API_ENABLED` variable.

### Effect on dev-ai
On the next `platform.yml` deploy from `develop`, dev-ai gets `MEMORY_SPACES_ENABLED=true` automatically (plus the table/bucket, if not already created) — which is the infra prerequisite for the live Oliver dogfood.

### Testing
`tsc --noEmit` clean; **437 infra tests pass** (incl. the 5 new memory-spaces config tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)