### PR TITLE
feat(agent-designer): resolve skill bindings at invocation (replace + force skill-mode)

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -10,12 +10,13 @@ Resolution scope:
   (``ToolCatalogService.get_user_accessible_tools``, the SAME source the picker fetches, so
   "if the palette offers it, the write accepts it" — cf. the model check). Run-time then
   re-resolves each bound tool against the *invoker* (``AppRoleService.can_access_tool``, D5).
+- ``skill``          → feature-flagged; author must have the skill in the ``/agents/bindable``
+  palette (``resolve_accessible_skill_ids``, the SAME source the picker fetches). Run-time then
+  re-resolves each bound skill against the *invoker* (``AppRoleService.can_access_skill``, D5).
 - ``memory_space``   → feature-flagged; author needs viewer+ (read) / editor+ (readwrite).
 - ``knowledge_base`` → **managed implicitly** (the KB is welded to the agent and its index
   is not user-configurable), so it is NOT author-settable; the compat layer synthesizes it
   on read. An explicit knowledge_base binding is rejected.
-- ``skill``          → **inert**: shape-checked only, stored verbatim, no catalog lookup and
-  no RBAC (its run-time fold interacts with ``agent_type``/skill resolution — a later slice).
 """
 
 import logging
@@ -23,16 +24,16 @@ from typing import List, Optional
 
 from apis.shared.assistants.models import KNOWN_BINDING_KINDS, AgentBinding, AgentModelConfig
 from apis.shared.auth.models import User
-from apis.shared.feature_flags import memory_spaces_enabled
+from apis.shared.feature_flags import memory_spaces_enabled, skills_enabled
 from apis.shared.memory.service import MemorySpaceService
 from apis.shared.models.managed_models import list_all_managed_models
+from apis.shared.skills.access import resolve_accessible_skill_ids
 
 from apis.app_api.admin.services.model_access import ModelAccessService
 from apis.app_api.tools.service import ToolCatalogService
 
 logger = logging.getLogger(__name__)
 
-_INERT_KINDS = ("skill",)
 _ROLE_RANK = {"viewer": 1, "editor": 2, "owner": 3}
 
 
@@ -68,15 +69,19 @@ async def validate_agent_write(
 
     if bindings is not None:
         mem = memory_service or MemorySpaceService()
-        # Resolve the author's accessible tools ONCE (async) if any tool binding is present,
-        # then validate each binding synchronously against that set — same source the palette
-        # uses, so the picker and the write agree (cf. the model check).
+        # Resolve the author's accessible tools/skills ONCE (async) when a binding of that
+        # kind is present, then validate each binding synchronously against those sets — the
+        # same sources the palette uses, so the picker and the write agree (cf. the model
+        # check). Each is fetched lazily (only when that kind is actually bound).
         accessible_tool_ids: Optional[set] = None
         if any(b.kind == "tool" for b in bindings):
             svc = tool_service or ToolCatalogService()
             accessible_tool_ids = {t.tool_id for t in await svc.get_user_accessible_tools(user)}
+        accessible_skill_ids: Optional[set] = None
+        if skills_enabled() and any(b.kind == "skill" for b in bindings):
+            accessible_skill_ids = set(await resolve_accessible_skill_ids(user))
         for binding in bindings:
-            _validate_binding(user, binding, mem, accessible_tool_ids)
+            _validate_binding(user, binding, mem, accessible_tool_ids, accessible_skill_ids)
 
 
 async def _validate_model(user: User, cfg: AgentModelConfig, svc: ModelAccessService) -> None:
@@ -105,6 +110,7 @@ def _validate_binding(
     binding: AgentBinding,
     mem: MemorySpaceService,
     accessible_tool_ids: Optional[set] = None,
+    accessible_skill_ids: Optional[set] = None,
 ) -> None:
     kind = binding.kind
     if kind not in KNOWN_BINDING_KINDS:
@@ -116,14 +122,12 @@ def _validate_binding(
             status_code=400,
         )
 
-    if kind in _INERT_KINDS:
-        # Inert: shape only, no RBAC, no catalog lookup.
-        if not binding.ref or not binding.ref.strip():
-            raise BindingValidationError(f"{kind} binding requires a non-empty 'ref'.", status_code=400)
-        return
-
     if kind == "tool":
         _validate_tool(binding, accessible_tool_ids or set())
+        return
+
+    if kind == "skill":
+        _validate_skill(binding, accessible_skill_ids or set())
         return
 
     if kind == "memory_space":
@@ -140,6 +144,21 @@ def _validate_tool(binding: AgentBinding, accessible_tool_ids: set) -> None:
     if ref not in accessible_tool_ids:
         raise BindingValidationError(
             f"You do not have access to tool '{ref}'.", status_code=403
+        )
+
+
+def _validate_skill(binding: AgentBinding, accessible_skill_ids: set) -> None:
+    if not skills_enabled():
+        raise BindingValidationError("Skills are not enabled.", status_code=400)
+    ref = (binding.ref or "").strip()
+    if not ref:
+        raise BindingValidationError("skill binding requires a non-empty 'ref'.", status_code=400)
+    # The skill id must be in the author's palette (resolve_accessible_skill_ids) — the exact
+    # source the Designer picker fetches. Run-time re-resolves against the invoker via
+    # AppRoleService.can_access_skill (D5).
+    if ref not in accessible_skill_ids:
+        raise BindingValidationError(
+            f"You do not have access to skill '{ref}'.", status_code=403
         )
 
 

--- a/backend/src/apis/inference_api/chat/agent_binding_resolver.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_resolver.py
@@ -20,8 +20,13 @@ Phase 3 lands incrementally:
   override): when an Agent binds tools they *are* its toolset, re-resolved per invoker via
   the same ``AppRoleService.can_access_tool`` gate; a bound tool the invoker lacks blocks the
   turn (D5). Absent tool bindings ⇒ the request's ``enabled_tools`` drive the turn as today.
-- ``knowledge_base`` stays with the existing RAG path; ``skill`` bindings are still inert
-  here (their runtime fold interacts with ``agent_type``/skill resolution — a later slice).
+- ``skill`` bindings → the effective skill set (**replace**, same shape as tools): when an
+  Agent binds skills they *are* the turn's skills, re-resolved per invoker via
+  ``AppRoleService.can_access_skill``; a bound skill the invoker lacks — or the skills feature
+  being disabled in this environment — blocks the turn (D5). The caller then forces skill-mode
+  (``agent_type="skill"``) for the turn so the SkillAgent actually discloses them. Absent skill
+  bindings ⇒ the request's ``agent_type``/``enabled_skills`` drive the turn as today.
+- ``knowledge_base`` stays with the existing RAG path.
 """
 
 from __future__ import annotations
