### PR TITLE
feat(agent-designer): reflect governed agent bindings in the chat-input (lock pickers)

### DIFF
--- a/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroCheck } from '@ng-icons/heroicons/outline';
+import { heroCheck, heroLockClosed } from '@ng-icons/heroicons/outline';
 import { ModelService } from '../../session/services/model/model.service';
 import { SessionService } from '../../session/services/session/session.service';
 import { ManagedModel } from '../../admin/manage-models/models/managed-model.model';
@@ -12,9 +12,20 @@ import { ManagedModel } from '../../admin/manage-models/models/managed-model.mod
   selector: 'app-model-dropdown',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CdkMenuTrigger, CdkMenu, CdkMenuItem, NgIcon],
-  providers: [provideIcons({ heroCheck })],
+  providers: [provideIcons({ heroCheck, heroLockClosed })],
   template: `
     <div class="relative">
+      @if (modelService.agentModelLocked()) {
+        <!-- Agent-dictated: the active agent pins this model; the picker is locked. -->
+        <div
+          class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400"
+          title="This agent runs on a fixed model"
+        >
+          <ng-icon name="heroLockClosed" class="size-3.5 shrink-0" aria-hidden="true" />
+          <span>{{ modelService.selectedModel().modelName || 'Loading...' }}</span>
+          <span class="sr-only">(set by this agent)</span>
+        </div>
+      } @else {
       <button
         type="button"
         [cdkMenuTriggerFor]="modelMenu"
@@ -37,6 +48,7 @@ import { ManagedModel } from '../../admin/manage-models/models/managed-model.mod
           />
         </svg>
       </button>
+      }
 
       <ng-template #modelMenu>
         <div

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -50,6 +50,15 @@
           <div class="mt-2 text-sm/6 text-red-600 dark:text-red-400" role="alert">
             {{ modelService.modelsError() }}
           </div>
+        } @else if (modelService.agentModelLocked()) {
+          <!-- Agent-dictated: the active agent pins this model; the picker is locked. -->
+          <div class="mt-1.5 flex items-center gap-2 rounded-2xl border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-white/5">
+            <ng-icon name="heroLockClosed" class="size-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+            <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+              {{ modelService.selectedModel().modelName }}
+            </span>
+            <span class="ml-auto shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">Set by agent</span>
+          </div>
         } @else {
           <!-- Custom dropdown -->
           <div class="relative mt-1.5">
@@ -353,6 +362,12 @@
 
           @if (isSkillsOpen()) {
             <div id="skills-body" class="px-4 pb-4">
+              @if (skillService.agentLocked()) {
+                <p class="mb-3 flex items-center gap-1.5 rounded-md bg-gray-50 px-3 py-2 text-xs/5 text-gray-500 dark:bg-white/5 dark:text-gray-400">
+                  <ng-icon name="heroLockClosed" class="size-3.5 shrink-0" aria-hidden="true" />
+                  This agent uses a fixed set of skills.
+                </p>
+              }
               @if (skillService.loading()) {
                 <div class="text-sm/6 text-gray-500 dark:text-gray-400">Loading skills...</div>
               } @else if (skillService.error()) {
@@ -392,19 +407,23 @@
                         type="button"
                         role="switch"
                         [id]="'skill-toggle-' + skill.skillId"
-                        [attr.aria-checked]="skill.isEnabled"
+                        [attr.aria-checked]="skillService.isSkillShownEnabled(skill)"
                         [attr.aria-labelledby]="'skill-label-' + skill.skillId"
                         [attr.aria-describedby]="'skill-desc-' + skill.skillId"
+                        [disabled]="skillService.agentLocked()"
                         (click)="toggleSkill(skill.skillId)"
                         (keydown.space)="$event.preventDefault(); toggleSkill(skill.skillId)"
                         (keydown.enter)="toggleSkill(skill.skillId)"
-                        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                        [class]="skill.isEnabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                        class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                        [class.cursor-pointer]="!skillService.agentLocked()"
+                        [class.cursor-not-allowed]="skillService.agentLocked()"
+                        [class.opacity-60]="skillService.agentLocked()"
+                        [class]="skillService.isSkillShownEnabled(skill) ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
                         <span
                           aria-hidden="true"
                           class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                          [class.translate-x-5]="skill.isEnabled"
-                          [class.translate-x-0]="!skill.isEnabled">
+                          [class.translate-x-5]="skillService.isSkillShownEnabled(skill)"
+                          [class.translate-x-0]="!skillService.isSkillShownEnabled(skill)">
                         </span>
                       </button>
                     </div>
@@ -436,6 +455,12 @@
 
         @if (isToolsOpen()) {
           <div id="tools-body" class="px-4 pb-4">
+            @if (toolService.agentLocked()) {
+              <p class="mb-3 flex items-center gap-1.5 rounded-md bg-gray-50 px-3 py-2 text-xs/5 text-gray-500 dark:bg-white/5 dark:text-gray-400">
+                <ng-icon name="heroLockClosed" class="size-3.5 shrink-0" aria-hidden="true" />
+                This agent uses a fixed set of tools.
+              </p>
+            }
             @if (toolService.loading()) {
               <div class="text-sm/6 text-gray-500 dark:text-gray-400">Loading tools...</div>
             } @else if (toolService.error()) {
@@ -482,19 +507,23 @@
                         type="button"
                         role="switch"
                         [id]="'tool-toggle-' + tool.toolId"
-                        [attr.aria-checked]="tool.isEnabled"
+                        [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
                         [attr.aria-labelledby]="'tool-label-' + tool.toolId"
                         [attr.aria-describedby]="'tool-desc-' + tool.toolId"
+                        [disabled]="toolService.agentLocked()"
                         (click)="toggleTool(tool.toolId)"
                         (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
                         (keydown.enter)="toggleTool(tool.toolId)"
-                        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                        [class]="tool.isEnabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                        class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                        [class.cursor-pointer]="!toolService.agentLocked()"
+                        [class.cursor-not-allowed]="toolService.agentLocked()"
+                        [class.opacity-60]="toolService.agentLocked()"
+                        [class]="toolService.isToolShownEnabled(tool) ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
                         <span
                           aria-hidden="true"
                           class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                          [class.translate-x-5]="tool.isEnabled"
-                          [class.translate-x-0]="!tool.isEnabled">
+                          [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
+                          [class.translate-x-0]="!toolService.isToolShownEnabled(tool)">
                         </span>
                       </button>
                     </div>
@@ -514,18 +543,22 @@
                               <button
                                 type="button"
                                 role="switch"
-                                [attr.aria-checked]="sub.enabled"
+                                [attr.aria-checked]="toolService.isSubToolShownEnabled(tool, sub)"
                                 [attr.aria-labelledby]="'subtool-label-' + tool.toolId + '-' + sub.name"
+                                [disabled]="toolService.agentLocked()"
                                 (click)="toggleServerTool(tool.toolId, sub.name)"
                                 (keydown.space)="$event.preventDefault(); toggleServerTool(tool.toolId, sub.name)"
                                 (keydown.enter)="toggleServerTool(tool.toolId, sub.name)"
-                                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                                [class]="sub.enabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                                class="relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                                [class.cursor-pointer]="!toolService.agentLocked()"
+                                [class.cursor-not-allowed]="toolService.agentLocked()"
+                                [class.opacity-60]="toolService.agentLocked()"
+                                [class]="toolService.isSubToolShownEnabled(tool, sub) ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
                                 <span
                                   aria-hidden="true"
                                   class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                                  [class.translate-x-4]="sub.enabled"
-                                  [class.translate-x-0]="!sub.enabled">
+                                  [class.translate-x-4]="toolService.isSubToolShownEnabled(tool, sub)"
+                                  [class.translate-x-0]="!toolService.isSubToolShownEnabled(tool, sub)">
                                 </span>
                               </button>
                             </div>

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, inject, input, output, signal, computed, effect, ElementRef } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroLockClosed } from '@ng-icons/heroicons/outline';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService, Tool } from '../../services/tool/tool.service';
 import { SkillService } from '../../services/skill/skill.service';
@@ -42,7 +42,7 @@ interface AdvancedParamRow {
   selector: 'app-model-settings',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
-  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath })],
+  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroLockClosed })],
   host: {
     '(document:click)': 'onDocumentClick($event)',
   },

--- a/frontend/ai.client/src/app/services/skill/skill.service.spec.ts
+++ b/frontend/ai.client/src/app/services/skill/skill.service.spec.ts
@@ -57,6 +57,45 @@ describe('SkillService', () => {
     });
   });
 
+  describe('agent binding lock', () => {
+    beforeEach(setup);
+
+    it('is unlocked by default', () => {
+      expect(service.agentLocked()).toBe(false);
+    });
+
+    it('locks enabledSkillIds to the bound set (replace semantics)', () => {
+      // web_research is user-disabled; the lock forces exactly the bound set.
+      service.lockToAgentSkills(['web_research']);
+      expect(service.agentLocked()).toBe(true);
+      expect(service.enabledSkillIds()).toEqual(['web_research']);
+      expect(service.enabledCount()).toBe(1);
+    });
+
+    it('reflects the bound set in per-skill shown state', () => {
+      service.lockToAgentSkills(['web_research']);
+      const pdf = service.skills().find(s => s.skillId === 'pdf_workflows')!;
+      const web = service.skills().find(s => s.skillId === 'web_research')!;
+      expect(service.isSkillShownEnabled(pdf)).toBe(false);
+      expect(service.isSkillShownEnabled(web)).toBe(true);
+    });
+
+    it('ignores toggles while locked (no HTTP)', async () => {
+      service.lockToAgentSkills(['web_research']);
+      await service.toggleSkill('pdf_workflows');
+      httpMock.expectNone('http://localhost:8000/skills/preferences');
+      expect(service.enabledSkillIds()).toEqual(['web_research']);
+    });
+
+    it('restores the user set when cleared', () => {
+      service.lockToAgentSkills(['web_research']);
+      service.clearAgentLock();
+      expect(service.agentLocked()).toBe(false);
+      // Back to per-skill state: only pdf_workflows is user-enabled.
+      expect(service.enabledSkillIds()).toEqual(['pdf_workflows']);
+    });
+  });
+
   describe('loadSkills', () => {
     beforeEach(setup);
 

--- a/frontend/ai.client/src/app/services/skill/skill.service.ts
+++ b/frontend/ai.client/src/app/services/skill/skill.service.ts
@@ -51,11 +51,20 @@ export class SkillService {
   private _error = signal<string | null>(null);
   private _initialized = signal(false);
 
+  // Agent Designer: when the active conversation is bound to an Agent that binds
+  // skills, the picker is locked to exactly that set — the backend governs skills
+  // (and forces skill-mode) at invocation regardless of the client. Holds the
+  // bound skill ids, or null when not agent-bound.
+  private readonly _agentLockedSkillIds = signal<string[] | null>(null);
+
   // Public readonly signals
   readonly skills = this._skills.asReadonly();
   readonly loading = this._loading.asReadonly();
   readonly error = this._error.asReadonly();
   readonly initialized = this._initialized.asReadonly();
+
+  /** True when the skill set is dictated by the active Agent and toggles are locked. */
+  readonly agentLocked = computed(() => this._agentLockedSkillIds() !== null);
 
   constructor() {
     // Load the user's skills once the feature is known to be enabled. While
@@ -78,13 +87,47 @@ export class SkillService {
   );
 
   /** Skill ids to send as `enabled_skills` on a skills-mode chat request. */
-  readonly enabledSkillIds = computed(() =>
-    this.enabledSkills().map(s => s.skillId)
-  );
+  readonly enabledSkillIds = computed(() => {
+    // Agent-bound: the Agent's skills are the effective set (the backend enforces
+    // the same, replace semantics, and forces skill-mode). Toggling is disabled.
+    const locked = this._agentLockedSkillIds();
+    if (locked !== null) {
+      return [...locked];
+    }
+    return this.enabledSkills().map(s => s.skillId);
+  });
 
-  readonly enabledCount = computed(() => this.enabledSkills().length);
+  readonly enabledCount = computed(() => {
+    const locked = this._agentLockedSkillIds();
+    if (locked !== null) {
+      return locked.length;
+    }
+    return this.enabledSkills().length;
+  });
 
   readonly hasSkills = computed(() => this._skills().length > 0);
+
+  /**
+   * Whether a skill row should render as ON. Agent-locked → membership in the
+   * bound set; otherwise the user's own enabled state.
+   */
+  isSkillShownEnabled(skill: UserSkill): boolean {
+    const locked = this._agentLockedSkillIds();
+    if (locked !== null) {
+      return locked.includes(skill.skillId);
+    }
+    return skill.isEnabled;
+  }
+
+  /** Lock the picker to an Agent's bound skills (Agent Designer). */
+  lockToAgentSkills(skillIds: string[]): void {
+    this._agentLockedSkillIds.set([...skillIds]);
+  }
+
+  /** Release an Agent skill lock. */
+  clearAgentLock(): void {
+    this._agentLockedSkillIds.set(null);
+  }
 
   /**
    * Fetch the user's accessible skills. Called on service construction;
@@ -114,6 +157,8 @@ export class SkillService {
 
   /** Toggle a skill's enabled state (optimistic, reverts on save failure). */
   async toggleSkill(skillId: string): Promise<void> {
+    // Agent-locked: the skill set is dictated by the Agent; ignore toggles.
+    if (this._agentLockedSkillIds() !== null) return;
     const skill = this._skills().find(s => s.skillId === skillId);
     if (!skill) return;
 

--- a/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.spec.ts
@@ -66,6 +66,51 @@ describe('ToolService', () => {
     });
   });
 
+  describe('agent binding lock', () => {
+    beforeEach(setup);
+
+    it('is unlocked by default', () => {
+      expect(service.agentLocked()).toBe(false);
+    });
+
+    it('locks enabledToolIds to the bound set (replace semantics)', () => {
+      service.lockToAgentTools(['code-interp']);
+      expect(service.agentLocked()).toBe(true);
+      // Replaces the user's set entirely, even though search-web is user-enabled.
+      expect(service.enabledToolIds()).toEqual(['code-interp']);
+      expect(service.enabledCount()).toBe(1);
+    });
+
+    it('reflects the bound set in per-tool shown state', () => {
+      service.lockToAgentTools(['code-interp']);
+      const search = service.getTool('search-web')!;
+      const code = service.getTool('code-interp')!;
+      expect(service.isToolShownEnabled(search)).toBe(false);
+      expect(service.isToolShownEnabled(code)).toBe(true);
+    });
+
+    it('ignores toggles while locked (no HTTP)', async () => {
+      service.lockToAgentTools(['code-interp']);
+      await service.toggleTool('search-web');
+      httpMock.expectNone('http://localhost:8000/tools/preferences');
+      expect(service.enabledToolIds()).toEqual(['code-interp']);
+    });
+
+    it('restores the user set when cleared', () => {
+      service.lockToAgentTools(['code-interp']);
+      service.clearAgentLock();
+      expect(service.agentLocked()).toBe(false);
+      // Back to the per-tool computation (both mock tools are enabled).
+      expect(service.enabledToolIds().sort()).toEqual(['code-interp', 'search-web']);
+    });
+
+    it('locks to an empty set (agent with no tools ≠ free-select)', () => {
+      service.lockToAgentTools([]);
+      expect(service.agentLocked()).toBe(true);
+      expect(service.enabledToolIds()).toEqual([]);
+    });
+  });
+
   describe('toggleTool', () => {
     beforeEach(setup);
 

--- a/frontend/ai.client/src/app/services/tool/tool.service.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.ts
@@ -99,12 +99,21 @@ export class ToolService {
   private _appRolesApplied = signal<string[]>([]);
   private _initialized = signal(false);
 
+  // Agent Designer: when the active conversation is bound to an Agent that binds
+  // tools, the picker is locked to exactly that set — the backend governs the
+  // toolset at invocation regardless of the client, so a free-select picker would
+  // be dishonest. Holds the bound tool ids, or null when not agent-bound.
+  private readonly _agentLockedToolIds = signal<string[] | null>(null);
+
   // Public readonly signals
   readonly tools = this._tools.asReadonly();
   readonly loading = this._loading.asReadonly();
   readonly error = this._error.asReadonly();
   readonly appRolesApplied = this._appRolesApplied.asReadonly();
   readonly initialized = this._initialized.asReadonly();
+
+  /** True when the toolset is dictated by the active Agent and toggles are locked. */
+  readonly agentLocked = computed(() => this._agentLockedToolIds() !== null);
 
   constructor() {
     // Load tools on initialization (similar to ModelService pattern)
@@ -124,6 +133,12 @@ export class ToolService {
    * (or a tool with no sub-tools) emits its bare id.
    */
   readonly enabledToolIds = computed(() => {
+    // Agent-bound: the Agent's tools are the effective set (the backend enforces
+    // the same, replace semantics). Toggling is disabled, so nothing else feeds in.
+    const locked = this._agentLockedToolIds();
+    if (locked !== null) {
+      return [...locked];
+    }
     const ids: string[] = [];
     for (const tool of this._tools()) {
       const subs = tool.serverTools ?? [];
@@ -145,9 +160,48 @@ export class ToolService {
     return ids;
   });
 
-  readonly enabledCount = computed(() =>
-    this.enabledTools().length
-  );
+  readonly enabledCount = computed(() => {
+    const locked = this._agentLockedToolIds();
+    if (locked !== null) {
+      return locked.length;
+    }
+    return this.enabledTools().length;
+  });
+
+  /**
+   * Whether a tool row should render as ON. Agent-locked → membership in the
+   * bound set (so greyed toggles honestly show the Agent's toolset, not the
+   * user's underlying prefs); otherwise the user's own enabled state.
+   */
+  isToolShownEnabled(tool: Tool): boolean {
+    const locked = this._agentLockedToolIds();
+    if (locked !== null) {
+      return locked.includes(tool.toolId);
+    }
+    return tool.isEnabled;
+  }
+
+  /**
+   * Whether an MCP sub-tool row should render as ON. Agent-locked → follows the
+   * server's shown state (agents bind whole tools, so all subs match); otherwise
+   * the sub-tool's own enabled flag.
+   */
+  isSubToolShownEnabled(tool: Tool, sub: { enabled: boolean }): boolean {
+    if (this._agentLockedToolIds() !== null) {
+      return this.isToolShownEnabled(tool);
+    }
+    return sub.enabled;
+  }
+
+  /** Lock the picker to an Agent's bound tools (Agent Designer). */
+  lockToAgentTools(toolIds: string[]): void {
+    this._agentLockedToolIds.set([...toolIds]);
+  }
+
+  /** Release an Agent tool lock. */
+  clearAgentLock(): void {
+    this._agentLockedToolIds.set(null);
+  }
 
   readonly toolsByCategory = computed(() => {
     const grouped = new Map<string, Tool[]>();
@@ -196,6 +250,8 @@ export class ToolService {
    * per-tool selection.
    */
   async toggleTool(toolId: string): Promise<void> {
+    // Agent-locked: the toolset is dictated by the Agent; ignore toggles.
+    if (this._agentLockedToolIds() !== null) return;
     const tool = this._tools().find(t => t.toolId === toolId);
     if (!tool) return;
 
@@ -259,6 +315,8 @@ export class ToolService {
    * `isEnabled` becomes "any tool enabled".
    */
   async toggleServerTool(toolId: string, name: string): Promise<void> {
+    // Agent-locked: the toolset is dictated by the Agent; ignore toggles.
+    if (this._agentLockedToolIds() !== null) return;
     const tool = this._tools().find(t => t.toolId === toolId);
     const sub = tool?.serverTools?.find(s => s.name === name);
     if (!tool || !sub) return;

--- a/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
@@ -58,6 +58,34 @@ describe('ModelService', () => {
     TestBed.resetTestingModule();
   });
 
+  describe('agent model lock', () => {
+    beforeEach(setup);
+
+    it('is unlocked by default', () => {
+      expect(service.agentModelLocked()).toBe(false);
+    });
+
+    it('locks to and selects the agent-pinned model', () => {
+      service.lockToAgentModel('claude-haiku');
+      expect(service.agentModelLocked()).toBe(true);
+      expect(service.selectedModel().modelId).toBe('claude-haiku');
+    });
+
+    it('records the lock even when the pinned model is not available', () => {
+      // Backend blocks the turn (D5) in this case; the picker still disables and
+      // does not silently pretend a different model was chosen.
+      service.lockToAgentModel('ghost-model');
+      expect(service.agentModelLocked()).toBe(true);
+      expect(service.selectedModel().modelId).not.toBe('ghost-model');
+    });
+
+    it('releases the lock when cleared', () => {
+      service.lockToAgentModel('claude-haiku');
+      service.clearAgentModelLock();
+      expect(service.agentModelLocked()).toBe(false);
+    });
+  });
+
   describe('loadModels', () => {
     beforeEach(setup);
 

--- a/frontend/ai.client/src/app/session/services/model/model.service.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.ts
@@ -55,6 +55,12 @@ export class ModelService {
   // Selected model (defaults to first model when available, or system default)
   private readonly _selectedModel = signal<ManagedModel | null>(null);
 
+  // Agent Designer: when the active conversation is bound to an Agent that pins
+  // a model, the picker is locked to it — the backend governs the model at
+  // invocation regardless of what the client sends, so a free-select picker
+  // would be dishonest. Holds the pinned modelId, or null when not agent-bound.
+  private readonly _agentLockedModelId = signal<string | null>(null);
+
   // Per-model canonical inference param overrides. Outer key = modelId, inner
   // key = canonical param name (temperature, top_p, thinking, ...). Sent on
   // each chat request as `inference_params`; backend layers them on top of
@@ -78,6 +84,9 @@ export class ModelService {
   });
   readonly modelsLoading = this.isLoading.asReadonly();
   readonly modelsError = this.error.asReadonly();
+
+  /** True when the model is dictated by the active Agent and the picker is locked. */
+  readonly agentModelLocked = computed(() => this._agentLockedModelId() !== null);
 
   /** Inference param overrides for the currently selected model. */
   readonly selectedModelOverrides = computed<Record<string, unknown>>(() => {
@@ -232,6 +241,24 @@ export class ModelService {
     }
 
     return false;
+  }
+
+  /**
+   * Lock the picker to an Agent's pinned model (Agent Designer). Selects the
+   * model by its modelId and marks it agent-locked so the dropdown disables.
+   * If the pinned model isn't in the user's available set, the lock is still
+   * recorded (dropdown disabled) but the selection is left unchanged — the
+   * backend blocks the turn with a message in that case (D5), so we don't
+   * silently pretend a different model.
+   */
+  lockToAgentModel(modelId: string): void {
+    this._agentLockedModelId.set(modelId);
+    this.setSelectedModelById(modelId);
+  }
+
+  /** Release an Agent model lock (e.g. navigating away from an agent conversation). */
+  clearAgentModelLock(): void {
+    this._agentLockedModelId.set(null);
   }
 
   /**

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -26,6 +26,10 @@ import { McpAppConsentService } from './services/mcp-apps/mcp-app-consent.servic
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
 import { Assistant } from '../assistants/models/assistant.model';
+import { AgentService } from '../agents/services/agent.service';
+import { Agent } from '../agents/models/agent.model';
+import { ToolService } from '../services/tool/tool.service';
+import { SkillService } from '../services/skill/skill.service';
 import { ChatContainerComponent, ChatContainerConfig } from './components/chat-container/chat-container.component';
 import {
   ShareAssistantDialogComponent,
@@ -63,6 +67,9 @@ export class ConversationPage implements OnDestroy {
   private oauthConsent = inject(OAuthConsentService);
   private artifactHttp = inject(ArtifactHttpService);
   private assistantService = inject(AssistantService);
+  private agentService = inject(AgentService);
+  private toolService = inject(ToolService);
+  private skillService = inject(SkillService);
   private router = inject(Router);
   private dialog = inject(Dialog);
   private voiceChatService = inject(VoiceChatService);
@@ -87,6 +94,10 @@ export class ConversationPage implements OnDestroy {
 
   assistant = signal<Assistant | null>(null);
   assistantError = signal<string | null>(null);
+  // Agent Designer: the governed Agent behind this conversation (agentId ==
+  // assistantId), when the /agents surface is enabled and it resolves. Drives
+  // the per-primitive picker locks; null for plain chat or a legacy assistant.
+  agent = signal<Agent | null>(null);
   isLoadingAssistant = signal(false);
   isSettingsOpen = signal(false);
 
@@ -330,9 +341,11 @@ export class ConversationPage implements OnDestroy {
       }
 
       // No assistant in the URL — clear any stale state from a prior load.
-      if (loadedAssistant || this.assistantError()) {
+      if (loadedAssistant || this.assistantError() || this.agent()) {
         this.assistant.set(null);
         this.assistantError.set(null);
+        this.agent.set(null);
+        this.clearAgentBindingLocks();
       }
     });
 
@@ -719,6 +732,9 @@ export class ConversationPage implements OnDestroy {
       // Only check existence (404), not access (403) - access validated on backend
       const loadedAssistant = await this.assistantService.getAssistant(assistantId);
       this.assistant.set(loadedAssistant);
+      // Reflect the Agent's governed bindings in the chat-input (Agent Designer).
+      // Best-effort and independent of the assistant fetch above.
+      await this.loadAgentBindings(assistantId);
     } catch (error: any) {
       console.error('Failed to load assistant:', error);
       
@@ -735,6 +751,57 @@ export class ConversationPage implements OnDestroy {
     } finally {
       this.isLoadingAssistant.set(false);
     }
+  }
+
+  /**
+   * Fetch the governed Agent behind this conversation and lock the chat-input
+   * pickers to its bindings (Agent Designer). `agentId == assistantId`, so the
+   * same query-param id resolves the Agent. Best-effort: the /agents surface may
+   * be disabled (404) or the assistant may be a legacy assistant with no
+   * bindings — in every failure case the pickers stay free-select (locks cleared),
+   * and the conversation is never blocked on this. The backend still governs
+   * bindings at invocation regardless, so this is UI honesty, not enforcement.
+   */
+  private async loadAgentBindings(assistantId: string): Promise<void> {
+    try {
+      const agent = await this.agentService.getAgent(assistantId);
+      this.agent.set(agent);
+      this.applyAgentBindingLocks(agent);
+    } catch {
+      this.agent.set(null);
+      this.clearAgentBindingLocks();
+    }
+  }
+
+  /** Lock each picker to the Agent's binding, or release it when unbound. */
+  private applyAgentBindingLocks(agent: Agent): void {
+    const modelId = agent.modelConfig?.modelId;
+    if (modelId) {
+      this.modelService.lockToAgentModel(modelId);
+    } else {
+      this.modelService.clearAgentModelLock();
+    }
+
+    const toolIds = agent.bindings.filter(b => b.kind === 'tool').map(b => b.ref);
+    if (toolIds.length > 0) {
+      this.toolService.lockToAgentTools(toolIds);
+    } else {
+      this.toolService.clearAgentLock();
+    }
+
+    const skillIds = agent.bindings.filter(b => b.kind === 'skill').map(b => b.ref);
+    if (skillIds.length > 0) {
+      this.skillService.lockToAgentSkills(skillIds);
+    } else {
+      this.skillService.clearAgentLock();
+    }
+  }
+
+  /** Release every Agent picker lock (plain chat / navigating away). */
+  private clearAgentBindingLocks(): void {
+    this.modelService.clearAgentModelLock();
+    this.toolService.clearAgentLock();
+    this.skillService.clearAgentLock();
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes the frontend half of the Agent binding-resolution work. The backend now **governs** an Agent's model/tool/skill bindings at invocation (#601, #602) — the agent's set wins regardless of what the client sends. But the chat-input still showed the model/tool/skill pickers as **free-select**, which was dishonest: the user could "change" a model the backend would ignore. This **locks each picker to the active Agent's bindings**, per primitive.

This is **UI honesty, not enforcement** — the backend remains the authority. Per-primitive: an agent that binds a model but no tools locks only the model; the rest stay free-select. Plain chat and legacy assistants are unchanged.

## What changed

- **Session page** (`session.page.ts`): inject `AgentService`/`ToolService`/`SkillService`; fetch the governed Agent alongside the assistant (`agentId == assistantId`) in `loadAssistant`; apply per-primitive locks from `modelConfig`/`bindings`, and release them when navigating to plain chat. Best-effort: the `/agents` surface may be disabled (404) or the assistant may be a legacy assistant with no bindings — every failure leaves the pickers free-select and never blocks the conversation.
- **ModelService / ToolService / SkillService**: small agent-lock API (`lockToAgent*` / `clearAgentLock` + `agentLocked`/`agentModelLocked`). While locked, `enabledToolIds`/`enabledSkillIds` return the bound set (replace semantics, matching the backend), toggles no-op, and `isToolShownEnabled`/`isSkillShownEnabled` render the bound set honestly (greyed).
- **UI**: model-dropdown shows a locked read-only chip; model-settings shows a "Set by agent" model row and a "This agent uses a fixed set of tools/skills" banner, with tool/skill/sub-tool toggles disabled while locked.

## Tests

- +5 tool-lock, +5 skill-lock, +4 model-lock service specs (`ng test`, 51 pass in the affected specs)
- `tsc` clean; production build (AOT template validation) clean
- No local preview (needs backend + `AGENTS_API_ENABLED` + auth) — see the manual test script in the PR discussion.

## Known limitations (follow-up)

- **Model race**: if the pinned model isn't in the user's loaded set yet, the dropdown disables but may show the fallback name until models load. (Models load on app init, so rare.)
- **Skill-lock banner** only renders in skills chat-mode (the skills section is mode-gated); the backend still forces skill-mode + the bound skills regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)