### PR TITLE
fix(frontend): guarantee JIT compiler in vitest runs to stop PlatformLocation flake

### DIFF
--- a/frontend/ai.client/angular.json
+++ b/frontend/ai.client/angular.json
@@ -102,7 +102,10 @@
           }
         },
         "test": {
-          "builder": "@angular/build:unit-test"
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "setupFiles": ["src/test-setup.ts"]
+          }
         }
       }
     }

--- a/frontend/ai.client/src/app/shared/shared-view.page.spec.ts
+++ b/frontend/ai.client/src/app/shared/shared-view.page.spec.ts
@@ -125,10 +125,13 @@ describe('SharedViewPage', () => {
   // Basic component creation and lifecycle
   // -----------------------------------------------------------------------
 
+  // The first test in this file pays the one-time cost of the dynamic
+  // shared-view.page chunk import, which can exceed the default 5s timeout
+  // when the full suite runs in parallel.
   it('should create the component', async () => {
     const { component } = await createComponent();
     expect(component).toBeTruthy();
-  });
+  }, 15_000);
 
   it('should initialize with loading state', async () => {
     const { component } = await createComponent();

--- a/frontend/ai.client/src/test-setup.spec.ts
+++ b/frontend/ai.client/src/test-setup.spec.ts
@@ -1,0 +1,42 @@
+// Guards the invariant established by test-setup.ts: the JIT compiler must be
+// available before spec code evaluates any raw (unlinked) Angular fesm chunk.
+// Deliberately imports nothing from Angular statically — mirroring specs like
+// app.spec.ts that only dynamic-import application code — so this fails
+// deterministically if the setup file stops loading '@angular/compiler',
+// instead of the suite failing flakily with "The injectable 'PlatformLocation'
+// needs to be compiled using the JIT compiler".
+import { describe, it, expect } from 'vitest';
+import type { Type } from '@angular/core';
+
+describe('test setup', () => {
+  it('registers the JIT compiler facade before specs run', () => {
+    const ng = (globalThis as { ng?: Record<string, unknown> }).ng;
+    expect(ng?.['ɵcompilerFacade']).toBeDefined();
+  });
+
+  it('compiles a partial-declared (unlinked) injectable via the JIT fallback', async () => {
+    const i0 = await import('@angular/core');
+    const { TestBed } = await import('@angular/core/testing');
+    const declare = i0 as unknown as Record<string, (d: object) => unknown>;
+    class FakeUnlinked {
+      static ɵfac = declare['ɵɵngDeclareFactory']({
+        minVersion: '12.0.0',
+        version: '21.2.17',
+        ngImport: i0,
+        type: FakeUnlinked,
+        deps: [],
+        target: (i0 as unknown as { ɵɵFactoryTarget: { Injectable: unknown } }).ɵɵFactoryTarget
+          .Injectable,
+      });
+      static ɵprov = declare['ɵɵngDeclareInjectable']({
+        minVersion: '12.0.0',
+        version: '21.2.17',
+        ngImport: i0,
+        type: FakeUnlinked,
+        providedIn: 'root',
+      });
+    }
+    const instance = TestBed.inject(FakeUnlinked as unknown as Type<unknown>);
+    expect(instance).toBeInstanceOf(FakeUnlinked);
+  });
+});

--- a/frontend/ai.client/src/test-setup.ts
+++ b/frontend/ai.client/src/test-setup.ts
@@ -1,0 +1,15 @@
+// Loads the JIT compiler before any spec runs.
+//
+// Angular packages ship fesm2022 chunks with partial declarations
+// (ɵɵngDeclareInjectable / ɵɵngDeclareFactory) that compile EAGERLY at module
+// evaluation. The unit-test builder keeps node_modules external
+// (externalPackages: true), so those chunks reach the vitest module runner
+// unlinked and fall back to JIT. Normally `@angular/core/testing` (imported by
+// the builder's init-testbed setup) transitively evaluates `@angular/compiler`
+// first, but that ordering is incidental — specs with no static Angular imports
+// (e.g. app.spec.ts's dynamic `import('./app')`) can evaluate a raw
+// `@angular/common` chunk before the compiler is present and die with
+// "The injectable 'PlatformLocation' needs to be compiled using the JIT
+// compiler, but '@angular/compiler' is not available". This import makes the
+// compiler's presence an explicit invariant. See angular/angular-cli#31993.
+import '@angular/compiler';

--- a/frontend/ai.client/tsconfig.spec.json
+++ b/frontend/ai.client/tsconfig.spec.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "src/**/*.d.ts",
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/test-setup.ts"
   ]
 }


### PR DESCRIPTION
## Problem

On a clean checkout, `npm test` in `frontend/ai.client` can fail in `src/app/app.spec.ts` with:

> The injectable 'PlatformLocation' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available

raised from `import('./app')` → `@angular/router` → `@angular/common` `_platform_location-chunk`. Both tests in the file fail (module-level import failure). The failure is flaky and environment/timing dependent.

## Root cause

- `@angular/build:unit-test` builds specs with `externalPackages: true`, so `@angular/*` packages are never bundled/linked — vitest loads the **raw npm fesm2022 files** at runtime (`_platform_location-chunk.mjs` is a file shipped inside `@angular/common` 21.2).
- Those shipped chunks contain partial declarations (`ɵɵngDeclareInjectable`/`ɵɵngDeclareFactory`) that compile **eagerly at module evaluation** via `getCompilerFacade` — they require `@angular/compiler` the moment the module is evaluated, not at first injection.
- The compiler was only present **incidentally**: the builder's `init-testbed` setup imports `@angular/core/testing`, which transitively evaluates `@angular/compiler`. Nothing guarantees that ordering. `app.spec.ts` is uniquely exposed because it has no static Angular imports — when the evaluation order breaks, the whole file dies at import time.

Upstream reports of the same failure mode: angular/angular-cli#31993, angular/angular-cli#32095; the upstream remedy (angular/angular-cli#32304) is the same one applied here — guarantee the compiler is loaded.

## Fix

- **`src/test-setup.ts`** — `import '@angular/compiler';`, wired via the test target's `setupFiles` in `angular.json`, so the JIT fallback is an explicit invariant in every vitest worker instead of an accident of import order.
- **`tsconfig.spec.json`** — includes the setup file in the spec TS program (the builder hard-errors otherwise).
- **`src/test-setup.spec.ts`** — guard spec mirroring app.spec.ts's shape (no static Angular imports): asserts the compiler facade is registered and that an unlinked partial-declared injectable actually JIT-compiles. If the setup file is ever removed, this fails deterministically instead of the suite failing flakily.
- **`shared-view.page.spec.ts`** — separate flake caught while soak-testing (1-in-9 full-suite runs): the file's first test pays the one-time dynamic page-chunk import and exceeded vitest's 5s default under parallel load (5011ms observed). Bumped that single test to 15s.

## Verification

- 5 consecutive full `ng test` runs green (126 files / 1449 tests) on the pinned dependency tree (`npm ci`), including cold-cache runs (`.angular/cache` + `node_modules/.vite` removed).
- Confirmed `setup-test-setup.js` appears as a build entry point and runs before specs.
- Failure mode reproduced directly during diagnosis: a probe spec declaring an unlinked partial injectable fails/passes exactly according to compiler availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)