### PR TITLE
feat(sidenav): gate Memory Spaces + Agents to system-admin, add Preview badges

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -46,8 +46,8 @@
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
 
-        <!-- Agents (Agent Designer — hidden until the accessibility probe resolves true; kill switch off = no entry) -->
-        @if (showAgents()) {
+        <!-- Agents (Agent Designer — preview: system-admin only, plus the accessibility probe) -->
+        @if (showAgents() && isAdmin()) {
             <a
                 routerLink="/agents"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"
@@ -59,11 +59,12 @@
                     </svg>
                 </div>
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
+                <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
             </a>
         }
 
-        <!-- Memory Spaces (hidden until the accessibility probe resolves true — kill switch off = no entry) -->
-        @if (showMemorySpaces()) {
+        <!-- Memory Spaces (preview: system-admin only, plus the accessibility probe) -->
+        @if (showMemorySpaces() && isAdmin()) {
             <a
                 routerLink="/memory-spaces"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"
@@ -75,10 +76,11 @@
                     </svg>
                 </div>
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Memory Spaces</span>
+                <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
             </a>
         }
 
-        <!-- Scheduled runs (system-admin only, plus the capability gate — hidden until the accessibility probe resolves true) -->
+        <!-- Scheduled runs (preview: system-admin only, plus the capability gate) -->
         @if (showSchedules() && isAdmin()) {
             <a
                 routerLink="/schedules"
@@ -91,6 +93,7 @@
                     </svg>
                 </div>
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Scheduled Runs</span>
+                <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
             </a>
         }
     </div>


### PR DESCRIPTION
## Summary

Brings the two other preview surfaces in line with **Scheduled Runs**:

- **Memory Spaces** and **Agents** nav entries now also require the `system_admin` AppRole (`showX() && isAdmin()`), in addition to their existing accessibility probe — same gate Scheduled Runs already uses.
- Adds a small amber **Preview** badge to all three entries (Agents, Memory Spaces, Scheduled Runs) so their preview status is visible at a glance.

## Notes

- Nav-visibility only — this hides the entries for non-admins; the routes and per-primitive RBAC are unchanged (matches the Scheduled Runs approach, where the nav gate and the capability gate are independent).
- Template-only change in `sidenav.html`. The `showAgents` / `showMemorySpaces` / `showSchedules` computed signals are untouched, so the existing sidenav specs remain valid (14 pass).

## Testing

- `npm run build` clean; `ng test` sidenav spec passes (14).

Base is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)