### PR TITLE
fix(agents): resolve model provider for agent-bound invocations

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -336,20 +336,25 @@ async def _resolve_model_settings(
     model_id: str | None,
     explicit_caching_enabled: bool | None,
     request_inference_params: dict | None,
-) -> tuple[bool | None, dict, str | None, str | None]:
+) -> tuple[bool | None, dict, str | None, str | None, str | None]:
     """Resolve runtime model knobs from the managed-model registry.
 
     Returns ``(caching_enabled, inference_params, mantle_api_mode,
-    mantle_region)``. A single registry lookup drives all of them. The Mantle
-    fields are server-authoritative (recorded on the model): ``mantle_api_mode``
-    selects Chat Completions vs the Responses API and ``mantle_region`` optionally
-    pins inference to a specific region; both ``None`` for non-Mantle models.
-    Resolving them here keeps them off the client request — the SPA can't override.
+    mantle_region, provider)``. A single registry lookup drives all of them.
+    The Mantle fields are server-authoritative (recorded on the model):
+    ``mantle_api_mode`` selects Chat Completions vs the Responses API and
+    ``mantle_region`` optionally pins inference to a specific region; both
+    ``None`` for non-Mantle models. ``provider`` is the model's registered
+    provider (e.g. ``"mantle"``), returned so callers can recover it when the
+    request/binding didn't carry one — without it a Mantle model like
+    ``openai.gpt-5.4`` misroutes to Bedrock ConverseStream and fails with an
+    invalid-model-identifier error. Resolving these here keeps them off the
+    client request — the SPA can't override.
     """
     request_params = dict(request_inference_params or {})
 
     if not model_id:
-        return explicit_caching_enabled, request_params, None, None
+        return explicit_caching_enabled, request_params, None, None, None
 
     managed_model = await _find_managed_model(model_id)
 
@@ -370,14 +375,19 @@ async def _resolve_model_settings(
         if managed_model is not None
         else None
     )
+    provider = (
+        getattr(managed_model, "provider", None)
+        if managed_model is not None
+        else None
+    )
 
     inference_params = _merge_inference_params(managed_model, request_params)
-    return caching, inference_params, mantle_api_mode, mantle_region
+    return caching, inference_params, mantle_api_mode, mantle_region, provider
 
 
 async def _resolve_caching_enabled(model_id: str | None, explicit_caching_enabled: bool | None) -> bool | None:
     """Backward-compat wrapper around :func:`_resolve_model_settings`."""
-    caching, _, _, _ = await _resolve_model_settings(model_id, explicit_caching_enabled, None)
+    caching, _, _, _, _ = await _resolve_model_settings(model_id, explicit_caching_enabled, None)
     return caching
 
 
@@ -933,7 +943,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         atc = input_data.app_tool_call
         try:
             request_inference_params = dict(input_data.inference_params or {})
