### PR TITLE
fix(infra): grant app-api task role access to shared-conversations table

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -156,6 +156,7 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     { sid: 'BffSessionsAccess', arn: props.refs.bffSessionsTable.tableArn },
     { sid: 'VoiceTicketReplayAccess', arn: props.refs.voiceTicketReplayTable.tableArn },
     { sid: 'UserFilesTableAccess', arn: props.refs.fileUploadTable.tableArn },
+    { sid: 'SharedConversationsAccess', arn: props.refs.sharedConversationsTable.tableArn },
   ];
 
   for (const { sid, arn } of coreTables) {

--- a/infrastructure/test/security-policy.test.ts
+++ b/infrastructure/test/security-policy.test.ts
@@ -161,6 +161,60 @@ describe('Security policy hardening', () => {
   });
 
   // ──────────────────────────────────────────────────────────
+  // 2b. App-api DynamoDB table grants
+  // ──────────────────────────────────────────────────────────
+
+  describe('App-api shared-conversations table grant', () => {
+    // Regression guard: the shared-conversations table was threaded
+    // into the app-api container as an env var but never granted on
+    // the task role, so every /conversations/{id}/share PutItem and
+    // /conversations/{id}/shares Query returned AccessDeniedException
+    // (surfaced to users as a 500 "Failed to create share"). The grant
+    // lives in app-api-iam-grants.ts under Sid 'SharedConversationsAccess'.
+    it("app-api role can PutItem/Query/GetItem on the shared-conversations table (incl. its GSIs)", () => {
+      // Iterate both AWS::IAM::Policy AND AWS::IAM::ManagedPolicy because
+      // CDK auto-splits oversized inline policies into managed overflow
+      // policies attached to the same role.
+      const candidates: PolicyStatement[] = [];
+      for (const [, r] of Object.entries(template.findResources('AWS::IAM::Policy'))) {
+        const stmts = ((r.Properties as { PolicyDocument?: { Statement?: PolicyStatement[] } })?.PolicyDocument?.Statement) ?? [];
+        for (const s of stmts) candidates.push(s);
+      }
+      for (const [, r] of Object.entries(template.findResources('AWS::IAM::ManagedPolicy'))) {
+        const stmts = ((r.Properties as { PolicyDocument?: { Statement?: PolicyStatement[] } })?.PolicyDocument?.Statement) ?? [];
+        for (const s of stmts) candidates.push(s);
+      }
+
+      const matches = candidates.filter((s) => s.Sid === 'SharedConversationsAccess');
+
+      if (matches.length === 0) {
+        throw new Error(
+          "Could not locate the shared-conversations DynamoDB grant. " +
+            "Looked for Sid 'SharedConversationsAccess' in AWS::IAM::Policy + AWS::IAM::ManagedPolicy. " +
+            "Without it, creating/listing conversation shares fails with AccessDeniedException. " +
+            "If the Sid was renamed, update this test.",
+        );
+      }
+
+      for (const s of matches) {
+        const actions = asArray(s.Action);
+        // The share service does PutItem (create), Query on SessionShareIndex
+        // (list/delete-for-session), and GetItem (retrieve a single share).
+        expect(actions).toContain('dynamodb:PutItem');
+        expect(actions).toContain('dynamodb:Query');
+        expect(actions).toContain('dynamodb:GetItem');
+        // Never a wildcard resource.
+        const resources = asArray(s.Resource);
+        expect(resources).not.toContain('*');
+        // Must cover the table's GSIs (SessionShareIndex) — the list/revoke
+        // paths Query that index, which requires an index/* resource entry.
+        const resourceStrs = resources.map((r) => JSON.stringify(r));
+        expect(resourceStrs.some((r) => r.includes('index/'))).toBe(true);
+      }
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
   // 3. S3 hardening (encryption + public-access-block)
   // ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Prod fix for the **500 "Failed to create share"** users hit when sharing a conversation.

The `shared-conversations` DynamoDB table is threaded into the app-api container as `SHARED_CONVERSATIONS_TABLE_NAME` but its access was **never granted on the app-api task role**. Every share operation therefore failed against DynamoDB with `AccessDeniedException`, which the route handler catches and returns as a generic `500 {"detail":"Failed to create share"}`.

Confirmed in prod-ai logs (`boisestateai-v2` app-api log group):

```
Error creating share for session 8ecc0b52-... : AccessDeniedException when calling PutItem:
... is not authorized to perform: dynamodb:PutItem on resource:
table/boisestateai-v2-shared-conversations
```

The list path fails the same way with `dynamodb:Query` denied on the `SessionShareIndex` GSI, which is why the share dialog also shows an empty list.

## Fix

Add `SharedConversationsAccess` to the app-api `coreTables` grant list (`app-api-iam-grants.ts`), giving the role the standard DynamoDB action set on the table and its GSIs (`index/*`) — identical to every other table the app-api touches.

## Test

Adds a regression test in `security-policy.test.ts` that synthesizes `PlatformStack` and asserts the app-api role has a `SharedConversationsAccess` statement granting `PutItem`/`Query`/`GetItem`, covering a GSI resource, with no wildcard. Verified the test **fails without the grant** and passes with it.

- `npx tsc --noEmit` — clean
- `npx jest security-policy` — 8/8 pass

## Deploy note

This is an IAM change, so it requires a **`platform.yml` (CDK) deploy** to take effect in prod. Until deployed, prod shares keep 500ing.

## Out of scope

A separate pre-existing failure — very large conversation snapshots exceeding DynamoDB's 400KB item limit (`ValidationException: Item size has exceeded the maximum allowed size`) — is **not** addressed here and is being tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)