### PR TITLE
feat(admin): make admin sidebar nav sticky on desktop

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -79,7 +79,7 @@ interface NavGroup {
       <div class="mx-auto max-w-[96rem] px-4 py-8 sm:px-6 lg:px-8">
         <div class="lg:flex lg:gap-x-8">
           <!-- Sidebar Navigation -->
-          <aside class="lg:w-60 lg:shrink-0">
+          <aside class="lg:sticky lg:top-20 lg:max-h-[calc(100dvh-6rem)] lg:w-60 lg:shrink-0 lg:self-start lg:overflow-y-auto">
             <!-- Mobile dropdown (shown on small screens) -->
             <div class="lg:hidden">
               <label for="admin-nav" class="sr-only">Admin section</label>


### PR DESCRIPTION
## What

Makes the admin section navigation (`<aside>`) sticky on desktop so it stays in view while the content area scrolls.

## Why

On admin pages with tall bodies, the left nav scrolled out of view, forcing users back to the top to switch sections. Pinning it keeps navigation reachable at all times.

## How

Single change in `admin.layout.ts` — added `lg:`-prefixed classes to the aside:

- `lg:sticky lg:top-20` — pins the nav just below the existing sticky top bar (`h-14`), with a small gap.
- `lg:self-start` — the key bit: flex items stretch to full container height by default, which silently defeats `position: sticky`. `self-start` lets the aside shrink to its content so it can actually stick.
- `lg:max-h-[calc(100dvh-6rem)] lg:overflow-y-auto` — safety so a long nav scrolls internally rather than overflowing the viewport.

All classes are `lg:`-prefixed, so the mobile experience (the `<select>` dropdown) is unchanged.

## Testing

CSS-only change. To verify: load an admin page (e.g. `/admin/costs`) at ≥1024px width, scroll a section with a tall body — the left nav should stay pinned under the top bar. Below `lg`, the mobile dropdown is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)