@@ -32,7 +37,7 @@ from typing import List, Optional
 
 from apis.shared.assistants.models import Assistant
 from apis.shared.auth.models import User
-from apis.shared.feature_flags import memory_spaces_enabled
+from apis.shared.feature_flags import memory_spaces_enabled, skills_enabled
 from apis.shared.memory.service import MemorySpaceService
 from apis.shared.rbac.service import get_app_role_service
 
@@ -93,18 +98,35 @@ class ResolvedTools:
 
 
 @dataclass
+class ResolvedSkills:
+    """The Agent's ``skill`` bindings resolved to an effective skill set for the invoker.
+
+    ``skill_ids`` **replaces** the request's ``enabled_skills`` for this turn and the caller
+    forces ``agent_type="skill"`` so the SkillAgent discloses exactly these (an Agent that
+    binds skills owns its skills, like tools own the toolset). Every id has already passed the
+    invoker's ``AppRoleService.can_access_skill`` gate; a bound skill the invoker could not
+    access blocks the turn before this is constructed (D5). Always non-empty — the resolver
+    returns ``None`` (no skill binding) rather than an empty ``ResolvedSkills``.
+    """
+
+    skill_ids: List[str]
+
+
+@dataclass
 class AgentInvocationPlan:
     """What the Harness should apply for this turn after resolving the Agent.
 
     ``model_override`` is ``None`` when the Agent pins no model — the caller then
     resolves the model exactly as today. ``memory`` is ``None`` when the Agent binds no
     Memory Space. ``tools`` is ``None`` when the Agent binds no tools — the caller then
-    uses the request's ``enabled_tools`` unchanged.
+    uses the request's ``enabled_tools`` unchanged. ``skills`` is ``None`` when the Agent
+    binds no skills — the caller then uses the request's ``agent_type``/``enabled_skills``.
     """
 
     model_override: Optional[ResolvedModel] = None
     memory: Optional[ResolvedMemoryBinding] = None
     tools: Optional[ResolvedTools] = None
+    skills: Optional[ResolvedSkills] = None
 
 
 async def resolve_agent_invocation(assistant: Assistant, invoker: User) -> AgentInvocationPlan:
@@ -133,7 +155,43 @@ async def resolve_agent_invocation(assistant: Assistant, invoker: User) -> Agent
 
     plan.memory = await _resolve_memory(assistant, invoker)
     plan.tools = await _resolve_tools(assistant, invoker)
+    plan.skills = await _resolve_skills(assistant, invoker)
     return plan
