### PR TITLE
fix(memory-spaces): namespaced-slug 404 + agent-editable MEMORY.md

### DIFF
--- a/backend/src/agents/builtin_tools/memory_spaces/tools.py
+++ b/backend/src/agents/builtin_tools/memory_spaces/tools.py
@@ -30,6 +30,20 @@ from apis.shared.memory.service import (
 
 logger = logging.getLogger(__name__)
 
+# The space's human-readable index (MEMORY.md) is not a manifest entry — it's a
+# standalone S3 object addressed by ``space.index_s3_key`` and auto-injected into
+# the agent's context each session via hydration (``always_load`` starts with
+# "MEMORY.md"). It never appears in ``memory_list``. To let the agent keep that
+# index in sync with the entries it writes, ``memory_read``/``memory_write`` treat
+# this reserved slug specially, routing to ``read_index``/``update_index`` instead
+# of the entry manifest. The slug is reserved: an agent cannot create an ordinary
+# entry named "MEMORY.md".
+_INDEX_SLUG = "MEMORY.md"
+
+
+def _is_index_slug(slug: str) -> bool:
+    return slug.strip().lower() == _INDEX_SLUG.lower()
+
 
 def _error(text: str) -> dict[str, Any]:
     return {"content": [{"text": f"❌ {text}"}], "status": "error"}
@@ -43,6 +57,10 @@ def make_memory_list_tool(space_id: str, space_name: str, user_id: str, user_ema
         Use this to see what you remember before deciding whether to `memory_read` a
         specific entry. Returns each entry's slug, type, description, and last-updated
         time. Optionally filter by `entry_type` ("entity", "episodic", or "fact").
+
+        The `MEMORY.md` index is not an entry and never appears here — it's injected
+        into your context each session and is read/written via `memory_read("MEMORY.md")`
+        / `memory_write("MEMORY.md", ...)`.
 
         Args:
             entry_type: Optional filter — one of "entity", "episodic", "fact".
@@ -72,14 +90,23 @@ def make_memory_read_tool(space_id: str, space_name: str, user_id: str, user_ema
         """Read the full content of one entry in your bound memory space.
 
         Pass a `slug` from `memory_list` (or referenced in your injected memory index).
+        The special slug `MEMORY.md` reads the space's human-readable index (the same
+        text injected into your context each session) — use it to see the current index
+        before updating it with `memory_write`.
 
         Args:
-            slug: The entry's stable id within the space (e.g. "jane-doe").
+            slug: The entry's stable id within the space (e.g. "jane-doe"), or the
+                reserved slug "MEMORY.md" for the space index.
         """
         try:
-            body = await asyncio.to_thread(
-                MemorySpaceService().read_entry, space_id, user_id, user_email, slug
-            )
+            if _is_index_slug(slug):
+                body = await asyncio.to_thread(
+                    MemorySpaceService().read_index, space_id, user_id, user_email
+                )
+            else:
+                body = await asyncio.to_thread(
+                    MemorySpaceService().read_entry, space_id, user_id, user_email, slug
+                )
         except MemorySpaceNotFoundError:
             return _error(f"No memory entry '{slug}' exists in '{space_name}'.")
         except MemorySpacePermissionError as exc:
@@ -105,13 +132,28 @@ def make_memory_write_tool(space_id: str, space_name: str, user_id: str, user_em
         will want recalled later. Writing an existing `slug` replaces that entry. Only
         available when the agent's memory binding grants write access.
 
+        The special slug `MEMORY.md` replaces the space's human-readable index instead of
+        creating an entry — keep it in sync as you add entries (e.g. a one-line pointer or
+        `[[slug]]` wikilink per entry). Read the current index first with
+        `memory_read("MEMORY.md")`; `entry_type` and `description` are ignored for it.
+
         Args:
-            slug: Stable id for the entry (e.g. "jane-doe", "daily-2026-07-07").
-            body: The entry's markdown content.
+            slug: Stable id for the entry (e.g. "jane-doe", "daily-2026-07-07"), or the
+                reserved slug "MEMORY.md" to replace the space index.
+            body: The entry's (or index's) markdown content.
             entry_type: "entity", "episodic", or "fact" (default "fact").
             description: Short one-line summary shown in listings.
         """
         try:
+            if _is_index_slug(slug):
+                await asyncio.to_thread(
+                    MemorySpaceService().update_index,
+                    space_id, user_id, user_email, body,
+                )
+                return {
+                    "content": [{"text": f'Updated the MEMORY.md index of "{space_name}".'}],
+                    "status": "success",
+                }
             ref = await asyncio.to_thread(
                 lambda: MemorySpaceService().write_entry(
                     space_id, user_id, user_email, slug, body,

--- a/backend/src/apis/app_api/memory_spaces/routes.py
+++ b/backend/src/apis/app_api/memory_spaces/routes.py
@@ -428,7 +428,7 @@ def list_entries(
     return EntriesListResponse(entries=[EntryRefResponse.from_ref(r) for r in entries])
 
 
-@router.get("/{space_id}/entries/{slug}", response_model=EntryContentResponse)
+@router.get("/{space_id}/entries/{slug:path}", response_model=EntryContentResponse)
 def read_entry(
     space_id: str, slug: str, user: User = Depends(require_memory_spaces_user)
 ) -> EntryContentResponse:
@@ -439,7 +439,7 @@ def read_entry(
     return EntryContentResponse(slug=slug, content=content)
 
 
-@router.put("/{space_id}/entries/{slug}", response_model=EntryRefResponse)
+@router.put("/{space_id}/entries/{slug:path}", response_model=EntryRefResponse)
 def upsert_entry(
     space_id: str,
     slug: str,
@@ -462,7 +462,7 @@ def upsert_entry(
     return EntryRefResponse.from_ref(ref)
 
 
-@router.delete("/{space_id}/entries/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{space_id}/entries/{slug:path}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_entry(
     space_id: str, slug: str, user: User = Depends(require_memory_spaces_user)
 ) -> None:

--- a/backend/tests/agents/builtin_tools/memory_spaces/test_memory_tools.py
+++ b/backend/tests/agents/builtin_tools/memory_spaces/test_memory_tools.py
@@ -76,6 +76,19 @@ class TestMemoryRead:
         result = await _call(tool, slug="ghost")
         assert result["status"] == "error" and "No memory entry 'ghost'" in result["content"][0]["text"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("slug", ["MEMORY.md", "memory.md", " MEMORY.MD "])
+    async def test_memory_md_slug_reads_index(self, monkeypatch, slug):
+        svc = _patch_service(monkeypatch)
+        svc.read_index.return_value = "# Index\n- [[jane]]"
+        tool = make_memory_read_tool("spc_1", "Brain", "u1", "u1@x.edu")
+        result = await _call(tool, slug=slug)
+        assert result["status"] == "success"
+        assert result["content"][0]["text"] == "# Index\n- [[jane]]"
+        # routed to the index, never the entry manifest
+        svc.read_index.assert_called_once_with("spc_1", "u1", "u1@x.edu")
+        svc.read_entry.assert_not_called()
+
 
 class TestMemoryWrite:
     @pytest.mark.asyncio
@@ -97,4 +110,24 @@ class TestMemoryWrite:
         svc.write_entry.side_effect = MemorySpacePermissionError("read-only")
         tool = make_memory_write_tool("spc_1", "Brain", "u1", "u1@x.edu")
         result = await _call(tool, slug="jane", body="x")
+        assert result["status"] == "error" and "don't have write access" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("slug", ["MEMORY.md", "memory.md"])
+    async def test_memory_md_slug_updates_index(self, monkeypatch, slug):
+        svc = _patch_service(monkeypatch)
+        tool = make_memory_write_tool("spc_1", "Brain", "u1", "u1@x.edu")
+        result = await _call(tool, slug=slug, body="# Index\n- [[jane]]", entry_type="entity")
+        assert result["status"] == "success"
+        assert "Updated the MEMORY.md index" in result["content"][0]["text"]
+        # routed to update_index (body only); never creates an entry
+        svc.update_index.assert_called_once_with("spc_1", "u1", "u1@x.edu", "# Index\n- [[jane]]")
+        svc.write_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_memory_md_write_permission_error_is_error_result(self, monkeypatch):
+        svc = _patch_service(monkeypatch)
+        svc.update_index.side_effect = MemorySpacePermissionError("read-only")
+        tool = make_memory_write_tool("spc_1", "Brain", "u1", "u1@x.edu")
+        result = await _call(tool, slug="MEMORY.md", body="x")
         assert result["status"] == "error" and "don't have write access" in result["content"][0]["text"]

--- a/backend/tests/apis/app_api/test_memory_spaces_routes.py
+++ b/backend/tests/apis/app_api/test_memory_spaces_routes.py
@@ -198,6 +198,27 @@ class TestIndexAndEntries:
         assert client.delete(f"/memory/spaces/{sid}/entries/jane-doe").status_code == 204
         assert client.get(f"/memory/spaces/{sid}/entries/jane-doe").status_code == 404
 
+    def test_namespaced_slug_with_slash(self, service, monkeypatch):
+        """Slugs are namespaced (``people/brian-bolt``); the `{slug:path}` converter
+        must route the embedded slash instead of 404-ing on it."""
+        client, sid = self._make_space(service, monkeypatch)
+        slug = "people/brian-bolt"
+
+        up = client.put(
+            f"/memory/spaces/{sid}/entries/{slug}",
+            json={"body": "# Brian\nDirector", "type": "entity"},
+        )
+        assert up.status_code == 200
+        assert up.json()["slug"] == slug
+
+        got = client.get(f"/memory/spaces/{sid}/entries/{slug}")
+        assert got.status_code == 200
+        assert got.json()["slug"] == slug
+        assert "Director" in got.json()["content"]
+
+        assert client.delete(f"/memory/spaces/{sid}/entries/{slug}").status_code == 204
+        assert client.get(f"/memory/spaces/{sid}/entries/{slug}").status_code == 404
+
 
 class TestAccessControl:
     def test_stranger_cannot_read_space(self, service, monkeypatch):

--- a/docs/specs/user-markdown-memory.md
+++ b/docs/specs/user-markdown-memory.md
@@ -331,12 +331,26 @@ reconstructed on demand (MRAgent discipline).
 `{type: entity, "commitments.open": true}`) returning refs, not bodies — this is how "who owes
 what" and staleness scans avoid a full-corpus load.
 
+> **The `MEMORY.md` index is a reserved slug, not a manifest entry.** It lives outside the
+> entries manifest (a standalone `index_s3_key` on the space row), so it never appears in
+> `memory_list`/`memory_query`. To let the agent inspect the index it's already given at wake-up,
+> `memory_read("MEMORY.md")` routes to `read_index` instead of the manifest (case-insensitive
+> match). The slug is reserved — the agent cannot create an ordinary entry named `MEMORY.md`.
+
 ### 5. Write path
 
 - **(W1) Synchronous agentic write** — `memory_write(space, slug, body)` /
   `memory_update(space, slug, patch)` tools the model calls mid-turn, stamping `updated_by` with
   the invoking user, plus an index-update step. Transparent, matches the coding-agent model.
   **v1 default.**
+  - **Index writes reuse the reserved slug.** `memory_write("MEMORY.md", body)` routes to
+    `update_index` (editor+) rather than creating an entry, so the agent can keep the
+    human-readable index in sync with the entries it writes — a one-line pointer / `[[slug]]`
+    wikilink per entry, exactly the coding-agent `MEMORY.md` discipline this feature is modeled
+    on. `entry_type`/`description` are ignored for it. Gated identically to entry writes: the
+    tool is only bound when the agent's memory binding grants `readwrite`, and the service
+    re-checks `editor+`. This closes the drift gap where the agent could add entries but not
+    update the index describing them.
 - **(W2) Async post-turn reflection** — a background job reads the completed turn and proposes
   edits, hung off [`turn_based_session_manager.update_after_turn`](../../backend/src/agents/main_agent/session/turn_based_session_manager.py)
   (the seam compaction uses). Reliable, no in-loop discipline needed, adds an LLM call/turn.


### PR DESCRIPTION
Two independent memory-spaces fixes surfaced while testing the feature. Branched off `develop`; kept as two commits.

## 1. `fix`: namespaced entry slugs 404 on the app-api surface

Viewing or editing an entry returned **404**:

```
GET /memory/spaces/{id}/entries/people%2Fbrian-bolt → 404 Not Found
```

Entry slugs are **namespaced with a slash** (the Chief-of-Staff template files entities under `people/`, `projects/`, episodics under `daily/`). The entry routes declared a plain `{slug}` param, whose converter stops at `/`. Uvicorn percent-decodes `%2F`→`/` **before** routing, so `/entries/people/brian-bolt` never matched `/entries/{slug}`.

**Fix:** switch the GET/PUT/DELETE entry routes to the `{slug:path}` converter so the embedded slash is captured and the slug arrives matching the manifest. No frontend change needed — the SPA already `encodeURIComponent`s the slug correctly.

## 2. `feat`: agent can read/write MEMORY.md via a reserved slug

`MEMORY.md` is a space's human-readable index — a standalone S3 object outside the entries manifest, injected into the agent's context each session via hydration. It never appears in `memory_list`, and the agent had **no tool to read it back or keep it in sync** with the entries it writes, so the manifest and the index could silently drift (the opposite of the coding-agent memory model this feature is based on, where the agent actively maintains `MEMORY.md`).

**Fix:** route the reserved `"MEMORY.md"` slug (case-insensitive) through the existing service methods — no new tool surface, matching the literal hydration already uses:
- `memory_read("MEMORY.md")` → `read_index` (viewer+)
- `memory_write("MEMORY.md", body)` → `update_index` (editor+, body only; `type`/`description` ignored)

The slug is **reserved** — the agent cannot create an ordinary entry named `MEMORY.md`. Write stays gated identically to entry writes: the tool is only bound when the agent's memory binding grants `readwrite`, and the service re-checks `editor+`.

## Reviewer notes

- The two commits are unrelated and can be reviewed independently; #1 is a pure routing bugfix, #2 is a small capability addition on the agent tool surface.
- Consequence of #2: a `readwrite`-bound agent can now rewrite a **shared** space's index (the always-loaded orientation file every member sees). This is the same `editor+` trust surface editors already had via the SPA, so no new gate — flagged for awareness.
- Spec updated: `docs/specs/user-markdown-memory.md` §4 (read path) + §5 (W1 write path).

## Testing

`tests/agents/builtin_tools/memory_spaces/`, `tests/apis/app_api/test_memory_spaces_routes.py`, `tests/shared/test_memory_spaces.py` — **94 passed**. New tests: slashed-slug upsert→read→delete route test, and MEMORY.md read/write routing (case-insensitive, permission-error path, and asserting the entry manifest is never touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)