### PR TITLE
chore(kaizen): weekly research scan 2026-07-17

### DIFF
--- a/docs/kaizen/research/2026-07-17.md
+++ b/docs/kaizen/research/2026-07-17.md
@@ -1,0 +1,211 @@
+# Kaizen Research — Friday, July 17, 2026
+> Scan window: July 10 – July 17, 2026 (7 days)
+> Web budget: ~55/50 used (modest overage — 11 subagents + version-pin registry churn; see Web Budget block).
+
+## TL;DR
+
+**The release we've queued for six weeks finally exists, and it landed inside this window.** `bedrock-agentcore` **1.18.0 shipped July 10** and carries the **#571 cross-process Memory event-reorder fix** (PR #572/#573) on top of the **#482 SSE-deadlock fix** already in 1.17.0 — one bump off our pinned **1.9.1** closes both. This matters more than last week because the internal delta is enormous: **147 non-merge commits** across releases 1.3.0→1.6.1 shipped Agent Designer, Scheduled Runs, Memory Spaces, conversation-sharing, and — most tellingly — a **1.6.0 reliability cluster** (single-flight lease, restore-time tool-pairing repair, tab-switch SSE fix) that *hand-built* protection against the exact multi-replica Memory-ordering corruption class the unadopted SDK fix addresses upstream. **The #1 idea is unchanged and now target-1.18.0: bump `bedrock-agentcore` off 1.9.1.** Strands is now current at **1.47.0** (last week's bump shipped, closing that queue item). External week was otherwise quiet — a pre-July-28 MCP-RC lull.
+
+## External Scan
+
+### What's moving this week
+
+The shape of the week is **a quiet ecosystem against a very loud repo.** Externally it's the pre-RC lull: the MCP 2026-07-28 spec is still locked (no in-window movement), the reference repo is dormant a second straight week, FastMCP holds at 3.4.4, LibreChat and NN/g were silent, and no new frontier model reached Bedrock with an actionable capability delta (Gemini 3.5 Pro's rumored July-17 launch is off-Bedrock/watchlist). The one concrete upstream event that *does* matter is a version number: **`bedrock-agentcore` 1.18.0 (Jul 10)** — the release we've been waiting on since the #482 fix, now with #571 folded in. The only other on-Bedrock signal is **GPT-5.6 reportedly reaching Bedrock (Mantle) ~Jul 13** (conflicting sources — flagged for verification) and an AWS ML-blog **Strands multi-agent (Swarm vs Graph) reference build** that is the closest public mirror of our own architecture. On the harness side, Claude Code (2.1.207–212) and opencode (1.18.x) **converged on the same new safety rail** — bounded sub-agent delegation depth/count — while assistant-ui shipped an **SSE-decoder hardening** release that lands squarely on the parser surface we spent all of 1.6.0 stabilizing.
+
+### Notable items by source
+
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens.
+> - `*unlocks*:` — capability-unlock lens (new primitive / new product surface).
+
+#### AWS Bedrock / AgentCore
+- **`bedrock-agentcore` SDK 1.18.0 (Jul 10) — #571 cross-process Memory reorder fix + LangGraph payment integration** — Ships PR #572 ("order AgentCore Memory events at millisecond resolution") + PR #573 ("floor event timestamps to milliseconds"), closing the class-level-counter regression that made `AgentCoreMemorySessionManager` emit `tool_result` before `tool_use` across processes. — https://github.com/aws/bedrock-agentcore-sdk-python/releases — *relevance*: **the keystone bump** (see idea #1); we're on 1.9.1, ~9 minors behind, exposed to both #571 and #482 while Scheduled Runs + Memory Spaces + conversation-sharing now lean hard on Memory. Validate the ms-flooring against `TurnBasedSessionManager` flush ordering before rolling.
+- **GPT-5.6 (Sol / Terra / Luna) reportedly GA on Bedrock via Mantle (~Jul 13)** — Three-tier GPT-5.6 family surfaced on the AWS What's New feed as Bedrock/Mantle-served. **Conflicting signal**: the frontier-model scan still classes GPT-5.6 as off-Bedrock, and the feed slug wasn't captured — **verify before acting.** — https://aws.amazon.com/about-aws/whats-new/recent/feed/ — *relevance*: if confirmed, net-new model IDs for the catalog that ride the *existing* `apiMode=responses` + per-model-region Mantle path we built for gpt-5.4 (mechanical add). — *unlocks*: a cheaper/newer Responses-API tier alongside gpt-5.4. **Gate on Bedrock-availability confirmation.**
+- **AWS ML blog: "Multi-agent social intelligence with Strands Agents + Amazon Bedrock" (Jul 14)** — Thrad.ai reference build benchmarking **Swarm vs Graph** orchestration on latency/cost/quality; CDK stack = Runtime (microVMs + IAM) + Gateway (single MCP endpoint) + Strands `MCPClient` dynamic tool discovery at startup. — https://aws.amazon.com/blogs/machine-learning/multi-agent-social-intelligence-with-strands-agents-and-amazon-bedrock/ — *relevance*: closest public mirror of our exact architecture; the Swarm/Graph cost-latency numbers are directly comparable if/when we formalize a multi-agent path (A2A is client-only today).
+- **AgentCore release-notes page: nothing new in-window** — the only July entry remains `ActiveSessionCount` (already logged). Two ML how-to posts (agentic vision via MCP servers Jul 15; Managed KB enterprise-search Jul 16) are adoption references, not new capability. — https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html
+
+#### Strands Agents
+**Latest `strands-agents==1.47.0`; we now pin 1.47.0 — current, zero lag.** The [2026-07-03] queued 1.40→1.45 bump **shipped** (commit `42e69bc7`, "upgrade Strands to 1.47.0"), overshooting the target. No Python release after 1.47.0 in-window (only a TS-side `typescript/v1.9.0`).
+- **#3144 — `CacheConfig(strategy="auto")` never caches the system prompt (OPEN, updated Jul 16; fix PR #3145 open, not merged)** — `strategy="auto"` only sets a breakpoint at the final user message; a static system prefix is written-but-not-read (~94% read ratio only after a manual system `cachePoint`). — https://github.com/strands-agents/sdk-python/issues/3144 — *relevance*: **validates keeping our manual cache-point injection in `to_bedrock_config`** — do NOT switch to `strategy="auto"` expecting system-prompt caching. Feeds idea #2 (the multi-provider caching audit, internal issue #642).
+- **#3317 — strands-mcp search quality/ergonomics (tracking, OPEN Jul 17)** — umbrella for MCP search/tooling ergonomics. — https://github.com/strands-agents/sdk-python/issues/3317 — *relevance*: watch for `FilteredMCPClient`-adjacent improvements; no behavior change this week.
+- No in-window hooks / AgentCore-Memory-session-manager / A2A-server regression touching `TurnBasedSessionManager`, the Before/AfterToolCall hooks, or `CountTokensBedrockModel`.
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **No commits July 10–17 (second consecutive dormant window).** Latest activity is still July 1 (Sonnet 5 `NO_TEMPERATURE_MODELS` + React/Tailwind modernization). — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main — *applicability*: nothing to port. **Cadence recommendation: drop this source to bi-weekly** (see Retirement Candidates); the signal is burst-y and low-frequency.
+
+#### MCP ecosystem
+- **No in-window signal; July 28 RC still locked (not final, ~11 days out).** All datable movement clusters before the window (May 21 RC lock, June 18 EMA-stable, June 29 beta SDKs). — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ — *relevance*: next Friday is the GA-cutover scan to watch.
+- **Standing watch-item sharpened — SEP-2567 also removes the `initialize`/`initialized` handshake (via SEP-2575)**: protocol version + client info + capabilities move into `_meta` on every request, plus a new `server/discover` method. — same RC URL — *relevance*: **high for our MCP Apps host** — the `initialize` `serverInfo` we read for the App-frame `serverName`/`icon` (per CLAUDE.md) is exactly what's being replaced; the icon/title-resolution path needs rework before we adopt the final-spec SDKs. Pair with SEP-2322 Multi-Round-Trip elicitation (request/echo state instead of a held-open SSE) for the App user-input flow.
+- **MCP Apps host matrix: no change** (Claude/Desktop, VS Code Copilot, M365 Copilot, Goose, Postman, MCPJam, Archestra) — our SEP-1865 host stays on-spec and interoperable. — https://modelcontextprotocol.io/extensions/apps/overview
+
+#### FastMCP
+- **No release in-window; latest holds at v3.4.4 (Jul 9).** ≥3.4.4 remains the safe floor for externally-hosted Lambda-behind-Gateway servers (restored the ASGI/serverless/reverse-proxy compat that 3.4.3's Host/Origin guard broke). No further Host/Origin/SSRF or transport/Lambda-adapter change this week. — https://github.com/jlowin/fastmcp/releases
+
+#### Agentic UI/UX patterns
+- **assistant-stream@0.3.26 (Jul 16) — spec-complete SSE event decoder** — Standalone SSE-decoder export: parameterized content-types, strict line-ending compliance, and **discarding of unterminated frames**. — https://github.com/Yonom/assistant-ui/releases — *fit*: pattern-only (Angular) — *where it'd land*: our SPA SSE parser service (the one allowlisting `session_title` past Completed-state gating). **Strong fit** — the unterminated-frame + line-ending robustness is exactly the class of edge case behind the interrupt-resume and tab-switch-duplicate-invocation bugs we just fought in 1.6.0. See idea #4.
+- **Cursor v3.11 "Side Chats + Conversation Search" (Jul 10)** — Branch an ephemeral sub-conversation off the main thread without derailing it. — https://www.cursor.com/blog — *fit*: pattern-only — *where it'd land*: a session-tree UX over our concurrent-streaming-per-session architecture (parser/loading/abort already keyed by `sessionId`); a side-chat is a child session sharing context but streaming independently. No new SSE event. **Queue-worthy pattern, not a near-term port.**
+- **Vercel AI SDK tool-approvals — batching rule (undated, likely not in-window)** — `lastAssistantMessageIsCompleteWithApprovalResponses` gates auto-send until *every* pending approval in the turn resolves. — https://ai-sdk.dev/docs/agents/tool-approvals — *fit*: design cue for `beginContinuationStreaming` when a turn has multiple `oauth_required` providers; enriches the queued [2026-07-03] tool-approval item (not a fresh finding).
+- **tw-shimmer@0.4.12 (Jul 16) — Firefox shimmer-speed fix** — https://github.com/Yonom/assistant-ui/releases — *fit*: QA nit — verify our MCP App header-shell + tool-running shimmers don't show the same Firefox regression. No code dependency.
+- NN/g, Linear, Anthropic news: **quiet on agentic UI/UX this window** (Anthropic's only in-window post is "Claude for Teachers," a product launch, no UX writeup).
+
+#### Frontier model announcements
+- **Gemini 3.5 Pro (2M context + "Deep Think") — rumored launch ~Jul 17** — Leak-sourced, specs unconfirmed by Google; conflicting reports (one Jul 16 source still reported a missed deadline). **Off-Bedrock (watchlist)** — ships via Google/Vertex; we only reach Gemma through Mantle. — https://finance.biggo.com/news/6f0c6bb2-795f-4c57-9d09-6db691d7638a — *relevance*: the 2M context is the delta to re-check only if it reaches Vertex/Bedrock.
+- **Anthropic / Meta — no new frontier model in-window.** Anthropic posts are product/policy ("Claude for Teachers" Jul 14, a Canadian research commitment); no Bedrock/Claude capability change. OpenAI blog returned HTTP 403 (not re-fetched) — no confirmed in-window OpenAI signal beyond the GPT-5.6-on-Bedrock item above.
+
+#### Agent harness patterns
+- **Convergent safety rail — bounded sub-agent delegation (Claude Code 2.1.212 + opencode 1.18.2)** — Claude Code added a per-session **subagent-spawn cap (default 200)** + WebSearch cap "to stop runaway delegation loops"; opencode added a configurable **`subagent_depth`** limit stopping nested sub-agents by default. — https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md · https://github.com/anomalyco/opencode/releases — *relevance*: two independent harnesses shipped the same rail in the same week; maps to our multi-protocol tool architecture + the **unattended Scheduled Runs lane** (highest blast radius for a runaway loop). Pairs with Strands `Limits` — see idea #3.
+- **Claude Code 2.1.212 / 2.1.208 — MCP + stream resilience** — 2.1.212 auto-backgrounds MCP tool calls running >2 min and fixes a `continue:false` hook-halt dropped when a tool "fails or completes mid-stream"; 2.1.208 fixes crashes on server-closed HTTP/2 connections + truncated stream-json output. — same CHANGELOG — *relevance*: the >2-min MCP auto-background and mid-stream hook-halt map to our agent loop's MCP-timeout + mid-stream-partial handling; the truncated-stream fix mirrors our "compaction/metadata events at stream tail can be lost on truncation" risk.
+- **opencode v1.17.19 (Jul 13) — per-model context pinning + default-off response storage for GPT-5.6** — https://github.com/anomalyco/opencode/releases — *relevance*: reinforces our per-model region/apiMode routing (Mantle Responses refactor); the "Codex context limits for GPT-5.6" pinning is a concrete precedent if GPT-5.6 lands in our catalog.
+
+#### Pricing / quota
+- **No change July 10–17.** Sonnet 5 promo **$2/$10** per 1M in/out holds through Aug 31 (reverts $3/$15); Opus 4.8 unchanged ($6/$30). No July quota change. — https://aws.amazon.com/bedrock/pricing/
+
+#### Community + GitHub issues
+- **New SDK issues (in-window): #580 (Jul 17) tool-search plugin allow-list; #577 (Jul 13) gen_ai OTel spans omit caller identity + client IP; #567 (Jul 6, OPEN) `tool_filters` for `AgentCoreToolSearchPlugin`.** — https://github.com/aws/bedrock-agentcore-sdk-python/issues — *relevance*: #567/#580 track the native filtering primitive we hand-rolled in `FilteredMCPClient` (subtraction candidate when it ships); #577 matters if we lean on gen_ai spans for per-user attribution.
+- **#564 (eventually-consistent `ListEvents` drops history) still OPEN — NOT fixed by 1.18.0** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/564 — *relevance*: upgrading fixes ordering (#571) but not the eventual-consistency read gap; our agent-cache continuity (Memory write-only in cloud) already mitigates. Keep that path primary post-bump.
+- **Starter-toolkit: #498 (Jul 12) no API to list/force-terminate active runtime sessions** — https://github.com/aws/bedrock-agentcore-starter-toolkit/issues — *relevance*: a cost-control gap adjacent to our session single-flight/lease work; #549 (`.dockerignore`) doesn't hit us (we ship out-of-band via `backend.yml`).
+- **HN: zero in-window threads** on AgentCore/Strands/Bedrock-agent/Claude-Code — nothing to action.
+
+#### Cookbook / courses
+- **Anthropic cookbook — maintenance only; one load-bearing fact: assistant-message *prefill* now returns 400 on current Claude models** (metaprompt notebook fix, PR #771, Jul 10–13). — https://github.com/anthropics/anthropic-cookbook/commit/5d5e2f4 — *relevance*: **cheap grep worth running** — if any Bedrock/Mantle prompt-assembly path in `agents/` or `apis/shared` still prefills an assistant turn to steer output, that's a latent break. No new caching/tool-use/agent-loop/MCP notebooks in-window.
+
+#### opencode / LibreChat (light references)
+- **opencode**: covered under Agent harness above (delegation depth cap; per-model context pinning).
+- **LibreChat: no new release; latest holds at v0.8.7 (Jun 24).** Nothing to evaluate this week. — https://github.com/danny-avila/LibreChat/releases
+
+#### Seasonal
+- Out of window — none scanned this week.
+
+### Patterns worth considering
+
+- **Bounded delegation as a default safety rail** — Claude Code (spawn cap) and opencode (`subagent_depth`) independently shipped it the same week; the industry is standardizing "cap runaway agent fan-out" as a default, not an option.
+  - **Where**: Claude Code 2.1.212, opencode 1.18.2.
+  - **Fit**: our highest-exposure surface is the **unattended Scheduled Runs lane** — a runaway tool loop there burns quota silently with no human watching. Strands `Limits` (available now that we're on 1.47) is the library-native lever; a per-invocation cap on the headless lane is the concrete adoption.
+  - **Verdict**: Worth trying (scope to the scheduled/headless lane first).
+- **Multi-provider caching correctness** — internal issue #642 (Jul 11) + Strands #3144 both point at the same gap: caching semantics diverge across Bedrock Converse / Mantle Responses / OpenAI, and the SDK's auto strategy doesn't even cache the system prompt.
+  - **Where**: issue #642, Strands #3144, our multi-provider routing (Mantle refactor `67e2653e`).
+  - **Fit**: we now route three provider shapes; only the Bedrock path has a validated manual cache-point. A Mantle/OpenAI turn may cache nothing — a silent full-input-token cost regression.
+  - **Verdict**: Worth trying (audit first, then consolidate).
+
+## Internal Audit
+
+### Activity (last 14 days — a double window; the July 10 research PR #616 is unmerged)
+- **Commits on develop**: **147 non-merge** across releases 1.3.0 → 1.6.1 — Agent Designer (model-param governance, live preview, provider-persistence), Scheduled Runs (target Agents, dispatcher clock de-flake), Memory Spaces (MEMORY.md reserved slug, namespaced routing, app-api env wiring), conversation-sharing S3 offload, distributed turn cancellation, single-flight lease, tab-switch SSE fix, restore-time tool-pairing repair, model RBAC single-source-of-truth, Mantle Responses/region refactor, Sonnet 5 + GPT-5.4 curated cards, OAuth-gated MCP discover. **Very high velocity.**
+- **PRs opened**: 1 open against develop — **#616 (the July 10 kaizen research scan, unmerged, no comments)**. — **merged**: the 1.3.0–1.6.1 release train — **reverted**: 0.
+- **Issues opened (7d)**: 3 — **#649** Feature: Projects; **#642** Provider-agnostic prompt caching (enhancement, tech debt); **#640** monetize via x402 micropayments (low relevance). — **closed**: n/a.
+- **CI failures (workflow → count)**: Nightly Build & Test → 2 (Jul 12–13, curl-pin); Backend Deploy → 3 (Jul 11–13, curl-pin); CI → 1 (Jul 15, tool-pairing branch). **Nightly is GREEN Jul 14–17** after the float-curl fix reached main via 1.5.0.
+
+### Repeated friction signals
+- **Pinned-curl Docker builds broke deploys twice in-window** (Nightly Jul 12–13 + Backend Deploy Jul 11–13) — evidence: `E: Version '8.14.1-2+deb13u3' for 'curl' was not found` across app-api + inference-api image builds (runs 29241546259, 29294178533). Root cause: the Dockerfiles pinned curl to an **exact Debian security-patch version** that the Debian mirror purged.
+  - **Hypothesis**: Debian rolls its `deb13uN` security patch and drops the prior exact version from the mirror; any exact pin becomes un-installable the moment the patch increments.
+  - **Fix candidate (partially shipped)**: commit `74cd7b0a` (Jul 13, in 1.5.0) floated the pin to `curl=8.14.1-2+deb13u*` — nightly went green Jul 14. **But `deb13u*` is still a version constraint**: a Debian *series* bump (`8.14.1-2` → `8.14.1-3`, or a base-image minor) re-breaks it. The durable fix is to not pin curl to an upstream version at all (install the latest security patch, or use the base image's `curl-minimal` as the Lambda images already do). **See idea #5** — a simplification that removes a recurring deploy-breaker class.
+
+### Version-pin lag
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| bedrock-agentcore | 1.9.1 | **1.18.0 (Jul 10)** | ~9 minors | **#571 (cross-process Memory reorder) fixed in 1.18.0 + #482 (SSE deadlock) in 1.17.0 — we're exposed to both today.** Keystone bump. |
+| strands-agents | **1.47.0** | 1.47.0 | 0 | **Current** — the [2026-07-03] bump shipped (`42e69bc7`). Queue item resolvable. Only breaking history is Mistral (N/A). |
+| fastapi | 0.136.1 | 0.139.2 | ~3 minors | routine |
+| boto3 | 1.43.9 | 1.43.50 | ~41 patches | routine (coupled to the agentcore bump — bump together) |
+| pydantic | (latest) | 2.13.4 | — | not pinned exact; informational |
+| mcp | (latest) | 1.28.1 | — | informational |
+| @angular/core | 21.2.17 | 22.0.7 | **1 major** | Angular 22 — hold; major migration, not a kaizen bump |
+| vitest | 4.1.5 | 4.1.10 | 5 patches | routine |
+| aws-cdk-lib | 2.260.0 | 2.261.0 | 1 minor | routine |
+| constructs | 10.6.0 | 10.7.0 | 1 minor | routine |
+| fastmcp (unpinned) | — | 3.4.4 (Jul 9) | — | not pinned; ≥3.4.4 safe floor for external Lambda MCP servers |
+
+### Retirement candidates
+- **Reference-repo source → bi-weekly cadence** — `aws-samples/sample-strands-agent-with-agentcore` has been dormant two consecutive weekly windows (no commits July 3–17; latest activity July 1). Its signal is burst-y; a fortnightly check saves web budget with negligible miss risk. Skill-hygiene subtraction (edit `kaizen-research/SKILL.md` source 3 cadence note — not this run's scope, flag for a skill-maintenance PR).
+- **Hand-rolled `FilteredMCPClient` — watch for native replacement** — AgentCore SDK #567/#580 track `tool_filters` on `AgentCoreToolSearchPlugin`; when it ships, our filtering shim becomes a subtraction candidate. Not yet actionable.
+- No dormant skills flagged (all `.claude/skills/*` referenced in recent PRs or actively maintained).
+
+### Risks introduced this week
+- **Still exposed to #571 (cross-process Memory event reorder) + #482 (SSE deadlock) at 1.9.1** — https://github.com/aws/bedrock-agentcore-sdk-python/releases — the 1.6.0 reliability work (single-flight lease, tool-pairing repair) reduces the *symptom* surface but the SDK-level ordering bug persists; multi-replica Runtime is the exposure and Scheduled Runs + Memory Spaces + conversation-sharing just increased Memory load.
+- **`deb13u*` curl pin is a partial fix** — a Debian series/base-image bump re-breaks all image builds; the failure is invisible until the next deploy (see Friction).
+- **Assistant-prefill 400 on current Claude models** — https://github.com/anthropics/anthropic-cookbook/commit/5d5e2f4 — if any prompt-assembly path prefills an assistant turn, it now hard-fails; unverified against our code (cheap grep).
+- **SEP-2567 will remove the `initialize` handshake our MCP App header reads for `serverName`/`icon`** — not in-window, but the July 28 RC makes it near-term; the icon/title-resolution path needs rework before adopting final-spec SDKs.
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | Bump `bedrock-agentcore` 1.9.1 → 1.18.0 (closes #571 + #482) | backend | M | H | Retires the queued [2026-05-22] hand-written #482 guard; complements the just-shipped tool-pairing repair | — |
+| 2 | Audit multi-provider prompt caching (issue #642 + Strands #3144) | backend | L–M | M–H | Consolidates per-provider cache logic; kills silent Mantle/OpenAI token-cost regression | — |
+| 3 | Adopt Strands `Limits` on the unattended Scheduled Runs / headless lane | backend | L–M | M | Retires any hand-rolled turn/cost guard; library-native | Per-invocation cost/turn cap on the highest-blast-radius lane |
+| 4 | Harden the SPA SSE parser (unterminated-frame + line-ending handling) | frontend | L–M | M | Replaces ad-hoc frame handling with spec-complete decode | Fewer restore/interrupt-resume corruption edge cases |
+| 5 | Durable curl fix — stop pinning curl to an upstream version in the Dockerfiles | infra/CI | L | M–H | Removes a recurring deploy-breaker class (the `deb13u*` wildcard is still fragile) | — |
+
+### 1. Bump `bedrock-agentcore` 1.9.1 → 1.18.0 (closes #571 + #482)
+- **Source**: https://github.com/aws/bedrock-agentcore-sdk-python/releases (1.18.0, Jul 10 — PR #572/#573 close #571); #482 fix in 1.17.0 (PR #563); internal 1.6.0 reliability cluster + Memory-heavy features.
+- **Surface area**: `backend/pyproject.toml` (coupled `boto3` bump), inference-api chat router + `TurnBasedSessionManager` flush ordering; full local pytest suite (the PR-gate as of #490).
+- **Change**: bump the pin to `1.18.0`; verify (a) the async→sync streaming-bridge fix on `/invocations`, and (b) the millisecond event-flooring against our Memory flush ordering; keep the agent-cache continuity path primary (#564 read-gap unfixed).
+- **Subtracts**: retires the queued [2026-05-22] hand-written #482 guard (library-native); the #571 ordering fix complements — does not replace — the hand-rolled `_repair_tool_pairing` (belt-and-suspenders on a corruption class the product just leaned harder into).
+- **Effort × Impact**: Med × High.
+- **Verdict**: Worth trying — **highest priority; active exposure, the release we queued now exists.** Supersedes the [2026-07-03] "→ 1.17.0" queue item (retarget 1.18.0).
+
+### 2. Audit multi-provider prompt caching (issue #642 + Strands #3144)
+- **Source**: internal issue #642 (Jul 11, "Provider-agnostic prompt caching — Bedrock Converse vs Mantle vs OpenAI/Gemini"); Strands #3144 (`CacheConfig(strategy="auto")` never caches the system prompt).
+- **Surface area**: `to_bedrock_config` cache-point injection (Bedrock), the Mantle Responses builder (`build_mantle_model` / `_create_mantle_model`), any OpenAI-compatible caching path; `CountTokensBedrockModel` / context-attribution read of cache tokens.
+- **Change**: instrument `cache_read` / `cache_write` token ratios per provider (Strands 1.46 surfaces them in the metadata chunk); confirm whether Mantle/OpenAI turns cache at all, and whether the Bedrock manual cache-point still engages post-1.47. Consolidate the per-provider cache decision behind one predicate rather than provider-scattered logic.
+- **Subtracts**: consolidates per-provider cache plumbing; kills a silent full-input-token cost regression if a provider path caches nothing.
+- **Effort × Impact**: Low–Med × Med–High.
+- **Verdict**: Worth trying — a filed internal issue with a library-confirmed failure mode; strongest internal-signal fit after the bump.
+
+### 3. Adopt Strands `Limits` on the unattended Scheduled Runs / headless lane
+- **Source**: convergent harness signal — Claude Code 2.1.212 spawn cap + opencode 1.18.2 `subagent_depth`; Strands `Limits` now available (we're on 1.47). Internal: Scheduled Runs shipped (1.1.0+) and run unattended.
+- **Surface area**: the headless/scheduled invocation path (`apis/shared/harness/run_agent_headless` per the [2026-07-06] managed-Harness spike) + the agent loop's per-invocation config.
+- **Change**: wire Strands `Limits` (per-invocation token/turn cap) on the scheduled/headless lane first — where a runaway tool loop burns quota with no human watching — before extending to interactive. Dovetails with the queued quota-cooldown work.
+- **Subtracts**: retires any need for a hand-rolled `max_turns` guard on the headless lane (library-native).
+- **Unlocks**: a first-class cost/turn ceiling on the highest-blast-radius lane — a capability the [2026-07-03] Strands bump listed but that still needs wiring now that the bump landed.
+- **Effort × Impact**: Low–Med × Med.
+- **Verdict**: Worth trying — the bump unlocked it; the convergent harness rail + unattended lane make it timely.
+
+### 4. Harden the SPA SSE parser (unterminated-frame + line-ending handling)
+- **Source**: assistant-stream@0.3.26 (Jul 16, spec-complete SSE decoder — discards unterminated frames, strict line endings). Internal: the 1.6.0 SSE/restore bug cluster (#653 tab-switch duplicate invocation, tool-pairing repair, single-flight lease).
+- **Surface area**: the SPA SSE parser service (the one allowlisting `session_title` past Completed-state gating; keyed per-session per the concurrent-streaming architecture).
+- **Change**: adopt the pattern (implement in Angular signals — do NOT add the React dep): discard unterminated/partial SSE frames rather than mis-parsing them, and tighten line-ending handling, on the interrupt-resume + tab-switch paths we just stabilized.
+- **Subtracts**: replaces ad-hoc frame handling with a spec-complete decode pass.
+- **Effort × Impact**: Low–Med × Med.
+- **Verdict**: Worth trying — defensive, and it lands on exactly the surface a full release just hardened.
+
+### 5. Durable curl fix — stop pinning curl to an upstream version in the Dockerfiles
+- **Source**: internal friction — Nightly + Backend Deploy broke Jul 11–13 on `curl=8.14.1-2+deb13u3` "version not found"; partially fixed by floating to `deb13u*` (commit `74cd7b0a`, 1.5.0).
+- **Surface area**: `backend/Dockerfile.app-api`, `backend/Dockerfile.inference-api` (line 42, the `apt-get install curl=...` step); `Dockerfile.scheduled-runs` / `kb-sync` if they carry the same pin.
+- **Change**: replace the version-pinned `curl=8.14.1-2+deb13u*` with an unpinned `curl` (latest security patch) — or drop to the base image's `curl-minimal` as the Lambda images already do — so a Debian series/base-image bump can't re-break every image build. Keep the HEALTHCHECK intent; the pin was never a supply-chain control (it's a runtime health probe).
+- **Subtracts**: removes a recurring deploy-breaker class; the current wildcard only defers the next break to a series bump.
+- **Effort × Impact**: Low × Med–High.
+- **Verdict**: Worth trying — cheapest durable win; the wildcard band-aid will bite again.
+
+## Take
+
+The system is trending hard *toward* the ecosystem — Strands is current, the reliability release cluster mirrors where the industry is (bounded delegation, SSE hardening, Memory-ordering correctness), and the one upstream release that matters landed exactly when we needed it. The single change that matters most is the **`bedrock-agentcore` 1.18.0 bump**: it is simultaneously a subtraction (retires a queued guard), a reliability fix for *two* corruption classes (#571 + #482), and belt-and-suspenders under the exact Memory-heavy features (Scheduled Runs, Memory Spaces, sharing) the last four releases shipped. Phil would notice idea #2 or #5 as an operator (a caching-cost drop, or deploys that stop breaking on curl), but idea #1 is what he'd want in before the next multi-replica Memory incident. The external week was quiet by design — the real story is that a very productive fortnight of feature work left one reliability bump on the table, and the fix for the bug that work was defending against is now one line in `pyproject.toml`.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock/AgentCore What's New + release notes + ML blog | https://aws.amazon.com/about-aws/whats-new/recent/feed/ | 2026-07-17 | 4 |
+| 2 | Strands Agents releases + issues | https://github.com/strands-agents/sdk-python/releases | 2026-07-17 | 3 |
+| 3 | Reference repo commits | https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main | 2026-07-17 | 0 (dormant 2 wks) |
+| 4 | MCP blog / RC / apps overview / servers | https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ | 2026-07-17 | 0 in-window (RC locked) |
+| 4a | FastMCP releases + PyPI | https://github.com/jlowin/fastmcp/releases | 2026-07-17 | 0 (holds 3.4.4) |
+| 4b | Agentic UI/UX (assistant-ui, AI SDK, Cursor, NN/g, Linear) | https://github.com/Yonom/assistant-ui/releases | 2026-07-17 | 3 |
+| 5 | Frontier models (Anthropic/Google/Meta/OpenAI) | https://www.anthropic.com/news | 2026-07-17 | 2 |
+| 6 | Agent harness (Claude Code CHANGELOG + Anthropic eng) | https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md | 2026-07-17 | 3 |
+| 6a | opencode releases | https://github.com/anomalyco/opencode/releases | 2026-07-17 | 2 |
+| 7 | Bedrock pricing | https://aws.amazon.com/bedrock/pricing/ | 2026-07-17 | 0 (no change) |
+| 8 | AgentCore SDK / starter-toolkit issues + releases | https://github.com/aws/bedrock-agentcore-sdk-python/releases | 2026-07-17 | 5 |
+| 9 | Community (HN) | https://hn.algolia.com/ | 2026-07-17 | 0 |
+| 10 | Anthropic cookbook commits | https://github.com/anthropics/anthropic-cookbook/commits/main | 2026-07-17 | 1 |
+| 12 | LibreChat releases | https://github.com/danny-avila/LibreChat/releases | 2026-07-17 | 0 (holds v0.8.7) |
+| 19 | Version pins (PyPI + npm registry JSON) | https://pypi.org/pypi/bedrock-agentcore/json | 2026-07-17 | 10 deps |
+
+## Web Budget
+
+Used: **~55 / 50 requests** (modest overage).
+Skipped (unreachable / rate-limited): openai.com/blog (HTTP 403 — no in-window OpenAI signal confirmed; GPT-5.6-on-Bedrock item flagged for verification); NN/g AI topic page (404); Reddit (domain-blocked, per decisions.md 2026-05-18).
+Skipped (other): none material.
+Notes: overage driven by 11 subagents + the version-pin registry sweep (11 rows). Signal density justified it — the `bedrock-agentcore` 1.18.0 release (with the #571 fix) landing in-window is the single highest-value confirmation of the run, and the GPT-5.6-on-Bedrock conflict needed a second cross-check.

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -5,12 +5,48 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 ## Open
 <!-- Newest at top. -->
 
+### [2026-07-17] Bump `bedrock-agentcore` 1.9.1 → 1.18.0 (closes #571 cross-process Memory reorder + #482 SSE deadlock)
+- **Source**: research/2026-07-17.md ▸ Top 5 #1 — bedrock-agentcore 1.18.0 (Jul 10, PR #572/#573 close #571; #482 fix in 1.17.0/PR #563) — https://github.com/aws/bedrock-agentcore-sdk-python/releases
+- **Surface**: backend (`backend/pyproject.toml` + coupled `boto3`; inference-api chat router + `TurnBasedSessionManager` flush ordering; full local pytest suite)
+- **Effort × Impact**: M × H
+- **Subtracts**: yes — retires the queued [2026-05-22] hand-written #482 guard (library-native); the #571 ordering fix complements (not replaces) the just-shipped `_repair_tool_pairing`
+- **Status**: open — **highest priority; the release we've queued for six weeks now exists and landed in-window.** SUPERSEDES the [2026-07-03] "→ 1.17.0" item AND the [2026-07-10] "double-forced" item below (which said "bump to 1.17.0, track 1.18 for #571" — 1.18.0 now exists with the #571 fix, so retarget 1.18.0 and consolidate the two into this one). We're on 1.9.1, ~9 minors behind, exposed to both #571 and #482 while Scheduled Runs + Memory Spaces + conversation-sharing lean hard on Memory. Validate ms event-flooring vs our flush ordering; #564 (eventual-consistency read gap) stays unfixed — keep agent-cache continuity primary.
+
+### [2026-07-17] Audit multi-provider prompt caching (issue #642 + Strands #3144)
+- **Source**: research/2026-07-17.md ▸ Top 5 #2 — internal issue #642 (Jul 11); Strands #3144 (`CacheConfig(strategy="auto")` never caches system prompt, fix PR #3145 open) — https://github.com/strands-agents/sdk-python/issues/3144
+- **Surface**: backend (`to_bedrock_config` cache-point injection; Mantle Responses builder `build_mantle_model`/`_create_mantle_model`; OpenAI-compatible path; `CountTokensBedrockModel` cache-token read)
+- **Effort × Impact**: L–M × M–H
+- **Subtracts**: yes — consolidates per-provider cache logic; kills a silent full-input-token cost regression if a Mantle/OpenAI path caches nothing
+- **Status**: open — a filed internal tech-debt issue with a library-confirmed failure mode. Instrument `cache_read`/`cache_write` ratios per provider (Strands 1.46 surfaces them); confirm the Bedrock manual cache-point still engages post-1.47 and do NOT switch to `strategy="auto"` expecting system-prompt caching. Strongest internal-signal fit after the bump.
+
+### [2026-07-17] Adopt Strands `Limits` on the unattended Scheduled Runs / headless lane
+- **Source**: research/2026-07-17.md ▸ Top 5 #3 — convergent harness rail (Claude Code 2.1.212 spawn cap + opencode 1.18.2 `subagent_depth`); Strands `Limits` now available (we're on 1.47).
+- **Surface**: backend (headless/scheduled path `apis/shared/harness/run_agent_headless` per [2026-07-06] managed-Harness spike + agent-loop per-invocation config)
+- **Effort × Impact**: L–M × M
+- **Subtracts**: yes — retires any hand-rolled `max_turns` guard on the headless lane (library-native)
+- **Unlocks**: first-class per-invocation cost/turn cap on the highest-blast-radius lane (a runaway loop there burns quota unattended) — the capability the [2026-07-03] Strands bump listed but that still needs wiring now the bump landed
+- **Status**: open — scope to the scheduled/headless lane first; dovetails with the queued quota-cooldown work.
+
+### [2026-07-17] Harden the SPA SSE parser (unterminated-frame + line-ending handling)
+- **Source**: research/2026-07-17.md ▸ Top 5 #4 — assistant-stream@0.3.26 (Jul 16, spec-complete SSE decoder) — https://github.com/Yonom/assistant-ui/releases — reinforced by the 1.6.0 SSE/restore bug cluster (#653 tab-switch duplicate invocation, tool-pairing repair, single-flight lease)
+- **Surface**: frontend (SPA SSE parser service — the one allowlisting `session_title` past Completed-state gating; keyed per-session)
+- **Effort × Impact**: L–M × M
+- **Subtracts**: yes — replaces ad-hoc frame handling with a spec-complete decode pass
+- **Status**: open — pattern-only (implement in Angular signals, do NOT add the React dep): discard unterminated/partial frames + tighten line-endings on the interrupt-resume + tab-switch paths just stabilized. Defensive, lands on exactly the surface 1.6.0 hardened.
+
+### [2026-07-17] Durable curl fix — stop pinning curl to an upstream version in the Dockerfiles
+- **Source**: research/2026-07-17.md ▸ Top 5 #5 — internal friction (Nightly + Backend Deploy broke Jul 11–13 on `curl=8.14.1-2+deb13u3` "version not found"); partially fixed by floating to `deb13u*` (commit `74cd7b0a`, 1.5.0)
+- **Surface**: infra/CI (`backend/Dockerfile.app-api` + `Dockerfile.inference-api` line 42 `apt-get install curl=...`; check `scheduled-runs`/`kb-sync`)
+- **Effort × Impact**: L × M–H
+- **Subtracts**: yes — removes a recurring deploy-breaker class; the `deb13u*` wildcard only defers the next break to a Debian series/base-image bump
+- **Status**: open — replace the version-pinned curl with unpinned (latest security patch) or the base image's `curl-minimal` (as the Lambda images already do). The pin was never a supply-chain control — it's a HEALTHCHECK runtime probe. Cheapest durable win; the band-aid will bite again.
+
 ### [2026-07-10] Bump `bedrock-agentcore` off 1.9.1 — now double-forced (#482 SSE deadlock + NEW #571 Memory-reorder)
 - **Source**: research/2026-07-10.md ▸ Top 5 #1 — https://github.com/aws/bedrock-agentcore-sdk-python/pull/563 (#482, in 1.17.0) + **NEW** https://github.com/aws/bedrock-agentcore-sdk-python/issues/571 (cross-process Memory event-reorder corruption, fix pending a post-1.17.0 release).
 - **Surface**: backend (`backend/pyproject.toml`, inference-api chat router, `AgentCoreMemorySessionManager` usage; full local pytest suite)
 - **Effort × Impact**: M × H
 - **Subtracts**: yes — retires the queued [2026-05-22] #482 hand-written guard (library-native subtraction)
-- **Status**: open — **updates/supersedes the [2026-07-03] agentcore bump item with #571 evidence + a feature-tied forcing function.** 1.1.0/1.2.0 shipped Scheduled Runs (multi-replica Runtime) + Memory Spaces (heavier Memory use), amplifying exactly the failure classes #482/#571 corrupt. Bump to 1.17.0 now (closes #482); **track 1.18 for the #571 fix** (not yet released — latest is still 1.17.0). Frame the PR as incident-prevention against the new features, not hygiene.
+- **Status**: open — **CONSOLIDATED into the [2026-07-17] "→ 1.18.0" item above** (the #571 fix this entry was tracking landed in 1.18.0 on Jul 10 — the post-1.17.0 release it awaited). Treat as one item; review-prep should resolve this stub. 1.1.0/1.2.0 shipped Scheduled Runs (multi-replica Runtime) + Memory Spaces (heavier Memory use), amplifying exactly the failure classes #482/#571 corrupt.
 
 ### [2026-07-10] Bump Strands 1.40 → 1.47; adopt `continue_on_error` MCP resilience (#3101) + hook ordering
 - **Source**: research/2026-07-10.md ▸ Top 5 #2 — Strands 1.46–1.47 (https://github.com/strands-agents/sdk-python/releases). **Supersedes the [2026-07-03] 1.45 item** (now 7 minors behind).
@@ -18,7 +54,7 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Effort × Impact**: M–H × H
 - **Subtracts**: candidate — hand-rolled MCP-abort handling (`continue_on_error`), custom cache-point plumbing (`cache_tools_ttl`), runaway guard (`Limits`)
 - **Unlocks**: a flaky external/Gateway MCP server no longer aborts the turn (newly relevant — Scheduled Runs use external tools unattended); `Limits` per-invocation cost caps; deterministic hook ordering (the enabler for the tool-approval fix)
-- **Status**: open — adopt `continue_on_error` on the MCP client + optional hook ordering (#2559); audit `cache_tools_ttl`/`context_manager="auto"`/`Limits` (decisions.md 2026-05-18 bars a bare compaction swap). Only breaking change 1.45→1.47 is the N/A in-process memory-store rename. Run full local pytest; watch compaction + context-attribution.
+- **Status**: open — **the bump itself SHIPPED** (commit `42e69bc7` "upgrade Strands to 1.47.0"; the pin is now 1.47.0). Remaining follow-on work is separately queued: `Limits` adoption on the headless lane is the [2026-07-17] item above; `continue_on_error` on the MCP client + optional hook ordering (#2559) + the `cache_tools_ttl`/`context_manager="auto"` audits are still open here (decisions.md 2026-05-18 bars a bare compaction swap). Review-prep should split "bump = done" from the un-adopted capabilities.
 
 ### [2026-07-10] Audit whether prompt caching actually engages in `to_bedrock_config` (Strands #3144)
 - **Source**: research/2026-07-10.md ▸ Top 5 #3 — **NEW** Strands open issue #3144 (`CacheConfig(strategy="auto")` never caches the system prompt); Strands 1.46 now surfaces `cache_read`/`cache_write` tokens in the metadata chunk (#2302). https://github.com/strands-agents/sdk-python/issues
@@ -26,7 +62,7 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 - **Effort × Impact**: L–M × M–H
 - **Subtracts**: no — a cost-correctness audit (may confirm we're fine, or expose a silent full-input-token regression)
 - **Unlocks**: potentially large per-turn cost cut if caching is silently off; a verifiable caching invariant
-- **Status**: open — cheapest high-upside item this week. Assert cache points are written *and* read by inspecting `cache_read`/`cache_write` counts across a multi-turn session; fix cache-point placement if the system prompt/tool schema isn't caching. Measurement is nearly free now that 1.46 surfaces the tokens.
+- **Status**: open — **subsumed by / merge with the [2026-07-17] "multi-provider prompt caching" item above** (same Bedrock cache-point surface + Strands #3144, extended to the Mantle/OpenAI provider shapes). Assert cache points are written *and* read via `cache_read`/`cache_write` counts; measurement is nearly free now that 1.46 surfaces the tokens.
 
 ### [2026-07-10] Tool-approval policy layer + signed approvals (Vercel AI SDK) — evolve the queued approval item
 - **Source**: research/2026-07-10.md ▸ Top 5 #4 — Vercel AI SDK tool-approvals (https://ai-sdk.dev/docs/agents/tool-approvals). Builds on the [2026-07-03] tool-approval item.


### PR DESCRIPTION
## Summary
- External scan (11 subagents): AWS Bedrock/AgentCore, Strands, FastMCP, reference repo, MCP, agentic UI/UX, frontier models, agent-harness + opencode, pricing, AgentCore SDK issues, cookbook + LibreChat.
- Internal audit: 1.3.0→1.6.1 release train (147 commits), open PRs, new issues, CI failures, version-pin lag, retirement candidates.
- Top 5 ideas in the dated research doc and queued in `docs/kaizen/review-queue.md`.

## Headline
Quiet external week (pre-July-28 MCP-RC lull) against a very loud repo. **`bedrock-agentcore` 1.18.0 shipped July 10** and carries the **#571 cross-process Memory event-reorder fix** on top of the **#482 SSE-deadlock fix** (1.17.0) — one bump off our pinned **1.9.1** closes both. Meanwhile the 1.6.0 reliability cluster (single-flight lease, restore-time tool-pairing repair, tab-switch SSE fix) *hand-built* protection against the exact corruption class that SDK fix addresses upstream. Strands is now current at **1.47.0** (last week's bump shipped). Nightly went green Jul 14–17 after the float-curl fix.

## Top 5
1. Bump `bedrock-agentcore` 1.9.1 → 1.18.0 (closes #571 + #482) — M×H — **subtracts**
2. Audit multi-provider prompt caching (issue #642 + Strands #3144) — L–M×M–H — **subtracts**
3. Adopt Strands `Limits` on the unattended Scheduled Runs / headless lane — L–M×M — **subtracts**
4. Harden the SPA SSE parser (unterminated-frame + line-ending handling) — L–M×M — **subtracts**
5. Durable curl fix — stop pinning curl to an upstream version in the Dockerfiles — L×M–H — **subtracts**

## Coordination note
PR #616 (the July 10 kaizen scan) is still **open/unmerged** with no comments, so its queue additions live only on that branch. This week's Top 5 supersede/retarget its overlapping items (agentcore → now 1.18.0; the Strands bump has since shipped). Two research PRs are open — review-prep reads both from the working tree.

## Review
- Read the research doc.
- Comment on the PR with reactions and any weekend POC findings — these become first-class signal for next Friday's `kaizen-review-prep`.
- POC promising ideas over the weekend.

## Decision
Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)