### PR TITLE
fix(sessions): guard synthetic error persistence against role-alternation breaks

### DIFF
--- a/backend/src/agents/main_agent/session/persistence.py
+++ b/backend/src/agents/main_agent/session/persistence.py
@@ -21,10 +21,17 @@ inside the agent stream; user+assistant for paths that short-circuit
 before the agent runs). Call sites in ``stream_coordinator`` and
 ``chat/routes.py`` repeat the high-level reasoning inline; if you need to
 revisit the invariant, start here.
+
+ROLE-ALTERNATION GUARD (also canonical here):
+Passing ``last_persisted_role`` makes this helper drop any synthetic turn
+that would create two consecutive same-role messages — the corruption that
+bricks a session under Bedrock's strict alternation rule. Centralizing it
+here protects every caller that writes an assistant turn after an error,
+consistent with this module being the single source of truth.
 """
 
 import logging
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from strands.types.content import Message
 from strands.types.session import SessionMessage
@@ -40,6 +47,7 @@ def persist_synthetic_messages(
     messages: List[Tuple[str, str]],
     *,
     agent_id: str = "default",
+    last_persisted_role: Optional[str] = None,
 ) -> bool:
     """Write one or more synthetic ``(role, text)`` messages to a session.
 
@@ -58,17 +66,69 @@ def persist_synthetic_messages(
             user turn has not been written yet.
         agent_id: AgentCore Memory agent_id. Defaults to ``"default"`` to
             match read paths in ``apis.shared.sessions.messages``.
+        last_persisted_role: Role of the message already at the tail of the
+            session (``"user"`` / ``"assistant"``), typically
+            ``agent.messages[-1]["role"]``. When provided, this helper drops
+            any synthetic turn that would land adjacent to a same-role turn,
+            preserving Bedrock's strict user/assistant alternation — see the
+            ROLE-ALTERNATION GUARD below. Pass ``None`` (the default) to
+            persist verbatim, e.g. the quota-exceeded path that writes a
+            fresh ``user`` + ``assistant`` pair onto an empty session.
 
     Returns:
-        ``True`` if all messages were written. ``False`` (with an ERROR
-        log) if the session manager has no ``create_message`` method —
-        the failure mode that previously went silent.
+        ``True`` if every message that survived alternation filtering was
+        written (including the case where the guard dropped all of them —
+        that is a successful no-op, not a failure). ``False`` (with an ERROR
+        log) if the session manager has no ``create_message`` method — the
+        failure mode that previously went silent.
 
     Raises:
         Whatever ``create_message`` raises is propagated. Callers wrap
         with their own try/except so the failure appears in logs at
         the call site rather than being swallowed here.
     """
+    # ROLE-ALTERNATION GUARD (single source of truth for all callers).
+    #
+    # Bedrock Converse requires strict user/assistant alternation. TWO
+    # consecutive same-role turns ANYWHERE in stored history make EVERY
+    # subsequent turn on that session fail with a ValidationException,
+    # permanently bricking the conversation. The classic amplifier: a turn
+    # ends with a dangling assistant toolUse (or a prior synthetic error
+    # turn), an error fires, and the error handler appends ANOTHER assistant
+    # turn — assistant, assistant — which then fails the next turn, which
+    # persists yet another assistant error, and so on.
+    #
+    # When the caller knows the tail role (``last_persisted_role``), skip any
+    # synthetic turn that would sit next to a same-role turn. In practice
+    # this is the "error persisted after a dangling assistant turn" case: the
+    # synthetic assistant message is dropped and the error stays a live-only
+    # UI affordance for that turn — the same deliberate choice the max_tokens
+    # path already makes (see ``stream_coordinator``). Only the FIRST tuple can
+    # collide with the tail; the tuples within ``messages`` already alternate,
+    # so we thread ``prev_role`` through the loop to stay correct for any
+    # multi-message batch.
+    if last_persisted_role is not None:
+        filtered: List[Tuple[str, str]] = []
+        prev_role = last_persisted_role
+        for role, text in messages:
+            if role == prev_role:
+                logger.warning(
+                    f"Skipping synthetic {role} message for session "
+                    f"{scrub_log(session_id)} to preserve role alternation "
+                    f"(tail role is already {role})"
+                )
+                continue
+            filtered.append((role, text))
+            prev_role = role
+        messages = filtered
+
+    if not messages:
+        logger.info(
+            f"No synthetic messages to persist to session {scrub_log(session_id)} "
+            f"after role-alternation filtering"
+        )
+        return True
+
     target_manager = next(
         (
             m

--- a/backend/src/agents/main_agent/session/tests/test_persistence.py
+++ b/backend/src/agents/main_agent/session/tests/test_persistence.py
@@ -130,3 +130,101 @@ def test_create_message_exception_propagates():
     sm = _RaisingSessionManager()
     with pytest.raises(RuntimeError, match="rejected the write"):
         persist_synthetic_messages(sm, "sess-x", [("assistant", "boom")])
+
+
+# ---------------------------------------------------------------------------
+# Role-alternation guard (last_persisted_role).
+#
+# Bedrock Converse requires strict user/assistant alternation. TWO consecutive
+# same-role turns anywhere in stored history permanently brick the session.
+# The synthetic-error paths append an assistant turn after a failure; if the
+# session tail is ALREADY an assistant turn (a dangling toolUse or a prior
+# synthetic error), that append is the corruption. The guard drops it.
+# ---------------------------------------------------------------------------
+
+
+def test_skips_assistant_write_when_tail_is_assistant():
+    """The core fix: error persisted after a dangling assistant turn must NOT
+    create a second consecutive assistant message — it is dropped entirely."""
+    sm = _RecordingSessionManager()
+
+    ok = persist_synthetic_messages(
+        sm,
+        "sess-brick",
+        [("assistant", "⚠️ Something went wrong")],
+        last_persisted_role="assistant",
+    )
+
+    # No write happened, but it's a successful no-op (True), not a failure.
+    assert ok is True
+    assert sm.calls == []
+
+
+def test_persists_assistant_write_when_tail_is_user():
+    """The common, healthy case: the user turn is the tail (persisted by the
+    hook at turn start), so appending the assistant error is valid."""
+    sm = _RecordingSessionManager()
+
+    ok = persist_synthetic_messages(
+        sm,
+        "sess-ok",
+        [("assistant", "the error explanation")],
+        last_persisted_role="user",
+    )
+
+    assert ok is True
+    assert len(sm.calls) == 1
+    assert _extract(sm.calls[0]["message"]) == {"role": "assistant", "text": "the error explanation"}
+
+
+def test_none_last_role_preserves_verbatim_behavior():
+    """``last_persisted_role=None`` (the default) means "caller doesn't know the
+    tail" → persist verbatim, matching pre-guard behavior. This is the
+    quota-exceeded path that writes a fresh user+assistant pair."""
+    sm = _RecordingSessionManager()
+
+    ok = persist_synthetic_messages(
+        sm,
+        "sess-quota",
+        [("user", "hi"), ("assistant", "quota exceeded")],
+    )
+
+    assert ok is True
+    assert len(sm.calls) == 2
+
+
+def test_guard_drops_leading_user_but_keeps_alternating_tail():
+    """The guard tracks the running role through a multi-message batch: a
+    leading ``user`` that collides with a ``user`` tail is dropped, and the
+    following ``assistant`` (now valid after the user tail) is kept."""
+    sm = _RecordingSessionManager()
+
+    ok = persist_synthetic_messages(
+        sm,
+        "sess-multi",
+        [("user", "dup user"), ("assistant", "answer")],
+        last_persisted_role="user",
+    )
+
+    assert ok is True
+    assert len(sm.calls) == 1
+    assert _extract(sm.calls[0]["message"]) == {"role": "assistant", "text": "answer"}
+
+
+def test_guard_logs_when_skipping(caplog):
+    """A dropped synthetic turn is logged loudly so the skip is observable in
+    incident forensics, not silent."""
+    sm = _RecordingSessionManager()
+
+    with caplog.at_level("WARNING"):
+        persist_synthetic_messages(
+            sm,
+            "sess-log",
+            [("assistant", "dropped")],
+            last_persisted_role="assistant",
+        )
+
+    assert any(
+        "preserve role alternation" in rec.message and "sess-log" in rec.message
+        for rec in caplog.records
+    ), f"expected a skip warning, got: {[r.message for r in caplog.records]}"

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -669,6 +669,16 @@ class StreamCoordinator:
                         # content_block_delta below yields to the SSE
                         # stream. Persisting it keeps live and
                         # refresh-hydrated views in sync.
+                        #
+                        # Alternation guard: if the turn already ended with a
+                        # dangling assistant turn (an in-flight toolUse, or a
+                        # prior synthetic error), appending another assistant
+                        # message would create two consecutive assistant turns
+                        # and brick the session under Bedrock's strict
+                        # alternation rule. Passing the tail role makes
+                        # persist_synthetic_messages drop the write in that case
+                        # (the error stays a live-only UI affordance for this
+                        # turn, mirroring the max_tokens path above).
                         try:
                             from agents.main_agent.session.persistence import persist_synthetic_messages
                             from agents.main_agent.session.session_factory import SessionFactory
@@ -678,6 +688,7 @@ class StreamCoordinator:
                                 persist_session_manager,
                                 session_id,
                                 [("assistant", conv_error_event.message)],
+                                last_persisted_role=self._last_persisted_role(agent),
                             )
                         except Exception as persist_error:
                             logger.error(f"Failed to persist intercepted error to session: {persist_error}", exc_info=True)
@@ -983,7 +994,10 @@ class StreamCoordinator:
 
             # Persist ONLY the assistant turn. Same reasoning as the
             # AGENT_ERROR path above — the user turn was already persisted
-            # at turn start by Strands' MessageAddedEvent hook.
+            # at turn start by Strands' MessageAddedEvent hook. The same
+            # alternation guard applies: skip the write if the tail is
+            # already an assistant turn so we never append a second
+            # consecutive assistant message.
             try:
                 from agents.main_agent.session.persistence import persist_synthetic_messages
                 from agents.main_agent.session.session_factory import SessionFactory
@@ -993,6 +1007,7 @@ class StreamCoordinator:
                     persist_session_manager,
                     session_id,
                     [("assistant", error_event.message)],
+                    last_persisted_role=self._last_persisted_role(agent),
                 )
             except Exception as persist_error:
                 logger.error(f"Failed to persist stream error to session: {persist_error}")
@@ -1013,6 +1028,29 @@ class StreamCoordinator:
                     logger.warning(
                         "MCP Apps broker unsubscribe failed", exc_info=True
                     )
+
+    @staticmethod
+    def _last_persisted_role(agent: Any) -> Optional[str]:
+        """Role of the message at the tail of ``agent.messages``, or ``None``.
+
+        Strands' ``MessageAddedEvent``/``append_message`` hook persists each
+        completed message to AgentCore Memory as it lands, so the live
+        ``agent.messages`` list mirrors the persisted session tail. The
+        synthetic-error persistence paths pass this to
+        ``persist_synthetic_messages`` so it can drop a write that would create
+        two consecutive same-role turns (the corruption that bricks a session
+        under Bedrock's strict alternation rule). Reads the in-memory list
+        rather than round-tripping AgentCore Memory — the same 80-250ms query
+        the coordinator deliberately avoids elsewhere. Best-effort: any failure
+        returns ``None`` so the caller persists verbatim (prior behavior).
+        """
+        try:
+            messages = getattr(agent, "messages", None) or []
+            if messages:
+                return messages[-1].get("role")
+        except Exception:  # noqa: BLE001 - guard is best-effort
+            logger.debug("Could not read agent.messages tail for alternation guard", exc_info=True)
+        return None
 
     async def _persist_interruption(
         self,
@@ -1044,13 +1082,19 @@ class StreamCoordinator:
         reasoning as the error paths; canonical reference in
         ``session/persistence.py``).
 
-        Role-alternation repair: when the interruption lands before any token
-        of the in-flight message streamed (empty partial), a minimal
-        placeholder assistant turn is persisted ONLY if the last committed
-        message is a user turn — that is the dangling user→user case the
-        placeholder exists to fix. On continuation/resume turns (history tail
-        is an assistant message) or a pre-turn cancellation nothing needs
-        repair, so no synthetic write happens and only the marker is set.
+        Role-alternation repair: a synthetic assistant turn is persisted only
+        when it keeps user/assistant alternation valid — i.e. the last
+        committed message is NOT itself an assistant turn. This covers two
+        cases at once:
+          * empty partial + dangling user tail → persist a minimal placeholder
+            so the orphan user turn is answered (the user→user repair);
+          * non-empty partial + assistant tail (an interrupted continuation/
+            resume, where the tail is the message being extended) → SKIP, so we
+            don't append a second consecutive assistant turn and brick the
+            session. The partial stays a live-only affordance for that turn.
+        Whenever nothing is persisted, only the marker is set. The write itself
+        also passes ``last_persisted_role`` to ``persist_synthetic_messages`` so
+        the centralized alternation guard is the single enforcement point.
         """
         async def _do() -> None:
             text = partial_text.strip()
@@ -1063,7 +1107,13 @@ class StreamCoordinator:
                 logger.debug("Could not read agent.messages tail", exc_info=True)
 
             message = text if text else "[Response interrupted before any content was generated]"
-            should_persist = bool(text) or last_role == "user"
+            # Persist the synthetic assistant turn only when it preserves
+            # alternation: never when the tail is already an assistant turn
+            # (an interrupted continuation/resume — appending here would create
+            # consecutive assistant turns and brick the session). Otherwise a
+            # non-empty partial is worth persisting, and an empty partial is
+            # persisted only to answer a dangling user turn.
+            should_persist = (bool(text) or last_role == "user") and last_role != "assistant"
             if should_persist:
                 try:
                     from agents.main_agent.session.persistence import persist_synthetic_messages
@@ -1076,6 +1126,7 @@ class StreamCoordinator:
                         persist_session_manager,
                         session_id,
                         [("assistant", message)],
+                        last_persisted_role=last_role,
                     )
                 except Exception as persist_error:
                     logger.error(
@@ -1084,9 +1135,9 @@ class StreamCoordinator:
                     )
             else:
                 logger.info(
-                    "Interruption with no in-flight partial and non-user history tail "
-                    "(role=%s) for session %s — marker only, no synthetic write",
-                    last_role, session_id,
+                    "Interruption for session %s — marker only, no synthetic write "
+                    "(in-flight partial present=%s, history tail role=%s)",
+                    session_id, bool(text), last_role,
                 )
 
             try:

--- a/backend/tests/agents/main_agent/streaming/test_force_stop_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_force_stop_persistence.py
@@ -310,3 +310,111 @@ def _extract_text(session_message: Any) -> str:
     content = msg.get("content", []) if isinstance(msg, dict) else []
     parts = [block.get("text", "") for block in content if isinstance(block, dict)]
     return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Role-alternation guard: an error persisted after a DANGLING ASSISTANT turn
+# must not create two consecutive assistant messages.
+#
+# This is the amplifier that permanently bricked prod session f761f59b: a turn
+# ended with a dangling assistant toolUse (a duplicate concurrent invocation
+# double-wrote tool results), an error fired, and the handler appended ANOTHER
+# assistant turn — assistant, assistant — which then failed every subsequent
+# turn, each failure persisting yet another consecutive assistant error.
+#
+# The write-side fix: both synthetic-error paths pass the tail role
+# (agent.messages[-1]["role"]) to persist_synthetic_messages, which drops the
+# write when it would land next to a same-role turn. The error stays a
+# live-only UI affordance for that turn (mirroring the max_tokens path).
+# ---------------------------------------------------------------------------
+
+
+def _assistant_tail_agent_force_stop(reason: str) -> _FakeAgent:
+    """A force_stop agent whose history tail is a dangling assistant toolUse."""
+    agent = _FakeAgent([_force_stop_event(reason)])
+    agent.messages = [
+        {"role": "user", "content": [{"text": "run the tool"}]},
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "t1", "name": "search", "input": {}}}],
+        },
+    ]
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_agent_error_skips_persist_when_tail_is_assistant():
+    """AGENT_ERROR (force_stop) path: history tail is a dangling assistant
+    turn, so the synthetic assistant error must NOT be persisted — that would
+    create consecutive assistant messages and brick the session."""
+    raw_reason = (
+        "An error occurred (ValidationException) when calling the "
+        "ConverseStream operation: This model doesn't support documents."
+    )
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_assistant_tail_agent_force_stop(raw_reason), _NoopSessionManager())
+
+    assert persist_sm.calls == [], (
+        f"expected NO create_message call (assistant tail → skip to preserve "
+        f"alternation), got {len(persist_sm.calls)}: {persist_sm.calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_error_skips_persist_when_tail_is_assistant():
+    """Emergency path (raw exception out of stream_async → STREAM_ERROR):
+    history tail is a dangling assistant turn, so the synthetic error is
+    dropped rather than appended as a second consecutive assistant message."""
+    exc = Exception(
+        "An error occurred (ValidationException) when calling the "
+        "ConverseStream operation: This model doesn't support documents."
+    )
+    agent = _RaisingAgent(exc)
+    agent.messages = [
+        {"role": "user", "content": [{"text": "run the tool"}]},
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "t1", "name": "search", "input": {}}}],
+        },
+    ]
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(agent, _NoopSessionManager())
+
+    assert persist_sm.calls == [], (
+        f"expected NO create_message call (assistant tail → skip), got "
+        f"{len(persist_sm.calls)}: {persist_sm.calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_error_still_persists_when_tail_is_user():
+    """Control: the healthy case (user turn is the tail, as at turn start) still
+    persists the assistant error exactly once — the guard only suppresses the
+    consecutive-assistant case, not normal error persistence."""
+    raw_reason = (
+        "An error occurred (ValidationException) when calling the "
+        "ConverseStream operation: This model doesn't support documents."
+    )
+    # _FakeAgent's default tail is the user turn.
+    persist_sm = _RecordingPersistSessionManager()
+
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ):
+        await _collect(_FakeAgent([_force_stop_event(raw_reason)]), _NoopSessionManager())
+
+    assert len(persist_sm.calls) == 1
+    inner = getattr(persist_sm.calls[0]["message"], "message", None)
+    role = inner.get("role") if isinstance(inner, dict) else None
+    assert role == "assistant"

