### PR TITLE
fix(rbac): make AppRole the single source of truth for model access

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -97,6 +97,14 @@ The `inference-api` runs inside an AgentCore Runtime container. The runtime data
 
 If you're tempted to add to inference-api because of an existing route there (`converse_router`, `voice_router`), don't use them as templates without confirming their access path — they predate this rule and may rely on bypasses (API key, WebSocket upgrade, direct container reach in environments where the runtime isn't the only path).
 
+### RBAC: the AppRole record is the source of truth
+
+A role grants a tool/model/skill by listing it in its own `grantedTools` / `grantedModels` / `grantedSkills` (or by granting the `*` wildcard, or inheriting from a parent). **That is the only thing access checks read.** The `allowedAppRoles` field on a resource (tool, model, skill) is a *derived, display-only* projection of those role records — never an independent grant.
+
+**Rule:** When an admin page offers a "which roles can use this?" picker on the resource, it must write *through* to each role's `granted*` list (`set_roles_for_tool`, `set_roles_for_model`) and derive the field back on read (`hydrate_model_roles`). Never persist a role list on the resource and expect it to grant anything: it will silently do nothing, and the resource page and the role page will disagree.
+
+Access decisions for models live in `apis/app_api/admin/services/model_access.py`. `can_access_model` and `filter_accessible_models` both delegate to a single `_grants_access` predicate — keep it that way. They previously diverged (one gated on `allowed_app_roles`, one didn't), so a model could be *listed* by the catalog and *denied* on use.
+
 ### Auth dependency on app_api routes
 
 The SPA sends an httpOnly session cookie — not `Authorization: Bearer`. A route that declares a bare Bearer-only dependency on the SPA-facing surface causes a 401 → centralized redirect loop the moment the SPA hits it.

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -5,7 +5,7 @@ Requires admin role (Admin or SuperAdmin) via JWT token.
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Query, status
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 import logging
 import os
 import re
@@ -27,6 +27,7 @@ from apis.shared.models.models import (
     ManagedModelCreate,
     ManagedModelUpdate,
     ManagedModel,
+    ModelRoleAssignment,
 )
 from apis.shared.auth import User, require_admin
 from apis.shared.feature_flags import skills_enabled
@@ -37,6 +38,7 @@ from apis.shared.models.managed_models import (
     update_managed_model,
     delete_managed_model,
 )
+from .services.model_roles import get_model_role_service
 
 logger = logging.getLogger(__name__)
 
@@ -531,9 +533,13 @@ async def list_managed_models_endpoint(
     try:
         models = await list_managed_models(user_roles=None)  # None = no role filtering
 
+        # Derive each model's role access from the AppRole records (one role query
+        # for the whole catalog), so the admin list reflects real grants.
+        await get_model_role_service().hydrate_model_roles(models)
+
         # Convert ManagedModel instances to dicts for Pydantic v2 validation
         models_dict = [model.model_dump(by_alias=True) for model in models]
-        
+
         return ManagedModelsListResponse(
             models=models_dict,
             total_count=len(models),
@@ -576,10 +582,20 @@ async def create_managed_model_endpoint(
 
     try:
         model = await create_managed_model(model_data)
+
+        # Grant the model to the requested roles. This is the write that actually
+        # controls access — the role record is the source of truth — after which
+        # we derive the role fields back onto the response.
+        role_service = get_model_role_service()
+        await role_service.set_roles_for_model(
+            model.model_id, model_data.allowed_app_roles, admin_user
+        )
+        await role_service.hydrate_model_roles([model])
+
         return model
 
     except ValueError as e:
-        # Model already exists
+        # Model already exists, or an unknown AppRole was named
         logger.warning("Model creation failed")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -626,6 +642,10 @@ async def get_managed_model_endpoint(
                 detail=f"Model with ID '{model_id}' not found"
             )
 
+        # Derive role access from the AppRole records so the edit form shows the
+        # grants that are actually in effect.
+        await get_model_role_service().hydrate_model_roles([model])
+
         return model
 
     except HTTPException:
@@ -668,6 +688,16 @@ async def update_managed_model_endpoint(
     logger.info("Admin updating enabled model")
 
     try:
+        # Capture the provider model id before the update: roles key their grants
+        # on it, so a rename has to move those grants rather than orphan them.
+        existing = await get_managed_model(model_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Model with ID '{model_id}' not found"
+            )
+        previous_model_id = existing.model_id
+
         model = await update_managed_model(model_id, updates)
 
         if not model:
@@ -676,10 +706,30 @@ async def update_managed_model_endpoint(
                 detail=f"Model with ID '{model_id}' not found"
             )
 
+        role_service = get_model_role_service()
+
+        # `None` means the caller didn't touch role access — but a rename still
+        # has to carry the existing direct grants over to the new model id.
+        requested_roles = updates.allowed_app_roles
+        renamed = model.model_id != previous_model_id
+        if requested_roles is None and renamed:
+            current = await role_service.get_roles_for_model(previous_model_id)
+            requested_roles = [a.role_id for a in current if a.grant_type == "direct"]
+
+        if requested_roles is not None:
+            await role_service.set_roles_for_model(
+                model.model_id,
+                requested_roles,
+                admin_user,
+                previous_model_id=previous_model_id,
+            )
+
+        await role_service.hydrate_model_roles([model])
+
         return model
 
     except ValueError as e:
-        # Duplicate modelId or other validation error
+        # Duplicate modelId, or an unknown AppRole was named
         logger.warning("Model update failed")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -719,12 +769,21 @@ async def delete_managed_model_endpoint(
     logger.info("Admin deleting enabled model")
 
     try:
+        # Read the provider model id before deleting — roles key their grants on
+        # it, and we need to strip those so no role keeps granting a dead model.
+        existing = await get_managed_model(model_id)
+
         deleted = await delete_managed_model(model_id)
 
         if not deleted:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Model with ID '{model_id}' not found"
+            )
+
+        if existing:
+            await get_model_role_service().revoke_model_from_all_roles(
+                existing.model_id, admin_user
             )
 
         return None
@@ -739,38 +798,39 @@ async def delete_managed_model_endpoint(
         )
 
 
-@router.post("/managed-models/{model_id}/sync-roles", response_model=ManagedModel)
-async def sync_model_roles(
+@router.get("/managed-models/{model_id}/roles", response_model=List[ModelRoleAssignment])
+async def get_managed_model_roles(
     model_id: str,
     admin_user: User = Depends(require_admin),
 ):
     """
-    Sync a model's allowedAppRoles with the AppRole system.
+    List every AppRole that grants access to a model, and how.
 
-    This endpoint updates the model's allowedAppRoles based on which AppRoles
-    have this model in their granted_models list. It ensures bidirectional
-    consistency between models and roles.
+    Each assignment is tagged `direct` (the role lists the model in its
+    grantedModels), `wildcard` (the role grants '*'), or `inherited` (a parent
+    role grants it). Only `direct` grants are editable from the model form —
+    the others are changed by editing the role.
 
-    Requires system administrator access.
+    Replaces the old POST /sync-roles endpoint: role records are now the single
+    source of truth, so there is nothing left to reconcile.
 
     Args:
-        model_id: Model identifier
-        admin_user: Authenticated system admin user (injected by dependency)
+        model_id: Model identifier (the record's internal id)
+        admin_user: Authenticated admin user (injected by dependency)
 
     Returns:
-        ManagedModel: Updated model with synced allowedAppRoles
+        List[ModelRoleAssignment]
 
     Raises:
         HTTPException:
             - 401 if not authenticated
-            - 403 if user lacks system admin role
+            - 403 if user lacks admin role
             - 404 if model not found
             - 500 if server error
     """
-    logger.info("Admin syncing roles for model")
+    logger.info("Admin listing roles for model")
 
     try:
-        # Get the model
         model = await get_managed_model(model_id)
         if not model:
             raise HTTPException(
@@ -778,47 +838,15 @@ async def sync_model_roles(
                 detail=f"Model with ID '{model_id}' not found"
             )
 
-        # Import here to avoid circular imports
-        from apis.shared.rbac.admin_service import get_app_role_admin_service
-
-        # Get all roles and find which ones grant access to this model
-        admin_service = get_app_role_admin_service()
-        all_roles = await admin_service.list_roles(enabled_only=False)
-
-        # Find roles that grant access to this model
-        granting_roles = []
-        for role in all_roles:
-            if model.model_id in role.granted_models:
-                granting_roles.append(role.role_id)
-            # Also check effective_permissions in case inheritance grants access
-            if role.effective_permissions and model.model_id in role.effective_permissions.models:
-                if role.role_id not in granting_roles:
-                    granting_roles.append(role.role_id)
-
-        # Update the model's allowed_app_roles
-        from apis.shared.models.models import ManagedModelUpdate
-        updates = ManagedModelUpdate(allowed_app_roles=granting_roles)
-        updated_model = await update_managed_model(model_id, updates)
-
-        if not updated_model:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to update model after computing roles"
-            )
-
-        logger.info(
-            "✅ Synced model allowedAppRoles"
-        )
-
-        return updated_model
+        return await get_model_role_service().get_roles_for_model(model.model_id)
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Unexpected error syncing model roles", exc_info=True)
+        logger.error("Unexpected error listing model roles", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error syncing model roles: {str(e)}"
+            detail=f"Error listing model roles: {str(e)}"
         )
 
 

--- a/backend/src/apis/app_api/admin/services/model_access.py
+++ b/backend/src/apis/app_api/admin/services/model_access.py
@@ -4,14 +4,21 @@ This service provides hybrid access checking for managed models,
 supporting both the new AppRole system and legacy JWT role-based access.
 
 During the transition period, access is granted if the user matches EITHER:
-1. AppRole-based access (via allowed_app_roles)
-2. Legacy JWT role-based access (via available_to_roles)
+1. AppRole-based access — the model is in the user's resolved ``permissions.models``
+   (i.e. some role of theirs lists it in ``grantedModels``, or grants ``*``)
+2. Legacy JWT role-based access (via ``available_to_roles``)
 
 Once migration is complete, the legacy JWT role check can be removed.
+
+Note ``ManagedModel.allowed_app_roles`` is NOT an input to either check: it is a
+field derived *from* the role records for display (see :mod:`.model_roles`).
+Access is decided by the roles alone. Both entry points below funnel through
+``_grants_access`` so a single-model check and a catalog filter can never
+disagree about the same model.
 """
 
 import logging
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from apis.shared.auth.models import User
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
@@ -40,14 +47,53 @@ class ModelAccessService:
             self._app_role_service = get_app_role_service()
         return self._app_role_service
 
+    async def _resolve_model_permissions(self, user: User) -> Set[str]:
+        """
+        Resolve the set of model ids the user's AppRoles grant (may contain '*').
+
+        Returns an empty set if permission resolution fails, so the caller falls
+        through to the legacy JWT check rather than erroring.
+        """
+        try:
+            permissions = await self.app_role_service.resolve_user_permissions(user)
+            return set(permissions.models)
+        except Exception as e:
+            # JUSTIFICATION: AppRole permission resolution failures should not block access checks.
+            # We fall back to legacy JWT role checking to maintain system availability during
+            # the AppRole migration period. This ensures users can still access models even if
+            # the AppRole system has issues. We log the error for monitoring.
+            logger.warning(
+                f"Error resolving AppRole permissions for {user.email} (falling back to JWT roles): {e}",
+                exc_info=True
+            )
+            return set()
+
+    @staticmethod
+    def _grants_access(
+        model: ManagedModel, model_permissions: Set[str], user_roles: Set[str]
+    ) -> bool:
+        """
+        Decide whether a user may use a model. The single access rule.
+
+        Both ``can_access_model`` and ``filter_accessible_models`` delegate here,
+        so a model is never listed by one and denied by the other.
+        """
+        if not model.enabled:
+            return False
+
+        # AppRole-based access: a role of the user's grants this model (or all models).
+        if "*" in model_permissions or model.model_id in model_permissions:
+            return True
+
+        # Legacy JWT role-based access (deprecated).
+        if model.available_to_roles and user_roles.intersection(model.available_to_roles):
+            return True
+
+        return False
+
     async def can_access_model(self, user: User, model: ManagedModel) -> bool:
         """
         Check if a user can access a specific model.
-
-        Access is granted if ANY of the following is true:
-        1. Model has allowed_app_roles AND user has matching AppRole permissions
-        2. Model has available_to_roles AND user has matching JWT role
-        3. Neither field is set (model is unrestricted - should not happen in practice)
 
         Args:
             user: Authenticated user
@@ -56,49 +102,17 @@ class ModelAccessService:
         Returns:
             True if user can access the model, False otherwise
         """
+        # Short-circuit before paying for a permission resolve.
         if not model.enabled:
             return False
 
-        # Check AppRole-based access first (new system)
-        if model.allowed_app_roles:
-            try:
-                permissions = await self.app_role_service.resolve_user_permissions(user)
+        model_permissions = await self._resolve_model_permissions(user)
+        allowed = self._grants_access(model, model_permissions, set(user.roles or []))
 
-                # Wildcard grants access to all models
-                if "*" in permissions.models:
-                    logger.debug(
-                        f"User {user.email} has wildcard model access via AppRole"
-                    )
-                    return True
-
-                # Check if user has access to this specific model
-                if model.model_id in permissions.models:
-                    logger.debug(
-                        f"User {user.email} has AppRole access to model {model.model_id}"
-                    )
-                    return True
-
-            except Exception as e:
-                # JUSTIFICATION: AppRole permission resolution failures should not block access checks.
-                # We fall back to legacy JWT role checking to maintain system availability during
-                # the AppRole migration period. This ensures users can still access models even if
-                # the AppRole system has issues. We log the error for monitoring.
-                logger.warning(
-                    f"Error checking AppRole permissions for {user.email} (falling back to JWT roles): {e}",
-                    exc_info=True
-                )
-
-        # Check legacy JWT role-based access (deprecated)
-        if model.available_to_roles:
-            user_roles = user.roles or []
-            if any(role in model.available_to_roles for role in user_roles):
-                logger.debug(
-                    f"User {user.email} has legacy JWT role access to model {model.model_id}"
-                )
-                return True
-
-        # No access configured or user doesn't match any access rules
-        return False
+        logger.debug(
+            f"User {user.email} access to model {model.model_id}: {allowed}"
+        )
+        return allowed
 
     async def filter_accessible_models(
         self, user: User, models: List[ManagedModel]
@@ -113,48 +127,15 @@ class ModelAccessService:
         Returns:
             List of ManagedModel objects the user can access
         """
-        accessible = []
-
-        # Get user's AppRole permissions once (cached)
-        try:
-            permissions = await self.app_role_service.resolve_user_permissions(user)
-            has_wildcard = "*" in permissions.models
-            model_permissions = set(permissions.models)
-        except Exception as e:
-            # JUSTIFICATION: AppRole permission resolution failures should not block model filtering.
-            # We fall back to legacy JWT role checking to maintain system availability during
-            # the AppRole migration period. This ensures users can still see accessible models
-            # even if the AppRole system has issues. We log the error for monitoring.
-            logger.warning(
-                f"Error resolving AppRole permissions for {user.email} (using JWT roles only): {e}",
-                exc_info=True
-            )
-            permissions = None
-            has_wildcard = False
-            model_permissions = set()
-
+        # Resolve the user's AppRole permissions once (cached) for the whole catalog.
+        model_permissions = await self._resolve_model_permissions(user)
         user_roles = set(user.roles or [])
 
-        for model in models:
-            if not model.enabled:
-                continue
-
-            # Check AppRole-based access (wildcard or specific model)
-            if has_wildcard or model.model_id in model_permissions:
-                accessible.append(model)
-                continue
-
-            # Check if model has allowed_app_roles and user matches
-            if model.allowed_app_roles and permissions:
-                # This model requires AppRole access, but user didn't have it
-                # Still check legacy JWT roles as fallback
-                pass
-
-            # Check legacy JWT role-based access
-            if model.available_to_roles:
-                if user_roles.intersection(model.available_to_roles):
-                    accessible.append(model)
-                    continue
+        accessible = [
+            model
+            for model in models
+            if self._grants_access(model, model_permissions, user_roles)
+        ]
 
         logger.debug(
             f"Filtered {len(models)} models to {len(accessible)} accessible for {user.email}"

--- a/backend/src/apis/app_api/admin/services/model_roles.py
+++ b/backend/src/apis/app_api/admin/services/model_roles.py
@@ -1,0 +1,259 @@
+"""Model Role Service
+
+Keeps model↔role permissions in one place: the AppRole record.
+
+A role grants a model by listing it in its own ``grantedModels`` (or by granting
+the ``*`` wildcard, or by inheriting from a parent that does). That is the only
+thing the access checks in :mod:`.model_access` ever read.
+
+The admin model form still presents a "which roles can use this model?" picker.
+This service is what makes that picker honest:
+
+* :meth:`set_roles_for_model` writes the picker's selection *through* to each
+  role's ``grantedModels`` — the same shape as ``set_roles_for_tool`` in
+  ``app_api/tools/service.py``.
+* :meth:`hydrate_model_roles` recomputes ``allowed_app_roles`` /
+  ``inherited_app_roles`` from the role records on read, so the model record
+  never stores a role list that can drift out of date.
+
+Historically ``allowedAppRoles`` was a stored, client-writable field that no
+access check consulted, so editing it on the model page silently did nothing.
+"""
+
+import logging
+from typing import Dict, List, Optional, Set
+
+from apis.shared.auth.models import User
+from apis.shared.models.models import ManagedModel, ModelRoleAssignment
+from apis.shared.rbac.admin_service import (
+    AppRoleAdminService,
+    get_app_role_admin_service,
+)
+from apis.shared.rbac.models import AppRole, AppRoleUpdate
+
+logger = logging.getLogger(__name__)
+
+WILDCARD = "*"
+
+
+class ModelRoleService:
+    """Reads and writes model grants against the AppRole records."""
+
+    def __init__(self, app_role_admin_service: Optional[AppRoleAdminService] = None):
+        self._admin_service = app_role_admin_service
+
+    @property
+    def admin_service(self) -> AppRoleAdminService:
+        """Lazy-load AppRoleAdminService to avoid circular imports."""
+        if self._admin_service is None:
+            self._admin_service = get_app_role_admin_service()
+        return self._admin_service
+
+    # =========================================================================
+    # Read — derive a model's roles from the role records
+    # =========================================================================
+
+    async def get_roles_for_model(self, model_id: str) -> List[ModelRoleAssignment]:
+        """
+        Get every AppRole that grants access to a model.
+
+        Args:
+            model_id: The *provider* model id (e.g. ``anthropic.claude-...``),
+                which is what roles store in ``grantedModels`` — not the model
+                record's internal UUID.
+
+        Returns:
+            One assignment per granting role, tagged direct / wildcard / inherited.
+        """
+        roles = await self.admin_service.list_roles(enabled_only=False)
+        return self._assignments_for(model_id, roles)
+
+    async def hydrate_model_roles(self, models: List[ManagedModel]) -> List[ManagedModel]:
+        """
+        Populate the derived ``allowed_app_roles`` / ``inherited_app_roles`` on
+        each model from the role records.
+
+        Loads the role list once and resolves every model against it in memory,
+        so hydrating a full catalog costs a single role query.
+
+        Args:
+            models: Models to hydrate (mutated in place and returned).
+
+        Returns:
+            The same list, with derived role fields populated.
+        """
+        if not models:
+            return models
+
+        roles = await self.admin_service.list_roles(enabled_only=False)
+
+        for model in models:
+            assignments = self._assignments_for(model.model_id, roles)
+            model.allowed_app_roles = [
+                a.role_id for a in assignments if a.grant_type == "direct"
+            ]
+            model.inherited_app_roles = [
+                a.role_id for a in assignments if a.grant_type != "direct"
+            ]
+
+        return models
+
+    def _assignments_for(
+        self, model_id: str, roles: List[AppRole]
+    ) -> List[ModelRoleAssignment]:
+        """Classify how (if at all) each role grants ``model_id``."""
+        by_id: Dict[str, AppRole] = {r.role_id: r for r in roles}
+        assignments: List[ModelRoleAssignment] = []
+
+        for role in roles:
+            granted = set(role.granted_models)
+
+            if model_id in granted:
+                grant_type, inherited_from = "direct", None
+            elif WILDCARD in granted:
+                grant_type, inherited_from = "wildcard", None
+            else:
+                # Not granted directly — see whether a parent supplies it.
+                inherited_from = self._parent_granting(model_id, role, by_id)
+                if inherited_from is None:
+                    continue
+                grant_type = "inherited"
+
+            assignments.append(
+                ModelRoleAssignment(
+                    role_id=role.role_id,
+                    display_name=role.display_name,
+                    grant_type=grant_type,
+                    inherited_from=inherited_from,
+                    enabled=role.enabled,
+                )
+            )
+
+        return assignments
+
+    @staticmethod
+    def _parent_granting(
+        model_id: str, role: AppRole, by_id: Dict[str, AppRole]
+    ) -> Optional[str]:
+        """Return the id of the first enabled parent role granting the model."""
+        for parent_id in role.inherits_from:
+            parent = by_id.get(parent_id)
+            if not parent or not parent.enabled:
+                continue
+            parent_grants = set(parent.granted_models)
+            if model_id in parent_grants or WILDCARD in parent_grants:
+                return parent_id
+        return None
+
+    # =========================================================================
+    # Write — push the model form's role picker into the role records
+    # =========================================================================
+
+    async def set_roles_for_model(
+        self,
+        model_id: str,
+        app_role_ids: List[str],
+        admin: User,
+        previous_model_id: Optional[str] = None,
+    ) -> None:
+        """
+        Make exactly ``app_role_ids`` grant this model directly.
+
+        Adds the model to each named role's ``grantedModels`` and removes it from
+        any role that grants it directly but isn't named. Roles that grant the
+        model only via wildcard or inheritance are left alone — they aren't
+        "direct" grants, so they're neither added to nor stripped by this call.
+
+        Args:
+            model_id: The provider model id roles store in ``grantedModels``.
+            app_role_ids: Roles that should grant the model directly.
+            admin: Admin performing the change (for the audit log).
+            previous_model_id: Set when an update renamed the model id, so grants
+                pointing at the old id are migrated rather than orphaned.
+
+        Raises:
+            ValueError: If any named role does not exist.
+        """
+        roles = await self.admin_service.list_roles(enabled_only=False)
+        by_id: Dict[str, AppRole] = {r.role_id: r for r in roles}
+
+        requested: Set[str] = set(app_role_ids)
+        unknown = requested - by_id.keys()
+        if unknown:
+            raise ValueError(f"Unknown AppRole(s): {sorted(unknown)}")
+
+        # A rename leaves grants pointing at the old id; drop them so the role's
+        # grantedModels doesn't accumulate a dangling entry.
+        stale_id = (
+            previous_model_id
+            if previous_model_id and previous_model_id != model_id
+            else None
+        )
+
+        for role in roles:
+            granted = list(role.granted_models)
+            updated = [m for m in granted if m != stale_id] if stale_id else list(granted)
+
+            should_grant = role.role_id in requested
+            grants_directly = model_id in updated
+
+            if should_grant and not grants_directly:
+                # A wildcard role already covers every model; adding the explicit
+                # id would be redundant noise in its grantedModels.
+                if WILDCARD not in updated:
+                    updated.append(model_id)
+            elif not should_grant and grants_directly:
+                updated = [m for m in updated if m != model_id]
+
+            if updated != granted:
+                await self.admin_service.update_role(
+                    role.role_id, AppRoleUpdate(granted_models=updated), admin
+                )
+
+        logger.info(
+            f"Admin {admin.email} set roles for model {model_id}",
+            extra={
+                "event": "model_roles_updated",
+                "model_id": model_id,
+                "admin_user_id": admin.user_id,
+                "roles": sorted(requested),
+            },
+        )
+
+    async def revoke_model_from_all_roles(self, model_id: str, admin: User) -> None:
+        """
+        Strip a model from every role's ``grantedModels``.
+
+        Called when a model is deleted so roles don't retain grants for a model
+        that no longer exists.
+        """
+        roles = await self.admin_service.list_roles(enabled_only=False)
+
+        for role in roles:
+            if model_id not in role.granted_models:
+                continue
+            remaining = [m for m in role.granted_models if m != model_id]
+            await self.admin_service.update_role(
+                role.role_id, AppRoleUpdate(granted_models=remaining), admin
+            )
+
+        logger.info(
+            f"Admin {admin.email} revoked model {model_id} from all roles",
+            extra={
+                "event": "model_roles_revoked",
+                "model_id": model_id,
+                "admin_user_id": admin.user_id,
+            },
+        )
+
+
+# Global service instance
+_service_instance: Optional[ModelRoleService] = None
+
+
+def get_model_role_service() -> ModelRoleService:
+    """Get or create the global ModelRoleService instance."""
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = ModelRoleService()
+    return _service_instance

--- a/backend/src/apis/app_api/admin/services/tests/test_model_access.py
+++ b/backend/src/apis/app_api/admin/services/tests/test_model_access.py
@@ -392,3 +392,85 @@ class TestModelAccessServiceFilterModels:
         # Should still work via JWT role fallback
         assert len(result) == 1
         assert result[0].model_id == "model-1"
+
+
+class TestModelAccessIgnoresAllowedAppRoles:
+    """
+    ``allowed_app_roles`` is a display-only field derived from the role records.
+    It must never influence an access decision, and the single-model check must
+    always agree with the catalog filter.
+
+    Regression: a model granted via a role's ``grantedModels`` but with an empty
+    ``allowed_app_roles`` was *listed* by ``filter_accessible_models`` and yet
+    *denied* by ``can_access_model``, because the latter gated on the field.
+    """
+
+    @pytest.fixture
+    def mock_app_role_service(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_app_role_service):
+        return ModelAccessService(app_role_service=mock_app_role_service)
+
+    def _grant(self, user, mock_app_role_service, models):
+        mock_app_role_service.resolve_user_permissions.return_value = (
+            UserEffectivePermissions(
+                user_id=user.user_id,
+                app_roles=["staff"],
+                tools=[],
+                models=models,
+                quota_tier=None,
+                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_role_grant_with_empty_allowed_app_roles_is_accessible(
+        self, service, mock_app_role_service
+    ):
+        """A role grant alone is sufficient — the model's role list is irrelevant."""
+        user = create_test_user(roles=["Staff"])
+        model = create_test_model(model_id="claude-sonnet-5", allowed_app_roles=[])
+        self._grant(user, mock_app_role_service, ["claude-sonnet-5"])
+
+        assert await service.can_access_model(user, model) is True
+
+    @pytest.mark.asyncio
+    async def test_allowed_app_roles_alone_grants_nothing(
+        self, service, mock_app_role_service
+    ):
+        """
+        Listing a role on the model must NOT grant access on its own. Only the
+        role's own grantedModels does — otherwise the model record becomes a
+        second, competing source of truth.
+        """
+        user = create_test_user(roles=["Staff"])
+        model = create_test_model(
+            model_id="claude-sonnet-5",
+            allowed_app_roles=["staff"],  # says "staff" but no role actually grants it
+        )
+        self._grant(user, mock_app_role_service, [])
+
+        assert await service.can_access_model(user, model) is False
+
+    @pytest.mark.asyncio
+    async def test_single_check_agrees_with_filter(
+        self, service, mock_app_role_service
+    ):
+        """can_access_model and filter_accessible_models must never disagree."""
+        user = create_test_user(roles=["Staff"])
+        models = [
+            create_test_model(model_id="granted", allowed_app_roles=[]),
+            create_test_model(model_id="not-granted", allowed_app_roles=["staff"]),
+        ]
+        self._grant(user, mock_app_role_service, ["granted"])
+
+        listed = {m.model_id for m in await service.filter_accessible_models(user, models)}
+
+        for model in models:
+            assert (
+                await service.can_access_model(user, model)
+            ) is (model.model_id in listed)
+
+        assert listed == {"granted"}

--- a/backend/src/apis/app_api/admin/services/tests/test_model_roles.py
+++ b/backend/src/apis/app_api/admin/services/tests/test_model_roles.py
@@ -1,0 +1,240 @@
+"""Unit tests for ModelRoleService.
+
+The AppRole record is the single source of truth for model access. These tests
+pin the two directions of that contract:
+
+* the model form's role picker writes THROUGH to each role's ``grantedModels``
+  (previously it wrote a model-side field that no access check ever read, so
+  enabling a model for a role from the model page silently did nothing);
+* the model's role fields are derived back FROM the roles on read, so the model
+  page and the role page can never show different answers.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from apis.app_api.admin.services.model_roles import ModelRoleService
+from apis.shared.auth.models import User
+from apis.shared.models.models import ManagedModel
+from apis.shared.rbac.models import AppRole
+
+
+def make_admin() -> User:
+    return User(
+        user_id="admin-1", email="admin@example.com", name="Admin", roles=["Admin"]
+    )
+
+
+def make_role(
+    role_id: str,
+    granted_models: list = None,
+    inherits_from: list = None,
+    enabled: bool = True,
+) -> AppRole:
+    return AppRole(
+        role_id=role_id,
+        display_name=role_id.title(),
+        description=f"{role_id} role",
+        granted_models=granted_models or [],
+        inherits_from=inherits_from or [],
+        enabled=enabled,
+    )
+
+
+def make_model(model_id: str = "claude-sonnet-5") -> ManagedModel:
+    now = datetime.now(timezone.utc)
+    return ManagedModel(
+        id="uuid-1",
+        model_id=model_id,
+        model_name="Claude Sonnet 5",
+        provider="bedrock",
+        provider_name="AWS Bedrock",
+        input_modalities=["TEXT"],
+        output_modalities=["TEXT"],
+        max_input_tokens=200000,
+        enabled=True,
+        input_price_per_million_tokens=3.0,
+        output_price_per_million_tokens=15.0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def make_service(roles: list) -> tuple:
+    """Build a ModelRoleService over a fixed role list. Returns (service, admin_mock)."""
+    admin_service = AsyncMock()
+    admin_service.list_roles.return_value = roles
+    return ModelRoleService(app_role_admin_service=admin_service), admin_service
+
+
+def granted_models_written(admin_service, role_id: str) -> list:
+    """The grantedModels passed to update_role for a given role."""
+    for call in admin_service.update_role.await_args_list:
+        if call.args[0] == role_id:
+            return call.args[1].granted_models
+    raise AssertionError(f"update_role was never called for {role_id}")
+
+
+class TestSetRolesForModel:
+    """The write-through: the picker's selection lands on the ROLE records."""
+
+    @pytest.mark.asyncio
+    async def test_grant_adds_model_to_role_granted_models(self):
+        """
+        The bug this fixes: enabling Sonnet 5 for Staff on the model page must
+        add the model to the Staff role's grantedModels — that is the only field
+        the chat model list reads.
+        """
+        service, admin_service = make_service([make_role("staff")])
+
+        await service.set_roles_for_model("claude-sonnet-5", ["staff"], make_admin())
+
+        assert granted_models_written(admin_service, "staff") == ["claude-sonnet-5"]
+
+    @pytest.mark.asyncio
+    async def test_deselecting_a_role_revokes_the_grant(self):
+        service, admin_service = make_service(
+            [make_role("staff", granted_models=["claude-sonnet-5", "other"])]
+        )
+
+        await service.set_roles_for_model("claude-sonnet-5", [], make_admin())
+
+        assert granted_models_written(admin_service, "staff") == ["other"]
+
+    @pytest.mark.asyncio
+    async def test_untouched_roles_are_not_rewritten(self):
+        """Only roles whose grants actually change should be written."""
+        service, admin_service = make_service(
+            [
+                make_role("staff", granted_models=["claude-sonnet-5"]),
+                make_role("student", granted_models=["haiku"]),
+            ]
+        )
+
+        await service.set_roles_for_model("claude-sonnet-5", ["staff"], make_admin())
+
+        admin_service.update_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wildcard_role_is_not_given_a_redundant_grant(self):
+        """A role granting '*' already covers every model; don't add the id too."""
+        service, admin_service = make_service(
+            [make_role("system_admin", granted_models=["*"])]
+        )
+
+        await service.set_roles_for_model(
+            "claude-sonnet-5", ["system_admin"], make_admin()
+        )
+
+        admin_service.update_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_role_is_rejected(self):
+        service, admin_service = make_service([make_role("staff")])
+
+        with pytest.raises(ValueError, match="Unknown AppRole"):
+            await service.set_roles_for_model("claude-sonnet-5", ["ghost"], make_admin())
+
+        admin_service.update_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rename_migrates_grants_to_the_new_model_id(self):
+        """Roles key grants on the provider model id, so a rename must move them."""
+        service, admin_service = make_service(
+            [make_role("staff", granted_models=["old-id", "other"])]
+        )
+
+        await service.set_roles_for_model(
+            "new-id", ["staff"], make_admin(), previous_model_id="old-id"
+        )
+
+        written = granted_models_written(admin_service, "staff")
+        assert "old-id" not in written
+        assert written == ["other", "new-id"]
+
+
+class TestRevokeModelFromAllRoles:
+    @pytest.mark.asyncio
+    async def test_delete_strips_the_model_from_every_role(self):
+        service, admin_service = make_service(
+            [
+                make_role("staff", granted_models=["claude-sonnet-5", "haiku"]),
+                make_role("student", granted_models=["claude-sonnet-5"]),
+                make_role("guest", granted_models=["haiku"]),
+            ]
+        )
+
+        await service.revoke_model_from_all_roles("claude-sonnet-5", make_admin())
+
+        assert granted_models_written(admin_service, "staff") == ["haiku"]
+        assert granted_models_written(admin_service, "student") == []
+        # 'guest' never granted it, so it should not be rewritten.
+        assert admin_service.update_role.await_count == 2
+
+
+class TestHydrateModelRoles:
+    """The derived read: role records -> the model's displayed role fields."""
+
+    @pytest.mark.asyncio
+    async def test_direct_grants_populate_allowed_app_roles(self):
+        service, _ = make_service(
+            [
+                make_role("staff", granted_models=["claude-sonnet-5"]),
+                make_role("student", granted_models=["haiku"]),
+            ]
+        )
+        model = make_model()
+
+        await service.hydrate_model_roles([model])
+
+        assert model.allowed_app_roles == ["staff"]
+        assert model.inherited_app_roles == []
+
+    @pytest.mark.asyncio
+    async def test_wildcard_and_inherited_grants_are_reported_separately(self):
+        """
+        A wildcard or inherited grant is real access, but it isn't a direct grant
+        — it must not show up as a checked box the admin could 'uncheck'.
+        """
+        service, _ = make_service(
+            [
+                make_role("system_admin", granted_models=["*"]),
+                make_role("staff", granted_models=["claude-sonnet-5"]),
+                make_role("ta", inherits_from=["staff"]),
+            ]
+        )
+        model = make_model()
+
+        await service.hydrate_model_roles([model])
+
+        assert model.allowed_app_roles == ["staff"]
+        assert sorted(model.inherited_app_roles) == ["system_admin", "ta"]
+
+    @pytest.mark.asyncio
+    async def test_inheritance_from_a_disabled_parent_does_not_grant(self):
+        service, _ = make_service(
+            [
+                make_role("staff", granted_models=["claude-sonnet-5"], enabled=False),
+                make_role("ta", inherits_from=["staff"]),
+            ]
+        )
+        model = make_model()
+
+        await service.hydrate_model_roles([model])
+
+        assert model.inherited_app_roles == []
+
+    @pytest.mark.asyncio
+    async def test_hydrating_a_catalog_queries_roles_once(self):
+        """Cost guard: one role query for the whole model list, not one per model."""
+        service, admin_service = make_service(
+            [make_role("staff", granted_models=["m1"])]
+        )
+        models = [make_model("m1"), make_model("m2"), make_model("m3")]
+
+        await service.hydrate_model_roles(models)
+
+        admin_service.list_roles.assert_awaited_once()
+        assert models[0].allowed_app_roles == ["staff"]
+        assert models[1].allowed_app_roles == []

--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -92,13 +92,11 @@ async def _validate_model(user: User, cfg: AgentModelConfig, svc: ModelAccessSer
     model = next((m for m in await list_all_managed_models() if m.model_id == cfg.model_id), None)
     if model is None:
         raise BindingValidationError(f"Model '{cfg.model_id}' is not available.", status_code=400)
-    # Use the SAME predicate the ``/agents/bindable`` catalog uses (``filter_accessible_models``),
-    # not ``can_access_model``: the latter only honors an AppRole model grant when the model
-    # record also carries a non-empty ``allowed_app_roles``, so a model granted purely via the
-    # user's AppRole ``permissions.models`` (empty ``allowed_app_roles``) is *listed* by the
-    # palette but would be *rejected* here — the picker shows it, saving 403s. Filtering the
-    # single model guarantees "if the palette offers it, the write accepts it", and matches the
-    # runtime's membership grant.
+    # Use the SAME predicate the ``/agents/bindable`` catalog uses, so "if the palette
+    # offers it, the write accepts it". ``can_access_model`` is now equivalent (both
+    # delegate to one ``_grants_access`` rule); this once had to avoid it because it
+    # additionally gated on the model's ``allowed_app_roles``, rejecting models the
+    # palette had just listed.
     if not await svc.filter_accessible_models(user, [model]):
         raise BindingValidationError(
             f"You do not have access to model '{cfg.model_id}'.", status_code=403

--- a/backend/src/apis/app_api/models/routes.py
+++ b/backend/src/apis/app_api/models/routes.py
@@ -30,14 +30,16 @@ async def list_models_for_user(
 
     This endpoint returns models filtered by the user's permissions. Only models
     that are:
-    1. Enabled
-    2. Accessible via AppRole permissions (allowedAppRoles) OR
+    1. Enabled, AND
+    2. Granted by one of the user's AppRoles — the role lists the model in its
+       grantedModels, or grants the '*' wildcard — OR
     3. Available via legacy JWT role matching (availableToRoles)
 
     will be returned.
 
     Access Control:
-    - AppRole-based access is checked first (via allowedAppRoles field)
+    - The AppRole record is the source of truth. The model's own allowedAppRoles
+      field is DERIVED from those roles for display and is not consulted here.
     - Legacy JWT role-based access is checked as fallback (via availableToRoles field)
     - During the transition period, access is granted if EITHER method matches
 

--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -234,7 +234,9 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         output_modalities=model_data.output_modalities,
         max_input_tokens=model_data.max_input_tokens,
         max_output_tokens=model_data.max_output_tokens,
-        allowed_app_roles=model_data.allowed_app_roles,
+        # allowed_app_roles is intentionally not set here: it is derived from the
+        # AppRole records on read (see app_api/admin/services/model_roles.py).
+        # The caller writes the requested roles through to those records.
         available_to_roles=model_data.available_to_roles,
         enabled=model_data.enabled,
         input_price_per_million_tokens=model_data.input_price_per_million_tokens,
@@ -265,7 +267,6 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         'inputModalities': model_data.input_modalities,
         'outputModalities': model_data.output_modalities,
         'maxInputTokens': model_data.max_input_tokens,
-        'allowedAppRoles': model_data.allowed_app_roles,
         'availableToRoles': model_data.available_to_roles,
         'enabled': model_data.enabled,
         'inputPricePerMillionTokens': model_data.input_price_per_million_tokens,
@@ -536,6 +537,12 @@ async def _update_managed_model_cloud(model_id: str, updates: ManagedModelUpdate
 
     # Get update data
     update_data = updates.model_dump(exclude_none=True, by_alias=True)
+
+    # Role access is owned by the AppRole records, not the model item. The admin
+    # route writes allowedAppRoles through to each role's grantedModels and the
+    # value is derived back on read, so persisting it here would only create a
+    # copy that drifts out of date.
+    update_data.pop('allowedAppRoles', None)
 
     if not update_data:
         return existing_model  # No updates to apply

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -161,11 +161,13 @@ class ManagedModelCreate(BaseModel):
     # value is only a ceiling for the admin-configured max_tokens inference
     # param — it is never sent to the provider — so leaving it unset is safe.
     max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens", ge=1)
-    # Access control: AppRoles (preferred) or legacy JWT roles
+    # Access control. Not stored on the model item: the admin routes write this
+    # through to each named role's ``grantedModels``, which is the source of truth.
     allowed_app_roles: List[str] = Field(
         default_factory=list,
         alias="allowedAppRoles",
-        description="AppRole IDs that can access this model (preferred over availableToRoles)"
+        description="AppRole IDs that should grant this model. Written through to each "
+                    "role's grantedModels; not persisted on the model record."
     )
     available_to_roles: List[str] = Field(
         default_factory=list,
@@ -247,11 +249,14 @@ class ManagedModelUpdate(BaseModel):
     output_modalities: Optional[List[str]] = Field(None, alias="outputModalities")
     max_input_tokens: Optional[int] = Field(None, alias="maxInputTokens", ge=1)
     max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens", ge=1)
-    # Access control: AppRoles (preferred) or legacy JWT roles
+    # Access control. Not stored on the model item: the admin routes write this
+    # through to each named role's ``grantedModels``, which is the source of truth.
+    # None means "leave role grants alone"; [] means "revoke every direct grant".
     allowed_app_roles: Optional[List[str]] = Field(
         None,
         alias="allowedAppRoles",
-        description="AppRole IDs that can access this model (preferred over availableToRoles)"
+        description="AppRole IDs that should grant this model. Written through to each "
+                    "role's grantedModels; not persisted on the model record."
     )
     available_to_roles: Optional[List[str]] = Field(
         None,
@@ -327,11 +332,23 @@ class ManagedModel(BaseModel):
     output_modalities: List[str] = Field(..., alias="outputModalities")
     max_input_tokens: int = Field(..., alias="maxInputTokens")
     max_output_tokens: Optional[int] = Field(None, alias="maxOutputTokens")
-    # Access control: AppRoles (preferred) or legacy JWT roles
+    # Access control. The AppRole record is the single source of truth: a role
+    # grants a model via its own ``grantedModels``. The two fields below are
+    # DERIVED from those role records on read (see ModelRoleService) and are not
+    # persisted on the model item — access checks never read them.
     allowed_app_roles: List[str] = Field(
         default_factory=list,
         alias="allowedAppRoles",
-        description="AppRole IDs that can access this model (preferred over availableToRoles)"
+        description="[DERIVED] AppRole IDs that grant this model DIRECTLY (the role lists "
+                    "it in grantedModels). Editable via the admin model form, which writes "
+                    "through to each role's grantedModels."
+    )
+    inherited_app_roles: List[str] = Field(
+        default_factory=list,
+        alias="inheritedAppRoles",
+        description="[DERIVED, read-only] AppRole IDs that grant this model indirectly — "
+                    "via a wildcard ('*') grant or via inheritance from a parent role. "
+                    "Cannot be toggled from the model form; edit the role instead."
     )
     available_to_roles: List[str] = Field(
         default_factory=list,
@@ -387,3 +404,20 @@ class ManagedModel(BaseModel):
     )
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: datetime = Field(..., alias="updatedAt")
+
+
+class ModelRoleAssignment(BaseModel):
+    """Role assignment info for a model. Mirrors ToolRoleAssignment."""
+
+    role_id: str = Field(..., alias="roleId")
+    display_name: str = Field(..., alias="displayName")
+    grant_type: str = Field(
+        ...,
+        alias="grantType",
+        description="'direct' (role lists the model in grantedModels), "
+                    "'wildcard' (role grants '*'), or 'inherited' (a parent role grants it)",
+    )
+    inherited_from: Optional[str] = Field(None, alias="inheritedFrom")
+    enabled: bool
+
+    model_config = {"populate_by_name": True}

--- a/backend/tests/routes/test_admin.py
+++ b/backend/tests/routes/test_admin.py
@@ -82,6 +82,25 @@ def _override_require_admin_403(app: FastAPI):
     app.dependency_overrides[require_admin] = _raise
 
 
+@pytest.fixture(autouse=True)
+def stub_model_role_service():
+    """
+    Stub the ModelRoleService for every test in this module.
+
+    The managed-model routes treat the AppRole records as the source of truth for
+    model access: reads derive allowedAppRoles from them, writes push the picker's
+    selection back into each role's grantedModels. These tests cover the model
+    storage layer only, so without this stub every request would hit the real
+    roles table. ``hydrate_model_roles`` passes the models straight through.
+    """
+    service = AsyncMock()
+    service.hydrate_model_roles.side_effect = lambda models: models
+    with patch(
+        f"{MANAGED_MODELS_PATH}.get_model_role_service", return_value=service
+    ):
+        yield service
+
+
 # ---------------------------------------------------------------------------
 # Requirement 7.1: Admin endpoint returns 200 for user with Admin role
 # ---------------------------------------------------------------------------
@@ -252,6 +271,46 @@ class TestCreateManagedModel:
         body = resp.json()
         assert body["modelId"] == "anthropic.claude-3-haiku"
 
+    def test_create_grants_the_model_to_the_selected_roles(
+        self, app, make_user, stub_model_role_service
+    ):
+        """
+        The role picker must write through to the ROLE records — that is what
+        actually grants access. Previously it wrote a field on the model that no
+        access check read, so selecting a role here did nothing at all.
+        """
+        admin = make_user(email="admin@example.com", user_id="admin-001", roles=["Admin"])
+        _override_require_admin(app, admin)
+
+        with patch(
+            f"{MANAGED_MODELS_PATH}.create_managed_model",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_MODEL,
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/admin/managed-models",
+                json={
+                    "modelId": "anthropic.claude-3-haiku",
+                    "modelName": "Claude 3 Haiku",
+                    "provider": "bedrock",
+                    "providerName": "Anthropic",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "maxInputTokens": 200000,
+                    "maxOutputTokens": 4096,
+                    "inputPricePerMillionTokens": 0.25,
+                    "outputPricePerMillionTokens": 1.25,
+                    "allowedAppRoles": ["staff"],
+                },
+            )
+
+        assert resp.status_code == 201
+        stub_model_role_service.set_roles_for_model.assert_awaited_once()
+        model_id, role_ids, *_ = stub_model_role_service.set_roles_for_model.await_args.args
+        assert model_id == SAMPLE_MODEL.model_id
+        assert role_ids == ["staff"]
+
 
 # ---------------------------------------------------------------------------
 # Requirement 7.7: DELETE managed model returns 204 for admin
@@ -266,7 +325,13 @@ class TestDeleteManagedModel:
         admin = make_user(email="admin@example.com", user_id="admin-001", roles=["Admin"])
         _override_require_admin(app, admin)
 
+        # The route reads the model before deleting it so it knows which provider
+        # model id to strip from the roles' grantedModels.
         with patch(
+            f"{MANAGED_MODELS_PATH}.get_managed_model",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_MODEL,
+        ), patch(
             f"{MANAGED_MODELS_PATH}.delete_managed_model",
             new_callable=AsyncMock,
             return_value=True,
@@ -275,3 +340,29 @@ class TestDeleteManagedModel:
             resp = client.delete("/admin/managed-models/model-001")
 
         assert resp.status_code == 204
+
+    def test_delete_revokes_the_model_from_every_role(
+        self, app, make_user, stub_model_role_service
+    ):
+        """Deleting a model must not leave roles granting a model that's gone."""
+        admin = make_user(email="admin@example.com", user_id="admin-001", roles=["Admin"])
+        _override_require_admin(app, admin)
+
+        with patch(
+            f"{MANAGED_MODELS_PATH}.get_managed_model",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_MODEL,
+        ), patch(
+            f"{MANAGED_MODELS_PATH}.delete_managed_model",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            client = TestClient(app)
+            resp = client.delete("/admin/managed-models/model-001")
+
+        assert resp.status_code == 204
+        stub_model_role_service.revoke_model_from_all_roles.assert_awaited_once()
+        assert (
+            stub_model_role_service.revoke_model_from_all_roles.await_args.args[0]
+            == SAMPLE_MODEL.model_id
+        )

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -296,10 +296,11 @@
           <!-- Allowed AppRoles -->
           <div>
             <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-              Allowed Roles <span class="text-red-600">*</span>
+              Allowed Roles
             </label>
             <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-              Select which application roles can access this model.
+              Select which application roles can access this model. Saving grants the model
+              to each selected role, exactly as if you had added it on the role's own page.
             </p>
             @if (rolesResource.isLoading()) {
               <div class="mt-2 text-sm/6 text-gray-500 dark:text-gray-400">Loading roles…</div>
@@ -309,10 +310,11 @@
               </div>
             } @else {
               <div class="mt-2 flex flex-wrap gap-2">
-                @for (role of availableAppRoles(); track role.roleId) {
+                @for (role of selectableAppRoles(); track role.roleId) {
                   <button
                     type="button"
                     (click)="toggleArrayValue('allowedAppRoles', role.roleId)"
+                    [attr.aria-pressed]="isSelected('allowedAppRoles', role.roleId)"
                     [class.bg-purple-600]="isSelected('allowedAppRoles', role.roleId)"
                     [class.text-white]="isSelected('allowedAppRoles', role.roleId)"
                     [class.bg-gray-100]="!isSelected('allowedAppRoles', role.roleId)"
@@ -332,9 +334,22 @@
                   No roles configured. Please create roles in Admin &gt; Roles first.
                 </p>
               }
-            }
-            @if (modelForm.controls.allowedAppRoles.invalid && modelForm.controls.allowedAppRoles.touched) {
-              <p class="mt-1 text-sm/6 text-red-600 dark:text-red-400">Select at least one role</p>
+              @if (inheritedRoleDetails().length > 0) {
+                <p class="mt-3 text-xs/5 text-gray-500 dark:text-gray-400">
+                  These roles already reach this model through an “all models” grant or by
+                  inheriting from a parent role. To change that, edit the role itself.
+                </p>
+                <div class="mt-2 flex flex-wrap gap-2">
+                  @for (role of inheritedRoleDetails(); track role.roleId) {
+                    <span
+                      class="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-3 py-1.5 text-sm/6 font-medium text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      [title]="role.description"
+                    >
+                      {{ role.displayName }}
+                    </span>
+                  }
+                </div>
+              }
             }
           </div>
 

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -282,6 +282,20 @@ export class ModelFormPage implements OnInit {
   readonly rolesResource = this.appRolesService.rolesResource;
   readonly availableAppRoles = computed(() => this.appRolesService.getEnabledRoles());
 
+  /**
+   * Roles that already reach this model without a direct grant — they hold a
+   * wildcard ('*') grant or inherit it from a parent. The server derives these;
+   * they can't be toggled here, so they're shown separately from the picker
+   * rather than as unchecked boxes that would look like "no access".
+   */
+  readonly inheritedAppRoles = signal<string[]>([]);
+  readonly selectableAppRoles = computed(() =>
+    this.availableAppRoles().filter(r => !this.inheritedAppRoles().includes(r.roleId)),
+  );
+  readonly inheritedRoleDetails = computed(() =>
+    this.availableAppRoles().filter(r => this.inheritedAppRoles().includes(r.roleId)),
+  );
+
   // Form state
   readonly isEditMode = signal<boolean>(false);
   readonly modelId = signal<string | null>(null);
@@ -303,7 +317,10 @@ export class ModelFormPage implements OnInit {
     outputModalities: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
     maxInputTokens: this.fb.control(0, { nonNullable: true, validators: [Validators.required, Validators.min(1)] }),
     maxOutputTokens: this.fb.control<number | null>(null, { validators: [Validators.min(1)] }),
-    allowedAppRoles: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
+    // No `required` validator: a model can legitimately have zero direct grants
+    // and still be reachable via a role's wildcard grant or inheritance, so
+    // forcing a selection would block saving those models.
+    allowedAppRoles: this.fb.control<string[]>([], { nonNullable: true }),
     availableToRoles: this.fb.control<string[]>([], { nonNullable: true }),
     enabled: this.fb.control(true, { nonNullable: true }),
     isDefault: this.fb.control(false, { nonNullable: true }),
@@ -802,6 +819,10 @@ export class ModelFormPage implements OnInit {
     this.isLoading.set(true);
     try {
       const model = await this.managedModelsService.getModel(id);
+
+      // Roles that reach this model via a wildcard grant or inheritance. Held
+      // outside the form: they're server-derived and not editable here.
+      this.inheritedAppRoles.set(model.inheritedAppRoles ?? []);
 
       // Populate form with model data
       this.modelForm.patchValue({

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -82,8 +82,17 @@ export interface ManagedModel {
   maxOutputTokens: number | null;
   /** Lifecycle status of the model (e.g., 'ACTIVE', 'LEGACY') */
   modelLifecycle?: string | null;
-  /** AppRole IDs that have access to this model (preferred over availableToRoles) */
+  /**
+   * AppRole IDs that grant this model DIRECTLY. Derived server-side from the
+   * role records (the source of truth); saving the form writes it back through
+   * to each role's grantedModels.
+   */
   allowedAppRoles: string[];
+  /**
+   * AppRole IDs that grant this model indirectly — via a wildcard ('*') grant or
+   * inheritance from a parent role. Read-only: change these by editing the role.
+   */
+  inheritedAppRoles?: string[];
   /** @deprecated Legacy JWT role names - use allowedAppRoles instead */
   availableToRoles: string[];
   /** Whether the model is enabled for use */


### PR DESCRIPTION
## Problem

A disconnect between the model detail page and the role detail page: enabling a model for a role on the **model** page appeared to work but silently did nothing. The role page still showed the model unchecked, and users couldn't see the model in the chat picker.

**Root cause:** the two admin pages wrote to two different, unlinked fields.

| Page | Wrote | Read by access checks? |
|---|---|---|
| Model detail | `allowedAppRoles` on the model record | **No** |
| Role detail | `grantedModels` on the role record | Yes |

The user-facing `GET /models` filter (`filter_accessible_models`) grants access purely from the role's resolved `permissions.models` — derived from `grantedModels`. It never read `allowedAppRoles`; the branch that looked like it should was a literal no-op. So the model page's role picker was inert, and the field it wrote never became a real grant.

A second, quieter bug: `can_access_model` gated on `allowed_app_roles` before checking role permissions, while `filter_accessible_models` didn't — so a model granted only via a role could be **listed** by one function and **denied** by the other (already worked around in `binding_validation.py`).

## Fix

Make the AppRole record the single source of truth, matching the pattern tools and skills already use (`set_roles_for_tool` + derived `allowed_app_roles`):

- **Write-through.** The model form's role picker now writes to each selected role's `grantedModels` via the new `ModelRoleService.set_roles_for_model`. Create/update/delete routes wire it up — migrating grants on a `modelId` rename, revoking them on delete.
- **Derived read.** `allowedAppRoles` is no longer persisted on the model; it's recomputed from the role records on read (`hydrate_model_roles`, one role query per catalog load). The model page and role page can no longer disagree. Adds `inheritedAppRoles` for wildcard/inherited grants.
- **One access rule.** `can_access_model` and `filter_accessible_models` both delegate to a single `_grants_access` predicate, so they can't drift again.
- Removes the dead `POST /sync-roles` endpoint (never called; only existed to paper over the drift); replaces it with `GET /managed-models/{id}/roles`.
- SPA: drops `Validators.required` on the picker (a model reachable only via a wildcard grant legitimately has zero direct grants), and shows wildcard/inherited roles as read-only dashed chips rather than unchecked boxes.

## Reviewer notes

- **Data:** grants made from the model page *before* this fix never took effect — they were written to the dead field. After deploy, re-apply any such pairings (either page now works and both show the same thing). The fix does not retroactively create them.
- Not exercised against a running app — it needs live DynamoDB roles/models tables. Verified via unit/route tests.

## Tests

- Backend: 4766 passed. Adds regression coverage for the write-through, the derived read (direct vs wildcard vs inherited), and the two access checks agreeing. The 8 remaining failures (`get_metadata_storage`) are pre-existing on `develop` and unrelated — being fixed separately.
- Frontend: 1454 passed; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)