### PR TITLE
feat(shares): offload large-conversation snapshots to S3

### DIFF
--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -323,6 +323,14 @@ DYNAMODB_USER_MENU_LINKS_TABLE_NAME=
 # Example: dev-boisestateai-v2-shared-conversations
 SHARED_CONVERSATIONS_TABLE_NAME=
 
+# Shared-conversations snapshot-body S3 bucket. The share BODY (messages +
+# metadata) is offloaded here because a long conversation exceeds DynamoDB's
+# 400 KB item limit; only a pointer stays in the table. Leave empty locally
+# (creating a share then returns a 503 "temporarily unavailable" rather than a
+# 400 KB PutItem failure). Set to the CDK-created bucket name in deployed envs.
+# Example: dev-boisestateai-v2-shared-conversations
+SHARED_CONVERSATIONS_BUCKET_NAME=
+
 # =============================================================================
 # OAUTH PROVIDER MANAGEMENT (OPTIONAL)
 # =============================================================================

--- a/backend/src/apis/app_api/shares/routes.py
+++ b/backend/src/apis/app_api/shares/routes.py
@@ -26,6 +26,7 @@ from .service import (
     NotOwnerError,
     SessionNotFoundError,
     ShareNotFoundError,
+    ShareStorageUnavailableError,
     ShareTableNotFoundError,
     get_share_service,
 )
@@ -71,6 +72,11 @@ async def create_share(
         raise HTTPException(status_code=403, detail="You do not have permission to share this session")
     except ShareTableNotFoundError:
         raise HTTPException(status_code=503, detail="Share feature unavailable - table not deployed")
+    except ShareStorageUnavailableError:
+        raise HTTPException(
+            status_code=503,
+            detail="Sharing is temporarily unavailable. Please try again later.",
+        )
     except Exception as e:
         safe_session_id = session_id.replace("\r", "").replace("\n", "")
         logger.error(f"Error creating share for session {safe_session_id}: {e}", exc_info=True)

--- a/backend/src/apis/app_api/shares/service.py
+++ b/backend/src/apis/app_api/shares/service.py
@@ -4,13 +4,14 @@ Business logic for creating, retrieving, updating, and revoking
 conversation share snapshots.  Supports multiple shares per session.
 """
 
+import json
 import logging
 import os
 import re
 import uuid
 from decimal import Decimal
 from datetime import datetime, timezone
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -27,6 +28,15 @@ from .models import (
     SharedConversationResponse,
     UpdateShareRequest,
 )
+from .snapshot_store import (
+    ShareSnapshotStore,
+    ShareSnapshotStoreError,
+    get_share_snapshot_store,
+)
+
+# Snapshot schema version stamped on the S3 body pointer, for forward
+# migration if the body shape ever changes.
+_SNAPSHOT_SCHEMA_VERSION = 1
 
 logger = logging.getLogger(__name__)
 
@@ -34,10 +44,13 @@ logger = logging.getLogger(__name__)
 class ShareService:
     """Handles share CRUD operations against the shared-conversations DynamoDB table."""
 
-    def __init__(self) -> None:
+    def __init__(self, snapshot_store: Optional[ShareSnapshotStore] = None) -> None:
         table_name = os.environ.get("SHARED_CONVERSATIONS_TABLE_NAME", "")
         self._table_name = table_name
         self._enabled = bool(table_name)
+        # S3-backed snapshot body store. Injectable for tests; otherwise the
+        # process-global store (bucket from SHARED_CONVERSATIONS_BUCKET_NAME).
+        self._snapshot_store = snapshot_store or get_share_snapshot_store()
 
         if self._enabled:
             self._dynamodb = boto3.resource("dynamodb")
@@ -78,16 +91,32 @@ class ShareService:
 
         metadata_snapshot = metadata.model_dump(by_alias=True, exclude_none=True)
 
-        # Convert floats to Decimal for DynamoDB compatibility
-        messages_snapshot = self._convert_floats_to_decimal(messages_snapshot)
-        metadata_snapshot = self._convert_floats_to_decimal(metadata_snapshot)
-
-        # Build item
         share_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
         allowed_emails = self._resolve_allowed_emails(
             request.access_level, request.allowed_emails, user.email
         )
+
+        # Offload the snapshot BODY (messages + metadata) to S3 — a long
+        # conversation exceeds DynamoDB's 400 KB item limit if inlined. The
+        # DynamoDB row keeps only the small control fields plus a pointer.
+        # The body is opaque JSON bytes in S3, so we serialize the raw
+        # model_dump directly and skip the float→Decimal dance (that only
+        # exists to satisfy DynamoDB's boto3 resource, which rejects floats).
+        if not self._snapshot_store.enabled:
+            raise ShareStorageUnavailableError()
+
+        body_bytes = json.dumps(
+            {"metadata": metadata_snapshot, "messages": messages_snapshot}
+        ).encode("utf-8")
+
+        try:
+            bucket_key = self._snapshot_store.put(share_id=share_id, body=body_bytes)
+        except ShareSnapshotStoreError as e:
+            logger.error(
+                f"Failed to store snapshot body for share {self._sanitize_id(share_id)}: {e}"
+            )
+            raise ShareStorageUnavailableError() from e
 
         item = {
             "share_id": share_id,
@@ -96,8 +125,12 @@ class ShareService:
             "owner_email": user.email,
             "access_level": request.access_level,
             "created_at": now,
-            "metadata": metadata_snapshot,
-            "messages": messages_snapshot,
+            "body_ref": {
+                "bucket_key": bucket_key,
+                "format": "json",
+                "schema_version": _SNAPSHOT_SCHEMA_VERSION,
+                "byte_size": len(body_bytes),
+            },
         }
         if allowed_emails is not None:
             item["allowed_emails"] = allowed_emails
@@ -194,6 +227,7 @@ class ShareService:
             raise NotOwnerError()
 
         self._table.delete_item(Key={"share_id": item["share_id"]})
+        self._delete_snapshot_body(item)
         logger.info(f"Revoked share {item['share_id']}")
 
     async def delete_shares_for_session(self, session_id: str) -> int:
@@ -219,6 +253,12 @@ class ShareService:
             with self._table.batch_writer() as batch:
                 for item in items:
                     batch.delete_item(Key={"share_id": item["share_id"]})
+
+            # Best-effort cleanup of each share's S3 snapshot body. The
+            # DynamoDB delete above is what makes the share link stop working;
+            # an S3 miss here only leaves an orphan object, never a live share.
+            for item in items:
+                self._delete_snapshot_body(item)
 
             logger.info(
                 f"Deleted {len(items)} share(s) for session "
@@ -264,8 +304,7 @@ class ShareService:
 
         self._check_access(item, requester)
 
-        snapshot_messages = item.get("messages", [])
-        metadata = item.get("metadata", {})
+        metadata, snapshot_messages = self._load_snapshot_body(item)
         original_title = metadata.get("title", "Untitled Conversation")
         new_title = f"{original_title} (shared)"
 
@@ -428,6 +467,23 @@ class ShareService:
         return obj
 
     @staticmethod
+    def _convert_decimals_to_float(obj: Any) -> Any:
+        """Recursively convert DynamoDB ``Decimal`` values back to native types.
+
+        Legacy inline shares were written with ``_convert_floats_to_decimal``,
+        so their bodies come back off DynamoDB as ``Decimal``. Convert them
+        back — to ``int`` when integral, else ``float`` — so the legacy read
+        path yields the same plain-JSON shape as the S3-backed path.
+        """
+        if isinstance(obj, Decimal):
+            return int(obj) if obj % 1 == 0 else float(obj)
+        elif isinstance(obj, dict):
+            return {k: ShareService._convert_decimals_to_float(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [ShareService._convert_decimals_to_float(item) for item in obj]
+        return obj
+
+    @staticmethod
     def _sanitize_id(value: str, max_length: int = 128) -> str:
         """Return a log-safe version of an ID string.
 
@@ -507,11 +563,64 @@ class ShareService:
             share_url=f"/shared/{item['share_id']}",
         )
 
