### PR TITLE
feat(identity): MCP user identity forwarding via access-token enrichment

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -112,6 +112,19 @@ jobs:
       # `CDK_AGENTS_API_ENABLED` variable to "true" in an environment (e.g. dev)
       # to enable it there for dogfooding.
       CDK_AGENTS_API_ENABLED: ${{ vars.CDK_AGENTS_API_ENABLED }}
+      # MCP user-identity forwarding — optional Cognito Pre-Token-Generation v2
+      # Lambda that copies user attributes into access-token claims so
+      # personalized MCP tools can identify the caller
+      # (docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md). Default OFF (opt-in):
+      # unset resolves to empty string, which config.ts treats as disabled, so
+      # NO Lambda/trigger is created. Set `CDK_MCP_TOKEN_ENRICHMENT_ENABLED` to
+      # "true" AND provide the claim map in `CDK_MCP_TOKEN_ENRICHMENT_CLAIMS`
+      # (a JSON object {namespacedClaimName: sourceCognitoAttribute}, e.g.
+      # {"https://boisestate.edu/employee_number":"custom:provider_sub"}) to
+      # enable it. Keeping the map in a variable lets the public
+      # cdk.context.json stay inert.
+      CDK_MCP_TOKEN_ENRICHMENT_ENABLED: ${{ vars.CDK_MCP_TOKEN_ENRICHMENT_ENABLED }}
+      CDK_MCP_TOKEN_ENRICHMENT_CLAIMS: ${{ vars.CDK_MCP_TOKEN_ENRICHMENT_CLAIMS }}
       # Secrets
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/docs/feature-summaries/MCP_USER_IDENTITY_FORWARDING_IMPLEMENTATION.md
+++ b/docs/feature-summaries/MCP_USER_IDENTITY_FORWARDING_IMPLEMENTATION.md
@@ -1,0 +1,121 @@
+# MCP User Identity Forwarding — Implementation Guide
+
+## Overview
+
+Personalized MCP tools (e.g. `student-myboisestate`) need to identify the
+logged-in user to scope data to them. The only token forwarded end-to-end to MCP
+servers is the Cognito **access token**, which carries `sub` and little else.
+This feature enriches the access token, in place, with configured identity claims
+via a Cognito **Pre-Token-Generation v2** Lambda trigger — so the existing
+forwarding path (SPA → app-api → inference-api → MCP server) needs no changes.
+
+Design decision and rationale: `docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md`
+(Option A). Shipped **disabled by default** in the public stack.
+
+## Flow
+
+```
+User login / token refresh
+   ↓
+Cognito issues tokens
+   ↓  (only if mcpIdentity.tokenEnrichment.enabled)
+Pre-Token-Generation v2 Lambda (token-enrichment/handler.py)
+   ↓  copies present user attributes → namespaced ACCESS-token claims
+Access token (now carries e.g. https://boisestate.edu/employee_number)
+   ↓  forwarded unchanged: SPA → app-api → inference-api → MCP server
+MCP server reads IDENTITY_CLAIM (default `sub`; BSU: the namespaced claim)
+```
+
+## Two knobs
+
+| Layer | Where | Default | Purpose |
+|---|---|---|---|
+| Identity claim | mcp-servers repo, `IDENTITY_CLAIM` env | `sub` | Which claim a server reads as the user id. Generic forks use `sub` and need nothing else. |
+| Token enrichment | this repo, `mcpIdentity.tokenEnrichment` | `enabled: false` | Opt-in Pre-Token-Generation v2 Lambda that copies attributes → access-token claims. |
+
+## Components (this repo)
+
+### 1. Config (`infrastructure/lib/config.ts`)
+
+`McpIdentityConfig.tokenEnrichment`:
+- `enabled` — env `CDK_MCP_TOKEN_ENRICHMENT_ENABLED` > context
+  `mcpIdentity.tokenEnrichment.enabled` > `false`.
+- `accessTokenClaims` — a `{claimName: sourceCognitoAttribute}` map, from the
+  JSON env var `CDK_MCP_TOKEN_ENRICHMENT_CLAIMS` > context > `{}`. The JSON env
+  var means a fork can enable the feature entirely through GitHub Actions
+  variables while the committed `cdk.context.json` stays inert.
+
+Claim names SHOULD be **namespaced** (full reverse-DNS form) to avoid colliding
+with Cognito's reserved access-token claims.
+
+### 2. Handler (`infrastructure/lambda-assets/token-enrichment/handler.py`)
+
+Stdlib-only, dependency-free, no I/O. Reads `ACCESS_TOKEN_CLAIMS` (JSON), and for
+each `{claim: attribute}` copies the attribute's value into
+`response.claimsAndScopeOverrideDetails.accessTokenGeneration.claimsToAddOrOverride`.
+Missing attributes are skipped (native Cognito users lack federated attributes).
+
+**Fail-open contract:** the trigger runs on every token issuance for the whole
+pool, so the handler wraps its body in a catch-all that returns the event
+**unchanged** on any error. Worst case is "claim not added", never "login
+blocked". Covered by `test_handler.py`.
+
+### 3. Construct (`infrastructure/lib/constructs/identity/token-enrichment-construct.ts`)
+
+Python 3.13 / ARM64 Lambda shipping its **real** handler via
+`lambda.Code.fromAsset` (no bootstrap placeholder — it's generic, tiny, and
+rarely changes, so it rides the normal `platform.yml` CDK deploy path). Attaches
+as the pool's Pre-Token-Generation v2 trigger via
+`userPool.addTrigger(PRE_TOKEN_GENERATION_CONFIG, fn, LambdaVersion.V2_0)`, which
+also auto-grants Cognito invoke permission. Instantiated by `platform-stack.ts`
+only when `config.mcpIdentity.tokenEnrichment.enabled`.
+
+`CognitoConstruct` pins the pool `featurePlan` to `ESSENTIALS` (required for
+access-token customization; a no-op on already-Essentials pools).
+
+## Enabling it (BSU / any deployer)
+
+Disabled by default — a fork that does nothing gets no Lambda and no trigger.
+To enable, set two GitHub Actions **variables** on the environment used by
+`platform.yml`:
+
+```
+CDK_MCP_TOKEN_ENRICHMENT_ENABLED = true
+CDK_MCP_TOKEN_ENRICHMENT_CLAIMS  = {"https://boisestate.edu/employee_number":"custom:provider_sub"}
+```
+
+Then run the platform (CDK) deploy. Flipping the flag on creates the Lambda +
+trigger and attaches it to the existing pool in place; flipping it off removes
+them cleanly. (This is an infrastructure change — it goes through `platform.yml`,
+not the fast `backend.yml` code-deploy path.)
+
+**Requirement:** the Cognito pool must be on the Essentials (or Plus) feature
+plan. The construct pins Essentials, and existing pools already are.
+
+## Follow-on (mcp-servers repo — not in this repo)
+
+The platform now emits the claim; servers consume it:
+
+1. Personalized servers validate the Cognito access token (reuse the
+   `class-search/auth.py` pattern) and read `os.environ["IDENTITY_CLAIM"]`
+   (default `sub`; BSU sets `https://boisestate.edu/employee_number`).
+2. `student-myboisestate` swaps Entra-ID JWKS validation for Cognito
+   access-token validation, deploys its Function URL with `AuthType: NONE`, and
+   registers as `mcp_external` + `forward_auth_token: true` in the admin
+   dashboard. It must degrade gracefully to "no student identity" for native
+   users that lack `custom:provider_sub`.
+
+**Stale-claim discipline:** only stable identity / coarse-role claims belong in
+the token. Volatile fine-grained authorization must be a runtime lookup in the
+tool keyed on the identity claim — never baked into the token.
+
+## Tests
+
+- `infrastructure/lambda-assets/token-enrichment/test_handler.py` — handler
+  enrichment + fail-open (14 cases, `uv run pytest`).
+- `infrastructure/test/config.test.ts` — config precedence (env > context >
+  default) for the flag and the claim map, including malformed-JSON fall-through.
+- `infrastructure/test/token-enrichment.test.ts` — construct synth: Lambda,
+  v2 trigger, invoke permission, empty-map no-op, and the disabled no-resources case.
+- `infrastructure/test/platform-stack.test.ts` — stack-level wiring: disabled
+  default emits no trigger; enabled emits the trigger + claim-map Lambda.

