### PR TITLE
fix(scheduled-runs): remove RBAC gate causing prod 403 "Access Denied"

### DIFF
--- a/backend/src/apis/app_api/runs/routes.py
+++ b/backend/src/apis/app_api/runs/routes.py
@@ -8,12 +8,17 @@ does NOT shortcut through the caller's live access token: the point of the
 surface is to validate the unattended path end-to-end (scheduled-runs PR-1,
 docs/specs/scheduled-agent-runs.md §7).
 
-Gating — two independent controls (spec §6):
+Gating — a single per-environment control (spec §6):
 
-* ``SCHEDULED_RUNS_ENABLED`` — per-environment kill switch (default on).
-  Off → every route here 404s, as if unmounted.
-* ``scheduled-runs`` RBAC capability — *who* may use the surface. Granted
-  to the beta cohort's AppRole; missing → 403. GA = grant to ``default``.
+* ``SCHEDULED_RUNS_ENABLED`` — kill switch (default on). Off → every route
+  here 404s, as if unmounted.
+
+The surface is otherwise open to any authenticated user — deliberately *not*
+behind the ``scheduled-runs`` RBAC capability, which turned every non-beta
+caller into a 403 the SPA surfaced as an "Access Denied" toast. Each run
+still executes with the caller's own RBAC-allowed tools (see
+``run_agent_headless``), so this widens *who* can reach the surface, not
+*what* any one caller can do.
 
 Auth is the standard SPA cookie dependency (``get_current_user_from_session``)
 per the CLAUDE.md app-api rule. The headless grant is **created-on-enable**:
@@ -41,10 +46,6 @@ from apis.shared.harness import (
     RunResult,
     run_agent_headless,
 )
-from apis.shared.rbac.capabilities import (
-    SCHEDULED_RUNS_CAPABILITY,
-    user_has_capability,
-)
 from apis.shared.rbac.service import get_app_role_service
 
 logger = logging.getLogger(__name__)
@@ -67,20 +68,15 @@ def get_headless_grant_service() -> HeadlessGrantService:
 async def require_scheduled_runs_user(
     user: User = Depends(get_current_user_from_session),
 ) -> User:
-    """Cookie auth + kill switch + cohort capability, in that order.
+    """Cookie auth + kill switch, in that order.
 
     404 when the environment kill switch is off (the surface behaves as if
     unmounted — runtime-checked so tests and env flips need no module
-    reload), 403 when the authenticated caller lacks the ``scheduled-runs``
-    capability.
+    reload). Otherwise any authenticated user may use the surface — it is
+    intentionally not behind an RBAC capability (see module docstring).
     """
     if not scheduled_runs_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    if not await user_has_capability(user, SCHEDULED_RUNS_CAPABILITY):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have access to scheduled runs.",
-        )
     return user
 
 

--- a/backend/src/apis/app_api/schedules/routes.py
+++ b/backend/src/apis/app_api/schedules/routes.py
@@ -5,13 +5,15 @@ paused/resumed, and deleted here, but nothing fires yet — the
 dispatcher/worker that reads ``DueScheduleIndex`` and calls
 ``run_agent_headless`` is B2 (docs/specs/scheduled-agent-runs.md §7).
 
-Gating mirrors the Phase A "Run now" surface exactly (two independent
-controls, spec §6):
+Gating is a single per-environment control (spec §6):
 
-* ``SCHEDULED_RUNS_ENABLED`` — per-environment kill switch (default on).
-  Off -> every route here 404s, as if unmounted.
-* ``scheduled-runs`` RBAC capability -- *who* may use the surface. Granted
-  to the beta cohort's AppRole; missing -> 403. GA = grant to ``default``.
+* ``SCHEDULED_RUNS_ENABLED`` — kill switch (default on). Off -> every route
+  here 404s, as if unmounted.
+
+The surface is otherwise open to any authenticated user. It carries no nav
+entry and isn't linked from the SPA, so it stays low-key / reachable only by
+direct URL — deliberately *not* behind the ``scheduled-runs`` RBAC capability
+(which turned every non-beta caller into a 403 the SPA surfaced as a toast).
 
 Auth is the standard SPA cookie dependency (``get_current_user_from_session``)
 per the CLAUDE.md app-api rule.
@@ -27,7 +29,6 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.feature_flags import scheduled_runs_enabled
-from apis.shared.rbac.capabilities import SCHEDULED_RUNS_CAPABILITY, user_has_capability
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.scheduled_prompts.service import (
     MIN_INTERVAL_MINUTES,
@@ -58,19 +59,15 @@ router = APIRouter(prefix="/schedules", tags=["schedules"])
 async def require_scheduled_runs_user(
     user: User = Depends(get_current_user_from_session),
 ) -> User:
-    """Cookie auth + kill switch + cohort capability, in that order.
+    """Cookie auth + kill switch, in that order.
 
     404 when the environment kill switch is off (the surface behaves as if
-    unmounted), 403 when the authenticated caller lacks the
-    ``scheduled-runs`` capability. Mirrors ``apis.app_api.runs.routes``.
+    unmounted). Otherwise any authenticated user may use the surface — it is
+    intentionally not behind an RBAC capability (see module docstring).
+    Mirrors ``apis.app_api.runs.routes``.
     """
     if not scheduled_runs_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    if not await user_has_capability(user, SCHEDULED_RUNS_CAPABILITY):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have access to scheduled runs.",