+    def _load_snapshot_body(self, item: dict) -> Tuple[dict, list]:
+        """Return ``(metadata, messages)`` for a share item.
+
+        Handles three item shapes for backward compatibility:
+
+          - **New** (``body_ref`` present): fetch the JSON body from S3.
+          - **Legacy inline** (``messages`` present, no ``body_ref``): read the
+            body straight off the DynamoDB item, exactly as before the S3
+            offload. Existing shares predate the offload and stay readable
+            with no migration.
+          - **Malformed** (neither): unreadable → ``ShareNotFoundError``.
+        """
+        body_ref = item.get("body_ref")
+        if body_ref:
+            key = body_ref.get("bucket_key")
+            try:
+                raw = self._snapshot_store.get(key)
+                body = json.loads(raw)
+            except (ShareSnapshotStoreError, ValueError) as e:
+                logger.error(
+                    f"Failed to load snapshot body for share "
+                    f"{self._sanitize_id(str(item.get('share_id', '')))} "
+                    f"key={key}: {e}"
+                )
+                raise ShareNotFoundError() from e
+            return body.get("metadata", {}) or {}, body.get("messages", []) or []
+
+        if item.get("messages") is not None:
+            # Legacy inline share — DynamoDB stored floats as Decimal; convert
+            # back so downstream JSON/Pydantic handling matches the S3 path.
+            metadata = self._convert_decimals_to_float(item.get("metadata", {}) or {})
+            messages = self._convert_decimals_to_float(item.get("messages", []))
+            return metadata, messages
+
+        logger.warning(
+            f"Share {self._sanitize_id(str(item.get('share_id', '')))} has neither "
+            "body_ref nor inline messages — treating as unreadable"
+        )
+        raise ShareNotFoundError()
+
+    def _delete_snapshot_body(self, item: dict) -> None:
+        """Best-effort delete of a share's S3 snapshot body.
+
+        No-op for legacy inline shares (no ``body_ref``). Never raises — the
+        store's delete swallows storage misses; a failure here logs but never
+        blocks the DynamoDB delete that actually revokes the share.
+        """
+        body_ref = item.get("body_ref")
+        if not body_ref:
+            return
+        key = body_ref.get("bucket_key")
+        if key:
+            self._snapshot_store.delete(key)
+
     def _build_shared_conversation_response(self, item: dict) -> SharedConversationResponse:
         from apis.shared.sessions.models import MessageResponse
 
-        metadata = item.get("metadata", {})
-        raw_messages = item.get("messages", [])
+        metadata, raw_messages = self._load_snapshot_body(item)
 
         messages = []
         for msg_data in raw_messages:
@@ -554,6 +663,18 @@ class AccessDeniedError(Exception):
 
 class ShareTableNotFoundError(Exception):
     """Raised when the DynamoDB table does not exist (CDK not deployed)."""
+    pass
+
+
+class ShareStorageUnavailableError(Exception):
+    """Raised when the S3 snapshot-body store is unconfigured or unreachable.
+
+    The share body is offloaded to S3; if the bucket is unset (misconfigured
+    deploy / local dev without AWS) or the write fails, creating a share can't
+    proceed. Surfaced to the client as a 503 with a friendly message rather
+    than silently falling back to inline (which would reintroduce the 400 KB
+    item-size failure).
+    """
     pass
 
 

