### PR TITLE
fix(web-sources): let editors start and view crawls

### DIFF
--- a/backend/src/apis/app_api/web_sources/routes.py
+++ b/backend/src/apis/app_api/web_sources/routes.py
@@ -53,7 +53,7 @@ from apis.app_api.web_sources.url_utils import (
     assert_url_is_public,
     url_extension_hint,
 )
-from apis.shared.assistants.service import get_assistant, resolve_assistant_permission
+from apis.shared.assistants.service import resolve_assistant_permission
 from apis.shared.auth import User, get_current_user_from_session
 
 from apis.shared.security.log_sanitize import scrub_log
@@ -88,6 +88,7 @@ async def _require_edit_permission(assistant_id: str, current_user: User) -> str
         )
     return assistant.owner_id
 
+
 # Strong refs to in-flight crawl tasks. Python's event loop tracks tasks
 # with weak references, so a bare `asyncio.ensure_future(run_crawl(...))`
 # can be garbage-collected mid-execution — leaving the root document
@@ -112,13 +113,13 @@ async def start_crawl(
     with `max_depth=0` — the BFS visits only the root and terminates. The
     same async pipeline is used either way so there is no separate code
     path to keep in sync.
+
+    Owner or editor may crawl. Note the document writes below are keyed on
+    the assistant (`PK=AST#<id>`), not on its owner, so no owner_id needs
+    threading through — and `imported_by_user_id`/`started_by_user_id` stay
+    the *acting* user, which is the point of recording them.
     """
-    assistant = await get_assistant(assistant_id, current_user.user_id)
-    if not assistant:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Assistant not found: {assistant_id}",
-        )
+    await _require_edit_permission(assistant_id, current_user)
 
     try:
         normalized = assert_url_is_public(request.url)
@@ -193,12 +194,7 @@ async def list_crawls(
     `?active=true` is the only filter currently honored — drives the SPA's
     "should I keep polling for new docs" decision.
     """
-    assistant = await get_assistant(assistant_id, current_user.user_id)
-    if not assistant:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Assistant not found: {assistant_id}",
-        )
+    await _require_edit_permission(assistant_id, current_user)
     if active:
         crawls = await list_active_crawls(assistant_id)
     else:
@@ -215,12 +211,7 @@ async def get_crawl(
     current_user: User = Depends(get_current_user_from_session),
 ) -> CrawlJob:
     """Return a single crawl's current status + counters."""
-    assistant = await get_assistant(assistant_id, current_user.user_id)
-    if not assistant:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Assistant not found: {assistant_id}",
-        )
+    await _require_edit_permission(assistant_id, current_user)
     job = await get_crawl_job(assistant_id, crawl_id)
     if not job:
         raise HTTPException(

--- a/backend/tests/apis/app_api/web_sources/test_routes.py
+++ b/backend/tests/apis/app_api/web_sources/test_routes.py
@@ -68,6 +68,11 @@ def _stub_crawl(crawl_id: str = "CRAWL-1") -> CrawlJob:
     )
 
 
+def _stub_permission(permission: str = "owner"):
+    """(assistant, permission) as `resolve_assistant_permission` returns it."""
+    return SimpleNamespace(owner_id=USER_ID), permission
+
+
 @pytest.fixture
 def app() -> FastAPI:
     _app = FastAPI()