--- a/docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md
+++ b/docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md
@@ -1,0 +1,280 @@
+# MCP User Identity Forwarding — Decision Doc
+
+**Status:** Accepted — platform enrichment IMPLEMENTED (public stack, disabled by
+default). MCP-server consumption (items 3–4) pending in the mcp-servers repo.
+**Audience:** Auth architecture owner, platform maintainers
+**Scope:** How the platform forwards the authenticated end user's identity to
+personalized MCP tools, so a tool can answer "who is the current user?" and
+scope data to them.
+
+> **Implementation note (this repo, agentcore-public-stack).** Option A is built
+> and shipped disabled-by-default:
+> - Config: `mcpIdentity.tokenEnrichment` in `infrastructure/lib/config.ts`
+>   (`enabled` default `false`; claim map via context or the
+>   `CDK_MCP_TOKEN_ENRICHMENT_CLAIMS` JSON env var). Inert block in
+>   `cdk.context.json`.
+> - Handler: `infrastructure/lambda-assets/token-enrichment/handler.py`
+>   (stdlib-only, fail-open) + co-located pytest.
+> - Construct: `infrastructure/lib/constructs/identity/token-enrichment-construct.ts`,
+>   wired conditionally into `platform-stack.ts`. The Cognito pool's
+>   `featurePlan` is pinned to `ESSENTIALS`.
+> - Workflow: `CDK_MCP_TOKEN_ENRICHMENT_ENABLED` + `CDK_MCP_TOKEN_ENRICHMENT_CLAIMS`
+>   job-level env in `platform.yml`.
+>
+> Items 3–4 (server-side token validation + `student-myboisestate` cutover) live
+> in the separate mcp-servers repo — see "Follow-on: mcp-servers repo" below.
+
+---
+
+## Problem
+
+Personalized MCP servers (e.g. `student-myboisestate`) need to identify the
+logged-in user to fetch that user's data from a downstream system (MyBoiseState
+/ Boomi keys on the 9-digit **employee number**). Today the tool fails with:
+
+```
+No authenticated user found. Please ensure the Authorization header
+contains a valid Bearer token.
+```
+
+even with the "Forward user's OIDC token to MCP server" checkbox enabled.
+
+## Context: how identity flows today (verified)
+
+Request path (SPA → agent → MCP tool):
+
+```
+SPA --(session cookie)--> app-api /chat proxy
+     --(Authorization: Bearer <ACCESS token>)--> inference-api (AgentCore Runtime)
+     --(forward_auth_token → Authorization: Bearer <ACCESS token>)--> MCP server
+```
+
+Key findings (all verified against the running dev environment):
+
+1. **The token forwarded end-to-end is the Cognito _access_ token.**
+   - `app-api` proxy sets `Authorization: Bearer {current_user.raw_token}`
+     (`apis/app_api/chat/proxy_routes.py`).
+   - `raw_token` = `record.cognito_access_token`
+     (`apis/shared/auth/dependencies.py`).
+   - `inference-api` re-derives `raw_token = token` from the forwarded header
+     (`get_current_user_trusted`), and the agent forwards that to the MCP server.
+
+2. **The access token does NOT carry identity claims.** Decoded live token:
+   `sub` (Cognito UUID), `username` (`ms-entra-id_...`), `client_id`, `scope`,
+   `token_use`. No `email`, `name`, `custom:roles`, or `custom:provider_sub`.
+
+3. **The ID token DOES carry them** (via Cognito attribute mapping). Decoded live
+   ID token for a federated user included `custom:provider_sub: "113124161"`
+   (the employee number), `custom:roles`, `email`, `name`.
+
+4. **The ID token is NOT available at agent-request time.** It stays in the BFF
+   session record (`record.id_token`) in app-api and is never threaded to the
+   inference-api or the agent. Only the access token makes the trip.
+
+5. **The employee number source exists on federated users.** Cognito custom
+   attribute `custom:provider_sub` is populated for `ms-entra-id_*` users
+   (confirmed for 3 users), absent for native Cognito users.
+
+6. **Cognito pool is on the ESSENTIALS tier** (`describe-user-pool` →
+   `UserPoolTier: ESSENTIALS`), which supports Pre-Token-Generation **v2**
+   access-token customization. No triggers currently configured
+   (`LambdaConfig: {}`).
+
+### Why not the Gateway
+
+AgentCore Gateway targets with `GATEWAY_IAM_ROLE` authenticate as the *gateway*
+(SigV4) and do not forward the end user's token. So **personalized tools cannot
+go through the Gateway** — they must be `mcp_external` + Function URL
+`AuthType: NONE` + `forward_auth_token`, and validate the forwarded token
+in-app. Gateway remains the right home for non-personalized/shared tools
+(policy-search, grants-gov, arxiv, semantic-scholar).
+
+---
+
+## Options considered
+
+**A. Pre-Token-Generation v2 hook — enrich the access token (RECOMMENDED)**
+A Cognito trigger copies configured attributes (e.g. `custom:provider_sub`) into
+named claims (e.g. `employee_number`) on the **access token**. The token already
+flows end-to-end, so no handoff plumbing changes. Requires ESSENTIALS/Plus (have
+it). Blast radius: runs on every token issuance pool-wide (mitigated by a
+trivial, fail-safe Lambda).
+
+**B. Forward the ID token instead of the access token**
+The ID token already has the claims, but is not present at agent-request time.
+Would require threading a second token through app-api → Runtime → agent → MCP
+client without disturbing the Runtime's inbound auth (which validates the access
+token). More plumbing across a security boundary.
+
+**C. Per-server lookup (AdminGetUser / DynamoDB)**
+Each MCP server re-derives identity from `sub`. Rejected: pushes an identity
+concern into every server, needs per-server AWS permissions, re-solves a problem
+the issuer already knows the answer to.
+
+### Decision
+
+**Ship Option A only.** Rationale:
+- The access token is already wired end-to-end to the MCP handoff, so
+  enrichment requires **zero** changes to the token-forwarding path.
+- Option B solves the same problem with more plumbing across the Runtime
+  inbound-auth boundary, for no additional capability.
+- We only build the path we use. If a forker needs the ID-token path (their
+  claims live in the ID token, or they can't use the enrichment hook), that is
+  a documented, unimplemented extension point they can contribute back. Building
+  it speculatively means maintaining an untested branch nothing exercises.
+
+---
+
+## Public-stack / forkability design
+
+The mechanism must not hardcode an IdP, a claim name, or assume anyone needs it.
+
+**Defaults make it inert.** A fork that doesn't need personalized MCP tools
+configures nothing; the access token (with `sub`) is forwarded as it is today,
+and no Lambda/trigger is created.
+
+**Layered knobs:**
+
+| Layer | Where | Default | Purpose |
+|---|---|---|---|
+| Identity claim | mcp-servers repo, `IDENTITY_CLAIM` env | `sub` | Which claim a server reads as the user id. Generic forks use `sub` and need nothing else. |
+| Token enrichment | this repo, `mcpIdentity.tokenEnrichment` | `enabled: false` | Opt-in Pre-Token-Generation v2 Lambda that copies attributes → access-token claims. |
+
+The enrichment mapping is `{claimName: sourceCognitoAttribute}` — generic. BSU's
+`{ "employee_number": "custom:provider_sub" }` is *one configuration*, not the
+canonical path.
+
+### Config schema (`infrastructure/lib/config.ts`)
+
+```typescript
+export interface McpIdentityConfig {
+  // Optional Pre-Token-Generation (v2) enrichment of the access token.
+  // Off by default — no Lambda/trigger created when disabled.
+  // Requires the Cognito Essentials/Plus feature plan.
+  tokenEnrichment?: {
+    enabled: boolean;
+    // {claimName: sourceCognitoAttribute}. Present attributes are copied to
+    // the named claim on the access token; missing attributes are skipped
+    // (native users, forks without that attribute). No IdP assumed.
+    accessTokenClaims?: { [claimName: string]: string };
+  };
+}
+
+// AppConfig gains:
+//   mcpIdentity: McpIdentityConfig;
+```
+
+`loadConfig()` (env > context > default):
+
+```typescript
+mcpIdentity: {
+  tokenEnrichment: {
+    enabled:
+      parseBooleanEnv(process.env.CDK_MCP_TOKEN_ENRICHMENT_ENABLED)
+      ?? scope.node.tryGetContext('mcpIdentity')?.tokenEnrichment?.enabled
+      ?? false,
+    accessTokenClaims:
+      scope.node.tryGetContext('mcpIdentity')?.tokenEnrichment?.accessTokenClaims
+      ?? {},
+  },
+},
+```
+
+`cdk.context.json` default (inert, documents the shape):
+
+```jsonc
+"mcpIdentity": {
+  "tokenEnrichment": { "enabled": false, "accessTokenClaims": {} }
+}
+```
+
+BSU deploy config:
+
+```jsonc
+"mcpIdentity": {
+  "tokenEnrichment": {
+    "enabled": true,
+    "accessTokenClaims": { "employee_number": "custom:provider_sub" }
+  }
+}
+```
+
+---
+
+## Implementation outline
+
+1. **CDK construct** `lib/constructs/identity/token-enrichment-construct.ts`,
+   instantiated only when `mcpIdentity.tokenEnrichment.enabled`:
+   - Pre-Token-Generation **v2** Lambda; `accessTokenClaims` map passed as env
+     (JSON). Generic asset — no per-fork code.
+   - Attach as the pool's Pre-Token-Generation (v2 / `V2_0`) trigger.
+2. **Lambda handler** (fail-safe): for each `{claim: attr}`, if the user
+   attribute is present, add the claim to
+   `claimsAndScopeOverrideDetails.accessTokenGeneration.claimsToAddOrOverride`.
+   Missing attribute → skip. Any error → return event unchanged (never block
+   login).
+3. **mcp-servers repo**: personalized servers validate the Cognito access token
+   (reuse `class-search/auth.py` pattern) and read `os.environ["IDENTITY_CLAIM"]`
+   (default `sub`). For BSU, `IDENTITY_CLAIM=employee_number`.
+4. **`student-myboisestate`**: replace Entra-ID JWKS validation with Cognito
+   access-token validation; Function URL `AuthType: NONE`; register in the admin
+   dashboard as `mcp_external` + `forward_auth_token: true`.
+
+---
+
+## Risks / caveats
+
+- **Blast radius:** the trigger runs on every token issuance for the pool. The
+  Lambda must be dependency-free, do no I/O, and fail open (return the event
+  unchanged on any exception). Roll out to dev first.
+- **Native vs federated users:** native Cognito users lack `custom:provider_sub`;
+  the claim is simply omitted for them and personalized tools should report "no
+  student identity" gracefully rather than error.
+- **Stale-claim discipline:** only *stable* identity/coarse-role claims belong in
+  the token. Fine-grained, volatile authorization (e.g. "is this instructor
+  teaching section 12345 this term") must be a **runtime lookup in the tool**
+  using the identity claim — never baked into the token.
+- **Feature-plan dependency:** access-token customization needs Cognito
+  ESSENTIALS/Plus. Confirmed for dev; verify the prod pool
+  (`us-west-2_HPdmKV3f0`) before enabling in prod.
+
+## Open questions
+
+1. ~~Confirm the prod Cognito pool tier is ESSENTIALS/Plus.~~ **RESOLVED.** Prod
+   and dev run the same CDK code, and the dev pool
+   (`dev-boisestateai-v2-user-pool`) is on **Essentials**, which includes
+   "Customize access token scopes and claims at runtime" (verified in console).
+   The construct now pins the pool's `featurePlan` to `ESSENTIALS` so a fresh
+   fork's pool supports the trigger before it attaches.
+2. ~~Claim naming convention (`employee_number` vs a namespaced form).~~
+   **RESOLVED: namespaced, full reverse-DNS form.** BSU uses
+   `{"https://boisestate.edu/employee_number": "custom:provider_sub"}`; the
+   public-stack inert example uses `https://example.com/employee_number`.
+3. ~~Ship the enrichment construct in the public stack (disabled) or keep as a
+   BSU overlay?~~ **RESOLVED: shipped in the public stack, disabled by default.**
+   A fork configures nothing and gets zero resources; BSU flips it on with two
+   GitHub Actions variables (`CDK_MCP_TOKEN_ENRICHMENT_ENABLED=true` +
+   `CDK_MCP_TOKEN_ENRICHMENT_CLAIMS='{"https://boisestate.edu/employee_number":"custom:provider_sub"}'`),
+   leaving the committed `cdk.context.json` inert.
+
+## Follow-on: mcp-servers repo (items 3–4, NOT in this repo)
+
+The platform now *emits* the enriched claim; consuming it is the mcp-servers
+repo's job and can proceed independently:
+
+3. **Personalized servers validate the Cognito access token** (reuse the
+   `class-search/auth.py` validation pattern) and read the identity from
+   `os.environ["IDENTITY_CLAIM"]`, defaulting to `sub`. Generic forks leave the
+   default and need no enrichment. BSU sets `IDENTITY_CLAIM` to the namespaced
+   claim `https://boisestate.edu/employee_number`.
+4. **`student-myboisestate`**: replace the Entra-ID JWKS validation with Cognito
+   access-token validation; deploy the Function URL with `AuthType: NONE`; and
+   register it in the admin dashboard as `mcp_external` with
+   `forward_auth_token: true`. Native Cognito users (no `custom:provider_sub`)
+   will lack the claim — the server must report "no student identity" gracefully
+   rather than error.
+
+**Discipline:** only stable identity / coarse-role claims belong in the token.
+Volatile, fine-grained authorization (e.g. "is this instructor teaching section
+12345 this term") must be a runtime lookup in the tool keyed on the identity
+claim — never baked into the token.

--- a/infrastructure/cdk.context.json
+++ b/infrastructure/cdk.context.json
@@ -38,6 +38,12 @@
     "certificateArn": "",
     "retentionDays": 90
   },
+  "mcpIdentity": {
+    "tokenEnrichment": {
+      "enabled": false,
+      "accessTokenClaims": {}
+    }
+  },
   "tags": {
     "ManagedBy": "CDK"
   },

--- a/infrastructure/lambda-assets/token-enrichment/handler.py
+++ b/infrastructure/lambda-assets/token-enrichment/handler.py
@@ -1,0 +1,123 @@
+"""Cognito Pre-Token-Generation (v2) trigger — access-token claim enrichment.
+
+WHY THIS EXISTS
+---------------
+Personalized MCP tools need to identify the logged-in user, but the only token
+forwarded end-to-end to MCP servers is the Cognito *access* token, which carries
+`sub` and little else. The identity-rich claims (e.g. an employee number mapped
+to ``custom:provider_sub``) live on the user's pool attributes. This trigger
+copies configured attributes into named claims on the access token so the
+existing SPA -> app-api -> inference-api -> MCP forwarding path works unchanged.
+
+See docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md.
+
+CONFIGURATION
+-------------
+``ACCESS_TOKEN_CLAIMS`` env var — a JSON object ``{claimName: sourceAttribute}``.
+For each entry, if the user has ``sourceAttribute`` populated, its value is
+written to ``claimName`` on the access token. Missing attributes are skipped
+(native Cognito users lack federated attributes, and that is fine — personalized
+tools should degrade gracefully to "no identity" rather than error). Claim names
+SHOULD be namespaced (full reverse-DNS form, e.g.
+``https://example.com/employee_number``) to avoid colliding with reserved claims.
+
+Example:
+    ACCESS_TOKEN_CLAIMS = {"https://boisestate.edu/employee_number": "custom:provider_sub"}
+
+FAIL-OPEN CONTRACT (critical)
+-----------------------------
+This trigger runs on EVERY token issuance for the entire user pool. A raised
+exception here blocks login pool-wide. Therefore the handler is dependency-free,
+does no I/O, and wraps its whole body in a catch-all that returns the event
+UNCHANGED on any error. The worst-case failure mode is "the claim is not added"
+(tools report no identity), never "the user cannot log in".
+
+V2 EVENT SHAPE (relevant subset)
+--------------------------------
+    {
+      "version": "2",
+      "triggerSource": "TokenGeneration_...",
+      "request": { "userAttributes": { "sub": "...", "custom:provider_sub": "..." } },
+      "response": {
+        "claimsAndScopeOverrideDetails": {
+          "accessTokenGeneration": {
+            "claimsToAddOrOverride": { "<claimName>": "<value>" }
+          }
+        }
+      }
+    }
+
+Cognito reads ``response.claimsAndScopeOverrideDetails.accessTokenGeneration
+.claimsToAddOrOverride`` and merges those claims into the issued access token.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _load_claim_map() -> dict[str, str]:
+    """Parse the ACCESS_TOKEN_CLAIMS env var into a {claim: attribute} map.
+
+    Returns an empty map (no-op enrichment) on any malformed/absent value.
+    Only string->string entries are kept; anything else is ignored.
+    """
+    raw = os.environ.get("ACCESS_TOKEN_CLAIMS", "").strip()
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(claim): str(attr)
+        for claim, attr in parsed.items()
+        if isinstance(claim, str) and isinstance(attr, str)
+    }
+
+
+def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Enrich the access token with configured identity claims (fail-open).
+
+    On ANY exception the original event is returned unchanged so that a bug or
+    unexpected payload can never block authentication for the whole pool.
+    """
+    try:
+        claim_map = _load_claim_map()
+        if not claim_map:
+            return event
+
+        user_attributes = (event.get("request") or {}).get("userAttributes") or {}
+
+        # Collect the claims we can actually populate (attribute present + truthy).
+        claims_to_add: dict[str, str] = {}
+        for claim_name, source_attribute in claim_map.items():
+            value = user_attributes.get(source_attribute)
+            if value is not None and value != "":
+                claims_to_add[claim_name] = value
+
+        if not claims_to_add:
+            return event
+
+        # Merge into response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        # .claimsToAddOrOverride, creating the nested structure as needed and
+        # preserving anything Cognito or another step already populated.
+        response = event.setdefault("response", {})
+        details = response.setdefault("claimsAndScopeOverrideDetails", {})
+        if details is None:  # Cognito may send an explicit null.
+            details = {}
+            response["claimsAndScopeOverrideDetails"] = details
+        access_token_gen = details.setdefault("accessTokenGeneration", {})
+        existing = access_token_gen.setdefault("claimsToAddOrOverride", {})
+        existing.update(claims_to_add)
+
+        return event
+    except Exception:  # noqa: BLE001 — fail-open is the whole point.
+        # Never block login. Log for diagnosis and return the event untouched.
+        logger.exception("token-enrichment trigger failed; returning event unchanged")
+        return event

--- a/infrastructure/lambda-assets/token-enrichment/test_handler.py
+++ b/infrastructure/lambda-assets/token-enrichment/test_handler.py
@@ -1,0 +1,244 @@
+"""Tests for the Cognito Pre-Token-Generation v2 access-token enrichment handler.
+
+Run with: uv run pytest infrastructure/lambda-assets/token-enrichment/ (from repo root)
+or point pytest at this directory. The handler is stdlib-only, so these tests
+have no third-party dependencies beyond pytest itself.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Load handler.py directly by path so the test doesn't depend on package layout.
+_HANDLER_PATH = Path(__file__).parent / "handler.py"
+_spec = importlib.util.spec_from_file_location(
+    "token_enrichment_handler", _HANDLER_PATH
+)
+assert _spec and _spec.loader
+handler_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(handler_module)
+handler = handler_module.handler
+
+
+BSU_CLAIM = "https://boisestate.edu/employee_number"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test starts with no ACCESS_TOKEN_CLAIMS unless it sets one."""
+    monkeypatch.delenv("ACCESS_TOKEN_CLAIMS", raising=False)
+
+
+def _make_event(user_attributes: dict[str, Any] | None = None) -> dict[str, Any]:
+    """A minimal but realistic Pre-Token-Generation v2 event."""
+    return {
+        "version": "2",
+        "triggerSource": "TokenGeneration_HostedAuth",
+        "userPoolId": "us-west-2_Example",
+        "userName": "ms-entra-id_113124161",
+        "request": {
+            "userAttributes": user_attributes if user_attributes is not None else {},
+            "scopes": ["openid", "email"],
+        },
+        "response": {},
+    }
+
+
+def _access_claims(event: dict[str, Any]) -> dict[str, Any]:
+    """Extract the claimsToAddOrOverride map (or {} if not present)."""
+    response = event.get("response") or {}
+    details = response.get("claimsAndScopeOverrideDetails") or {}
+    access_token_gen = details.get("accessTokenGeneration") or {}
+    claims: dict[str, Any] = access_token_gen.get("claimsToAddOrOverride") or {}
+    return claims
+
+
+class TestEnrichment:
+    def test_present_attribute_is_copied_to_the_namespaced_claim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = _make_event({"sub": "uuid-1", "custom:provider_sub": "113124161"})
+
+        result = handler(event, None)
+
+        assert _access_claims(result)[BSU_CLAIM] == "113124161"
+
+    def test_multiple_claims_mapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS",
+            json.dumps(
+                {
+                    BSU_CLAIM: "custom:provider_sub",
+                    "https://boisestate.edu/roles": "custom:roles",
+                }
+            ),
+        )
+        event = _make_event(
+            {"custom:provider_sub": "113124161", "custom:roles": "student,alum"}
+        )
+
+        claims = _access_claims(handler(event, None))
+
+        assert claims[BSU_CLAIM] == "113124161"
+        assert claims["https://boisestate.edu/roles"] == "student,alum"
+
+    def test_missing_attribute_is_skipped_not_errored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Native Cognito user has no custom:provider_sub — claim must be omitted.
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = _make_event({"sub": "native-user"})
+
+        result = handler(event, None)
+
+        assert BSU_CLAIM not in _access_claims(result)
+
+    def test_empty_string_attribute_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = _make_event({"custom:provider_sub": ""})
+
+        assert BSU_CLAIM not in _access_claims(handler(event, None))
+
+    def test_only_present_subset_is_copied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS",
+            json.dumps(
+                {
+                    BSU_CLAIM: "custom:provider_sub",
+                    "https://boisestate.edu/roles": "custom:roles",
+                }
+            ),
+        )
+        event = _make_event({"custom:provider_sub": "113124161"})  # no roles attr
+
+        claims = _access_claims(handler(event, None))
+
+        assert claims == {BSU_CLAIM: "113124161"}
+
+    def test_preserves_preexisting_claims_to_add(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = _make_event({"custom:provider_sub": "113124161"})
+        event["response"] = {
+            "claimsAndScopeOverrideDetails": {
+                "accessTokenGeneration": {
+                    "claimsToAddOrOverride": {"existing": "keep-me"}
+                }
+            }
+        }
+
+        claims = _access_claims(handler(event, None))
+
+        assert claims["existing"] == "keep-me"
+        assert claims[BSU_CLAIM] == "113124161"
+
+
+class TestFailOpen:
+    def test_no_env_returns_event_unchanged(self) -> None:
+        event = _make_event({"custom:provider_sub": "113124161"})
+
+        result = handler(event, None)
+
+        assert result is event
+        assert _access_claims(result) == {}
+
+    def test_empty_env_returns_event_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACCESS_TOKEN_CLAIMS", "")
+        event = _make_event({"custom:provider_sub": "113124161"})
+
+        assert handler(event, None) is event
+
+    def test_malformed_json_env_returns_event_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACCESS_TOKEN_CLAIMS", "{not valid json")
+        event = _make_event({"custom:provider_sub": "113124161"})
+
+        result = handler(event, None)
+
+        assert result is event
+        assert _access_claims(result) == {}
+
+    def test_non_object_json_env_is_treated_as_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACCESS_TOKEN_CLAIMS", json.dumps(["not", "a", "map"]))
+        event = _make_event({"custom:provider_sub": "113124161"})
+
+        assert _access_claims(handler(event, None)) == {}
+
+    def test_unexpected_event_shape_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        # No "request" key at all.
+        event: dict[str, Any] = {"version": "2"}
+
+        # Must not raise; returns the event (enrichment simply can't happen).
+        result = handler(event, None)
+
+        assert result is event
+
+    def test_request_missing_user_attributes_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = {"version": "2", "request": {}}
+
+        assert handler(event, None) == {"version": "2", "request": {}}
+
+    def test_null_claims_details_is_replaced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Cognito can send claimsAndScopeOverrideDetails as an explicit null.
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS", json.dumps({BSU_CLAIM: "custom:provider_sub"})
+        )
+        event = _make_event({"custom:provider_sub": "113124161"})
+        event["response"] = {"claimsAndScopeOverrideDetails": None}
+
+        claims = _access_claims(handler(event, None))
+
+        assert claims[BSU_CLAIM] == "113124161"
+
+
+class TestClaimMapParsing:
+    def test_non_string_values_are_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "ACCESS_TOKEN_CLAIMS",
+            json.dumps({BSU_CLAIM: "custom:provider_sub", "bad": 123}),
+        )
+        event = _make_event(
+            {"custom:provider_sub": "113124161", "123": "should-not-map"}
+        )
+
+        claims = _access_claims(handler(event, None))
+
+        assert claims == {BSU_CLAIM: "113124161"}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -55,6 +55,7 @@ export interface AppConfig {
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
   mcpSandbox: McpSandboxConfig;
+  mcpIdentity: McpIdentityConfig;
   appVersion: string;
   tags: { [key: string]: string };
 }
