### PR TITLE
feat(admin-tools): discover OAuth-gated MCP servers with the admin's vaulted token

### DIFF
--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -9,6 +9,16 @@ from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from apis.shared.auth import User, require_admin
+from apis.shared.oauth.agentcore_identity import (
+    CallbackUrlUnavailableError,
+    WorkloadTokenUnavailableError,
+    custom_parameters_for,
+    get_agentcore_identity_client,
+)
+from apis.shared.oauth.provider_repository import (
+    OAuthProviderRepository,
+    get_provider_repository,
+)
 from apis.app_api.tools.service import get_tool_catalog_service
 from apis.app_api.tools.discovery import discover_tools_for_saved_tool
 from apis.shared.tools.gateway_target_service import (
@@ -358,6 +368,7 @@ def _discovery_failure_detail(status: int) -> str:
 async def admin_discover_mcp_tools(
     request: MCPDiscoverRequest,
     admin: User = Depends(require_admin),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
 ):
     """Connect to an MCP server with the given config and return its tool list.
 
@@ -385,11 +396,55 @@ async def admin_discover_mcp_tools(
         create_external_mcp_client,
     )
 
-    if request.auth_type in (MCPAuthType.OAUTH2.value, MCPAuthType.OAUTH2):
+    # An OAuth (3LO) gated server is discovered using the admin's *own* vaulted
+    # token for the named provider — mirroring how the agent loop attaches the
+    # end-user's provider token at runtime. This validates the admin's own
+    # connection and returns the tools their token can see (providers such as
+    # GitHub scope-filter the tool list to the token's grants). It fetches the
+    # admin's token only; it can't mint an arbitrary end-user's token, so the
+    # discovered list reflects the admin's connection, not every user's.
+    oauth_token: Optional[str] = None
+    if request.requires_oauth_provider:
+        if request.forward_auth_token:
+            raise HTTPException(
+                status_code=400,
+                detail="Choose either an OAuth provider or forwarded-auth "
+                "discovery, not both.",
+            )
+        provider = await provider_repo.get_provider(request.requires_oauth_provider)
+        if provider is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown OAuth provider "
+                f"'{request.requires_oauth_provider}'.",
+            )
+        identity = get_agentcore_identity_client()
+        try:
+            result = await identity.get_token_for_user(
+                provider_name=provider.provider_id,
+                scopes=provider.scopes,
+                user_id=admin.user_id,
+                # Match the customParameters used at consent time — AgentCore
+                # factors them into the vault key, so omitting them would
+                # falsely report consent-required for a vaulted token.
+                custom_parameters=custom_parameters_for(provider.custom_parameters),
+            )
+        except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+            logger.warning("OAuth discovery token unavailable: %s", err)
+            raise HTTPException(status_code=503, detail=str(err))
+        if result.requires_consent or not result.access_token:
+            raise HTTPException(
+                status_code=409,
+                detail=f"You haven't connected '{provider.display_name}' yet. "
+                "Connect it in your connector settings, then retry discovery.",
+            )
+        oauth_token = result.access_token
+
+    elif request.auth_type in (MCPAuthType.OAUTH2.value, MCPAuthType.OAUTH2):
         raise HTTPException(
             status_code=400,
-            detail="OAuth-gated MCP servers can't be discovered server-side; "
-            "list the tool names manually.",
+            detail="Select the OAuth provider for this server to discover its "
+            "tools, or list the tool names manually.",
         )
 
     # Forward-auth servers (same-team MCP that validates a forwarded JWT, behind
@@ -400,8 +455,7 @@ async def admin_discover_mcp_tools(
     # trust-boundary note above); forwarding their own session token to that URL
     # is a strictly lower bar than the end-user token forwarding they're
     # configuring for the tool.
-    oauth_token: Optional[str] = None
-    if request.forward_auth_token:
+    elif request.forward_auth_token:
         if not admin.raw_token:
             raise HTTPException(
                 status_code=400,

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -1354,9 +1354,17 @@ class MCPDiscoverRequest(BaseModel):
     """Request body for POST /api/admin/tools/discover.
 
     Same fields as MCPServerConfigRequest minus the `tools` list — the
-    point of discovery is to populate that list. Provider-gated OAuth (3LO)
-    servers can't be discovered admin-side (no end-user provider token
-    available); the route returns a 400 in that case.
+    point of discovery is to populate that list.
+
+    `requires_oauth_provider` mirrors the catalog flag of the same name: when
+    set, the route discovers an OAuth (3LO) gated server using the *admin's
+    own* vaulted token for that provider (fetched via AgentCore Identity),
+    injected as a bearer. This validates the admin's connection and lists the
+    tools their token can see — providers like GitHub scope-filter the tool
+    list to the token's grants. It fetches the admin's token only; it cannot
+    mint an arbitrary end-user's token, so the discovered list reflects the
+    admin's own connection. If the admin hasn't connected the provider the
+    route returns 409. Mutually exclusive with `forward_auth_token`.
 
     `forward_auth_token` mirrors the catalog flag of the same name: when set,
     the route signs the discovery request with the *admin's own* OIDC token
