### PR TITLE
feat(manage-models): add Sonnet 5 + GPT-5.4 curated cards, order by capability

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.ts
@@ -30,9 +30,9 @@ interface ProviderTab {
 
 const PROVIDER_TABS: ProviderTab[] = [
   { id: 'bedrock', label: 'Bedrock' },
+  { id: 'mantle', label: 'Bedrock Mantle' },
   { id: 'openai', label: 'OpenAI' },
   { id: 'gemini', label: 'Gemini' },
-  { id: 'mantle', label: 'Bedrock Mantle' },
 ];
 
 const PROVIDER_LOGO_DIR: Record<string, string> = {

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -49,26 +49,54 @@ const claude4xDefaults = (): Pick<
 
 export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
   {
-    key: 'claude-haiku-4-5',
-    tagline: "Anthropic's fastest model — great for high-throughput tasks.",
-    capabilities: ['Extended thinking', 'Vision', 'Prompt caching'],
+    key: 'claude-opus-4-7',
+    tagline: 'Anthropic\'s most capable model — for the hardest reasoning.',
+    capabilities: ['Adaptive thinking', 'Effort control', 'Vision', 'Prompt caching'],
     template: {
       ...claude4xDefaults(),
-      modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
-      modelName: 'Claude Haiku 4.5',
+      modelId: 'us.anthropic.claude-opus-4-7',
+      modelName: 'Claude Opus 4.7',
       maxOutputTokens: 64_000,
-      inputPricePerMillionTokens: 1.0,
-      outputPricePerMillionTokens: 5.0,
-      cacheWritePricePerMillionTokens: 1.25,
-      cacheReadPricePerMillionTokens: 0.1,
-      knowledgeCutoffDate: '2025-02-01',
+      inputPricePerMillionTokens: 5.0,
+      outputPricePerMillionTokens: 25.0,
+      cacheWritePricePerMillionTokens: 6.25,
+      cacheReadPricePerMillionTokens: 0.5,
+      knowledgeCutoffDate: '2025-10-01',
       supportedParams: {
         params: {
-          temperature: { supported: true, min: 0, max: 1, default: 1.0 },
-          top_p: { supported: true, min: 0, max: 1, default: null },
-          top_k: { supported: true, min: 1, default: null },
-          max_tokens: { supported: true, min: 1, max: 64_000, default: 8192 },
-          thinking: { supported: true, min: 1024, max: 32_000, default: 4096 },
+          max_tokens: { supported: true, min: 1, max: 64_000, default: 32_000 },
+          effort: {
+            supported: true,
+            allowed: ['low', 'medium', 'high', 'xhigh', 'max'],
+            default: 'medium',
+          },
+        },
+      },
+    },
+  },
+  {
+    key: 'claude-sonnet-5',
+    tagline: 'Anthropic\'s Sonnet 5 — 1M-token context with effort-based reasoning.',
+    capabilities: ['Effort control', 'Vision', 'Long context', 'Prompt caching'],
+    template: {
+      ...claude4xDefaults(),
+      modelId: 'global.anthropic.claude-sonnet-5',
+      modelName: 'Claude Sonnet 5',
+      maxInputTokens: 1_000_000,
+      maxOutputTokens: 128_000,
+      inputPricePerMillionTokens: 2.0,
+      outputPricePerMillionTokens: 10.0,
+      cacheWritePricePerMillionTokens: 2.5,
+      cacheReadPricePerMillionTokens: 0.2,
+      knowledgeCutoffDate: null,
+      supportedParams: {
+        params: {
+          max_tokens: { supported: true, min: 1, max: 128_000, default: 128_000 },
+          effort: {
+            supported: true,
+            allowed: ['low', 'medium', 'high', 'xhigh'],
+            default: 'medium',
+          },
         },
       },
     },
@@ -99,27 +127,26 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
     },
   },
   {
-    key: 'claude-opus-4-7',
-    tagline: 'Anthropic\'s most capable model — for the hardest reasoning.',
-    capabilities: ['Adaptive thinking', 'Effort control', 'Vision', 'Prompt caching'],
+    key: 'claude-haiku-4-5',
+    tagline: "Anthropic's fastest model — great for high-throughput tasks.",
+    capabilities: ['Extended thinking', 'Vision', 'Prompt caching'],
     template: {
       ...claude4xDefaults(),
-      modelId: 'us.anthropic.claude-opus-4-7',
-      modelName: 'Claude Opus 4.7',
+      modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      modelName: 'Claude Haiku 4.5',
       maxOutputTokens: 64_000,
-      inputPricePerMillionTokens: 5.0,
-      outputPricePerMillionTokens: 25.0,
-      cacheWritePricePerMillionTokens: 6.25,
-      cacheReadPricePerMillionTokens: 0.5,
-      knowledgeCutoffDate: '2025-10-01',
+      inputPricePerMillionTokens: 1.0,
+      outputPricePerMillionTokens: 5.0,
+      cacheWritePricePerMillionTokens: 1.25,
+      cacheReadPricePerMillionTokens: 0.1,
+      knowledgeCutoffDate: '2025-02-01',
       supportedParams: {
         params: {
-          max_tokens: { supported: true, min: 1, max: 64_000, default: 32_000 },
-          effort: {
-            supported: true,
-            allowed: ['low', 'medium', 'high', 'xhigh', 'max'],
-            default: 'medium',
-          },
+          temperature: { supported: true, min: 0, max: 1, default: 1.0 },
+          top_p: { supported: true, min: 0, max: 1, default: null },
+          top_k: { supported: true, min: 1, default: null },
+          max_tokens: { supported: true, min: 1, max: 64_000, default: 8192 },
+          thinking: { supported: true, min: 1024, max: 32_000, default: 4096 },
         },
       },
     },
@@ -162,6 +189,27 @@ const mantleDefaults = (): Pick<
 // Mantle per-token pricing equals the bedrock-runtime price for the same model.
 // Re-verify when AWS revises pricing or a newer model version ships.
 export const CURATED_MANTLE_MODELS: CuratedModel[] = [
+  {
+    key: 'gpt-5-4',
+    tagline: 'OpenAI GPT-5.4 on Bedrock Mantle — multimodal reasoning via the Responses API.',
+    capabilities: ['Reasoning', 'Vision', 'Long context'],
+    template: {
+      ...mantleDefaults(),
+      modelId: 'openai.gpt-5.4',
+      modelName: 'GPT-5.4',
+      providerName: 'OpenAI',
+      inputModalities: ['TEXT', 'IMAGE'],
+      maxInputTokens: 272_000,
+      maxOutputTokens: 128_000,
+      // GPT-5.x is served on Mantle's `/openai/v1` base path and requires the
+      // Responses API. Its `openai.gpt-5.*` model id matches the SDK's
+      // _OPENAI_PATH_MODEL_PREFIXES, so one-click create routes correctly
+      // (unlike the Gemma case noted below).
+      apiMode: 'responses',
+      inputPricePerMillionTokens: 2.75,
+      outputPricePerMillionTokens: 16.5,
+    },
+  },
   {
     key: 'qwen3-coder-30b',
     tagline: 'Qwen3 Coder 30B — long-context coding model on Bedrock Mantle.',


### PR DESCRIPTION
## What changed

Adds two new curated model cards to the admin **Manage Models → Browse catalog** view and cleans up the ordering.

**New curated cards** (`curated-models.ts`):
- **Claude Sonnet 5** (`global.anthropic.claude-sonnet-5`, bedrock) — 1M input / 128K output, caching on ($2.50 / $0.20 write/read), effort-model param idiom (`max_tokens` + `effort` low/medium/high/xhigh, default medium). Appears on the **Bedrock** tab.
- **GPT-5.4** (`openai.gpt-5.4`, mantle) — 272K / 128K, `apiMode: 'responses'`, $2.75 / $16.50, no caching. Appears on the **Bedrock Mantle** tab.

**Ordering:**
- Bedrock Claude cards now sort most-capable-first: Opus 4.7 → Sonnet 5 → Sonnet 4.6 → Haiku 4.5.
- GPT-5.4 placed ahead of Qwen3 Coder 30B in the Mantle list.
- The **Bedrock Mantle** provider tab moved next to **Bedrock** in the catalog selector (`model-catalog.page.ts`): Bedrock, Bedrock Mantle, OpenAI, Gemini.

## Why

Surfaces the two newest flagship models as one-click curated entries so admins don't have to hand-fill the create form, and orders both the cards and the provider tabs so the most relevant options lead.

## Reviewer notes

- **GPT-5.4 routing is safe to curate.** Its `openai.gpt-5.*` model id matches the Strands SDK's `_OPENAI_PATH_MODEL_PREFIXES`, so it routes to the `/openai/v1` base path with the Responses API — unlike the commented-out Gemma card, which is excluded precisely because its id would build a `/v1` client and fail at chat time.
- **Sonnet 5 temperature:** the source export marked `temperature` as `supported: false`; this follows the existing Opus 4.7 reasoning-model idiom (omit unsupported params — functionally identical) rather than carrying a `supported:false` stub.
- **App-role scoping** is intentionally left empty on the templates; the card's "Add to models" action opens the role-picker dialog so roles are chosen at add-time.
- Default active tab is unchanged (`bedrock`).

## Testing

- `model-catalog.page.spec.ts` — 11/11 pass.
- `tsc --noEmit` clean.

Data-only change to a spec-covered catalog; the admin page is auth-gated so no browser clickthrough was run.