@@ -82,9 +87,9 @@ class TestStartCrawl:
         crawl = _stub_crawl()
         run_crawl_mock = AsyncMock(return_value=None)
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ), patch(
             "apis.app_api.web_sources.routes.create_document",
             new_callable=AsyncMock,
@@ -115,12 +120,68 @@ class TestStartCrawl:
         # exercising the real crawler.
         run_crawl_mock.assert_called_once()
 
-    def test_returns_404_when_assistant_not_owned(self, app: FastAPI):
+    def test_editor_may_start_a_crawl(self, app: FastAPI):
+        """An editor share is enough to add web content — the SPA already
+        renders the "Add web content" button for anyone who isn't a viewer.
+        """
+        editor = User(
+            email="editor@example.com", user_id="user-editor", name="E", roles=["User"]
+        )
+        mock_auth_user(app, editor)
+        run_crawl_mock = AsyncMock(return_value=None)
+        create_doc_mock = AsyncMock(return_value=_stub_document())
+        create_job_mock = AsyncMock(return_value=_stub_crawl())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("editor"),
+        ), patch(
+            "apis.app_api.web_sources.routes.create_document", create_doc_mock,
+        ), patch(
+            "apis.app_api.web_sources.routes.create_crawl_job", create_job_mock,
+        ), patch(
+            "apis.app_api.web_sources.routes.run_crawl", run_crawl_mock,
+        ), patch(
+            "apis.app_api.web_sources.routes.assert_url_is_public",
+            return_value="https://example.com/",
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={"url": "https://example.com/"},
+            )
+        assert resp.status_code == 202
+
+        # The document row is keyed on the assistant, so the editor's crawl
+        # lands under the same assistant the owner's would...
+        assert create_doc_mock.await_args.kwargs["assistant_id"] == ASSISTANT_ID
+        # ...and the actor fields record the *editor*, not the owner — that
+        # is the whole point of tracking who imported/started.
+        provenance = create_doc_mock.await_args.kwargs["provenance"]
+        assert provenance.imported_by_user_id == "user-editor"
+        assert create_job_mock.await_args.kwargs["started_by_user_id"] == "user-editor"
+        assert run_crawl_mock.call_args.kwargs["user_id"] == "user-editor"
+
+    def test_viewer_gets_403(self, app: FastAPI):
         mock_auth_user(app, _user())
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value=None,
+            return_value=_stub_permission("viewer"),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawl",
+                json={"url": "https://example.com/"},
+            )
+        assert resp.status_code == 403
+
+    def test_returns_404_when_assistant_not_visible(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(None, None),
         ):
             client = TestClient(app)
             resp = client.post(
@@ -132,9 +193,9 @@ class TestStartCrawl:
     def test_returns_422_on_invalid_url(self, app: FastAPI):
         mock_auth_user(app, _user())
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ):
             client = TestClient(app)
             # Loopback URL → SSRF guard rejects it.
@@ -147,9 +208,9 @@ class TestStartCrawl:
     def test_returns_422_on_bad_settings_bounds(self, app: FastAPI):
         mock_auth_user(app, _user())
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ):
             client = TestClient(app)
             # max_pages above the cap
