### PR TITLE
feat(schedules): target Agents instead of Assistants on scheduled runs

### DIFF
--- a/frontend/ai.client/src/app/schedules/models/schedule.model.ts
+++ b/frontend/ai.client/src/app/schedules/models/schedule.model.ts
@@ -104,6 +104,12 @@ export interface ScheduledPromptsListResponse {
 export interface RunNowRequest {
   prompt: string;
   title?: string | null;
+  /**
+   * Target Agent for the run (`agentId == assistantId`; the backend field is
+   * `ragAssistantId`). When set, the Agent's bound tools govern the turn and
+   * `enabledTools` is left null.
+   */
+  ragAssistantId?: string | null;
   enabledTools?: string[] | null;
 }
 

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.html
@@ -199,13 +199,13 @@
         <section class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
           <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Target (optional)</h2>
           <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-            Point this run at a specific assistant, and/or limit which tools it may use. Leave both
-            unset to use your normal defaults.
+            Point this run at a specific agent. An agent runs with the tools bound to it. Leave it on
+            the default agent to limit tools manually below.
           </p>
 
           <div class="mt-4">
             <label for="assistantId" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
-              Assistant
+              Agent
             </label>
             <select
               id="assistantId"
@@ -214,8 +214,8 @@
               class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
             >
               <option [value]="null">Default agent</option>
-              @for (assistant of assistants(); track assistant.assistantId) {
-                <option [value]="assistant.assistantId">{{ assistant.name }}</option>
+              @for (agent of agents(); track agent.agentId) {
+                <option [value]="agent.agentId">{{ agent.name }}</option>
               }
             </select>
 
@@ -227,47 +227,60 @@
                   (change)="onClearAssistantChange($any($event.target).checked)"
                   class="size-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
                 />
-                Detach assistant (use the default agent)
+                Detach agent (use the default agent)
               </label>
             }
           </div>
 
-          <div class="mt-5">
-            <div class="flex items-center justify-between">
-              <span class="block text-sm/6 font-medium text-gray-900 dark:text-white">Tools</span>
-              @if (mode() === 'edit') {
-                <label class="flex items-center gap-2 text-xs/5 text-gray-600 dark:text-gray-400">
-                  <input
-                    type="checkbox"
-                    [checked]="clearTools()"
-                    (change)="onClearToolsChange($any($event.target).checked)"
-                    class="size-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
-                  />
-                  Reset to all my tools
-                </label>
-              }
+          @if (agentSelected()) {
+            <!-- A selected Agent's bound tools replace the run's tools server-side,
+                 so the manual picker is hidden — showing it would let the user pick
+                 tools that are silently discarded. -->
+            <div class="mt-5 rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
+              <p class="text-xs/5 text-gray-600 dark:text-gray-400">
+                This run uses the tools bound to
+                <span class="font-medium text-gray-900 dark:text-white">{{ selectedAgentName() }}</span>.
+                To change them, edit the agent.
+              </p>
             </div>
-            <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-              The tool set is snapshotted when the schedule is created — later changes to your tool
-              access won't silently expand what a sleeping schedule can do.
-            </p>
-            <div class="mt-2 max-h-56 space-y-1 overflow-y-auto rounded-2xl border border-gray-200 p-2 dark:border-gray-700">
-              @for (tool of tools(); track tool.toolId) {
-                <label class="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm/6 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/40">
-                  <input
-                    type="checkbox"
-                    [checked]="isToolSelected(tool.toolId)"
-                    [disabled]="clearTools()"
-                    (change)="toggleTool(tool.toolId)"
-                    class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
-                  />
-                  {{ tool.displayName }}
-                </label>
-              } @empty {
-                <p class="px-2 py-1.5 text-xs/5 text-gray-500 dark:text-gray-400">No tools available.</p>
-              }
+          } @else {
+            <div class="mt-5">
+              <div class="flex items-center justify-between">
+                <span class="block text-sm/6 font-medium text-gray-900 dark:text-white">Tools</span>
+                @if (mode() === 'edit') {
+                  <label class="flex items-center gap-2 text-xs/5 text-gray-600 dark:text-gray-400">
+                    <input
+                      type="checkbox"
+                      [checked]="clearTools()"
+                      (change)="onClearToolsChange($any($event.target).checked)"
+                      class="size-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                    />
+                    Reset to all my tools
+                  </label>
+                }
+              </div>
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                The tool set is snapshotted when the schedule is created — later changes to your tool
+                access won't silently expand what a sleeping schedule can do.
+              </p>
+              <div class="mt-2 max-h-56 space-y-1 overflow-y-auto rounded-2xl border border-gray-200 p-2 dark:border-gray-700">
+                @for (tool of tools(); track tool.toolId) {
+                  <label class="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm/6 text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/40">
+                    <input
+                      type="checkbox"
+                      [checked]="isToolSelected(tool.toolId)"
+                      [disabled]="clearTools()"
+                      (change)="toggleTool(tool.toolId)"
+                      class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-700"
+                    />
+                    {{ tool.displayName }}
+                  </label>
+                } @empty {
+                  <p class="px-2 py-1.5 text-xs/5 text-gray-500 dark:text-gray-400">No tools available.</p>
+                }
+              </div>
             </div>
-          </div>
+          }
         </section>
 
         <!-- Actions -->

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.spec.ts
@@ -6,7 +6,7 @@ import { signal } from '@angular/core';
 import { ScheduleFormPage } from './schedule-form.page';
 import { ScheduleService } from '../services/schedule.service';
 import { RunNowService } from '../services/run-now.service';
-import { AssistantService } from '../../assistants/services/assistant.service';
+import { AgentService } from '../../agents/services/agent.service';
 import { ToolService } from '../../services/tool/tool.service';
 import { ToastService } from '../../services/toast/toast.service';
 import { ScheduledPrompt } from '../models/schedule.model';
@@ -48,9 +48,9 @@ describe('ScheduleFormPage', () => {
     updateSchedule: vi.fn().mockResolvedValue(stubSchedule()),
   };
 
-  const mockAssistantService = {
-    assistants$: signal([]),
-    loadAssistants: vi.fn().mockResolvedValue(undefined),
+  const mockAgentService = {
+    agents$: signal([]),
+    loadAgents: vi.fn().mockResolvedValue(undefined),
   };
 
   const mockToolService = {
@@ -81,7 +81,7 @@ describe('ScheduleFormPage', () => {
         provideRouter([{ path: 'schedules', children: [] }]),
         { provide: ScheduleService, useValue: mockScheduleService },
         { provide: RunNowService, useValue: mockRunNow },
-        { provide: AssistantService, useValue: mockAssistantService },
+        { provide: AgentService, useValue: mockAgentService },
         { provide: ToolService, useValue: mockToolService },
         { provide: ToastService, useValue: mockToast },
         {
@@ -143,6 +143,43 @@ describe('ScheduleFormPage', () => {
           hourLocal: 8,
           timezone: 'UTC',
           enabledTools: ['class_search'],
+        }),
+      );
+    });
+
+    it('drops the manual tool snapshot when an agent is selected', async () => {
+      component.form.patchValue({
+        label: 'Test',
+        promptText: 'Do the thing',
+        cadence: 'daily',
+        hourLocal: 8,
+        timezone: 'UTC',
+      });
+      // Pick some tools first, then target an agent — the agent's bound tools
+      // govern the run, so the snapshot must not be sent.
+      component.toggleTool('class_search');
+      component.form.controls.assistantId.setValue('ast-9');
+
+      expect(component.agentSelected()).toBe(true);
+      await component.onSubmit();
+
+      expect(mockScheduleService.createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({ assistantId: 'ast-9', enabledTools: null }),
+      );
+    });
+
+    it('run now targets the selected agent and omits the tool snapshot', () => {
+      component.form.patchValue({ label: 'Test', promptText: 'Do the thing' });
+      component.toggleTool('class_search');
+      component.form.controls.assistantId.setValue('ast-9');
+
+      component.runNow();
+
+      expect(mockRunNow.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'Do the thing',
+          ragAssistantId: 'ast-9',
+          enabledTools: null,
         }),
       );
     });

--- a/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedule-form/schedule-form.page.ts
@@ -12,8 +12,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft } from '@ng-icons/heroicons/outline';
 import { ScheduleService } from '../services/schedule.service';
 import { RunNowService } from '../services/run-now.service';
-import { AssistantService } from '../../assistants/services/assistant.service';
-import { Assistant } from '../../assistants/models/assistant.model';
+import { AgentService } from '../../agents/services/agent.service';
+import { Agent } from '../../agents/models/agent.model';
 import { ToolService } from '../../services/tool/tool.service';
 import {
   CreateScheduleRequest,
@@ -71,13 +71,22 @@ function timezoneOptions(): string[] {
  * (daily / weekday / weekly at an hour + IANA timezone) — no cron field,
  * per docs/specs/scheduled-agent-runs.md §3.
  *
- * Optional fields (assistant, tool selection) use explicit "clear"
- * checkboxes rather than relying on sending null: the backend's
- * `update_scheduled_prompt` reads a bare `null` as "leave unchanged", so a
- * clear is signalled with the explicit `clearAssistant` / `clearTools`
- * booleans instead. `clearAssistant` reverts to the default agent;
- * `clearTools` re-snapshots the caller's current RBAC-allowed tools. See
- * `buildUpdateRequest`.
+ * The "target" is an Agent (the Agent Designer primitive that supersedes the
+ * Assistant — same underlying record, `agentId == assistantId`, so the wire
+ * field stays `assistantId` for backend compatibility). When an Agent is
+ * selected, its **bound tools govern the run**: the inference path replaces the
+ * request's `enabled_tools` with the Agent's `tool` bindings at invocation
+ * (`agent_binding_resolver` / routes.py `effective_enabled_tools`). So the
+ * manual tool picker is only shown for the "Default agent" case — selecting an
+ * Agent hides it, and any prior snapshot is dropped so it can't shadow the
+ * Agent's own toolset.
+ *
+ * Optional fields (agent, tool selection) use explicit "clear" checkboxes
+ * rather than relying on sending null: the backend's `update_scheduled_prompt`
+ * reads a bare `null` as "leave unchanged", so a clear is signalled with the
+ * explicit `clearAssistant` / `clearTools` booleans instead. `clearAssistant`
+ * reverts to the default agent; `clearTools` re-snapshots the caller's current
+ * RBAC-allowed tools. See `buildUpdateRequest`.
  */
 @Component({
   selector: 'app-schedule-form-page',
@@ -92,7 +101,7 @@ export class ScheduleFormPage implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly scheduleService = inject(ScheduleService);
   private readonly runNowService = inject(RunNowService);
-  private readonly assistantService = inject(AssistantService);
+  private readonly agentService = inject(AgentService);
   private readonly toolService = inject(ToolService);
   private readonly toast = inject(ToastService);
 
@@ -105,7 +114,7 @@ export class ScheduleFormPage implements OnInit {
   readonly minIntervalMinutes = MIN_INTERVAL_MINUTES;
   readonly intervalUnitOptions: IntervalUnit[] = ['minutes', 'hours'];
 
-  readonly assistants = this.assistantService.assistants$;
+  readonly agents = this.agentService.agents$;
   readonly tools = this.toolService.tools;
 
   readonly hourOptions = hourOptions();
@@ -113,14 +122,28 @@ export class ScheduleFormPage implements OnInit {
   readonly weekdayLabels = WEEKDAY_LABELS;
 
   /**
-   * Whether the assistant/tools sections should send a clear intent on
-   * submit. Only meaningful in edit mode — create simply omits the field
-   * when unchecked and nothing has been picked.
+   * Whether the agent/tools sections should send a clear intent on submit.
+   * Only meaningful in edit mode — create simply omits the field when
+   * unchecked and nothing has been picked.
    */
   readonly clearAssistant = signal(false);
   readonly clearTools = signal(false);
 
   readonly selectedToolIds = signal<Set<string>>(new Set());
+
+  /**
+   * Mirror of the `assistantId` control value (form values aren't signals) so
+   * the template can reactively hide the manual tool picker when an Agent is
+   * chosen. A selected Agent's bound tools replace the run's `enabled_tools`
+   * server-side, so a manual picker there would be silently discarded.
+   */
+  readonly selectedAgentId = signal<string | null>(null);
+  readonly agentSelected = computed(() => !!this.selectedAgentId());
+  readonly selectedAgentName = computed<string>(() => {
+    const id = this.selectedAgentId();
+    if (!id) return '';
+    return (this.agents() as Agent[]).find((a) => a.agentId === id)?.name ?? id;
+  });
 
   readonly form = this.fb.group({
     label: ['', [Validators.required, Validators.maxLength(200)]],
@@ -142,7 +165,7 @@ export class ScheduleFormPage implements OnInit {
     const id = this.route.snapshot.paramMap.get('scheduleId');
     this.scheduleId.set(id);
 
-    void this.assistantService.loadAssistants(false, false);
+    void this.agentService.loadAgents(false);
     if (!this.toolService.initialized()) {
       void this.toolService.loadTools();
     }
@@ -150,6 +173,13 @@ export class ScheduleFormPage implements OnInit {
     if (id) {
       void this.loadSchedule(id);
     }
+
+    // Keep the selected-agent signal in sync with the control so the tool
+    // picker hides/shows reactively.
+    this.selectedAgentId.set(this.form.controls.assistantId.value ?? null);
+    this.form.controls.assistantId.valueChanges.subscribe((value) => {
+      this.selectedAgentId.set(value ?? null);
+    });
 
     // Keep the cadence-driven signals in sync (form values aren't signals, so
     // the isWeekly/isInterval computeds read this instead of the control).
@@ -203,12 +233,6 @@ export class ScheduleFormPage implements OnInit {
     } catch {
       return 'UTC';
     }
-  }
-
-  assistantName(assistantId: string | null): string {
-    if (!assistantId) return '';
-    const match = (this.assistants() as Assistant[]).find((a) => a.assistantId === assistantId);
-    return match?.name ?? assistantId;
   }
 
   toggleTool(toolId: string): void {
@@ -272,7 +296,11 @@ export class ScheduleFormPage implements OnInit {
 
     this.saving.set(true);
     try {
-      const toolIds = Array.from(this.selectedToolIds());
+      // A selected Agent owns its toolset — its `tool` bindings replace the
+      // run's `enabled_tools` server-side — so never send a manual snapshot
+      // alongside one; it would be dead data. The picker is hidden in that
+      // case, but guard here too so a stale selection can't leak through.
+      const toolIds = value.assistantId ? [] : Array.from(this.selectedToolIds());
       if (this.mode() === 'create') {
         const request: CreateScheduleRequest = {
           label: value.label!,
@@ -361,10 +389,15 @@ export class ScheduleFormPage implements OnInit {
       return;
     }
 
-    const toolIds = Array.from(this.selectedToolIds());
+    const agentId = this.form.controls.assistantId.value ?? null;
+    // Mirror the schedule's targeting: run against the selected Agent (whose
+    // bound tools govern the turn), else fall back to the manual tool snapshot
+    // for the default agent.
+    const toolIds = agentId ? [] : Array.from(this.selectedToolIds());
     const request: RunNowRequest = {
       prompt: promptText,
       title: this.form.controls.label.value?.trim() || null,
+      ragAssistantId: agentId,
       enabledTools: toolIds.length > 0 ? toolIds : null,
     };
     this.runNowService.run(request);


### PR DESCRIPTION
## What

On the scheduled-run form (`/schedules/new` and edit), the **Target** selector now lists **Agents** instead of Assistants, and the tools section adapts to the Agent's own bound tools.

## Why

Agent (the Agent Designer primitive) supersedes Assistant going forward. An Agent is the same underlying record (`agentId == assistantId`) but carries `bindings[]` — including its own tools. Pointing scheduled runs at Agents aligns the surface with the direction of the product and lets a run inherit an Agent's governed toolset.

## Changes

- **Dropdown → Agents:** swapped `AssistantService` → `AgentService`; options come from `agents$` (`loadAgents(false)`, drafts excluded), labeled "Agent" with "Default agent" as the null option. The wire field stays `assistantId` for backend compatibility (same record).
- **Tools section — hide when an Agent is selected:** the inference path already **replaces** a run's `enabled_tools` with the selected Agent's `tool` bindings at invocation (`agent_binding_resolver` / `routes.py` `effective_enabled_tools`). So when an Agent is selected the manual picker is hidden and replaced with a note (*"This run uses the tools bound to {agent}. To change them, edit the agent."*), and submit drops any stale snapshot (`enabledTools: null`) so it can't shadow the Agent's toolset. The editable picker + snapshot semantics remain for the **Default agent** case.
- **Run now fix:** "Run now" now targets the selected Agent via `ragAssistantId` (the `/runs/now` backend already accepts it). Previously it ignored the target entirely, so the attended test surface didn't match what the schedule would actually run.

## Reviewer notes

- No backend change: the swap reuses the existing `assistantId` wire field and the existing binding-resolution path.
- If `AGENTS_API_ENABLED` is off in an environment, the dropdown degrades to just "Default agent" (the `AgentService` list 404 → `[]`). A fallback to Assistants during the deprecation window would be a follow-up if desired.
- Manual verification needed (auth guard + `AGENTS_API_ENABLED` required; no SKIP_AUTH locally): confirm the Agent dropdown populates, the tool picker hides/shows on Agent vs Default, a saved schedule targeting an Agent stores no tool snapshot, and Run now executes against the selected Agent.

## Tests

- `ng test` schedule-form spec: 16/16 pass (added 2 covering drop-snapshot-when-agent-selected and run-now-targets-agent).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)