### PR TITLE
Add Word document tools (create/modify/list/read)

### DIFF
--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -431,6 +431,21 @@ DEFAULT_TOOLS: list[dict[str, Any]] = [
         "isPublic": True,
         "forwardAuthToken": False,
     },
+    {
+        # Single catalog entry / toggle that provisions the whole Word
+        # document toolset. Enabling this one id injects create/modify/list/
+        # read at runtime — see WORD_DOCUMENT_TOOL_IDS and
+        # _build_word_document_tools in apis/inference_api/chat/routes.py.
+        # Keep the toolId as "create_word_document": it is the gate key.
+        "toolId": "create_word_document",
+        "displayName": "Word Documents",
+        "description": "Create, edit, read, and list Word (.docx) documents using python-docx in a sandboxed environment. Generated files are saved to the chat's Files with a download link.",
+        "category": "document",
+        "protocol": "local",
+        "enabledByDefault": False,
+        "isPublic": True,
+        "forwardAuthToken": False,
+    },
 ]
 
 

--- a/backend/src/agents/builtin_tools/word_document_tool.py
+++ b/backend/src/agents/builtin_tools/word_document_tool.py
@@ -1,0 +1,734 @@
+"""Word document tools (create / modify / list / read).
+
+Each tool runs python-docx code inside AWS Bedrock Code Interpreter and uses
+the existing user-files store (``apis.shared.files``) for persistence and
+delivery — generated/modified ``.docx`` files land in
+``S3_USER_FILES_BUCKET_NAME`` with a ``FileMetadata`` row (status READY) in
+``DYNAMODB_USER_FILES_TABLE_NAME``, so they appear in the chat's Files panel
+and are downloadable via the app-api ``/files/{id}/preview-url`` route.
+
+Tools
+-----
+* ``create_word_document`` — build a new document from python-docx code.
+* ``modify_word_document`` — edit an existing document with python-docx code.
+* ``list_word_documents``  — list the .docx files available in this chat.
+* ``read_word_document``   — extract an existing document's text content.
+
+(A page-screenshot/preview tool is intentionally omitted: rasterizing a
+.docx requires LibreOffice/poppler, which the Python-only Code Interpreter
+sandbox does not provide.)
+
+Design notes
+------------
+* Code Interpreter usage mirrors ``code_interpreter_diagram_tool.py`` — the
+  interpreter id is resolved from ``AGENTCORE_CODE_INTERPRETER_ID`` (or SSM),
+  a session is started with ``CodeInterpreter(region).start(identifier=...)``,
+  and always stopped in a ``finally`` block.
+* Identity (``user_id`` / ``session_id``) is captured by closure via the
+  ``make_*`` factories — the same pattern used by the artifacts and
+  spreadsheet_analysis tools (the Strands runtime here does NOT populate
+  ``ToolContext.invocation_state`` with identity). The tools are injected
+  per-request through ``extra_tools`` (see ``_build_word_document_tools`` in
+  ``apis/inference_api/chat/routes.py``); they are deliberately NOT registered
+  in ``builtin_tools/__init__`` because they need request-scoped identity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+import boto3
+from botocore.config import Config
+
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+# Word document MIME type (matches apis.shared.files.ALLOWED_MIME_TYPES).
+_DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+
+# Presigned download links are short-lived; long enough for the user to click.
+_DOWNLOAD_URL_TTL = 60 * 60  # 1 hour
+
+# Sandbox path used to stage a source document loaded from S3.
+_SANDBOX_SOURCE = "_source.docx"
+
+
+class _DocGenError(Exception):
+    """Raised when Code Interpreter fails to run the document code."""
+
+
+def _region() -> str:
+    return (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-west-2"
+    )
+
+
+def _get_code_interpreter_id() -> Optional[str]:
+    """Resolve the Custom Code Interpreter id (env first, then SSM)."""
+    ci_id = os.getenv("AGENTCORE_CODE_INTERPRETER_ID")
+    if ci_id:
+        return ci_id
+    try:
+        project_name = os.getenv("PROJECT_NAME", "strands-agent-chatbot")
+        environment = os.getenv("ENVIRONMENT", "dev")
+        ssm = boto3.client("ssm", region_name=_region())
+        resp = ssm.get_parameter(
+            Name=f"/{project_name}/{environment}/agentcore/code-interpreter-id"
+        )
+        return resp["Parameter"]["Value"]
+    except Exception as exc:  # pragma: no cover - best-effort fallback
+        logger.warning(f"Code Interpreter id not found in env or SSM: {exc}")
+        return None
+
+
+def _validate_document_name(name: str) -> Tuple[bool, Optional[str]]:
+    """Validate a document name (without extension).
+
+    Rules: letters, numbers, hyphens and underscores only; no spaces or other
+    special characters; no consecutive, leading, or trailing hyphens.
+    """
+    if not name:
+        return False, "Document name cannot be empty"
+
+    if not re.match(r"^[a-zA-Z0-9_\-]+$", name):
+        invalid = sorted(set(re.findall(r"[^a-zA-Z0-9_\-]", name)))
+        return (
+            False,
+            f"Invalid characters in name: {invalid}. Use only letters, "
+            "numbers, hyphens, and underscores.",
+        )
+    if "--" in name:
+        return False, "Name cannot contain consecutive hyphens (--)"
+    if name.startswith("-") or name.endswith("-"):
+        return False, "Name cannot start or end with a hyphen"
+    return True, None
+
+
+_s3_client = None
+
+
+def _s3():
+    """Regional, SigV4 S3 client (matches FileUploadService config)."""
+    global _s3_client
+    if _s3_client is None:
+        region = _region()
+        _s3_client = boto3.client(
+            "s3",
+            region_name=region,
+            config=Config(
+                signature_version="s3v4",
+                s3={"addressing_style": "virtual"},
+            ),
+            endpoint_url=f"https://s3.{region}.amazonaws.com",
+        )
+    return _s3_client
+
+
+def _user_files_bucket() -> str:
+    return os.environ.get("S3_USER_FILES_BUCKET_NAME", "user-files")
+
+
+# ---------------------------------------------------------------------------
+# Code Interpreter primitives
+# ---------------------------------------------------------------------------
+
+
+def _ci_exec(code_interpreter, code: str) -> str:
+    """Run Python in the sandbox; return stdout or raise _DocGenError."""
+    response = code_interpreter.invoke(
+        "executeCode",
+        {"code": code, "language": "python", "clearContext": False},
+    )
+    stdout = ""
+    for event in response.get("stream", []):
+        result = event.get("result", {})
+        if result.get("isError", False):
+            stderr = result.get("structuredContent", {}).get(
+                "stderr", "Unknown error"
+            )
+            logger.error(f"Code Interpreter error: {stderr[:500]}")
+            raise _DocGenError(stderr[:1000])
+        out = result.get("structuredContent", {}).get("stdout", "")
+        if out:
+            stdout += out
+    return stdout
+
+
+def _ci_read_bytes(code_interpreter, filename: str) -> Optional[bytes]:
+    """Read a file out of the sandbox as bytes (or None if missing)."""
+    download = code_interpreter.invoke("readFiles", {"paths": [filename]})
+    content = None
+    for event in download.get("stream", []):
+        result = event.get("result", {})
+        for block in result.get("content", []) or []:
+            if "data" in block:
+                content = block["data"]
+            elif "resource" in block and "blob" in block["resource"]:
+                content = block["resource"]["blob"]
+            if content:
+                break
+        if content:
+            break
+    if content is None:
+        return None
+    # Code Interpreter may hand back raw bytes or a base64 string.
+    if isinstance(content, str):
+        content = base64.b64decode(content)
+    return content
+
+
+def _ci_write_bytes(code_interpreter, path: str, data: bytes) -> None:
+    """Write binary bytes into the sandbox (base64 text + decode in-sandbox)."""
+    b64 = base64.b64encode(data).decode("ascii")
+    code_interpreter.invoke(
+        "writeFiles",
+        {"content": [{"path": f"{path}.b64", "text": b64}]},
+    )
+    _ci_exec(
+        code_interpreter,
+        (
+            "import base64\n"
+            f"with open({path + '.b64'!r}) as _f:\n"
+            "    _raw = base64.b64decode(_f.read())\n"
+            f"with open({path!r}, 'wb') as _o:\n"
+            "    _o.write(_raw)\n"
+        ),
+    )
+
+
+_DOCX_PREAMBLE = (
+    "from docx import Document\n"
+    "from docx.shared import Pt, RGBColor, Inches\n"
+    "from docx.enum.text import WD_ALIGN_PARAGRAPH\n"
+)
+
+
+def _generate_docx_bytes(
+    code_interpreter_id: str, python_code: str, filename: str
+) -> bytes:
+    """Build a new .docx from user code and return its bytes.
+
+    Blocking (boto3 / Code Interpreter) — call via ``asyncio.to_thread``.
+    """
+    from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+
+    code_interpreter = CodeInterpreter(_region())
+    code_interpreter.start(identifier=code_interpreter_id)
+    try:
+        # The user's code operates on a pre-initialized ``doc`` and must not
+        # call Document()/doc.save() itself — we own the lifecycle.
+        _ci_exec(
+            code_interpreter,
+            (
+                f"{_DOCX_PREAMBLE}\n"
+                "doc = Document()\n\n"
+                f"{python_code}\n\n"
+                f"doc.save({filename!r})\n"
+            ),
+        )
+        data = _ci_read_bytes(code_interpreter, filename)
+        if data is None:
+            raise _DocGenError(
+                f"Document '{filename}' was not produced. Make sure your code "
+                "adds content to `doc`."
+            )
+        return data
+    finally:
+        try:
+            code_interpreter.stop()
+        except Exception:  # pragma: no cover - cleanup best-effort
+            pass
+
+
+def _modify_docx_bytes(
+    code_interpreter_id: str,
+    source_bytes: bytes,
+    python_code: str,
+    output_filename: str,
+) -> bytes:
+    """Load an existing .docx, apply user edits, return the new bytes.
+
+    Blocking — call via ``asyncio.to_thread``.
+    """
+    from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+
+    code_interpreter = CodeInterpreter(_region())
+    code_interpreter.start(identifier=code_interpreter_id)
+    try:
+        _ci_write_bytes(code_interpreter, _SANDBOX_SOURCE, source_bytes)
+        _ci_exec(
+            code_interpreter,
+            (
+                f"{_DOCX_PREAMBLE}\n"
+                f"doc = Document({_SANDBOX_SOURCE!r})\n\n"
+                f"{python_code}\n\n"
+                f"doc.save({output_filename!r})\n"
+            ),
+        )
+        data = _ci_read_bytes(code_interpreter, output_filename)
+        if data is None:
+            raise _DocGenError(
+                f"Modified document '{output_filename}' was not produced."
+            )
+        return data
+    finally:
+        try:
+            code_interpreter.stop()
+        except Exception:  # pragma: no cover - cleanup best-effort
+            pass
+
+
+def _extract_docx_text(code_interpreter_id: str, source_bytes: bytes) -> str:
+    """Extract readable text (headings, paragraphs, tables) from a .docx.
+
+    Blocking — call via ``asyncio.to_thread``.
+    """
+    from bedrock_agentcore.tools.code_interpreter_client import CodeInterpreter
+
+    code_interpreter = CodeInterpreter(_region())
+    code_interpreter.start(identifier=code_interpreter_id)
+    try:
+        _ci_write_bytes(code_interpreter, _SANDBOX_SOURCE, source_bytes)
+        extraction = (
+            "from docx import Document\n"
+            f"doc = Document({_SANDBOX_SOURCE!r})\n"
+            "lines = []\n"
+            "for p in doc.paragraphs:\n"
+            "    t = p.text.strip()\n"
+            "    if not t:\n"
+            "        continue\n"
+            "    style = (p.style.name if p.style else '') or ''\n"
+            "    if style.startswith('Heading'):\n"
+            "        level = ''.join(ch for ch in style if ch.isdigit()) or '1'\n"
+            "        lines.append('#' * min(int(level), 6) + ' ' + t)\n"
+            "    else:\n"
+            "        lines.append(t)\n"
+            "for i, table in enumerate(doc.tables):\n"
+            "    lines.append('')\n"
+            "    lines.append('[Table %d]' % (i + 1))\n"
+            "    for row in table.rows:\n"
+            "        lines.append(' | '.join(c.text.strip() for c in row.cells))\n"
+            "print('\\n'.join(lines))\n"
+        )
+        return _ci_exec(code_interpreter, extraction).strip()
+    finally:
+        try:
+            code_interpreter.stop()
+        except Exception:  # pragma: no cover - cleanup best-effort
+            pass
+
+
+# ---------------------------------------------------------------------------
+# User-files store helpers
+# ---------------------------------------------------------------------------
+
+
+def _download_s3_bytes(bucket: str, key: str) -> bytes:
+    """Read an object's bytes from S3 (blocking — use ``asyncio.to_thread``)."""
+    resp = _s3().get_object(Bucket=bucket, Key=key)
+    return resp["Body"].read()
+
+
+async def _find_word_document(
+    user_id: str, session_id: str, document_name: str
+):
+    """Find the newest READY .docx in this session matching ``document_name``.
+
+    Returns the ``FileMetadata`` or ``None``. ``list_session_files`` returns
+    newest-first, so the first match is the latest version.
+    """
+    from apis.shared.files import FileStatus, get_file_upload_repository
+
+    target = (
+        document_name
+        if document_name.lower().endswith(".docx")
+        else f"{document_name}.docx"
+    )
+    files = await get_file_upload_repository().list_session_files(
+        session_id, status=FileStatus.READY
+    )
+    for meta in files:
+        if (
+            meta.user_id == user_id
+            and meta.mime_type == _DOCX_MIME
+            and meta.filename.lower() == target.lower()
+        ):
+            return meta
+    return None
+
+
+async def _store_document(
+    user_id: str, session_id: str, filename: str, file_bytes: bytes
+) -> Tuple[str, str, str]:
+    """Persist the .docx to the user-files store and mint a download URL.
+
+    Returns ``(upload_id, download_url, size_kb)``.
+    """
+    from apis.shared.files import (
+        FileMetadata,
+        FileStatus,
+        get_file_upload_repository,
+    )
+
+    bucket = _user_files_bucket()
+    timestamp_hex = format(
+        int(datetime.now(timezone.utc).timestamp() * 1000), "x"
+    )
+    upload_id = f"{timestamp_hex}_{uuid.uuid4().hex[:16]}"
+    s3_key = f"user-files/{user_id}/{session_id}/{upload_id}/{filename}"
+
+    await asyncio.to_thread(
+        _s3().put_object,
+        Bucket=bucket,
+        Key=s3_key,
+        Body=file_bytes,
+        ContentType=_DOCX_MIME,
+    )
+
+    metadata = FileMetadata(
+        upload_id=upload_id,
+        user_id=user_id,
+        session_id=session_id,
+        filename=filename,
+        mime_type=_DOCX_MIME,
+        size_bytes=len(file_bytes),
+        s3_key=s3_key,
+        s3_bucket=bucket,
+        status=FileStatus.READY,
+    )
+    await get_file_upload_repository().create_file(metadata)
+
+    download_url = await asyncio.to_thread(
+        _s3().generate_presigned_url,
+        "get_object",
+        Params={
+            "Bucket": bucket,
+            "Key": s3_key,
+            "ResponseContentType": _DOCX_MIME,
+            "ResponseContentDisposition": f'attachment; filename="{filename}"',
+        },
+        ExpiresIn=_DOWNLOAD_URL_TTL,
+    )
+
+    size_kb = f"{len(file_bytes) / 1024:.1f} KB"
+    return upload_id, download_url, size_kb
+
+
+def _download_card(filename: str, download_url: str, size_kb: str, verb: str) -> str:
+    """Build the promoted inline-download-card tool result (JSON string).
+
+    The ``ui_type``/``ui_display: inline`` discriminators make the frontend
+    render a first-class download card (see inline-visual.component.ts,
+    ``word_document``) instead of burying the link in the collapsed tool card.
+    """
+    return json.dumps(
+        {
+            "success": True,
+            "ui_type": "word_document",
+            "ui_display": "inline",
+            "payload": {
+                "filename": filename,
+                "download_url": download_url,
+                "size_kb": size_kb,
+            },
+            "summary": (
+                f"{verb} {filename} ({size_kb}). Also saved to this chat's Files."
+            ),
+        }
+    )
+
+
+def _error(text: str) -> Dict[str, Any]:
+    return {"content": [{"text": text}], "status": "error"}
+
+
+_NO_CI_MESSAGE = (
+    "❌ Code Interpreter is not configured. AGENTCORE_CODE_INTERPRETER_ID was "
+    "not found in the environment or Parameter Store."
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool factories
+# ---------------------------------------------------------------------------
+
+
+def make_create_word_document_tool(session_id: str, user_id: str):
+    """Create a ``create_word_document`` tool bound to the given identity."""
+
+    @tool
+    async def create_word_document(
+        python_code: str,
+        document_name: str,
+    ) -> Any:
+        """Create a new Word (.docx) document using python-docx code.
+
+        Executes python-docx code in a sandboxed Code Interpreter to build a
+        document from scratch, saves it to the user's files, and returns a
+        download card. Great for structured reports with headings,
+        paragraphs, tables, and matplotlib charts.
+
+        Available libraries in the sandbox: python-docx, matplotlib, pandas,
+        numpy.
+
+        Args:
+            python_code: python-docx code that builds the document. A blank
+                document is already available as ``doc = Document()`` — do NOT
+                call ``Document()`` or ``doc.save()`` yourself; the tool saves
+                it for you. ``Pt``, ``RGBColor``, ``Inches`` and
+                ``WD_ALIGN_PARAGRAPH`` are already imported.
+
+                Example:
+                    doc.add_heading('Quarterly Report', level=1)
+                    doc.add_paragraph('Revenue increased by 15%...')
+                    table = doc.add_table(rows=2, cols=2)
+                    table.style = 'Light Grid Accent 1'
+                    table.rows[0].cells[0].text = 'Quarter'
+
+                To embed a chart, save a PNG with matplotlib then insert it:
+                    import matplotlib.pyplot as plt
+                    plt.figure(figsize=(8, 5))
+                    plt.bar(['Q1', 'Q2'], [100, 120])
+                    plt.savefig('chart.png', dpi=200, bbox_inches='tight')
+                    plt.close()
+                    doc.add_picture('chart.png', width=Inches(6))
+
+            document_name: File name WITHOUT extension (.docx is added
+                automatically). Use only letters, numbers, hyphens, and
+                underscores (e.g. "sales-report", "Q4_analysis").
+
+        Returns:
+            An inline download card. The document is also saved to this
+            chat's Files.
+        """
+        is_valid, error_msg = _validate_document_name(document_name)
+        if not is_valid:
+            return _error(
+                f"❌ Invalid document name '{document_name}': {error_msg}\n\n"
+                "Examples: sales-report, Q4_analysis, report-final"
+            )
+
+        filename = f"{document_name}.docx"
+        code_interpreter_id = _get_code_interpreter_id()
+        if not code_interpreter_id:
+            return _error(_NO_CI_MESSAGE)
+
+        try:
+            file_bytes = await asyncio.to_thread(
+                _generate_docx_bytes, code_interpreter_id, python_code, filename
+            )
+        except _DocGenError as exc:
+            return _error(
+                f"❌ Failed to create '{filename}'.\n\n```\n{exc}\n```\n\n"
+                "Check the python-docx code for errors."
+            )
+        except Exception as exc:  # noqa: BLE001 - surface any sandbox error
+            logger.error(f"create_word_document sandbox error: {exc}")
+            return _error(f"❌ Failed to create '{filename}': {exc}")
+
+        try:
+            _id, download_url, size_kb = await _store_document(
+                user_id, session_id, filename, file_bytes
+            )
+        except Exception as exc:  # noqa: BLE001 - storage failure is terminal
+            logger.error(f"create_word_document storage error: {exc}")
+            return _error(f"❌ Created '{filename}' but failed to save it: {exc}")
+
+        return _download_card(filename, download_url, size_kb, "Created")
+
+    return create_word_document
+
+
+def make_modify_word_document_tool(session_id: str, user_id: str):
+    """Create a ``modify_word_document`` tool bound to the given identity."""
+
+    @tool
+    async def modify_word_document(
+        document_name: str,
+        python_code: str,
+        output_name: Optional[str] = None,
+    ) -> Any:
+        """Modify an existing Word (.docx) document with python-docx code.
+
+        Loads a document previously created in this chat, runs your
+        python-docx code against it, and saves the result (as a new file so
+        the original is preserved). Returns a download card.
+
+        Use ``list_word_documents`` first if you are unsure of the exact name.
+
+        Args:
+            document_name: Name of the existing document to edit (with or
+                without the .docx extension), e.g. "sales-report".
+            python_code: python-docx code that edits the document. The loaded
+                document is available as ``doc = Document(...)`` — do NOT call
+                ``Document()`` or ``doc.save()`` yourself. ``Pt``, ``RGBColor``,
+                ``Inches`` and ``WD_ALIGN_PARAGRAPH`` are already imported.
+
+                Example (append a section):
+                    doc.add_heading('Addendum', level=1)
+                    doc.add_paragraph('Updated figures for Q2.')
+
+            output_name: Optional name (without extension) for the edited copy.
+                Defaults to the source name (a new versioned copy is saved).
+
+        Returns:
+            An inline download card for the edited document.
+        """
+        code_interpreter_id = _get_code_interpreter_id()
+        if not code_interpreter_id:
+            return _error(_NO_CI_MESSAGE)
+
+        source = await _find_word_document(user_id, session_id, document_name)
+        if source is None:
+            return _error(
+                f"❌ No Word document named '{document_name}' was found in this "
+                "chat. Use list_word_documents to see what's available."
+            )
+
+        out_base = output_name or source.filename
+        if out_base.lower().endswith(".docx"):
+            out_base = out_base[: -len(".docx")]
+        is_valid, error_msg = _validate_document_name(out_base)
+        if not is_valid:
+            return _error(
+                f"❌ Invalid output name '{out_base}': {error_msg}"
+            )
+        output_filename = f"{out_base}.docx"
+
+        try:
+            source_bytes = await asyncio.to_thread(
+                _download_s3_bytes, source.s3_bucket, source.s3_key
+            )
+            file_bytes = await asyncio.to_thread(
+                _modify_docx_bytes,
+                code_interpreter_id,
+                source_bytes,
+                python_code,
+                output_filename,
+            )
+        except _DocGenError as exc:
+            return _error(
+                f"❌ Failed to modify '{source.filename}'.\n\n```\n{exc}\n```\n\n"
+                "Check the python-docx code for errors."
+            )
+        except Exception as exc:  # noqa: BLE001 - surface any sandbox error
+            logger.error(f"modify_word_document error: {exc}")
+            return _error(f"❌ Failed to modify '{source.filename}': {exc}")
+
+        try:
+            _id, download_url, size_kb = await _store_document(
+                user_id, session_id, output_filename, file_bytes
+            )
+        except Exception as exc:  # noqa: BLE001 - storage failure is terminal
+            logger.error(f"modify_word_document storage error: {exc}")
+            return _error(
+                f"❌ Modified '{source.filename}' but failed to save it: {exc}"
+            )
+
+        return _download_card(output_filename, download_url, size_kb, "Updated")
+
+    return modify_word_document
+
+
+def make_list_word_documents_tool(session_id: str, user_id: str):
+    """Create a ``list_word_documents`` tool bound to the given identity."""
+
+    @tool
+    async def list_word_documents() -> Dict[str, Any]:
+        """List the Word (.docx) documents available in this chat.
+
+        Returns the file names and sizes of documents created or modified in
+        this conversation. Use the names with modify_word_document or
+        read_word_document.
+        """
+        from apis.shared.files import FileStatus, get_file_upload_repository
+
+        files = await get_file_upload_repository().list_session_files(
+            session_id, status=FileStatus.READY
+        )
+        seen: set[str] = set()
+        rows = []
+        for meta in files:  # newest-first
+            if meta.user_id != user_id or meta.mime_type != _DOCX_MIME:
+                continue
+            if meta.filename in seen:
+                continue
+            seen.add(meta.filename)
+            rows.append(f"- {meta.filename} ({meta.size_bytes / 1024:.1f} KB)")
+
+        if not rows:
+            text = (
+                "No Word documents in this chat yet. Use create_word_document "
+                "to make one."
+            )
+        else:
+            text = "Word documents in this chat:\n" + "\n".join(rows)
+        return {"content": [{"text": text}], "status": "success"}
+
+    return list_word_documents
+
+
+def make_read_word_document_tool(session_id: str, user_id: str):
+    """Create a ``read_word_document`` tool bound to the given identity."""
+
+    @tool
+    async def read_word_document(document_name: str) -> Dict[str, Any]:
+        """Read the text content of an existing Word (.docx) document.
+
+        Extracts headings, paragraphs, and tables from a document created in
+        this chat so you can reference or summarize its contents. Use
+        list_word_documents first if unsure of the exact name.
+
+        Args:
+            document_name: Name of the document to read (with or without the
+                .docx extension), e.g. "sales-report".
+
+        Returns:
+            The document's text content.
+        """
+        code_interpreter_id = _get_code_interpreter_id()
+        if not code_interpreter_id:
+            return _error(_NO_CI_MESSAGE)
+
+        source = await _find_word_document(user_id, session_id, document_name)
+        if source is None:
+            return _error(
+                f"❌ No Word document named '{document_name}' was found in this "
+                "chat. Use list_word_documents to see what's available."
+            )
+
+        try:
+            source_bytes = await asyncio.to_thread(
+                _download_s3_bytes, source.s3_bucket, source.s3_key
+            )
+            text = await asyncio.to_thread(
+                _extract_docx_text, code_interpreter_id, source_bytes
+            )
+        except _DocGenError as exc:
+            return _error(f"❌ Failed to read '{source.filename}': {exc}")
+        except Exception as exc:  # noqa: BLE001 - surface any sandbox error
+            logger.error(f"read_word_document error: {exc}")
+            return _error(f"❌ Failed to read '{source.filename}': {exc}")
+
+        body = text or "(The document has no extractable text.)"
+        return {
+            "content": [
+                {"text": f"Content of {source.filename}:\n\n{body}"}
+            ],
+            "status": "success",
+        }
+
+    return read_word_document

--- a/backend/src/agents/main_agent/session/turn_based_session_manager.py
+++ b/backend/src/agents/main_agent/session/turn_based_session_manager.py
@@ -213,6 +213,19 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         except Exception as e:
             logger.warning(f"Document byte stripping failed, continuing: {e}", exc_info=True)
 
+        # Drop empty/unrecognized content blocks from restored history. The
+        # write side runs `_filter_empty_text` in `append_message`, but history
+        # restored from AgentCore Memory bypasses it — a single block that comes
+        # back without a recognized Bedrock discriminator (an empty {} block, or
+        # a key lost on the memory serialization round-trip) makes Bedrock reject
+        # EVERY subsequent turn with "messages.N.content.M.type: Field required",
+        # permanently bricking the session. Runs unconditionally, mirroring
+        # `_strip_document_bytes` / `_repair_restored_history`.
+        try:
+            agent.messages = self._sanitize_restored_content_blocks(agent.messages)
+        except Exception as e:
+            logger.warning(f"Content-block sanitize failed, continuing: {e}", exc_info=True)
+
         if not self.compaction_config or not self.compaction_config.enabled:
             self._repair_restored_history(agent)
             return
@@ -746,6 +759,44 @@ class TurnBasedSessionManager(AgentCoreMemorySessionManager):
         if len(text) <= max_length:
             return text
         return text[:max_length] + f"\n... [truncated, {len(text) - max_length} chars removed]"
+
+    def _sanitize_restored_content_blocks(self, messages: List[Dict]) -> List[Dict]:
+        """Drop empty/unrecognized content blocks from restored history.
+
+        ``append_message`` runs ``_filter_empty_text`` on the write side, but
+        history restored from AgentCore Memory bypasses it. A single block that
+        comes back without a recognized Bedrock discriminator — an empty ``{}``
+        block, an empty/whitespace ``text`` block, or a key dropped on the
+        memory serialization round-trip — triggers Bedrock's
+        "messages.N.content.M.type: Field required" ValidationException, which
+        fails every subsequent turn on the session. This reuses the same
+        recognized-key filter as the write path and additionally drops any
+        message left with no content (``_repair_restored_history`` runs after
+        and fixes any role-alternation gap the drop introduces).
+        """
+        sanitized: List[Dict] = []
+        dropped_blocks = 0
+        dropped_messages = 0
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            original = msg.get("content", [])
+            cleaned = self._filter_empty_text(msg)
+            content = cleaned.get("content", [])
+            if isinstance(original, list) and isinstance(content, list):
+                dropped_blocks += max(0, len(original) - len(content))
+            if isinstance(content, list) and len(content) == 0:
+                dropped_messages += 1
+                continue
+            sanitized.append(cleaned)
+
+        if dropped_blocks or dropped_messages:
+            logger.warning(
+                "Restore sanitize: dropped %d invalid content block(s) and %d "
+                "empty message(s) from restored history for session %s",
+                dropped_blocks, dropped_messages, self.config.session_id,
+            )
+        return sanitized
 
     def _strip_document_bytes(self, messages: List[Dict]) -> List[Dict]:
         """Replace document content blocks' inline bytes with a text placeholder.

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -459,6 +459,47 @@ def _build_artifact_tools(
     return tools
 
 
+# ============================================================
+# Word Document Tool Injection
+# ============================================================
+
+WORD_DOCUMENT_TOOL_IDS = {"create_word_document"}
+
+
+def _build_word_document_tools(
+    enabled_tools: list | None,
+    session_id: str,
+    user_id: str,
+) -> list:
+    """Create context-bound Word document tools if enabled by the user.
+
+    Identity is captured by closure (same pattern as the artifact and
+    spreadsheet tools) since the runtime does not populate ToolContext.
+    """
+    if not enabled_tools or not WORD_DOCUMENT_TOOL_IDS.intersection(enabled_tools):
+        return []
+
+    # The Word capability is a single toggle: enabling create_word_document
+    # provisions the full document toolset (create/modify/list/read) so the
+    # model can round-trip on a document without extra admin catalog entries.
+    from agents.builtin_tools.word_document_tool import (
+        make_create_word_document_tool,
+        make_list_word_documents_tool,
+        make_modify_word_document_tool,
+        make_read_word_document_tool,
+    )
+
+    tools = [
+        make_create_word_document_tool(session_id, user_id),
+        make_modify_word_document_tool(session_id, user_id),
+        make_list_word_documents_tool(session_id, user_id),
+        make_read_word_document_tool(session_id, user_id),
+    ]
+
+    logger.info(f"Created {len(tools)} word document tools")
+    return tools
+
+
 def _build_memory_tools(agent_memory, user_id: str, user_email: str) -> list:
     """Context-bound Memory-Space tools for an Agent's resolved memory binding.
 
@@ -1777,6 +1818,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 session_id=input_data.session_id,
                 user_id=user_id,
             ) + _build_artifact_tools(
+                enabled_tools=effective_enabled_tools,
+                session_id=input_data.session_id,
+                user_id=user_id,
+            ) + _build_word_document_tools(
                 enabled_tools=effective_enabled_tools,
                 session_id=input_data.session_id,
                 user_id=user_id,

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -131,7 +131,7 @@ class TestSeedDefaultTools:
         """Creates the default tool entries."""
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 6
+        assert result.created == 7
         assert result.failed == 0
 
         # Verify fetch_url_content
@@ -207,13 +207,27 @@ class TestSeedDefaultTools:
         assert item["enabledByDefault"] is True
         assert item["isPublic"] is True
 
+        # Verify create_word_document (single toggle for the whole Word toolset)
+        resp = dynamodb_table.get_item(
+            Key={"PK": "TOOL#create_word_document", "SK": "METADATA"}
+        )
+        item = resp["Item"]
+        assert item["toolId"] == "create_word_document"
+        assert item["displayName"] == "Word Documents"
+        assert item["category"] == "document"
+        assert item["protocol"] == "local"
+        assert item["enabledByDefault"] is False
+        assert item["isPublic"] is True
+        assert item["GSI1PK"] == "CATEGORY#document"
+        assert item["GSI1SK"] == "TOOL#create_word_document"
+
     def test_skips_existing_tools(self, dynamodb_table):
         """Skips tools that already exist."""
         seed_default_tools(TABLE_NAME, REGION)
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.skipped == 6
+        assert result.skipped == 7
         assert result.created == 0
 
     def test_partial_skip(self, dynamodb_table):
@@ -227,7 +241,7 @@ class TestSeedDefaultTools:
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 5
+        assert result.created == 6
         assert result.skipped == 1
 
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/inline-visual/inline-visual.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/inline-visual/inline-visual.component.ts
@@ -1,6 +1,7 @@
 import { Component, input, computed, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ChartRendererComponent } from './renderers/chart-renderer.component';
 import { DefaultRendererComponent } from './renderers/default-renderer.component';
+import { WordDocumentRendererComponent } from './renderers/word-document-renderer.component';
 import { VisualStateService } from '../../../../services/visual-state/visual-state.service';
 
 /**
@@ -10,7 +11,7 @@ import { VisualStateService } from '../../../../services/visual-state/visual-sta
 @Component({
   selector: 'app-inline-visual',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ChartRendererComponent, DefaultRendererComponent],
+  imports: [ChartRendererComponent, DefaultRendererComponent, WordDocumentRendererComponent],
   template: `
     @if (!isDismissed()) {
       <div class="inline-visual-container">
@@ -22,6 +23,9 @@ import { VisualStateService } from '../../../../services/visual-state/visual-sta
               (dismiss)="onDismiss()"
               (toggleExpanded)="onToggleExpanded()"
             />
+          }
+          @case ('word_document') {
+            <app-word-document-renderer [payload]="payload()" />
           }
           @default {
             <app-default-renderer

--- a/frontend/ai.client/src/app/session/components/message-list/components/inline-visual/renderers/word-document-renderer.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/inline-visual/renderers/word-document-renderer.component.ts
@@ -1,0 +1,96 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+/**
+ * Payload for the word_document inline visual, produced by the
+ * create_word_document tool. download_url is a short-lived presigned S3 GET
+ * URL whose response forces Content-Disposition: attachment, so a plain
+ * click downloads the file (no new tab / navigation needed).
+ */
+interface WordDocumentPayload {
+  filename: string;
+  download_url: string;
+  size_kb?: string;
+}
+
+/**
+ * Inline download card for a generated Word document. Rendered as a
+ * first-class message block (not inside the collapsed tool-output card), so
+ * the download action is always visible and clickable.
+ *
+ * The download link uses the trailing-! important modifiers (text-white! and
+ * no-underline!) because the global ".message-block a" rule in styles.css
+ * (dark-blue text + underline) outranks a plain text-white utility by
+ * specificity. The ! modifier emits !important, which wins regardless.
+ */
+@Component({
+  selector: 'app-word-document-renderer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block' },
+  template: `
+    @if (doc(); as d) {
+      <div
+        class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700
+               bg-white dark:bg-gray-800 p-3"
+      >
+        <!-- Document icon -->
+        <div
+          class="flex size-10 shrink-0 items-center justify-center rounded-md
+                 bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+        >
+          <svg class="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+        </div>
+
+        <!-- Filename + size -->
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+            {{ d.filename }}
+          </p>
+          @if (d.size_kb) {
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">{{ d.size_kb }}</p>
+          }
+        </div>
+
+        <!-- Download button -->
+        <a
+          class="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary-500 px-3.5 py-1.5
+                 text-sm/5 font-semibold text-white! no-underline! transition-colors
+                 hover:bg-primary-700
+                 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          [href]="d.download_url"
+          [attr.download]="d.filename"
+          rel="noopener noreferrer"
+        >
+          <svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+          <span>Download</span>
+        </a>
+      </div>
+    }
+  `,
+})
+export class WordDocumentRendererComponent {
+  /** The payload data from the backend tool result. */
+  payload = input.required<unknown>();
+
+  /** Narrowed, validated payload (null when malformed). */
+  doc = computed<WordDocumentPayload | null>(() => {
+    const raw = this.payload();
+    if (!raw || typeof raw !== 'object') return null;
+    const p = raw as Partial<WordDocumentPayload>;
+    if (!p.filename || !p.download_url) return null;
+    return { filename: p.filename, download_url: p.download_url, size_kb: p.size_kb };
+  });
+}


