### PR TITLE
feat(web-sources): allow removing a web source

### DIFF
--- a/backend/src/apis/app_api/web_sources/crawl_repository.py
+++ b/backend/src/apis/app_api/web_sources/crawl_repository.py
@@ -175,12 +175,16 @@ async def hard_delete_crawl_job(assistant_id: str, crawl_id: str) -> bool:
         return False
 
 
-def _is_crawl_stale(job: CrawlJob) -> bool:
+def is_crawl_stale(job: CrawlJob) -> bool:
     """A `running` crawl past the crawler's own budget is dead.
 
     The crawler always finalizes in a `finally` block; the only way a
     `running` row outlives the budget is the owning process died. Mirrors
     the same staleness pattern documents use in `document_service`.
+
+    Also read by the delete path: a live crawl refuses deletion (its pages
+    are still being written), but a dead-but-`running` row must stay
+    removable or a zombie web source could never be cleared from the UI.
     """
     try:
         started_str = job.started_at.rstrip("Z")
@@ -226,7 +230,7 @@ async def list_active_crawls(assistant_id: str) -> List[CrawlJob]:
             logger.warning("Skipping unparseable CrawlJob row: %s", e)
             continue
 
-        if _is_crawl_stale(job):
+        if is_crawl_stale(job):
             logger.info(
                 "Auto-reaping stale crawl %s/%s (started_at=%s)",
                 assistant_id,

--- a/backend/src/apis/app_api/web_sources/deletion_service.py
+++ b/backend/src/apis/app_api/web_sources/deletion_service.py
@@ -1,0 +1,132 @@
+"""Removal of a whole web source — the crawl record plus every page it ingested.
+
+A "web source" is not a single stored entity: it is a `CrawlJob` row, the
+fan-out of `Document` rows the crawler wrote beneath it, and (optionally) a
+`web_crawl` sync policy keyed on the crawl id. Removing one therefore has to
+walk that fan-out itself.
+
+The reverse relationship already exists: deleting the *last* page of a crawl
+lets `documents.services.cleanup_service._cascade_delete_orphaned_crawl_jobs`
+drop the now-orphaned `CrawlJob`. This module drives the same graph from the
+other end — delete the source, and the pages go with it.
+
+Pages are matched to their crawl by URL prefix (`source_file_id` starts with
+the crawl's `root_url`), the same rule the orphan cascade uses and sound for
+the same reason: the crawler only enqueues URLs that already passed its
+same-domain / same-root filter.
+"""
+
+import asyncio
+import logging
+from typing import List, Set
+
+from apis.app_api.documents.models import Document
+from apis.app_api.documents.services.cleanup_service import cleanup_assistant_documents
+from apis.app_api.documents.services.document_service import (
+    list_assistant_documents,
+    soft_delete_document,
+)
+from apis.app_api.web_sources.crawl_repository import hard_delete_crawl_job
+from apis.shared.security.log_sanitize import scrub_log
+from apis.shared.sync_policies.service import delete_sync_policies_for_source
+
+logger = logging.getLogger(__name__)
+
+# Strong refs to the fire-and-forget cleanup task. The event loop only holds
+# weak references to tasks, so a bare `create_task` can be collected mid-run —
+# the same trap the route documents for its background crawls.
+_BACKGROUND_CLEANUPS: Set[asyncio.Task] = set()
+
+
+class WebSourceDeletionError(Exception):
+    """The crawl record itself could not be removed."""
+
+
+async def delete_web_source(
+    *,
+    assistant_id: str,
+    crawl_id: str,
+    root_url: str,
+    owner_id: str,
+) -> int:
+    """Remove a web source and everything it owns. Returns the page count removed.
+
+    Order matters:
+
+    1. The sync policy goes first. It keys on the crawl id, so a dispatcher
+       sweep landing mid-delete would otherwise re-crawl the very source we
+       are removing and resurrect its pages.
+    2. Pages are soft-deleted (status `deleting` + TTL) so they leave the KB
+       immediately, with the slow half — vectors and S3 objects — handed to a
+       background task, exactly as the single-document delete path does.
+    3. The crawl row is hard-deleted last. If a soft-delete fails partway, the
+       surviving row still lists the source and the user can retry; deleting
+       the row first would strand its pages with nothing to remove them from.
+
+    Raises `WebSourceDeletionError` if the crawl row survives — leaving it
+    behind would show the caller a source that is now empty but still listed.
+    """
+    pages = await _list_crawl_pages(assistant_id, owner_id, root_url)
+
+    policies_removed = await delete_sync_policies_for_source(assistant_id, crawl_id)
+
+    deleted: List[Document] = []
+    for page in pages:
+        document = await soft_delete_document(assistant_id, page.document_id, owner_id)
+        if document:
+            deleted.append(document)
+
+    if not await hard_delete_crawl_job(assistant_id, crawl_id):
+        raise WebSourceDeletionError(
+            "Removed the pages but could not remove the web source record. "
+            "Try again in a moment."
+        )
+
+    # Vectors + S3, off the request path. `cleanup_assistant_documents` gathers
+    # per-document cleanup and never raises; it also hard-deletes each DynamoDB
+    # row on success. It is deliberately *not* given the docs' `web` connector
+    # id — that would fire the orphaned-CrawlJob cascade once per page (a full
+    # document scan each), and we just deleted the crawl row ourselves.
+    if deleted:
+        task = asyncio.create_task(cleanup_assistant_documents(assistant_id, deleted))
+        _BACKGROUND_CLEANUPS.add(task)
+        task.add_done_callback(_BACKGROUND_CLEANUPS.discard)
+
+    logger.info(
+        "Removed web source %s from assistant %s (root=%s, pages=%d, sync_policies=%d)",
+        scrub_log(crawl_id),
+        scrub_log(assistant_id),
+        scrub_log(root_url),
+        len(deleted),
+        policies_removed,
+    )
+    return len(deleted)
+
+
+async def _list_crawl_pages(
+    assistant_id: str, owner_id: str, root_url: str
+) -> List[Document]:
+    """Every live document this crawl produced, across all pages of results.
+
+    Rows already in `deleting` are skipped — their cleanup is in flight and
+    re-soft-deleting them would just reset the TTL.
+    """
+    pages: List[Document] = []
+    next_token = None
+    while True:
+        batch, next_token = await list_assistant_documents(
+            assistant_id, owner_id, next_token=next_token
+        )
+        for document in batch:
+            if document.source_connector_id != "web":
+                continue
+            if not document.source_file_id:
+                continue
+            if not document.source_file_id.startswith(root_url):
+                continue
+            if document.status == "deleting":
+                continue
+            pages.append(document)
+        if not next_token:
+            break
+    return pages

--- a/backend/src/apis/app_api/web_sources/routes.py
+++ b/backend/src/apis/app_api/web_sources/routes.py
@@ -32,10 +32,15 @@ from apis.app_api.documents.services.storage_service import (
 from apis.app_api.web_sources.crawl_repository import (
     create_crawl_job,
     get_crawl_job,
+    is_crawl_stale,
     list_active_crawls,
     list_all_crawls,
 )
 from apis.app_api.web_sources.crawler import run_crawl
+from apis.app_api.web_sources.deletion_service import (
+    WebSourceDeletionError,
+    delete_web_source,
+)
 from apis.app_api.web_sources.models import (
     ActiveCrawlsResponse,
     CrawlJob,
@@ -48,7 +53,7 @@ from apis.app_api.web_sources.url_utils import (
     assert_url_is_public,
     url_extension_hint,
 )
-from apis.shared.assistants.service import get_assistant
+from apis.shared.assistants.service import get_assistant, resolve_assistant_permission
 from apis.shared.auth import User, get_current_user_from_session
 
 from apis.shared.security.log_sanitize import scrub_log
@@ -58,6 +63,30 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/assistants/{assistant_id}/web-sources", tags=["web-sources"]
 )
+
+
+async def _require_edit_permission(assistant_id: str, current_user: User) -> str:
+    """Owner or editor share required — the same gate the documents surface uses.
+
+    Returns the assistant's real owner_id, which the owner-keyed document
+    services below need in order to see an editor's assistant at all.
+    """
+    assistant, permission = await resolve_assistant_permission(
+        assistant_id=assistant_id,
+        user_id=current_user.user_id,
+        user_email=current_user.email,
+    )
+    if not assistant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assistant not found: {assistant_id}",
+        )
+    if permission not in ("owner", "editor"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to manage web sources for this assistant",
+        )
+    return assistant.owner_id
 
 # Strong refs to in-flight crawl tasks. Python's event loop tracks tasks
 # with weak references, so a bare `asyncio.ensure_future(run_crawl(...))`
@@ -199,3 +228,58 @@ async def get_crawl(
             detail=f"Crawl not found: {crawl_id}",
         )
     return job
+
+
+@router.delete("/crawls/{crawl_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_crawl(
+    assistant_id: str,
+    crawl_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+) -> None:
+    """Remove a web source: the crawl record, its pages, and its sync policy.
+
+    A crawl that is genuinely still in flight is refused (409) rather than
+    raced — the crawler would keep writing pages we just enumerated, stranding
+    them under a deleted parent. A crawl stuck at `running` because its owning
+    process died is *not* in flight, and stays deletable (`is_crawl_stale`).
+    """
+    owner_id = await _require_edit_permission(assistant_id, current_user)
+
+    job = await get_crawl_job(assistant_id, crawl_id)
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Crawl not found: {crawl_id}",
+        )
+
+    if job.status == "running" and not is_crawl_stale(job):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This crawl is still running. Wait for it to finish, then remove it.",
+        )
+
+    try:
+        removed = await delete_web_source(
+            assistant_id=assistant_id,
+            crawl_id=crawl_id,
+            root_url=job.root_url,
+            owner_id=owner_id,
+        )
+    except WebSourceDeletionError as e:
+        logger.error(
+            "Failed to remove web source %s from assistant %s: %s",
+            scrub_log(crawl_id),
+            scrub_log(assistant_id),
+            e,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+        )
+
+    logger.info(
+        "Deleted web source %s (%d pages) from assistant %s",
+        scrub_log(crawl_id),
+        removed,
+        scrub_log(assistant_id),
+    )
+    return None

