### PR TITLE
feat(agent-designer): lock preview model picker; trim preview nav

### DIFF
--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -326,6 +326,7 @@
         [description]="liveFormDescription()"
         [emoji]="liveFormEmoji()"
         [starters]="liveFormStarters()"
+        [modelId]="selectedModelId()"
         [modelLabel]="previewModelLabel()"
         [toolCount]="selectedToolRefs().size"
         [skillCount]="selectedSkillRefs().size"

--- a/frontend/ai.client/src/app/agents/agent-form/components/agent-preview.component.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/components/agent-preview.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  OnDestroy,
   input,
   output,
   computed,
@@ -20,6 +21,7 @@ import { ChatContainerComponent, ChatContainerConfig } from '../../../session/co
 import { ChatInputComponent } from '../../../session/components/chat-input/chat-input.component';
 import { PreviewChatService } from '../../../assistants/assistant-form/services/preview-chat.service';
 import { AssistantCardComponent } from '../../../assistants/components/assistant-card.component';
+import { ModelService } from '../../../session/services/model/model.service';
 
 /**
  * Live preview for the Agent Designer, side-by-side with the editor.
@@ -177,8 +179,9 @@ import { AssistantCardComponent } from '../../../assistants/components/assistant
   `,
   styles: [':host { display: block; height: 100%; }'],
 })
-export class AgentPreviewComponent {
+export class AgentPreviewComponent implements OnDestroy {
   readonly previewChatService = inject(PreviewChatService);
+  private readonly modelService = inject(ModelService);
 
   // Persona (live from the form)
   readonly agentId = input<string | null>(null);
@@ -188,6 +191,7 @@ export class AgentPreviewComponent {
   readonly starters = input<string[]>([]);
 
   // Capability strip (current selections — reflected once saved)
+  readonly modelId = input<string | null>(null);
   readonly modelLabel = input<string | null>(null);
   readonly toolCount = input<number>(0);
   readonly skillCount = input<number>(0);
@@ -223,6 +227,26 @@ export class AgentPreviewComponent {
     effect(() => {
       if (this.agentId()) this.previewChatService.reset();
     });
+
+    // Pin the chat-input model picker to the agent's model — the same lock the
+    // main session page applies for a real agent conversation. Without it the
+    // preview's picker shows the user's global model and lets them switch it,
+    // which is a lie: the harness resolves the model from the agent's binding
+    // server-side regardless. The lock lives in the root ModelService (shared
+    // with the main chat), so we release it on destroy; navigating into a plain
+    // chat also clears it idempotently via the session page's self-heal effect.
+    effect(() => {
+      const modelId = this.modelId();
+      if (modelId) {
+        this.modelService.lockToAgentModel(modelId);
+      } else {
+        this.modelService.clearAgentModelLock();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.modelService.clearAgentModelLock();
   }
 
   /** Agents resolve instructions + model + tools + skills + memory server-side from

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -62,40 +62,6 @@
                 <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
             </a>
         }
-
-        <!-- Memory Spaces (preview: system-admin only, plus the accessibility probe) -->
-        @if (showMemorySpaces() && isAdmin()) {
-            <a
-                routerLink="/memory-spaces"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Memory Spaces</span>
-                <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
-            </a>
-        }
-
-        <!-- Scheduled runs (preview: system-admin only, plus the capability gate) -->
-        @if (showSchedules() && isAdmin()) {
-            <a
-                routerLink="/schedules"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Scheduled Runs</span>
-                <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
-            </a>
-        }
     </div>
 
     <nav class="flex-1 overflow-y-auto px-3 pb-4">


### PR DESCRIPTION
## Summary

Two changes packaged together for the Agent Designer preview surface.

### 1. Lock the preview chat's model picker to the agent's model
The Agent Designer's live preview reuses the main `<app-chat-input>`, whose `<app-model-dropdown />` reads the root singleton `ModelService`. In the designer that picker showed the user's **global** model (e.g. Sonnet 5) and let them switch it — misleading, since the harness resolves the model from the agent's binding server-side regardless of the picker.

The locked-picker UX already existed (`ModelService.lockToAgentModel` + the dropdown's `heroLockClosed` "This agent runs on a fixed model" state) and is applied by the session page for real agent conversations; the designer preview just never wired it up.

- `AgentPreviewComponent` now takes a `modelId` input and locks/clears `ModelService` via an effect, releasing the lock in `ngOnDestroy`. The session page's self-heal effect also clears it idempotently on the next plain chat.
- `agent-form.page.html` passes the live `selectedModelId()`, keeping the picker consistent with the capability strip above it.

### 2. Trim preview side-nav entries
Hide **Memory Spaces** and **Scheduled Runs** from the side nav for now. **Agents** stays (already system-admin only). Routes/pages and the capability probes are unchanged, so re-enabling is just re-adding the two template blocks.

## Testing
- `tsc --noEmit` clean.
- `ng test` sidenav spec — 14/14 pass.
- Manual: in the Designer, set model to Haiku → preview picker shows Haiku locked (no dropdown); switching the form model updates the locked picker; clearing the model returns it to free-select; navigating to a plain chat does not leave the main picker locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)