-        )
     return user
 
 

--- a/backend/tests/apis/app_api/test_runs_routes.py
+++ b/backend/tests/apis/app_api/test_runs_routes.py
@@ -1,8 +1,8 @@
 """Route tests for the headless "Run now" surface (`/runs/*`).
 
-Pins the three-layer gate (cookie auth → SCHEDULED_RUNS_ENABLED kill switch
-→ `scheduled-runs` RBAC capability), the create-on-enable grant flow, and
-the RunResult → camelCase response mapping.
+Pins the two-layer gate (cookie auth → SCHEDULED_RUNS_ENABLED kill switch;
+no RBAC capability gate), the create-on-enable grant flow, and the
+RunResult → camelCase response mapping.
 """
 
 from __future__ import annotations
@@ -127,7 +127,6 @@ def _make_client(
     monkeypatch: pytest.MonkeyPatch,
     *,
     authed: bool = True,
-    capability: bool = True,
     flag: Optional[str] = None,
     grants: Optional[FakeGrantService] = None,
     with_session_record: bool = False,
@@ -140,12 +139,6 @@ def _make_client(
         monkeypatch.delenv("SCHEDULED_RUNS_ENABLED", raising=False)
     else:
         monkeypatch.setenv("SCHEDULED_RUNS_ENABLED", flag)
-
-    async def fake_capability(user, capability_id):
-        assert capability_id == "scheduled-runs"
-        return capability
-
-    monkeypatch.setattr(runs_routes, "user_has_capability", fake_capability)
 
     grants = grants or FakeGrantService()
     monkeypatch.setattr(runs_routes, "get_headless_grant_service", lambda: grants)
@@ -228,11 +221,11 @@ class TestGating:
         client, _, _ = _make_client(monkeypatch, flag="", with_session_record=True)
         assert client.post("/runs/now", json={"prompt": "hi"}).status_code == 200
 
-    def test_missing_capability_is_403(self, monkeypatch):
-        client, _, _ = _make_client(monkeypatch, capability=False)
-        response = client.post("/runs/now", json={"prompt": "hi"})
-        assert response.status_code == 403
-        assert client.get("/runs/grant").status_code == 403
+    def test_any_authenticated_user_is_allowed(self, monkeypatch):
+        # No RBAC capability gate: an ordinary authenticated user gets 200,
+        # not the old 403. (Regression for the prod "Access Denied" toast.)
+        client, _, _ = _make_client(monkeypatch, with_session_record=True)
+        assert client.post("/runs/now", json={"prompt": "hi"}).status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -408,10 +401,6 @@ class TestEnableGrant:
     def test_kill_switch_off_hides_the_surface_as_404(self, monkeypatch):
         client, _, _ = _make_client(monkeypatch, flag="false")
         assert client.post("/runs/grant").status_code == 404
-
-    def test_missing_capability_is_403(self, monkeypatch):
-        client, _, _ = _make_client(monkeypatch, capability=False)
-        assert client.post("/runs/grant").status_code == 403
 
     def test_unauthenticated_request_is_401(self, monkeypatch):
         client, _, _ = _make_client(monkeypatch, authed=False)

--- a/backend/tests/routes/test_schedules_routes.py
+++ b/backend/tests/routes/test_schedules_routes.py
@@ -9,9 +9,9 @@ Endpoints under test:
 - POST   /schedules/{id}/resume -> resume (200; 404)
 - DELETE /schedules/{id}        -> delete (204; 404)
 
-Every route shares the three-layer gate (cookie auth -> SCHEDULED_RUNS_ENABLED
-kill switch -> `scheduled-runs` RBAC capability), pinned once via `TestGating`
-and assumed enabled/authorized everywhere else. The service layer is mocked
+Every route shares the two-layer gate (cookie auth -> SCHEDULED_RUNS_ENABLED
+kill switch), pinned once via `TestGating` and assumed enabled everywhere
+else. The surface carries no RBAC capability gate. The service layer is mocked
 (DynamoDB semantics are covered by tests/shared/test_scheduled_prompts.py);
 these tests pin the HTTP contract and ownership isolation.
 """
@@ -91,7 +91,6 @@ def _make_client(
     monkeypatch: pytest.MonkeyPatch,
     *,
     authed: bool = True,
-    capability: bool = True,
     flag: Optional[str] = None,
     user_id: str = USER_ID,
 ) -> TestClient:
@@ -101,11 +100,6 @@ def _make_client(
     else:
         monkeypatch.setenv("SCHEDULED_RUNS_ENABLED", flag)
 
-    async def fake_capability(user, capability_id):
-        assert capability_id == "scheduled-runs"
-        return capability
-
-    monkeypatch.setattr(schedules_routes, "user_has_capability", fake_capability)
     monkeypatch.setattr(schedules_routes, "get_app_role_service", lambda: FakeRoleService())
 
     app = FastAPI()
@@ -143,10 +137,12 @@ class TestGating:
         monkeypatch.setattr(schedules_routes, "list_scheduled_prompts", AsyncMock(return_value=[]))
         assert client.get("/schedules").status_code == 200
 
-    def test_missing_capability_is_403(self, monkeypatch):
-        client = _make_client(monkeypatch, capability=False)
-        assert client.get("/schedules").status_code == 403
-        assert client.post("/schedules", json={}).status_code == 403
+    def test_any_authenticated_user_is_allowed(self, monkeypatch):
+        # No RBAC capability gate: an ordinary authenticated user gets 200,
+        # not the old 403. (Regression for the prod "Access Denied" toast.)
+        client = _make_client(monkeypatch)
+        monkeypatch.setattr(schedules_routes, "list_scheduled_prompts", AsyncMock(return_value=[]))
+        assert client.get("/schedules").status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -6,7 +6,6 @@ import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
-import { ScheduleService } from '../../schedules/services/schedule.service';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
 
@@ -16,7 +15,6 @@ describe('Sidenav', () => {
   let mockBffSession: any;
   let mockSidenavService: any;
   let mockUserService: any;
-  let mockScheduleService: any;
   let mockMemorySpaceService: any;
   let mockAgentService: any;
 
@@ -39,10 +37,6 @@ describe('Sidenav', () => {
       currentUser: signal(null),
       isAdmin: signal(false),
     };
-    mockScheduleService = {
-      accessible$: signal<boolean | null>(null),
-      loadSchedules: vi.fn().mockResolvedValue(undefined),
-    };
     mockMemorySpaceService = {
       accessible$: signal<boolean | null>(null),
       loadSpaces: vi.fn().mockResolvedValue(undefined),
@@ -59,7 +53,6 @@ describe('Sidenav', () => {
         { provide: BffSessionService, useValue: mockBffSession },
         { provide: SidenavService, useValue: mockSidenavService },
         { provide: UserService, useValue: mockUserService },
-        { provide: ScheduleService, useValue: mockScheduleService },
         { provide: MemorySpaceService, useValue: mockMemorySpaceService },
         { provide: AgentService, useValue: mockAgentService },
       ],
@@ -73,7 +66,7 @@ describe('Sidenav', () => {
   async function createComponent() {
     const { Sidenav } = await import('./sidenav');
     const component = TestBed.runInInjectionContext(() => new Sidenav());
-    TestBed.tick(); // flush the constructor effect that probes schedule accessibility
+    TestBed.tick(); // flush the constructor effect that probes feature accessibility
     return component;
   }
 
@@ -103,38 +96,6 @@ describe('Sidenav', () => {
     await component.handleLogout();
     expect(mockBffSession.logout).toHaveBeenCalledTimes(1);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/auth/login']);
-  });
-
-  it('probes schedule accessibility once a user is authenticated', async () => {
-    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
-    await createComponent();
-    expect(mockScheduleService.loadSchedules).toHaveBeenCalled();
-  });
-
-  it('does not probe schedule accessibility while unauthenticated', async () => {
-    mockUserService.currentUser.set(null);
-    await createComponent();
-    expect(mockScheduleService.loadSchedules).not.toHaveBeenCalled();
-  });
-
-  it('hides the Scheduled Runs nav entry until accessibility resolves true', async () => {
-    const component = await createComponent();
-
-    mockScheduleService.accessible$.set(null);
-    expect(component.showSchedules()).toBe(false);
-
-    mockScheduleService.accessible$.set(false);
-    expect(component.showSchedules()).toBe(false);
-
-    mockScheduleService.accessible$.set(true);
-    expect(component.showSchedules()).toBe(true);
-  });
-
-  it('navigates to /schedules and closes the sidenav', async () => {
-    const component = await createComponent();
-    component.navigateToSchedules();
-    expect(mockSidenavService.close).toHaveBeenCalled();
-    expect(mockRouter.navigate).toHaveBeenCalledWith(['/schedules']);
   });
 
   it('probes memory-space accessibility once a user is authenticated', async () => {

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -7,7 +7,6 @@ import { SessionService as BffSessionService } from '../../auth/session.service'
 import { UserDropdownComponent } from '../topnav/components/user-dropdown.component';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
-import { ScheduleService } from '../../schedules/services/schedule.service';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
 
@@ -21,7 +20,6 @@ export class Sidenav {
   private router = inject(Router);
   private sessionService = inject(SessionService);
   private bffSession = inject(BffSessionService);
-  private scheduleService = inject(ScheduleService);
   private memorySpaceService = inject(MemorySpaceService);
   private agentService = inject(AgentService);
   protected sidenavService = inject(SidenavService);
@@ -44,22 +42,11 @@ export class Sidenav {
   protected isAdmin = this.userService.isAdmin;
 
   /**
-   * Whether to show the "Scheduled runs" nav entry. There is no dedicated
-   * client-side capability signal for `scheduled-runs` yet, so this rides
-   * the schedules list call itself: a successful (even empty) list means
-   * the caller has the capability and the kill switch is on; a 403/404
-   * flips `accessible$` to false and the nav entry stays hidden. `null`
-   * (not yet resolved) also hides it, so the item doesn't flash in before
+   * Whether to show the "Memory Spaces" nav entry. Rides the spaces list
+   * call: a successful (even empty) list means the `MEMORY_SPACES_ENABLED`
+   * kill switch is on; a 404 flips `accessible$` false and the entry stays
+   * hidden. `null` (unresolved) also hides it so it doesn't flash in before
    * disappearing.
-   */
-  readonly showSchedules = computed(() => this.scheduleService.accessible$() === true);
-
-  /**
-   * Whether to show the "Memory Spaces" nav entry. Rides the spaces list call
-   * the same way `showSchedules` rides schedules: a successful (even empty)
-   * list means the `MEMORY_SPACES_ENABLED` kill switch is on; a 404 flips
-   * `accessible$` false and the entry stays hidden. `null` (unresolved) also
-   * hides it so it doesn't flash in before disappearing.
    */
   readonly showMemorySpaces = computed(() => this.memorySpaceService.accessible$() === true);
 
@@ -77,7 +64,6 @@ export class Sidenav {
     // mirrors UserService's own permissions-fetch gating.
     effect(() => {
       if (this.userService.currentUser()) {
-        void this.scheduleService.loadSchedules();
         void this.memorySpaceService.loadSpaces();
         void this.agentService.loadAgents();
       }
@@ -92,11 +78,6 @@ export class Sidenav {
   navigateToAssistants() {
     this.sidenavService.close();
     this.router.navigate(['/assistants']);
-  }
-
-  navigateToSchedules() {
-    this.sidenavService.close();
-    this.router.navigate(['/schedules']);
   }
 
   toggleCollapse() {


### PR DESCRIPTION
## Problem

Regular users in prod saw a **403 "Access Denied — You do not have access to scheduled runs"** toast on page load (`GET /api/schedules`).

**Root cause:** `/schedules` and `/runs/*` were gated by the `scheduled-runs` **RBAC capability**, granted only to a beta cohort's AppRole (admins passed via the `*` wildcard). The `SCHEDULED_RUNS_ENABLED` kill switch was on (it 404s, not 403s), so the flag wasn't the cause — the capability check was.

Why the raw dialog: the sidenav fires a **background** `loadSchedules()` probe on every load, and the global `errorInterceptor` pops the toast on that 403 *before* the schedule service's graceful catch runs. The sidenav template renders **no** "Scheduled runs" link — the feature was already not navigable; the probe was vestigial.

## Change

The feature doesn't need admin/beta gating. Keep it low-key and reachable only by direct URL for now:

- **Backend** — dropped the RBAC capability check from both `require_scheduled_runs_user` gates (`schedules/routes.py`, `runs/routes.py`). Only the `SCHEDULED_RUNS_ENABLED` kill switch remains (404 when off). Each run still executes with the **caller's own** RBAC-allowed tools, so this widens *who* can reach the surface, not *what* any one caller can do.
- **Frontend** — removed the vestigial sidenav schedules probe and dead `showSchedules`/`navigateToSchedules` wiring. Nothing surfaces the feature now, and there's no latent toast if the kill switch is ever flipped. `/schedules` stays reachable only by direct URL.
- **Tests** — updated both route suites (403 assertions → "any authenticated user gets 200") and the sidenav spec.

## Reviewer notes

- `apis/shared/rbac/capabilities.py` (`SCHEDULED_RUNS_CAPABILITY` / `user_has_capability`) is now **unreferenced**. Left in place intentionally as generic RBAC infra — re-gating is a two-line revert. Happy to delete if preferred.
- No CDK/infra changes; ships via `backend.yml` (app-api) + `frontend-deploy.yml`.

## Verification

- `test_schedules_routes.py` — **38 passed**
- `test_runs_routes.py` — **28 passed**
- `sidenav.spec.ts` via `ng test` — **10 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)