--- a/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
@@ -250,6 +250,40 @@ async def test_empty_partial_skips_synthetic_write_when_tail_is_assistant():
 
 
 @pytest.mark.asyncio
+async def test_nonempty_partial_skips_write_when_tail_is_assistant():
+    """An interrupted continuation/resume: the tail is already an assistant
+    message (the one being extended) and a partial streamed before teardown.
+    Persisting the partial as a NEW assistant turn would create consecutive
+    assistant messages and brick the session, so it is SKIPPED — the partial
+    stays a live-only affordance and only the marker is set."""
+    persist_sm = _RecordingPersistSessionManager()
+    marker_calls: List[Dict[str, Any]] = []
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        marker_calls.append({"reason": reason})
+
+    agent = _InterruptingAgent()
+    agent.messages = [
+        {"role": "user", "content": [{"text": "hi"}]},
+        {"role": "assistant", "content": [{"text": "resuming the truncated answer"}]},
+    ]
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch("apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted):
+        await coordinator._persist_interruption(
+            agent=agent,
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="…and here is the continuation",
+        )
+
+    assert persist_sm.calls == []
+    assert marker_calls == [{"reason": "connection_lost"}]
+
+
+@pytest.mark.asyncio
 async def test_interruption_persists_partial_turn_metadata():
     """A Stop with a partial persists per-message metadata (which also bumps
     the session cost aggregates) keyed to the interrupted message's index, so


### PR DESCRIPTION
Follow-up to #653 (task 2 of 2 from that incident).

## Problem
When a turn errors inside the agent stream, the handler persists a synthetic `⚠️ Something went wrong` **assistant** turn via `persist_synthetic_messages`. If the last persisted message was already an assistant turn (a dangling assistant `toolUse`, or a prior synthetic error turn), this appends a **second consecutive assistant message** → breaks Bedrock's strict user/assistant alternation → the next turn fails → another synthetic error turn is persisted, and so on. This is the amplifier that turned one corrupt turn into a permanently-bricked session in the prod incident (session `f761f59b`).

## Fix
Centralized role-alternation guard in `persist_synthetic_messages` via a new `last_persisted_role` param: any synthetic turn that would land adjacent to a same-role turn is dropped (the error stays a live-only UI affordance for that turn — the same deliberate choice the `max_tokens` path already makes). Callers in `stream_coordinator` pass the history tail role via a new `_last_persisted_role(agent)` helper.

## Relationship to #653
#653 added the restore-time `_repair_tool_pairing`, which **masks** this corruption on the model-request path (it merges consecutive same-role turns before the Bedrock call). This PR fixes the **write side** so the corruption is never persisted — keeping stored history and the message display (which does not run the repair) clean too. The two are complementary; independent files, no overlap.

## Tests
28 passing across `test_persistence.py`, `test_force_stop_persistence.py`, `test_interrupted_turn_persistence.py`, including: an error persisted after a dangling assistant turn must not create consecutive assistant messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)