--- a/backend/tests/apis/app_api/web_sources/test_deletion_service.py
+++ b/backend/tests/apis/app_api/web_sources/test_deletion_service.py
@@ -1,0 +1,209 @@
+"""Unit tests for the web-source deletion cascade.
+
+The cascade's whole job is deciding *which* documents belong to a crawl and
+tearing them down in an order that can't strand state, so that's what these
+assert: prefix scoping, page-by-page soft-delete, sync-policy removal, and the
+crawl row going last.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apis.app_api.documents.models import Document
+from apis.app_api.web_sources.deletion_service import (
+    WebSourceDeletionError,
+    delete_web_source,
+)
+
+ASSISTANT_ID = "ast-1"
+OWNER_ID = "user-1"
+CRAWL_ID = "CRAWL-1"
+ROOT_URL = "https://example.com/docs/"
+
+MODULE = "apis.app_api.web_sources.deletion_service"
+
+
+def _doc(
+    document_id: str,
+    *,
+    source_file_id: str | None = None,
+    connector: str | None = "web",
+    status: str = "complete",
+) -> Document:
+    return Document.model_validate(
+        {
+            "documentId": document_id,
+            "assistantId": ASSISTANT_ID,
+            "filename": f"{document_id}.html",
+            "contentType": "text/html",
+            "sizeBytes": 10,
+            "s3Key": f"assistants/{ASSISTANT_ID}/documents/{document_id}/page.html",
+            "status": status,
+            "chunkCount": 2,
+            "sourceConnectorId": connector,
+            "sourceFileId": source_file_id,
+            "createdAt": "2026-07-14T00:00:00Z",
+            "updatedAt": "2026-07-14T00:00:00Z",
+        }
+    )
+
+
+@pytest.fixture
+def patched():
+    """Patch every collaborator the cascade reaches out to."""
+    with patch(
+        f"{MODULE}.list_assistant_documents", new_callable=AsyncMock
+    ) as list_docs, patch(
+        f"{MODULE}.soft_delete_document", new_callable=AsyncMock
+    ) as soft_delete, patch(
+        f"{MODULE}.hard_delete_crawl_job", new_callable=AsyncMock, return_value=True
+    ) as hard_delete, patch(
+        f"{MODULE}.delete_sync_policies_for_source",
+        new_callable=AsyncMock,
+        return_value=0,
+    ) as delete_policies, patch(
+        f"{MODULE}.cleanup_assistant_documents", new_callable=AsyncMock
+    ) as cleanup:
+        soft_delete.side_effect = lambda assistant_id, document_id, owner_id: _doc(
+            document_id, source_file_id=f"{ROOT_URL}{document_id}"
+        )
+        yield {
+            "list_docs": list_docs,
+            "soft_delete": soft_delete,
+            "hard_delete": hard_delete,
+            "delete_policies": delete_policies,
+            "cleanup": cleanup,
+        }
+
+
+async def _run(patched) -> int:
+    removed = await delete_web_source(
+        assistant_id=ASSISTANT_ID,
+        crawl_id=CRAWL_ID,
+        root_url=ROOT_URL,
+        owner_id=OWNER_ID,
+    )
+    # The cleanup fan-out is a background task; let it start so the assertion
+    # on `cleanup_assistant_documents` isn't racing the event loop.
+    await asyncio.sleep(0)
+    return removed
+
+
+@pytest.mark.asyncio
+async def test_deletes_only_pages_under_the_crawl_root(patched):
+    patched["list_docs"].return_value = (
+        [
+            _doc("DOC-1", source_file_id=f"{ROOT_URL}intro"),
+            _doc("DOC-2", source_file_id=f"{ROOT_URL}guide/setup"),
+            # Same site, different crawl root — must survive.
+            _doc("DOC-3", source_file_id="https://example.com/blog/post"),
+            # A device upload — no provenance at all.
+            _doc("DOC-4", connector=None, source_file_id=None),
+            # A Drive import that happens to sit under a similar path.
+            _doc("DOC-5", connector="google_drive", source_file_id=f"{ROOT_URL}sheet"),
+        ],
+        None,
+    )
+
+    removed = await _run(patched)
+
+    assert removed == 2
+    deleted_ids = {c.args[1] for c in patched["soft_delete"].await_args_list}
+    assert deleted_ids == {"DOC-1", "DOC-2"}
+
+
+@pytest.mark.asyncio
+async def test_skips_pages_already_being_deleted(patched):
+    patched["list_docs"].return_value = (
+        [
+            _doc("DOC-1", source_file_id=f"{ROOT_URL}intro"),
+            _doc("DOC-2", source_file_id=f"{ROOT_URL}gone", status="deleting"),
+        ],
+        None,
+    )
+
+    removed = await _run(patched)
+
+    assert removed == 1
+    patched["soft_delete"].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_walks_every_page_of_results(patched):
+    patched["list_docs"].side_effect = [
+        ([_doc("DOC-1", source_file_id=f"{ROOT_URL}a")], "token-2"),
+        ([_doc("DOC-2", source_file_id=f"{ROOT_URL}b")], None),
+    ]
+
+    removed = await _run(patched)
+
+    assert removed == 2
+    assert patched["list_docs"].await_count == 2
+    assert patched["list_docs"].await_args_list[1].kwargs["next_token"] == "token-2"
+
+
+@pytest.mark.asyncio
+async def test_removes_the_sync_policy_before_the_pages(patched):
+    """A dispatcher sweep landing mid-delete would re-crawl the source and
+    resurrect the very pages we're removing."""
+    order: list[str] = []
+    patched["list_docs"].return_value = (
+        [_doc("DOC-1", source_file_id=f"{ROOT_URL}a")],
+        None,
+    )
+    patched["delete_policies"].side_effect = lambda *a: order.append("policy") or 1
+    patched["soft_delete"].side_effect = lambda assistant_id, document_id, owner_id: (
+        order.append("page") or _doc(document_id, source_file_id=f"{ROOT_URL}a")
+    )
+    patched["hard_delete"].side_effect = lambda *a: order.append("crawl") or True
+
+    await _run(patched)
+
+    assert order == ["policy", "page", "crawl"]
+    patched["delete_policies"].assert_awaited_once_with(ASSISTANT_ID, CRAWL_ID)
+
+
+@pytest.mark.asyncio
+async def test_hands_the_pages_to_background_cleanup(patched):
+    patched["list_docs"].return_value = (
+        [_doc("DOC-1", source_file_id=f"{ROOT_URL}a")],
+        None,
+    )
+
+    await _run(patched)
+
+    patched["cleanup"].assert_awaited_once()
+    assistant_id, documents = patched["cleanup"].await_args.args
+    assert assistant_id == ASSISTANT_ID
+    assert [d.document_id for d in documents] == ["DOC-1"]
+
+
+@pytest.mark.asyncio
+async def test_removes_a_crawl_that_produced_no_pages(patched):
+    """A crawl that failed on its root page has nothing to sweep, but the row
+    itself still has to go — otherwise it's undeletable from the UI."""
+    patched["list_docs"].return_value = ([], None)
+
+    removed = await _run(patched)
+
+    assert removed == 0
+    patched["hard_delete"].assert_awaited_once_with(ASSISTANT_ID, CRAWL_ID)
+    patched["cleanup"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raises_when_the_crawl_row_survives(patched):
+    patched["list_docs"].return_value = ([], None)
+    patched["hard_delete"].return_value = False
+
+    with pytest.raises(WebSourceDeletionError):
+        await delete_web_source(
+            assistant_id=ASSISTANT_ID,
+            crawl_id=CRAWL_ID,
+            root_url=ROOT_URL,
+            owner_id=OWNER_ID,
+        )

--- a/backend/tests/apis/app_api/web_sources/test_routes.py
+++ b/backend/tests/apis/app_api/web_sources/test_routes.py
@@ -8,6 +8,7 @@ background task is never actually scheduled.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from fastapi.testclient import TestClient
 
 from apis.app_api.documents.models import Document
 from apis.app_api.web_sources import routes as web_routes
+from apis.app_api.web_sources.deletion_service import WebSourceDeletionError
 from apis.app_api.web_sources.models import CrawlJob, CrawlSettings
 from apis.shared.auth.models import User
 from apis.shared.auth.dependencies import get_current_user_from_session
@@ -251,3 +253,178 @@ class TestGetCrawl:
                 f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-X"
             )
         assert resp.status_code == 404
