### PR TITLE
feat(chat): distributed turn cancellation — make Stop actually stop the server turn

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -23,6 +23,18 @@ from .stream_processor import process_agent_stream
 logger = logging.getLogger(__name__)
 
 
+class _CooperativeStopSignal(Exception):
+    """Internal: a user Stop was observed mid-stream (cooperative cancellation).
+
+    Raised from the stream loop when ``session_manager.cancelled`` is set, and
+    caught in ``stream_response`` to persist the partial + end the stream
+    cleanly. A plain ``Exception`` (not ``CancelledError``) so it never reaches
+    the ASGI server as a spurious task cancellation when the client is still
+    connected, and so the generic ``except Exception`` error arm can't mistake
+    a deliberate stop for a failure.
+    """
+
+
 class StreamCoordinator:
     """Coordinates streaming lifecycle for agent responses"""
 
@@ -165,6 +177,26 @@ class StreamCoordinator:
 
             # Process through new stream processor and format as SSE
             async for event in process_agent_stream(agent_stream):
+                # Cooperative stop. A user Stop arms a cancel on the session's
+                # single-flight lease; the inference-api heartbeat observes it
+                # and flips ``session_manager.cancelled``. Because a client
+                # abort does not propagate through the AgentCore Runtime data
+                # plane, this in-loop check is what actually ends a token-only
+                # turn — StopHook only fires at tool boundaries, of which a
+                # pure-chat turn has none. Raise into the dedicated stop arm
+                # below, which persists the partial the user already saw, marks
+                # the turn interrupted, and ends the stream cleanly so the lease
+                # releases and the user's resend isn't rejected. Checked before
+                # yielding so no further tokens are emitted once stop is seen;
+                # we then abandon the (suspended) agent stream, which cannot
+                # progress or write to Memory without a consumer.
+                if getattr(session_manager, "cancelled", False):
+                    logger.info(
+                        "Cooperative stop observed mid-stream for session %s; ending turn",
+                        session_id,
+                    )
+                    raise _CooperativeStopSignal()
+
                 # Track when new assistant messages start (to associate metadata with them)
                 if event.get("type") == "message_start":
                     role = event.get("data", {}).get("role")
@@ -930,6 +962,34 @@ class StreamCoordinator:
                 except Exception as e:
                     logger.error(f"Failed to store user displayText: {e}", exc_info=True)
 
+        except _CooperativeStopSignal:
+            # Deliberate user Stop observed mid-stream (see the in-loop check).
+            # Unlike the CancelledError/GeneratorExit backstop below — which
+            # fires only when a client disconnect actually reaches this process
+            # — this path runs even when the client is still connected, because
+            # the stop was signalled out-of-band via the lease. Persist the
+            # partial the user already saw and mark the turn interrupted
+            # (user_stopped), then end the SSE stream cleanly rather than
+            # re-raising, so a still-connected client sees a proper close and
+            # the route's finally releases the lease.
+            await self._persist_interruption(
+                agent=agent,
+                session_id=session_id,
+                user_id=user_id,
+                partial_text="".join(assistant_text_acc),
+                main_agent_wrapper=main_agent_wrapper,
+                accumulated_metadata=accumulated_metadata,
+                initial_message_count=initial_message_count,
+                current_assistant_message_index=current_assistant_message_index,
+                stream_start_time=stream_start_time,
+                first_token_time=first_token_time,
+                reason="user_stopped",
+            )
+            # Terminal frames so any still-connected client ends cleanly; the
+            # SPA already stopped rendering on Stop, so this is belt-and-braces.
+            yield 'event: message_stop\ndata: {"stopReason": "stopped"}\n\n'
+            yield "event: done\ndata: {}\n\n"
+            # No re-raise: the turn ended on purpose.
         except (asyncio.CancelledError, GeneratorExit):
             # Client interruption: Stop click, page refresh, or dropped
             # socket. Depending on where the generator is suspended when the
@@ -1064,9 +1124,16 @@ class StreamCoordinator:
         current_assistant_message_index: int = -1,
         stream_start_time: Optional[float] = None,
         first_token_time: Optional[float] = None,
