### PR TITLE
feat(manage-models): make max output tokens optional

### DIFF
--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -265,7 +265,6 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         'inputModalities': model_data.input_modalities,
         'outputModalities': model_data.output_modalities,
         'maxInputTokens': model_data.max_input_tokens,
-        'maxOutputTokens': model_data.max_output_tokens,
         'allowedAppRoles': model_data.allowed_app_roles,
         'availableToRoles': model_data.available_to_roles,
         'enabled': model_data.enabled,
@@ -278,6 +277,8 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
     }
 
     # Add optional fields
+    if model_data.max_output_tokens is not None:
+        item['maxOutputTokens'] = model_data.max_output_tokens
     if model_data.cache_write_price_per_million_tokens is not None:
         item['cacheWritePricePerMillionTokens'] = model_data.cache_write_price_per_million_tokens
     if model_data.cache_read_price_per_million_tokens is not None:

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -156,7 +156,11 @@ class ManagedModelCreate(BaseModel):
     input_modalities: List[str] = Field(..., alias="inputModalities", min_length=1)
     output_modalities: List[str] = Field(..., alias="outputModalities", min_length=1)
     max_input_tokens: int = Field(..., alias="maxInputTokens", ge=1)
-    max_output_tokens: int = Field(..., alias="maxOutputTokens", ge=1)
+    # Optional: newer reasoning/Responses-API models don't publish a discrete
+    # output cap (output shares the context budget with reasoning tokens). This
+    # value is only a ceiling for the admin-configured max_tokens inference
+    # param — it is never sent to the provider — so leaving it unset is safe.
+    max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens", ge=1)
     # Access control: AppRoles (preferred) or legacy JWT roles
     allowed_app_roles: List[str] = Field(
         default_factory=list,
@@ -322,7 +326,7 @@ class ManagedModel(BaseModel):
     input_modalities: List[str] = Field(..., alias="inputModalities")
     output_modalities: List[str] = Field(..., alias="outputModalities")
     max_input_tokens: int = Field(..., alias="maxInputTokens")
-    max_output_tokens: int = Field(..., alias="maxOutputTokens")
+    max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens")
     # Access control: AppRoles (preferred) or legacy JWT roles
     allowed_app_roles: List[str] = Field(
         default_factory=list,

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.html
@@ -142,7 +142,11 @@
                       </dt>
                       <dd class="mt-0.5 text-gray-700 dark:text-gray-300">
                         {{ model.template.maxInputTokens / 1000 }}K in /
-                        {{ model.template.maxOutputTokens / 1000 }}K out
+                        @if (model.template.maxOutputTokens) {
+                          {{ model.template.maxOutputTokens / 1000 }}K out
+                        } @else {
+                          — out
+                        }
                       </dd>
                     </div>
                     <div>

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -267,7 +267,7 @@
             <!-- Max Output Tokens -->
             <div>
               <label for="maxOutputTokens" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                Max Output Tokens <span class="text-red-600">*</span>
+                Max Output Tokens <span class="font-normal text-gray-400 dark:text-gray-500">(optional)</span>
               </label>
               <input
                 type="number"
@@ -275,10 +275,13 @@
                 formControlName="maxOutputTokens"
                 min="1"
                 step="1"
-                placeholder="e.g., 16384"
+                placeholder="Leave blank if the provider doesn't publish one"
                 class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
                 [class.border-red-500]="modelForm.controls.maxOutputTokens.invalid && modelForm.controls.maxOutputTokens.touched"
               />
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                Ceiling for the model's max_tokens setting. Leave blank for reasoning models that share output with the context window.
+              </p>
               @if (modelForm.controls.maxOutputTokens.invalid && modelForm.controls.maxOutputTokens.touched) {
                 <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Enter a valid token limit (1 or greater)</p>
               }

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -221,7 +221,7 @@ interface ModelFormGroup {
   inputModalities: FormControl<string[]>;
   outputModalities: FormControl<string[]>;
   maxInputTokens: FormControl<number>;
-  maxOutputTokens: FormControl<number>;
+  maxOutputTokens: FormControl<number | null>;
   allowedAppRoles: FormControl<string[]>;
   availableToRoles: FormControl<string[]>;
   enabled: FormControl<boolean>;
@@ -302,7 +302,7 @@ export class ModelFormPage implements OnInit {
     inputModalities: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
     outputModalities: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
     maxInputTokens: this.fb.control(0, { nonNullable: true, validators: [Validators.required, Validators.min(1)] }),
-    maxOutputTokens: this.fb.control(0, { nonNullable: true, validators: [Validators.required, Validators.min(1)] }),
+    maxOutputTokens: this.fb.control<number | null>(null, { validators: [Validators.min(1)] }),
     allowedAppRoles: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
     availableToRoles: this.fb.control<string[]>([], { nonNullable: true }),
     enabled: this.fb.control(true, { nonNullable: true }),
@@ -886,7 +886,7 @@ export class ModelFormPage implements OnInit {
         inputModalities: params['inputModalities'] ? params['inputModalities'].split(',') : [],
         outputModalities: params['outputModalities'] ? params['outputModalities'].split(',') : [],
         maxInputTokens: params['maxInputTokens'] ? parseInt(params['maxInputTokens'], 10) : 0,
-        maxOutputTokens: params['maxOutputTokens'] ? parseInt(params['maxOutputTokens'], 10) : 0,
+        maxOutputTokens: params['maxOutputTokens'] ? parseInt(params['maxOutputTokens'], 10) : null,
         knowledgeCutoffDate: params['knowledgeCutoffDate'] || null,
       });
     }

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -74,8 +74,12 @@ export interface ManagedModel {
   responseStreamingSupported?: boolean;
   /** Maximum number of input tokens the model can accept */
   maxInputTokens: number;
-  /** Maximum number of output tokens the model can generate */
-  maxOutputTokens: number;
+  /**
+   * Maximum number of output tokens the model can generate. Optional — newer
+   * reasoning/Responses-API models don't publish a discrete output cap. Acts
+   * only as a ceiling for the configured max_tokens inference param.
+   */
+  maxOutputTokens: number | null;
   /** Lifecycle status of the model (e.g., 'ACTIVE', 'LEGACY') */
   modelLifecycle?: string | null;
   /** AppRole IDs that have access to this model (preferred over availableToRoles) */
@@ -141,8 +145,12 @@ export interface ManagedModelFormData {
   responseStreamingSupported: boolean;
   /** Maximum number of input tokens the model can accept */
   maxInputTokens: number;
-  /** Maximum number of output tokens the model can generate */
-  maxOutputTokens: number;
+  /**
+   * Maximum number of output tokens the model can generate. Optional — leave
+   * blank when the provider doesn't publish an output cap. Ceiling only for
+   * the configured max_tokens inference param; never sent to the provider.
+   */
+  maxOutputTokens: number | null;
   /** Lifecycle status of the model */
   modelLifecycle?: string | null;
   /** AppRole IDs that have access to this model */


### PR DESCRIPTION
## What

Makes the **Max Output Tokens** field optional in the admin model form (and across the backend schema + SPA), so admins can register models that don't publish a discrete output cap.

## Why

Several newer models no longer expose a fixed max-output-tokens value:
- **Reasoning / Responses-API models** (GPT-5.x via Mantle, Claude with adaptive thinking) share their output budget with reasoning tokens, bounded by the context window — there's no separate fixed cap to enter.
- Providers/catalogs (OpenAI Responses API, the Bedrock model catalog) increasingly ship these with `max_output_tokens` omitted.
- Our own **GPT-5.4** curated card already carries a decorative `maxOutputTokens: 128_000` with **no backing `max_tokens` spec** — proof the value is often cosmetic.

Crucially, `maxOutputTokens` is **never sent to any provider** — it's only a *validation ceiling* for the admin-configured `max_tokens` inference param. What reaches Strands/Bedrock/Mantle is the `max_tokens` param (request → `supportedParams.max_tokens.default` → provider default). So leaving it unset is safe at inference time; a required form field was the only thing forcing an invented number.

## Changes

**Backend**
- `ManagedModelCreate` / `ManagedModel`: `max_output_tokens` → `Optional[int]` (`models.py`)
- DynamoDB write: `maxOutputTokens` moved into the conditional "optional fields" block, omitted when absent — matches how `cacheWritePrice`, `knowledgeCutoffDate`, etc. are persisted (`managed_models.py`)

**Frontend**
- Form control: dropped `Validators.required`; now `number | null` defaulting to `null` (the old `0` default + `min(1)` would otherwise still block submit)
- `ManagedModel` / `ManagedModelFormData` interfaces → `number | null`
- Catalog card null-guarded — shows `— out` when unset
- Label `*` → `(optional)`, added a help line

Both ceiling validators (`maxTokensCeilingValidator`, `_max_tokens_within_ceiling`) already skipped an absent value, so no validator changes were needed.

## Verification

- **Backend** — pydantic round-trip covering: create without a cap (→ `None`), create with a cap (still accepted), read-model deserializing an item missing the key (→ `None`), and the ceiling validator still rejecting an over-ceiling `max_tokens` spec when a cap *is* set. All pass.
- **Frontend** — full `ng build` exits 0 (AOT strict template checking passes). No spec asserts required-ness; existing fixtures pass concrete numbers (assignable to `number | null`).

## Notes for reviewer

- **Cross-package contract:** backend schema + SPA interfaces moved together in this PR, as required.
- **No migration needed** — existing DynamoDB items keep their value; new ones may omit it. The read model deserializes an absent key to `null`.
- **Follow-up (not in this PR):** the GPT-5.4 curated card still carries the decorative `128_000`; now that blank is allowed it could be set to `null` to reflect reality — left as a separate data decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)