### PR TITLE
fix: prevent + repair tool-use/tool-result history corruption from tab-switch duplicate invocations

### DIFF
--- a/backend/src/agents/main_agent/config/constants.py
+++ b/backend/src/agents/main_agent/config/constants.py
@@ -28,6 +28,12 @@ class EnvVars:
     COMPACTION_PROTECTED_TURNS = "AGENTCORE_MEMORY_COMPACTION_PROTECTED_TURNS"
     COMPACTION_MAX_TOOL_CONTENT_LENGTH = "AGENTCORE_MEMORY_COMPACTION_MAX_TOOL_CONTENT_LENGTH"
 
+    # --- Restored-history repair ---
+    # Kill switch for the restore-time tool-pairing/alternation repair
+    # (`TurnBasedSessionManager._repair_tool_pairing`). Default ON; set to
+    # "false" to disable. See the method docstring for the failure it guards.
+    HISTORY_REPAIR_ENABLED = "AGENTCORE_MEMORY_HISTORY_REPAIR_ENABLED"
+
     # --- DynamoDB Tables ---
     DYNAMODB_SESSIONS_METADATA_TABLE = "DYNAMODB_SESSIONS_METADATA_TABLE_NAME"
     DYNAMODB_QUOTA_TABLE = "DYNAMODB_QUOTA_TABLE"