+
+
+async def _resolve_skills(assistant: Assistant, invoker: User) -> Optional[ResolvedSkills]:
+    """Resolve the Agent's ``skill`` bindings to an effective skill set for ``invoker`` (D5).
+
+    Each bound skill is re-checked against the invoker with ``AppRoleService.can_access_skill``
+    (the same AppRole layer the harness's model/tool gates use); a single missing skill blocks
+    the turn (block-with-message, no silent drop — D5). The skills feature being disabled in
+    this environment also blocks — design-time refuses to create these while the flag is off,
+    so reaching here with the flag off is environment drift (mirror ``_resolve_memory``).
+    Returns ``None`` when the Agent binds no skills, leaving the request's ``agent_type`` /
+    ``enabled_skills`` in force.
+    """
+    skill_bindings = [b for b in (assistant.bindings or []) if b.kind == "skill"]
+    if not skill_bindings:
+        return None
+
+    if not skills_enabled():
+        raise AgentBindingBlockedError(
+            "This agent uses Skills, which aren't enabled in this environment."
+        )
+
+    app_role_service = get_app_role_service()
+    resolved: List[str] = []
+    for binding in skill_bindings:
+        ref = binding.ref
+        if not await app_role_service.can_access_skill(invoker, ref):
+            raise AgentBindingBlockedError(
+                f"This agent uses the skill **{ref}**, which isn't available to your account. "
+                "Ask an administrator for access, or use a different agent."
+            )
+        if ref not in resolved:
+            resolved.append(ref)
+
+    return ResolvedSkills(skill_ids=resolved)
 
 
 async def _resolve_tools(assistant: Assistant, invoker: User) -> Optional[ResolvedTools]:

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1177,6 +1177,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # the request's ``enabled_tools`` for the turn (like ``model_override`` replaces the
     # model). None ⇒ the Agent binds no tools ⇒ the request's enabled_tools drive the turn.
     agent_tools_override = None