+        reason: str = "connection_lost",
     ) -> None:
         """Persist the in-flight partial assistant turn + an interrupted
         marker when a turn is torn down mid-stream.
+
+        ``reason`` records why: the default ``connection_lost`` is the
+        disconnect backstop (conditional, never downgrades a stronger
+        ``user_stopped`` the client beacon may have written); the cooperative
+        Stop arm passes ``user_stopped`` so the marker is correct even if that
+        beacon never landed.
 
         Runs from inside the ``except (CancelledError, GeneratorExit)`` arm,
         i.e. while the request task is being torn down. Any bare ``await``
@@ -1144,7 +1211,7 @@ class StreamCoordinator:
                 from apis.shared.sessions.metadata import set_interrupted_turn
 
                 await set_interrupted_turn(
-                    session_id, user_id, reason="connection_lost", source="cancellation"
+                    session_id, user_id, reason=reason, source="cancellation"
                 )
             except Exception as marker_error:
                 logger.error(

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -678,6 +678,18 @@ async def signal_turn_interrupted_endpoint(
             reason=body.reason,
             source="client_signal",
         )
+        # Distributed turn cancellation: a client abort doesn't propagate
+        # through the AgentCore Runtime data plane, so arm a cancel on the
+        # session's single-flight lease. The container running the turn
+        # observes it on its next heartbeat and unwinds — releasing the lease
+        # so the user's resend isn't rejected with 409 and stopping wasted
+        # model/tool work. Owner-scoped, so a stale Stop can't kill a later
+        # turn. Best-effort: never fail the Stop signal on this.
+        try:
+            from apis.shared.sessions.session_lease import request_session_cancel
+            await request_session_cancel(session_id, user_id)
+        except Exception:
+            logger.warning("Failed to arm session cancel on stop", exc_info=True)
         return Response(status_code=204)
     except Exception:
         logger.error("Error recording turn interruption", exc_info=True)

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -95,14 +95,30 @@ PREVIEW_SESSION_PREFIX = "preview-"
 DEFAULT_AGENT_TYPE = DEFAULT_CHAT_MODE
 
 
-async def _lease_heartbeat_loop(lease) -> None:
-    """Renew the single-flight session lease on a fixed cadence while a turn runs.
+def _mark_session_cancelled(agent) -> None:
+    """Flip the agent's session-manager ``cancelled`` flag (cooperative stop).
+
+    Both StopHook (tool boundaries) and the stream coordinator (mid-generation)
+    read this flag to unwind the turn. Defensive: a nonstandard agent without a
+    session manager is simply a no-op.
+    """
+    session_manager = getattr(agent, "session_manager", None)
+    if session_manager is not None:
+        session_manager.cancelled = True
+        logger.info("Cooperative stop: cancel observed for the running turn")
+
+
+async def _lease_heartbeat_loop(lease, agent) -> None:
+    """Renew the single-flight session lease and observe cancel requests.
 
     Runs as a background task for the life of the SSE stream. Renewing on a wall
     clock (rather than piggybacking on SSE-event cadence) keeps the lease alive
     across a long silent tool call — code-interpreter / browser can run past the
-    lease window between yielded events. Cancelled in the stream generator's
-    ``finally``; each renew is best-effort and owner-scoped.
+    lease window between yielded events — and bounds Stop→resend latency to one
+    interval. Each renew also reports whether a cancel has been armed for this
+    lease owner; on the first such observation we flip the agent's ``cancelled``
+    flag and stop renewing (the turn is unwinding). Best-effort and owner-scoped;
+    cancelled in the stream generator's ``finally``.
     """
     from apis.shared.sessions.session_lease import (
         LEASE_HEARTBEAT_SECONDS,
@@ -111,7 +127,10 @@ async def _lease_heartbeat_loop(lease) -> None:
 
     while True:
         await asyncio.sleep(LEASE_HEARTBEAT_SECONDS)
-        await renew_session_lease(lease)
+        cancel_requested = await renew_session_lease(lease)
+        if cancel_requested:
+            _mark_session_cancelled(agent)
+            return
 
 
 def is_preview_session(session_id: str) -> bool:
@@ -1976,7 +1995,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         # except handlers below cover pre-stream failures).
         async def _guarded_stream() -> AsyncGenerator[str, None]:
             heartbeat_task = (
-                asyncio.create_task(_lease_heartbeat_loop(session_lease))
+                asyncio.create_task(_lease_heartbeat_loop(session_lease, agent))
                 if session_lease is not None
                 else None
             )

--- a/backend/src/apis/shared/sessions/session_lease.py
+++ b/backend/src/apis/shared/sessions/session_lease.py
@@ -42,8 +42,11 @@ logger = logging.getLogger(__name__)
 # so a normal long turn never self-evicts).
 LEASE_WINDOW_SECONDS = 90
 
-# Heartbeat cadence — how often the live turn renews ``leaseExpiresAt``.
-LEASE_HEARTBEAT_SECONDS = 30
+# Heartbeat cadence — how often the live turn renews ``leaseExpiresAt`` and
+# observes a cancel request. Also bounds worst-case Stop→resend latency: a
+# cooperative stop is seen within one interval. Kept well under the window so a
+# single missed tick never expires the lease.
+LEASE_HEARTBEAT_SECONDS = 10
 
 # DynamoDB ``ttl`` backstop: how long an orphaned lease item lingers before
 # DynamoDB reaps it. Only prevents unbounded accumulation; correctness rides on
@@ -128,9 +131,14 @@ async def acquire_session_lease(
 
     update_kwargs = {
         "Key": {"PK": f"USER#{user_id}", "SK": f"LEASE#{session_id}"},
+        # REMOVE clears any stale cancel marker when taking over an expired
+        # lease item, so a prior turn's cancel request can't bleed into this
+        # one. (Owner-scoping already protects — the new owner token won't match
+        # the old cancelRequestedFor — but clearing keeps the row honest.)
         "UpdateExpression": (
             "SET leaseOwner = :owner, leaseExpiresAt = :exp, "
-            "#ttl = :ttl, updatedAt = :updated"
+            "#ttl = :ttl, updatedAt = :updated "
+            "REMOVE cancelRequestedFor, cancelRequestedAt"
         ),
         "ExpressionAttributeNames": {"#ttl": "ttl"},
         "ExpressionAttributeValues": {
@@ -173,23 +181,26 @@ async def acquire_session_lease(
     return SessionLease(session_id=session_id, user_id=user_id, owner=owner)
 
 
-async def renew_session_lease(lease: Optional[SessionLease]) -> None:
-    """Extend our lease's validity window. Best-effort, owner-scoped.
+async def renew_session_lease(lease: Optional[SessionLease]) -> bool:
+    """Extend our lease's window and observe a cancel request in one round-trip.
 
     Owner-conditional so a container that already lost the lease (its window
     lapsed and another turn took over) can't clobber the new owner's window.
+    Returns ``True`` iff a cancel has been requested for *this* lease owner —
+    the caller flips the session manager's ``cancelled`` flag to stop the turn.
+    Best-effort: any error (including having lost ownership) returns ``False``.
     """
     if lease is None:
-        return
+        return False
     table = _table()
     if table is None:
-        return
+        return False
 
     from botocore.exceptions import ClientError
 
     now = int(time.time())
     try:
-        table.update_item(
+        resp = table.update_item(
             Key={"PK": lease.pk, "SK": lease.sk},
             UpdateExpression="SET leaseExpiresAt = :exp, #ttl = :ttl, updatedAt = :updated",
             ConditionExpression="leaseOwner = :owner",
@@ -200,15 +211,21 @@ async def renew_session_lease(lease: Optional[SessionLease]) -> None:
                 ":owner": lease.owner,
                 ":updated": datetime.now(timezone.utc).isoformat(),
             },
+            ReturnValues="ALL_NEW",
         )
+        attrs = resp.get("Attributes", {})
+        # Owner-scoped: only honor a cancel aimed at *our* turn, so a stale
+        # marker from a prior turn on the same row can't stop us.
+        return attrs.get("cancelRequestedFor") == lease.owner
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
             # We no longer own the lease (took too long, another turn took over).
             # Nothing to renew; the live loop will still finish, but the session
             # is no longer reserved for it.
             logger.warning("Session lease renew skipped for %s — no longer owner", lease.session_id)
-            return
+            return False
         logger.warning("Session lease renew failed for %s: %s", lease.session_id, e)
+        return False
 
 
 async def release_session_lease(lease: Optional[SessionLease]) -> None:
@@ -238,3 +255,61 @@ async def release_session_lease(lease: Optional[SessionLease]) -> None:
             # Already released, expired-and-retaken, or never persisted — fine.
             return
         logger.warning("Session lease release failed for %s: %s", lease.session_id, e)
+
+
+async def request_session_cancel(session_id: str, user_id: str) -> bool:
+    """Ask the turn currently holding this session's lease to stop.
+
+    Called from the app-api ``user_stopped`` path (any container). Reads the
+    lease's current ``leaseOwner`` and stamps ``cancelRequestedFor = <owner>``
+    so the running container observes it on its next heartbeat and unwinds the
+    turn. Owner-scoping is the safety property: the request names the *current*
+    owner, so if the turn has already ended and a new one started (new owner
+    token), the new turn ignores it — a stale Stop can never kill a later turn.
+
+    Returns ``True`` if a cancel was armed against an active lease. ``False``
+    when there is no active turn (no lease item) or the guard is inactive
+    (table unconfigured) — both mean "nothing running to stop." Best-effort:
+    any DynamoDB error returns ``False`` rather than raising.
+    """
+    table = _table()
+    if table is None:
+        return False
+
+    from botocore.exceptions import ClientError
+
+    try:
+        resp = table.get_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"LEASE#{session_id}"}
+        )
+    except ClientError as e:
+        logger.warning("Session cancel lookup failed for %s: %s", session_id, e)
+        return False
+
+    item = resp.get("Item")
+    owner = item.get("leaseOwner") if item else None
+    if not owner:
+        # No lease → no turn is streaming server-side for this session.
+        return False
+
+    try:
+        table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"LEASE#{session_id}"},
+            UpdateExpression="SET cancelRequestedFor = :owner, cancelRequestedAt = :ts",
+            # Only arm if that same owner still holds the lease — otherwise the
+            # turn already ended/rotated and there is nothing to cancel.
+            ConditionExpression="leaseOwner = :owner",
+            ExpressionAttributeValues={
+                ":owner": owner,
+                ":ts": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        logger.info("Armed cancel for session %s (owner=%s)", session_id, owner)
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            # The turn ended or rotated between the read and the write — nothing
+            # to cancel.
+            return False
+        logger.warning("Session cancel arm failed for %s: %s", session_id, e)
+        return False

--- a/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
+++ b/backend/tests/agents/main_agent/streaming/test_interrupted_turn_persistence.py
@@ -368,3 +368,97 @@ async def test_interruption_metadata_skipped_without_wrapper():
 
     assert store_calls == []
     assert len(persist_sm.calls) == 1  # partial still persisted
+
+
+# ---------------------------------------------------------------------------
+# Cooperative stop (distributed cancellation): a user Stop is observed via the
+# session lease and flips session_manager.cancelled while the turn is still
+# streaming server-side (the client abort never reached this process). Unlike
+# the CancelledError/GeneratorExit backstop, this ends the stream CLEANLY
+# (persist + terminal frames, no re-raise) so the lease releases and resend works.
+# ---------------------------------------------------------------------------
+
+
+class _CancellingSessionManager:
+    """Session manager whose ``cancelled`` flag the running agent flips mid-stream."""
+
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    async def update_after_turn(self, input_tokens: int, current_messages=None):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_cooperative_stop_persists_partial_and_ends_cleanly():
+    sm = _CancellingSessionManager()
+
+    class _Agent:
+        def __init__(self) -> None:
+            self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+
+        def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+            async def _gen() -> AsyncIterator[Dict[str, Any]]:
+                yield _raw_message_start()
+                yield _raw_text_delta("Hello")
+                yield _raw_text_delta(" world")
+                # User clicks Stop; the heartbeat flips the flag. The NEXT
+                # loop-top check must end the turn before "!" is accumulated.
+                sm.cancelled = True
+                yield _raw_text_delta("!")
+                yield _raw_message_stop()
+
+            return _gen()
+
+    captured: Dict[str, Any] = {}
+
+    async def _fake_persist(self, *, agent, session_id, user_id, partial_text, reason="connection_lost", **kwargs):
+        captured.update(partial_text=partial_text, reason=reason, session_id=session_id)
+
+    sse: List[str] = []
+    coordinator = StreamCoordinator()
+    with patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
+        # No exception escapes — the stream ends cleanly (contrast with the
+        # CancelledError arm, which re-raises).
+        async for chunk in coordinator.stream_response(
+            agent=_Agent(),
+            prompt="write an essay",
+            session_manager=sm,
+            session_id="sess-coop",
+            user_id="user-1",
+            main_agent_wrapper=None,
+        ):
+            sse.append(chunk)
+
+    # Partial covers what streamed before Stop, not the post-stop delta.
+    assert captured["partial_text"] == "Hello world"
+    # Marked as a deliberate stop, not the connection_lost fallback.
+    assert captured["reason"] == "user_stopped"
+    assert captured["session_id"] == "sess-coop"
+    # A clean terminal frame was emitted for any still-connected client.
+    assert "event: done" in "".join(sse)
+
+
+@pytest.mark.asyncio
+async def test_persist_interruption_threads_user_stopped_reason():
+    """The cooperative arm passes reason=user_stopped through to the marker."""
+    persist_sm = _RecordingPersistSessionManager()
+    marker_calls: List[Dict[str, Any]] = []
+
+    async def _fake_set_interrupted(session_id, user_id, reason="unknown", source="cancellation"):
+        marker_calls.append({"reason": reason, "source": source})
+
+    coordinator = StreamCoordinator()
+    with patch(
+        "agents.main_agent.session.session_factory.SessionFactory.create_session_manager",
+        return_value=persist_sm,
+    ), patch("apis.shared.sessions.metadata.set_interrupted_turn", _fake_set_interrupted):
+        await coordinator._persist_interruption(
+            agent=_InterruptingAgent(),
+            session_id="sess-interrupt",
+            user_id="user-1",
+            partial_text="partial answer",
+            reason="user_stopped",
+        )
+
+    assert marker_calls == [{"reason": "user_stopped", "source": "cancellation"}]

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -800,6 +800,49 @@ class TestSignalTurnInterrupted:
             source="client_signal",
         )
 
+    def test_arms_session_cancel_on_stop(self, app, make_user, authenticated_client):
+        """Stop also arms a cancel on the session lease so the container running
+        the turn can unwind it (distributed cancellation) — a client abort
+        doesn't propagate through the AgentCore Runtime data plane."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        cancel = AsyncMock(return_value=True)
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            AsyncMock(),
+        ), patch(
+            # Patched at the source module — the route imports it locally.
+            "apis.shared.sessions.session_lease.request_session_cancel",
+            cancel,
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "user_stopped"},
+            )
+
+        assert resp.status_code == 204
+        cancel.assert_awaited_once_with("sess-001", user.user_id)
+
+    def test_stop_succeeds_even_if_cancel_arm_fails(self, app, make_user, authenticated_client):
+        """Arming the cancel is best-effort — a failure never fails the Stop."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            AsyncMock(),
+        ), patch(
+            "apis.shared.sessions.session_lease.request_session_cancel",
+            AsyncMock(side_effect=RuntimeError("dynamo down")),
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "user_stopped"},
+            )
+
+        assert resp.status_code == 204
+
     def test_rejects_non_client_attested_reason(self, app, make_user, authenticated_client):
         """`connection_lost` is server-inferred only — a client must not be
         able to plant (or downgrade to) it through this endpoint."""

--- a/backend/tests/shared/test_session_lease.py
+++ b/backend/tests/shared/test_session_lease.py
@@ -19,6 +19,7 @@ from apis.shared.sessions.session_lease import (
     acquire_session_lease,
     release_session_lease,
     renew_session_lease,
+    request_session_cancel,
 )
 
 
@@ -162,6 +163,63 @@ class TestRelease:
     @pytest.mark.asyncio
     async def test_release_none_is_noop(self, sessions_metadata_table):
         await release_session_lease(None)  # must not raise
+
+
+class TestCancel:
+    @pytest.mark.asyncio
+    async def test_renew_reports_no_cancel_by_default(self, sessions_metadata_table):
+        lease = await acquire_session_lease("s1", "u1")
+        assert await renew_session_lease(lease) is False
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_is_observed_by_owner_renew(self, sessions_metadata_table):
+        lease = await acquire_session_lease("s1", "u1")
+        armed = await request_session_cancel("s1", "u1")
+        assert armed is True
+        # The container running the turn sees it on its next heartbeat renew.
+        assert await renew_session_lease(lease) is True
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_with_no_active_lease_is_noop(self, sessions_metadata_table):
+        # No turn streaming → nothing to cancel.
+        assert await request_session_cancel("s1", "u1") is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_is_owner_scoped_across_takeover(self, sessions_metadata_table):
+        # A Stop arms a cancel against the current owner; then that turn ends
+        # and a new one force-acquires (resume). The new owner must NOT inherit
+        # the old cancel.
+        first = await acquire_session_lease("s1", "u1")
+        await request_session_cancel("s1", "u1")
+        assert await renew_session_lease(first) is True  # armed for `first`
+
+        resumed = await acquire_session_lease("s1", "u1", force=True)
+        assert resumed.owner != first.owner
+        # acquire cleared the stale marker; the new owner sees no cancel.
+        item = _lease_item(sessions_metadata_table)
+        assert "cancelRequestedFor" not in item
+        assert await renew_session_lease(resumed) is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_takeover_targets_only_new_owner(self, sessions_metadata_table):
+        first = await acquire_session_lease("s1", "u1")
+        resumed = await acquire_session_lease("s1", "u1", force=True)
+        # A fresh Stop now arms against the current (resumed) owner.
+        await request_session_cancel("s1", "u1")
+        assert await renew_session_lease(resumed) is True
+        # The superseded owner never sees it (it lost the lease anyway).
+        assert await renew_session_lease(first) is False
+
+    @pytest.mark.asyncio
+    async def test_release_after_cancel_frees_session(self, sessions_metadata_table):
+        lease = await acquire_session_lease("s1", "u1")
+        await request_session_cancel("s1", "u1")
+        await release_session_lease(lease)
+        assert _lease_item(sessions_metadata_table) is None
+        # Resend acquires cleanly, with no leftover cancel marker.
+        again = await acquire_session_lease("s1", "u1")
+        assert again is not None
+        assert await renew_session_lease(again) is False
 
 
 class TestLifecycle:

--- a/docs/specs/session-single-flight-guard.md
+++ b/docs/specs/session-single-flight-guard.md
@@ -209,9 +209,55 @@ for the distributed-cancel follow-on below:
 
 ## Follow-on: distributed turn cancellation (make Stop real)
 
-**Status:** proposed, not built. Separate, larger change — it touches the agent
-step loop, not just the `/invocations` entry point. Complementary to the lease,
-not a replacement.
+**Status: IMPLEMENTED** (branch `feat/distributed-turn-cancellation`, off
+`develop` after the lease landed). Complementary to the lease, not a
+replacement — the lease prevents corruption; this makes Stop actually end the
+server turn, which shrinks the 409-on-resend window from "up to a full turn" to
+"one heartbeat interval (~10s)" and reclaims wasted model/tool spend.
+
+### What shipped
+
+- **Signal** — the app-api `POST /sessions/{id}/interrupt` (`user_stopped`)
+  handler calls `request_session_cancel`, which reads the lease's current
+  `leaseOwner` and stamps `cancelRequestedFor = <owner>` (owner-scoped, so a
+  stale Stop can't kill a later turn). Best-effort — never fails the Stop.
+- **Observe** — the inference-api lease heartbeat (`_lease_heartbeat_loop`,
+  tightened to a 10s cadence) renews with `ReturnValues=ALL_NEW`; when it sees
+  `cancelRequestedFor == our owner` it flips `agent.session_manager.cancelled`.
+- **Effect A (tools)** — the always-on `StopHook` cancels the next tool call
+  (existing machinery; zero new code).
+- **Effect B (model stream)** — a cooperative check at the top of the
+  `StreamCoordinator` loop raises `_CooperativeStopSignal` when `cancelled` is
+  set. A dedicated `except` arm persists the partial via `_persist_interruption`
+  (marked `user_stopped`), emits terminal SSE frames, and ends **cleanly**
+  (no re-raise) — so a still-connected client sees a proper close and the
+  route's `finally` releases the lease. This is what ends a pure-chat turn,
+  which has no tool boundary for `StopHook` to catch.
+- **Release** — unchanged: the route's `_guarded_stream` `finally` releases the
+  lease as the turn unwinds.
+
+The spike that de-risked this: the teardown-and-persist-partial path already
+existed (the `(CancelledError, GeneratorExit)` arm built for interrupted-turn /
+connection-lost, hardened by #653's `_repair_tool_pairing`), so stopping
+mid-stream never orphans or corrupts history. We abandon the *suspended* agent
+stream, which cannot progress or write to Memory without a consumer.
+
+### Residual limitations (documented, not fixed)
+
+- **In-flight tool calls finish.** `StopHook` cancels at tool *boundaries*; a
+  browser / code-interpreter call already executing runs to completion before
+  the cancel is seen. Genuinely interrupting a running tool is a deeper change
+  (cooperative cancellation inside the tool executor) and is out of scope.
+- **Bedrock token tail.** Aborting stops *further* generation, but tokens the
+  model already produced server-side are billed. The dominant saving is halting
+  the loop (no further model calls / tools), which both effects achieve.
+- **Observe latency.** Stop→release is bounded by the heartbeat cadence (~10s).
+  The client already stops rendering instantly on Stop; only *resend* waits, and
+  the SPA's 409 handling covers that window.
+
+### Why Stop couldn't propagate before this
+
+Two stacked reasons, both confirmed in code:
 
 ### Why Stop can't propagate today
 


### PR DESCRIPTION
## Why

Follow-on to the single-flight lease (#655). A client abort does **not** propagate through the AgentCore Runtime data plane, so Stop was cosmetic server-side: the container ran the turn to completion, held the lease, and kept burning model/tool spend. That left **"Stop → resend" returning 409** until the prior turn finished on its own, and wasted compute on output nobody would read.

This makes Stop **actually end the server turn**, using the lease we already have as the cross-container signalling channel.

## Spike that de-risked it

The teardown-and-persist-partial path **already existed** — the `StreamCoordinator`'s `(CancelledError, GeneratorExit)` arm built for interrupted-turn / connection-lost, hardened by #653's `_repair_tool_pairing`. So stopping mid-stream never orphans or corrupts history; we only needed to *trigger* it. Breaking the loop doesn't rely on fragile `GeneratorExit` propagation either — we abandon the *suspended* agent stream, which can't progress or write to Memory without a consumer.

## What ships

| Piece | Where | What |
|---|---|---|
| **Signal** | `session_lease.py`, `app_api/sessions/routes.py` | `request_session_cancel` stamps `cancelRequestedFor=<leaseOwner>` (owner-scoped, so a stale Stop can't kill a later turn); the `user_stopped` endpoint arms it, best-effort |
| **Observe** | `session_lease.py`, inference `routes.py` | heartbeat (tightened 30s→**10s**) renews with `ReturnValues=ALL_NEW`; on `cancelRequestedFor==owner` flips `session_manager.cancelled` |
| **Effect A — tools** | — | existing always-on `StopHook` cancels the next tool call (zero new code) |
| **Effect B — model stream** | `stream_coordinator.py` | cooperative check raises `_CooperativeStopSignal`; a dedicated arm persists the partial (`_persist_interruption`, marked `user_stopped`), emits terminal SSE frames, and ends **cleanly** (no re-raise) so a still-connected client closes and the lease releases. This is what ends a pure-chat turn, which has no tool boundary for `StopHook` |
| **Cleanup** | `session_lease.py` | `acquire` clears any stale cancel marker (`REMOVE`) on takeover |

**Net:** Stop ends the server turn. The 409-on-resend window shrinks from *a full turn* to *~one heartbeat (10s)*, and wasted spend after Stop is halted. Composes with #655's SPA 409 handling — no new frontend work.

## Residual limitations (documented, not fixed)

- **In-flight tool calls finish.** `StopHook` cancels at tool *boundaries*; a browser / code-interpreter call already executing runs to completion before the cancel is seen. Interrupting a running tool is a deeper change (out of scope).
- **Bedrock token tail.** Aborting stops *further* generation; tokens already produced server-side are billed. The dominant saving is halting the loop.
- **Observe latency ~10s.** The client stops rendering instantly on Stop; only *resend* waits, and the SPA's 409 handling covers that window.

## Tests

- `test_session_lease.py` (+6 → 20): arm/observe on renew, owner-scoping across takeover, stale-marker clear on acquire, release-after-cancel.
- `test_interrupted_turn_persistence.py` (+2 → 10): cooperative stop persists the partial + ends cleanly; `user_stopped` reason threaded through.
- `test_sessions.py` (+2): Stop arms the cancel; best-effort — a cancel-arm failure never fails the Stop.

Design note updated: [`docs/specs/session-single-flight-guard.md`](../blob/feat/distributed-turn-cancellation/docs/specs/session-single-flight-guard.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)