+
+
+def _stub_permission(permission: str = "owner"):
+    """(assistant, permission) as `resolve_assistant_permission` returns it."""
+    return SimpleNamespace(owner_id=USER_ID), permission
+
+
+class TestDeleteCrawl:
+    def test_removes_web_source_and_returns_204(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        crawl.status = "complete"
+        delete_mock = AsyncMock(return_value=3)
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("owner"),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.delete_web_source", delete_mock
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 204
+        # The crawl's own root_url is what scopes the page sweep — not a value
+        # the caller supplies, so a stale client can't widen the blast radius.
+        delete_mock.assert_awaited_once_with(
+            assistant_id=ASSISTANT_ID,
+            crawl_id="CRAWL-1",
+            root_url="https://example.com/",
+            owner_id=USER_ID,
+        )
+
+    def test_editor_may_delete(self, app: FastAPI):
+        """The web-sources list is rendered for editors, so the delete must
+        work for them — the owner-keyed services get the real owner_id."""
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        crawl.status = "complete"
+        owner = SimpleNamespace(owner_id="someone-else")
+        delete_mock = AsyncMock(return_value=1)
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(owner, "editor"),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.delete_web_source", delete_mock
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 204
+        assert delete_mock.await_args.kwargs["owner_id"] == "someone-else"
+
+    def test_viewer_gets_403(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("viewer"),
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 403
+
+    def test_returns_404_when_crawl_missing(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission(),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-X"
+            )
+        assert resp.status_code == 404
+
+    def test_returns_409_while_crawl_is_running(self, app: FastAPI):
+        """Deleting mid-crawl would strand pages the crawler is still writing."""
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()  # status='running', started just now
+        delete_mock = AsyncMock(return_value=0)
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission(),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.is_crawl_stale", return_value=False
+        ), patch(
+            "apis.app_api.web_sources.routes.delete_web_source", delete_mock
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 409
+        delete_mock.assert_not_awaited()
+
+    def test_deletes_a_stale_running_crawl(self, app: FastAPI):
+        """A `running` row whose process died is a zombie — it must stay
+        removable, or the UI would show an undeletable 'Crawling…' source."""
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()  # status='running'
+        delete_mock = AsyncMock(return_value=0)
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission(),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.is_crawl_stale", return_value=True
+        ), patch(
+            "apis.app_api.web_sources.routes.delete_web_source", delete_mock
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 204
+        delete_mock.assert_awaited_once()
+
+    def test_returns_500_when_crawl_row_survives(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        crawl = _stub_crawl()
+        crawl.status = "complete"
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission(),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=crawl,
+        ), patch(
+            "apis.app_api.web_sources.routes.delete_web_source",
+            new_callable=AsyncMock,
+            side_effect=WebSourceDeletionError("boom"),
+        ):
+            client = TestClient(app)
+            resp = client.delete(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 500
+
+    def test_returns_401_unauthenticated(self, app: FastAPI):
+        mock_no_auth(app)
+        client = TestClient(app)
+        resp = client.delete(
+            f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+        )
+        assert resp.status_code == 401

--- a/frontend/ai.client/src/app/assistants/services/web-source.service.spec.ts
+++ b/frontend/ai.client/src/app/assistants/services/web-source.service.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { WebSourceService, WebSourceError } from './web-source.service';
+import { ConfigService } from '../../services/config.service';
+import { CrawlJob } from '../models/web-source.model';
+
+const BASE = 'http://localhost:8000/assistants/assistant1/web-sources';
+
+function stubCrawl(overrides: Partial<CrawlJob> = {}): CrawlJob {
+  return {
+    crawlId: 'CRAWL-abc123',
+    assistantId: 'assistant1',
+    rootUrl: 'https://example.com/docs/',
+    status: 'complete',
+    settings: { maxDepth: 1, maxPages: 25 },
+    discoveredCount: 12,
+    fetchedCount: 10,
+    failedCount: 2,
+    startedAt: '2026-07-14T00:00:00Z',
+    startedByUserId: 'user-1',
+    ...overrides,
+  } as CrawlJob;
+}
+
+describe('WebSourceService', () => {
+  let service: WebSourceService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        WebSourceService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(WebSourceService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('should list crawls', async () => {
+    const crawls = [stubCrawl()];
+
+    const promise = service.listCrawls('assistant1');
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/crawls`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ crawls });
+    });
+
+    expect(await promise).toEqual(crawls);
+  });
+
+  it('should delete a crawl', async () => {
+    const promise = service.deleteCrawl('assistant1', 'CRAWL-abc123');
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/crawls/CRAWL-abc123`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('should surface the server message when a running crawl refuses deletion', async () => {
+    const promise = service.deleteCrawl('assistant1', 'CRAWL-abc123');
+    const caught = promise.catch((err: unknown) => err);
+
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(`${BASE}/crawls/CRAWL-abc123`);
+      req.flush(
+        { detail: 'This crawl is still running. Wait for it to finish, then remove it.' },
+        { status: 409, statusText: 'Conflict' },
+      );
+    });
+
+    const error = (await caught) as WebSourceError;
+    expect(error).toBeInstanceOf(WebSourceError);
+    expect(error.status).toBe(409);
+    expect(error.code).toBe('HTTP_409');
+    expect(error.message).toContain('still running');
+  });
+});

--- a/frontend/ai.client/src/app/assistants/services/web-source.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/web-source.service.ts
@@ -106,6 +106,24 @@ export class WebSourceService {
     }
   }
 
+  /**
+   * Remove a web source — its crawl record, every page it ingested, and any
+   * sync policy covering it. Rejects with `HTTP_409` while the crawl is still
+   * running (its pages are still being written).
+   */
+  async deleteCrawl(assistantId: string, crawlId: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.http.delete<void>(
+          `${this.baseUrl()}/assistants/${encodeURIComponent(assistantId)}/web-sources/crawls/${encodeURIComponent(crawlId)}`,
+          this.requestOptions(),
+        ),
+      );
+    } catch (err) {
+      throw this.toError(err, 'Failed to remove web source');
+    }
+  }
+
   private toError(err: unknown, fallback: string): WebSourceError {
     if (err instanceof HttpErrorResponse) {
       const detail =

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
@@ -224,6 +224,19 @@
                 />
               }
             </div>
+            <!-- Enabled even while the crawl is running: the backend refuses a
+                 live crawl with a 409 (surfaced as a toast), but a crawl whose
+                 process died is stuck at 'running' forever and must stay
+                 removable. -->
+            <button
+              type="button"
+              (click)="removeWebSource(crawl)"
+              title="Remove web source"
+              [attr.aria-label]="'Remove ' + crawl.rootUrl"
+              class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            >
+              <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+            </button>
           </li>
         }
       </ul>

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
@@ -43,6 +43,10 @@ import {
   SyncPolicyControlComponent,
   SyncIntervalSelection,
 } from '../assistants/components/sync-policy-control.component';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog';
 import { UserConnectorsService } from '../settings/connectors/services/user-connectors.service';
 import { OAuthConsentService } from '../services/oauth-consent/oauth-consent.service';
 import { ToastService } from '../services/toast/toast.service';
@@ -773,6 +777,85 @@ export class KnowledgeBaseSectionComponent implements OnDestroy {
       const message = error instanceof Error ? error.message : 'Failed to delete document.';
       this.toast.error(message);
     }
+  }
+
+  /**
+   * Remove a web source: the crawl record, every page it added to the
+   * knowledge base, and any sync policy covering it. Confirmed first — unlike
+   * a single document this can take dozens of pages with it, so the dialog
+   * names the count.
+   */
+  async removeWebSource(crawl: CrawlJob): Promise<void> {
+    const recordId = this.id();
+    if (!recordId) {
+      return;
+    }
+
+    const pages = crawl.fetchedCount;
+    const pageCount = `${pages} page${pages === 1 ? '' : 's'}`;
+    const dialogRef = this.dialog.open<boolean, ConfirmationDialogData>(
+      ConfirmationDialogComponent,
+      {
+        data: {
+          title: 'Remove web source',
+          message:
+            `${crawl.rootUrl} and the ${pageCount} it added will be removed from ` +
+            `this knowledge base, along with any sync schedule on it. ` +
+            `This cannot be undone.`,
+          confirmText: 'Remove',
+          destructive: true,
+        },
+      },
+    );
+    if ((await firstValueFrom(dialogRef.closed)) !== true) {
+      return;
+    }
+
+    // Optimistic, like deleteDocument: drop the source and its pages up front
+    // so the click lands immediately, and restore both lists if the call fails
+    // (a still-running crawl is refused with a 409).
+    const previousCrawls = this.webCrawls();
+    const previousDocuments = this.uploadedDocuments();
+    const pageDocuments = previousDocuments.filter((doc) => this.isPageOf(doc, crawl));
+
+    this.webCrawls.update((crawls) => crawls.filter((c) => c.crawlId !== crawl.crawlId));
+    this.uploadedDocuments.update((docs) => docs.filter((doc) => !this.isPageOf(doc, crawl)));
+    // Stop polling any page still mid-processing, so its spinner can't
+    // reappear on the next tick before the GET starts 404ing.
+    this.pollingDocuments.update((set) => {
+      const next = new Set(set);
+      for (const doc of pageDocuments) {
+        next.delete(doc.documentId);
+      }
+      return next;
+    });
+
+    try {
+      await this.webSourceService.deleteCrawl(recordId, crawl.crawlId);
+      // The backend cascades the sync policy with its source — mirror that
+      // locally so the control disappears with the row.
+      const covering = this.syncPolicyFor(crawl.crawlId);
+      if (covering) {
+        this.removePolicy(covering.policyId);
+      }
+      this.toast.success('Web source removed.');
+    } catch (error) {
+      this.webCrawls.set(previousCrawls);
+      this.uploadedDocuments.set(previousDocuments);
+      const message = error instanceof Error ? error.message : 'Failed to remove web source.';
+      this.toast.error(message);
+    }
+  }
+
+  /**
+   * Whether a document is one of the pages a crawl produced. Mirrors the
+   * backend's rule (a `web` document whose source URL sits under the crawl
+   * root) so the optimistic removal matches what the server actually deletes.
+   */
+  private isPageOf(doc: Document, crawl: CrawlJob): boolean {
+    return (
+      doc.sourceConnectorId === 'web' && !!doc.sourceFileId?.startsWith(crawl.rootUrl)
+    );
   }
 
   // ── KB sync policy actions ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Web sources could be added to an Assistant/Agent but never removed. There was no `DELETE` route, no client method, and no UI affordance. The only way to drop a web source was to delete every page document it produced, one at a time, and let the orphan cascade in `cleanup_service` pick up the `CrawlJob` row as a side effect.

