### PR TITLE
fix(frontend): size chat scroll space to the response, adapt scrolling to shell scroll container

### DIFF
--- a/frontend/ai.client/src/app/app.html
+++ b/frontend/ai.client/src/app/app.html
@@ -108,8 +108,10 @@
     [class.lg:pl-0]="sidenavService.isCollapsed() || sidenavService.isHidden()"
     [class.artifact-pane-open]="artifactPanelOpen()">
     <main class="flex h-dvh flex-col">
-      <!-- Scrollable Content -->
-      <div class="flex-1 overflow-y-auto">
+      <!-- Scrollable Content. The id is a stable hook for code that reads
+           or sets the scroll position (session scroll save/restore) — the
+           window itself no longer scrolls now that this container is real. -->
+      <div id="app-scroll-container" class="flex-1 overflow-y-auto">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10">
           <router-outlet />
         </div>

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.css
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.css
@@ -143,13 +143,16 @@
   background-color: var(--color-gray-900);
 }
 
-/* Messages container for embedded mode - scrollable with bottom padding */
+/* Messages container for embedded mode - scrollable with bottom padding.
+   A size query container so the message list's last-turn min-height
+   (100cqh) tracks this scrollport rather than the window viewport. */
 .chat-messages-container.embedded {
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
   padding-bottom: 5rem; /* Space for the fixed input */
   min-width: 0;
+  container-type: size;
 }
 
 /* Chat input footer for embedded mode - absolutely positioned at bottom */

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -5,9 +5,22 @@
     <pre class="mt-2 overflow-x-auto text-xs">{{ messages() | json }}</pre>
   </details> -->
 