--- a/backend/src/apis/app_api/shares/snapshot_store.py
+++ b/backend/src/apis/app_api/shares/snapshot_store.py
@@ -1,0 +1,217 @@
+"""S3-backed store for a conversation share's snapshot body.
+
+A share is a point-in-time snapshot of a conversation. The body — the full
+message list plus the session-metadata snapshot — is too large to inline in a
+single DynamoDB item (400 KB limit; a long conversation with tool results,
+images, or documents blows past it and PutItem fails with a
+``ValidationException``). So the body lives in the ``shared-conversations`` S3
+bucket and the DynamoDB row carries only the small control fields plus a
+pointer (``body_ref``) to the object.
+
+This store is a faithful sibling of ``apis/shared/memory/store.py`` (the Memory
+Spaces S3 offload) and ``apis/shared/skills/resource_store.py``:
+
+  - Objects are **content-addressed**: the key is
+    ``shares/{share_id}/{content_hash}`` where ``content_hash`` is the sha256
+    hex of the bytes. A share is immutable once created (``update_share`` only
+    touches access-control fields, never the body), so there is exactly one
+    object per share; content-addressing makes a retried ``create_share``
+    idempotent.
+  - The DynamoDB row references the object by key; the bytes never travel
+    through DynamoDB.
+
+It lives under ``app_api/shares/`` rather than ``apis/shared/`` because app-api
+is the only consumer (create writes; view/export read; revoke deletes). If a
+second consumer ever appears it moves to ``apis.shared`` per the import
+boundary rule.
+
+Configuration: the bucket name comes from ``SHARED_CONVERSATIONS_BUCKET_NAME``
+(set on the app-api role by the CDK ``SharedConversationsConstruct`` wiring).
+When boto3 or the bucket name is absent (local dev without AWS), the store is
+``enabled == False`` and every write raises ``ShareSnapshotStoreError`` so a
+misconfigured deploy surfaces loudly rather than silently reintroducing the
+400 KB inline cliff.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Optional
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# AWS-managed (SSE-S3 / AES256) encryption, matching the bucket default and the
+# memory-spaces / skills / artifacts / file-upload buckets.
+_SSE_ALGORITHM = "AES256"
+
+
+class ShareSnapshotStoreError(RuntimeError):
+    """Raised when the store cannot complete a requested operation.
+
+    Covers both "storage not configured" (no bucket / no boto3) and an
+    unexpected S3 failure, so callers have one error type to translate.
+    """
+
+
+def content_key(share_id: str, content_hash: str) -> str:
+    """Return the content-addressed object key for a share's snapshot body."""
+    return f"shares/{share_id}/{content_hash}"
+
+
+def compute_content_hash(content: bytes) -> str:
+    """Return the sha256 hex digest used as the content address."""
+    return hashlib.sha256(content).hexdigest()
+
+
+class ShareSnapshotStore:
+    """Put / get / delete a share's snapshot-body bytes in S3."""
+
+    def __init__(
+        self,
+        bucket_name: Optional[str] = None,
+        s3_client: Optional[object] = None,
+    ) -> None:
+        self.bucket_name = bucket_name or os.environ.get(
+            "SHARED_CONVERSATIONS_BUCKET_NAME"
+        )
+        # Allow an explicit client (tests inject a moto client); otherwise it is
+        # created lazily on first use so importing the module never needs creds.
+        self._s3 = s3_client
+
+    @property
+    def enabled(self) -> bool:
+        """True when a bucket is configured and boto3 is importable."""
+        return bool(self.bucket_name) and boto3 is not None
+
+    def _client(self):
+        if self._s3 is None:
+            if boto3 is None:  # pragma: no cover - import-guarded above
+                raise ShareSnapshotStoreError(
+                    "share snapshot storage unavailable: boto3 is not installed"
+                )
+            self._s3 = boto3.client("s3")
+        return self._s3
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise ShareSnapshotStoreError(
+                "share snapshot storage is not configured "
+                "(SHARED_CONVERSATIONS_BUCKET_NAME is unset)"
+            )
+
+    def put(self, *, share_id: str, body: bytes) -> str:
+        """Persist snapshot-body bytes content-addressed; return the object key.
+
+        Computes the sha256 of ``body``, derives the
+        ``shares/{share_id}/{content_hash}`` key, and uploads. If an object
+        already exists at that key (same content — a retried create), the
+        upload is skipped (dedupe); the key is returned either way.
+        """
+        self._require_enabled()
+        digest = compute_content_hash(body)
+        key = content_key(share_id, digest)
+        client = self._client()
+
+        if self._object_exists(key):
+            logger.info(
+                "shared-conversations: dedupe hit for share=%s key=%s (%d bytes)",
+                share_id,
+                key,
+                len(body),
+            )
+            return key
+
+        try:
+            client.put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=body,
+                ContentType="application/json",
+                ServerSideEncryption=_SSE_ALGORITHM,
+            )
+        except ClientError as e:  # pragma: no cover - network/permission path
+            logger.error(
+                "shared-conversations: put failed for share=%s key=%s: %s",
+                share_id,
+                key,
+                e,
+            )
+            raise ShareSnapshotStoreError(
+                f"failed to store snapshot body for share '{share_id}'"
+            ) from e
+
+        logger.info(
+            "shared-conversations: stored share=%s key=%s (%d bytes)",
+            share_id,
+            key,
+            len(body),
+        )
+        return key
+
+    def get(self, bucket_key: str) -> bytes:
+        """Return the bytes for an object key. Raises if missing/unavailable."""
+        self._require_enabled()
+        client = self._client()
+        try:
+            response = client.get_object(Bucket=self.bucket_name, Key=bucket_key)
+            return response["Body"].read()
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "404"):
+                raise ShareSnapshotStoreError(
+                    f"snapshot body not found at key '{bucket_key}'"
+                ) from e
+            logger.error(
+                "shared-conversations: get failed for key=%s: %s", bucket_key, e
+            )
+            raise ShareSnapshotStoreError(
+                f"failed to read snapshot body at key '{bucket_key}'"
+            ) from e
+
+    def delete(self, bucket_key: str) -> None:
+        """Delete an object key. Best-effort — never raises on the storage
+        miss path (deleting an already-absent object is a no-op in S3)."""
+        if not self.enabled:
+            return
+        client = self._client()
+        try:
+            client.delete_object(Bucket=self.bucket_name, Key=bucket_key)
+        except ClientError:  # pragma: no cover - best-effort cleanup
+            logger.warning(
+                "shared-conversations: delete failed for key=%s",
+                bucket_key,
+                exc_info=True,
+            )
+
+    def _object_exists(self, key: str) -> bool:
+        client = self._client()
+        try:
+            client.head_object(Bucket=self.bucket_name, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            # Any other error (permissions, throttling) is real — surface it
+            # rather than masquerading as "absent" and double-uploading.
+            raise
+
+
+_store: Optional[ShareSnapshotStore] = None
+
+
+def get_share_snapshot_store() -> ShareSnapshotStore:
+    """Get or create the process-global share snapshot store."""
+    global _store
+    if _store is None:
+        _store = ShareSnapshotStore()
+    return _store

--- a/backend/tests/apis/app_api/shares/test_share_s3_offload.py
+++ b/backend/tests/apis/app_api/shares/test_share_s3_offload.py
@@ -1,0 +1,254 @@
+"""Tests for the S3 snapshot-body offload in ShareService.
+
+Covers the regression this feature fixes — a conversation too large to inline
+in a DynamoDB item (>400 KB) can now be shared — plus the write shape
+(``body_ref``, no inline ``messages``), the S3-backed and legacy-inline read
+paths, revoke cleanup, and the storage-unavailable guard.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.shares.service import (
+    ShareService,
+    ShareStorageUnavailableError,
+)
+from apis.app_api.shares.snapshot_store import ShareSnapshotStore
+from apis.app_api.shares.models import CreateShareRequest
+from apis.shared.auth.models import User
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-shared-conversations"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def s3_client(aws_env):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+@pytest.fixture()
+def store(s3_client):
+    return ShareSnapshotStore(bucket_name=BUCKET, s3_client=s3_client)
+
+
+@pytest.fixture()
+def service(store, monkeypatch):
+    """A ShareService with a real moto S3 store and a mock DynamoDB table."""
+    monkeypatch.setenv("SHARED_CONVERSATIONS_TABLE_NAME", "shares-table")
+    with patch("boto3.resource"):
+        svc = ShareService(snapshot_store=store)
+    svc._table = MagicMock()
+    return svc
+
+
+def _owner() -> User:
+    return User(email="owner@example.com", user_id="owner-1", name="Owner", roles=["User"])
+
+
+def _message_dict(text: str, msg_id: str = "m0") -> dict:
+    return {
+        "id": msg_id,
+        "role": "user",
+        "content": [{"type": "text", "text": text}],
+        "createdAt": "2025-06-01T00:00:00Z",
+    }
+
+
+def _patch_snapshot_sources(metadata_dump: dict, message_dumps: list):
+    """Patch get_session_metadata + get_messages used by create_share."""
+    meta = MagicMock()
+    meta.model_dump.return_value = metadata_dump
+
+    messages = [MagicMock(model_dump=MagicMock(return_value=m)) for m in message_dumps]
+    messages_response = MagicMock(messages=messages)
+
+    return (
+        patch(
+            "apis.app_api.shares.service.get_session_metadata",
+            new=AsyncMock(return_value=meta),
+        ),
+        patch(
+            "apis.app_api.shares.service.get_messages",
+            new=AsyncMock(return_value=messages_response),
+        ),
+    )
+
+
+class TestCreateOffloadsToS3:
+    @pytest.mark.asyncio
+    async def test_item_carries_body_ref_not_inline_messages(self, service, s3_client):
+        meta_patch, msgs_patch = _patch_snapshot_sources(
+            {"title": "Hello Chat"}, [_message_dict("hi")]
+        )
+        with meta_patch, msgs_patch:
+            resp = await service.create_share(
+                "sess-1", _owner(), CreateShareRequest(accessLevel="public")
+            )
+
+        # The DynamoDB item was written with a body_ref and NO inline body.
+        item = service._table.put_item.call_args[1]["Item"]
+        assert "messages" not in item
+        assert "metadata" not in item
+        assert item["body_ref"]["bucket_key"].startswith("shares/")
+        assert item["body_ref"]["format"] == "json"
+        assert item["body_ref"]["byte_size"] > 0
+        assert resp.session_id == "sess-1"
+
+        # The S3 object decodes to the full snapshot body.
+        obj = s3_client.get_object(Bucket=BUCKET, Key=item["body_ref"]["bucket_key"])
+        body = json.loads(obj["Body"].read())
+        assert body["metadata"]["title"] == "Hello Chat"
+        assert body["messages"][0]["content"][0]["text"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_large_conversation_succeeds(self, service):
+        """Regression: a >400 KB snapshot no longer fails on PutItem."""
+        big = [_message_dict("x" * 5000, msg_id=f"m{i}") for i in range(120)]
+        # Sanity: the inline body would have blown DynamoDB's 400 KB item cap.
+        assert len(json.dumps({"metadata": {}, "messages": big})) > 400_000
+
+        meta_patch, msgs_patch = _patch_snapshot_sources({"title": "Big"}, big)
+        with meta_patch, msgs_patch:
+            resp = await service.create_share(
+                "sess-big", _owner(), CreateShareRequest(accessLevel="public")
+            )
+
+        assert resp.session_id == "sess-big"
+        item = service._table.put_item.call_args[1]["Item"]
+        assert item["body_ref"]["byte_size"] > 400_000
+
+    @pytest.mark.asyncio
+    async def test_storage_unavailable_raises(self, monkeypatch):
+        monkeypatch.setenv("SHARED_CONVERSATIONS_TABLE_NAME", "shares-table")
+        with patch("boto3.resource"):
+            svc = ShareService(snapshot_store=ShareSnapshotStore(bucket_name=None))
+        svc._table = MagicMock()
+
+        meta_patch, msgs_patch = _patch_snapshot_sources({"title": "T"}, [_message_dict("hi")])
+        with meta_patch, msgs_patch:
+            with pytest.raises(ShareStorageUnavailableError):
+                await svc.create_share(
+                    "sess-1", _owner(), CreateShareRequest(accessLevel="public")
+                )
+        # Nothing was written to DynamoDB when storage is unavailable.
+        svc._table.put_item.assert_not_called()
+
+
+class TestReadPaths:
+    @pytest.mark.asyncio
+    async def test_s3_backed_read_round_trips(self, service, store):
+        # Create, then read back through get_shared_conversation.
+        meta_patch, msgs_patch = _patch_snapshot_sources(
+            {"title": "Round Trip"}, [_message_dict("hello", "m1")]
+        )
+        with meta_patch, msgs_patch:
+            await service.create_share(
+                "sess-1", _owner(), CreateShareRequest(accessLevel="public")
+            )
+        written = service._table.put_item.call_args[1]["Item"]
+
+        with patch.object(service, "_get_share_item", return_value=written):
+            result = await service.get_shared_conversation("share-x", _owner())
+
+        assert result.title == "Round Trip"
+        assert len(result.messages) == 1
+        assert result.messages[0].content[0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_legacy_inline_read_still_works(self, service):
+        """A pre-offload item (inline messages, no body_ref) still resolves."""
+        legacy_item = {
+            "share_id": "share-legacy",
+            "session_id": "sess-old",
+            "owner_id": "owner-1",
+            "access_level": "public",
+            "created_at": "2025-01-01T00:00:00Z",
+            "metadata": {"title": "Old One"},
+            "messages": [_message_dict("legacy hi", "m0")],
+        }
+        with patch.object(service, "_get_share_item", return_value=legacy_item):
+            result = await service.get_shared_conversation("share-legacy", _owner())
+
+        assert result.title == "Old One"
+        assert result.messages[0].content[0].text == "legacy hi"
+
+    @pytest.mark.asyncio
+    async def test_malformed_item_raises_not_found(self, service):
+        from apis.app_api.shares.service import ShareNotFoundError
+
+        bad = {
+            "share_id": "share-bad",
+            "session_id": "s",
+            "owner_id": "owner-1",
+            "access_level": "public",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        with patch.object(service, "_get_share_item", return_value=bad):
+            with pytest.raises(ShareNotFoundError):
+                await service.get_shared_conversation("share-bad", _owner())
+
+
+    @pytest.mark.asyncio
+    async def test_export_reads_s3_backed_body(self, service):
+        """export_shared_conversation loads the body from S3, not inline."""
+        meta_patch, msgs_patch = _patch_snapshot_sources(
+            {"title": "Export Me"},
+            [_message_dict("one", "m0"), _message_dict("two", "m1")],
+        )
+        with meta_patch, msgs_patch:
+            await service.create_share(
+                "sess-1", _owner(), CreateShareRequest(accessLevel="public")
+            )
+        item = service._table.put_item.call_args[1]["Item"]
+
+        with patch.object(service, "_get_share_item", return_value=item), \
+             patch.object(service, "_check_access"), \
+             patch.object(
+                 service, "_copy_messages_to_memory",
+                 new_callable=AsyncMock, return_value=2,
+             ) as mock_copy, \
+             patch(
+                 "apis.app_api.shares.service.store_session_metadata",
+                 new_callable=AsyncMock,
+             ):
+            result = await service.export_shared_conversation("share-x", _owner())
+
+        assert result["title"] == "Export Me (shared)"
+        # The two S3-stored messages were the ones handed to the memory copy.
+        assert len(mock_copy.call_args[0][2]) == 2
+
+
+class TestRevokeCleansUpS3:
+    @pytest.mark.asyncio
+    async def test_revoke_deletes_s3_object(self, service, s3_client):
+        meta_patch, msgs_patch = _patch_snapshot_sources({"title": "T"}, [_message_dict("hi")])
+        with meta_patch, msgs_patch:
+            await service.create_share(
+                "sess-1", _owner(), CreateShareRequest(accessLevel="public")
+            )
+        item = service._table.put_item.call_args[1]["Item"]
+        key = item["body_ref"]["bucket_key"]
+        # Object exists before revoke.
+        assert s3_client.get_object(Bucket=BUCKET, Key=key)["Body"].read()
+
+        with patch.object(service, "_get_share_item", return_value=item):
+            await service.revoke_share(item["share_id"], _owner())
+
+        with pytest.raises(s3_client.exceptions.NoSuchKey):
+            s3_client.get_object(Bucket=BUCKET, Key=key)

--- a/backend/tests/apis/app_api/shares/test_snapshot_store.py
+++ b/backend/tests/apis/app_api/shares/test_snapshot_store.py
@@ -1,0 +1,100 @@
+"""Tests for the S3-backed share snapshot-body store.
+
+moto-backed: exercises content-hash keying, dedupe (no second put for
+identical bytes), get/delete round-trip, and the not-configured guard.
+Mirrors ``tests/shared/test_memory_store.py``.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.shares.snapshot_store import (
+    ShareSnapshotStore,
+    ShareSnapshotStoreError,
+    compute_content_hash,
+    content_key,
+)
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-shared-conversations"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def s3_client(aws_env):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+@pytest.fixture()
+def store(s3_client):
+    return ShareSnapshotStore(bucket_name=BUCKET, s3_client=s3_client)
+
+
+class TestContentKey:
+    def test_key_is_content_addressed(self):
+        digest = compute_content_hash(b"body")
+        assert content_key("share-1", digest) == f"shares/share-1/{digest}"
+
+    def test_hash_is_stable_and_distinct(self):
+        assert compute_content_hash(b"a") == compute_content_hash(b"a")
+        assert compute_content_hash(b"a") != compute_content_hash(b"b")
+
+
+class TestPutGetDelete:
+    def test_put_returns_content_addressed_key(self, store):
+        key = store.put(share_id="share-1", body=b'{"messages":[]}')
+        assert key == content_key("share-1", compute_content_hash(b'{"messages":[]}'))
+
+    def test_get_round_trip(self, store):
+        key = store.put(share_id="share-1", body=b"hello-body")
+        assert store.get(key) == b"hello-body"
+
+    def test_put_is_idempotent_dedupe(self, store, s3_client):
+        k1 = store.put(share_id="s", body=b"same")
+        k2 = store.put(share_id="s", body=b"same")
+        assert k1 == k2
+        # Exactly one object under the prefix.
+        listing = s3_client.list_objects_v2(Bucket=BUCKET, Prefix="shares/s/")
+        assert listing["KeyCount"] == 1
+
+    def test_get_missing_key_raises(self, store):
+        with pytest.raises(ShareSnapshotStoreError):
+            store.get("shares/nope/deadbeef")
+
+    def test_delete_is_best_effort(self, store):
+        key = store.put(share_id="s", body=b"x")
+        store.delete(key)
+        # Deleting an already-absent object is a no-op (never raises).
+        store.delete(key)
+        with pytest.raises(ShareSnapshotStoreError):
+            store.get(key)
+
+
+class TestEnabledGuard:
+    def test_disabled_when_bucket_unset(self, monkeypatch):
+        monkeypatch.delenv("SHARED_CONVERSATIONS_BUCKET_NAME", raising=False)
+        assert ShareSnapshotStore(bucket_name=None).enabled is False
+
+    def test_put_raises_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("SHARED_CONVERSATIONS_BUCKET_NAME", raising=False)
+        store = ShareSnapshotStore(bucket_name=None)
+        with pytest.raises(ShareSnapshotStoreError):
+            store.put(share_id="s", body=b"x")
+
+    def test_delete_when_disabled_is_noop(self, monkeypatch):
+        monkeypatch.delenv("SHARED_CONVERSATIONS_BUCKET_NAME", raising=False)
+        store = ShareSnapshotStore(bucket_name=None)
+        # No exception even though storage is unconfigured.
+        store.delete("shares/s/abc")

--- a/docs/specs/share-large-conversations-s3-offload.md
+++ b/docs/specs/share-large-conversations-s3-offload.md
@@ -1,0 +1,329 @@
+# Sharing large conversations — S3 snapshot offload
+
+**Status:** Draft (spec-first; implementation gated on approval)
+**Branch:** `feature/share-large-conversations-s3-offload` (off `develop`)
+**Owner:** Phil Merrell
+**Related:** Conversation share feature (`apis/app_api/shares/`); PR #657 (share IAM-grant fix — *separate* bug); Memory Spaces S3 store (`apis/shared/memory/store.py`); Artifacts / Skills / RAG S3-offload precedent.
+
+---
+
+## 1. Problem
+
+Creating a share for a large conversation fails. `ShareService.create_share` inlines the full message list into a single DynamoDB item on the `shared-conversations` table:
+
+```python
+item = {
+    "share_id": share_id,
+    ...
+    "metadata": metadata_snapshot,
+    "messages": messages_snapshot,   # ← entire conversation, inline
+}
+self._table.put_item(Item=item)
+```
+
+DynamoDB caps an item at **400 KB**. A long conversation — especially one with tool results, images, documents, or reasoning blocks — blows past that. Observed in **prod-ai** (`897729136999`, `us-west-2`) app-api logs:
+
+```
+apis.app_api.shares.routes - ERROR - Error creating share for session 69ea19d9-...:
+An error occurred (ValidationException) when calling the PutItem operation:
+Item size has exceeded the maximum allowed size
+```
+
+The route's catch-all turns this into a bare `500 {"detail":"Failed to create share"}`. The user is told sharing failed with no reason and no recourse.
+
+This is **distinct** from the `AccessDeniedException` IAM-grant bug fixed in PR #657. This one is `ValidationException` / item-size.
+
+### Why this recurs
+
+The snapshot is a *copy* of the conversation taken at share time, so it grows monotonically with conversation length and with the richness of each turn (a single image or document block can be tens/hundreds of KB after base64). There is no upper bound on conversation size, so any "just trim it" mitigation only moves the cliff.
+
+---
+
+## 2. Goal
+
+Support sharing conversations of any size, transparently, while:
+
+- Keeping the existing share read/write/update/revoke/export API contract unchanged (SPA needs no changes).
+- Mirroring the **established S3-offload pattern** already used for Memory Spaces, Skills reference files, Artifacts, and RAG documents — not inventing a new one.
+- Remaining backward-compatible with existing inline-item shares in prod/dev.
+- Replacing the bare `500` with a specific, honest error if a share genuinely cannot be created.
+
+---
+
+## 3. Design overview
+
+Offload the **snapshot body** (`messages`, and defensively `metadata`) to an S3 object. Keep in the DynamoDB item only:
+
+- the share's control-plane fields (`share_id`, `session_id`, `owner_id`, `owner_email`, `access_level`, `allowed_emails`, `created_at`) — these are small, queried by GSIs, and mutated by `update_share`; they **must** stay in DynamoDB, and
+- a **pointer** to the S3 object holding the body.
+
+The DynamoDB item thus becomes small and bounded regardless of conversation size. The read path (`get_shared_conversation`, `export_shared_conversation`, `get_shares_for_session`) fetches the body from S3 when the pointer is present, and falls back to the inline `messages`/`metadata` fields when it is not (legacy items).
+
+```
+create_share
+  ├─ snapshot messages + metadata (unchanged)
+  ├─ serialize body → JSON bytes
+  ├─ store.put(share_id, body) → s3_key            (NEW)
+  └─ put_item { control fields..., body_ref: {bucket_key, format, ...} }   (no inline messages)
+
+get_shared_conversation / export_shared_conversation
+  ├─ get_item → control fields + (body_ref | inline messages)
+  ├─ if body_ref: store.get(key) → messages/metadata     (NEW)
+  └─ else: read inline item["messages"]/["metadata"]     (legacy fallback)
+```
+
+### Why S3, always (not a size threshold)
+
+The task raised "inline under N KB vs always-S3." **Recommendation: always offload the body to S3.** Rationale:
+
+- **One code path.** A size gate means two write paths and two read paths, each needing tests and each a place for the 400 KB cliff to hide (the gate has to account for DynamoDB's *item* overhead — attribute names, the `Decimal` re-encoding, the control fields — not just `len(json)`, so a naive threshold is itself a source of bugs).
+- **The body is never queried.** Nothing in the share feature does a DynamoDB `Query`/`Scan` *on message content*; the GSIs key on `session_id` and `owner_id` only. So there is zero DynamoDB-side benefit to keeping messages inline.
+- **The offloaded read is one `get_object`.** For a share view that already crosses the network and renders a whole conversation, a single S3 GET is negligible latency and removes a class of failure entirely.
+- Precedent: Memory Spaces, Skills, and Artifacts all offload bytes to S3 unconditionally and keep only manifests/pointers in DynamoDB. This proposal is deliberately the *same shape*, for reviewer familiarity and code reuse.
+
+The one concession to "small items": we still **read** legacy inline items (they predate this change), but we never **write** new ones.
+
+---
+
+## 4. Storage design
+
+### 4.1 New bucket: `shared-conversations`
+
+A dedicated private S3 bucket, created by extending `SharedConversationsConstruct` (co-locating bucket + table in the one construct that already owns this domain — same as `MemorySpacesConstruct` owning both its bucket and table, and `ArtifactsDataConstruct` owning both).
+
+```ts
+// infrastructure/lib/constructs/data/shared-conversations-construct.ts
+public readonly bucket: s3.Bucket;
+
+this.bucket = new s3.Bucket(this, 'SharedConversationsBucket', {
+  bucketName: getResourceName(config, 'shared-conversations'),
+  encryption: s3.BucketEncryption.S3_MANAGED,
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  enforceSSL: true,
+  lifecycleRules: [
+    { id: 'abort-stale-multipart', abortIncompleteMultipartUploadAfter: cdk.Duration.days(7) },
+  ],
+  removalPolicy: getRemovalPolicy(config),
+  autoDeleteObjects: getAutoDeleteObjects(config),
+});
+```
+
+Private, server-side-only access (app-api reads/writes; never loaded cross-origin — the share view is JSON served by app-api, not an iframe). Byte-for-byte the Memory Spaces bucket recipe.
+
+**No expiration lifecycle rule.** A share's object lives exactly as long as the share row: it is deleted when the share is revoked or the session's shares are cleaned up (§5.4). Age-based reaping would break live shares — the same "reference recency ≠ object age" lesson from the MCP App UI-resource persistence work (`project_mcp_apps_uires_persistence`: never age-based deletes when a live row can still point at the object).
+
+> **Decision point for review:** dedicated bucket vs. reusing an existing one. A dedicated bucket keeps IAM scoping clean (its own ARN, its own grant sid) and lifecycle independent, at the cost of one more bucket. This is the pattern every sibling feature follows, so the spec assumes a dedicated bucket. (Reusing e.g. the file-upload bucket would muddy IAM and lifecycle for no real saving.)
+
+### 4.2 Object key layout
+
+Content-addressed, mirroring `memory/store.py` and the skills resource store:
+
+```
+shares/{share_id}/{content_hash}
+```
+
+- `content_hash` = `sha256(body_bytes)` hex.
+- One object per share (a share is immutable once created — `update_share` only touches access-control fields, never the body). Content-addressing gives us free idempotency on retry: a re-run of the same `create_share` body writes the same key.
+- Keyed under `share_id` so §5.4 revoke can delete the object by known key, and a stray-object sweep can list by `shares/{share_id}/` prefix.
+
+### 4.3 DynamoDB item shape (new writes)
+
+```python
+item = {
+    "share_id": share_id,
+    "session_id": session_id,
+    "owner_id": user.user_id,
+    "owner_email": user.email,
+    "access_level": request.access_level,
+    "created_at": now,
+    "allowed_emails": [...],          # when access_level == "specific"
+    "body_ref": {                     # ← NEW: pointer replaces inline body
+        "bucket_key": "shares/{share_id}/{hash}",
+        "format": "json",             # serialization of the body object
+        "schema_version": 1,          # snapshot schema, for forward migration
+        "byte_size": 812345,          # observability / future gating
+    },
+    # NOTE: no "messages" / "metadata" attributes on new items
+}
+```
+
+The body object itself is the JSON serialization of:
+
+```json
+{ "metadata": { ...session metadata snapshot... },
+  "messages": [ ...MessageResponse dicts... ] }
+```
+
+Serialized with plain `json.dumps` (UTF-8 bytes). **The float→Decimal conversion is dropped for the offloaded body** — that conversion only exists to satisfy DynamoDB's boto3 resource, which rejects Python floats. S3 stores opaque bytes, so we serialize the raw Pydantic `model_dump` directly and skip `_convert_floats_to_decimal` for anything going to S3. (Control fields going into DynamoDB are all strings/lists, so no Decimal concern there.) This also sidesteps the read-side `Decimal`→float round-trip.
+
+### 4.4 Backward compatibility
+
+Reads must handle three item shapes:
+
+| Item shape | How it's read |
+|---|---|
+| **New** (`body_ref` present, no inline `messages`) | fetch body from S3 via `store.get(body_ref["bucket_key"])` |
+| **Legacy inline** (`messages`/`metadata` present, no `body_ref`) | read inline exactly as today |
+| **Malformed** (neither) | raise `ShareNotFoundError` / log; treat as unreadable |
+
+No data migration is required — existing inline shares keep working untouched. New shares are S3-backed. Optional one-time backfill is **out of scope** (existing inline shares are, by definition, already small enough to have been written).
+
+---
+
+## 5. Backend changes
+
+All under `backend/src/apis/app_api/shares/`, plus one shared store.
+
+### 5.1 New: snapshot body store
+
+`apis/app_api/shares/snapshot_store.py` — a thin S3 put/get keyed by `share_id`, structurally identical to `memory/store.py` but domain-scoped to shares. (It lives under `app_api/shares/` because app-api is the only consumer; if a second consumer ever appears it moves to `apis/shared/` per the import-boundary rule. Memory's store is under `apis/shared/` precisely because both app-api and inference-api use it — shares are app-api-only.)
+
+```python
+class ShareSnapshotStore:
+    def __init__(self, bucket_name: str | None = None, s3_client=None): ...
+    @property
+    def enabled(self) -> bool: ...            # bucket configured AND boto3 present
+    def put(self, *, share_id: str, body: bytes) -> str:   # → bucket_key
+    def get(self, bucket_key: str) -> bytes:
+    def delete(self, bucket_key: str) -> None:             # best-effort
+```
+
+- `put`: content-address (`sha256`), `head_object` dedupe, `put_object` with `ServerSideEncryption="AES256"`, `ContentType="application/json"`.
+- `get`: `get_object`; `NoSuchKey`/`404` → a typed `ShareSnapshotStoreError` the service maps to a friendly error.
+- Errors raise `ShareSnapshotStoreError` (module-local), consistent with `MemorySpaceStoreError`.
+
+Env var: **`SHARED_CONVERSATIONS_BUCKET_NAME`** (naming parallels the existing `SHARED_CONVERSATIONS_TABLE_NAME`).
+
+### 5.2 `create_share`
+
+- Build `metadata_snapshot` + `messages_snapshot` as today (still via `model_dump(by_alias=True, exclude_none=True)`), **without** `_convert_floats_to_decimal` for the S3 body.
+- Serialize `{"metadata": ..., "messages": ...}` → UTF-8 JSON bytes.
+- `bucket_key = store.put(share_id=share_id, body=body_bytes)`.
+- Put the item with `body_ref` and **no** inline `messages`/`metadata`.
+- If `store.enabled` is False (bucket unset) → raise a new `ShareStorageUnavailableError` (maps to a specific message, §5.5), instead of silently falling back to inline (which would reintroduce the 400 KB cliff).
+
+### 5.3 Read paths
+
+- `_get_share_item` unchanged (still `get_item` by `share_id`).
+- New helper `_load_snapshot_body(item) -> tuple[metadata, messages]`:
+  - if `item.get("body_ref")`: `json.loads(store.get(item["body_ref"]["bucket_key"]))` → `(body["metadata"], body["messages"])`.
+  - elif `item.get("messages") is not None`: legacy inline → `(item.get("metadata", {}), item["messages"])`.
+  - else: log + raise `ShareNotFoundError`.
+- `_build_shared_conversation_response` and `export_shared_conversation._copy_messages_to_memory` consume `messages` from this helper rather than `item["messages"]` directly.
+- `get_shares_for_session` / `_build_share_response` **do not** need the body — they only surface control fields — so listing stays a pure DynamoDB read with **no** S3 fetch. (Good: the list view is unaffected and fast.)
+
+### 5.4 Delete / revoke
+
+- `revoke_share`: after `delete_item`, best-effort `store.delete(body_ref["bucket_key"])` (guarded on `body_ref` present).
+- `delete_shares_for_session`: for each item being batch-deleted, best-effort delete its S3 object. (These are cleanup paths; an S3 delete failure logs but never blocks the DynamoDB delete — matching the "revoked link stops working" guarantee, which is enforced by the DynamoDB row's absence, not the object's.)
+- Legacy inline items have no `body_ref` → nothing to delete in S3.
+
+### 5.5 Friendlier errors (route layer)
+
+Replace the bare `500` with specific handling in `routes.create_share`:
+
+- New `ShareStorageUnavailableError` → `503 {"detail":"Sharing is temporarily unavailable. Please try again later."}` (bucket unset / boto3 missing — a config problem, not the user's fault).
+- The 400 KB path essentially disappears for the body. If a *control* item still somehow exceeds limits (it can't in practice — it's a handful of strings), the generic `500` remains as the final catch-all, but with the item-size failure mode designed out.
+- The catch-all `except Exception` stays as a backstop but the common failure now has a real message.
+
+> The SPA already renders `detail` from error responses, so a clearer `detail` string improves UX with zero frontend change. (A dedicated toast copy tweak is optional and out of scope here.)
+
+---
+
+## 6. Infrastructure changes
+
+### 6.1 Construct
+
+`SharedConversationsConstruct` gains a `public readonly bucket: s3.Bucket` (§4.1) and an SSM publication for symmetry with the table:
+
+```ts
+new ssm.StringParameter(this, 'SharedConversationsBucketNameParameter', {
+  parameterName: `/${config.projectPrefix}/shares/shared-conversations-bucket-name`,
+  stringValue: this.bucket.bucketName,
+  ...
+});
+```
+
+### 6.2 Platform wiring
+
+- `platform-stack.ts`: `this.sharedConversationsBucket = sharedConversations.bucket;` and add to the `PlatformComputeRefs` bundle passed to app-api (alongside the existing `sharedConversationsTable`).
+- `platform-compute-refs.ts`: add `sharedConversationsBucket: s3.IBucket;`.
+- `app-api-environment.ts`: thread `sharedConversationsBucketName` and set env `SHARED_CONVERSATIONS_BUCKET_NAME: params.sharedConversationsBucketName`.
+
+### 6.3 IAM grant (app-api task role)
+
+Add to `app-api-iam-grants.ts`, mirroring `MemorySpacesBucketReadWrite`:
+
+```ts
+taskRole.addToPrincipalPolicy(new iam.PolicyStatement({
+  sid: 'SharedConversationsBucketReadWrite',
+  effect: iam.Effect.ALLOW,
+  actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+  resources: [
+    props.refs.sharedConversationsBucket.bucketArn,
+    `${props.refs.sharedConversationsBucket.bucketArn}/*`,
+  ],
+}));
+```
+
+app-api is the only reader/writer (create writes; view/export read; revoke deletes). Inference-api is **not** granted — it never touches shares. This respects the service boundary (`feedback_service_boundaries`).
+
+### 6.4 Local dev
+
+Add `SHARED_CONVERSATIONS_BUCKET_NAME=` to `backend/src/.env.example` next to the existing `SHARED_CONVERSATIONS_TABLE_NAME`. Locally unset → `store.enabled == False` → create returns the `503` "temporarily unavailable" message rather than a confusing 500, which is the honest state of a machine with no bucket.
+
+---
+
+## 7. Backward-compat & rollout
+
+1. **Deploy order:** `platform.yml` (CDK — creates bucket, grant, env) **before** the `backend.yml` app-api image that writes `body_ref`. Because reads fall back to inline, an app-api that predates the bucket keeps working; an app-api that has the code but no bucket yet returns the `503` on *create* only (reads unaffected). So the CDK deploy must land first, but there is no hard coupling that breaks reads.
+2. **Existing inline shares** keep resolving via the legacy read path indefinitely. No migration.
+3. **Rollback:** reverting the app-api image returns to inline writes (large shares fail again, as before) but every S3-backed share created in the interim becomes unreadable by the old code (it doesn't know `body_ref`). This is the one rollback caveat — **note it in the PR.** Mitigation if that matters: land the *read* support (fallback + `body_ref` handling) in an earlier, separately-deployed change than the *write* switch, so a rollback target already understands `body_ref`. See §9 phasing.
+
+---
+
+## 8. Testing
+
+Existing suites to extend (all present): `tests/routes/test_shares.py`, `test_share_export.py`, `test_share_properties.py`, `tests/apis/app_api/shares/`.
+
+- **Store unit tests** (moto S3): put→get round-trip, dedupe on identical body, `NoSuchKey`→typed error, `enabled` False when bucket unset.
+- **create_share** writes `body_ref` and **no** inline `messages`; body object in S3 decodes to the snapshot.
+- **Large conversation:** a snapshot > 400 KB now succeeds (regression test for the actual bug — build a message list that exceeds 400 KB inline and assert `create_share` returns 201).
+- **Legacy read:** an item with inline `messages` and no `body_ref` still resolves via `get_shared_conversation` and `export_shared_conversation`.
+- **Revoke** deletes the S3 object; `delete_shares_for_session` cleans up objects.
+- **Storage-unavailable:** bucket unset → `create_share` → `503` with the friendly detail.
+- **Float handling:** a message with a float (e.g. a cost/score) round-trips through S3 JSON without the `Decimal` dance and validates back into `MessageResponse`.
+- **Infra:** `infrastructure` jest snapshot updated for the new bucket + grant; `npx tsc --noEmit` + `npx cdk synth` clean.
+
+---
+
+## 9. Phasing (PRs into `develop`)
+
+Small, reviewable, rollback-aware:
+
+- **PR-1 — Read support + infra (no behavior change to writes).**
+  CDK: bucket, SSM, compute-ref, env, IAM grant. Backend: `ShareSnapshotStore`, `_load_snapshot_body` with legacy fallback wired into read/export paths. **Writes still inline.** Deploying this makes every running app-api `body_ref`-aware *before* anything writes one — this is the rollback-safety anchor (§7.3).
+- **PR-2 — Switch writes to S3.**
+  `create_share` serializes + `store.put` + `body_ref` item, drops inline body; revoke/session-cleanup delete objects; `ShareStorageUnavailableError` + friendly `503`. Tests: large-conversation regression, storage-unavailable.
+- **PR-3 (optional) — SPA copy polish.**
+  Nicer toast for the `503`/failure states. Pure frontend; can be skipped if the `detail` passthrough is deemed sufficient.
+
+Each PR branches from `develop`, targets `develop`, conventional-commit titled (`feat(shares): ...`).
+
+---
+
+## 10. Alternatives considered
+
+- **Size-gated inline vs. S3.** Rejected — two code paths, and the gate itself has to model DynamoDB item overhead correctly or it just relocates the cliff (§3).
+- **Compress inline (gzip the body attribute).** Buys a ~3–5× headroom but does not remove the ceiling; a big enough conversation with images still exceeds 400 KB compressed, and it adds an opaque binary blob to DynamoDB that PITR/console can't inspect. Rejected as a stopgap, not a fix.
+- **Split across multiple DynamoDB items (chunking).** Reintroduces multi-item transactional complexity (partial writes, ordering) that S3 avoids entirely. Rejected.
+- **Reference the live session instead of snapshotting.** Would eliminate the copy, but breaks the share's point-in-time semantics and its independence from later edits/deletes of the source session (a share deliberately survives the owner continuing or deleting the conversation — see `delete_shares_for_session`'s "exported conversations unaffected" note). Rejected — changes product behavior.
+
+---
+
+## 11. Open questions
+
+1. **Dedicated bucket vs. reuse** (§4.1 decision point). Spec assumes dedicated, per sibling-feature precedent. Confirm.
+2. **Backfill of legacy inline shares** — spec says skip (they're already small). Confirm no desire to normalize storage.
+3. **SPA toast copy** — is the `detail` passthrough enough, or do we want PR-3?
+4. **Object encryption** — S3-managed (SSE-S3/AES256) matches every sibling bucket. A share body is the same data-class as the session it came from (behind the same auth), so no case for KMS/CMK here (`feedback_governance_via_identity_claims`). Confirm.

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -91,6 +91,7 @@ export interface AppApiSsmParams {
   ragDocumentsBucketArn: string;
   sharedConversationsTableName: string;
   sharedConversationsTableArn: string;
+  sharedConversationsBucketName: string;
   memoryId: string;
   // Memory Spaces
   memorySpacesTableName: string;
@@ -206,6 +207,7 @@ export function resolveAppApiParams(
     ragDocumentsBucketArn: refs.ragDocumentsBucket.bucketArn,
     sharedConversationsTableName: refs.sharedConversationsTable.tableName,
     sharedConversationsTableArn: refs.sharedConversationsTable.tableArn,
+    sharedConversationsBucketName: refs.sharedConversationsBucket.bucketName,
     memoryId: overrides.memoryId,
     // Memory Spaces
     memorySpacesTableName: refs.memorySpacesTable.tableName,
@@ -265,6 +267,7 @@ export function buildAppApiEnvironment(
     COGNITO_DOMAIN_URL: params.cognitoDomainUrl,
     COGNITO_REGION: config.awsRegion,
     SHARED_CONVERSATIONS_TABLE_NAME: params.sharedConversationsTableName,
+    SHARED_CONVERSATIONS_BUCKET_NAME: params.sharedConversationsBucketName,
     BFF_SESSIONS_TABLE_NAME: params.bffSessionsTableName,
     BFF_COOKIE_SIGNING_KEY_ARN: params.bffCookieSigningKeyArn,
     BFF_COOKIE_DATA_KEY_SECRET_ARN: params.bffCookieDataKeySecretArn,

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -138,6 +138,23 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Shared-conversations snapshot bucket ──
+  // The share BODY (messages + metadata) is offloaded to S3 because a long
+  // conversation exceeds DynamoDB's 400 KB item limit; only a pointer stays
+  // in the shared-conversations table. app-api is the sole reader/writer:
+  // create writes, view/export read, revoke/session-cleanup delete. Mirrors
+  // MemorySpacesBucketReadWrite. See
+  // docs/specs/share-large-conversations-s3-offload.md.
+  const sharedConversationsBucketArn = props.refs.sharedConversationsBucket.bucketArn;
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'SharedConversationsBucketReadWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+      resources: [sharedConversationsBucketArn, `${sharedConversationsBucketArn}/*`],
+    }),
+  );
+
   // ── Core tables (OIDC, Users, Roles, API Keys, OAuth) ──
   const coreTables = [
     { sid: 'OidcStateAccess', arn: props.refs.oidcStateTable.tableArn },

--- a/infrastructure/lib/constructs/data/shared-conversations-construct.ts
+++ b/infrastructure/lib/constructs/data/shared-conversations-construct.ts
@@ -1,8 +1,15 @@
+import * as cdk from 'aws-cdk-lib';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
-import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';
+import {
+  AppConfig,
+  getAutoDeleteObjects,
+  getRemovalPolicy,
+  getResourceName,
+} from '../../config';
 
 export interface SharedConversationsConstructProps {
   config: AppConfig;
@@ -18,9 +25,18 @@ export interface SharedConversationsConstructProps {
  *   PK: share_id
  *   GSI: SessionShareIndex     — lookup by original session_id
  *   GSI: OwnerShareIndex       — list shares by owner, sorted by created_at
+ *
+ * The snapshot BODY (messages + metadata) is offloaded to the sibling S3
+ * bucket, because a long conversation exceeds DynamoDB's 400 KB item limit
+ * (PutItem ValidationException). The DynamoDB item keeps only the small
+ * control fields plus an S3 pointer (`body_ref`); the bytes live in S3.
+ * Mirrors the Memory Spaces / Artifacts / Skills S3-offload pattern.
+ * Private, server-side-only (app-api reads/writes; never loaded cross-origin).
+ * See docs/specs/share-large-conversations-s3-offload.md.
  */
 export class SharedConversationsConstruct extends Construct {
   public readonly table: dynamodb.Table;
+  public readonly bucket: s3.Bucket;
 
   constructor(
     scope: Construct,
@@ -30,6 +46,25 @@ export class SharedConversationsConstruct extends Construct {
     super(scope, id);
 
     const { config } = props;
+
+    // Snapshot-body bucket — private, bytes-only, fetched server-side by
+    // app-api. No expiration lifecycle rule: a share's object lives exactly
+    // as long as its DynamoDB row and is deleted explicitly on revoke /
+    // session cleanup. Age-based reaping would break live shares.
+    this.bucket = new s3.Bucket(this, 'SharedConversationsBucket', {
+      bucketName: getResourceName(config, 'shared-conversations'),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      lifecycleRules: [
+        {
+          id: 'abort-stale-multipart',
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(7),
+        },
+      ],
+      removalPolicy: getRemovalPolicy(config),
+      autoDeleteObjects: getAutoDeleteObjects(config),
+    });
 
     this.table = new dynamodb.Table(this, 'SharedConversationsTable', {
       tableName: getResourceName(config, 'shared-conversations'),
@@ -66,6 +101,13 @@ export class SharedConversationsConstruct extends Construct {
       parameterName: `/${config.projectPrefix}/shares/shared-conversations-table-name`,
       stringValue: this.table.tableName,
       description: 'Shared conversations table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'SharedConversationsBucketNameParameter', {
+      parameterName: `/${config.projectPrefix}/shares/shared-conversations-bucket-name`,
+      stringValue: this.bucket.bucketName,
+      description: 'Shared conversations snapshot-body S3 bucket name',
       tier: ssm.ParameterTier.STANDARD,
     });
 

--- a/infrastructure/lib/constructs/platform-compute-refs.ts
+++ b/infrastructure/lib/constructs/platform-compute-refs.ts
@@ -79,6 +79,7 @@ export interface PlatformComputeRefs {
   userMenuLinksTable: dynamodb.ITable;
   systemPromptsTable: dynamodb.ITable;
   sharedConversationsTable: dynamodb.ITable;
+  sharedConversationsBucket: s3.IBucket;
   fileUploadBucket: s3.IBucket;
   fileUploadTable: dynamodb.ITable;
 

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -162,6 +162,7 @@ export class PlatformStack extends cdk.Stack {
   public readonly userMenuLinksTable: dynamodb.ITable;
   public readonly systemPromptsTable: dynamodb.ITable;
   public readonly sharedConversationsTable: dynamodb.ITable;
+  public readonly sharedConversationsBucket: s3.IBucket;
   public readonly fileUploadBucket: s3.IBucket;
   public readonly fileUploadTable: dynamodb.ITable;
 
@@ -369,6 +370,7 @@ export class PlatformStack extends cdk.Stack {
       { config },
     );
     this.sharedConversationsTable = sharedConversations.table;
+    this.sharedConversationsBucket = sharedConversations.bucket;
 
     // ============================================================
     // RAG data
@@ -689,6 +691,7 @@ export class PlatformStack extends cdk.Stack {
       userMenuLinksTable: this.userMenuLinksTable,
       systemPromptsTable: this.systemPromptsTable,
       sharedConversationsTable: this.sharedConversationsTable,
+      sharedConversationsBucket: this.sharedConversationsBucket,
       fileUploadBucket: this.fileUploadBucket,
       fileUploadTable: this.fileUploadTable,
       ragDocumentsBucket: this.ragDocumentsBucket,

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -117,8 +117,9 @@ describe('PlatformStack', () => {
     it('creates all data buckets', () => {
       // file-uploads, SPA static, mcp-sandbox, rag-documents, fine-tuning-data,
       // artifacts-content, skill-resources (admin-managed Skills reference files),
-      // memory-spaces (Memory Spaces feature content bucket)
-      template.resourceCountIs('AWS::S3::Bucket', 8);
+      // memory-spaces (Memory Spaces feature content bucket),
+      // shared-conversations (share snapshot-body offload)
+      template.resourceCountIs('AWS::S3::Bucket', 9);
     });
   });
 


### PR DESCRIPTION
## Problem

Sharing a large conversation fails. `ShareService.create_share` inlines the full message list into a single DynamoDB item on the `shared-conversations` table, exceeding DynamoDB's **400 KB item limit**. Users see a bare `500 {"detail":"Failed to create share"}`. Observed in **prod-ai** (`897729136999`, us-west-2) as a `PutItem` `ValidationException` ("Item size has exceeded the maximum allowed size").

This is **separate** from the IAM-grant bug fixed in #657 (that was `AccessDeniedException`; this is item-size).

## Fix

Offload the snapshot **body** (messages + metadata) to a new private `shared-conversations` S3 bucket, keeping only control fields + a `body_ref` pointer in DynamoDB — mirroring the Memory Spaces / Artifacts / Skills S3-offload pattern (content-addressed keys, SSE-S3, dedicated bucket owned by the same construct, IAM grant threaded through `PlatformComputeRefs`).

Reads fall back to inline for legacy shares, so **existing shares keep working with no migration** and the SPA contract is unchanged.

### Backend (`apis/app_api/shares/`)
- **New** `snapshot_store.py` — `ShareSnapshotStore`: content-addressed S3 put/get/delete (`shares/{share_id}/{sha256}`), SSE-S3, dedupe. Sibling of `apis/shared/memory/store.py`.
- `service.py` — `create_share` serializes `{metadata, messages}` → JSON → S3, writes a `body_ref` item (no inline body). New `_load_snapshot_body` reads from S3 or falls back to legacy inline. Revoke + session-cleanup best-effort delete the S3 object. New `ShareStorageUnavailableError`.
- `routes.py` — bare `500` → friendly `503` when storage is unconfigured.
- Dropped the `float→Decimal` dance for the S3 body (only DynamoDB's boto3 resource needs it); legacy inline items get `Decimal→float` on read for a uniform shape.

### Infra
- Extended `SharedConversationsConstruct` with a private bucket + SSM param.
- Threaded `sharedConversationsBucket` through `PlatformComputeRefs` → `platform-stack` → `app-api-environment` (`SHARED_CONVERSATIONS_BUCKET_NAME`).
- Added `SharedConversationsBucketReadWrite` IAM grant (app-api only — inference-api never touches shares).

## Verification
- **Backend:** 90 tests pass, incl. a **>400 KB regression test** proving large conversations now share, plus store round-trip/dedupe, S3 + legacy-inline reads, export-from-S3, revoke cleanup, storage-unavailable, and the import-boundary gate.
- **Infra:** `tsc --noEmit` clean; `jest` 467 pass (bucket-count assertion bumped 8→9).

## Deploy notes
- Deploy order (already standard): `platform.yml` (CDK — creates bucket/grant/env) **before** the app-api image in `backend.yml`.
- **Rollback caveat (accepted):** if rolled back after S3-backed shares are created, the old code can't read them (it doesn't understand `body_ref`). Deemed acceptable — a re-share is a trivial ask. Spec documents the read-support-first phasing that would avoid it if ever needed.

## Spec
`docs/specs/share-large-conversations-s3-offload.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)