@@ -177,9 +238,9 @@ class TestListActiveCrawls:
         mock_auth_user(app, _user())
         crawl = _stub_crawl()
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ), patch(
             "apis.app_api.web_sources.routes.list_active_crawls",
             new_callable=AsyncMock,
@@ -195,15 +256,42 @@ class TestListActiveCrawls:
         assert len(body["crawls"]) == 1
         assert body["crawls"][0]["crawlId"] == "CRAWL-1"
 
+    def test_editor_may_list_crawls(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("editor"),
+        ), patch(
+            "apis.app_api.web_sources.routes.list_all_crawls",
+            new_callable=AsyncMock,
+            return_value=[_stub_crawl()],
+        ):
+            client = TestClient(app)
+            resp = client.get(f"/assistants/{ASSISTANT_ID}/web-sources/crawls")
+        assert resp.status_code == 200
+        assert len(resp.json()["crawls"]) == 1
+
+    def test_viewer_gets_403(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("viewer"),
+        ):
+            client = TestClient(app)
+            resp = client.get(f"/assistants/{ASSISTANT_ID}/web-sources/crawls")
+        assert resp.status_code == 403
+
     def test_returns_all_jobs_without_active_filter(self, app: FastAPI):
         """Default (no ?active=true) is full history — the sync-policy UI
         lists completed crawls as syncable sources."""
         mock_auth_user(app, _user())
         crawl = _stub_crawl()
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ), patch(
             "apis.app_api.web_sources.routes.list_all_crawls",
             new_callable=AsyncMock,
@@ -222,9 +310,9 @@ class TestGetCrawl:
         mock_auth_user(app, _user())
         crawl = _stub_crawl()
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ), patch(
             "apis.app_api.web_sources.routes.get_crawl_job",
             new_callable=AsyncMock,
@@ -237,12 +325,42 @@ class TestGetCrawl:
         assert resp.status_code == 200
         assert resp.json()["crawlId"] == "CRAWL-1"
 
+    def test_editor_may_get_a_crawl(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("editor"),
+        ), patch(
+            "apis.app_api.web_sources.routes.get_crawl_job",
+            new_callable=AsyncMock,
+            return_value=_stub_crawl(),
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 200
+
+    def test_viewer_gets_403(self, app: FastAPI):
+        mock_auth_user(app, _user())
+        with patch(
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_stub_permission("viewer"),
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-1"
+            )
+        assert resp.status_code == 403
+
     def test_returns_404_when_missing(self, app: FastAPI):
         mock_auth_user(app, _user())
         with patch(
-            "apis.app_api.web_sources.routes.get_assistant",
+            "apis.app_api.web_sources.routes.resolve_assistant_permission",
             new_callable=AsyncMock,
-            return_value={"assistantId": ASSISTANT_ID},
+            return_value=_stub_permission("owner"),
         ), patch(
             "apis.app_api.web_sources.routes.get_crawl_job",
             new_callable=AsyncMock,
@@ -253,11 +371,6 @@ class TestGetCrawl:
                 f"/assistants/{ASSISTANT_ID}/web-sources/crawls/CRAWL-X"
             )
         assert resp.status_code == 404
-
-
-def _stub_permission(permission: str = "owner"):
-    """(assistant, permission) as `resolve_assistant_permission` returns it."""
-    return SimpleNamespace(owner_id=USER_ID), permission
 
 
 class TestDeleteCrawl:


### PR DESCRIPTION
## Problem

`start_crawl`, `list_crawls` and `get_crawl` gated on `get_assistant(assistant_id, current_user.user_id)`, which is **owner-keyed** — it returns `None` for a user holding only an *editor* share, producing a 404.

The SPA already renders the "Add web content" button and the web-sources list for anyone who isn't a viewer (`canManageSync()` in `knowledge-base-section.component.ts`), so an editor saw the affordance and the call failed.

This was inconsistent with the rest of the knowledge-base surface — `documents/routes.py`, `sync_policies/routes.py`, and the `delete_crawl` route added in #648 all gate on `_require_edit_permission` (owner|editor).

## Change

Route the three endpoints through the existing `_require_edit_permission` helper in the same file. Owner|editor now pass; a viewer gets a **403** instead of a misleading 404. Drops the now-unused `get_assistant` import.

### Why no `owner_id` threading

The obvious-looking follow-on — pass the resolved `owner_id` into the downstream calls — would have been a **bug**, so it is deliberately not done:

- `create_document` writes `PK=AST#{assistant_id}` / `SK=DOC#{document_id}`. It takes no owner parameter; it is assistant-keyed, not owner-keyed. Same for the crawler's document writes.
- The `user_id` flowing into `run_crawl` and `create_crawl_job` lands in `imported_by_user_id` / `started_by_user_id`. Those are **actor** fields — substituting `owner_id` would credit an editor's import to the owner.

`owner_id` is genuinely owner-keyed only in the DELETE path (`soft_delete_document`, `_list_crawl_pages`), which is why #648 needed it. It stays confined there.

## Verification

The route unit tests stub `resolve_assistant_permission`, so they would pass even if share resolution were broken. To close that gap I drove the real route through the **real** resolver against a moto-backed DynamoDB with an actual `SHARE#editor@example.com` record:

- editor → `POST /crawl` **202**; document row written under `AST#<id>` with `importedByUserId = user-editor`; `run_crawl` invoked with the editor's id
- editor → `GET /crawls` **200**, `GET /crawls/{id}` **200**
- viewer → **403**; user with no share → **403**

Also confirmed `check_share_access` returns exactly `"viewer"`/`"editor"` (so the gate's string comparison holds), and that `_require_edit_permission` passes `current_user.email` — without it, share lookup silently fails for every editor.

Backend suite: **601 passed** (`tests/apis/app_api/` + `tests/architecture/`). Web-sources route tests 17 → 23, adding editor-allowed and viewer-403 coverage on all three routes.

Not exercised against live dev-ai — that needs a second Cognito user with a real editor share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)