-  @for (message of messages(); track message.id; let i = $index) {
+  <!-- Turn groups: user message + the assistant messages that follow it.
+       The LAST group carries a min-height that reserves exactly the space
+       scrollToMessage needs to pin the user message at the top — the
+       response streams into that reserved space instead of pushing a
+       fixed spacer further down, so a long response leaves no dead
+       scroll below it. Groups are keyed by their first message id so a
+       finished turn's DOM (including live MCP App iframes) never moves
+       or remounts when the next turn starts. -->
+  @for (turn of turns(); track turn.key; let isLastTurn = $last) {
+  <div class="space-y-6" [style.minHeight]="isLastTurn ? lastTurnMinHeight() : null">
+  @for (message of turn.messages; track message.id) {
     @if (message.role === 'user') {
-      <div [attr.id]="'message-' + message.id">
+      <!-- scroll-mt matches the fixed-header offset (4rem) + gap (1rem) so
+           scrollIntoView pins the message just below the frosted top nav in
+           full-page mode; embedded scrollports have no overlaying header. -->
+      <div [attr.id]="'message-' + message.id" [class.scroll-mt-20]="!embeddedMode()">
         <app-user-message [message]="message"></app-user-message>
       </div>
     } @else {
@@ -57,6 +70,19 @@
 
   }
 
+  <!-- End-of-conversation sections render INSIDE the last turn's reserved
+       space so they stay adjacent to the response instead of landing a
+       viewport below it — the loading indicator and the consent/approval
+       prompts must be visible without scrolling. -->
+  @if (isLastTurn) {
+    <ng-container [ngTemplateOutlet]="conversationTail" />
+  }
+  </div>
+  }
+
+  <!-- Defined once, rendered inside the last turn group above (or in
+       plain flow when the conversation has no turns yet). -->
+  <ng-template #conversationTail>
   <!-- Single subtle compaction summary at the end of the conversation,
        shown when the backend has rolled older turns into a summary. The
        inline-divider variant of this was dropped because it caused
@@ -124,21 +150,17 @@
       <app-pulsating-loader />
     </div>
   }
+  </ng-template>
 
-  
+  <!-- No turns yet — no group to anchor the tail inside. -->
+  @if (turns().length === 0) {
+    <ng-container [ngTemplateOutlet]="conversationTail" />
+  }
+
   @if (messages().length === 0) {
     <div class="py-12 text-center text-gray-500 dark:text-gray-400">
       <p class="text-lg">No messages yet</p>
       <p class="text-sm">Start a conversation to see messages here</p>
-    </div>
-  }
-
-  <!-- Spacer div to create scrollable space at the bottom -->
-  @if (messages().length > 0) {
-    <div
-      aria-hidden="true"
-      [style.height.px]="spacerHeight()"
-      class="pointer-events-none">
     </div>
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -1,5 +1,5 @@
-import { Component, computed, input, output, signal, effect, OnDestroy, inject, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, input, output, inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import { Message } from '../../services/models/message.model';
 import type { Artifact } from '../../services/artifacts/artifact.model';
 import { UserMessageComponent } from './components/user-message.component';
@@ -30,6 +30,7 @@ import { ChatStateService } from '../../services/chat/chat-state.service';
 @Component({
   selector: 'app-message-list',
   imports: [
+    NgTemplateOutlet,
     UserMessageComponent,
     AssistantMessageComponent,
     MessageActionsComponent,
@@ -46,14 +47,13 @@ import { ChatStateService } from '../../services/chat/chat-state.service';
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
 })
-export class MessageListComponent implements OnDestroy {
+export class MessageListComponent {
   private platformId = inject(PLATFORM_ID);
   private isBrowser = isPlatformBrowser(this.platformId);
 
   // Constants for scroll behavior and layout
   private readonly HEADER_HEIGHT = 64;
   private readonly SCROLL_PADDING = 16;
-  private readonly RESIZE_DEBOUNCE_MS = 150;
 
   messages = input.required<Message[]>();
   isChatLoading = input<boolean>(false);
@@ -219,55 +219,69 @@ export class MessageListComponent implements OnDestroy {
     this.toolApprovalService.pending(),
   );
 
-  // Calculate the spacer height dynamically
-  // This creates space at the bottom so user messages can scroll to the top
-  spacerHeight = signal(0);
-
-  // Store debounced resize listener for cleanup
-  private resizeListener = this.debounce(
-    () => this.calculateSpacerHeight(),
-    this.RESIZE_DEBOUNCE_MS
-  );
-
-  constructor() {
-    if (this.isBrowser) {
-      // Only recalculate when message count changes, not on every message update
-      effect(() => {
-        this.messages().length;
-        this.calculateSpacerHeight();
-      });
-
-      // Add resize listener
-      window.addEventListener('resize', this.resizeListener);
+  /** Messages grouped into turns: each user message starts a group and the
+   *  assistant messages that follow it belong to that group. Keyed by the
+   *  first message's id so a group's identity (and its DOM subtree — which
+   *  can hold live MCP App iframes) is stable for the conversation's
+   *  lifetime: when a new turn starts, prior groups are untouched; only the
+   *  min-height binding on the previously-last group flips off. A leading
+   *  assistant message with no preceding user message (pagination cutting
+   *  mid-turn) forms a headless first group. */
+  protected readonly turns = computed<{ key: string; messages: Message[] }[]>(() => {
+    const groups: { key: string; messages: Message[] }[] = [];
+    for (const m of this.messages()) {
+      if (m.role === 'user' || groups.length === 0) {
+        groups.push({ key: m.id, messages: [m] });
+      } else {
+        groups[groups.length - 1].messages.push(m);
+      }
     }
-  }
-
-  ngOnDestroy() {
-    if (this.isBrowser) {
-      window.removeEventListener('resize', this.resizeListener);
-    }
-  }
+    return groups;
+  });
 
   /**
-   * Calculates the height needed for the bottom spacer
-   * This ensures there's enough space for user messages to scroll to the top
+   * Min-height for the LAST turn group, replacing the old fixed
+   * viewport-sized bottom spacer. Reserving the space around the turn
+   * instead of after it means the assistant response streams into the
+   * reserved space (no scroll-height growth mid-stream) and a response
+   * taller than the viewport leaves zero dead space below it — the
+   * scrollable extent past the last user message is always exactly what
+   * scrollToMessage needs to pin it at the top, and no more.
    *
-   * Set synchronously (it only reads window.innerHeight, no DOM measurement)
-   * so the extra scrollable height exists in the same layout pass as the
-   * messages — the navigation scroll restore in ConversationPage relies on
-   * the full scroll height being available right after render.
+   * Pure CSS (no measurement), so the full scroll height exists in the
+   * same layout pass as the messages — the navigation scroll restore in
+   * ConversationPage relies on that.
+   *
+   * Full-page mode scrolls the app shell's overflow container, which is
+   * exactly 100dvh tall (main.h-dvh in app.html): 100dvh minus the
+   * scroll-mt-20 anchor offset (HEADER_HEIGHT + SCROLL_PADDING) minus the
+   * 7.5rem padding-bottom of .chat-messages-container.full-page minus the
+   * shell wrapper's py-10 bottom padding (2.5rem) — both paddings already
+   * contribute scrollable space below the turn.
+   *
+   * Embedded mode scrolls .chat-messages-container.embedded, which is a
+   * size query container: 100cqh is its content-box height; its 5rem
+   * padding-bottom counts toward the scroll extent but its 1rem
+   * padding-top sits above the scrollIntoView target, hence +1rem net.
+   * Where no query container exists (shared view), cqh falls back to
+   * small-viewport units, which errs slightly roomy — harmless there.
    */
-  private calculateSpacerHeight(): void {
-    if (!this.isBrowser) return;
-
-    const viewportHeight = window.innerHeight;
-    this.spacerHeight.set(viewportHeight - this.HEADER_HEIGHT);
-  }
+  protected readonly lastTurnMinHeight = computed<string>(() =>
+    this.embeddedMode()
+      ? 'calc(100cqh + 1rem)'
+      : `calc(100dvh - ${this.HEADER_HEIGHT + this.SCROLL_PADDING + 120 + 40}px)`
+  );
 
   /**
    * Scrolls to a specific message by ID
    * Call this explicitly when user submits a message
-   * Works in both full-page mode (window scroll) and embedded mode (container scroll)
+   *
+   * scrollIntoView works against whichever ancestor actually scrolls — the
+   * app shell's overflow container in full-page mode (the window itself no
+   * longer scrolls since the shell became a real scroll container for the
+   * sticky frosted nav), the embedded chat scrollport in embedded mode.
+   * The fixed-header offset in full-page mode comes from scroll-mt-20 on
+   * the user-message wrapper, not from math here.
    *
    * @param behavior 'smooth' for user-visible animation (submit affordance),
    *   'auto' for instant positioning (navigation restore — animating a jump
@@ -279,20 +293,7 @@ export class MessageListComponent implements OnDestroy {
     const element = document.getElementById(`message-${messageId}`);
     if (!element) return;
 
-    if (this.embeddedMode()) {
-      // In embedded mode, use scrollIntoView which works with any scroll container
-      element.scrollIntoView({ behavior, block: 'start' });
-    } else {
-      // In full-page mode, use window scroll with offset for fixed header
-      const elementRect = element.getBoundingClientRect();
-      const absoluteElementTop = elementRect.top + window.scrollY;
-      const offset = this.HEADER_HEIGHT + this.SCROLL_PADDING;
-
-      window.scrollTo({
-        top: absoluteElementTop - offset,
-        behavior
-      });
-    }
+    element.scrollIntoView({ behavior, block: 'start' });
   }
 
   /**
@@ -304,20 +305,6 @@ export class MessageListComponent implements OnDestroy {
     if (lastUserMsg) {
       this.scrollToMessage(lastUserMsg.id, behavior);
     }
-  }
-
-  /**
-   * Debounces a function to limit how often it can be called
-   */
-  private debounce<T extends (...args: any[]) => any>(
-    fn: T,
-    delay: number
-  ): (...args: Parameters<T>) => void {
-    let timeoutId: ReturnType<typeof setTimeout>;
-    return (...args: Parameters<T>) => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => fn(...args), delay);
-    };
   }
 }
 

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -82,6 +82,16 @@ export class ConversationPage implements OnDestroy {
   private chatContainer = viewChild(ChatContainerComponent);
 
   /**
+   * The app shell's scroll container (#app-scroll-container in app.html).
+   * Since the shell became a real scroll container (frosted sticky nav),
+   * the window itself never scrolls — all scroll save/restore reads and
+   * writes go through this element. Browser-only callers guard isBrowser.
+   */
+  private get scrollContainer(): HTMLElement | null {
+    return document.getElementById('app-scroll-container');
+  }
+
+  /**
    * The conversation whose scroll position we're currently tracking.
    * Captured into ScrollPositionService the moment the user navigates away
    * (route change or component teardown) — see the scroll policy note on
@@ -403,9 +413,9 @@ export class ConversationPage implements OnDestroy {
 
       if (this.isBrowser && this.lastViewedSessionId !== id) {
         if (this.lastViewedSessionId) {
-          this.scrollPositions.save(this.lastViewedSessionId, window.scrollY);
+          this.scrollPositions.save(this.lastViewedSessionId, this.scrollContainer?.scrollTop ?? 0);
         }
-        window.scrollTo({ top: 0, behavior: 'auto' });
+        this.scrollContainer?.scrollTo({ top: 0, behavior: 'auto' });
       }
       this.lastViewedSessionId = id;
 
@@ -494,7 +504,7 @@ export class ConversationPage implements OnDestroy {
     if (this.isBrowser) {
       const id = this.sessionId();
       if (id) {
-        this.scrollPositions.save(id, window.scrollY);
+        this.scrollPositions.save(id, this.scrollContainer?.scrollTop ?? 0);
       }
     }
     this.routeSubscription?.unsubscribe();
@@ -510,8 +520,9 @@ export class ConversationPage implements OnDestroy {
    * across a whole conversation is noise.
    *
    * Runs two animation frames after the messages landed in the map so the
-   * message DOM and the bottom spacer have committed and the full scroll
-   * height exists; bails if the user has already navigated elsewhere.
+   * message DOM (and the last-turn min-height that provides the scroll
+   * room) has committed and the full scroll height exists; bails if the
+   * user has already navigated elsewhere.
    */
   private restoreScrollPosition(sessionId: string): void {
     if (!this.isBrowser) return;
@@ -522,7 +533,7 @@ export class ConversationPage implements OnDestroy {
 
         const saved = this.scrollPositions.get(sessionId);
         if (saved !== undefined) {
-          window.scrollTo({ top: saved, behavior: 'auto' });
+          this.scrollContainer?.scrollTo({ top: saved, behavior: 'auto' });
         } else {
           this.chatContainer()?.scrollToLastUserMessage('auto');
         }


### PR DESCRIPTION
## What changed

**Dynamic last-turn spacing.** The message list's fixed viewport-tall bottom spacer is replaced by a `min-height` on the *last turn group* (a user message plus the assistant messages that follow it). Reserving space around the turn instead of after it means:

- A short response leaves exactly the room needed to pin the submitted message at the top — you can no longer scroll a full screen past the end of the conversation.
- A response taller than the viewport leaves **zero** dead space below it.
- While streaming, the response grows into the reserved space, so total scroll height doesn't creep mid-turn.
- Pure CSS (`100dvh` full-page / `100cqh` embedded via a size query container) — no measurement, no ResizeObserver, no resize listener; the scroll height exists in the same layout pass as the messages, which the navigation scroll restore relies on.

Turn groups are keyed by their first message id, so a finished turn's DOM never moves or remounts when the next turn starts — this matters for live MCP App iframes, which persist for the conversation's lifetime. End-of-conversation sections (loading indicator, OAuth consent and tool-approval prompts, compaction summary, orphan artifacts, MCP app cards) render *inside* the last turn's reserved space so they stay visible adjacent to the response instead of landing a viewport below it.

**Adaptation to #634 (frosted sticky nav), fixing a develop regression.** #634 made the app shell a real scroll container (`main.h-dvh` + inner `overflow-y-auto`), so the window never scrolls anymore — which silently broke the session page's window-based scrolling (submit scroll-to-message and per-session scroll save/restore were no-ops on develop). This PR:

- switches `scrollToMessage` to `scrollIntoView`, with the fixed-header offset expressed as `scroll-mt-20` on the user-message wrapper (full-page only);
- routes scroll save/restore through the shell container's `scrollTop`, reachable via a new stable `id="app-scroll-container"` hook in `app.html`.

## Reviewer notes

- The full-page min-height constant (`calc(100dvh - 240px)`) is derived, not eyeballed: header 64 + anchor gap 16 + `.chat-messages-container.full-page` padding-bottom 120 + shell wrapper `py-10` bottom 40. If any of those paddings change, the calc comment in `message-list.component.ts` documents the chain.
- `container-type: size` is added only to the embedded scrollport (`.chat-messages-container.embedded`). It must NOT be added to the shell scroll container — size containment would turn it into a containing block for the session view's `position: fixed` topnav/footer.
- In the shared view (no query container ancestor), `100cqh` falls back to small-viewport units, which errs slightly roomy — harmless in a read-only view.
- Tested: `ng build` clean; `npm test` green except the pre-existing `app.spec.ts` JIT-linker failures being fixed separately on `fix/vitest-jit-compiler-flake`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)