### PR TITLE
fix(inference): bind effective_enabled_tools on resume path (prod 424 on OAuth-gated MCP connect)

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1652,6 +1652,16 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                     else None
                 ),
             )
+            # The `stream_with_quota_warning` closure below references
+            # `effective_enabled_tools` unconditionally (attachment guidance,
+            # tabular inventory). It is only assigned in the non-resume branch,
+            # so a resume turn — e.g. the client re-invoking after granting an
+            # OAuth-gated MCP tool's consent, or answering a tool-approval
+            # interrupt — would otherwise raise `NameError: cannot access free
+            # variable 'effective_enabled_tools'`, surfacing as a 500 from the
+            # container and a 424 Failed Dependency to the caller. Bind it to the
+            # snapshot's toolset, the same source the resume `get_agent` used.
+            effective_enabled_tools = snapshot.enabled_tools
         else:
             # Build the canonical request inference-params dict. The frontend
             # sends ``inference_params`` directly; legacy ``temperature`` /

--- a/backend/tests/routes/test_inference.py
+++ b/backend/tests/routes/test_inference.py
@@ -430,3 +430,95 @@ class TestInvocationsSingleFlight:
 
         assert resp.status_code == 200
         acquire_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Resume path: interrupt_responses set (OAuth-gated MCP consent / tool approval)
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationsResume:
+    """POST /invocations on the resume path must not raise.
+
+    Regression for the scope bug where ``effective_enabled_tools`` was assigned
+    only in the non-resume branch but referenced unconditionally by the
+    ``stream_with_quota_warning`` closure (attachment guidance + tabular
+    inventory). A resume turn — e.g. the client re-invoking after the user
+    grants an OAuth-gated MCP tool's consent ("connect to Gmail for employees")
+    or answers a tool-approval interrupt — hit
+    ``NameError: cannot access free variable 'effective_enabled_tools'`` before
+    the streaming closure's first yield. That surfaced as a 500 from the
+    inference-api container and, once the AgentCore Runtime data plane
+    translated it, a ``424 Failed Dependency`` to app-api and the SPA.
+
+    The fix binds ``effective_enabled_tools`` from the paused-turn snapshot on
+    the resume branch (the same source the resume ``get_agent`` call uses).
+    """
+
+    @staticmethod
+    def _paused_agent(interrupt_id):
+        """Mock agent whose ``_interrupt_state`` advertises ``interrupt_id`` as a
+        known paused interrupt, so the route's resume id-validation accepts the
+        submitted response instead of rejecting it with a 400."""
+        mock_agent = MagicMock()
+        interrupt_state = MagicMock()
+        interrupt_state.activated = True
+        interrupt_state.interrupts = {interrupt_id: MagicMock()}
+        mock_agent.agent = MagicMock()
+        mock_agent.agent._interrupt_state = interrupt_state
+
+        async def fake_stream(*args, **kwargs):
+            yield 'event: message_start\ndata: {"role": "assistant"}\n\n'
+            yield "event: done\ndata: {}\n\n"
+
+        mock_agent.stream_async = fake_stream
+        return mock_agent
+
+    @staticmethod
+    def _snapshot(enabled_tools):
+        from datetime import datetime, timedelta, timezone
+
+        from apis.shared.sessions.models import PausedTurnSnapshot
+
+        now = datetime.now(timezone.utc)
+        return PausedTurnSnapshot(
+            enabled_tools=enabled_tools,
+            model_id="anthropic.claude-sonnet-4",
+            provider="bedrock",
+            system_prompt="You are helpful.",
+            agent_type="chat",
+            captured_at=now.isoformat(),
+            expires_at=(now + timedelta(minutes=10)).isoformat(),
+        )
+
+    def test_resume_turn_does_not_raise_nameerror(self, authed_app, authed_client):
+        """A resume request (interrupt_responses set) streams a 200 instead of
+        500-ing on the unbound ``effective_enabled_tools``."""
+        interrupt_id = "int-abc"
+        snapshot = self._snapshot(enabled_tools=["gmail_employee"])
+
+        with patch(
+            "apis.inference_api.chat.routes.get_agent",
+            return_value=self._paused_agent(interrupt_id),
+        ), patch(
+            "apis.inference_api.chat.routes.is_quota_enforcement_enabled",
+            return_value=False,
+        ), patch(
+            "apis.shared.sessions.metadata.get_paused_turn",
+            return_value=snapshot,
+        ):
+            resp = authed_client.post(
+                "/invocations",
+                json={
+                    "session_id": "sess-resume-1",
+                    "message": "",
+                    "interrupt_responses": [
+                        {"interruptId": interrupt_id, "response": {"approved": True}}
+                    ],
+                },
+            )
+            body = resp.text  # force the streaming generator to run to completion
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert "event: done" in body


### PR DESCRIPTION
## Summary

Resume turns (`/invocations` with `interrupt_responses` set — OAuth-gated MCP consent or tool-approval) were crashing in prod with:

```
NameError: cannot access free variable 'effective_enabled_tools'
where it is not associated with a value in enclosing scope
```

`effective_enabled_tools` is referenced unconditionally by the `stream_with_quota_warning` streaming closure (attachment guidance + tabular inventory) but was assigned **only in the non-resume branch**. On a resume turn the closure raised before its first `yield`, the inference-api container returned **500**, and the AgentCore Runtime data plane translated that into a **424 Failed Dependency** to app-api and the SPA.

## Impact

This broke **every interrupt-resume turn** since the agent-designer tool-binding refactor (`0b9b039a`, 2026-07-08). Most visible symptom: **"connect to Gmail for employees"** (and the other Google/Canvas employee connectors), which complete via an OAuth-consent resume. Observed as a burst of 424s in prod-ai.

## Root cause diagnosis

Traced from prod-ai logs: app-api logged `POST /chat/stream 424 Failed Dependency` + the httpx `.../invocations 424`. The real exception was in the runtime container log group (`/aws/bedrock-agentcore/runtimes/boisestateai_v2_agentcore_runtime-h4MSyY7YSh-DEFAULT`): a container **500** from the `NameError`, at `stream_with_quota_warning` (routes.py). Confirmed the same signature across multiple failure timestamps.

## Fix

Bind `effective_enabled_tools` from the paused-turn snapshot on the resume branch — the same source the resume `get_agent` call already uses:

```python
effective_enabled_tools = snapshot.enabled_tools
```

## Test

Adds `TestInvocationsResume` to `tests/routes/test_inference.py` — drives `/invocations` with `interrupt_responses` and asserts a 200 stream. Verified it **fails with the NameError when the fix is reverted**, passes with it in place. Full `test_inference.py` + `test_chat_service.py` (22 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)