### PR TITLE
fix(app-api): grant CreateTokenVault for admin OAuth provider create (502 fix)

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -636,6 +636,11 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
   //     called by shared/oauth/agentcore_registrar.py when an
   //     admin adds, edits, or removes an OAuth provider via the
   //     admin UI. Stored under the default token vault.
+  //   - Create/GetTokenVault: CreateOauth2CredentialProvider ensures
+  //     the default token vault exists on the first provider create,
+  //     which requires CreateTokenVault on token-vault/default. Without
+  //     it the admin "add OAuth provider" POST fails with
+  //     AccessDeniedException, surfaced to the SPA as a 502.
   // Resources: scoped to this account's AgentCore Identity surface.
   // Action names verified against
   //   https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrockagentcore.html
@@ -653,6 +658,8 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
         'bedrock-agentcore:DeleteOauth2CredentialProvider',
         'bedrock-agentcore:GetOauth2CredentialProvider',
         'bedrock-agentcore:ListOauth2CredentialProviders',
+        'bedrock-agentcore:CreateTokenVault',
+        'bedrock-agentcore:GetTokenVault',
       ],
       resources: [
         `arn:aws:bedrock-agentcore:${config.awsRegion}:${config.awsAccount}:token-vault/*`,


### PR DESCRIPTION
## What

Adds `bedrock-agentcore:CreateTokenVault` and `bedrock-agentcore:GetTokenVault` to the app-api ECS task role (`AgentCoreWorkloadIdentityAccess` statement in `app-api-iam-grants.ts`).

## Why

`POST /admin/oauth-providers/` — the admin "add OAuth provider" action — returned **502 Bad Gateway** in prod and dev-ai.

The real cause was IAM, not a timeout. dev-ai app-api logs:

```
Admin creating OAuth provider google-drive-student
AWS ClientError on POST /admin/oauth-providers/: code=AccessDeniedException
  not authorized to perform: bedrock-agentcore:CreateTokenVault
  on resource arn:...:token-vault/default
POST /admin/oauth-providers/ HTTP/1.1" 502 Bad Gateway
```

AgentCore's `CreateOauth2CredentialProvider` ensures the default token vault exists on the first provider create, which requires `CreateTokenVault` (+ `GetTokenVault`) on the caller. The task role already had the `...Oauth2CredentialProvider` actions but not the TokenVault ones. The shared `apis.shared.security.error_handler` maps an uncaught AWS `ClientError` to HTTP 502, so the missing permission surfaced as a 502 rather than a 403 — worth remembering for future admin-endpoint 502 triage (grep the app-api log group for `AWS ClientError on <path>`).

The resource scope (`token-vault/*`) already covered `token-vault/default`; only the two actions were missing.

## Reviewer notes

- **Deploy:** this is a CDK/IAM change — it needs a **`platform.yml` (CDK)** redeploy to take effect. A `backend.yml`-only push won't update the task role.
- `npx tsc --noEmit` clean; `test/kb-sync.test.ts` (the only test touching these actions — it asserts the *narrower* kb-sync role does **not** gain write-side oauth actions) still passes. My change is on the app-api task role, so that assertion is unaffected.
- Scope kept deliberately minimal (two actions). A separate, orthogonal hygiene issue exists — the create/update/delete handlers call the synchronous `registrar` boto3 methods directly in the async event loop (only the rollback path off-threads) — but that's not this 502 and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)