@@ -185,6 +186,41 @@ export interface AgentsConfig {
 
 export interface FineTuningConfig {
   additionalCorsOrigins?: string; // Extra CORS origins to append (comma-separated)
+}
+
+/**
+ * MCP user-identity forwarding (docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md).
+ *
+ * Personalized MCP tools need to know *who* the logged-in user is. The only
+ * token forwarded end-to-end to MCP servers is the Cognito **access token**,
+ * which carries `sub` but no richer identity claims. This config gates an
+ * optional Cognito Pre-Token-Generation **v2** Lambda that copies configured
+ * user-pool attributes into named claims on the access token, so the existing
+ * SPA -> app-api -> inference-api -> MCP forwarding path works unchanged.
+ *
+ * Off by default (opt-in). A fork that doesn't need personalized MCP tools
+ * configures nothing: no Lambda and no pool trigger are created, and the
+ * access token (with `sub`) is forwarded exactly as it is today. This inverts
+ * the repo's usual "default ON with a kill switch" idiom precisely because the
+ * feature has a pool-wide blast radius and an external (Cognito feature-plan)
+ * dependency — it must be a deliberate opt-in.
+ */
+export interface McpIdentityConfig {
+  // Optional Pre-Token-Generation (v2) enrichment of the access token.
+  // No Lambda/trigger is created when disabled or omitted.
+  // Requires the Cognito Essentials/Plus feature plan (access-token
+  // customization) — the TokenEnrichmentConstruct sets the pool's
+  // featurePlan to ESSENTIALS to guarantee support on fresh forks.
+  tokenEnrichment?: {
+    enabled: boolean;
+    // {claimName: sourceCognitoAttribute}. Each present attribute is copied to
+    // the named claim on the access token; missing attributes are skipped
+    // (native users, or forks without that attribute). No IdP is assumed.
+    // Claim names SHOULD be namespaced (full reverse-DNS form, e.g.
+    // "https://example.com/employee_number") to avoid colliding with Cognito's
+    // reserved access-token claims.
+    accessTokenClaims?: { [claimName: string]: string };
+  };
 }
 
 /**
@@ -371,6 +407,27 @@ export function loadConfig(scope: cdk.App): AppConfig {
         || scope.node.tryGetContext('mcpSandbox')?.extraFrameAncestors
         || [],
     },
+    mcpIdentity: {
+      // Off by default (opt-in). Env wins over context; context wins over the
+      // false default. `parseBooleanEnv` returns undefined for unset/empty
+      // (including the empty string an unset GitHub Actions variable renders
+      // to), so `??` falls through to context, then to `false`.
+      tokenEnrichment: {
+        enabled:
+          parseBooleanEnv(process.env.CDK_MCP_TOKEN_ENRICHMENT_ENABLED)
+          ?? scope.node.tryGetContext('mcpIdentity')?.tokenEnrichment?.enabled
+          ?? false,
+        // {claimName: sourceCognitoAttribute}. Settable as a JSON object via
+        // the CDK_MCP_TOKEN_ENRICHMENT_CLAIMS env var (so a fork can enable the
+        // feature entirely through GitHub Actions variables while the public
+        // cdk.context.json stays inert), or via context. Env wins over context;
+        // both default to an empty map (no claims copied).
+        accessTokenClaims:
+          parseJsonRecordEnv(process.env.CDK_MCP_TOKEN_ENRICHMENT_CLAIMS)
+          ?? scope.node.tryGetContext('mcpIdentity')?.tokenEnrichment?.accessTokenClaims
+          ?? {},
+      },
+    },
     tags: {
       ...(scope.node.tryGetContext('tags') || {}),
     },
@@ -452,6 +509,39 @@ function parseIntEnv(value: string | undefined): number | undefined {
   }
   const parsed = parseInt(value, 10);
   return isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Parse a JSON object of string->string from an environment variable.
+ *
+ * Used for structured config that can't be expressed as a scalar `--context`
+ * value (e.g. the MCP token-enrichment claim map). Returns undefined for
+ * unset/empty/invalid input so nullish coalescing (??) can fall through to a
+ * context value or default. Non-object JSON, or entries whose key/value aren't
+ * both strings, are rejected/filtered — a malformed value must never crash the
+ * synth, it simply falls through.
+ */
+export function parseJsonRecordEnv(
+  value: string | undefined,
+): { [key: string]: string } | undefined {
+  if (value === undefined || value.trim() === '') {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const result: { [key: string]: string } = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof k === 'string' && typeof v === 'string') {
+        result[k] = v;
+      }
+    }
+    return result;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/infrastructure/lib/constructs/identity/cognito-construct.ts
+++ b/infrastructure/lib/constructs/identity/cognito-construct.ts
@@ -42,6 +42,14 @@ export class CognitoConstruct extends Construct {
 
     this.userPool = new cognito.UserPool(this, 'CognitoUserPool', {
       userPoolName: getResourceName(config, 'user-pool'),
+      // ESSENTIALS is required for access-token customization via the
+      // Pre-Token-Generation v2 trigger (the MCP identity-forwarding feature,
+      // docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md). Set explicitly so a
+      // fresh fork's pool comes up on a plan that supports the trigger before
+      // TokenEnrichmentConstruct attaches it. Existing pools are already on
+      // ESSENTIALS, so this is a no-op for current deployments. The feature
+      // itself stays opt-in (default off) — this only guarantees capability.
+      featurePlan: cognito.FeaturePlan.ESSENTIALS,
       selfSignUpEnabled: true,
       signInAliases: { username: true, email: true },
       autoVerify: { email: true },

--- a/infrastructure/lib/constructs/identity/token-enrichment-construct.ts
+++ b/infrastructure/lib/constructs/identity/token-enrichment-construct.ts
@@ -1,0 +1,103 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as path from 'path';
+import { Construct } from 'constructs';
+
+import { AppConfig, getResourceName } from '../../config';
+
+export interface TokenEnrichmentConstructProps {
+  config: AppConfig;
+  /**
+   * The Cognito user pool to attach the Pre-Token-Generation v2 trigger to.
+   * MUST be on the ESSENTIALS (or Plus) feature plan for access-token
+   * customization to take effect — CognitoConstruct sets that explicitly.
+   */
+  userPool: cognito.UserPool;
+}
+
+/**
+ * TokenEnrichmentConstruct — Cognito Pre-Token-Generation (v2) Lambda that
+ * copies configured user-pool attributes into named claims on the *access*
+ * token (docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md).
+ *
+ * WHY: the access token is the only token forwarded end-to-end to MCP servers,
+ * but it carries `sub` and little else. Personalized MCP tools need a stable
+ * identity claim (e.g. an employee number). This trigger enriches the access
+ * token in place, so the existing SPA -> app-api -> inference-api -> MCP
+ * forwarding path needs no changes.
+ *
+ * OPT-IN: this construct is only instantiated by PlatformStack when
+ * `config.mcpIdentity.tokenEnrichment.enabled` is true. When disabled (the
+ * default) it produces zero resources and the pool has no trigger — the access
+ * token is forwarded exactly as before. Flipping the flag on and redeploying
+ * via the platform (CDK) workflow creates the Lambda + trigger and attaches it
+ * to the existing pool in place; flipping it off removes them cleanly.
+ *
+ * BLAST RADIUS / FAIL-OPEN: the trigger runs on EVERY token issuance for the
+ * whole pool. The handler (lambda-assets/token-enrichment/handler.py) is
+ * dependency-free, does no I/O, and returns the event unchanged on any error,
+ * so a bug degrades to "claim not added", never "login blocked".
+ *
+ * CODE SHIPPING: unlike the bootstrap-container Lambdas (artifact-render,
+ * rag-ingestion), this handler ships its REAL code via `lambda.Code.fromAsset`
+ * on the normal platform (CDK) deploy path. It's generic, tiny, dependency-free
+ * and rarely changes, so there's no reason to put it on the fast backend
+ * code-deploy path. The claim map is passed as an env var (function
+ * configuration), so it updates on a plain CDK deploy.
+ */
+export class TokenEnrichmentConstruct extends Construct {
+  public readonly enrichmentFunction: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: TokenEnrichmentConstructProps) {
+    super(scope, id);
+
+    const { config, userPool } = props;
+
+    const accessTokenClaims =
+      config.mcpIdentity.tokenEnrichment?.accessTokenClaims ?? {};
+
+    // Auto-generated log group name (no explicit name) so a failed-deploy
+    // orphan can't collide with a redeploy. Short retention — these logs are
+    // only useful for diagnosing a misconfigured claim map.
+    const logGroup = new logs.LogGroup(this, 'TokenEnrichmentLogGroup', {
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.enrichmentFunction = new lambda.Function(this, 'TokenEnrichmentFunction', {
+      functionName: getResourceName(config, 'token-enrichment'),
+      description:
+        'Cognito Pre-Token-Generation v2 trigger — copies configured user attributes into access-token claims for MCP identity forwarding (fail-open)',
+      runtime: lambda.Runtime.PYTHON_3_13,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.handler',
+      logGroup,
+      // Real handler code (NOT a bootstrap placeholder) — see class docstring.
+      // `exclude` keeps the test out of the deployed zip.
+      code: lambda.Code.fromAsset(
+        path.resolve(__dirname, '..', '..', '..', 'lambda-assets', 'token-enrichment'),
+        { exclude: ['test_*.py', '*_test.py', '__pycache__', '.pytest_cache'] },
+      ),
+      memorySize: 128,
+      timeout: cdk.Duration.seconds(5),
+      environment: {
+        // {claimName: sourceCognitoAttribute}. The handler skips attributes the
+        // user doesn't have, so an empty map is a safe no-op.
+        ACCESS_TOKEN_CLAIMS: JSON.stringify(accessTokenClaims),
+      },
+    });
+
+    // Attach as the pool's Pre-Token-Generation v2 trigger. `addTrigger`
+    // automatically grants Cognito (`cognito-idp.amazonaws.com`) permission to
+    // invoke the function, scoped to this pool's ARN — no manual addPermission
+    // needed. V2_0 is the trigger version that can customize the ACCESS token
+    // (V1 could only touch the ID token).
+    userPool.addTrigger(
+      cognito.UserPoolOperation.PRE_TOKEN_GENERATION_CONFIG,
+      this.enrichmentFunction,
+      cognito.LambdaVersion.V2_0,
+    );
+  }
+}

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -28,6 +28,7 @@ import { BffCookieKeyConstruct } from './constructs/identity/bff-cookie-key-cons
 import { CognitoConstruct } from './constructs/identity/cognito-construct';
 import { OAuthTablesConstruct } from './constructs/identity/oauth-tables-construct';
 import { PlatformIdentityConstruct } from './constructs/identity/platform-identity-construct';
+import { TokenEnrichmentConstruct } from './constructs/identity/token-enrichment-construct';
 import { VoiceTicketConstruct } from './constructs/identity/voice-ticket-construct';
 
 // Data
@@ -299,6 +300,24 @@ export class PlatformStack extends cdk.Stack {
     this.bffAppClient = cognitoConstruct.bffAppClient;
     this.bffAppClientSecret = cognitoConstruct.bffAppClientSecret;
     this.cognitoDomain = cognitoConstruct.cognitoDomain;
+
+    // MCP user-identity forwarding — optional Cognito Pre-Token-Generation v2
+    // Lambda that copies configured user attributes into access-token claims so
+    // personalized MCP tools can identify the caller
+    // (docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md).
+    //
+    // Opt-in (default OFF): when disabled, this block creates nothing and the
+    // access token is forwarded exactly as before. It's gated rather than
+    // default-on because the trigger runs pool-wide on every token issuance and
+    // depends on the Cognito Essentials feature plan — a deliberate opt-in. The
+    // handler is fail-open (returns the event unchanged on any error), so the
+    // worst case is "claim not added", never "login blocked".
+    if (config.mcpIdentity.tokenEnrichment?.enabled) {
+      new TokenEnrichmentConstruct(this, 'TokenEnrichment', {
+        config,
+        userPool: cognitoConstruct.userPool,
+      });
+    }
 
     const artifactRenderToken = new ArtifactRenderTokenSecretConstruct(
       this,

--- a/infrastructure/test/config.test.ts
+++ b/infrastructure/test/config.test.ts
@@ -936,4 +936,146 @@ describe('RAG Ingestion Configuration', () => {
       expect(() => loadConfig(app)).not.toThrow();
     });
   });
+
+  // ============================================================
+  // MCP Identity — token-enrichment feature flag
+  //
+  // Opt-in (default OFF), unlike the default-ON feature flags above.
+  // The claim map is context-only (structured, not a scalar env var).
+  // ============================================================
+
+  describe('MCP Identity token enrichment feature flag', () => {
+    const MCP_ENV_KEY = 'CDK_MCP_TOKEN_ENRICHMENT_ENABLED';
+    const MCP_CLAIMS_ENV_KEY = 'CDK_MCP_TOKEN_ENRICHMENT_CLAIMS';
+
+    beforeEach(() => {
+      delete process.env[MCP_ENV_KEY];
+      delete process.env[MCP_CLAIMS_ENV_KEY];
+    });
+    afterEach(() => {
+      delete process.env[MCP_ENV_KEY];
+      delete process.env[MCP_CLAIMS_ENV_KEY];
+    });
+
+    test('defaults to DISABLED when env is unset and no context is provided', () => {
+      const config = loadConfig(app);
+
+      expect(config.mcpIdentity.tokenEnrichment?.enabled).toBe(false);
+      expect(config.mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({});
+    });
+
+    test('treats empty string (unset GitHub Actions variable) as disabled', () => {
+      // `${{ vars.CDK_MCP_TOKEN_ENRICHMENT_ENABLED }}` renders to "" when unset.
+      process.env[MCP_ENV_KEY] = '';
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.enabled).toBe(false);
+    });
+
+    test('CDK_MCP_TOKEN_ENRICHMENT_ENABLED="true" enables it (env opt-in)', () => {
+      process.env[MCP_ENV_KEY] = 'true';
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.enabled).toBe(true);
+    });
+
+    test('CDK_MCP_TOKEN_ENRICHMENT_ENABLED="false" stays disabled', () => {
+      process.env[MCP_ENV_KEY] = 'false';
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.enabled).toBe(false);
+    });
+
+    test('cdk.json context mcpIdentity.tokenEnrichment.enabled=true enables when env is unset', () => {
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: { enabled: true, accessTokenClaims: {} },
+      });
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.enabled).toBe(true);
+    });
+
+    test('env takes precedence over context (env=false beats context=true)', () => {
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: { enabled: true, accessTokenClaims: {} },
+      });
+      process.env[MCP_ENV_KEY] = 'false';
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.enabled).toBe(false);
+    });
+
+    test('parses the namespaced accessTokenClaims map from context', () => {
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: {
+          enabled: true,
+          accessTokenClaims: {
+            'https://boisestate.edu/employee_number': 'custom:provider_sub',
+          },
+        },
+      });
+
+      const config = loadConfig(app);
+
+      expect(config.mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({
+        'https://boisestate.edu/employee_number': 'custom:provider_sub',
+      });
+    });
+
+    test('accessTokenClaims defaults to an empty map when context omits it', () => {
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: { enabled: true },
+      });
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({});
+    });
+
+    test('accessTokenClaims parses from CDK_MCP_TOKEN_ENRICHMENT_CLAIMS JSON env', () => {
+      process.env[MCP_CLAIMS_ENV_KEY] = JSON.stringify({
+        'https://boisestate.edu/employee_number': 'custom:provider_sub',
+      });
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({
+        'https://boisestate.edu/employee_number': 'custom:provider_sub',
+      });
+    });
+
+    test('claims JSON env takes precedence over context', () => {
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: {
+          enabled: true,
+          accessTokenClaims: { 'ctx:claim': 'custom:from_context' },
+        },
+      });
+      process.env[MCP_CLAIMS_ENV_KEY] = JSON.stringify({
+        'env:claim': 'custom:from_env',
+      });
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({
+        'env:claim': 'custom:from_env',
+      });
+    });
+
+    test('malformed claims JSON env falls through to context/default (never throws)', () => {
+      process.env[MCP_CLAIMS_ENV_KEY] = '{not valid json';
+
+      expect(() => loadConfig(app)).not.toThrow();
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({});
+    });
+
+    test('non-object claims JSON env is ignored (falls through to default)', () => {
+      process.env[MCP_CLAIMS_ENV_KEY] = JSON.stringify(['not', 'a', 'map']);
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({});
+    });
+
+    test('empty claims JSON env falls through to context/default', () => {
+      process.env[MCP_CLAIMS_ENV_KEY] = '';
+      app.node.setContext('mcpIdentity', {
+        tokenEnrichment: {
+          enabled: true,
+          accessTokenClaims: { 'ctx:claim': 'custom:from_context' },
+        },
+      });
+
+      expect(loadConfig(app).mcpIdentity.tokenEnrichment?.accessTokenClaims).toEqual({
+        'ctx:claim': 'custom:from_context',
+      });
+    });
+  });
 });

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -65,6 +65,12 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     mcpSandbox: {
       extraFrameAncestors: [],
     },
