### PR TITLE
feat(agent-designer): Phase 4 — Agent Designer UI + bindable catalog API

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -22,6 +22,10 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from apis.app_api.agent_designer.services.bindable_catalog import (
+    BINDABLE_KINDS,
+    list_bindable,
+)
 from apis.app_api.agent_designer.services.binding_validation import (
     BindingValidationError,
     validate_agent_write,
@@ -31,6 +35,7 @@ from apis.shared.assistants.models import (
     AgentResponse,
     AgentSharesResponse,
     AgentsListResponse,
+    BindableListResponse,
     CreateAssistantDraftRequest,
     CreateAssistantRequest,
     ShareAssistantRequest,
@@ -165,6 +170,33 @@ async def list_agents_endpoint(
     except Exception as e:
         logger.error(f"Error listing agents: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list agents: {str(e)}")
+
+
+# --------------------------------------------------------------------------- palette
+# Declared BEFORE ``/{agent_id}`` so the literal path is not captured by the path param.
+@router.get("/bindable", response_model=BindableListResponse)
+async def list_bindable_endpoint(
+    kind: str, current_user: User = Depends(require_agents_enabled)
+):
+    """RBAC-filtered catalog of bindable primitives of ``kind`` for the caller (D4).
+
+    The Designer palette: each picker fetches ``?kind=model|tool|skill|knowledge_base|
+    memory_space`` and shows only what the user's role enables. Composes the existing
+    per-primitive access services (see ``bindable_catalog``).
+    """
+    if kind not in BINDABLE_KINDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported bindable kind '{kind}'. Expected one of: {', '.join(BINDABLE_KINDS)}.",
+        )
+    try:
+        items = await list_bindable(kind, current_user)
+        return BindableListResponse(kind=kind, items=items)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error listing bindable '{kind}': {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list bindable '{kind}': {str(e)}")
 
 
 @router.get("/{agent_id}", response_model=AgentResponse, response_model_exclude_none=True)

--- a/backend/src/apis/app_api/agent_designer/services/bindable_catalog.py
+++ b/backend/src/apis/app_api/agent_designer/services/bindable_catalog.py
@@ -1,0 +1,180 @@
+"""Agent Designer Phase 2 — the bindable-primitives catalog (D4).
+
+The read/list dual of ``binding_validation``: where that module *validates* an Agent
+write against the author's per-primitive access, this one *lists* what the caller may
+bind, composing the **same** existing per-primitive access services. It invents no new
+RBAC — it is the palette **and** the design-time enforcement point (D4).
+
+One entry point, ``list_bindable(kind, user)``, fans out to the primitive's existing
+list + access service and projects each result into the uniform ``BindableItem`` shape
+so every Designer picker consumes one contract. Services are injectable for testing,
+mirroring ``validate_agent_write``.
+
+Per-kind sourcing (see the write-side rules in ``binding_validation``):
+
+- ``model``          → ``filter_accessible_models(user, list_all_managed_models())``.
+- ``tool``           → ``ToolCatalogService.get_user_accessible_tools(user)`` (already
+  RBAC-filtered + MCP-server-tool grouped).
+- ``skill``          → ``resolve_accessible_skill_ids(user)`` hydrated via
+  ``batch_get_skills`` — **empty when ``skills_enabled()`` is off**.
+- ``knowledge_base`` → **empty**. The KB is welded to the agent and its index is not
+  user-configurable, so it is never author-settable (``binding_validation`` rejects an
+  explicit KB write); the compat layer synthesizes it on read. Nothing to pick.
+- ``memory_space``   → ``MemorySpaceService.list_spaces_for_user`` — **empty when
+  ``memory_spaces_enabled()`` is off**.
+"""
+
+import logging
+from typing import List, Optional
+
+from apis.shared.assistants.models import BindableItem
+from apis.shared.auth.models import User
+from apis.shared.feature_flags import memory_spaces_enabled, skills_enabled
+from apis.shared.memory.service import MemorySpaceService
+from apis.shared.models.managed_models import list_all_managed_models
+from apis.shared.skills.access import resolve_accessible_skill_ids
+from apis.shared.skills.repository import get_skill_catalog_repository
+
+from apis.app_api.admin.services.model_access import (
+    ModelAccessService,
+    get_model_access_service,
+)
+from apis.app_api.tools.service import ToolCatalogService, get_tool_catalog_service
+
+logger = logging.getLogger(__name__)
+
+# The kinds the catalog can serve. ``model`` is not a binding kind (it is the governed
+# single-select ``modelConfig``) but rides the same palette endpoint so the Designer has
+# one place to fetch every choice.
+BINDABLE_KINDS = ("model", "tool", "skill", "knowledge_base", "memory_space")
+
+
+async def list_bindable(
+    kind: str,
+    user: User,
+    *,
+    model_access_service: Optional[ModelAccessService] = None,
+    tool_service: Optional[ToolCatalogService] = None,
+    memory_service: Optional[MemorySpaceService] = None,
+) -> List[BindableItem]:
+    """Return the RBAC-filtered bindable primitives of ``kind`` for ``user``.
+
+    Raises ``ValueError`` for an unknown ``kind`` (the route maps that to 400). Each
+    sub-lister is best-effort: a failure in one primitive's service logs and yields an
+    empty list rather than failing the whole palette.
+    """
+    if kind == "model":
+        return await _list_models(user, model_access_service or get_model_access_service())
+    if kind == "tool":
+        return await _list_tools(user, tool_service or get_tool_catalog_service())
+    if kind == "skill":
+        return await _list_skills(user)
+    if kind == "knowledge_base":
+        # Welded to the agent, synthesized on read, never author-settable (D2/F4).
+        return []
+    if kind == "memory_space":
+        return _list_memory_spaces(user, memory_service or MemorySpaceService())
+    raise ValueError(f"Unknown bindable kind '{kind}'.")
+
+
+async def _list_models(user: User, svc: ModelAccessService) -> List[BindableItem]:
+    try:
+        models = await list_all_managed_models()
+        accessible = await svc.filter_accessible_models(user, models)
+    except Exception:
+        logger.warning("Failed to list bindable models", exc_info=True)
+        return []
+    # ``ref`` is the Bedrock/provider model id — the identifier the runtime resolver,
+    # RBAC (``permissions.models``) and invocation all key on. NOT the internal UUID.
+    return [
+        BindableItem(
+            kind="model",
+            ref=m.model_id,
+            label=m.model_name,
+            description=m.provider_name or m.provider or "",
+            meta={
+                "provider": m.provider,
+                "providerName": m.provider_name,
+                "isDefault": m.is_default,
+                "maxInputTokens": m.max_input_tokens,
+                "maxOutputTokens": m.max_output_tokens,
+                "supportsCaching": m.supports_caching,
+                "inputModalities": m.input_modalities,
+                "outputModalities": m.output_modalities,
+                "supportedParams": m.supported_params,
+            },
+        )
+        for m in accessible
+    ]
+
+
+async def _list_tools(user: User, svc: ToolCatalogService) -> List[BindableItem]:
+    try:
+        tools = await svc.get_user_accessible_tools(user)
+    except Exception:
+        logger.warning("Failed to list bindable tools", exc_info=True)
+        return []
+    return [
+        BindableItem(
+            kind="tool",
+            ref=t.tool_id,
+            label=t.display_name,
+            description=t.description or "",
+            meta={
+                "category": t.category,
+                "protocol": t.protocol,
+                "requiresOauthProvider": t.requires_oauth_provider,
+                "serverTools": [
+                    {
+                        "name": st.name,
+                        "description": st.description,
+                        "needsApproval": st.needs_approval,
+                        "enabled": st.enabled,
+                    }
+                    for st in t.server_tools
+                ],
+            },
+        )
+        for t in tools
+    ]
+
+
+async def _list_skills(user: User) -> List[BindableItem]:
+    if not skills_enabled():
+        return []
+    try:
+        skill_ids = await resolve_accessible_skill_ids(user)
+        skills = await get_skill_catalog_repository().batch_get_skills(skill_ids)
+    except Exception:
+        logger.warning("Failed to list bindable skills", exc_info=True)
+        return []
+    return [
+        BindableItem(
+            kind="skill",
+            ref=s.skill_id,
+            label=s.display_name,
+            description=s.description or "",
+            meta={"boundToolIds": s.bound_tool_ids, "compose": s.compose},
+        )
+        for s in skills
+    ]
+
+
+def _list_memory_spaces(user: User, svc: MemorySpaceService) -> List[BindableItem]:
+    if not memory_spaces_enabled():
+        return []
+    try:
+        spaces = svc.list_spaces_for_user(user.user_id, user.email)
+    except Exception:
+        logger.warning("Failed to list bindable memory spaces", exc_info=True)
+        return []
+    return [
+        BindableItem(
+            kind="memory_space",
+            ref=space.space_id,
+            label=space.name,
+            description=space.template or "",
+            meta={"role": role, "ownerId": space.owner_id, "template": space.template},
+        )
+        for space, role in spaces
+    ]

--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -21,7 +21,7 @@ from apis.shared.assistants.models import KNOWN_BINDING_KINDS, AgentBinding, Age
 from apis.shared.auth.models import User
 from apis.shared.feature_flags import memory_spaces_enabled
 from apis.shared.memory.service import MemorySpaceService
-from apis.shared.models.managed_models import get_managed_model
+from apis.shared.models.managed_models import list_all_managed_models
 
 from apis.app_api.admin.services.model_access import ModelAccessService
 
@@ -67,7 +67,11 @@ async def validate_agent_write(
 
 
 async def _validate_model(user: User, cfg: AgentModelConfig, svc: ModelAccessService) -> None:
-    model = await get_managed_model(cfg.model_id)
+    # ``modelConfig.modelId`` is the Bedrock/provider model id — the identifier the
+    # runtime resolver, RBAC (``permissions.models``) and invocation all key on. Look
+    # the record up by ``model_id`` (NOT ``get_managed_model``, which keys on the
+    # internal UUID PK and would reject a valid Bedrock id with a 400).
+    model = next((m for m in await list_all_managed_models() if m.model_id == cfg.model_id), None)
     if model is None:
         raise BindingValidationError(f"Model '{cfg.model_id}' is not available.", status_code=400)
     if not await svc.can_access_model(user, model):

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -220,6 +220,35 @@ class AgentSharesResponse(BaseModel):
     shared_with: List["ShareEntry"] = Field(..., alias="sharedWith", description="Share records (email + permission)")
 
 
+class BindableItem(BaseModel):
+    """A single bindable primitive in the Agent Designer palette (Phase 2, D4).
+
+    The ``GET /agents/bindable?kind=…`` catalog returns a uniform, RBAC-filtered list
+    of these so every picker in the Designer consumes the same shape. ``ref`` is the
+    value the UI stores: ``modelConfig.modelId`` for ``kind == "model"``, otherwise a
+    ``binding.ref``. ``meta`` carries kind-specific display extras (provider, MCP
+    server sub-tools, memory-space role, …) that the picker renders but never has to
+    understand structurally.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str = Field(..., description="'model' or a binding kind (see KNOWN_BINDING_KINDS)")
+    ref: str = Field(..., description="Value to store: modelConfig.modelId (model) or binding.ref")
+    label: str = Field(..., description="Human-readable display name")
+    description: str = Field("", description="Short summary for the picker")
+    meta: Dict[str, Any] = Field(default_factory=dict, description="Kind-specific display extras")
+
+
+class BindableListResponse(BaseModel):
+    """RBAC-filtered catalog of bindable primitives of one kind (Phase 2)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str = Field(..., description="The requested primitive kind")
+    items: List[BindableItem] = Field(default_factory=list, description="Primitives the caller may bind")
+
+
 class AssistantTestChatRequest(BaseModel):
     """Request body for testing assistant chat with RAG"""
 

--- a/backend/tests/apis/app_api/agent_designer/test_bindable_catalog.py
+++ b/backend/tests/apis/app_api/agent_designer/test_bindable_catalog.py
@@ -1,0 +1,134 @@
+"""Agent Designer Phase 2 — the bindable-primitives catalog (D4).
+
+Unit tests for ``list_bindable``: each primitive's list/access service is mocked so
+these stay fast. Asserts the uniform ``BindableItem`` projection per kind, that ``ref``
+carries the correct identifier (Bedrock model_id for models — not the internal UUID),
+the feature-flag gating for skills/memory_space, the welded-KB empty result, and the
+best-effort degradation on a sub-service failure.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.app_api.agent_designer.services import bindable_catalog as bc
+from apis.shared.auth.models import User
+
+MODULE = "apis.app_api.agent_designer.services.bindable_catalog"
+
+
+def _user() -> User:
+    return User(email="alice@x.edu", user_id="u1", name="Alice", roles=[])
+
+
+def _model(**kw):
+    base = dict(
+        model_id="us.anthropic.claude", model_name="Claude", provider="bedrock",
+        provider_name="Bedrock", is_default=True, max_input_tokens=200000,
+        max_output_tokens=8192, supports_caching=True, input_modalities=["text"],
+        output_modalities=["text"], supported_params=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _model_svc(models):
+    svc = MagicMock()
+    svc.filter_accessible_models = AsyncMock(return_value=models)
+    return svc
+
+
+# --------------------------------------------------------------------------- model
+class TestModels:
+    @pytest.mark.asyncio
+    async def test_model_ref_is_bedrock_model_id(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.list_all_managed_models", AsyncMock(return_value=[_model()]))
+        items = await bc.list_bindable("model", _user(), model_access_service=_model_svc([_model()]))
+        assert len(items) == 1
+        it = items[0]
+        assert it.kind == "model"
+        assert it.ref == "us.anthropic.claude"  # NOT the internal UUID id
+        assert it.label == "Claude"
+        assert it.meta["provider"] == "bedrock"
+        assert it.meta["isDefault"] is True
+
+    @pytest.mark.asyncio
+    async def test_model_service_failure_degrades_to_empty(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.list_all_managed_models", AsyncMock(side_effect=RuntimeError("boom")))
+        items = await bc.list_bindable("model", _user(), model_access_service=_model_svc([]))
+        assert items == []
+
+
+# --------------------------------------------------------------------------- tool
+class TestTools:
+    @pytest.mark.asyncio
+    async def test_tool_projection_with_server_tools(self):
+        tool = SimpleNamespace(
+            tool_id="wikipedia", display_name="Wikipedia", description="Search Wikipedia",
+            category="research", protocol="mcp", requires_oauth_provider=None,
+            server_tools=[SimpleNamespace(name="search", description="d", needs_approval=False, enabled=True)],
+        )
+        svc = MagicMock()
+        svc.get_user_accessible_tools = AsyncMock(return_value=[tool])
+        items = await bc.list_bindable("tool", _user(), tool_service=svc)
+        assert items[0].ref == "wikipedia"
+        assert items[0].meta["serverTools"][0]["name"] == "search"
+
+
+# --------------------------------------------------------------------------- skill
+class TestSkills:
+    @pytest.mark.asyncio
+    async def test_skills_empty_when_flag_off(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.skills_enabled", lambda: False)
+        items = await bc.list_bindable("skill", _user())
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_skills_hydrated_when_flag_on(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.skills_enabled", lambda: True)
+        monkeypatch.setattr(f"{MODULE}.resolve_accessible_skill_ids", AsyncMock(return_value=["pdf"]))
+        skill = SimpleNamespace(skill_id="pdf", display_name="PDF", description="PDF tools",
+                                bound_tool_ids=["t1"], compose=[])
+        repo = MagicMock()
+        repo.batch_get_skills = AsyncMock(return_value=[skill])
+        monkeypatch.setattr(f"{MODULE}.get_skill_catalog_repository", lambda: repo)
+        items = await bc.list_bindable("skill", _user())
+        assert items[0].ref == "pdf"
+        assert items[0].meta["boundToolIds"] == ["t1"]
+
+
+# --------------------------------------------------------------------------- kb
+class TestKnowledgeBase:
+    @pytest.mark.asyncio
+    async def test_kb_always_empty(self):
+        # Welded to the agent, synthesized on read, never author-settable.
+        assert await bc.list_bindable("knowledge_base", _user()) == []
+
+
+# --------------------------------------------------------------------------- memory
+class TestMemorySpaces:
+    @pytest.mark.asyncio
+    async def test_empty_when_flag_off(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.memory_spaces_enabled", lambda: False)
+        items = await bc.list_bindable("memory_space", _user(), memory_service=MagicMock())
+        assert items == []
+
+    @pytest.mark.asyncio
+    async def test_projection_when_flag_on(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.memory_spaces_enabled", lambda: True)
+        space = SimpleNamespace(space_id="spc_1", name="Oliver", template="chief-of-staff", owner_id="u1")
+        svc = MagicMock()
+        svc.list_spaces_for_user = MagicMock(return_value=[(space, "owner")])
+        items = await bc.list_bindable("memory_space", _user(), memory_service=svc)
+        assert items[0].ref == "spc_1"
+        assert items[0].label == "Oliver"
+        assert items[0].meta["role"] == "owner"
+
+
+# --------------------------------------------------------------------------- misc
+class TestUnknownKind:
+    @pytest.mark.asyncio
+    async def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError):
+            await bc.list_bindable("nonsense", _user())

--- a/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
+++ b/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
@@ -40,7 +40,12 @@ def _mem_svc(space, role) -> MagicMock:
 class TestModelValidation:
     @pytest.mark.asyncio
     async def test_accessible_model_passes(self, monkeypatch):
-        monkeypatch.setattr(f"{MODULE}.get_managed_model", AsyncMock(return_value=SimpleNamespace(model_id="m1")))
+        # The model is resolved by its Bedrock ``model_id`` from the full catalog, not
+        # by the internal-UUID PK — so a valid Bedrock id round-trips through the write.
+        monkeypatch.setattr(
+            f"{MODULE}.list_all_managed_models",
+            AsyncMock(return_value=[SimpleNamespace(model_id="m1")]),
+        )
         await validate_agent_write(
             _user(),
             model_settings=AgentModelConfig(model_id="m1"),
@@ -49,7 +54,10 @@ class TestModelValidation:
 
     @pytest.mark.asyncio
     async def test_unknown_model_400(self, monkeypatch):
-        monkeypatch.setattr(f"{MODULE}.get_managed_model", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            f"{MODULE}.list_all_managed_models",
+            AsyncMock(return_value=[SimpleNamespace(model_id="m1")]),
+        )
         with pytest.raises(BindingValidationError) as ei:
             await validate_agent_write(
                 _user(), model_settings=AgentModelConfig(model_id="ghost"), model_access_service=_model_svc(True)
@@ -58,7 +66,10 @@ class TestModelValidation:
 
     @pytest.mark.asyncio
     async def test_forbidden_model_403(self, monkeypatch):
-        monkeypatch.setattr(f"{MODULE}.get_managed_model", AsyncMock(return_value=SimpleNamespace(model_id="m1")))
+        monkeypatch.setattr(
+            f"{MODULE}.list_all_managed_models",
+            AsyncMock(return_value=[SimpleNamespace(model_id="m1")]),
+        )
         with pytest.raises(BindingValidationError) as ei:
             await validate_agent_write(
                 _user(), model_settings=AgentModelConfig(model_id="m1"), model_access_service=_model_svc(False)

--- a/backend/tests/routes/test_agents.py
+++ b/backend/tests/routes/test_agents.py
@@ -193,3 +193,42 @@ class TestAgentShares:
         with patch(f"{ROUTES_MODULE}.share_assistant", new_callable=AsyncMock, return_value=False):
             resp = TestClient(app).post("/agents/ast-001/shares", json={"emails": ["b@x.edu"], "permission": "viewer"})
         assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- bindable
+class TestBindable:
+    def test_404_when_flag_off(self, app, make_user, monkeypatch):
+        monkeypatch.setenv("AGENTS_API_ENABLED", "false")
+        mock_auth_user(app, make_user())
+        resp = TestClient(app).get("/agents/bindable?kind=model")
+        assert resp.status_code == 404
+
+    def test_returns_projected_items(self, app, make_user, _flag_on):
+        from apis.shared.assistants.models import BindableItem
+
+        mock_auth_user(app, make_user())
+        items = [BindableItem(kind="model", ref="us.anthropic.claude", label="Claude", description="Bedrock")]
+        with patch(f"{ROUTES_MODULE}.list_bindable", new_callable=AsyncMock, return_value=items):
+            resp = TestClient(app).get("/agents/bindable?kind=model")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["kind"] == "model"
+        assert body["items"][0]["ref"] == "us.anthropic.claude"
+
+    def test_unsupported_kind_400(self, app, make_user, _flag_on):
+        mock_auth_user(app, make_user())
+        resp = TestClient(app).get("/agents/bindable?kind=nonsense")
+        assert resp.status_code == 400
+
+    def test_bindable_not_captured_by_agent_id_route(self, app, make_user, _flag_on):
+        """The literal /bindable path must not be swallowed by /{agent_id}."""
+        from apis.shared.assistants.models import BindableItem
+
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.list_bindable", new_callable=AsyncMock, return_value=[]) as m, patch(
+            f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock
+        ) as exists:
+            resp = TestClient(app).get("/agents/bindable?kind=tool")
+        assert resp.status_code == 200
+        m.assert_awaited_once()
+        exists.assert_not_called()  # did NOT fall through to get_agent_endpoint

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.css
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.css
@@ -1,0 +1,1 @@
+/* Agent Designer form — layout handled by Tailwind utilities in the template. */

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -1,0 +1,260 @@
+<div class="min-h-dvh bg-gray-50 dark:bg-gray-900">
+  <!-- Sticky header -->
+  <header class="sticky top-0 z-10 border-b border-gray-200/80 bg-white/80 backdrop-blur dark:border-gray-700/60 dark:bg-gray-900/80">
+    <div class="mx-auto flex max-w-4xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+      <div class="flex items-center gap-3">
+        <a routerLink="/agents" class="rounded-md p-1.5 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800" [attr.aria-label]="'Back to agents'">
+          <ng-icon name="heroArrowLeft" class="size-5" aria-hidden="true" />
+        </a>
+        <h1 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+          {{ mode() === 'create' ? 'New Agent' : 'Edit Agent' }}
+        </h1>
+      </div>
+      <div class="flex items-center gap-2">
+        @if (mode() === 'edit' && userPermission() === 'owner') {
+          <button type="button" (click)="openShareDialog()" class="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700">
+            <ng-icon name="heroShare" class="size-4" aria-hidden="true" />
+            Share
+          </button>
+        }
+        <button type="button" (click)="onCancel()" class="rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">
+          Cancel
+        </button>
+        <button type="button" (click)="onSubmit()" [disabled]="saving() || isViewer()" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-xs transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50">
+          <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+          {{ saving() ? 'Saving…' : 'Save Agent' }}
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" class="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6">
+    @if (isViewer()) {
+      <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800/50 dark:bg-amber-900/20 dark:text-amber-300">
+        You have viewer access to this agent — changes can't be saved.
+      </div>
+    }
+
+    <!-- Persona -->
+    <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+      <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Persona</h2>
+      <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Name, description and the system instructions that define this agent.</p>
+
+      <div class="mt-5 flex items-start gap-4">
+        <!-- Emoji -->
+        <div class="shrink-0">
+          <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Emoji</label>
+          <div class="relative mt-1">
+            <button type="button" cdkOverlayOrigin #emojiTrigger="cdkOverlayOrigin" (click)="toggleEmojiPicker()" class="flex size-10 items-center justify-center rounded-2xl border border-gray-300 bg-white text-xl hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700">
+              @if (form.get('emoji')?.value) {
+                <span>{{ form.get('emoji')?.value }}</span>
+              } @else {
+                <ng-icon name="heroFaceSmile" class="size-5 text-gray-400" />
+              }
+            </button>
+            <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="emojiTrigger" [cdkConnectedOverlayOpen]="isEmojiPickerOpen()" [cdkConnectedOverlayPositions]="emojiPickerPositions" [cdkConnectedOverlayHasBackdrop]="true" cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop" (backdropClick)="closeEmojiPicker()" (detach)="closeEmojiPicker()">
+              <div class="overflow-hidden rounded-2xl shadow-lg ring-1 ring-black/5 dark:ring-white/10">
+                <div class="flex items-center justify-between border-b border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
+                  <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Select Emoji</span>
+                  <button type="button" (click)="closeEmojiPicker()" class="rounded-2xl p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200">
+                    <ng-icon name="heroXMark" class="size-4" />
+                  </button>
+                </div>
+                <emoji-mart [darkMode]="isDarkMode() === 'dark'" [perLine]="8" [emojiSize]="24" [showPreview]="false" (emojiSelect)="onEmojiSelect($event)" />
+              </div>
+            </ng-template>
+          </div>
+          @if (form.get('emoji')?.value) {
+            <button type="button" (click)="clearEmoji()" class="mt-1 text-xs/5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">Clear</button>
+          }
+        </div>
+
+        <!-- Name -->
+        <div class="flex-1">
+          <label for="name" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Name</label>
+          <input id="name" type="text" formControlName="name" placeholder="e.g. Research Assistant" class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+          @if (getFieldError('name'); as e) { <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">{{ e }}</p> }
+        </div>
+      </div>
+
+      <!-- Description -->
+      <div class="mt-4">
+        <label for="description" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Description</label>
+        <input id="description" type="text" formControlName="description" placeholder="A short summary shown on the agent card" class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+        @if (getFieldError('description'); as e) { <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">{{ e }}</p> }
+      </div>
+
+      <!-- Instructions -->
+      <div class="mt-4">
+        <label for="instructions" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Instructions</label>
+        <textarea id="instructions" formControlName="instructions" rows="6" placeholder="You are a helpful assistant that…" class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"></textarea>
+        @if (getFieldError('instructions'); as e) { <p class="mt-1 text-xs/5 text-red-600 dark:text-red-400">{{ e }}</p> }
+      </div>
+
+      <!-- Visibility + tags -->
+      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label for="visibility" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Visibility</label>
+          <select id="visibility" formControlName="visibility" class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+            <option value="PRIVATE">Private</option>
+            <option value="SHARED">Shared</option>
+            <option value="PUBLIC">Public</option>
+          </select>
+        </div>
+        <div>
+          <label for="tag-input" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Tags</label>
+          <input id="tag-input" #tagInput type="text" (keydown.enter)="$event.preventDefault(); addTag(tagInput.value); tagInput.value=''" placeholder="Type a tag and press Enter" class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+          @if (tags.length) {
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              @for (tag of tags; track tag) {
+                <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs/5 text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                  {{ tag }}
+                  <button type="button" (click)="removeTag(tag)" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"><ng-icon name="heroXMark" class="size-3" /></button>
+                </span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Conversation starters -->
+      <div class="mt-4" formArrayName="starters">
+        <div class="flex items-center justify-between">
+          <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Conversation starters</label>
+          <button type="button" (click)="addStarter()" class="inline-flex items-center gap-1 text-xs/5 font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400">
+            <ng-icon name="heroPlus" class="size-3.5" /> Add
+          </button>
+        </div>
+        @for (starter of starters.controls; track $index) {
+          <div class="mt-2 flex items-center gap-2">
+            <input [formControlName]="$index" type="text" placeholder="Suggested first message" class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white" />
+            <button type="button" (click)="removeStarter($index)" class="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-700"><ng-icon name="heroTrash" class="size-4" /></button>
+          </div>
+        }
+      </div>
+    </section>
+
+    <!-- Model (governed single-select, D3) -->
+    <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+      <div class="flex items-center gap-2">
+        <ng-icon name="heroCpuChip" class="size-5 text-primary-500" aria-hidden="true" />
+        <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Model</h2>
+        <span class="text-xs/5 text-red-500">required</span>
+      </div>
+      <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">The agent runs on this model. Only models your role allows are shown.</p>
+
+      @if (models().length === 0) {
+        <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">No models are available to your role.</p>
+      } @else {
+        <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          @for (m of models(); track m.ref) {
+            <button type="button" (click)="selectModel(m.ref)" class="flex items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left transition" [class.border-primary-500]="selectedModelId() === m.ref" [class.ring-1]="selectedModelId() === m.ref" [class.ring-primary-500]="selectedModelId() === m.ref" [class.bg-primary-50]="selectedModelId() === m.ref" [class.dark:bg-primary-500/10]="selectedModelId() === m.ref" [class.border-gray-200]="selectedModelId() !== m.ref" [class.dark:border-gray-700]="selectedModelId() !== m.ref" [class.hover:border-gray-300]="selectedModelId() !== m.ref">
+              <div class="min-w-0">
+                <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ m.label }}</p>
+                <p class="truncate text-xs/5 text-gray-500 dark:text-gray-400">{{ m.description }}</p>
+              </div>
+              @if (selectedModelId() === m.ref) {
+                <ng-icon name="heroCheck" class="size-5 shrink-0 text-primary-500" aria-hidden="true" />
+              }
+            </button>
+          }
+        </div>
+      }
+    </section>
+
+    <!-- Tools -->
+    @if (tools().length) {
+      <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="flex items-center gap-2">
+          <ng-icon name="heroWrenchScrewdriver" class="size-5 text-blue-500" aria-hidden="true" />
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Tools</h2>
+        </div>
+        <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Capabilities this agent can call.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          @for (t of tools(); track t.ref) {
+            <button type="button" (click)="toggleTool(t.ref)" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition" [class.border-blue-500]="isToolSelected(t.ref)" [class.bg-blue-50]="isToolSelected(t.ref)" [class.text-blue-700]="isToolSelected(t.ref)" [class.dark:bg-blue-900/30]="isToolSelected(t.ref)" [class.dark:text-blue-300]="isToolSelected(t.ref)" [class.border-gray-200]="!isToolSelected(t.ref)" [class.text-gray-700]="!isToolSelected(t.ref)" [class.dark:border-gray-700]="!isToolSelected(t.ref)" [class.dark:text-gray-300]="!isToolSelected(t.ref)" [appTooltip]="t.description" appTooltipPosition="top">
+              @if (isToolSelected(t.ref)) { <ng-icon name="heroCheck" class="size-3.5" /> }
+              {{ t.label }}
+            </button>
+          }
+        </div>
+      </section>
+    }
+
+    <!-- Skills -->
+    @if (skills().length) {
+      <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="flex items-center gap-2">
+          <ng-icon name="heroSparkles" class="size-5 text-purple-500" aria-hidden="true" />
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Skills</h2>
+        </div>
+        <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Reusable instruction bundles with their own bound tools.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          @for (s of skills(); track s.ref) {
+            <button type="button" (click)="toggleSkill(s.ref)" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition" [class.border-purple-500]="isSkillSelected(s.ref)" [class.bg-purple-50]="isSkillSelected(s.ref)" [class.text-purple-700]="isSkillSelected(s.ref)" [class.dark:bg-purple-900/30]="isSkillSelected(s.ref)" [class.dark:text-purple-300]="isSkillSelected(s.ref)" [class.border-gray-200]="!isSkillSelected(s.ref)" [class.text-gray-700]="!isSkillSelected(s.ref)" [class.dark:border-gray-700]="!isSkillSelected(s.ref)" [class.dark:text-gray-300]="!isSkillSelected(s.ref)" [appTooltip]="s.description" appTooltipPosition="top">
+              @if (isSkillSelected(s.ref)) { <ng-icon name="heroCheck" class="size-3.5" /> }
+              {{ s.label }}
+            </button>
+          }
+        </div>
+      </section>
+    }
+
+    <!-- Memory spaces -->
+    @if (spaces().length) {
+      <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="flex items-center gap-2">
+          <ng-icon name="heroCircleStack" class="size-5 text-emerald-500" aria-hidden="true" />
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Memory spaces</h2>
+        </div>
+        <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">A persistent "second brain" the agent reads from — and can write to with editor access.</p>
+        <div class="mt-4 space-y-2">
+          @for (space of spaces(); track space.ref) {
+            <div class="rounded-xl border px-4 py-3 transition" [class.border-emerald-500]="isSpaceSelected(space.ref)" [class.bg-emerald-50]="isSpaceSelected(space.ref)" [class.dark:bg-emerald-900/20]="isSpaceSelected(space.ref)" [class.border-gray-200]="!isSpaceSelected(space.ref)" [class.dark:border-gray-700]="!isSpaceSelected(space.ref)">
+              <label class="flex cursor-pointer items-center justify-between gap-3">
+                <span class="min-w-0">
+                  <span class="block truncate text-sm font-medium text-gray-900 dark:text-white">{{ space.label }}</span>
+                  <span class="block text-xs/5 text-gray-500 dark:text-gray-400">your role: {{ space.meta['role'] }}</span>
+                </span>
+                <input type="checkbox" [checked]="isSpaceSelected(space.ref)" (change)="toggleSpace(space)" class="size-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500" />
+              </label>
+
+              @if (isSpaceSelected(space.ref)) {
+                @for (sel of memorySelections(); track sel.ref) {
+                  @if (sel.ref === space.ref) {
+                    <div class="mt-3 flex flex-wrap items-center gap-4 border-t border-emerald-200/60 pt-3 dark:border-emerald-800/40">
+                      <div class="flex items-center gap-2">
+                        <span class="text-xs/5 font-medium text-gray-600 dark:text-gray-300">Access:</span>
+                        <div class="flex rounded-lg border border-gray-300 p-0.5 dark:border-gray-600">
+                          <button type="button" (click)="setAccess(sel.ref, 'read')" class="rounded-md px-2.5 py-1 text-xs/5 font-medium transition" [class.bg-white]="sel.access === 'read'" [class.shadow-xs]="sel.access === 'read'" [class.text-gray-900]="sel.access === 'read'" [class.dark:bg-gray-700]="sel.access === 'read'" [class.dark:text-white]="sel.access === 'read'" [class.text-gray-500]="sel.access !== 'read'">Read</button>
+                          <button type="button" (click)="setAccess(sel.ref, 'readwrite')" [disabled]="!canWrite(sel)" class="rounded-md px-2.5 py-1 text-xs/5 font-medium transition disabled:cursor-not-allowed disabled:opacity-40" [class.bg-white]="sel.access === 'readwrite'" [class.shadow-xs]="sel.access === 'readwrite'" [class.text-gray-900]="sel.access === 'readwrite'" [class.dark:bg-gray-700]="sel.access === 'readwrite'" [class.dark:text-white]="sel.access === 'readwrite'" [class.text-gray-500]="sel.access !== 'readwrite'" [appTooltip]="canWrite(sel) ? '' : 'Editor access on the space is required to write'" appTooltipPosition="top">Read + write</button>
+                        </div>
+                      </div>
+                      <label class="flex items-center gap-2 text-xs/5 text-gray-600 dark:text-gray-300">
+                        <input type="checkbox" [checked]="sel.alwaysLoadIndex" (change)="toggleAlwaysLoad(sel.ref)" class="size-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500" />
+                        Always load MEMORY.md into the prompt
+                      </label>
+                    </div>
+                  }
+                }
+              }
+            </div>
+          }
+        </div>
+      </section>
+    }
+
+    <!-- Knowledge base (welded, read-only) -->
+    @if (kbBinding()) {
+      <section class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="flex items-center gap-2">
+          <ng-icon name="heroBookOpen" class="size-5 text-gray-400" aria-hidden="true" />
+          <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Knowledge base</h2>
+        </div>
+        <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+          This agent's document knowledge base is managed automatically and is edited from the classic assistant view.
+        </p>
+      </section>
+    }
+  </form>
+</div>

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -1,0 +1,409 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  FormArray,
+  FormControl,
+  Validators,
+} from '@angular/forms';
+import { Subscription, firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroFaceSmile,
+  heroXMark,
+  heroPlus,
+  heroTrash,
+  heroShare,
+  heroCpuChip,
+  heroWrenchScrewdriver,
+  heroSparkles,
+  heroCircleStack,
+  heroBookOpen,
+  heroCheck,
+} from '@ng-icons/heroicons/outline';
+import { Dialog } from '@angular/cdk/dialog';
+import { PickerComponent } from '@ctrl/ngx-emoji-mart';
+import { CdkConnectedOverlay, CdkOverlayOrigin, ConnectedPosition } from '@angular/cdk/overlay';
+import { AgentService } from '../services/agent.service';
+import { AgentBinding, BindableItem, MemorySpaceBindingConfig } from '../models/agent.model';
+import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ThemeService } from '../../components/topnav/components/theme-toggle/theme.service';
+import { ToastService } from '../../services/toast/toast.service';
+import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+import {
+  ShareAssistantDialogComponent,
+  ShareAssistantDialogData,
+} from '../../assistants/components/share-assistant-dialog.component';
+
+/** A memory-space selection with its per-binding config (access + alwaysLoad). */
+interface MemorySelection {
+  ref: string;
+  label: string;
+  role: string;
+  access: 'read' | 'readwrite';
+  alwaysLoadIndex: boolean; // maps to alwaysLoad: ['MEMORY.md']
+}
+
+/**
+ * Agent Designer — the authoring surface (Phase 4). A persona + a governed model
+ * single-select + binding pickers (tools, skills, memory spaces), each populated
+ * from `GET /agents/bindable?kind=…` so the user only sees what their role enables
+ * (D4). The KB is welded to the agent (synthesized on read, not author-settable) so
+ * it is shown read-only. Mirrors the write-side rules in `binding_validation`.
+ */
+@Component({
+  selector: 'app-agent-form-page',
+  templateUrl: './agent-form.page.html',
+  styleUrl: './agent-form.page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    NgIcon,
+    RouterLink,
+    PickerComponent,
+    CdkOverlayOrigin,
+    CdkConnectedOverlay,
+    TooltipDirective,
+  ],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroFaceSmile,
+      heroXMark,
+      heroPlus,
+      heroTrash,
+      heroShare,
+      heroCpuChip,
+      heroWrenchScrewdriver,
+      heroSparkles,
+      heroCircleStack,
+      heroBookOpen,
+      heroCheck,
+    }),
+  ],
+})
+export class AgentFormPage implements OnInit, OnDestroy {
+  private fb = inject(FormBuilder);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private agentService = inject(AgentService);
+  private sidenavService = inject(SidenavService);
+  private themeService = inject(ThemeService);
+  private toast = inject(ToastService);
+  private dialog = inject(Dialog);
+
+  form!: FormGroup;
+  private formSub?: Subscription;
+
+  readonly agentId = signal<string | null>(null);
+  readonly saving = signal(false);
+  readonly loadingAgent = signal(false);
+  readonly userPermission = signal<'owner' | 'editor' | 'viewer'>('owner');
+  readonly isEmojiPickerOpen = signal(false);
+  readonly isDarkMode = this.themeService.theme;
+
+  readonly mode = computed<'create' | 'edit'>(() => (this.agentId() ? 'edit' : 'create'));
+  readonly isViewer = computed(() => this.userPermission() === 'viewer');
+
+  // Bindable palettes (RBAC-filtered) + current selections.
+  readonly models = signal<BindableItem[]>([]);
+  readonly tools = signal<BindableItem[]>([]);
+  readonly skills = signal<BindableItem[]>([]);
+  readonly spaces = signal<BindableItem[]>([]);
+
+  readonly selectedModelId = signal<string | null>(null);
+  readonly selectedToolRefs = signal<Set<string>>(new Set());
+  readonly selectedSkillRefs = signal<Set<string>>(new Set());
+  readonly memorySelections = signal<MemorySelection[]>([]);
+  /** Welded KB binding synthesized by the backend — displayed read-only. */
+  readonly kbBinding = signal<AgentBinding | null>(null);
+
+  readonly emojiPickerPositions: ConnectedPosition[] = [
+    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 8 },
+    { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -8 },
+  ];
+
+  get starters(): FormArray {
+    return this.form.get('starters') as FormArray;
+  }
+
+  ngOnInit(): void {
+    this.sidenavService.hide();
+
+    this.form = this.fb.group({
+      name: ['', [Validators.required, Validators.minLength(3)]],
+      description: ['', [Validators.required, Validators.minLength(10)]],
+      instructions: ['', [Validators.required, Validators.minLength(20)]],
+      visibility: ['PRIVATE'],
+      tags: [[] as string[]],
+      starters: this.fb.array([]),
+      emoji: [''],
+    });
+
+    // Load the RBAC-filtered palettes in parallel; then hydrate an existing agent.
+    void this.loadPalettes();
+
+    const id = this.route.snapshot.paramMap.get('id');
+    this.agentId.set(id);
+    if (id) {
+      this.loadingAgent.set(true);
+      void this.loadAgent(id).finally(() => this.loadingAgent.set(false));
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.sidenavService.show();
+    this.formSub?.unsubscribe();
+  }
+
+  private async loadPalettes(): Promise<void> {
+    const [models, tools, skills, spaces] = await Promise.all([
+      this.agentService.loadBindable('model'),
+      this.agentService.loadBindable('tool'),
+      this.agentService.loadBindable('skill'),
+      this.agentService.loadBindable('memory_space'),
+    ]);
+    this.models.set(models);
+    this.tools.set(tools);
+    this.skills.set(skills);
+    this.spaces.set(spaces);
+  }
+
+  private async loadAgent(id: string): Promise<void> {
+    try {
+      const agent = await this.agentService.getAgent(id);
+      this.userPermission.set(agent.userPermission ?? 'owner');
+      this.form.patchValue({
+        name: agent.name,
+        description: agent.description,
+        instructions: agent.instructions,
+        visibility: agent.visibility,
+        tags: agent.tags ?? [],
+        emoji: agent.emoji ?? '',
+      });
+      this.starters.clear();
+      (agent.starters ?? []).forEach((s) => this.starters.push(new FormControl(s, Validators.required)));
+
+      this.selectedModelId.set(agent.modelConfig?.modelId ?? null);
+
+      const toolRefs = new Set<string>();
+      const skillRefs = new Set<string>();
+      const memory: MemorySelection[] = [];
+      for (const b of agent.bindings ?? []) {
+        if (b.kind === 'tool') toolRefs.add(b.ref);
+        else if (b.kind === 'skill') skillRefs.add(b.ref);
+        else if (b.kind === 'memory_space') {
+          const cfg = (b.config ?? {}) as Partial<MemorySpaceBindingConfig>;
+          memory.push({
+            ref: b.ref,
+            label: this.spaceLabel(b.ref),
+            role: this.spaceRole(b.ref),
+            access: cfg.access === 'readwrite' ? 'readwrite' : 'read',
+            alwaysLoadIndex: (cfg.alwaysLoad ?? []).includes('MEMORY.md'),
+          });
+        } else if (b.kind === 'knowledge_base') {
+          this.kbBinding.set(b);
+        }
+      }
+      this.selectedToolRefs.set(toolRefs);
+      this.selectedSkillRefs.set(skillRefs);
+      this.memorySelections.set(memory);
+    } catch (err) {
+      console.error('Error loading agent:', err);
+      this.toast.error('Could not load this agent.');
+    }
+  }
+
+  private spaceLabel(ref: string): string {
+    return this.spaces().find((s) => s.ref === ref)?.label ?? ref;
+  }
+
+  private spaceRole(ref: string): string {
+    return (this.spaces().find((s) => s.ref === ref)?.meta?.['role'] as string) ?? 'viewer';
+  }
+
+  // ---- persona helpers -------------------------------------------------
+  addStarter(): void {
+    this.starters.push(new FormControl('', Validators.required));
+  }
+  removeStarter(index: number): void {
+    this.starters.removeAt(index);
+  }
+  toggleEmojiPicker(): void {
+    this.isEmojiPickerOpen.update((o) => !o);
+  }
+  closeEmojiPicker(): void {
+    this.isEmojiPickerOpen.set(false);
+  }
+  onEmojiSelect(event: { emoji: { native: string } }): void {
+    this.form.patchValue({ emoji: event.emoji.native });
+    this.closeEmojiPicker();
+  }
+  clearEmoji(): void {
+    this.form.patchValue({ emoji: '' });
+  }
+
+  // ---- tags ------------------------------------------------------------
+  get tags(): string[] {
+    return (this.form.get('tags')?.value as string[]) ?? [];
+  }
+  addTag(value: string): void {
+    const t = value.trim();
+    if (t && !this.tags.includes(t)) {
+      this.form.get('tags')?.setValue([...this.tags, t]);
+    }
+  }
+  removeTag(tag: string): void {
+    this.form.get('tags')?.setValue(this.tags.filter((x) => x !== tag));
+  }
+
+  getFieldError(field: string): string | null {
+    const c = this.form.get(field);
+    if (!c || !c.touched || !c.errors) return null;
+    if (c.errors['required']) return 'This field is required';
+    if (c.errors['minlength']) return `Minimum length is ${c.errors['minlength'].requiredLength} characters`;
+    return null;
+  }
+
+  // ---- model -----------------------------------------------------------
+  selectModel(ref: string): void {
+    this.selectedModelId.set(this.selectedModelId() === ref ? null : ref);
+  }
+
+  // ---- tools / skills (multi-select toggles) ---------------------------
+  toggleTool(ref: string): void {
+    this.selectedToolRefs.update((set) => toggle(set, ref));
+  }
+  isToolSelected(ref: string): boolean {
+    return this.selectedToolRefs().has(ref);
+  }
+  toggleSkill(ref: string): void {
+    this.selectedSkillRefs.update((set) => toggle(set, ref));
+  }
+  isSkillSelected(ref: string): boolean {
+    return this.selectedSkillRefs().has(ref);
+  }
+
+  // ---- memory spaces ---------------------------------------------------
+  isSpaceSelected(ref: string): boolean {
+    return this.memorySelections().some((m) => m.ref === ref);
+  }
+  toggleSpace(item: BindableItem): void {
+    this.memorySelections.update((cur) => {
+      if (cur.some((m) => m.ref === item.ref)) {
+        return cur.filter((m) => m.ref !== item.ref);
+      }
+      const role = (item.meta?.['role'] as string) ?? 'viewer';
+      return [
+        ...cur,
+        { ref: item.ref, label: item.label, role, access: 'read', alwaysLoadIndex: true },
+      ];
+    });
+  }
+  /** readwrite requires editor+ on the space (D5) — the option is disabled otherwise. */
+  canWrite(sel: MemorySelection): boolean {
+    return sel.role === 'owner' || sel.role === 'editor';
+  }
+  setAccess(ref: string, access: 'read' | 'readwrite'): void {
+    this.memorySelections.update((cur) =>
+      cur.map((m) => (m.ref === ref ? { ...m, access } : m)),
+    );
+  }
+  toggleAlwaysLoad(ref: string): void {
+    this.memorySelections.update((cur) =>
+      cur.map((m) => (m.ref === ref ? { ...m, alwaysLoadIndex: !m.alwaysLoadIndex } : m)),
+    );
+  }
+
+  // ---- submit ----------------------------------------------------------
+  private buildBindings(): AgentBinding[] {
+    const bindings: AgentBinding[] = [];
+    for (const ref of this.selectedToolRefs()) bindings.push({ kind: 'tool', ref });
+    for (const ref of this.selectedSkillRefs()) bindings.push({ kind: 'skill', ref });
+    for (const m of this.memorySelections()) {
+      const config: Record<string, unknown> = { access: m.access };
+      if (m.alwaysLoadIndex) config['alwaysLoad'] = ['MEMORY.md'];
+      bindings.push({ kind: 'memory_space', ref: m.ref, config });
+    }
+    // KB bindings are welded/synthesized — never sent (backend rejects an explicit one).
+    return bindings;
+  }
+
+  async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    if (!this.selectedModelId()) {
+      this.toast.error('Select a model for this agent.');
+      return;
+    }
+
+    const v = this.form.value;
+    const payload = {
+      name: v.name,
+      description: v.description,
+      instructions: v.instructions,
+      visibility: v.visibility,
+      tags: v.tags ?? [],
+      starters: this.starters.value ?? [],
+      emoji: v.emoji || undefined,
+      modelConfig: { modelId: this.selectedModelId()! },
+      bindings: this.buildBindings(),
+    };
+
+    this.saving.set(true);
+    try {
+      if (this.mode() === 'create') {
+        await this.agentService.createAgent(payload);
+      } else {
+        await this.agentService.updateAgent(this.agentId()!, { ...payload, status: 'COMPLETE' });
+      }
+      this.toast.success('Agent saved.');
+      this.router.navigate(['/agents']);
+    } catch (err: unknown) {
+      const detail = (err as { error?: { detail?: string } } | null)?.error?.detail;
+      this.toast.error(detail ?? 'Could not save the agent.');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/agents']);
+  }
+
+  openShareDialog(): void {
+    const id = this.agentId();
+    if (!id) return;
+    this.dialog.open(ShareAssistantDialogComponent, {
+      data: {
+        assistant: {
+          assistantId: id,
+          name: this.form.get('name')?.value || 'Agent',
+          visibility: this.form.get('visibility')?.value,
+          userPermission: this.userPermission(),
+        },
+      } as unknown as ShareAssistantDialogData,
+      hasBackdrop: false,
+    });
+  }
+}
+
+function toggle(set: Set<string>, ref: string): Set<string> {
+  const next = new Set(set);
+  if (next.has(ref)) next.delete(ref);
+  else next.add(ref);
+  return next;
+}

--- a/frontend/ai.client/src/app/agents/agents.page.css
+++ b/frontend/ai.client/src/app/agents/agents.page.css
@@ -1,0 +1,1 @@
+/* Agents list page — layout handled by Tailwind utilities in the template. */

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -1,0 +1,136 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="mb-10">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
+            Agents
+          </h1>
+          <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+            Compose an agent from a model, tools, skills and memory — governed by your role.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          (click)="onCreateNew()"
+          [disabled]="loading()"
+          class="group relative inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm font-semibold text-white shadow-xs transition-all duration-200 hover:bg-primary-600 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] dark:focus-visible:ring-offset-gray-900"
+        >
+          <ng-icon name="heroPlus" class="size-4 transition-transform duration-200 group-hover:rotate-90" aria-hidden="true" />
+          {{ loading() ? 'Creating…' : 'New Agent' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <main>
+      @if (loading()) {
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          @for (i of [1, 2, 3]; track i) {
+            <div class="animate-pulse overflow-hidden rounded-2xl border border-gray-200/80 bg-white p-5 dark:border-gray-700/60 dark:bg-gray-800/80">
+              <div class="flex items-center gap-3">
+                <div class="size-11 rounded-xl bg-gray-100 dark:bg-gray-700/50"></div>
+                <div class="h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-700"></div>
+              </div>
+              <div class="mt-4 space-y-2">
+                <div class="h-3 w-full rounded bg-gray-100 dark:bg-gray-700/50"></div>
+                <div class="h-3 w-4/5 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else if (error()) {
+        <div class="flex flex-col items-center justify-center py-16 text-center">
+          <div class="flex size-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-900/20">
+            <svg class="size-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+            </svg>
+          </div>
+          <p class="mt-4 text-sm font-medium text-red-600 dark:text-red-400">{{ error() }}</p>
+        </div>
+      } @else if (agents().length === 0) {
+        <div class="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-300 py-16 text-center dark:border-gray-700">
+          <div class="flex size-14 items-center justify-center rounded-2xl bg-primary-50 text-primary-500 dark:bg-primary-500/10">
+            <ng-icon name="heroSparkles" class="size-7" aria-hidden="true" />
+          </div>
+          <h2 class="mt-4 text-base/7 font-semibold text-gray-900 dark:text-white">No agents yet</h2>
+          <p class="mt-1 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            Create your first agent to bind a model, tools, skills and a memory space together.
+          </p>
+          <button
+            type="button"
+            (click)="onCreateNew()"
+            class="mt-5 inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-xs transition hover:bg-primary-600"
+          >
+            <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
+            New Agent
+          </button>
+        </div>
+      } @else {
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          @for (agent of agents(); track agent.agentId) {
+            <div class="group flex flex-col overflow-hidden rounded-2xl border border-gray-200/80 bg-white p-5 shadow-xs transition-all duration-200 hover:border-gray-300 hover:shadow-sm dark:border-gray-700/60 dark:bg-gray-800/80 dark:hover:border-gray-600">
+              <!-- Head -->
+              <button type="button" (click)="onEdit(agent)" class="flex items-start gap-3 text-left">
+                <div class="flex size-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-primary-500/15 to-secondary-500/15 text-xl">
+                  {{ agent.emoji || '🤖' }}
+                </div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <h3 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">{{ agent.name }}</h3>
+                    @if (agent.status === 'DRAFT') {
+                      <span class="rounded-full bg-amber-100 px-2 py-0.5 text-xs/5 font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Draft</span>
+                    }
+                  </div>
+                  <p class="mt-0.5 line-clamp-2 text-xs/5 text-gray-500 dark:text-gray-400">{{ agent.description || 'No description' }}</p>
+                </div>
+              </button>
+
+              <!-- Binding summary -->
+              <div class="mt-4 flex flex-wrap gap-1.5">
+                @if (modelLabel(agent); as model) {
+                  <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs/5 font-medium text-gray-700 dark:bg-gray-700/60 dark:text-gray-300" [appTooltip]="model" appTooltipPosition="top">
+                    <ng-icon name="heroCpuChip" class="size-3.5" aria-hidden="true" />
+                    <span class="max-w-[10rem] truncate">{{ model }}</span>
+                  </span>
+                }
+                @if (bindingCount(agent, 'tool'); as n) {
+                  <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs/5 font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">{{ n }} tool{{ n === 1 ? '' : 's' }}</span>
+                }
+                @if (bindingCount(agent, 'skill'); as n) {
+                  <span class="inline-flex items-center rounded-md bg-purple-50 px-2 py-1 text-xs/5 font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">{{ n }} skill{{ n === 1 ? '' : 's' }}</span>
+                }
+                @if (bindingCount(agent, 'memory_space'); as n) {
+                  <span class="inline-flex items-center rounded-md bg-emerald-50 px-2 py-1 text-xs/5 font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">{{ n }} memory</span>
+                }
+              </div>
+
+              <!-- Actions -->
+              <div class="mt-4 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-700/60">
+                <span class="text-xs/5 lowercase text-gray-400 dark:text-gray-500">{{ agent.visibility }}</span>
+                <div class="flex items-center gap-0.5">
+                  <button (click)="onChat(agent)" class="rounded-md p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-gray-700" [appTooltip]="'Chat'" appTooltipPosition="top">
+                    <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
+                  </button>
+                  <button (click)="onEdit(agent)" class="rounded-md p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-gray-700" [appTooltip]="'Edit'" appTooltipPosition="top">
+                    <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                  </button>
+                  @if ((agent.userPermission ?? 'owner') === 'owner') {
+                    <button (click)="onShare(agent)" class="rounded-md p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-gray-700" [appTooltip]="'Share'" appTooltipPosition="top">
+                      <ng-icon name="heroShare" class="size-4" aria-hidden="true" />
+                    </button>
+                    <button (click)="onDelete(agent)" class="rounded-md p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20" [appTooltip]="'Delete'" appTooltipPosition="top">
+                      <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                    </button>
+                  }
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </main>
+  </div>
+</div>

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -1,0 +1,130 @@
+import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroPlus,
+  heroPencilSquare,
+  heroChatBubbleLeftRight,
+  heroShare,
+  heroTrash,
+  heroCpuChip,
+  heroSparkles,
+} from '@ng-icons/heroicons/outline';
+import { AgentService } from './services/agent.service';
+import { Agent } from './models/agent.model';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog/confirmation-dialog.component';
+import { ShareAssistantDialogComponent, ShareAssistantDialogData } from '../assistants/components/share-assistant-dialog.component';
+import { TooltipDirective } from '../components/tooltip/tooltip.directive';
+
+/**
+ * Agent Designer — the list surface. A sibling of the Assistants list page but
+ * over the `/agents` surface: each card carries the Agent's model + binding
+ * summary (the whole point of an Agent vs. a legacy Assistant). Share reuses the
+ * assistants share dialog since the records are the same (agentId == assistantId).
+ */
+@Component({
+  selector: 'app-agents',
+  templateUrl: './agents.page.html',
+  styleUrl: './agents.page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [
+    provideIcons({
+      heroPlus,
+      heroPencilSquare,
+      heroChatBubbleLeftRight,
+      heroShare,
+      heroTrash,
+      heroCpuChip,
+      heroSparkles,
+    }),
+  ],
+})
+export class AgentsPage implements OnInit {
+  private router = inject(Router);
+  private agentService = inject(AgentService);
+  private dialog = inject(Dialog);
+
+  readonly agents = this.agentService.agents$;
+  readonly loading = this.agentService.loading$;
+  readonly error = this.agentService.error$;
+
+  ngOnInit(): void {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    try {
+      await this.agentService.loadAgents(true);
+    } catch (err) {
+      console.error('Error loading agents:', err);
+    }
+  }
+
+  /** Count bindings by kind for the card summary (KB is welded, shown separately). */
+  bindingCount(agent: Agent, kind: string): number {
+    return agent.bindings.filter((b) => b.kind === kind).length;
+  }
+
+  modelLabel(agent: Agent): string | null {
+    return agent.modelConfig?.modelId ?? null;
+  }
+
+  async onCreateNew(): Promise<void> {
+    try {
+      const draft = await this.agentService.createDraft({ name: 'Untitled Agent' });
+      this.router.navigate(['/agents', draft.agentId, 'edit']);
+    } catch (err) {
+      console.error('Error creating draft agent:', err);
+    }
+  }
+
+  onEdit(agent: Agent): void {
+    this.router.navigate(['/agents', agent.agentId, 'edit']);
+  }
+
+  onChat(agent: Agent): void {
+    this.router.navigate(['/'], { queryParams: { assistantId: agent.agentId } });
+  }
+
+  async onShare(agent: Agent): Promise<void> {
+    // The share dialog operates on an Assistant shape; agentId == assistantId and
+    // the share records are identical, so we adapt the Agent into what it needs.
+    const dialogRef = this.dialog.open(ShareAssistantDialogComponent, {
+      data: {
+        assistant: {
+          assistantId: agent.agentId,
+          name: agent.name,
+          visibility: agent.visibility,
+          userPermission: agent.userPermission ?? 'owner',
+        },
+      } as unknown as ShareAssistantDialogData,
+    });
+    await firstValueFrom(dialogRef.closed);
+  }
+
+  async onDelete(agent: Agent): Promise<void> {
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: 'Delete Agent',
+        message: `Are you sure you want to delete "${agent.name}"? This action cannot be undone.`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (confirmed) {
+      try {
+        await this.agentService.deleteAgent(agent.agentId);
+      } catch (err) {
+        console.error('Error deleting agent:', err);
+      }
+    }
+  }
+}

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -1,0 +1,119 @@
+import { ShareEntry, UserPermission } from '../../assistants/models/assistant.model';
+
+/**
+ * Agent Designer contract (Phase 4). Mirrors the backend `/agents` surface
+ * (`AgentResponse` / `AgentBinding` / `AgentModelConfig` in
+ * `apis/shared/assistants/models.py`). An Agent evolves the Assistant: same
+ * underlying record (`agentId == assistantId`, legacy ids stay valid) but the
+ * Agent shape carries the governed `modelConfig` + uniform `bindings[]`.
+ */
+
+export type BindingKind = 'knowledge_base' | 'tool' | 'skill' | 'memory_space';
+
+/** Value stored in a `memory_space` binding's `config`. */
+export interface MemorySpaceBindingConfig {
+  /** Read-only injection vs. read + `memory_*` write tools (D5 gate). */
+  access: 'read' | 'readwrite';
+  /** Entry slugs (or `MEMORY.md`) always hydrated into the prompt. */
+  alwaysLoad?: string[];
+}
+
+/** Governed single-select model (D3). `modelId` is the Bedrock/provider id. */
+export interface AgentModelConfig {
+  modelId: string;
+  provider?: string;
+  params?: Record<string, unknown>;
+}
+
+/** A single primitive binding on an Agent (D3). `config` is kind-specific. */
+export interface AgentBinding {
+  kind: BindingKind;
+  ref: string;
+  config?: Record<string, unknown>;
+}
+
+export interface Agent {
+  agentId: string;
+  ownerName: string;
+  name: string;
+  description: string;
+  instructions: string;
+  modelConfig?: AgentModelConfig;
+  bindings: AgentBinding[];
+  visibility: 'PRIVATE' | 'PUBLIC' | 'SHARED';
+  tags: string[];
+  starters: string[];
+  emoji?: string;
+  imageUrl?: string;
+  usageCount: number;
+  status: 'DRAFT' | 'COMPLETE';
+  createdAt: string;
+  updatedAt: string;
+
+  // Share metadata (present for shared agents)
+  firstInteracted?: boolean;
+  isSharedWithMe?: boolean;
+  userPermission?: UserPermission;
+}
+
+export interface CreateAgentDraftRequest {
+  name?: string;
+}
+
+export interface CreateAgentRequest {
+  name: string;
+  description: string;
+  instructions: string;
+  visibility?: 'PRIVATE' | 'PUBLIC' | 'SHARED';
+  tags?: string[];
+  starters?: string[];
+  emoji?: string;
+  imageUrl?: string;
+  modelConfig?: AgentModelConfig;
+  bindings?: AgentBinding[];
+}
+
+export interface UpdateAgentRequest {
+  name?: string;
+  description?: string;
+  instructions?: string;
+  visibility?: 'PRIVATE' | 'PUBLIC' | 'SHARED';
+  tags?: string[];
+  starters?: string[];
+  emoji?: string;
+  status?: 'DRAFT' | 'COMPLETE';
+  imageUrl?: string;
+  modelConfig?: AgentModelConfig;
+  bindings?: AgentBinding[];
+}
+
+export interface AgentsListResponse {
+  agents: Agent[];
+  nextToken?: string;
+}
+
+export interface AgentSharesResponse {
+  agentId: string;
+  sharedWith: ShareEntry[];
+}
+
+/**
+ * Bindable-primitives catalog (Phase 2). `GET /agents/bindable?kind=…` returns
+ * the RBAC-filtered palette for the caller — a uniform item every picker
+ * consumes. `ref` is what the UI stores: `modelConfig.modelId` for
+ * `kind === 'model'`, otherwise a `binding.ref`.
+ */
+export type BindableKind = 'model' | BindingKind;
+
+export interface BindableItem {
+  kind: string;
+  ref: string;
+  label: string;
+  description: string;
+  meta: Record<string, unknown>;
+}
+
+export interface BindableListResponse {
+  kind: string;
+  items: BindableItem[];
+}

--- a/frontend/ai.client/src/app/agents/services/agent-api.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-api.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, inject, computed } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import {
+  Agent,
+  AgentsListResponse,
+  AgentSharesResponse,
+  BindableKind,
+  BindableListResponse,
+  CreateAgentDraftRequest,
+  CreateAgentRequest,
+  UpdateAgentRequest,
+} from '../models/agent.model';
+import {
+  ShareAssistantRequest,
+  UnshareAssistantRequest,
+  UpdateSharePermissionRequest,
+} from '../../assistants/models/assistant.model';
+
+/**
+ * Thin HTTP client over the `/agents` surface (Agent Designer). Mirrors
+ * `AssistantApiService`: raw `Observable`s, base URL from `ConfigService`, the
+ * signal facade (`AgentService`) owns state + error translation. Share requests
+ * reuse the assistants share DTOs — the records are the same (agentId == assistantId).
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentApiService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/agents`);
+
+  createDraft(request: CreateAgentDraftRequest = {}): Observable<Agent> {
+    return this.http.post<Agent>(`${this.baseUrl()}/draft`, request);
+  }
+
+  createAgent(request: CreateAgentRequest): Observable<Agent> {
+    return this.http.post<Agent>(this.baseUrl(), request);
+  }
+
+  getAgents(params?: { includeDrafts?: boolean }): Observable<AgentsListResponse> {
+    let httpParams = new HttpParams();
+    if (params?.includeDrafts !== undefined) {
+      httpParams = httpParams.set('include_drafts', params.includeDrafts.toString());
+    }
+    return this.http.get<AgentsListResponse>(this.baseUrl(), { params: httpParams });
+  }
+
+  getAgent(id: string): Observable<Agent> {
+    return this.http.get<Agent>(`${this.baseUrl()}/${id}`);
+  }
+
+  updateAgent(id: string, request: UpdateAgentRequest): Observable<Agent> {
+    return this.http.put<Agent>(`${this.baseUrl()}/${id}`, request);
+  }
+
+  deleteAgent(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl()}/${id}`);
+  }
+
+  /** RBAC-filtered palette of bindable primitives of one kind (Phase 2). */
+  getBindable(kind: BindableKind): Observable<BindableListResponse> {
+    const params = new HttpParams().set('kind', kind);
+    return this.http.get<BindableListResponse>(`${this.baseUrl()}/bindable`, { params });
+  }
+
+  shareAgent(id: string, request: ShareAssistantRequest): Observable<AgentSharesResponse> {
+    return this.http.post<AgentSharesResponse>(`${this.baseUrl()}/${id}/shares`, request);
+  }
+
+  unshareAgent(id: string, request: UnshareAssistantRequest): Observable<AgentSharesResponse> {
+    return this.http.delete<AgentSharesResponse>(`${this.baseUrl()}/${id}/shares`, { body: request });
+  }
+
+  updateSharePermission(id: string, request: UpdateSharePermissionRequest): Observable<AgentSharesResponse> {
+    return this.http.patch<AgentSharesResponse>(`${this.baseUrl()}/${id}/shares`, request);
+  }
+
+  getAgentShares(id: string): Observable<AgentSharesResponse> {
+    return this.http.get<AgentSharesResponse>(`${this.baseUrl()}/${id}/shares`);
+  }
+}

--- a/frontend/ai.client/src/app/agents/services/agent.service.spec.ts
+++ b/frontend/ai.client/src/app/agents/services/agent.service.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { AgentService } from './agent.service';
+import { AgentApiService } from './agent-api.service';
+import { Agent, BindableItem } from '../models/agent.model';
+
+function stubAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    agentId: 'ast-001',
+    ownerName: 'Alice',
+    name: 'My Agent',
+    description: 'Helpful',
+    instructions: 'You are helpful.',
+    bindings: [],
+    visibility: 'PRIVATE',
+    tags: [],
+    starters: [],
+    usageCount: 0,
+    status: 'COMPLETE',
+    createdAt: '2026-07-08T00:00:00Z',
+    updatedAt: '2026-07-08T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('AgentService', () => {
+  let service: AgentService;
+  let mockApi: {
+    getAgents: ReturnType<typeof vi.fn>;
+    getAgent: ReturnType<typeof vi.fn>;
+    createDraft: ReturnType<typeof vi.fn>;
+    createAgent: ReturnType<typeof vi.fn>;
+    updateAgent: ReturnType<typeof vi.fn>;
+    deleteAgent: ReturnType<typeof vi.fn>;
+    getBindable: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockApi = {
+      getAgents: vi.fn(),
+      getAgent: vi.fn(),
+      createDraft: vi.fn(),
+      createAgent: vi.fn(),
+      updateAgent: vi.fn(),
+      deleteAgent: vi.fn(),
+      getBindable: vi.fn(),
+    };
+    TestBed.configureTestingModule({
+      providers: [AgentService, { provide: AgentApiService, useValue: mockApi }],
+    });
+    service = TestBed.inject(AgentService);
+  });
+
+  it('loads agents and marks the feature accessible', async () => {
+    const agent = stubAgent();
+    mockApi.getAgents.mockReturnValue(of({ agents: [agent] }));
+
+    await service.loadAgents();
+
+    expect(service.agents$()).toEqual([agent]);
+    expect(service.accessible$()).toBe(true);
+    expect(service.loading$()).toBe(false);
+  });
+
+  it('marks the feature inaccessible on a 404 (kill switch off) without an error', async () => {
+    mockApi.getAgents.mockReturnValue(throwError(() => ({ status: 404 })));
+
+    await service.loadAgents();
+
+    expect(service.accessible$()).toBe(false);
+    expect(service.agents$()).toEqual([]);
+    expect(service.error$()).toBeNull();
+  });
+
+  it('surfaces a real error for non-gating failures and leaves accessible unresolved', async () => {
+    mockApi.getAgents.mockReturnValue(throwError(() => new Error('network blip')));
+
+    await expect(service.loadAgents()).rejects.toThrow('network blip');
+    expect(service.error$()).toBe('network blip');
+    expect(service.accessible$()).toBeNull();
+  });
+
+  it('prepends a created agent to local state', async () => {
+    mockApi.getAgents.mockReturnValue(of({ agents: [] }));
+    await service.loadAgents();
+
+    const created = stubAgent({ agentId: 'ast-new', name: 'New' });
+    mockApi.createAgent.mockReturnValue(of(created));
+
+    const result = await service.createAgent({ name: 'New', description: 'd', instructions: 'i' });
+
+    expect(result).toEqual(created);
+    expect(service.agents$()[0]).toEqual(created);
+  });
+
+  it('replaces an updated agent in local state', async () => {
+    const agent = stubAgent();
+    mockApi.getAgents.mockReturnValue(of({ agents: [agent] }));
+    await service.loadAgents();
+
+    const updated = stubAgent({ name: 'Renamed' });
+    mockApi.updateAgent.mockReturnValue(of(updated));
+    await service.updateAgent('ast-001', { name: 'Renamed' });
+
+    expect(service.agents$()[0].name).toBe('Renamed');
+  });
+
+  it('removes a deleted agent from local state', async () => {
+    const agent = stubAgent();
+    mockApi.getAgents.mockReturnValue(of({ agents: [agent] }));
+    await service.loadAgents();
+
+    mockApi.deleteAgent.mockReturnValue(of(undefined));
+    await service.deleteAgent('ast-001');
+
+    expect(service.agents$()).toEqual([]);
+  });
+
+  it('memoises the bindable palette per kind and returns [] on failure', async () => {
+    const items: BindableItem[] = [
+      { kind: 'model', ref: 'us.anthropic.claude', label: 'Claude', description: 'Bedrock', meta: {} },
+    ];
+    mockApi.getBindable.mockReturnValue(of({ kind: 'model', items }));
+
+    const first = await service.loadBindable('model');
+    const second = await service.loadBindable('model');
+
+    expect(first).toEqual(items);
+    expect(second).toEqual(items);
+    expect(mockApi.getBindable).toHaveBeenCalledTimes(1); // cached
+
+    mockApi.getBindable.mockReturnValue(throwError(() => new Error('boom')));
+    const skills = await service.loadBindable('skill');
+    expect(skills).toEqual([]); // degrades gracefully
+  });
+});

--- a/frontend/ai.client/src/app/agents/services/agent.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AgentApiService } from './agent-api.service';
+import {
+  Agent,
+  BindableItem,
+  BindableKind,
+  CreateAgentDraftRequest,
+  CreateAgentRequest,
+  UpdateAgentRequest,
+} from '../models/agent.model';
+
+/**
+ * Signal-based state for the Agent Designer. Mirrors the assistants / memory-spaces
+ * facades: private mutable signals, readonly public views, async methods that
+ * round-trip through the API service and keep local state in sync.
+ *
+ * `accessible$` rides the list call the same way `MemorySpaceService` does — a
+ * successful (even empty) list means the `AGENTS_API_ENABLED` kill switch is on;
+ * a 404 flips it false so the nav entry and page hide gracefully. The bindable
+ * palette is memoised per-kind (`loadBindable`) so the pickers don't re-fetch on
+ * every keystroke.
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentService {
+  private api = inject(AgentApiService);
+
+  private agents = signal<Agent[]>([]);
+  private loading = signal<boolean>(false);
+  private error = signal<string | null>(null);
+  private accessible = signal<boolean | null>(null);
+
+  readonly agents$ = this.agents.asReadonly();
+  readonly loading$ = this.loading.asReadonly();
+  readonly error$ = this.error.asReadonly();
+  readonly accessible$ = this.accessible.asReadonly();
+
+  private bindableCache = new Map<BindableKind, BindableItem[]>();
+
+  async loadAgents(includeDrafts = true): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const response = await firstValueFrom(this.api.getAgents({ includeDrafts }));
+      this.agents.set(response?.agents ?? []);
+      this.accessible.set(true);
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 404) {
+        // Kill switch off — fail gracefully rather than surfacing an error.
+        this.accessible.set(false);
+        this.agents.set([]);
+        return;
+      }
+      this.error.set(err instanceof Error ? err.message : 'Failed to load agents');
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  getAgent(id: string): Promise<Agent> {
+    return firstValueFrom(this.api.getAgent(id));
+  }
+
+  createDraft(request: CreateAgentDraftRequest = {}): Promise<Agent> {
+    return firstValueFrom(this.api.createDraft(request));
+  }
+
+  async createAgent(request: CreateAgentRequest): Promise<Agent> {
+    this.error.set(null);
+    const agent = await firstValueFrom(this.api.createAgent(request));
+    this.agents.update((current) => [agent, ...current]);
+    return agent;
+  }
+
+  async updateAgent(id: string, request: UpdateAgentRequest): Promise<Agent> {
+    this.error.set(null);
+    const agent = await firstValueFrom(this.api.updateAgent(id, request));
+    this.agents.update((current) => current.map((a) => (a.agentId === id ? agent : a)));
+    return agent;
+  }
+
+  async deleteAgent(id: string): Promise<void> {
+    this.error.set(null);
+    await firstValueFrom(this.api.deleteAgent(id));
+    this.agents.update((current) => current.filter((a) => a.agentId !== id));
+  }
+
+  /**
+   * Fetch (and memoise) the RBAC-filtered bindable palette for a kind. Returns
+   * `[]` on failure so a picker degrades to "nothing available" rather than
+   * breaking the form. Pass `force` to bypass the cache after a mutation elsewhere.
+   */
+  async loadBindable(kind: BindableKind, force = false): Promise<BindableItem[]> {
+    if (!force && this.bindableCache.has(kind)) {
+      return this.bindableCache.get(kind)!;
+    }
+    try {
+      const response = await firstValueFrom(this.api.getBindable(kind));
+      const items = response?.items ?? [];
+      this.bindableCache.set(kind, items);
+      return items;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -50,6 +50,21 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'agents/new',
+        loadComponent: () => import('./agents/agent-form/agent-form.page').then(m => m.AgentFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'agents/:id/edit',
+        loadComponent: () => import('./agents/agent-form/agent-form.page').then(m => m.AgentFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'agents',
+        loadComponent: () => import('./agents/agents.page').then(m => m.AgentsPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'schedules/new',
         loadComponent: () => import('./schedules/schedule-form/schedule-form.page').then(m => m.ScheduleFormPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -46,6 +46,22 @@
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
 
+        <!-- Agents (Agent Designer — hidden until the accessibility probe resolves true; kill switch off = no entry) -->
+        @if (showAgents()) {
+            <a
+                routerLink="/agents"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
+            </a>
+        }
+
         <!-- Memory Spaces (hidden until the accessibility probe resolves true — kill switch off = no entry) -->
         @if (showMemorySpaces()) {
             <a

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -8,6 +8,7 @@ import { SessionService as BffSessionService } from '../../auth/session.service'
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { ScheduleService } from '../../schedules/services/schedule.service';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
+import { AgentService } from '../../agents/services/agent.service';
 
 describe('Sidenav', () => {
   let mockRouter: any;
@@ -17,6 +18,7 @@ describe('Sidenav', () => {
   let mockUserService: any;
   let mockScheduleService: any;
   let mockMemorySpaceService: any;
+  let mockAgentService: any;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
@@ -45,6 +47,10 @@ describe('Sidenav', () => {
       accessible$: signal<boolean | null>(null),
       loadSpaces: vi.fn().mockResolvedValue(undefined),
     };
+    mockAgentService = {
+      accessible$: signal<boolean | null>(null),
+      loadAgents: vi.fn().mockResolvedValue(undefined),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -55,6 +61,7 @@ describe('Sidenav', () => {
         { provide: UserService, useValue: mockUserService },
         { provide: ScheduleService, useValue: mockScheduleService },
         { provide: MemorySpaceService, useValue: mockMemorySpaceService },
+        { provide: AgentService, useValue: mockAgentService },
       ],
     });
   });
@@ -153,5 +160,30 @@ describe('Sidenav', () => {
 
     mockMemorySpaceService.accessible$.set(true);
     expect(component.showMemorySpaces()).toBe(true);
+  });
+
+  it('probes agent accessibility once a user is authenticated', async () => {
+    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
+    await createComponent();
+    expect(mockAgentService.loadAgents).toHaveBeenCalled();
+  });
+
+  it('does not probe agent accessibility while unauthenticated', async () => {
+    mockUserService.currentUser.set(null);
+    await createComponent();
+    expect(mockAgentService.loadAgents).not.toHaveBeenCalled();
+  });
+
+  it('hides the Agents nav entry until accessibility resolves true', async () => {
+    const component = await createComponent();
+
+    mockAgentService.accessible$.set(null);
+    expect(component.showAgents()).toBe(false);
+
+    mockAgentService.accessible$.set(false);
+    expect(component.showAgents()).toBe(false);
+
+    mockAgentService.accessible$.set(true);
+    expect(component.showAgents()).toBe(true);
   });
 });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -9,6 +9,7 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
 import { ScheduleService } from '../../schedules/services/schedule.service';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
+import { AgentService } from '../../agents/services/agent.service';
 
 @Component({
   selector: 'app-sidenav',
@@ -22,6 +23,7 @@ export class Sidenav {
   private bffSession = inject(BffSessionService);
   private scheduleService = inject(ScheduleService);
   private memorySpaceService = inject(MemorySpaceService);
+  private agentService = inject(AgentService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -61,6 +63,15 @@ export class Sidenav {
    */
   readonly showMemorySpaces = computed(() => this.memorySpaceService.accessible$() === true);
 
+  /**
+   * Whether to show the "Agents" (Agent Designer) nav entry. Rides the agents
+   * list call the same way `showMemorySpaces` rides spaces: a successful (even
+   * empty) list means the `AGENTS_API_ENABLED` kill switch is on; a 404 flips
+   * `accessible$` false and the entry stays hidden. `null` (unresolved) also
+   * hides it so it doesn't flash in before disappearing.
+   */
+  readonly showAgents = computed(() => this.agentService.accessible$() === true);
+
   constructor() {
     // Kick off the accessibility probes once the user is authenticated —
     // mirrors UserService's own permissions-fetch gating.
@@ -68,6 +79,7 @@ export class Sidenav {
       if (this.userService.currentUser()) {
         void this.scheduleService.loadSchedules();
         void this.memorySpaceService.loadSpaces();
+        void this.agentService.loadAgents();
       }
     });
   }


### PR DESCRIPTION
## Summary

Ships the **Agent Designer** authoring surface (Phase 4 of the epic) and its Phase-2 precursor, the **bindable-primitives catalog**. The Designer pickers consume the catalog, so both land together. Spec: `docs/specs/agent-designer.md`. Gated behind `AGENTS_API_ENABLED` (default off) — deploys dark.

## Backend — Phase 2 catalog (`GET /agents/bindable`)

- `GET /agents/bindable?kind=model|tool|skill|knowledge_base|memory_space` returns an **RBAC-filtered palette** for the caller, composing the **5 existing per-primitive access services** (D4) — no new RBAC invented. Uniform `BindableItem` shape so every picker consumes one contract.
  - `model` → `filter_accessible_models`; `tool` → `get_user_accessible_tools`; `skill` → `resolve_accessible_skill_ids` + hydrate (empty when `SKILLS_ENABLED` off); `memory_space` → `list_spaces_for_user` (empty when `MEMORY_SPACES_ENABLED` off); `knowledge_base` → empty (welded to the agent, synthesized on read, not author-settable).
  - Route declared **before** `/{agent_id}` so the literal path isn't captured by the path param.
- **Bug fix (latent):** `binding_validation._validate_model` resolved the model via `get_managed_model()` — a **primary-key lookup on the internal UUID `id`** — but `modelConfig.modelId` is the **Bedrock `model_id`** that the runtime resolver, RBAC (`permissions.models`), and invocation all key on (`_find_managed_model` matches `model.model_id == model_id`). A valid model would have been rejected with a 400 on save the moment the picker set one. Now matches by `model_id`, consistent end-to-end.

## Frontend — Phase 4 UI

- New `agents/` feature dir (separate from the Assistants editor):
  - TS contracts: `Agent` / `AgentBinding` / `AgentModelConfig` / `BindableItem`.
  - `AgentApiService` (thin HTTP over `/agents` + `/agents/bindable`) and `AgentService` signal facade with the `accessible$` **404-probe** idiom (nav hides gracefully when the flag is off) + a per-kind bindable cache.
- **Agents list page** (redesign tokens; model + binding-count badges) and an **agent-form page**:
  - Persona (emoji picker, name, description, instructions, tags, conversation starters — reusing the assistant-form idioms).
  - **Required single-select model picker** (D3).
  - Tool / skill multi-select chips.
  - Memory-space picker with `access` (read / read+write — the write option is **disabled unless you have editor+ on the space**, per D5) and an `alwaysLoad MEMORY.md` toggle.
  - Knowledge base shown read-only (welded/synthesized).
  - Sharing reuses `ShareAssistantDialogComponent` (agentId == assistantId — same records).
- Routes `agents` / `agents/new` / `agents/:id/edit`, plus a sidenav **Agents** entry gated on the `accessible$` probe.

The form mirrors the write-side rules in `binding_validation` (model access, memory read/readwrite gate, KB not author-settable).

## Testing

- **Backend: 1552 tests pass** — 9 new catalog unit tests, 4 new `/agents/bindable` route tests (incl. path-precedence vs `/{agent_id}`), 3 updated model-validation tests.
- **SPA:** `npm run build` clean, `tsc --noEmit` clean, `ng test` → 7 new `AgentService` specs + 11 existing sidenav specs pass.

## Reviewer notes

- Base is **`develop`** (this branch's integration line; `main` is a disconnected history).
- Interactive preview was **not** run — the surface needs the full backend with `AGENTS_API_ENABLED=true` + auth. Verified via build + typecheck + unit tests.
- **Follow-up:** flip `AGENTS_API_ENABLED` default-on (per-env via `CDK_AGENTS_API_ENABLED`) once the UI is reviewed and shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)