### PR TITLE
feat(scripts): static-SK backfill for the cold tail + ghost cleanup (issue #175 Phase 2)

### DIFF
--- a/backend/scripts/backfill_session_static_sk.py
+++ b/backend/scripts/backfill_session_static_sk.py
@@ -1,0 +1,228 @@
+"""Backfill: migrate session-metadata rows to the static sort key (issue #175 Phase 2).
+
+Converts legacy session rows — whose sort key encodes ``lastMessageAt``
+(``S#ACTIVE#{lastMessageAt}#{id}`` / ``S#DELETED#{deletedAt}#{id}``) — to the
+static ``S#{session_id}`` scheme, populating the sparse ``SessionRecencyIndex``
+(GSI4) for active sessions, and deletes the ghost/stub rows the old rotating-SK
+writers produced. Once a full pass finds zero legacy rows remaining, it writes the
+"migration complete" marker that lets Phase 3 collapse the dual-scheme read to
+GSI-only.
+
+SAFETY
+------
+* **Dry-run by default.** Pass ``--apply`` to actually write/delete.
+* **Idempotent + re-runnable.** The static put uses ``attribute_not_exists(SK)``
+  so it never clobbers a row a live writer already migrated (with fresher data);
+  the legacy delete is a harmless no-op if already gone.
+* **Throttled.** ``--sleep`` between processed items (default 50ms) keeps read/write
+  pressure low on the live table.
+* **Marker is gated.** ``--set-marker`` re-scans and only writes the marker if zero
+  legacy rows remain, so Phase 3 can never be unblocked while data is un-migrated.
+
+Run against dev first, then prod::
+
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_session_static_sk.py \
+        --table dev-boisestateai-v2-sessions-metadata            # dry-run
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_session_static_sk.py \
+        --table dev-boisestateai-v2-sessions-metadata --apply --set-marker
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_session_static_sk")
+
+LEGACY_ACTIVE_PREFIX = "S#ACTIVE#"
+LEGACY_DELETED_PREFIX = "S#DELETED#"
+MARKER_PK = "MIGRATION#session-sk"
+MARKER_SK = "STATE"
+
+# Every real session row (legacy or static) carries these; a ghost/stub upsert
+# from the old rotating-SK race does not.
+REQUIRED_FIELDS = (
+    "sessionId", "userId", "title", "status", "createdAt", "lastMessageAt", "messageCount",
+)
+
+
+def _session_id_from_sk(sk: str) -> str:
+    """Legacy SK tail is the session id: S#ACTIVE#{ts}#{id} / S#DELETED#{ts}#{id}."""
+    return sk.rsplit("#", 1)[-1]
+
+
+def is_ghost(row: Dict[str, Any]) -> bool:
+    """A legacy-SK row that is not a valid session — the stub the migration cleans up.
+
+    Real session rows always have ``GSI_SK == 'META'`` and the required fields; the
+    ghost upserts (REMOVE/SET on a rotated-away key) have neither.
+    """
+    if row.get("GSI_SK") != "META":
+        return True
+    return any(field not in row for field in REQUIRED_FIELDS)
+
+
+def build_static_item(row: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    """Rewrite a legacy row to the static-SK shape.
+
+    Drops any stale GSI4 keys and re-derives them from status: active rows get the
+    sparse recency keys, deleted rows get none (so they leave the active listing).
+    """
+    user_id = row["userId"]
+    is_deleted = row.get("SK", "").startswith(LEGACY_DELETED_PREFIX) or row.get("deleted") is True \
+        or row.get("status") == "deleted"
+
+    new = {k: v for k, v in row.items() if k not in ("SK", "GSI4_PK", "GSI4_SK")}
+    new["SK"] = f"S#{session_id}"
+    new["GSI_PK"] = f"SESSION#{session_id}"
+    new["GSI_SK"] = "META"
+
+    if is_deleted:
+        new["status"] = "deleted"
+        new["deleted"] = True
+    else:
+        new["GSI4_PK"] = f"USER#{user_id}"
+        new["GSI4_SK"] = f"{row['lastMessageAt']}#{session_id}"
+    return new
+
+
+def process_row(table, row: Dict[str, Any], apply: bool, stats: Dict[str, int]) -> None:
+    pk, sk = row["PK"], row["SK"]
+    session_id = _session_id_from_sk(sk)
+
+    if is_ghost(row):
+        stats["ghosts"] += 1
+        logger.info("%s ghost delete PK=%s SK=%s", "APPLY" if apply else "DRYRUN", pk, sk[:60])
+        if apply:
+            table.delete_item(Key={"PK": pk, "SK": sk})
+        return
+
+    target_sk = f"S#{session_id}"
+    if sk == target_sk:
+        stats["already_static"] += 1
+        return
+
+    new_item = build_static_item(row, session_id)
+    stats["migrated"] += 1
+    logger.info("%s migrate %s -> %s", "APPLY" if apply else "DRYRUN", sk[:50], target_sk)
+    if not apply:
+        return
+
+    # Put the static row only if it doesn't already exist — a live writer may have
+    # migrated this session (with fresher data) between our scan and now; don't
+    # clobber it. Either way we then drop the legacy orphan.
+    try:
+        table.put_item(Item=new_item, ConditionExpression=Attr("SK").not_exists())
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            stats["skipped_live_migrated"] += 1
+            logger.info("  static row already present (live-migrated); dropping legacy orphan only")
+        else:
+            raise
+    table.delete_item(Key={"PK": pk, "SK": sk})
+
+
+def scan_legacy(table, limit: Optional[int]):
+    """Yield rows whose SK is a legacy session prefix, paginating the table."""
+    kwargs: Dict[str, Any] = {
+        "FilterExpression": Attr("SK").begins_with(LEGACY_ACTIVE_PREFIX)
+        | Attr("SK").begins_with(LEGACY_DELETED_PREFIX),
+    }
+    yielded = 0
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            yield item
+            yielded += 1
+            if limit and yielded >= limit:
+                return
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            return
+        kwargs["ExclusiveStartKey"] = lek
+
+
+def count_remaining_legacy(table) -> int:
+    kwargs: Dict[str, Any] = {
+        "FilterExpression": Attr("SK").begins_with(LEGACY_ACTIVE_PREFIX)
+        | Attr("SK").begins_with(LEGACY_DELETED_PREFIX),
+        "Select": "COUNT",
+    }
+    total = 0
+    while True:
+        resp = table.scan(**kwargs)
+        total += resp.get("Count", 0)
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            return total
+        kwargs["ExclusiveStartKey"] = lek
+
+
+def maybe_set_marker(table, apply: bool) -> bool:
+    """Set the migration-complete marker iff zero legacy rows remain."""
+    remaining = count_remaining_legacy(table)
+    if remaining > 0:
+        logger.warning(
+            "Marker NOT set: %d legacy rows still remain — re-run the backfill until zero.",
+            remaining,
+        )
+        return False
+    logger.info("%s set migration-complete marker (%s / %s)",
+                "APPLY" if apply else "DRYRUN", MARKER_PK, MARKER_SK)
+    if apply:
+        table.put_item(Item={"PK": MARKER_PK, "SK": MARKER_SK, "complete": True})
+    return True
+
+
+def run(table_name: str, region: str, apply: bool, sleep: float,
+        limit: Optional[int], set_marker: bool) -> Dict[str, int]:
+    table = boto3.Session(region_name=region).resource("dynamodb").Table(table_name)
+    stats = {"migrated": 0, "ghosts": 0, "already_static": 0, "skipped_live_migrated": 0}
+
+    logger.info("Backfill %s table=%s region=%s%s",
+                "APPLY" if apply else "DRY-RUN", table_name, region,
+                f" limit={limit}" if limit else "")
+    for row in scan_legacy(table, limit):
+        process_row(table, row, apply, stats)
+        if sleep:
+            time.sleep(sleep)
+
+    logger.info("Done: migrated=%(migrated)d ghosts=%(ghosts)d "
+                "already_static=%(already_static)d skipped_live_migrated=%(skipped_live_migrated)d",
+                stats)
+
+    if set_marker:
+        maybe_set_marker(table, apply)
+    return stats
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--table", default=os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME"),
+                   help="sessions-metadata table name (or DYNAMODB_SESSIONS_METADATA_TABLE_NAME)")
+    p.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    p.add_argument("--apply", action="store_true", help="actually write/delete (default: dry-run)")
+    p.add_argument("--sleep", type=float, default=0.05, help="seconds between items (throttle)")
+    p.add_argument("--limit", type=int, default=None, help="max rows to process (for testing)")
+    p.add_argument("--set-marker", action="store_true",
+                   help="after the pass, set the migration-complete marker if zero legacy remain")
+    args = p.parse_args()
+
+    if not args.table:
+        p.error("--table is required (or set DYNAMODB_SESSIONS_METADATA_TABLE_NAME)")
+
+    run(args.table, args.region, args.apply, args.sleep, args.limit, args.set_marker)
+    if not args.apply:
+        logger.info("DRY-RUN only — no changes written. Re-run with --apply to execute.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_backfill_session_static_sk.py
+++ b/backend/tests/test_backfill_session_static_sk.py
@@ -1,0 +1,190 @@
+"""Tests for the Phase 2 static-SK backfill script (issue #175)."""
+
+import os
+import sys
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from backfill_session_static_sk import (  # noqa: E402
+    build_static_item,
+    count_remaining_legacy,
+    is_ghost,
+    maybe_set_marker,
+    run,
+)
+
+REGION = "us-east-1"
+TABLE = "test-sessions-metadata"
+
+
+def _create_table(ddb):
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[{"AttributeName": "PK", "KeyType": "HASH"},
+                   {"AttributeName": "SK", "KeyType": "RANGE"}],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4_SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[{
+            "IndexName": "SessionRecencyIndex",
+            "KeySchema": [{"AttributeName": "GSI4_PK", "KeyType": "HASH"},
+                          {"AttributeName": "GSI4_SK", "KeyType": "RANGE"}],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+def _legacy_active(table, sid, la):
+    table.put_item(Item={
+        "PK": "USER#u1", "SK": f"S#ACTIVE#{la}#{sid}",
+        "GSI_PK": f"SESSION#{sid}", "GSI_SK": "META",
+        "sessionId": sid, "userId": "u1", "title": "T", "status": "active",
+        "createdAt": "2026-01-01T00:00:00Z", "lastMessageAt": la, "messageCount": 1,
+    })
+
+
+def _legacy_deleted(table, sid, da):
+    table.put_item(Item={
+        "PK": "USER#u1", "SK": f"S#DELETED#{da}#{sid}",
+        "GSI_PK": f"SESSION#{sid}", "GSI_SK": "META",
+        "sessionId": sid, "userId": "u1", "title": "T", "status": "deleted",
+        "createdAt": "2026-01-01T00:00:00Z", "lastMessageAt": "2026-01-01T00:00:00Z",
+        "messageCount": 3, "deleted": True, "deletedAt": da,
+    })
+
+
+def _ghost(table, sid, la):
+    # bare stub: no GSI_SK=META, no required fields
+    table.put_item(Item={"PK": "USER#u1", "SK": f"S#ACTIVE#{la}#{sid}"})
+
+
+def _static_active(table, sid, la):
+    table.put_item(Item={
+        "PK": "USER#u1", "SK": f"S#{sid}",
+        "GSI_PK": f"SESSION#{sid}", "GSI_SK": "META",
+        "GSI4_PK": "USER#u1", "GSI4_SK": f"{la}#{sid}",
+        "sessionId": sid, "userId": "u1", "title": "T", "status": "active",
+        "createdAt": "2026-01-01T00:00:00Z", "lastMessageAt": la, "messageCount": 1,
+    })
+
+
+def _meta_rows(table):
+    return [i for i in table.scan()["Items"] if i.get("GSI_SK") == "META"]
+
+
+class TestClassification:
+    def test_is_ghost_detects_bare_stub(self):
+        assert is_ghost({"PK": "USER#u1", "SK": "S#ACTIVE#2026#x"}) is True
+
+    def test_is_ghost_missing_required_field(self):
+        assert is_ghost({"GSI_SK": "META", "sessionId": "x"}) is True  # missing title etc.
+
+    def test_valid_row_is_not_ghost(self):
+        row = {"GSI_SK": "META", "sessionId": "x", "userId": "u", "title": "t",
+               "status": "active", "createdAt": "c", "lastMessageAt": "l", "messageCount": 1}
+        assert is_ghost(row) is False
+
+    def test_build_static_item_active_gets_gsi4(self):
+        row = {"PK": "USER#u1", "SK": "S#ACTIVE#2026-01-02T00:00:00Z#s1",
+               "userId": "u1", "status": "active", "lastMessageAt": "2026-01-02T00:00:00Z"}
+        out = build_static_item(row, "s1")
+        assert out["SK"] == "S#s1"
+        assert out["GSI4_PK"] == "USER#u1"
+        assert out["GSI4_SK"] == "2026-01-02T00:00:00Z#s1"
+
+    def test_build_static_item_deleted_no_gsi4(self):
+        row = {"PK": "USER#u1", "SK": "S#DELETED#2026-01-02T00:00:00Z#s1",
+               "userId": "u1", "status": "deleted", "lastMessageAt": "2026-01-01T00:00:00Z"}
+        out = build_static_item(row, "s1")
+        assert out["SK"] == "S#s1"
+        assert "GSI4_PK" not in out
+        assert out["status"] == "deleted" and out["deleted"] is True
+
+
+class TestBackfillRun:
+    @pytest.fixture()
+    def table(self):
+        with mock_aws():
+            ddb = boto3.client("dynamodb", region_name=REGION)
+            yield _create_table(ddb)
+
+    def test_dry_run_writes_nothing(self, table):
+        _legacy_active(table, "s1", "2026-01-01T00:00:00Z")
+        _ghost(table, "g1", "2026-01-02T00:00:00Z")
+        before = table.scan()["Items"]
+
+        stats = run(TABLE, REGION, apply=False, sleep=0, limit=None, set_marker=False)
+
+        assert stats["migrated"] == 1 and stats["ghosts"] == 1
+        assert table.scan()["Items"] == before  # unchanged
+
+    def test_apply_migrates_active_deletes_ghost(self, table):
+        _legacy_active(table, "s1", "2026-01-02T00:00:00Z")
+        _legacy_deleted(table, "s2", "2026-01-03T00:00:00Z")
+        _ghost(table, "g1", "2026-01-04T00:00:00Z")
+        _static_active(table, "s3", "2026-01-05T00:00:00Z")  # already migrated
+
+        stats = run(TABLE, REGION, apply=True, sleep=0, limit=None, set_marker=False)
+        assert stats == {"migrated": 2, "ghosts": 1, "already_static": 0, "skipped_live_migrated": 0}
+
+        items = table.scan()["Items"]
+        # ghost gone, no legacy rows remain
+        assert not any(i["SK"].startswith("S#ACTIVE#") for i in items)
+        assert not any(i["SK"].startswith("S#DELETED#") for i in items)
+        rows = {i["sessionId"]: i for i in _meta_rows(table)}
+        assert rows["s1"]["SK"] == "S#s1" and rows["s1"]["GSI4_PK"] == "USER#u1"   # active → GSI4
+        assert rows["s2"]["SK"] == "S#s2" and "GSI4_PK" not in rows["s2"]           # deleted → no GSI4
+        assert rows["s2"]["status"] == "deleted"
+        assert rows["s3"]["SK"] == "S#s3"                                           # untouched static
+
+    def test_idempotent_second_run_is_noop(self, table):
+        _legacy_active(table, "s1", "2026-01-02T00:00:00Z")
+        run(TABLE, REGION, apply=True, sleep=0, limit=None, set_marker=False)
+        after_first = _meta_rows(table)
+
+        stats2 = run(TABLE, REGION, apply=True, sleep=0, limit=None, set_marker=False)
+        assert stats2["migrated"] == 0 and stats2["ghosts"] == 0
+        assert _meta_rows(table) == after_first
+
+    def test_conditional_put_skips_live_migrated_row(self, table):
+        # legacy row AND a fresher static row already exist for the same session
+        _legacy_active(table, "s1", "2026-01-02T00:00:00Z")
+        table.put_item(Item={
+            "PK": "USER#u1", "SK": "S#s1", "GSI_PK": "SESSION#s1", "GSI_SK": "META",
+            "GSI4_PK": "USER#u1", "GSI4_SK": "2026-09-09T00:00:00Z#s1",
+            "sessionId": "s1", "userId": "u1", "title": "FRESH", "status": "active",
+            "createdAt": "2026-01-01T00:00:00Z", "lastMessageAt": "2026-09-09T00:00:00Z",
+            "messageCount": 9,
+        })
+
+        stats = run(TABLE, REGION, apply=True, sleep=0, limit=None, set_marker=False)
+        assert stats["skipped_live_migrated"] == 1
+
+        rows = _meta_rows(table)
+        assert len(rows) == 1                      # legacy orphan dropped
+        assert rows[0]["title"] == "FRESH"         # live row NOT clobbered
+        assert rows[0]["messageCount"] == 9
+
+    def test_marker_gated_on_zero_legacy(self, table):
+        _legacy_active(table, "s1", "2026-01-02T00:00:00Z")
+
+        # legacy still present → marker withheld
+        assert maybe_set_marker(table, apply=True) is False
+        assert count_remaining_legacy(table) == 1
+        marker = table.get_item(Key={"PK": "MIGRATION#session-sk", "SK": "STATE"}).get("Item")
+        assert marker is None
+
+        # migrate, then marker sets
+        run(TABLE, REGION, apply=True, sleep=0, limit=None, set_marker=True)
+        assert count_remaining_legacy(table) == 0
+        marker = table.get_item(Key={"PK": "MIGRATION#session-sk", "SK": "STATE"}).get("Item")
+        assert marker is not None and marker["complete"] is True


### PR DESCRIPTION
## What & why

Phase 2 of the session-metadata static-sort-key migration (issue #175): a one-shot backfill that finishes what the Phase 1b lazy write-path leaves behind. 1b migrates a session the next time it's used; this converts the **cold tail** that nobody has touched, deletes the **ghost/stub rows**, and writes the **migration-complete marker** that unblocks Phase 3.

`backend/scripts/backfill_session_static_sk.py`:
- Rewrites legacy `S#ACTIVE#`/`S#DELETED#` rows → static `S#{id}` (GSI4 keys for active, none for deleted).
- Deletes ghosts (bare stub rows with no `GSI_SK=META` / missing required fields).
- Writes the marker (`PK=MIGRATION#session-sk`, `SK=STATE`) **only** once a fresh scan finds zero legacy rows.

## Safety

- **Dry-run by default** — `--apply` required to write anything.
- **Never clobbers a live-migrated row:** the static put uses `attribute_not_exists(SK)`, so if a live writer already migrated a session (with fresher data) between the scan and the write, we skip the put and just drop the legacy orphan.
- **Idempotent + re-runnable** to convergence; `--sleep` throttles read/write pressure on the live table.
- **Marker gated:** `--set-marker` re-scans and **withholds** the marker while any legacy row remains, so Phase 3 can never be unblocked on partially-migrated data.

## Verification

- **10 moto tests** — classification (ghost vs valid; active vs deleted item shape), dry-run no-op, active+deleted migrate, ghost delete, idempotency, the conditional-put skip-of-live-migrated-row guard, and marker gating.
- **Real dev-ai dry-run** — 145 legacy rows, 0 ghosts, confirmed no writes. Run against real DynamoDB on purpose (after the earlier moto-masking lesson) to prove the `begins_with | begins_with` scan filter and classification behave on real AWS.

## How it's run (manual, not part of any deploy)

```
# dry-run
AWS_PROFILE=dev-ai python backend/scripts/backfill_session_static_sk.py \
    --table dev-boisestateai-v2-sessions-metadata
# apply + set marker
AWS_PROFILE=dev-ai python backend/scripts/backfill_session_static_sk.py \
    --table dev-boisestateai-v2-sessions-metadata --apply --set-marker
```

Run order: dev-ai (`--apply --set-marker`, verify) → prod-ai (2290 legacy + 5 ghosts, throttled, verify). PITR is the backstop on both tables.

## Next

Phase 3 (contract): gate the `list_user_sessions` union read on the marker → GSI-only; retain the legacy branch behind the marker so forks that haven't backfilled stay safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)