### PR TITLE
fix(mantle): route google.gemma-4-* to /openai/v1 (+ curated Sonnet 5 / GPT-5.4 cards)

### DIFF
--- a/backend/src/apis/shared/models/mantle.py
+++ b/backend/src/apis/shared/models/mantle.py
@@ -64,6 +64,29 @@ def param_map_for(api_mode: MantleApiMode) -> Dict[str, str]:
     )
 
 
+def _ensure_gemma4_openai_v1_routing() -> None:
+    """Teach the Strands SDK to route ``google.gemma-4-*`` to ``/openai/v1``.
+
+    Per its AWS model card, Gemma 4 is served *only* on the Mantle
+    ``/openai/v1`` base path — "different from the ``v1`` path used by other
+    models." But the SDK's ``_OPENAI_PATH_MODEL_PREFIXES`` only lists
+    ``openai.gpt-5.``, so ``google.gemma-4-*`` falls through to ``/v1`` and the
+    endpoint 401s ("... is not enabled for this account"). Append the family
+    prefix at build time until it lands upstream (strands-agents/sdk-python).
+
+    ``google.gemma-4-`` specifically — NOT ``google.gemma-``: Gemma 3 is served
+    on ``/v1`` and must not be rerouted. Idempotent; safe to call on every build.
+    """
+    from strands.models import _openai_bedrock as _sdk
+
+    prefix = "google.gemma-4-"
+    if prefix not in _sdk._OPENAI_PATH_MODEL_PREFIXES:
+        _sdk._OPENAI_PATH_MODEL_PREFIXES = (
+            *_sdk._OPENAI_PATH_MODEL_PREFIXES,
+            prefix,
+        )
+
+
 def build_mantle_model(
     model_id: str,
     api_mode: MantleApiMode,
@@ -87,6 +110,9 @@ def build_mantle_model(
     # Lazy import: strands is heavy, and apis.shared is imported broadly.
     from strands.models import OpenAIResponsesModel
     from strands.models.openai import OpenAIModel
+
+    # Bridge until google.gemma-4- lands in the SDK's base-path prefix table.
+    _ensure_gemma4_openai_v1_routing()
 
     bedrock_mantle_config: Dict[str, Any] = {}
     if region:

--- a/backend/tests/shared/test_mantle.py
+++ b/backend/tests/shared/test_mantle.py
@@ -69,6 +69,63 @@ class TestBuildMantleModel:
         assert mock_openai_cls.call_args.kwargs["params"] == {"temperature": 0.5, "max_tokens": 128}
 
 
+class TestGemma4Routing:
+    """The build path teaches the SDK to serve google.gemma-4-* from /openai/v1.
+
+    Gemma 4's model card pins it to the Mantle /openai/v1 base path, but the
+    SDK only lists openai.gpt-5. — so the builder appends the family prefix.
+    """
+
+    def _prefixes(self):
+        from strands.models import _openai_bedrock as sdk
+
+        return sdk._OPENAI_PATH_MODEL_PREFIXES
+
+    @patch("strands.models.openai.OpenAIModel")
+    def test_build_registers_gemma4_prefix(self, _mock_openai_cls):
+        build_mantle_model(
+            model_id="google.gemma-4-31b",
+            api_mode=MantleApiMode.CHAT_COMPLETIONS,
+            region="us-east-1",
+        )
+        assert "google.gemma-4-" in self._prefixes()
+
+    @patch("strands.models.openai.OpenAIModel")
+    def test_gemma4_variants_route_to_openai_v1(self, _mock_openai_cls):
+        from strands.models._openai_bedrock import _resolve_mantle_base_path
+
+        build_mantle_model(
+            model_id="google.gemma-4-31b",
+            api_mode=MantleApiMode.CHAT_COMPLETIONS,
+        )
+        for model_id in (
+            "google.gemma-4-31b",
+            "google.gemma-4-26b-a4b",
+            "google.gemma-4-e2b",
+        ):
+            assert _resolve_mantle_base_path(model_id) == "/openai/v1"
+
+    @patch("strands.models.openai.OpenAIModel")
+    def test_gemma3_stays_on_v1(self, _mock_openai_cls):
+        # Gemma 3 is served on /v1 — the narrower prefix must not reroute it.
+        from strands.models._openai_bedrock import _resolve_mantle_base_path
+
+        build_mantle_model(
+            model_id="google.gemma-4-31b",
+            api_mode=MantleApiMode.CHAT_COMPLETIONS,
+        )
+        assert _resolve_mantle_base_path("google.gemma-3-27b-it") == "/v1"
+
+    @patch("strands.models.openai.OpenAIModel")
+    def test_registration_is_idempotent(self, _mock_openai_cls):
+        for _ in range(3):
+            build_mantle_model(
+                model_id="google.gemma-4-31b",
+                api_mode=MantleApiMode.CHAT_COMPLETIONS,
+            )
+        assert self._prefixes().count("google.gemma-4-") == 1
+
+
 class TestParamMapFor:
     def test_chat_mode_map(self):
         assert param_map_for(MantleApiMode.CHAT_COMPLETIONS) is MANTLE_CHAT_PARAM_MAP

--- a/docs/specs/mantle-endpoint-path-admin-setting.md
+++ b/docs/specs/mantle-endpoint-path-admin-setting.md
@@ -1,0 +1,111 @@
+# Design note: revive `mantleEndpointPath` as a live admin setting
+
+**Status:** Proposal (not started)
+**Author:** (drafted with Claude)
+**Date:** 2026-07-13
+**Related:** `apis/shared/models/mantle.py`, `apis/shared/bedrock/bearer_token.py`,
+`frontend/.../admin/manage-models/models/curated-models.ts`
+
+## Problem
+
+Bedrock Mantle serves different models at different OpenAI-compatible base paths
+on the *same* host, and there is **no discovery API** — the path is a per-model
+fact published only in each model's AWS model card:
+
+| Model family | Mantle base path |
+|---|---|
+| `openai.gpt-oss-*`, `qwen.*` | `/v1` |
+| `google.gemma-3-*` | `/v1` |
+| `google.gemma-4-*` | `/openai/v1` |
+| `openai.gpt-5.*` | `/openai/v1` |
+
+Today the base path is derived *inside the Strands SDK* from a hardcoded
+prefix table (`strands.models._openai_bedrock._OPENAI_PATH_MODEL_PREFIXES`,
+currently just `("openai.gpt-5.",)`). Any model whose id isn't in that table
+falls through to `/v1`. When that's wrong (Gemma 4), inference 401s with
+`access_denied` / "... is not enabled for this account".
+
+We've now hit this **twice** (gpt-5, then Gemma 4). Each occurrence requires a
+dependency bump or a build-time monkeypatch of the SDK's private tuple
+(`_ensure_gemma4_openai_v1_routing`, added 2026-07-13 as the stopgap). The path
+is the one per-model Mantle fact we do **not** model as admin data — `apiMode`
+(`chat` vs `responses`) and `region` already are.
+
+## Why it's SDK-derived today
+
+The builder delegates the whole Mantle wire-up to the SDK's
+`bedrock_mantle_config`, which bundles three things:
+
+1. Region resolution
+2. **Per-request bearer-token minting + rotation** (`provide_token`)
+3. `base_url` derivation from the model id (the prefix table)
+
+`resolve_bedrock_client_args` sets `base_url` itself and the model classes
+**reject** a caller-supplied `base_url` when `bedrock_mantle_config` is set
+(fail-fast `ValueError`). So #3 is not separable from #1/#2 — to control the
+path you must stop using `bedrock_mantle_config` entirely.
+
+There is a now-`[DEPRECATED]` field `mantleEndpointPath` (`ManagedModel*` in
+`apis/shared/models/models.py`) and a helper `get_mantle_base_url(region,
+endpoint_path)` that already builds arbitrary paths. The plumbing is half
+present; it was retired, not removed.
+
+## Proposal
+
+Make the base path an **admin-set, per-model** value again — data, not code —
+by building the OpenAI client ourselves instead of via `bedrock_mantle_config`.
+
+### Backend (`build_mantle_model`)
+
+- Un-deprecate `mantleEndpointPath`. Default `/v1`; admin sets `/openai/v1` for
+  Gemma 4 / gpt-5 (documented on the model card, so it's a copy-paste fact).
+- When building the model, construct `client_args` ourselves:
+  - `base_url = get_mantle_base_url(region, endpoint_path)`
+  - `api_key = generate_bedrock_bearer_token(region)` (already exists)
+  - Do **not** pass `bedrock_mantle_config`.
+- Delete `_ensure_gemma4_openai_v1_routing` and the SDK-tuple monkeypatch.
+
+### Frontend
+
+- Add an "Endpoint path" field to the Mantle model form (default `/v1`), with a
+  hint linking to "the path shown on the model's AWS model card."
+- Curated cards carry the correct `mantleEndpointPath` per model.
+
+### The cost we take back: token lifecycle
+
+`bedrock_mantle_config` mints a **fresh token per request**; a self-set
+`api_key` is fixed at model construction. Mitigations:
+
+- The agent model is rebuilt per turn (`AgentFactory`), so a token minted at
+  build time is fresh for the turn's duration — the common case is covered.
+- The minted token's lifetime (~12h) far exceeds a single turn.
+- **Risk:** a very long-lived / resumed agent could outlive the token. Needs a
+  check of the longest-lived `build_mantle_model` consumer
+  (`/chat/api-converse`, agent resume) before committing. If any consumer holds
+  one model across the token lifetime, add a small refresh shim (mint via a
+  callable the client invokes per request) — reproducing what the SDK does.
+
+## Decision
+
+| | Revive admin path (this note) | Keep SDK-derived + patch (current) |
+|---|---|---|
+| New `/openai/v1` family | data change, zero code | dep bump or monkeypatch |
+| Token minting/rotation | **we own it** | free from SDK |
+| Consistency with `apiMode`/`region` | matches | inconsistent |
+| Blast radius | medium (touches token path) | tiny (one tuple) |
+
+**Recommendation:** ship the monkeypatch now (done) to unblock Gemma 4. Adopt
+this note **only if a third family** forces the issue, or if we want to stop
+tracking upstream SDK releases for a routing table we can trivially own. The
+one open question — token lifetime vs. longest-lived consumer — must be
+answered before implementation.
+
+## Open questions
+
+1. What is the longest-lived single `OpenAIModel`/`OpenAIResponsesModel`
+   instance across all `build_mantle_model` callers? (Determines whether a
+   static build-time token is safe or a refresh shim is required.)
+2. Does `provide_token` from `aws-bedrock-token-generator` expose the token
+   TTL, so we could set an explicit shorter expiry and know when to refresh?
+3. Any Mantle model served on a path *other* than `/v1` or `/openai/v1`? (If
+   the space stays two-valued, a boolean toggle may beat a free-text path.)

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -234,14 +234,14 @@ export const CURATED_MANTLE_MODELS: CuratedModel[] = [
       },
     },
   },
-  // NOTE: Gemma 4 31B (`google.gemma-4-31b`) is temporarily NOT curated. It is
-  // served on Mantle's `/openai/v1` base path, but the Strands SDK's
-  // bedrock_mantle_config only routes `openai.gpt-5.*` to `/openai/v1` (all
-  // other model ids -> `/v1`), and the config forbids overriding base_url. So a
-  // one-click Gemma card would build a `/v1` client and fail at chat time.
-  // Re-add once the `google.gemma-` family prefix lands in the SDK's
-  // _OPENAI_PATH_MODEL_PREFIXES (upstream strands-agents/sdk-python). Admins
-  // who need Gemma sooner can add it via the manual form.
+  // NOTE: Gemma 4 (`google.gemma-4-*`) is served ONLY on Mantle's `/openai/v1`
+  // base path (per its AWS model card — different from the `/v1` path Gemma 3
+  // and gpt-oss use). The Strands SDK's _OPENAI_PATH_MODEL_PREFIXES ships only
+  // `openai.gpt-5.`, so the backend appends `google.gemma-4-` at build time
+  // (see apis/shared/models/mantle.py::_ensure_gemma4_openai_v1_routing) until
+  // it lands upstream. That bridge makes a one-click Gemma 4 card route
+  // correctly, so this is safe to curate — pending confirmed pricing/params.
+  // Use the `google.gemma-4-` prefix, NOT `google.gemma-`: Gemma 3 is on `/v1`.
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes Gemma 4 inference on Bedrock Mantle and carries the earlier curated-card additions on this branch.

**The bug:** adding a Gemma 4 model (`google.gemma-4-31b`) and chatting failed with a 401 — `access_denied` / *"... is not enabled for this account."* Root cause is a base-path routing gap, **not** an AWS entitlement problem.

Bedrock Mantle serves different models at different OpenAI-compatible base paths on the same host, with **no discovery API** — the path is a per-model fact published only in each model's AWS model card:

| Model family | Mantle base path |
|---|---|
| `openai.gpt-oss-*`, `qwen.*`, `google.gemma-3-*` | `/v1` |
| `google.gemma-4-*`, `openai.gpt-5.*` | `/openai/v1` |

The Strands SDK derives the path from a hardcoded prefix table (`_OPENAI_PATH_MODEL_PREFIXES`) that ships only `openai.gpt-5.`, so `google.gemma-4-*` fell through to `/v1` and got rejected. Confirmed against the [Gemma 4 31B model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-31b.html), which explicitly notes Gemma 4 is on `/openai/v1`, "different from the `v1` path used by other models."

## Changes

- **`apis/shared/models/mantle.py`** — `_ensure_gemma4_openai_v1_routing()` appends `"google.gemma-4-"` to the SDK's prefix table at build time (lazy, idempotent, guarded). Scoped to the 4.x family so **Gemma 3 stays on `/v1`**. The SDK owns `base_url` and refuses a caller override, so patching its table is the minimal bridge until the prefix lands upstream (strands-agents/sdk-python).
- **`tests/shared/test_mantle.py`** — 4 guard tests: prefix registers on build, all three Gemma 4 variants (`31b` / `26b-a4b` / `e2b`) resolve to `/openai/v1`, Gemma 3 stays on `/v1`, registration idempotent.
- **`curated-models.ts`** — corrected the stale Gemma note (the "would fail at chat time" claim is obsolete; its `google.gemma-` re-add hint would have misrouted Gemma 3 → now specifies `google.gemma-4-`).
- **`docs/specs/mantle-endpoint-path-admin-setting.md`** — design note proposing `mantleEndpointPath` as a live admin setting (path as per-model data, like `apiMode`/`region`) as the durable alternative to chasing the SDK's table. Not implemented; recommends adopting only if a third family forces it.

Also included on this branch: the earlier `feat(manage-models)` commit adding Sonnet 5 + GPT-5.4 curated cards.

## Notes

- Gemma 4 supports both Chat Completions and Responses; per the model card, **reasoning tokens are only returned via the Responses API**, so `apiMode: responses` is preferable if you want reasoning surfaced.
- Not re-adding the curated Gemma 4 card here — held pending confirmed pricing/params.

## Testing

`pytest tests/shared/test_mantle.py tests/routes/test_api_converse_mantle.py tests/agents/main_agent/core/test_agent_factory.py tests/architecture/test_import_boundaries.py` — 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)