@@ -1373,6 +1381,9 @@ class MCPDiscoverRequest(BaseModel):
     api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
     secret_arn: Optional[str] = Field(None, alias="secretArn")
     forward_auth_token: bool = Field(default=False, alias="forwardAuthToken")
+    requires_oauth_provider: Optional[str] = Field(
+        None, alias="requiresOauthProvider"
+    )
 
     model_config = {"populate_by_name": True, "use_enum_values": True}
 

--- a/backend/tests/apis/app_api/admin/tools/test_discover_oauth_provider.py
+++ b/backend/tests/apis/app_api/admin/tools/test_discover_oauth_provider.py
@@ -1,0 +1,205 @@
+"""Tests for OAuth (3LO) MCP discovery on `/admin/tools/discover`.
+
+An OAuth-gated MCP server (e.g. the GitHub remote MCP server) is discovered
+using the *admin's own* vaulted token for the named provider — fetched via
+AgentCore Identity and injected as a bearer, mirroring how the agent loop
+attaches the end-user's provider token at runtime. See
+`apis/app_api/admin/tools/routes.py`.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from apis.app_api.admin.tools import routes
+from apis.shared.auth.models import User
+from apis.shared.tools.models import MCPAuthType, MCPDiscoverRequest
+
+_CREATE_TARGET = (
+    "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client"
+)
+_URL = "https://api.githubcopilot.com/mcp/"
+
+
+def _admin(raw_token="admin-tok"):
+    return User(
+        email="admin@example.edu",
+        user_id="u1",
+        name="Admin",
+        roles=["system_admin"],
+        raw_token=raw_token,
+    )
+
+
+class _FakeSpec:
+    def __init__(self, name, description=None):
+        self.name = name
+        self.description = description
+
+
+class _FakeTool:
+    def __init__(self, name, description=None):
+        self.mcp_tool = _FakeSpec(name, description)
+        self.tool_name = name
+
+
+class _FakeClient:
+    def __init__(self, tools):
+        self._tools = tools
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def list_tools_sync(self):
+        return list(self._tools)
+
+
+class _FakeProvider:
+    def __init__(self, provider_id="github", display_name="GitHub"):
+        self.provider_id = provider_id
+        self.display_name = display_name
+        self.scopes = ["repo", "read:org"]
+        self.custom_parameters = None
+
+
+class _FakeProviderRepo:
+    def __init__(self, provider):
+        self._provider = provider
+
+    async def get_provider(self, provider_id):
+        if self._provider and self._provider.provider_id == provider_id:
+            return self._provider
+        return None
+
+
+class _FakeTokenResult:
+    def __init__(self, access_token=None, requires_consent=False):
+        self.access_token = access_token
+        self.requires_consent = requires_consent
+
+
+class _FakeIdentity:
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    async def get_token_for_user(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_discovery_uses_admin_vaulted_token(monkeypatch):
+    """A connected provider yields a vaulted bearer injected into the client."""
+    captured = {}
+
+    def fake_create(config, oauth_token=None, **kwargs):
+        captured["oauth_token"] = oauth_token
+        return _FakeClient([_FakeTool("search_repositories", "Find repos")])
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    identity = _FakeIdentity(_FakeTokenResult(access_token="gho_vaulted"))
+    monkeypatch.setattr(routes, "get_agentcore_identity_client", lambda: identity)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL,
+        authType=MCPAuthType.OAUTH2,
+        requiresOauthProvider="github",
+    )
+    resp = await routes.admin_discover_mcp_tools(
+        req, admin=_admin(), provider_repo=_FakeProviderRepo(_FakeProvider())
+    )
+
+    assert captured["oauth_token"] == "gho_vaulted"
+    assert [t.name for t in resp.tools] == ["search_repositories"]
+    # The token was fetched for the admin's own actor id.
+    assert identity.calls[0]["user_id"] == "u1"
+    assert identity.calls[0]["provider_name"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_discovery_requires_consent_returns_409(monkeypatch):
+    """An unconnected admin gets an actionable 409, and no client is built."""
+
+    def fake_create(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("client must not be built without a vaulted token")
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    identity = _FakeIdentity(_FakeTokenResult(requires_consent=True))
+    monkeypatch.setattr(routes, "get_agentcore_identity_client", lambda: identity)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL,
+        authType=MCPAuthType.OAUTH2,
+        requiresOauthProvider="github",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.admin_discover_mcp_tools(
+            req, admin=_admin(), provider_repo=_FakeProviderRepo(_FakeProvider())
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "connect" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_oauth_provider_returns_400(monkeypatch):
+    def fake_create(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("client must not be built for an unknown provider")
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL,
+        authType=MCPAuthType.OAUTH2,
+        requiresOauthProvider="ghost",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.admin_discover_mcp_tools(
+            req, admin=_admin(), provider_repo=_FakeProviderRepo(_FakeProvider())
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_and_forward_auth_conflict_returns_400(monkeypatch):
+    def fake_create(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("client must not be built for a conflicting request")
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(
+        serverUrl=_URL,
+        authType=MCPAuthType.OAUTH2,
+        requiresOauthProvider="github",
+        forwardAuthToken=True,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.admin_discover_mcp_tools(
+            req, admin=_admin(), provider_repo=_FakeProviderRepo(_FakeProvider())
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_oauth2_authtype_without_provider_returns_400(monkeypatch):
+    """auth_type=oauth2 with no provider named can't be discovered — 400."""
+
+    def fake_create(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("client must not be built without a provider")
+
+    monkeypatch.setattr(_CREATE_TARGET, fake_create)
+
+    req = MCPDiscoverRequest(serverUrl=_URL, authType=MCPAuthType.OAUTH2)
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.admin_discover_mcp_tools(
+            req, admin=_admin(), provider_repo=_FakeProviderRepo(None)
+        )
+
+    assert exc_info.value.status_code == 400

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -234,6 +234,15 @@ export interface MCPDiscoverRequest {
    * servers that validate a forwarded JWT (Lambda Function URL AuthType=NONE).
    */
   forwardAuthToken?: boolean;
+  /**
+   * OAuth (3LO) provider id gating this server. When set, discovery connects
+   * using the admin's own vaulted token for that provider (matching the catalog
+   * `requiresOauthProvider` flag), injected as a bearer. Lets OAuth-gated
+   * servers (e.g. the GitHub MCP server) be discovered. Mutually exclusive with
+   * `forwardAuthToken`. Requires the `OAuth2CallbackUrl` request header so the
+   * backend can resolve the admin's token.
+   */
+  requiresOauthProvider?: string | null;
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.spec.ts
@@ -290,6 +290,88 @@ describe('ToolFormPage — Gateway target (protocol=mcp)', () => {
   });
 });
 