### PR DESCRIPTION
## Summary
Adds a full Word (.docx) toolset behind the single `create_word_document` capability toggle: **create / modify / list / read**. Each tool runs python-docx in Bedrock Code Interpreter and uses the existing user-files store (S3 + DynamoDB) for persistence and delivery, returning an inline download card.

- **Tools** (`agents/builtin_tools/word_document_tool.py`), injected per-request via `_build_word_document_tools` in `inference_api/chat/routes.py` — one toggle provisions all four.
- **Frontend**: `word_document` inline-visual renderer with an accessible Tailwind download button (no scoped CSS / `!important`).
- **History fix**: restore-time content-block sanitizer in `TurnBasedSessionManager` drops empty/typeless blocks from restored history that caused Bedrock ConverseStream `messages.N.content.M.type: Field required`.
- **Seed**: `create_word_document` ("Word Documents") added to bootstrap `DEFAULT_TOOLS` + updated seed tests.

## Testing
- Backend: ruff clean; gate check (0 tools off / 4 on); architecture import-boundary tests, session tests (43), and seed tests (9) all pass.
- Frontend: `npm run build` compiles clean.
- Manual: create -> inline download card renders and downloads.

## Notes
- `preview_word_page` intentionally omitted (needs LibreOffice/poppler, unavailable in the Python-only Code Interpreter sandbox).
- Authored against `main` then rebased onto `develop` (`routes.py` auto-merged, no conflicts). A smoke test on the develop base is recommended before merge.
- Squash-merge into `develop` per the branch model.
