### PR TITLE
fix(tests): repoint moved storage patch target, harden AWS integration gate

### DIFF
--- a/backend/src/agents/main_agent/session/tests/test_compaction_integration.py
+++ b/backend/src/agents/main_agent/session/tests/test_compaction_integration.py
@@ -20,10 +20,15 @@ Or run directly:
 import os
 import pytest
 
-# Skip all tests in this module unless AWS integration env vars are set
+# These hit real AWS services, so they must never run in the automated unit
+# suite. Gate them behind an explicit opt-in rather than AGENTCORE_MEMORY_ID:
+# that variable is present in any real environment (and a local backend/src/.env
+# leaks it into the process mid-suite via the apis.app_api.main reload's
+# load_dotenv(override=True)), which made these tests run order-dependently
+# instead of skipping. Set RUN_AGENTCORE_INTEGRATION_TESTS=1 to run them.
 pytestmark = pytest.mark.skipif(
-    not os.environ.get("AGENTCORE_MEMORY_ID"),
-    reason="Integration test requires AGENTCORE_MEMORY_ID environment variable"
+    os.environ.get("RUN_AGENTCORE_INTEGRATION_TESTS", "").lower() not in ("1", "true"),
+    reason="Integration test requires RUN_AGENTCORE_INTEGRATION_TESTS=1 and real AWS services"
 )
 import sys
 import uuid

--- a/backend/src/apis/app_api/sessions/tests/test_cache_savings.py
+++ b/backend/src/apis/app_api/sessions/tests/test_cache_savings.py
@@ -73,7 +73,7 @@ class TestCacheSavingsCalculation:
     async def test_cache_savings_calculation(self, mock_storage, sample_message_metadata):
         """Test that cache savings are calculated correctly"""
         with patch(
-            'apis.app_api.storage.get_metadata_storage',
+            'apis.shared.storage.get_metadata_storage',
             return_value=mock_storage
         ):
             from apis.app_api.sessions.services.metadata import _update_cost_summary_async
@@ -138,7 +138,7 @@ class TestCacheSavingsCalculation:
         )
 
         with patch(
-            'apis.app_api.storage.get_metadata_storage',
+            'apis.shared.storage.get_metadata_storage',
             return_value=mock_storage
         ):
             from apis.app_api.sessions.services.metadata import _update_cost_summary_async
@@ -180,7 +180,7 @@ class TestCacheSavingsCalculation:
         )
 
         with patch(
-            'apis.app_api.storage.get_metadata_storage',
+            'apis.shared.storage.get_metadata_storage',
             return_value=mock_storage
         ):
             from apis.app_api.sessions.services.metadata import _update_cost_summary_async
@@ -230,7 +230,7 @@ class TestCacheSavingsCalculation:
         )
 
         with patch(
-            'apis.app_api.storage.get_metadata_storage',
+            'apis.shared.storage.get_metadata_storage',
             return_value=mock_storage
         ):
             from apis.app_api.sessions.services.metadata import _update_cost_summary_async
@@ -287,7 +287,7 @@ class TestCacheSavingsCalculation:
         )
 
         with patch(
-            'apis.app_api.storage.get_metadata_storage',
+            'apis.shared.storage.get_metadata_storage',
             return_value=mock_storage
         ):
             from apis.app_api.sessions.services.metadata import _update_cost_summary_async


### PR DESCRIPTION
## Problem

8 backend tests failed on a clean `develop` checkout — the pre-existing failures called out in #651's reviewer notes as "being fixed separately." Two unrelated root causes:

### 1. `get_metadata_storage` moved modules (5 tests)

`get_metadata_storage` was relocated from `apis.app_api.storage` to `apis.shared.storage`; the old module is now an empty stub. Production code (`sessions/services/metadata.py`) already imports from the new location, but `test_cache_savings.py` still patched the old path:

```
AttributeError: <module 'apis.app_api.storage'> does not have the attribute 'get_metadata_storage'
```

### 2. Integration tests leaked into the unit suite (3 tests)

`test_compaction_integration.py` runs against **real AWS** and gated itself on `AGENTCORE_MEMORY_ID`. But that variable is injected into the process mid-suite: other tests reload `apis.app_api.main`, whose `load_dotenv(override=True)` pulls a local `backend/src/.env` (real memory id) permanently into `os.environ` — the same bleed `tests/conftest.py` already documents for `SKIP_AUTH`/`AWS_PROFILE`. So the `skipif` mis-evaluated depending on collection order: the tests **skipped in isolation but ran (and failed) in the full suite**. They never referenced `get_metadata_storage` — that part of the original report was a misattribution.

## Fix

- **Repoint the patch target** to `apis.shared.storage.get_metadata_storage` (all 5 sites in `test_cache_savings.py`).
- **Harden the integration gate**: require an explicit `RUN_AGENTCORE_INTEGRATION_TESTS=1` opt-in instead of piggybacking on an ambient config var, so these live-AWS tests can no longer be triggered accidentally by a local `.env`. They still run on demand with real AWS.

## Tests

`cd backend && uv run python -m pytest tests/ src/ -q` → **4771 passed, 6 skipped, 0 failed** (was 3 failed locally / would be 5 failed in a checkout carrying the storage rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)