+    # An Agent's ``skill`` bindings, resolved per invoker (D5). When set they replace the
+    # request's skills AND force skill-mode (agent_type="skill") for the turn. None ⇒ the
+    # Agent binds no skills ⇒ the request's agent_type/enabled_skills drive the turn.
+    agent_skills_override = None
 
     logger.info(
         "Invocation request - processing with assistant context"
@@ -1303,6 +1307,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 agent_model_override = agent_plan.model_override
                 agent_memory = agent_plan.memory
                 agent_tools_override = agent_plan.tools
+                agent_skills_override = agent_plan.skills
             except AgentBindingBlockedError as block:
                 blocked_event = ConversationalErrorEvent(
                     code=ErrorCode.FORBIDDEN, message=block.message, recoverable=False
@@ -1641,6 +1646,16 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 if agent_tools_override is not None
                 else input_data.enabled_tools
             )
+
+            # An Agent's skill bindings replace the request's skills for this turn and
+            # force skill-mode so the SkillAgent discloses exactly the bound set (D5,
+            # resolved per invoker above). Reassigning these function-scope locals here
+            # (before the main-turn get_agent below) makes them flow into construction —
+            # and thus the paused-turn snapshot — so a bound-skill agent resumes on the
+            # same skills_hash. None ⇒ no skill binding ⇒ the request drives skills/type.
+            if agent_skills_override is not None:
+                effective_agent_type = "skill"
+                effective_skill_ids = agent_skills_override.skill_ids
 
             extra_tools = _build_spreadsheet_tools(
                 enabled_tools=effective_enabled_tools,

--- a/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
+++ b/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
@@ -109,31 +109,75 @@ class TestModelValidation:
         svc.filter_accessible_models.assert_awaited_once()
 
 
-# --------------------------------------------------------------------------- inert
-class TestInertKinds:
-    @pytest.mark.asyncio
-    async def test_skill_stored_without_rbac(self):
-        # The inert guarantee (skill only now — tool is governed): no memory service is
-        # consulted, and a skill binding is stored verbatim.
-        mem = _mem_svc(space=None, role=None)
-        await validate_agent_write(
-            _user(),
-            bindings=[AgentBinding(kind="skill", ref="skill_1")],
-            memory_service=mem,
-        )
-        mem.resolve_permission.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_inert_kind_requires_ref(self):
-        with pytest.raises(BindingValidationError) as ei:
-            await validate_agent_write(_user(), bindings=[AgentBinding(kind="skill", ref="  ")])
-        assert ei.value.status_code == 400
-
+# --------------------------------------------------------------------------- kinds
+class TestBindingKinds:
     @pytest.mark.asyncio
     async def test_unknown_kind_rejected(self):
         with pytest.raises(BindingValidationError) as ei:
             await validate_agent_write(_user(), bindings=[AgentBinding(kind="bogus", ref="x")])
         assert ei.value.status_code == 400
+
+
+# --------------------------------------------------------------------------- skill
+class TestSkillValidation:
+    @pytest.fixture(autouse=True)
+    def _flag_on(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.skills_enabled", lambda: True)
+
+    def _patch_palette(self, monkeypatch, *skill_ids: str):
+        # Mirror the palette: resolve_accessible_skill_ids returns the author's granted ids.
+        monkeypatch.setattr(f"{MODULE}.resolve_accessible_skill_ids", AsyncMock(return_value=list(skill_ids)))
+
+    @pytest.mark.asyncio
+    async def test_accessible_skill_passes(self, monkeypatch):
+        self._patch_palette(monkeypatch, "skill_1", "skill_2")
+        await validate_agent_write(_user(), bindings=[AgentBinding(kind="skill", ref="skill_1")])
+
+    @pytest.mark.asyncio
+    async def test_inaccessible_skill_403(self, monkeypatch):
+        self._patch_palette(monkeypatch, "skill_1")
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(_user(), bindings=[AgentBinding(kind="skill", ref="secret")])
+        assert ei.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_empty_ref_400(self, monkeypatch):
+        self._patch_palette(monkeypatch, "skill_1")
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(_user(), bindings=[AgentBinding(kind="skill", ref="  ")])
+        assert ei.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_flag_off_400(self, monkeypatch):
+        monkeypatch.setattr(f"{MODULE}.skills_enabled", lambda: False)
+        # Palette isn't even consulted when the feature is off.
+        palette = AsyncMock(return_value=["skill_1"])
+        monkeypatch.setattr(f"{MODULE}.resolve_accessible_skill_ids", palette)
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(_user(), bindings=[AgentBinding(kind="skill", ref="skill_1")])
+        assert ei.value.status_code == 400
+        palette.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_palette_resolved_once_for_many_bindings(self, monkeypatch):
+        palette = AsyncMock(return_value=["a", "b"])
+        monkeypatch.setattr(f"{MODULE}.resolve_accessible_skill_ids", palette)
+        await validate_agent_write(
+            _user(),
+            bindings=[AgentBinding(kind="skill", ref="a"), AgentBinding(kind="skill", ref="b")],
+        )
+        palette.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_skill_binding_skips_palette(self, monkeypatch):
+        palette = AsyncMock(return_value=["a"])
+        monkeypatch.setattr(f"{MODULE}.resolve_accessible_skill_ids", palette)
+        await validate_agent_write(
+            _user(),
+            bindings=[AgentBinding(kind="tool", ref="a")],
+            tool_service=_tool_svc("a"),
+        )
+        palette.assert_not_awaited()
 
 
 # --------------------------------------------------------------------------- tool
@@ -179,11 +223,15 @@ class TestToolValidation:
         svc.get_user_accessible_tools.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_no_tool_binding_skips_tool_fetch(self):
+    async def test_no_tool_binding_skips_tool_fetch(self, monkeypatch):
         # No tool binding ⇒ the tool service is never consulted (lazy palette resolution).
+        monkeypatch.setattr(f"{MODULE}.memory_spaces_enabled", lambda: True)
         svc = _tool_svc("a")
         await validate_agent_write(
-            _user(), bindings=[AgentBinding(kind="skill", ref="skill_1")], tool_service=svc
+            _user(),
+            bindings=[AgentBinding(kind="memory_space", ref="spc_1", config={"access": "read"})],
+            memory_service=_mem_svc(space=object(), role="viewer"),
+            tool_service=svc,
         )
         svc.get_user_accessible_tools.assert_not_awaited()
 

--- a/backend/tests/apis/inference_api/test_agent_binding_resolver.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_resolver.py
@@ -80,6 +80,23 @@ def _tool_binding(ref: str) -> AgentBinding:
     return AgentBinding(kind="tool", ref=ref)
 
 
+def _patch_skill_access(monkeypatch, allowed, *, enabled=True) -> MagicMock:
+    """Patch the skills flag + AppRole gate for skill resolution. ``allowed`` is a bool or a
+    set of skill ids the invoker may access."""
+    monkeypatch.setattr(f"{MODULE}.skills_enabled", lambda: enabled)
+    svc = MagicMock()
+    if isinstance(allowed, bool):
+        svc.can_access_skill = AsyncMock(return_value=allowed)
+    else:
+        svc.can_access_skill = AsyncMock(side_effect=lambda user, sid: sid in allowed)
+    monkeypatch.setattr(f"{MODULE}.get_app_role_service", lambda: svc)
+    return svc
+
+
+def _skill_binding(ref: str) -> AgentBinding:
+    return AgentBinding(kind="skill", ref=ref)
+
+
 class TestModelResolution:
     @pytest.mark.asyncio
     async def test_no_modelconfig_is_empty_plan(self, monkeypatch):
@@ -235,3 +252,55 @@ class TestToolResolution:
         # can_access_tool(invoker, tool_id) — the INVOKING user, not the author.
         args = svc.can_access_tool.await_args.args
         assert args[0].user_id == "u-bob" and args[1] == "web_search"
+
+
+class TestSkillResolution:
+    @pytest.mark.asyncio
+    async def test_no_skill_binding_is_none(self, monkeypatch):
+        # No skill binding ⇒ plan.skills is None and we never consult the flag or RBAC.
+        svc = _patch_skill_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(_assistant(bindings=[]), _user())
+        assert plan.skills is None
+        svc.can_access_skill.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_accessible_skills_become_override(self, monkeypatch):
+        _patch_skill_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_skill_binding("research"), _skill_binding("writing")]), _user()
+        )
+        assert plan.skills is not None
+        assert plan.skills.skill_ids == ["research", "writing"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_refs_deduped(self, monkeypatch):
+        _patch_skill_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_skill_binding("research"), _skill_binding("research")]), _user()
+        )
+        assert plan.skills.skill_ids == ["research"]
+
+    @pytest.mark.asyncio
+    async def test_flag_off_blocks(self, monkeypatch):
+        # Skills disabled in this environment but the Agent binds one ⇒ block (env drift, D5).
+        _patch_skill_access(monkeypatch, True, enabled=False)
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(_assistant(bindings=[_skill_binding("research")]), _user())
+        assert "enabled" in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_missing_skill_blocks_with_message(self, monkeypatch):
+        _patch_skill_access(monkeypatch, {"writing"})
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(
+                _assistant(bindings=[_skill_binding("research"), _skill_binding("writing")]), _user()
+            )
+        assert "research" in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_skill_access_checked_against_invoker(self, monkeypatch):
+        svc = _patch_skill_access(monkeypatch, True)
+        await resolve_agent_invocation(_assistant(bindings=[_skill_binding("research")]), _user())
+        # can_access_skill(invoker, skill_id) — the INVOKING user, not the author.
+        args = svc.can_access_skill.await_args.args
+        assert args[0].user_id == "u-bob" and args[1] == "research"


