### PR TITLE
fix(agent-designer): model write-check rejects models the picker lists (403)

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -74,7 +74,14 @@ async def _validate_model(user: User, cfg: AgentModelConfig, svc: ModelAccessSer
     model = next((m for m in await list_all_managed_models() if m.model_id == cfg.model_id), None)
     if model is None:
         raise BindingValidationError(f"Model '{cfg.model_id}' is not available.", status_code=400)
-    if not await svc.can_access_model(user, model):
+    # Use the SAME predicate the ``/agents/bindable`` catalog uses (``filter_accessible_models``),
+    # not ``can_access_model``: the latter only honors an AppRole model grant when the model
+    # record also carries a non-empty ``allowed_app_roles``, so a model granted purely via the
+    # user's AppRole ``permissions.models`` (empty ``allowed_app_roles``) is *listed* by the
+    # palette but would be *rejected* here — the picker shows it, saving 403s. Filtering the
+    # single model guarantees "if the palette offers it, the write accepts it", and matches the
+    # runtime's membership grant.
+    if not await svc.filter_accessible_models(user, [model]):
         raise BindingValidationError(
             f"You do not have access to model '{cfg.model_id}'.", status_code=403
         )

--- a/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
+++ b/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
@@ -25,8 +25,10 @@ def _user() -> User:
 
 
 def _model_svc(allowed: bool) -> MagicMock:
+    # Mirror the catalog: design-time validation filters the single model via
+    # ``filter_accessible_models`` (accessible → the model is returned, else []).
     svc = MagicMock()
-    svc.can_access_model = AsyncMock(return_value=allowed)
+    svc.filter_accessible_models = AsyncMock(side_effect=lambda user, models: list(models) if allowed else [])
     return svc
 
 
@@ -75,6 +77,27 @@ class TestModelValidation:
                 _user(), model_settings=AgentModelConfig(model_id="m1"), model_access_service=_model_svc(False)
             )
         assert ei.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_membership_grant_without_allowed_app_roles_passes(self, monkeypatch):
+        """Regression: a model granted via the user's AppRole ``permissions.models`` but
+        with an empty ``allowed_app_roles`` is listed by the catalog and must save.
+
+        ``filter_accessible_models`` grants it (membership); the old ``can_access_model``
+        path would have rejected it (its membership check is gated on a non-empty
+        ``allowed_app_roles``), so the picker showed it but the write 403'd.
+        """
+        monkeypatch.setattr(
+            f"{MODULE}.list_all_managed_models",
+            AsyncMock(return_value=[SimpleNamespace(model_id="m1", allowed_app_roles=[])]),
+        )
+        svc = MagicMock()
+        # Catalog-style filter: this model is in the accessible subset.
+        svc.filter_accessible_models = AsyncMock(side_effect=lambda user, models: list(models))
+        await validate_agent_write(
+            _user(), model_settings=AgentModelConfig(model_id="m1"), model_access_service=svc
+        )
+        svc.filter_accessible_models.assert_awaited_once()
 
 
 # --------------------------------------------------------------------------- inert


### PR DESCRIPTION
## Summary

Follow-up to #598 (merged). The model-access fix landed on the branch **after** #598's merge commit, so it isn't in `develop` yet — this PR carries just that one commit.

## The bug

The Agent Designer model picker and the save path use **two different access checks that disagree**:

- **Catalog** (populates the picker) → `ModelAccessService.filter_accessible_models`, which grants a model whenever its id is in the user's AppRole `permissions.models`.
- **Save validation** → `ModelAccessService.can_access_model`, which only honors that same AppRole membership **when the model record also has a non-empty `allowed_app_roles`** (the membership check is nested under `if model.allowed_app_roles:`).

So a model granted purely via the user's AppRole, whose record has an empty `allowed_app_roles`, is **listed by the picker but 403s on save** — e.g. `us.anthropic.claude-sonnet-4-6`. The runtime resolver checks membership directly, so it would actually have allowed the model; the write check was the sole outlier.

## The fix

Design-time validation now uses the **same `filter_accessible_models` predicate the catalog uses**, so "if the palette offers it, the write accepts it" holds by construction. Adds a regression test for the empty-`allowed_app_roles` membership grant.

## Testing

- 41 agent-designer + `/agents` route tests pass (incl. the new regression test).

## Reviewer note

Base is `develop`. The diff is a single commit (`128729a9`) — the other Phase 4 commits are already in `develop` via #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)