## What this does

Makes removal a first-class operation, inverting that existing cascade.

**`DELETE /assistants/{assistant_id}/web-sources/crawls/{crawl_id}`** (204), backed by a new `web_sources/deletion_service.py`. Order matters and is load-bearing:

1. **Sync policy first.** It keys on the crawl id, so a dispatcher sweep landing mid-delete would re-crawl the source and resurrect the very pages being removed.
2. **Pages next.** Every `web` document whose `source_file_id` sits under the crawl's `root_url` is soft-deleted (leaving the KB immediately); vectors + S3 teardown hands off to `cleanup_assistant_documents`, the same background cleanup the single-document path uses. It is deliberately *not* given the docs' `web` connector id — that would fire the orphaned-`CrawlJob` cascade once per page (a full document scan each) to delete a row we delete ourselves.
3. **Crawl row last.** If a page delete fails partway, the source still lists and the user can retry; deleting the row first would strand its pages with no parent to remove them from. If the row survives, the route 500s rather than reporting a success that left a phantom source behind.

**Running crawls are refused with a 409** rather than raced — the crawler would keep writing pages we just enumerated. A crawl stuck at `running` because its owning process died is *not* in flight and stays deletable (`is_crawl_stale`, promoted from `_is_crawl_stale` now that it's used across modules). This matters: `list_all_crawls` doesn't reap zombies the way `list_active_crawls` does, so without the exception a dead crawl would show "Crawling…" in the UI forever with no way to remove it. That's also why the trash button stays enabled on running crawls instead of being disabled — the 409 surfaces as a toast, and the zombie case still works.

The route is **edit-gated (owner or editor)**, matching the documents surface that renders the list.

**SPA:** `WebSourceService.deleteCrawl()` + `removeWebSource()` in the shared knowledge-base section, so both the Assistant form and the Agent form get it. Confirms through the shared `ConfirmationDialogComponent` (naming the page count — this can take dozens of documents at once), then removes the source and its pages optimistically, restoring both lists on failure.

## Pre-existing bug found (not fixed here)

`start_crawl`, `list_crawls`, and `get_crawl` gate on the owner-keyed `get_assistant`, so an **editor** sees the "Add web content" button but gets a 404 when they use it — even though the SPA renders the whole web-source surface for editors. Fixing it means migrating three existing endpoints and their tests, so it's tracked separately rather than widening this PR.

## Testing

- 595 backend tests pass, including the architecture import-boundary gate.
- 7 new deletion-cascade tests: prefix scoping (a sibling crawl on the same domain, a device upload, and a Drive import sharing a path prefix all survive the sweep), pagination, already-`deleting` pages skipped, policy→pages→crawl ordering, background cleanup hand-off, a crawl that produced no pages, and the surviving-row failure path.
- 8 new route tests: 204 + correct scoping args, editor allowed, viewer 403, 404, 409 while running, 204 for a stale running crawl, 500 on a surviving row, 401.
- 3 new `WebSourceService` specs. SPA builds clean.

Not exercised in a browser — app-api needs the real DynamoDB tables, so there's no local run. Manual script:

1. Open an assistant with a web source; confirm the trash button appears on the row.
2. Click it — the dialog names the URL and the exact page count.
3. Confirm: source and all its pages disappear from both lists. Reload — still gone, along with any sync schedule on it.
4. Start a crawl of a multi-page site and click the trash mid-crawl → toast "This crawl is still running…", row returns.
5. As an editor (not owner) on a shared assistant, confirm removal works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)