+    mcpIdentity: {
+      tokenEnrichment: {
+        enabled: false,
+        accessTokenClaims: {},
+      },
+    },
     cognito: {
       domainPrefix: MOCK_PREFIX,
       passwordMinLength: 8,

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -7,6 +7,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { PlatformStack } from '../lib/platform-stack';
+import { McpIdentityConfig } from '../lib/config';
 import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
 
 describe('PlatformStack', () => {
@@ -215,6 +216,86 @@ describe('PlatformStack', () => {
 
     it('exposes artifactsFrameAncestors', () => {
       expect(stack.artifactsFrameAncestors).toContain('https://example.com');
+    });
+  });
+
+  describe('MCP token enrichment wiring', () => {
+    const cert = 'arn:aws:acm:us-east-1:123456789012:certificate/test';
+
+    function buildTemplate(mcpIdentity: McpIdentityConfig): Template {
+      const config = createMockConfig({
+        domainName: 'example.com',
+        infrastructureHostedZoneDomain: 'example.com',
+        certificateArn: cert,
+        frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
+        artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+        mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
+        fineTuning: {},
+        mcpIdentity,
+      });
+      const app = new cdk.App();
+      mockSsmContext(app, config);
+      const s = new PlatformStack(app, 'McpIdentityPlatformStack', {
+        config,
+        env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+      });
+      return Template.fromStack(s);
+    }
+
+    it('default (disabled): pool has no Pre-Token-Generation trigger', () => {
+      // The top-level `template` is built from the default mock config, which
+      // has mcpIdentity disabled.
+      const pools = template.findResources('AWS::Cognito::UserPool');
+      const poolProps = Object.values(pools)[0]?.Properties ?? {};
+      expect(poolProps.LambdaConfig?.PreTokenGenerationConfig).toBeUndefined();
+    });
+
+    it('default (disabled): no token-enrichment Lambda is created', () => {
+      const fns = template.findResources('AWS::Lambda::Function');
+      const names = Object.values(fns).map(
+        (r: any) => r.Properties?.FunctionName,
+      );
+      expect(names).not.toContain('test-project-token-enrichment');
+    });
+
+    it('enabled: pool gains the Pre-Token-Generation v2 trigger', () => {
+      const t = buildTemplate({
+        tokenEnrichment: {
+          enabled: true,
+          accessTokenClaims: {
+            'https://boisestate.edu/employee_number': 'custom:provider_sub',
+          },
+        },
+      });
+      t.hasResourceProperties('AWS::Cognito::UserPool', {
+        LambdaConfig: {
+          PreTokenGenerationConfig: {
+            LambdaVersion: 'V2_0',
+          },
+        },
+      });
+    });
+
+    it('enabled: the token-enrichment Lambda is created with the claim map', () => {
+      const t = buildTemplate({
+        tokenEnrichment: {
+          enabled: true,
+          accessTokenClaims: {
+            'https://boisestate.edu/employee_number': 'custom:provider_sub',
+          },
+        },
+      });
+      t.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'test-project-token-enrichment',
+        Runtime: 'python3.13',
+        Environment: {
+          Variables: {
+            ACCESS_TOKEN_CLAIMS: JSON.stringify({
+              'https://boisestate.edu/employee_number': 'custom:provider_sub',
+            }),
+          },
+        },
+      });
     });
   });
 });

