### PR TITLE
fix(deps): bump strands-agents to 1.48.0 for cachePoint-attachment fix

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 [project.optional-dependencies]
 # AgentCore-specific dependencies (for inference_api)
 agentcore = [
-    "strands-agents==1.47.0",
+    "strands-agents==1.48.0",
     "strands-agents-tools==0.5.2",
 
     "aws-opentelemetry-distro==0.17.0",
@@ -69,7 +69,7 @@ agentcore = [
 
 # Voice/BidiAgent dependencies (Nova Sonic speech-to-speech)
 bidi = [
-    "strands-agents[bidi]==1.47.0",
+    "strands-agents[bidi]==1.48.0",
 ]
 
 # Document ingestion pipeline dependencies (for Lambda deployment)

--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -334,12 +334,16 @@ class ModelConfig:
         # place cache points per-model: for a model that supports automatic
         # caching it injects a cachePoint on the system/tools/last-user blocks;
         # for one that doesn't it logs a warning and no-ops, so this is safe to
-        # set whenever caching is enabled. The earlier SDK blocker — strands PR
-        # #1438, where `cachePoint` blocks collided with non-PDF document
-        # attachments — was fixed in strands-agents 1.39.0 (we pin 1.40.0).
-        # Cache hits are user-visible in the cost/context badge the moment this
-        # is on.
-        # See: https://github.com/strands-agents/sdk-python/pull/1438
+        # set whenever caching is enabled. Requires strands-agents>=1.48.0: a
+        # cachePoint trailing a non-PDF `document` attachment is rejected by
+        # Bedrock's Anthropic adapter with "ValidationException ...
+        # content.N.type: Field required" (agent force-stop on any turn with a
+        # txt/docx/csv attachment; upstream issue #1966). 1.48.0 inserts the
+        # cachePoint before the first non-PDF document instead, and skips the
+        # cache point entirely (uncached turn, not an error) when a non-PDF
+        # document is the first content block. Cache hits are user-visible in
+        # the cost/context badge the moment this is on.
+        # See: https://github.com/strands-agents/sdk-python/issues/1966
         if self.caching_enabled:
             from strands.models import CacheConfig
             config["cache_config"] = CacheConfig(strategy="auto")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -116,8 +116,8 @@ requires-dist = [
     { name = "python-multipart", specifier = "==0.0.31" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "starlette", specifier = "==1.3.1" },
-    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.47.0" },
-    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.47.0" },
+    { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.48.0" },
+    { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.48.0" },
     { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.5.2" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "trafilatura", specifier = "==2.0.0" },
@@ -4634,7 +4634,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.47.0"
+version = "1.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -4650,9 +4650,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/05/5eb8431ff340739b1c21b0da7d19ec9604b9c4953a1c4638df915321573c/strands_agents-1.47.0.tar.gz", hash = "sha256:97770cb6beb6e5fd1a58849f41201eb7edb43fd67ad3de6544ada2f342c2bcf0", size = 1157139, upload-time = "2026-07-10T14:45:05.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/834e4a63c6ad039d10924b5ba8c0651ccb24d7e28fd8c07c1a09b859120f/strands_agents-1.48.0.tar.gz", hash = "sha256:bfbf5af9d8f1cb348b617d5f8d17b949ef3c3fdd74fa8c849f1fda46885449c2", size = 1174326, upload-time = "2026-07-17T14:03:45.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/cb/ceae892c5823bea9254160efc02a4553f2ced9d183676110c03c3a9ff0f3/strands_agents-1.47.0-py3-none-any.whl", hash = "sha256:1f6ce17404ff02079244ad7a4a180a2a7150546275e4b91187d71472ba8fe3f2", size = 600611, upload-time = "2026-07-10T14:45:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/25/67/67d1e267405f6ae119cc0412891f66997a5a97eed2dbba18fc430a9ac00a/strands_agents-1.48.0-py3-none-any.whl", hash = "sha256:7118a644e844ab6ef77f4bc9883b7082b2e7a309bcd689cc5ef5345e07abcc9e", size = 612156, upload-time = "2026-07-17T14:03:43.06Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes the prod **"Agent force-stopped: ValidationException … messages.0.content.2.type: Field required"** error (Brian Bolt's report, session `dd1a647a`) that hit any chat turn attaching a non-PDF document (txt/docx/csv/…) on a caching-enabled Claude model.

**Root cause:** strands' auto prompt caching (`CacheConfig(strategy="auto")`, enabled since #471) appends its `cachePoint` block to the **end** of the last user message. With an attachment, the request became `[text, document, cachePoint]`, and Bedrock's Anthropic adapter cannot fold a cachePoint that trails a non-PDF `document` block — the request is rejected before the model runs, surfacing as an agent force-stop. Deterministic: reproduced with a 3-line boto3 `converse_stream` call; ~5 distinct prod incidents Jul 14–16.

## Changes

- Bump `strands-agents` and `strands-agents[bidi]` 1.47.0 → 1.48.0, which ships *"fix(bedrock): place cache point before non-PDF document blocks"* (upstream [issue #1966](https://github.com/strands-agents/sdk-python/issues/1966)) — the cachePoint now lands **before** the first non-PDF document; a message whose first block is a non-PDF document simply goes uncached for that turn instead of erroring.
- Refresh `uv.lock` (only strands changes in the resolution).
- Correct the comment in `model_config.py` that credited strands PR #1438 / 1.39.0 with fixing this collision — #1438 was the auto-caching *feature* itself; the collision was live through 1.47.0.

## Verification

- Every placement 1.48.0's `_inject_cache_point` produces was verified live against `global.anthropic.claude-sonnet-4-6` via `ConverseStream` in the prod account: `[text, cachePoint, txt-doc]` ✅, `[text, pdf-doc, cachePoint]` ✅ (incl. a 2 MB real multi-page PDF), mixed txt+pdf ✅, doc-only (no cachePoint) ✅. The old broken shape still reproduces the error, confirming the fix targets it.
- Full backend suite on 1.48.0: **4705 passed, 3 skipped**.

## Notes

- One Jul 15 incident involved a **PDF** trailing the content, which 1.48.0 still places the cachePoint after; that failure is unreproducible as of Jul 17 (tested small/multipage/real PDFs, ± `anthropic_beta`, converse + converse_stream — all pass). Watch-item post-deploy: filter `"type: Field required"` in the prod runtime log group.
- Shipping to prod requires a `backend.yml` run once this reaches `main` (fix lives in the inference-api image). Until then, the no-deploy mitigation is flipping `supportsCaching` off on the prod model records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)