### PR TITLE
feat(settings): make user settings sidebar nav sticky on desktop

### DIFF
--- a/frontend/ai.client/src/app/settings/settings.page.ts
+++ b/frontend/ai.client/src/app/settings/settings.page.ts
@@ -63,7 +63,7 @@ interface NavItem {
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="lg:grid lg:grid-cols-12 lg:gap-x-8">
           <!-- Sidebar Navigation -->
-          <aside class="lg:col-span-2">
+          <aside class="lg:sticky lg:top-20 lg:col-span-2 lg:max-h-[calc(100dvh-6rem)] lg:self-start lg:overflow-y-auto">
             <!-- Mobile dropdown (shown on small screens) -->
             <div class="lg:hidden">
               <label for="settings-nav" class="sr-only">Settings section</label>


### PR DESCRIPTION
## What

Applies the sticky-aside treatment from the admin layout ([#632](https://github.com/Boise-State-Development/agentcore-public-stack/pull/632)) to the **user settings** view. On desktop (`lg` and up), the settings section nav now pins below the sticky top bar and stays in view while the content area scrolls.

Single-line change to the aside in `settings.page.ts`:

```
- <aside class="lg:col-span-2">
+ <aside class="lg:sticky lg:top-20 lg:col-span-2 lg:max-h-[calc(100dvh-6rem)] lg:self-start lg:overflow-y-auto">
```

## Why

Matches the admin experience so both settings surfaces behave consistently — the nav no longer scrolls out of view on longer pages.

## Notes for reviewers

- **`lg:self-start` is the key bit.** The settings layout uses a CSS grid (`lg:grid-cols-12`); grid items stretch to full row height by default, which defeats `position: sticky`. `self-start` shrinks the aside to its content so sticky engages. (Admin used the same trick on a flex layout.)
- **`lg:top-20`** (5rem) clears the `h-14` sticky top bar with a small gap, identical to admin.
- **`lg:max-h-[calc(100dvh-6rem)]` + `lg:overflow-y-auto`** let a long nav scroll internally. The current settings nav has only 6 items so this won't engage in practice, but it's kept for parity with admin.
- **Mobile is untouched** — the `lg:hidden` dropdown and all sub-`lg` behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)