--- a/infrastructure/test/token-enrichment.test.ts
+++ b/infrastructure/test/token-enrichment.test.ts
@@ -1,0 +1,114 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+
+import { TokenEnrichmentConstruct } from '../lib/constructs/identity/token-enrichment-construct';
+import { createMockConfig, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+const BSU_CLAIMS = {
+  'https://boisestate.edu/employee_number': 'custom:provider_sub',
+};
+
+/**
+ * Synthesize a stack with a real UserPool. When `enabled`, also instantiate the
+ * TokenEnrichmentConstruct — mirroring the conditional wiring in PlatformStack.
+ */
+function synth(
+  enabled: boolean,
+  accessTokenClaims: Record<string, string> = BSU_CLAIMS,
+): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'Test', {
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  const config = createMockConfig({
+    mcpIdentity: { tokenEnrichment: { enabled, accessTokenClaims } },
+  });
+  const userPool = new cognito.UserPool(stack, 'UserPool', {
+    featurePlan: cognito.FeaturePlan.ESSENTIALS,
+  });
+  if (enabled) {
+    new TokenEnrichmentConstruct(stack, 'TokenEnrichment', { config, userPool });
+  }
+  return Template.fromStack(stack);
+}
+
+describe('TokenEnrichmentConstruct', () => {
+  describe('enabled', () => {
+    let t: Template;
+    beforeAll(() => {
+      t = synth(true);
+    });
+
+    it('creates a single Python 3.13 ARM64 Lambda with the handler entrypoint', () => {
+      // Exactly one function is created (the enrichment Lambda; a bare UserPool
+      // adds none).
+      t.resourceCountIs('AWS::Lambda::Function', 1);
+      t.hasResourceProperties('AWS::Lambda::Function', {
+        Runtime: 'python3.13',
+        Handler: 'handler.handler',
+        Architectures: ['arm64'],
+      });
+    });
+
+    it('passes the claim map to the handler via ACCESS_TOKEN_CLAIMS env (JSON)', () => {
+      t.hasResourceProperties('AWS::Lambda::Function', {
+        Environment: {
+          Variables: Match.objectLike({
+            ACCESS_TOKEN_CLAIMS: JSON.stringify(BSU_CLAIMS),
+          }),
+        },
+      });
+    });
+
+    it('attaches the Lambda as the pool Pre-Token-Generation v2 trigger', () => {
+      t.hasResourceProperties('AWS::Cognito::UserPool', {
+        LambdaConfig: Match.objectLike({
+          PreTokenGenerationConfig: Match.objectLike({
+            LambdaVersion: 'V2_0',
+            LambdaArn: Match.anyValue(),
+          }),
+        }),
+      });
+    });
+
+    it('grants Cognito permission to invoke the function (auto-added by addTrigger)', () => {
+      t.hasResourceProperties('AWS::Lambda::Permission', {
+        Action: 'lambda:InvokeFunction',
+        Principal: 'cognito-idp.amazonaws.com',
+      });
+    });
+  });
+
+  describe('empty claim map', () => {
+    it('still synthesizes with an empty JSON object env (safe no-op enrichment)', () => {
+      const t = synth(true, {});
+      t.hasResourceProperties('AWS::Lambda::Function', {
+        Environment: {
+          Variables: Match.objectLike({ ACCESS_TOKEN_CLAIMS: '{}' }),
+        },
+      });
+    });
+  });
+
+  describe('disabled (construct not instantiated)', () => {
+    let t: Template;
+    beforeAll(() => {
+      t = synth(false);
+    });
+
+    it('creates no Lambda function', () => {
+      t.resourceCountIs('AWS::Lambda::Function', 0);
+    });
+
+    it('leaves the pool without a Pre-Token-Generation trigger', () => {
+      const pools = t.findResources('AWS::Cognito::UserPool');
+      const poolProps = Object.values(pools)[0]?.Properties ?? {};
+      expect(poolProps.LambdaConfig?.PreTokenGenerationConfig).toBeUndefined();
+    });
+
+    it('adds no Cognito invoke permission', () => {
+      t.resourceCountIs('AWS::Lambda::Permission', 0);
+    });
+  });
+});


### PR DESCRIPTION
Add an opt-in Cognito Pre-Token-Generation v2 Lambda that copies configured user-pool attributes into namespaced claims on the ACCESS token, so personalized MCP tools can identify the caller. The access token is the only token forwarded end-to-end to MCP servers, so enrichment needs no changes to the SPA -> app-api -> inference-api -> MCP forwarding path.

Shipped disabled by default (opt-in): a fork that configures nothing gets zero resources and the token is forwarded as before. Enabling requires the Cognito Essentials feature plan (pinned on the pool) plus two GitHub Actions variables (CDK_MCP_TOKEN_ENRICHMENT_ENABLED + CDK_MCP_TOKEN_ENRICHMENT_CLAIMS), keeping the committed cdk.context.json inert.

- config: McpIdentityConfig (enabled + accessTokenClaims); claim map settable via JSON env var or context; parseJsonRecordEnv helper.
- handler: stdlib-only, fail-open Pre-Token-Gen v2 trigger (returns event unchanged on any error so login is never blocked).
- construct: real-code Lambda (fromAsset) attached via addTrigger V2_0; pool featurePlan pinned to ESSENTIALS.
- wired conditionally into PlatformStack; platform.yml job-level env.
- docs: spec updated (open questions resolved) + implementation summary, incl. the mcp-servers follow-on handoff.

Ref: docs/specs/MCP_USER_IDENTITY_FORWARDING_SPEC.md