### PR TITLE
fix(frontend): engage sticky admin nav + frosted session topnav

### DIFF
--- a/frontend/ai.client/src/app/app.html
+++ b/frontend/ai.client/src/app/app.html
@@ -107,7 +107,7 @@
     [class.lg:pl-72]="!sidenavService.isCollapsed() && !sidenavService.isHidden()"
     [class.lg:pl-0]="sidenavService.isCollapsed() || sidenavService.isHidden()"
     [class.artifact-pane-open]="artifactPanelOpen()">
-    <main class="flex flex-col">
+    <main class="flex h-dvh flex-col">
       <!-- Scrollable Content -->
       <div class="flex-1 overflow-y-auto">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10">

--- a/frontend/ai.client/src/app/components/topnav/topnav.html
+++ b/frontend/ai.client/src/app/components/topnav/topnav.html
@@ -1,4 +1,4 @@
-<div class="sticky top-0 z-40 lg:mx-auto lg:max-w-7xl lg:px-8 bg-gray-50 dark:bg-gray-900">
+<div class="sticky top-0 z-40 lg:mx-auto lg:max-w-7xl lg:px-8 bg-gray-50/80 backdrop-blur-sm dark:bg-gray-900/50">
     <div
       class="flex h-16 items-center gap-x-4 border-b border-gray-200 px-4 shadow-xs sm:gap-x-6 sm:px-6 lg:shadow-none dark:border-white/10 dark:shadow-none transition-[padding] duration-300"
       [class.lg:pl-24]="sidenavService.isCollapsed()"


### PR DESCRIPTION
## Summary

Two small, related frontend polish changes stemming from the recently-merged sticky-admin-aside work (#632):

1. **The admin sticky aside now actually sticks.** The `lg:sticky` on the admin aside (added in #632) never engaged because its nearest scrolling ancestor was the app shell's `flex-1 overflow-y-auto` div — but that div had no bounded height, so it grew to fit content and the **window** scrolled instead. `position: sticky` binds to that overflow ancestor, which never scrolled, so the aside just sat in place. Pinning `<main>` to `h-dvh` makes the `overflow-y-auto` div a genuine, bounded scroll container. The admin aside **and** the admin top bar (`sticky top-0`) now stick as intended.

2. **Session topnav gets the frosted-glass treatment.** Swapped the opaque `bg-gray-50 dark:bg-gray-900` on the session top nav for the same translucent + blur tokens the admin bar uses (`bg-gray-50/80 backdrop-blur-sm dark:bg-gray-900/50`), so message content frosts under it as you scroll. The two surfaces now match.

## Changes

- `app.html` — `<main class="flex flex-col">` → `flex h-dvh flex-col`
- `topnav.html` — opaque bg → translucent + `backdrop-blur-sm`

## Verification notes

The `h-dvh` change touches the **shared app shell**, so it affects every route's scroll behavior. Verified surfaces to check on review:

- **Admin** — aside + top bar stick while content scrolls (short and long pages).
- **Chat / session** — the page does its own scroll + autoscroll-to-bottom; watch for double scrollbars or composer mis-sizing.
- **Docked artifact pane** — side-by-side scroll + the `artifact-pane-open` padding reservation.
- **Mobile** — `h-dvh` (dynamic viewport) with collapsing browser chrome.
- **Frosted topnav** — blur reads through in light + dark; title stays legible over busy message content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)