### PR TITLE
feat(sessions): dual-scheme union read for session listing (issue #175 Phase 1a)

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -1701,6 +1701,82 @@ async def list_user_sessions(
     )
 
 
+def _item_to_session_metadata(item: Dict[str, Any]) -> Optional[SessionMetadata]:
+    """Parse one DynamoDB item into SessionMetadata, or None if it should be skipped.
+
+    Skips preview sessions and ghost/corrupt rows (the latter logged). Shared by
+    both source queries in the transitional union read.
+    """
+    try:
+        item = _convert_decimal_to_float(item)
+        for key in ('PK', 'SK', 'GSI_PK', 'GSI_SK', 'GSI4_PK', 'GSI4_SK'):
+            item.pop(key, None)
+
+        # Skip preview sessions - they should not appear in user's session list
+        if is_preview_session(item.get('sessionId', '')):
+            return None
+
+        if "pendingInterrupts" in item:
+            item["pendingInterrupts"] = _dedupe_interrupt_dicts(item["pendingInterrupts"])
+
+        return SessionMetadata.model_validate(item)
+    except Exception as e:
+        # JUSTIFICATION: When listing sessions from DynamoDB, individual session parsing
+        # failures should not break the entire list operation. We skip corrupted sessions
+        # and continue processing others. This provides better UX than failing completely.
+        logger.warning(f"Failed to parse session item: {e}")
+        return None
+
+
+def _collect_valid_sessions(table, query_params: Dict[str, Any], want: Optional[int]) -> list[SessionMetadata]:
+    """Query one source, following LastEvaluatedKey until ``want`` valid rows collected.
+
+    DynamoDB ``Limit`` caps items *evaluated*, not *returned* after we drop previews
+    and ghosts, so we page until the partition is exhausted or ``want`` rows are in
+    hand. ``want`` is ``limit + 1`` at the call site — the extra row is the sentinel
+    that tells the merge whether another page exists.
+    """
+    results: list[SessionMetadata] = []
+    params = dict(query_params)
+    while True:
+        response = table.query(**params)
+        for item in response['Items']:
+            metadata = _item_to_session_metadata(item)
+            if metadata is None:
+                continue
+            results.append(metadata)
+            if want and len(results) >= want:
+                return results
+        lek = response.get('LastEvaluatedKey')
+        if not lek:
+            return results
+        params['ExclusiveStartKey'] = lek
+
+
+def _decode_list_cursor(next_token: Optional[str]) -> Optional[Tuple[str, str]]:
+    """Decode a session-list cursor into ``(last_message_at, session_id)``.
+
+    Tolerant: an undecodable or legacy-format token (the pre-migration
+    ``base64(json(LastEvaluatedKey))``) falls back to no-cursor (first page) rather
+    than erroring — a harmless page reset across the migration deploy boundary.
+    """
+    if not next_token:
+        return None
+    try:
+        obj = json.loads(base64.b64decode(next_token).decode('utf-8'))
+        if isinstance(obj, dict) and 'la' in obj:
+            return (obj['la'], obj.get('sid', ''))
+    except Exception as e:
+        logger.warning(f"Invalid next_token: {e}, starting from beginning")
+    return None
+
+
+def _encode_list_cursor(session: SessionMetadata) -> str:
+    """Encode the merge cursor from the last returned session (value-based, not key-based)."""
+    payload = {'la': session.last_message_at, 'sid': session.session_id}
+    return base64.b64encode(json.dumps(payload).encode('utf-8')).decode('utf-8')
+
+
 async def _list_user_sessions_cloud(
     user_id: str,
     table_name: str,
@@ -1708,117 +1784,105 @@ async def _list_user_sessions_cloud(
     next_token: Optional[str] = None
 ) -> Tuple[list[SessionMetadata], Optional[str]]:
     """
-    List active sessions for a user from DynamoDB with efficient pagination
+    List active sessions for a user from DynamoDB — transitional dual-scheme read.
 
-    Args:
-        user_id: User identifier
-        table_name: DynamoDB table name
-        limit: Maximum number of sessions to return (optional)
-        next_token: Pagination token for retrieving next page (optional)
+    Issue #175 Phase 1a (expand read): reads the UNION of two disjoint sources so a
+    session is visible whether or not its base sort key has been migrated to the
+    static ``S#{session_id}`` form:
 
-    Returns:
-        Tuple of (list of SessionMetadata objects, next_token if more sessions exist)
-        Sessions are sorted by last_message_at descending (most recent first)
+      - Legacy rows (un-migrated): base table, ``SK begins_with 'S#ACTIVE#'`` (the SK
+        encodes ``lastMessageAt``, so it sorts by recency natively).
+      - Migrated rows: ``SessionRecencyIndex`` GSI (``GSI4_PK=USER#{id}``,
+        ``GSI4_SK={lastMessageAt}#{session_id}``), sparse + active-only.
 
-    Schema:
-        PK: USER#{user_id}
-        SK: S#ACTIVE#{last_message_at}#{session_id}
+    A session is in exactly one source at a time (a migrated row's base SK no longer
+    matches ``S#ACTIVE#`` and it has GSI4 keys; an un-migrated row has neither), so
+    the two result sets are disjoint — dedupe by ``session_id`` is belt-and-suspenders
+    for the brief mid-migration instant.
 
-    Performance improvements over old schema:
-        - Query only returns session records (no cost records with C# prefix)
-        - No in-memory filtering needed
-        - Sessions sorted by timestamp in SK (no in-memory sorting)
-        - True server-side pagination via DynamoDB's native mechanism
-        - O(page_size) instead of O(sessions + messages)
+    Pagination uses a **value cursor** (``{lastMessageAt}#{session_id}``), not a
+    per-source ``LastEvaluatedKey``, so a page is derived independently from the last
+    returned position with no cross-page buffering. Fetching ``limit + 1`` valid rows
+    from each source is provably sufficient to know whether another page exists.
+
+    If ``SessionRecencyIndex`` does not exist yet (code deployed before the CDK GSI),
+    the GSI query is skipped and the read degrades to legacy-only.
+
+    Kept until the migration completes; Phase 3 collapses this to GSI-only.
     """
     try:
         import boto3
         from boto3.dynamodb.conditions import Key
+        from botocore.exceptions import ClientError
 
         dynamodb = boto3.resource('dynamodb')
         table = dynamodb.Table(table_name)
 
-        # Decode next_token to get ExclusiveStartKey if provided
-        exclusive_start_key = None
-        if next_token:
-            try:
-                decoded = base64.b64decode(next_token).decode('utf-8')
-                exclusive_start_key = json.loads(decoded)
-            except Exception as e:
-                # JUSTIFICATION: Invalid pagination tokens should not break the request.
-                # We fall back to no pagination, which is a reasonable default.
-                # This handles cases where tokens are corrupted, expired, or malformed.
-                logger.warning(f"Invalid next_token: {e}")
+        cursor = _decode_list_cursor(next_token)
+        want = (limit + 1) if limit else None
+        pk = f'USER#{user_id}'
 
-        # Build query parameters with new S#ACTIVE# prefix
-        # This cleanly separates from:
-        # - S#DELETED# (soft-deleted sessions)
-        # - C# (cost records)
-        query_params = {
-            'KeyConditionExpression': Key('PK').eq(f'USER#{user_id}') & Key('SK').begins_with('S#ACTIVE#'),
-            'ScanIndexForward': False  # Descending order (most recent first) - timestamp is in SK!
+        # Legacy source: base table, S#ACTIVE# prefix. Resuming after a cursor uses
+        # between('S#ACTIVE#', 'S#ACTIVE#{la}#{sid}') — a single range condition that
+        # keeps the prefix filter while bounding the upper end (inclusive; the exact
+        # cursor row is dropped by the strict-less filter below).
+        if cursor:
+            la, sid = cursor
+            legacy_cond = Key('PK').eq(pk) & Key('SK').between('S#ACTIVE#', f'S#ACTIVE#{la}#{sid}')
+        else:
+            legacy_cond = Key('PK').eq(pk) & Key('SK').begins_with('S#ACTIVE#')
+        legacy_params: Dict[str, Any] = {
+            'KeyConditionExpression': legacy_cond,
+            'ScanIndexForward': False,
         }
+        if want:
+            legacy_params['Limit'] = want
+        legacy_sessions = _collect_valid_sessions(table, legacy_params, want)
 
-        if exclusive_start_key:
-            query_params['ExclusiveStartKey'] = exclusive_start_key
+        # Migrated source: SessionRecencyIndex GSI. GSI4_SK < '{la}#{sid}' is a clean
+        # strict-less resume. Degrade to legacy-only if the index isn't there yet.
+        if cursor:
+            la, sid = cursor
+            gsi_cond = Key('GSI4_PK').eq(pk) & Key('GSI4_SK').lt(f'{la}#{sid}')
+        else:
+            gsi_cond = Key('GSI4_PK').eq(pk)
+        gsi_params: Dict[str, Any] = {
+            'IndexName': 'SessionRecencyIndex',
+            'KeyConditionExpression': gsi_cond,
+            'ScanIndexForward': False,
+        }
+        if want:
+            gsi_params['Limit'] = want
+        try:
+            gsi_sessions = _collect_valid_sessions(table, gsi_params, want)
+        except ClientError as e:
+            if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+                logger.warning(
+                    "SessionRecencyIndex not found; falling back to legacy-only session listing"
+                )
+                gsi_sessions = []
+            else:
+                raise
 
-        if limit:
-            query_params['Limit'] = limit
+        # Merge: sort by (lastMessageAt, sessionId) descending, drop anything not
+        # strictly older than the cursor (removes the inclusive legacy cursor row),
+        # dedupe by session_id.
+        combined = legacy_sessions + gsi_sessions
+        if cursor:
+            combined = [s for s in combined if (s.last_message_at, s.session_id) < cursor]
+        combined.sort(key=lambda s: (s.last_message_at, s.session_id), reverse=True)
 
-        # Pagination loop: DynamoDB's Limit caps items *evaluated*, not items
-        # *returned* after application-level filtering (preview sessions, parse
-        # failures). A single query may return fewer valid sessions than the
-        # requested limit while still having more data in the partition. We keep
-        # querying until we fill the page or exhaust the partition.
-        sessions: list[SessionMetadata] = []
-        last_evaluated_key = None
+        seen: set = set()
+        deduped: list[SessionMetadata] = []
+        for s in combined:
+            if s.session_id in seen:
+                continue
+            seen.add(s.session_id)
+            deduped.append(s)
 
-        while True:
-            response = table.query(**query_params)
-
-            for item in response['Items']:
-                try:
-                    item = _convert_decimal_to_float(item)
-
-                    for key in ['PK', 'SK', 'GSI_PK', 'GSI_SK']:
-                        item.pop(key, None)
-
-                    # Skip preview sessions - they should not appear in user's session list
-                    session_id = item.get('sessionId', '')
-                    if is_preview_session(session_id):
-                        continue
-
-                    if "pendingInterrupts" in item:
-                        item["pendingInterrupts"] = _dedupe_interrupt_dicts(item["pendingInterrupts"])
-
-                    metadata = SessionMetadata.model_validate(item)
-                    sessions.append(metadata)
-
-                    # Stop collecting once we have enough
-                    if limit and len(sessions) >= limit:
-                        break
-                except Exception as e:
-                    # JUSTIFICATION: When listing sessions from DynamoDB, individual session parsing
-                    # failures should not break the entire list operation. We skip corrupted sessions
-                    # and continue processing others. This provides better UX than failing completely.
-                    logger.warning(f"Failed to parse session item: {e}")
-                    continue
-
-            last_evaluated_key = response.get('LastEvaluatedKey')
-
-            # Stop if we've filled the page or there's no more data
-            if (limit and len(sessions) >= limit) or not last_evaluated_key:
-                break
-
-            # Continue querying from where DynamoDB left off
-            query_params['ExclusiveStartKey'] = last_evaluated_key
-
-        # Generate next_token only when there is genuinely more data to fetch
-        next_page_token = None
-        if last_evaluated_key and limit and len(sessions) >= limit:
-            next_page_token = base64.b64encode(
-                json.dumps(last_evaluated_key).encode('utf-8')
-            ).decode('utf-8')
+        has_more = bool(limit) and len(deduped) > limit
+        sessions = deduped[:limit] if limit else deduped
+        next_page_token = _encode_list_cursor(sessions[-1]) if (has_more and sessions) else None
 
         logger.info(f"Listed {len(sessions)} sessions for user {user_id} from DynamoDB")
 

--- a/backend/tests/shared/conftest.py
+++ b/backend/tests/shared/conftest.py
@@ -235,11 +235,14 @@ def sessions_metadata_table(aws, monkeypatch):
             {"AttributeName": "GSI_SK", "AttributeType": "S"},
             {"AttributeName": "GSI3_PK", "AttributeType": "S"},
             {"AttributeName": "GSI3_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_SK", "AttributeType": "S"},
         ],
         gsis=[
             _gsi("UserTimestampIndex", "GSI1PK", "GSI1SK"),
             _gsi("SessionLookupIndex", "GSI_PK", "GSI_SK"),
             _gsi("DueScheduleIndex", "GSI3_PK", "GSI3_SK"),
+            _gsi("SessionRecencyIndex", "GSI4_PK", "GSI4_SK"),
         ],
     )
 

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -263,6 +263,119 @@ class TestListUserSessions:
             await list_user_sessions("u1")
 
 
+def _put_legacy_row(table, sid, la, user_id="u1", **extra):
+    """Un-migrated session row: SK encodes lastMessageAt, no GSI4 keys."""
+    item = {
+        "PK": f"USER#{user_id}", "SK": f"S#ACTIVE#{la}#{sid}",
+        "GSI_PK": f"SESSION#{sid}", "GSI_SK": "META",
+        "sessionId": sid, "userId": user_id, "title": "T", "status": "active",
+        "createdAt": la, "lastMessageAt": la, "messageCount": 1,
+    }
+    item.update(extra)
+    table.put_item(Item=item)
+
+
+def _put_migrated_row(table, sid, la, user_id="u1", **extra):
+    """Migrated session row: static SK + sparse SessionRecencyIndex (GSI4) keys."""
+    item = {
+        "PK": f"USER#{user_id}", "SK": f"S#{sid}",
+        "GSI_PK": f"SESSION#{sid}", "GSI_SK": "META",
+        "GSI4_PK": f"USER#{user_id}", "GSI4_SK": f"{la}#{sid}",
+        "sessionId": sid, "userId": user_id, "title": "T", "status": "active",
+        "createdAt": la, "lastMessageAt": la, "messageCount": 1,
+    }
+    item.update(extra)
+    table.put_item(Item=item)
+
+
+class TestListUserSessionsDualScheme:
+    """Issue #175 Phase 1a — union read over legacy + migrated (SessionRecencyIndex) rows."""
+
+    @pytest.mark.asyncio
+    async def test_migrated_only_listed_via_gsi(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import list_user_sessions
+        _put_migrated_row(sessions_metadata_table, "m1", "2026-01-02T00:00:00Z")
+        _put_migrated_row(sessions_metadata_table, "m2", "2026-01-01T00:00:00Z")
+        sessions, token = await list_user_sessions("u1")
+        assert [s.session_id for s in sessions] == ["m1", "m2"]
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_union_ordered_newest_first(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import list_user_sessions
+        # interleave the two schemes by timestamp
+        _put_migrated_row(sessions_metadata_table, "m_06", "2026-01-06T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_05", "2026-01-05T00:00:00Z")
+        _put_migrated_row(sessions_metadata_table, "m_04", "2026-01-04T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_03", "2026-01-03T00:00:00Z")
+        _put_migrated_row(sessions_metadata_table, "m_02", "2026-01-02T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_01", "2026-01-01T00:00:00Z")
+
+        sessions, token = await list_user_sessions("u1")
+        assert [s.session_id for s in sessions] == ["m_06", "l_05", "m_04", "l_03", "m_02", "l_01"]
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_pagination_across_union_no_dupes_or_gaps(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import list_user_sessions
+        _put_migrated_row(sessions_metadata_table, "m_06", "2026-01-06T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_05", "2026-01-05T00:00:00Z")
+        _put_migrated_row(sessions_metadata_table, "m_04", "2026-01-04T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_03", "2026-01-03T00:00:00Z")
+        _put_migrated_row(sessions_metadata_table, "m_02", "2026-01-02T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l_01", "2026-01-01T00:00:00Z")
+
+        seen = []
+        token = None
+        for _ in range(5):  # safety bound
+            page, token = await list_user_sessions("u1", limit=2, next_token=token)
+            seen.extend(s.session_id for s in page)
+            if token is None:
+                break
+        assert seen == ["m_06", "l_05", "m_04", "l_03", "m_02", "l_01"]
+        assert len(seen) == len(set(seen))  # no duplicates across pages
+
+    @pytest.mark.asyncio
+    async def test_ghost_and_preview_rows_skipped(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import list_user_sessions
+        _put_migrated_row(sessions_metadata_table, "good", "2026-01-02T00:00:00Z")
+        # ghost: bare key, missing required fields (the exact prod failure)
+        sessions_metadata_table.put_item(
+            Item={"PK": "USER#u1", "SK": "S#ACTIVE#2026-01-01T00:00:00Z#ghost"}
+        )
+        # preview session should never surface
+        _put_legacy_row(sessions_metadata_table, "preview-abc", "2026-01-03T00:00:00Z")
+
+        sessions, _ = await list_user_sessions("u1")
+        ids = [s.session_id for s in sessions]
+        assert ids == ["good"]
+
+    @pytest.mark.asyncio
+    async def test_graceful_fallback_when_index_missing(self, aws, monkeypatch):
+        """Code deployed before the CDK GSI: GSI query 404s → legacy-only, no crash."""
+        import boto3
+        from apis.shared.sessions.metadata import list_user_sessions
+
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        name = "test-sessions-metadata-no-gsi"
+        ddb.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "PK", "KeyType": "HASH"},
+                       {"AttributeName": "SK", "KeyType": "RANGE"}],
+            AttributeDefinitions=[{"AttributeName": "PK", "AttributeType": "S"},
+                                  {"AttributeName": "SK", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setenv("DYNAMODB_SESSIONS_METADATA_TABLE_NAME", name)
+        table = boto3.resource("dynamodb", region_name="us-east-1").Table(name)
+        _put_legacy_row(table, "l1", "2026-01-02T00:00:00Z")
+        _put_legacy_row(table, "l2", "2026-01-01T00:00:00Z")
+
+        sessions, token = await list_user_sessions("u1")
+        assert [s.session_id for s in sessions] == ["l1", "l2"]
+        assert token is None
+
+
 class TestStoreUserDisplayText:
     """Tests for the displayText feature (D# records)."""
 


### PR DESCRIPTION
## What & why

Phase 1a (**expand read**) of the session-metadata static-sort-key migration (issue #175). `list_user_sessions` now reads the **union** of two disjoint sources, so a session is visible whether or not its base sort key has been migrated to the static `S#{session_id}` form:

- **Legacy** (un-migrated): base table, `SK begins_with 'S#ACTIVE#'` (the SK encodes `lastMessageAt`, so it sorts by recency natively)
- **Migrated**: `SessionRecencyIndex` GSI — `GSI4_PK=USER#{id}`, `GSI4_SK={lastMessageAt}#{session_id}` (added in Phase 0, PR #666)

This is the step that must be **fully rolled out before Phase 1b turns on self-migrating writes** — otherwise an old container mid-deploy would list legacy-only and a just-migrated row would briefly vanish from a user's sidebar.

Follows PR #666 (the GSI). Full design: [`docs/specs/session-metadata-static-sort-key.md`](docs/specs/session-metadata-static-sort-key.md).

## Changes

- **Union read.** The two sources are disjoint by construction (a migrated row's base SK no longer matches `S#ACTIVE#` and it has GSI4 keys; an un-migrated row has neither), merged newest-first, deduped by `session_id` as belt-and-suspenders.
- **Value-cursor pagination.** Switched from a per-source `LastEvaluatedKey` to a `{lastMessageAt}#{session_id}` value cursor, so each page is derived independently from the last returned position with no cross-page buffering. Fetching `limit + 1` valid rows per source is provably sufficient to detect a next page. The cursor decoder is **tolerant** — a legacy/undecodable token falls back to first page (a harmless reset across the deploy boundary). The token is opaque to the SPA, so the format change is transparent.
- **Graceful degradation.** If `SessionRecencyIndex` doesn't exist yet (code deployed ahead of the CDK GSI), the GSI query's `ResourceNotFoundException` is caught and the read degrades to legacy-only.
- Shared item→metadata parsing factored into `_item_to_session_metadata` (previews + ghost/corrupt rows skipped) so both source queries reuse it.

**No writes change and no row migrates in this phase.** This only teaches every reader to cope with both schemes.

## Deploy ordering

- **Soft dependency on #666, not hard.** Thanks to the graceful fallback, this is safe to deploy even before the Phase 0 GSI is live in an environment — it just runs legacy-only until the index exists. Ideally #666 deploys first (via `platform.yml`) so the union actually engages.
- Ships via `backend.yml` (backend code only; no infra change here).

## Verification

- New `TestListUserSessionsDualScheme`: union ordering, cross-union pagination (asserts **no dupes/gaps** across pages), migrated-only via GSI, ghost/preview skip, graceful fallback when the index is absent.
- **214 passed** across `test_sessions_metadata` + `test_sessions` (routes) + `test_coverage_boost` + `test_models_and_utils`; architecture import-boundaries green.
- conftest `sessions_metadata_table` fixture gains the `SessionRecencyIndex` GSI to match prod.

## Not in scope

- The dead `_apply_pagination` in `shared/sessions/metadata.py` is left untouched (unused — the live path builds its own token).

## Next

Phase 1b (self-migrating writes + new-scheme writes) as a separate PR, **after 1a is fully rolled out**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)