+describe('ToolFormPage — external MCP OAuth discovery (protocol=mcp_external)', () => {
+  let adminToolService: {
+    createTool: ReturnType<typeof vi.fn>;
+    updateTool: ReturnType<typeof vi.fn>;
+    fetchTool: ReturnType<typeof vi.fn>;
+    discoverMCPTools: ReturnType<typeof vi.fn>;
+  };
+
+  function makeComponent(): ToolFormPage {
+    adminToolService = {
+      createTool: vi.fn().mockResolvedValue({}),
+      updateTool: vi.fn().mockResolvedValue({}),
+      fetchTool: vi.fn(),
+      discoverMCPTools: vi.fn().mockResolvedValue({ tools: [] }),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ToolFormPage],
+      providers: [
+        provideRouter([]),
+        { provide: AdminToolService, useValue: adminToolService },
+        {
+          provide: ConnectorsService,
+          useValue: {
+            getEnabledConnectors: () => [{ providerId: 'github', displayName: 'GitHub' }],
+          },
+        },
+      ],
+    });
+    const cmp = TestBed.createComponent(ToolFormPage).componentInstance;
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    return cmp;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('sends the selected OAuth provider so the server is discovered with the admin token', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    cmp.form.patchValue({
+      toolId: 'github_mcp',
+      displayName: 'GitHub',
+      description: 'GitHub remote MCP server',
+      protocol: 'mcp_external',
+      mcpServerUrl: 'https://api.githubcopilot.com/mcp/',
+      mcpTransport: 'streamable-http',
+      mcpAuthType: 'oauth2',
+      requiresOauthProvider: 'github',
+    });
+
+    await cmp.discoverMcpTools();
+
+    expect(adminToolService.discoverMCPTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverUrl: 'https://api.githubcopilot.com/mcp/',
+        authType: 'oauth2',
+        requiresOauthProvider: 'github',
+      }),
+    );
+  });
+
+  it('sends a null provider when none is selected', async () => {
+    const cmp = makeComponent();
+    await cmp.ngOnInit();
+    cmp.form.patchValue({
+      toolId: 'x_mcp',
+      displayName: 'X',
+      description: 'A public MCP server',
+      protocol: 'mcp_external',
+      mcpServerUrl: 'https://mcp.example.com/mcp',
+      mcpAuthType: 'none',
+    });
+
+    await cmp.discoverMcpTools();
+
+    expect(adminToolService.discoverMCPTools).toHaveBeenCalledWith(
+      expect.objectContaining({ requiresOauthProvider: null }),
+    );
+  });
+});
+
 describe('AWS endpoint derivation helpers', () => {
   it('detects the AWS service from known endpoint hosts', () => {
     expect(detectAwsServiceFromUrl('https://x.lambda-url.us-west-2.on.aws/mcp')).toBe('lambda');

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -1098,6 +1098,7 @@ export class ToolFormPage implements OnInit {
         apiKeyHeader: formValue.mcpApiKeyHeader || null,
         secretArn: formValue.mcpSecretArn || null,
         forwardAuthToken: formValue.forwardAuthToken || false,
+        requiresOauthProvider: formValue.requiresOauthProvider || null,
       });
 
       // Merge: keep existing rows (and their needsApproval flag), append any

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
@@ -208,10 +208,18 @@ export class AdminToolService {
 
   /**
    * Connect to an MCP server with the given config and return its tool list.
+   *
+   * Sends `OAuth2CallbackUrl` so the backend can resolve the admin's vaulted
+   * token when discovering an OAuth-gated server (`requiresOauthProvider`). The
+   * value is a bare callback path with no query string — app-api's context
+   * middleware rejects a callback URL carrying query params.
    */
   async discoverMCPTools(request: MCPDiscoverRequest): Promise<MCPDiscoverResponse> {
+    const callback = new URL('/oauth-complete', window.location.origin).toString();
     return firstValueFrom(
-      this.http.post<MCPDiscoverResponse>(`${this.baseUrl()}/discover`, request)
+      this.http.post<MCPDiscoverResponse>(`${this.baseUrl()}/discover`, request, {
+        headers: { OAuth2CallbackUrl: callback },
+      })
     );
   }
 


### PR DESCRIPTION
## What & why

The admin tool **Discover** flow refused OAuth-gated MCP servers outright, so servers like the **GitHub remote MCP server** (`https://api.githubcopilot.com/mcp/`) couldn't be discovered. Depending on the configured auth type, discovery either 400'd on `auth_type=oauth2` or connected **unauthenticated** and got a 401 back from the server (which we wrap into a 400 with a "list tool names manually" message).

Discovery now accepts the OAuth provider id and connects using the **admin's own vaulted 3LO token** for that provider — fetched via AgentCore Identity (`get_token_for_user`) and injected as a bearer. This mirrors how the agent loop attaches the end-user's provider token at runtime, and reuses the exact path `connector_status` already uses.

It validates the admin's own connection and returns the tools **their token can see** (providers such as GitHub silently scope-filter the tool list to the token's grants). It fetches the admin's token only — it can't mint an arbitrary end-user's token, so the discovered list reflects the admin's connection.

## Changes

**Backend**
- `MCPDiscoverRequest` gains `requires_oauth_provider` (alias `requiresOauthProvider`).
- The discover handler loads the provider, fetches the admin's vaulted token, and injects it as `oauth_token` into `create_external_mcp_client`. Error mapping: `requires_consent` → **409** ("connect the provider first"); unknown provider / conflict with `forward_auth_token` / `oauth2` without a provider → **400**.

**Frontend**
- The discover payload now sends `requiresOauthProvider` (the form control already existed — no new UI field).
- `discoverMCPTools()` now sends the `OAuth2CallbackUrl` header (bare `/oauth-complete`, **no query string** — app-api's context middleware rejects query params) so the backend can resolve the admin's token.

## Reviewer notes

- **Admin-as-user semantics by design.** Discovery fetches the *admin's own* token — the right source for populating the tool list, but it is not (and can't be) a general end-user token fetch. This is the boundary the old 400 was gesturing at.
- **GitHub scope-filtering.** The discovered list is a floor, not necessarily the full server surface: a narrow-scope connector yields a trimmed list, silently. Recommended connector scopes for GitHub's default toolset: `repo`, `read:org`, `read:user`.
- **Runtime already worked** — a saved tool with `requires_oauth_provider` set already gets the vaulted token attached at invoke time; this PR only closes the discovery-time gap.

## Testing

- 5 new backend tests (`test_discover_oauth_provider.py`): vaulted-token happy path, `requires_consent` → 409, unknown provider → 400, provider+forward-auth conflict → 400, `oauth2` without provider → 400.
- 2 new SPA specs: discover payload sends the selected provider / null when none selected.
- Existing discover + import-boundary tests still green (17 backend admin-tools tests, frontend specs via `ng test`).
- **Not yet verified in cloud** — the token-fetch path needs a real GitHub connector + AgentCore Identity, which a local preview can't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)