### PR TITLE
fix(sessions): degrade to legacy-only on real ValidationException for missing GSI (issue #175)

### DIFF
--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -1856,9 +1856,21 @@ async def _list_user_sessions_cloud(
         try:
             gsi_sessions = _collect_valid_sessions(table, gsi_params, want)
         except ClientError as e:
-            if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
+            # An index that doesn't exist yet (code deployed ahead of the CDK GSI)
+            # surfaces differently across engines: real DynamoDB raises
+            # ValidationException ("The table does not have the specified index"),
+            # while moto/table-absent raises ResourceNotFoundException. Catch both
+            # (scoped by message for the ValidationException so genuinely malformed
+            # queries still surface) and degrade to legacy-only.
+            err = e.response.get('Error', {})
+            code = err.get('Code')
+            missing_index = code == 'ResourceNotFoundException' or (
+                code == 'ValidationException' and 'specified index' in err.get('Message', '')
+            )
+            if missing_index:
                 logger.warning(
-                    "SessionRecencyIndex not found; falling back to legacy-only session listing"
+                    "SessionRecencyIndex unavailable (%s); falling back to legacy-only "
+                    "session listing", code
                 )
                 gsi_sessions = []
             else:

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -375,6 +375,45 @@ class TestListUserSessionsDualScheme:
         assert [s.session_id for s in sessions] == ["l1", "l2"]
         assert token is None
 
+    @pytest.mark.asyncio
+    async def test_graceful_fallback_on_validationexception(self, sessions_metadata_table, monkeypatch):
+        """Real DynamoDB raises ValidationException (not ResourceNotFoundException) for a
+        missing GSI — moto masks this, so simulate the real error on the index query."""
+        import boto3
+        from botocore.exceptions import ClientError
+        from apis.shared.sessions.metadata import list_user_sessions
+
+        _put_legacy_row(sessions_metadata_table, "l1", "2026-01-02T00:00:00Z")
+        _put_legacy_row(sessions_metadata_table, "l2", "2026-01-01T00:00:00Z")
+
+        real_table = sessions_metadata_table
+
+        class _GsiFailingTable:
+            def query(self, **kwargs):
+                if kwargs.get("IndexName") == "SessionRecencyIndex":
+                    raise ClientError(
+                        {"Error": {
+                            "Code": "ValidationException",
+                            "Message": "The table does not have the specified index: SessionRecencyIndex",
+                        }},
+                        "Query",
+                    )
+                return real_table.query(**kwargs)
+
+        class _FakeResource:
+            def Table(self, _name):
+                return _GsiFailingTable()
+
+        real_resource = boto3.resource
+        monkeypatch.setattr(
+            boto3, "resource",
+            lambda svc, **kw: _FakeResource() if svc == "dynamodb" else real_resource(svc, **kw),
+        )
+
+        sessions, token = await list_user_sessions("u1")
+        assert [s.session_id for s in sessions] == ["l1", "l2"]
+        assert token is None
+
 
 class TestStoreUserDisplayText:
     """Tests for the displayText feature (D# records)."""


### PR DESCRIPTION
## What & why

Follow-up hardening to PR #667 (Phase 1a dual-scheme session listing, issue #175).

The 1a union read catches a missing `SessionRecencyIndex` and falls back to legacy-only listing — but the catch only handled `ResourceNotFoundException`, which is what **moto** raises. **Real DynamoDB raises `ValidationException`** ("The table does not have the specified index") for a missing GSI. I verified this against the live prod table:

```
$ aws dynamodb query --table-name boisestateai-v2-sessions-metadata \
    --index-name SessionRecencyIndex ...
An error occurred (ValidationException): The table does not have the specified index: SessionRecencyIndex
```

So the moto-backed fallback test passed while the real degradation path was broken: if the 1a backend deployed to an environment **before** the CDK GSI existed (e.g. a prod release where `backend.yml` runs before `platform.yml`), `list_user_sessions` would **503** instead of degrading to legacy-only.

Not an active incident — dev has the GSI (`SessionRecencyIndex` is ACTIVE there), so dev runs the real union and never hit this. This is defense-in-depth for the **prod release deploy ordering** and for **forked deployments** (the spec promises graceful degradation when the index is absent).

## Change

- Broaden the fallback to also catch `ValidationException`, scoped by the `"specified index"` message so genuinely malformed queries still surface as errors.
- New test reproduces the **real** `ValidationException` on the index query (moto masks it) and asserts fallback to legacy-only results. Keeps the existing moto/`ResourceNotFoundException` test too.

## Why the original test didn't catch it

moto raises `ResourceNotFoundException` for a missing index; real DynamoDB raises `ValidationException`. A green moto test isn't proof of real-AWS behavior — the new test pins the real error shape.

## Verification

- `test_graceful_fallback_on_validationexception` — new, reproduces real error → legacy-only
- **108 passed** across `test_sessions_metadata` + `test_sessions` (routes)

## Deploy

Ships via `backend.yml` (backend code only). Should land before any prod release carrying Phase 1a so 1a is genuinely order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)