--- a/backend/src/agents/main_agent/session/tests/test_history_repair.py
+++ b/backend/src/agents/main_agent/session/tests/test_history_repair.py
@@ -1,0 +1,240 @@
+"""Unit tests for restore-time tool-pairing / role-alternation repair.
+
+`TurnBasedSessionManager._repair_tool_pairing` is the safety net that keeps a
+structurally-corrupt persisted history from bricking a session with a Bedrock
+Converse ValidationException ("The number of toolResult blocks at messages.N
+exceeds the number of toolUse blocks of previous turn.").
+
+The corruption shapes exercised here are the ones observed in a real bricked
+production session (parallel tool calls interrupted by a user Stop):
+duplicate tool-result turns, tool-result turns reordered away from their
+tool-use turn (assistant/assistant/user/user), tool-results orphaned after a
+synthetic error turn, and consecutive synthetic error turns.
+"""
+
+from agents.main_agent.config.constants import EnvVars
+from agents.main_agent.session.turn_based_session_manager import (
+    TurnBasedSessionManager as T,
+)
+
+
+class _FakeConfig:
+    session_id = "test-session"
+
+
+class _FakeManager(T):
+    """TurnBasedSessionManager without the heavy AgentCore parent init."""
+
+    def __init__(self):
+        self.config = _FakeConfig()
+
+
+class _FakeAgent:
+    def __init__(self, messages):
+        self.messages = messages
+
+
+def _use(*ids):
+    return {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": t, "name": "search", "input": {}}} for t in ids],
+    }
+
+
+def _res(*ids):
+    return {
+        "role": "user",
+        "content": [{"toolResult": {"toolUseId": t, "content": [{"text": "ok"}]}} for t in ids],
+    }
+
+
+def _txt(role, text="hi"):
+    return {"role": role, "content": [{"text": text}]}
+
+
+def _is_valid(messages):
+    """Assert the message list satisfies Bedrock's structural constraints:
+    strict role alternation, and every toolResult turn matches the toolUseIds
+    of the immediately-preceding turn exactly.
+    """
+    for i, msg in enumerate(messages):
+        if i > 0 and messages[i - 1]["role"] == msg["role"]:
+            return False, f"consecutive role at {i}"
+        has_use, has_result = T._block_keys(msg)
+        if has_result:
+            prev_use = T._tool_use_ids(messages[i - 1]) if i > 0 else []
+            if set(T._tool_result_ids(msg)) != set(prev_use):
+                return False, f"pairing mismatch at {i}"
+    return True, "valid"
+
+
+class TestHealthyHistory:
+    def test_clean_history_is_noop_identity(self):
+        msgs = [_txt("user"), _use("a"), _res("a"), _txt("assistant")]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed == 0
+        assert repaired is msgs  # identity: no rebuild for healthy history
+
+    def test_clean_parallel_tools_is_noop(self):
+        msgs = [_txt("user"), _use("a", "b", "c"), _res("a", "b", "c"), _txt("assistant")]
+        _, fixed = T._repair_tool_pairing(msgs)
+        assert fixed == 0
+
+
+class TestDuplicateToolResults:
+    def test_duplicate_consecutive_result_turn_deduped(self):
+        # assistant USE x3, then the SAME results persisted twice.
+        msgs = [
+            _txt("user"),
+            _use("a", "b", "c"),
+            _res("a", "b", "c"),
+            _res("a", "b", "c"),  # duplicate
+            _txt("user", "next question"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+        # exactly one result turn survives
+        result_turns = [m for m in repaired if T._block_keys(m)[1]]
+        assert len(result_turns) == 1
+
+
+class TestReorderedParallelTools:
+    def test_assistant_assistant_user_user_reordered(self):
+        # Two tool-use turns back to back, then both result turns back to back.
+        msgs = [
+            _txt("user"),
+            _use("a", "b", "c"),
+            _use("d", "e"),
+            _res("a", "b", "c"),
+            _res("d", "e"),
+            _txt("assistant", "done"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+
+
+class TestOrphanedToolResults:
+    def test_orphan_result_after_assistant_text_dropped(self):
+        # A result turn re-injected after an assistant TEXT turn (no toolUse).
+        msgs = [
+            _txt("user"),
+            _use("a", "b"),
+            _res("a", "b"),
+            _txt("assistant", "here is the answer"),
+            _res("a", "b"),  # orphan: previous turn has no toolUse
+            _txt("user", "thanks"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+
+
+class TestConsecutiveTextTurns:
+    def test_consecutive_synthetic_assistant_errors_merged(self):
+        msgs = [
+            _txt("user"),
+            _txt("assistant", "⚠️ Something went wrong"),
+            _txt("assistant", "⚠️ Something went wrong"),
+            _txt("assistant", "final answer"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+        assert sum(1 for m in repaired if m["role"] == "assistant") == 1
+
+    def test_text_turn_merges_into_following_tooluse_turn(self):
+        # assistant text immediately followed by assistant tool-use.
+        msgs = [
+            _txt("user"),
+            _txt("assistant", "let me look that up"),
+            _use("a", "b"),
+            _res("a", "b"),
+            _txt("assistant", "done"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+        # merged assistant turn keeps toolUse at the tail so its result follows
+        merged = repaired[1]
+        assert merged["role"] == "assistant"
+        assert "text" in merged["content"][0]
+        assert "toolUse" in merged["content"][-1]
+
+
+class TestMissingResults:
+    def test_interrupted_tooluse_gets_synthesized_error_result(self):
+        # Mid-list tool-use whose results were never persisted.
+        msgs = [
+            _txt("user"),
+            _use("a", "b"),  # no result turn follows
+            _txt("assistant", "moving on"),
+            _txt("user", "ok"),
+        ]
+        repaired, fixed = T._repair_tool_pairing(msgs)
+        assert fixed > 0
+        ok, why = _is_valid(repaired)
+        assert ok, why
+        # a synthesized error result exists for both ids
+        results = [b for m in repaired for b in m["content"] if "toolResult" in b]
+        assert {r["toolResult"]["toolUseId"] for r in results} == {"a", "b"}
+        assert all(r["toolResult"].get("status") == "error" for r in results)
+
+    def test_trailing_tooluse_left_untouched(self):
+        # A tool-use turn as the LAST message is left for prompt-arrival
+        # handling (matching the SDK's own repair), not force-answered here.
+        msgs = [_txt("user"), _use("a")]
+        repaired, _ = T._repair_tool_pairing(msgs)
+        assert repaired[-1]["content"][-1].get("toolUse", {}).get("toolUseId") == "a"
+
+
+class TestIdempotency:
+    def test_repair_is_idempotent(self):
+        msgs = [
+            _txt("user"),
+            _use("a", "b", "c"),
+            _res("a", "b", "c"),
+            _res("a", "b", "c"),
+            _use("d", "e"),
+            _use("f"),
+            _res("d", "e"),
+            _res("f"),
+            _txt("assistant", "x"),
+            _txt("assistant", "y"),
+        ]
+        once, n1 = T._repair_tool_pairing(msgs)
+        assert n1 > 0 and _is_valid(once)[0]
+        twice, n2 = T._repair_tool_pairing(once)
+        assert n2 == 0
+        assert _is_valid(twice)[0]
+
+
+class TestRepairWrapper:
+    """Covers `_repair_restored_history`, the method wired into initialize()."""
+
+    def test_wrapper_mutates_agent_messages(self, monkeypatch):
+        monkeypatch.delenv(EnvVars.HISTORY_REPAIR_ENABLED, raising=False)
+        agent = _FakeAgent([_txt("user"), _use("a"), _res("a"), _res("a")])
+        _FakeManager()._repair_restored_history(agent)
+        ok, why = _is_valid(agent.messages)
+        assert ok, why
+
+    def test_kill_switch_disables_repair(self, monkeypatch):
+        monkeypatch.setenv(EnvVars.HISTORY_REPAIR_ENABLED, "false")
+        corrupt = [_txt("user"), _use("a"), _res("a"), _res("a")]
+        agent = _FakeAgent(corrupt)
+        _FakeManager()._repair_restored_history(agent)
+        assert agent.messages is corrupt  # untouched
+
+    def test_wrapper_noop_on_healthy_history(self, monkeypatch):
+        monkeypatch.delenv(EnvVars.HISTORY_REPAIR_ENABLED, raising=False)
+        healthy = [_txt("user"), _use("a"), _res("a"), _txt("assistant")]
+        agent = _FakeAgent(healthy)
+        _FakeManager()._repair_restored_history(agent)
+        assert agent.messages is healthy  # identity preserved, no rebuild

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -214,6 +214,7 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
             logger.warning(f"Document byte stripping failed, continuing: {e}", exc_info=True)
 
         if not self.compaction_config or not self.compaction_config.enabled:
+            self._repair_restored_history(agent)
             return
 
         try:
@@ -223,6 +224,14 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
             self.compaction_state = CompactionState()
             self._valid_cutoff_indices = []
             self._all_messages_for_summary = []
+
+        # Repair tool-use/tool-result pairing and role alternation on the FINAL
+        # restored list — after compaction slicing/truncation — so it is always
+        # the exact history sent to Bedrock. Runs unconditionally (independent of
+        # compaction), mirroring `_strip_document_bytes`, because the corruption
+        # it fixes originates on the write side and can exist regardless of
+        # whether compaction is enabled.
+        self._repair_restored_history(agent)
 
     # =========================================================================
     # Compaction — applied after SDK session restore
@@ -783,6 +792,192 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
             logger.debug(f"Stripped inline bytes from {strip_count} document block(s) in history")
 
         return stripped_messages
+
+    # =========================================================================
+    # Tool-pairing / role-alternation repair (restore-time safety net)
+    # =========================================================================
+
+    def _repair_restored_history(self, agent: "Agent") -> None:
+        """Repair tool-use/tool-result pairing on the restored history in place.
+
+        Bedrock Converse rejects any request whose history violates its
+        structural rules — most relevantly:
+        "The number of toolResult blocks at messages.N.content exceeds the
+        number of toolUse blocks of previous turn." A single such violation
+        anywhere in stored history makes EVERY subsequent turn on that session
+        fail, permanently bricking the conversation.
+
+        The corruption originates on the write side: a turn with parallel tool
+        calls in flight that is interrupted (user Stop / dropped connection) or
+        retried can persist duplicated tool-result messages, tool-result
+        messages reordered away from their tool-use turn (assistant, assistant,
+        user, user), or tool-result messages orphaned after a synthetic error
+        turn. The Strands SDK's own ``_fix_broken_tool_use`` only rebuilds the
+        single message immediately after each tool-use turn, so it does not
+        repair duplicates, reordering, or orphans — and it may not run at all on
+        the AgentCore Memory restore path. This is the unconditional safety net.
+
+        Runs on the FINAL ``agent.messages`` (after compaction), mirroring
+        ``_strip_document_bytes``. Best-effort: any failure logs and leaves the
+        history untouched rather than breaking the turn. Kill switch:
+        ``AGENTCORE_MEMORY_HISTORY_REPAIR_ENABLED=false``.
+        """
+        if os.environ.get(EnvVars.HISTORY_REPAIR_ENABLED, "").strip().lower() == "false":
+            return
+        try:
+            messages = agent.messages
+            if not messages:
+                return
+            repaired, fixed = self._repair_tool_pairing(messages)
+            if fixed > 0:
+                logger.warning(
+                    "Restore repair: fixed %d tool-pairing/alternation "
+                    "violation(s) in restored history (%d -> %d messages) "
+                    "for session %s",
+                    fixed, len(messages), len(repaired), self.config.session_id,
+                )
+                agent.messages = repaired
+        except Exception as e:
+            logger.error(f"Restore history repair failed, using history as-is: {e}", exc_info=True)
+
+    @staticmethod
+    def _block_keys(message: Dict) -> tuple:
+        """(has_tool_use, has_tool_result) for a message's content blocks."""
+        has_use = has_result = False
+        for block in message.get("content", []) or []:
+            if isinstance(block, dict):
+                if "toolUse" in block:
+                    has_use = True
+                elif "toolResult" in block:
+                    has_result = True
+        return has_use, has_result
+
+    @staticmethod
+    def _tool_use_ids(message: Dict) -> List[str]:
+        return [
+            b["toolUse"]["toolUseId"]
+            for b in message.get("content", []) or []
+            if isinstance(b, dict) and "toolUse" in b and "toolUseId" in b["toolUse"]
+        ]
+
+    @staticmethod
+    def _tool_result_ids(message: Dict) -> List[str]:
+        return [
+            b["toolResult"]["toolUseId"]
+            for b in message.get("content", []) or []
+            if isinstance(b, dict) and "toolResult" in b and "toolUseId" in b["toolResult"]
+        ]
+
+    @classmethod
+    def _count_pairing_violations(cls, messages: List[Dict]) -> int:
+        """Count Bedrock structural violations: consecutive same-role turns,
+        orphaned/mismatched toolResults, and tool-use turns not answered by the
+        next turn. Zero means the history is already valid — repair can no-op.
+        """
+        violations = 0
+        for i, msg in enumerate(messages):
+            role = msg.get("role")
+            prev = messages[i - 1] if i > 0 else None
+            if prev is not None and prev.get("role") == role:
+                violations += 1
+            has_use, has_result = cls._block_keys(msg)
+            if has_result:
+                prev_use = cls._tool_use_ids(prev) if prev is not None else []
+                if not prev_use or set(cls._tool_result_ids(msg)) != set(prev_use):
+                    violations += 1
+            if has_use and i + 1 < len(messages):
+                if set(cls._tool_use_ids(msg)) != set(cls._tool_result_ids(messages[i + 1])):
+                    violations += 1
+        return violations
+
+    @classmethod
+    def _repair_tool_pairing(cls, messages: List[Dict]) -> tuple:
+        """Return ``(repaired_messages, violations_fixed)``.
+
+        Rebuilds a Bedrock-valid history: every assistant tool-use turn is
+        immediately followed by exactly one user turn carrying one toolResult
+        per toolUseId (missing ones synthesized as errors), duplicate/orphaned
+        toolResult turns are dropped, and consecutive same-role turns are
+        merged. When the history is already valid the input list is returned
+        unchanged (identity) with a count of 0, so healthy sessions pay only a
+        scan.
+        """
+        violations = cls._count_pairing_violations(messages)
+        if violations == 0:
+            return messages, 0
+
+        # Global toolUseId -> toolResult block (last occurrence wins: the most
+        # recent result for an id is the authoritative one).
+        result_by_id: Dict[str, Dict] = {}
+        for msg in messages:
+            for block in msg.get("content", []) or []:
+                if isinstance(block, dict) and "toolResult" in block:
+                    tid = block["toolResult"].get("toolUseId")
+                    if tid:
+                        result_by_id[tid] = block
+
+        def missing_result(tid: str) -> Dict:
+            return {
+                "toolResult": {
+                    "toolUseId": tid,
+                    "content": [{"text": "[tool result unavailable: the turn was interrupted]"}],
+                    "status": "error",
+                }
+            }
+
+        # Forward pass: emit each assistant tool-use turn followed by a freshly
+        # built result turn; drop standalone toolResult-only turns (their blocks
+        # are re-emitted from the map at the correct slot).
+        rebuilt: List[Dict] = []
+        last_index = len(messages) - 1
+        for i, msg in enumerate(messages):
+            has_use, has_result = cls._block_keys(msg)
+
+            if has_result and not has_use:
+                # Standalone tool-result turn: keep only non-toolResult content
+                # (rare mixed text), drop the results themselves.
+                residual = [b for b in msg.get("content", []) if not (isinstance(b, dict) and "toolResult" in b)]
+                if residual:
+                    rebuilt.append({"role": msg.get("role", "user"), "content": residual})
+                continue
+
+            if has_use and i < last_index:
+                rebuilt.append(msg)
+                use_ids = cls._tool_use_ids(msg)
+                rebuilt.append({
+                    "role": "user",
+                    "content": [result_by_id.get(t, missing_result(t)) for t in use_ids],
+                })
+                continue
+
+            # Trailing tool-use turn (last message) or any non-tool turn: emit
+            # as-is. The trailing case is deliberately left for prompt-arrival
+            # handling, matching the SDK's own repair.
+            rebuilt.append(msg)
+
+        # Merge consecutive same-role turns. Guard only on the PREVIOUS turn
+        # having no toolUse: a tool-use turn must stay immediately adjacent to
+        # its result turn, so it can never absorb a following turn — but a
+        # text turn may legitimately merge into a following tool-use turn
+        # (assistant text + toolUse in one turn is valid), keeping the toolUse
+        # at the tail so its result turn still follows. In a merged user turn,
+        # toolResult blocks come first.
+        merged: List[Dict] = []
+        for msg in rebuilt:
+            prev = merged[-1] if merged else None
+            if (
+                prev is not None
+                and prev.get("role") == msg.get("role")
+                and not cls._block_keys(prev)[0]  # prev has no toolUse
+            ):
+                combined = list(prev.get("content", [])) + list(msg.get("content", []))
+                if msg.get("role") == "user":
+                    combined = sorted(combined, key=lambda b: 0 if isinstance(b, dict) and "toolResult" in b else 1)
+                prev["content"] = combined
+            else:
+                merged.append({"role": msg.get("role"), "content": list(msg.get("content", []))})
+
+        return merged, violations
 
     def _truncate_tool_contents(
         self,

--- a/backend/tests/agents/main_agent/session/test_turn_based_session_manager.py
+++ b/backend/tests/agents/main_agent/session/test_turn_based_session_manager.py
@@ -593,10 +593,14 @@ class TestInitialize:
         mgr = make_session_manager(compaction_config=compaction_config)
         mgr._load_compaction_state = MagicMock(return_value=CompactionState())
 
+        # A valid Converse history: the truncatable toolResult is preceded by
+        # its matching toolUse turn, so the restore-time pairing repair no-ops
+        # and this test exercises compaction/truncation in isolation.
         messages = [
             make_user_message("q1"),
             make_assistant_message("a1"),
             make_user_message("q2"),
+            make_tool_use_message("t1", "search", {"q": "x"}),
             make_tool_result_message("t1", "x" * 200),  # will be truncated
         ]
         session_agent = self._make_mock_session_agent()
@@ -607,9 +611,10 @@ class TestInitialize:
         agent = self._make_mock_agent()
         mgr.initialize(agent)
 
-        # All 4 messages kept (checkpoint=0), but truncation applied
-        assert len(agent.messages) == 4
-        # Valid cutoffs cached for user text messages (indices 0, 2)
+        # All 5 messages kept (checkpoint=0), but truncation applied
+        assert len(agent.messages) == 5
+        # Valid cutoffs cached for user text messages (indices 0, 2); the
+        # toolResult user turn at index 4 is not a valid cutoff.
         assert mgr._valid_cutoff_indices == [0, 2]
 
     def test_existing_agent_compaction_with_checkpoint_slices_messages(self, make_session_manager, compaction_config):
@@ -642,10 +647,14 @@ class TestInitialize:
             return_value=CompactionState(checkpoint=2)
         )
 
+        # Valid Converse history: the truncatable toolResult follows its
+        # matching toolUse turn, so the pairing repair no-ops and the slice
+        # boundary lands on a clean turn.
         messages = [
             make_user_message("old1"),
             make_assistant_message("old2"),
             make_user_message("new1"),
+            make_tool_use_message("t1", "search", {"q": "r"}),
             make_tool_result_message("t1", "r" * 200),  # truncatable
         ]
         session_agent = self._make_mock_session_agent()
@@ -656,8 +665,8 @@ class TestInitialize:
         agent = self._make_mock_agent()
         mgr.initialize(agent)
 
-        # Sliced from index 2: 2 messages remain
-        assert len(agent.messages) == 2
+        # Sliced from index 2: [new1, toolUse, toolResult] = 3 messages remain
+        assert len(agent.messages) == 3
 
     def test_duplicate_agent_id_raises(self, make_session_manager):
         """Second initialize with same agent_id should raise SessionException."""

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
@@ -261,6 +261,11 @@ export class PreviewChatService {
         },
         body: JSON.stringify(requestBody),
         signal: this.abortController.signal,
+        // Keep the stream alive when the tab is backgrounded. The library
+        // default aborts + reopens the POST on `visibilitychange`, which would
+        // re-issue the same turn on tab return. See the detailed note in
+        // chat-http.service.ts.
+        openWhenHidden: true,
         onmessage: (msg: EventSourceMessage) => {
           this.handleStreamEvent(msg, callbacks);
         },

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -125,6 +125,23 @@ export class ChatHttpService {
         },
         body: JSON.stringify(requestObject),
         signal: abortController.signal,
+        // Keep the stream open when the tab is backgrounded. With the library
+        // default (`openWhenHidden: false`) fetch-event-source aborts the
+        // connection on `visibilitychange` to hidden and REOPENS it — issuing
+        // a brand-new `POST /invocations` for the SAME turn — when the tab
+        // becomes visible again. That reopen happens inside the library, reusing
+        // this request and bypassing our per-session double-submit + streamId
+        // supersession guards, so nothing here catches it. Because a client
+        // abort does NOT propagate through the AgentCore Runtime data plane, the
+        // original backend agent keeps running; the reopened one runs the same
+        // turn concurrently, and both persist tool-use/tool-result events to the
+        // same AgentCore Memory session — corrupting history (duplicate /
+        // interleaved toolResult turns) and bricking the conversation with a
+        // Bedrock "toolResult blocks exceed toolUse blocks" ValidationException.
+        // Keeping the single stream alive across tab switches is also correct for
+        // long agentic turns. See the restore-time repair in
+        // TurnBasedSessionManager for the server-side safety net.
+        openWhenHidden: true,
         async onopen(response) {
           if (response.ok && response.headers.get('content-type')?.includes('text/event-stream')) {
             return; // everything's good


### PR DESCRIPTION
## Incident

Prod session `f761f59b` bricked with a Bedrock Converse error on **every** turn:

> `ValidationException … The number of toolResult blocks at messages.N.content exceeds the number of toolUse blocks of previous turn.`

Diagnosed against live prod data (AgentCore Memory events + runtime logs).

## Root cause

**Switching browser tabs mid-stream** — not the Stop button. `@microsoft/fetch-event-source` defaults to `openWhenHidden: false`, so on `visibilitychange` it aborts the SSE connection and, when the tab becomes visible again, **reopens it as a fresh `POST /invocations` for the same turn**. That reopen happens inside the library, reusing the request and bypassing the SPA's per-session double-submit + `streamId` supersession guards.

Because a client abort does **not** propagate through the AgentCore Runtime data plane, the original backend agent keeps running while the reopened one runs the same turn concurrently. Both persist tool-use/tool-result events to the same AgentCore Memory session → **duplicate + interleaved `toolResult` turns** (assistant/assistant/user/user, duplicate result batches, orphaned results). Runtime logs confirm **two `/invocations` ~1s apart**.

`user_stopped` in the logs is a red herring — it fires only from the Stop button, never from a tab switch.

Once corrupt, the SDK's own `_fix_broken_tool_use` can't recover it (it only rebuilds the single message after each tool-use turn), and each retry persists a synthetic error turn that deepens the corruption.

## Fix (two parts)

**1. Source — `fix(chat)`:** set `openWhenHidden: true` on both `fetchEventSource` call sites (`chat-http.service.ts`, `preview-chat.service.ts`) so a single stream stays alive across tab switches. Also correct for long agentic turns.

**2. Safety net — `fix(sessions)`:** `TurnBasedSessionManager._repair_tool_pairing`, an unconditional restore-time normalizer (sibling to `_strip_document_bytes`) that rebuilds a Bedrock-valid history on the final `agent.messages`: exact tool pairing (missing results synthesized as errors), duplicate/orphaned result turns dropped, consecutive same-role turns merged. No-op (identity) on healthy history. Kill switch: `AGENTCORE_MEMORY_HISTORY_REPAIR_ENABLED=false`. **Self-heals the bricked session on its next turn** — no prod-data surgery needed.

## Validation

- Repair run against the **real corrupt prod history**: 24 violations → 0, idempotent, strict alternation, all pairs matched.
- New `test_history_repair.py` (13 tests) reproducing each corruption shape; backend session suite 35 passed / 3 skipped; import-boundary tests green.
- Frontend: `tsc` clean; `chat-http.service.spec` 7/7 via `ng test`.

## Follow-ups (not in this PR)

- **Backend single-flight/idempotency per session** — since a client abort can't reach the runtime, dedupe/reject a second concurrent `/invocations` server-side (closes the general double-submit race, not just the tab-switch vector).
- Stop the retry cascade from persisting alternation-breaking synthetic error turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)