-            caching_enabled, inference_params, mantle_api_mode, mantle_region = await _resolve_model_settings(
+            caching_enabled, inference_params, mantle_api_mode, mantle_region, registry_provider = await _resolve_model_settings(
                 model_id=input_data.model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
@@ -946,7 +956,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 model_id=input_data.model_id,
                 system_prompt=input_data.system_prompt,
                 caching_enabled=caching_enabled,
-                provider=input_data.provider,
+                provider=input_data.provider or registry_provider,
                 inference_params=inference_params,
                 mantle_api_mode=mantle_api_mode,
                 mantle_region=mantle_region,
@@ -981,7 +991,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         acu = input_data.app_context_update
         try:
             request_inference_params = dict(input_data.inference_params or {})
-            caching_enabled, inference_params, mantle_api_mode, mantle_region = await _resolve_model_settings(
+            caching_enabled, inference_params, mantle_api_mode, mantle_region, registry_provider = await _resolve_model_settings(
                 model_id=input_data.model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
@@ -994,7 +1004,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 model_id=input_data.model_id,
                 system_prompt=input_data.system_prompt,
                 caching_enabled=caching_enabled,
-                provider=input_data.provider,
+                provider=input_data.provider or registry_provider,
                 inference_params=inference_params,
                 mantle_api_mode=mantle_api_mode,
                 mantle_region=mantle_region,
@@ -1700,13 +1710,23 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 request_inference_params = {**agent_model_override.params, **request_inference_params}
 
             # Single registry lookup resolves caching + inference params +
-            # the Mantle endpoint path, merging admin defaults with request
-            # overrides.
-            caching_enabled, inference_params, mantle_api_mode, mantle_region = await _resolve_model_settings(
+            # the Mantle endpoint path + provider, merging admin defaults with
+            # request overrides.
+            caching_enabled, inference_params, mantle_api_mode, mantle_region, registry_provider = await _resolve_model_settings(
                 model_id=effective_model_id,
                 explicit_caching_enabled=input_data.caching_enabled,
                 request_inference_params=request_inference_params,
             )
+
+            # Recover the provider from the registry when neither the request nor
+            # the Agent's model binding carried one. Agent bindings persist only
+            # ``model_id`` (no provider), so without this a Mantle model like
+            # ``openai.gpt-5.4`` resolves to provider=None → Bedrock and blows up
+            # in ConverseStream with "invalid model identifier" — even though the
+            # same model works from the normal chat path, which always sends
+            # ``provider`` alongside ``model_id``.
+            if not effective_provider and registry_provider:
+                effective_provider = registry_provider
 
             if caching_enabled is False:
                 logger.info("Prompt caching disabled for model")

--- a/backend/tests/routes/test_resolve_model_settings_provider.py
+++ b/backend/tests/routes/test_resolve_model_settings_provider.py
@@ -1,0 +1,80 @@
+"""Regression tests for provider recovery in `_resolve_model_settings`.
+
+Agent (assistant) model bindings persist only `model_id` — never `provider`
+(see `AgentModelConfig`). When such an agent is previewed/invoked, the request
+also carries no provider, so without server-side recovery a Mantle model like
+`openai.gpt-5.4` resolves to provider=None → Bedrock and fails in ConverseStream
+with "The provided model identifier is invalid" — even though the same model
+works from the normal chat path (which always sends `provider` with `model_id`).
+
+`_resolve_model_settings` therefore returns the model's registered provider so
+the caller can backfill it. These tests pin that contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apis.inference_api.chat import routes
+
+
+def _managed(**kwargs):
+    """Minimal managed-model stand-in for the resolver's attribute reads."""
+    defaults = dict(
+        model_id="openai.gpt-5.4",
+        provider="mantle",
+        supports_caching=False,
+        mantle_api_mode="responses",
+        mantle_region=None,
+        supported_params=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_returns_provider_for_mantle_model():
+    with patch.object(
+        routes, "_find_managed_model", AsyncMock(return_value=_managed())
+    ):
+        (
+            caching,
+            _params,
+            mantle_api_mode,
+            mantle_region,
+            provider,
+        ) = await routes._resolve_model_settings(
+            model_id="openai.gpt-5.4",
+            explicit_caching_enabled=None,
+            request_inference_params=None,
+        )
+
+    assert provider == "mantle"
+    assert mantle_api_mode == "responses"
+    assert mantle_region is None
+    assert caching is False
+
+
+@pytest.mark.asyncio
+async def test_provider_none_when_model_unknown():
+    with patch.object(routes, "_find_managed_model", AsyncMock(return_value=None)):
+        _, _, _, _, provider = await routes._resolve_model_settings(
+            model_id="openai.gpt-5.4",
+            explicit_caching_enabled=None,
+            request_inference_params=None,
+        )
+    assert provider is None
+
+
+@pytest.mark.asyncio
+async def test_provider_none_when_no_model_id():
+    # No registry lookup happens without a model id; provider stays None.
+    with patch.object(routes, "_find_managed_model", AsyncMock()) as find:
+        _, _, _, _, provider = await routes._resolve_model_settings(
+            model_id=None,
+            explicit_caching_enabled=None,
+            request_inference_params=None,
+        )
+    assert provider is None
+    find.assert_not_awaited()

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -509,6 +509,12 @@ export class AgentFormPage implements OnInit, OnDestroy {
 
     const v = this.form.value;
     const params = this.modelParams();
+    // Persist the model's provider alongside its id. The runtime resolver needs
+    // provider to route (e.g. Mantle models like `openai.gpt-5.4` go through the
+    // Responses API, not Bedrock ConverseStream); without it the binding resolves
+    // to provider=None and a Mantle model fails with an invalid-model-identifier
+    // error. Mirrors what the normal chat path sends with every request.
+    const provider = this.selectedModel()?.meta?.['provider'] as string | undefined;
     const payload = {
       name: v.name,
       description: v.description,
@@ -520,6 +526,7 @@ export class AgentFormPage implements OnInit, OnDestroy {
       // Omit `params` when empty so the agent falls back to today's exact resolution.
       modelConfig: {
         modelId: this.selectedModelId()!,
+        ...(provider ? { provider } : {}),
         ...(Object.keys(params).length ? { params } : {}),
       },
       bindings: this.buildBindings(),


### PR DESCRIPTION
## Problem

Previewing or invoking an agent bound to a Mantle model (e.g. **GPT-5.4** / `openai.gpt-5.4`) fails with:

> An error occurred (ValidationException) when calling the ConverseStream operation: The provided model identifier is invalid.

…even though the **same model works fine in the normal chat UI**.

## Root cause

The agent-preview / agent-invocation path and the normal chat path differ in how they resolve the model **provider**:

- **Normal chat** sends `provider` (`"mantle"`) alongside `model_id` on every request, so the model correctly routes through the Mantle Responses API.
- **Agent bindings** (`AgentModelConfig`) only ever persist `model_id` — never `provider` — and the preview request sends no provider either. So `effective_provider` resolves to `None`.

With `provider=None`, `ModelConfig.get_provider()` falls through to **Bedrock** for `openai.gpt-5.4` (its name doesn't match the `gpt-`/`claude`/`gemini-` heuristics), so it's sent to Bedrock `ConverseStream` → invalid-model-identifier. The Mantle `apiMode=responses` was already recovered from the registry, but provider — which actually decides the endpoint — was not.

## Fix (two complementary changes)

**Backend — server-authoritative provider recovery** (`inference_api/chat/routes.py`)
- `_resolve_model_settings` now also returns the model's registered `provider` from the managed-model registry (single lookup, keyed on the model actually being used).
- The invocation path backfills `effective_provider` from it whenever the request/binding didn't supply one. This fixes **all existing agents** with a provider-less stored binding — no data backfill — and mirrors how `mantle_api_mode` / `mantle_region` are already recovered off the registry.
- The app-tool-call / app-context-update rebuild paths get the same `provider or registry_provider` fallback so a rebuilt agent keys on the same provider as its main turn.

**Frontend — persist provider on save** (`agent-form.page.ts`)
- The Agent Designer save payload now includes the selected model's `provider` (from the catalog `meta.provider`) alongside `modelId`, so newly created/edited bindings are self-describing. `AgentModelConfig.provider?` already existed in the TS type; it was just never written.

## Testing

- New unit tests for the resolver's provider return (`test_resolve_model_settings_provider.py`): 3 passed.
- Existing model-access + Mantle route suites: 29 passed.
- Frontend `tsc --noEmit` clean.

## Reviewer notes

- The backend fix alone resolves the reported bug for existing agents; the frontend change makes future bindings self-describing so they don't rely on the registry fallback.
- No changes to the `AgentModelConfig` schema or API shape — `provider` was already an optional field.
- No browser clickthrough was run: this is an authenticated Agent Designer save path that needs a live model catalog + persistence to exercise meaningfully.