### PR DESCRIPTION
## Summary

Completes the tool/skill runtime-resolution gap (tools landed in #601). An Agent's `skill` bindings were stored by the Designer but **inert at run time** — chatting an Agent ignored its bound skills. This resolves them, mirroring the shipped `model`/`tool` overrides. With this, **every binding kind resolves at invocation and no inert kinds remain.**

## What changed

**Run-time (inference-api)** — `resolve_agent_invocation` now returns `plan.skills` (`ResolvedSkills`). When an Agent binds skills they **replace** the request's skills for the turn, and the route **forces `agent_type="skill"`** so the `SkillAgent` discloses exactly the bound set. Each bound skill is re-checked against the **invoking** user via `AppRoleService.can_access_skill`; a missing skill — or the Skills feature being disabled in the environment — **blocks the turn with a message** (D5). No skill binding ⇒ `plan.skills is None` ⇒ the request's `agent_type`/`enabled_skills` drive the turn exactly as today.

**Resume-safe by construction** — the effective `agent_type`/`enabled_skills` are reassigned before the main-turn `get_agent`, so they flow into the construction snapshot (`service.py:256-258`) and a paused bound-skill agent resumes on the same `skills_hash`. (Same mechanism the tool slice relies on; scope-verified there's no closure-local trap — the streaming generator starts after `get_agent`.)

**Design-time (app-api)** — `skill` dropped from inert (no inert kinds remain). A bound skill is flag-gated (`skills_enabled()`) and must be in the author's palette (`resolve_accessible_skill_ids`, the same source the Designer picker fetches — cf. the tool check). The palette is resolved once per write, only when skills are enabled.

## Governance note

Binding skills to an Agent **forces skill-mode for that turn**, bypassing the admin chat-mode policy. This is intentional — an Agent is a governed authored capability (like model-override winning over the request) — but worth knowing when debugging why an agent runs in skill mode.

## Tests

- +6 resolver cases (override, dedupe, flag-off block, block-on-missing, per-invoker, none→passthrough)
- +6 validation cases (accessible/inaccessible/empty-ref/flag-off/fetch-once/lazy)
- Full backend suite green: **4631 passed, 3 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)