### PR TITLE
feat(manage-models): optional max output tokens + fix(docker): float curl security patch

### DIFF
--- a/backend/Dockerfile.app-api
+++ b/backend/Dockerfile.app-api
@@ -39,7 +39,7 @@ WORKDIR /app
 
 # Install runtime dependencies (curl required for HEALTHCHECK)
 RUN apt-get update && apt-get install -y \
-    curl=8.14.1-2+deb13u3 \
+    curl=8.14.1-2+deb13u* \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the virtual environment from builder

--- a/backend/Dockerfile.inference-api
+++ b/backend/Dockerfile.inference-api
@@ -39,7 +39,7 @@ WORKDIR /app
 
 # Install runtime dependencies (curl required for HEALTHCHECK)
 RUN apt-get update && apt-get install -y \
-    curl=8.14.1-2+deb13u3 \
+    curl=8.14.1-2+deb13u* \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the virtual environment from builder


### PR DESCRIPTION
## Summary

Two changes on this branch:

### `feat(manage-models): make max output tokens optional`
Newer reasoning / Responses-API models (GPT-5.x, Claude with adaptive thinking) don't publish a discrete max-output-tokens value — output shares the context budget with reasoning tokens, so there's no fixed cap to enter. `maxOutputTokens` is only a ceiling for the admin-configured `max_tokens` inference param and is never sent to the provider, so leaving it unset is safe. The admin form field is now optional to match.

- `ManagedModelCreate` / `ManagedModel`: `max_output_tokens` → `Optional[int]`
- DynamoDB write omits `maxOutputTokens` when absent (matches other optionals)
- Form control drops `Validators.required`, defaults `null`
- SPA interfaces typed `number | null`; catalog card null-guarded (shows "— out")

### `fix(docker): float curl security patch to survive Debian mirror purges`
Debian removes the superseded point version of `curl` from the trixie mirror on each security update, so an exact `+deb13uN` pin breaks every image build once the next CVE lands (this is what red-lit CI: `Version '8.14.1-2+deb13u3' … was not found`). Pinned to `+deb13u*` in both `Dockerfile.app-api` and `Dockerfile.inference-api` to track the live patch while keeping the minor version fixed; the digest-pinned base image is what actually provides reproducibility.

## Test plan
- CI image build for app-api / inference-api passes the apt step
- Admin manage-models form submits with max output tokens left blank; catalog card renders "— out" for cards without the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)