### PR TITLE
fix(agents): correct stale skills copy and surface invalid-save feedback

### DIFF
--- a/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
@@ -65,7 +65,7 @@ import {
               {{ isEditMode() ? 'Edit Skill' : 'Create Skill' }}
             </h1>
             <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-              {{ isEditMode() ? 'Update skill instructions, reference files and bound tools.' : 'Author a new skill, or import a SKILL.md to prefill it.' }}
+              {{ isEditMode() ? 'Update skill instructions and reference files.' : 'Author a new skill, or import a SKILL.md to prefill it.' }}
             </p>
           </div>
 

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -252,7 +252,7 @@
           <ng-icon name="heroSparkles" class="size-5 text-purple-500" aria-hidden="true" />
           <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Skills</h2>
         </div>
-        <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Reusable instruction bundles with their own bound tools.</p>
+        <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Reusable instruction bundles the agent can load on demand.</p>
         <div class="mt-4 flex flex-wrap gap-2">
           @for (s of skills(); track s.ref) {
             <button type="button" (click)="toggleSkill(s.ref)" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition" [class.border-purple-500]="isSkillSelected(s.ref)" [class.bg-purple-50]="isSkillSelected(s.ref)" [class.text-purple-700]="isSkillSelected(s.ref)" [class.dark:bg-purple-900/30]="isSkillSelected(s.ref)" [class.dark:text-purple-300]="isSkillSelected(s.ref)" [class.border-gray-200]="!isSkillSelected(s.ref)" [class.text-gray-700]="!isSkillSelected(s.ref)" [class.dark:border-gray-700]="!isSkillSelected(s.ref)" [class.dark:text-gray-300]="!isSkillSelected(s.ref)" [appTooltip]="s.description" appTooltipPosition="top">

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
@@ -1,0 +1,154 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { provideRouter, ActivatedRoute } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Component, input, output } from '@angular/core';
+import { AgentFormPage } from './agent-form.page';
+import { AgentPreviewComponent } from './components/agent-preview.component';
+import { KnowledgeBaseSectionComponent } from '../../knowledge-base/knowledge-base-section.component';
+import { AgentService } from '../services/agent.service';
+import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ThemeService } from '../../components/topnav/components/theme-toggle/theme.service';
+import { ToastService } from '../../services/toast/toast.service';
+
+/**
+ * Stand-ins for the two heavy children — this suite only exercises the form shell.
+ * Every bound input must be declared or the template binding throws NG0303.
+ */
+@Component({ selector: 'app-agent-preview', template: '' })
+class StubPreviewComponent {
+  agentId = input<string | null>(null);
+  name = input('');
+  description = input('');
+  emoji = input('');
+  starters = input<string[]>([]);
+  modelId = input<string | null>(null);
+  modelLabel = input('');
+  toolCount = input(0);
+  skillCount = input(0);
+  memoryCount = input(0);
+  isDirty = input(false);
+  saving = input(false);
+  canSave = input(false);
+  save = output<void>();
+  openFull = output<void>();
+}
+
+@Component({ selector: 'app-knowledge-base-section', template: '' })
+class StubKnowledgeBaseComponent {
+  entityId = input<string | null>(null);
+  userPermission = input('owner');
+  permissionResolved = input(false);
+  createDraft = input<unknown>(null);
+}
+
+describe('AgentFormPage — invalid submit feedback', () => {
+  let component: AgentFormPage;
+  let fixture: ComponentFixture<AgentFormPage>;
+
+  const mockAgentService = {
+    loadBindable: vi.fn().mockResolvedValue([]),
+    createAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+    updateAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+    getAgent: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() };
+  const mockSidenav = { hide: vi.fn(), show: vi.fn() };
+  const mockTheme = { isDark: () => false };
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+
+    // jsdom has no layout engine and so implements no scrollIntoView; without this
+    // the reveal-on-invalid path throws instead of exercising the behaviour.
+    Element.prototype.scrollIntoView = vi.fn();
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      providers: [
+        // Register the route a successful save navigates to. An empty
+        // `provideRouter([])` makes that navigation reject with NG04002 as an
+        // unhandled rejection after the test body, failing the whole run.
+        provideRouter([{ path: 'agents', children: [] }]),
+        { provide: AgentService, useValue: mockAgentService },
+        { provide: ToastService, useValue: mockToast },
+        { provide: SidenavService, useValue: mockSidenav },
+        { provide: ThemeService, useValue: mockTheme },
+        // Create mode: no :id on the route.
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => null } } } },
+      ],
+    });
+
+    TestBed.overrideComponent(AgentFormPage, {
+      remove: { imports: [AgentPreviewComponent, KnowledgeBaseSectionComponent] },
+      add: { imports: [StubPreviewComponent, StubKnowledgeBaseComponent] },
+    });
+
+    fixture = TestBed.createComponent(AgentFormPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  /** Fill every required control except the one named, so it is the first invalid. */
+  function fillAllExcept(skip: 'name' | 'description' | 'instructions'): void {
+    const values: Record<string, string> = {
+      name: 'Research Assistant',
+      description: 'A short summary of the agent',
+      instructions: 'You are a helpful assistant that answers questions.',
+    };
+    delete values[skip];
+    component.form.patchValue(values);
+    fixture.detectChanges();
+  }
+
+  it('shows an error toast and issues no request when the form is invalid', async () => {
+    fillAllExcept('description');
+
+    await component.onSubmit();
+
+    expect(mockAgentService.createAgent).not.toHaveBeenCalled();
+    expect(mockToast.error).toHaveBeenCalledWith('Fix the highlighted fields before saving.');
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it('scrolls the first invalid control into view and focuses it', async () => {
+    fillAllExcept('description');
+
+    const scrollSpy = vi.fn();
+    const description: HTMLInputElement =
+      fixture.nativeElement.querySelector('input#description');
+    description.scrollIntoView = scrollSpy;
+
+    await component.onSubmit();
+
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    expect(document.activeElement).toBe(description);
+  });
+
+  it('marks the untouched invalid controls as touched so inline errors render', async () => {
+    fillAllExcept('description');
+    expect(component.form.get('description')?.touched).toBe(false);
+
+    await component.onSubmit();
+
+    expect(component.form.get('description')?.touched).toBe(true);
+  });
+
+  it('saves normally when every required field is filled', async () => {
+    component.form.patchValue({
+      name: 'Research Assistant',
+      description: 'A short summary of the agent',
+      instructions: 'You are a helpful assistant that answers questions.',
+    });
+    component.selectedModelId.set('anthropic.claude-opus-4-8');
+    fixture.detectChanges();
+
+    await component.onSubmit();
+
+    expect(mockAgentService.createAgent).toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -4,6 +4,7 @@ import {
   inject,
   signal,
   computed,
+  ElementRef,
   OnInit,
   OnDestroy,
 } from '@angular/core';
@@ -130,6 +131,7 @@ export class AgentFormPage implements OnInit, OnDestroy {
   private themeService = inject(ThemeService);
   private toast = inject(ToastService);
   private dialog = inject(Dialog);
+  private host = inject(ElementRef<HTMLElement>);
 
   form!: FormGroup;
   private formSub?: Subscription;
@@ -494,12 +496,32 @@ export class AgentFormPage implements OnInit, OnDestroy {
     return bindings;
   }
 
+  /**
+   * Scroll the first invalid control into view and focus it. `markAllAsTouched`
+   * alone only reveals the inline error, which is usually below the fold once the
+   * author has scrolled down to the Model/Skills sections — an invalid save then
+   * reads as a click that did nothing.
+   */
+  private revealFirstInvalidControl(): void {
+    // Match on the element type rather than [formControlName]: the starters array
+    // binds `[formControlName]="$index"`, which renders no attribute to select on.
+    const first = (this.host.nativeElement as HTMLElement).querySelector<HTMLElement>(
+      'form input.ng-invalid, form textarea.ng-invalid, form select.ng-invalid',
+    );
+    if (!first) return;
+    first.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // preventScroll: the smooth scroll above owns the movement; focus would jump it.
+    first.focus({ preventScroll: true });
+  }
+
   /** Save the current form and return the agent id, or null if it wasn't saved
    * (invalid form, no model, or a server error). Shows the error toast; the caller
    * decides where to go on success. */
   private async persist(): Promise<string | null> {
     if (this.form.invalid) {
       this.form.markAllAsTouched();
+      this.revealFirstInvalidControl();
+      this.toast.error('Fix the highlighted fields before saving.');
       return null;
     }
     if (!this.selectedModelId()) {


### PR DESCRIPTION
Two issues found while smoke-testing skills v2 PR-2 (#681).

## 1. Factually wrong skills copy

Skills v2 decision [D1](docs/specs/skills-as-agent-primitive.md) removed skill→tool binding entirely — a skill is a pure knowledge bundle and never grants, mounts, or folds a tool. Two surfaces still claimed otherwise:

| File | Before | After |
|---|---|---|
| `agent-form.page.html:255` | "Reusable instruction bundles with their own bound tools." | "Reusable instruction bundles the agent can load on demand." |
| `skill-form.page.ts:68` | "Update skill instructions, reference files and bound tools." | "Update skill instructions and reference files." |

## 2. Save silently no-ops on an invalid form

`persist()` marked the controls touched and returned `null`, so clicking **Save Agent** with a required field empty issued no request and showed no toast. The only feedback was an inline "This field is required" — usually below the fold once the author has scrolled down to the Model/Skills sections. The "Save to apply your latest changes" banner stayed up, making the click look ignored.

An invalid save now also:
- toasts "Fix the highlighted fields before saving.", and
- scrolls the first invalid control into view and focuses it.

The reveal helper matches on `input/textarea/select.ng-invalid` rather than `[formControlName].ng-invalid` — the starters array binds `[formControlName]="$index"`, a property binding that renders no DOM attribute to select on.

## Testing

- `npm run build` — clean (the 1.89 MB bundle-budget warning is pre-existing on `develop`).
- `ng test` — **127 files, 1452 tests passing** (up from 126/1448).

Adds `agent-form.page.spec.ts` covering the no-request/toast path, scroll + focus targeting, touched-marking, and the normal save path. Two harness gotchas are documented inline for future specs on this page: the child stubs must declare every bound input or the binding throws NG0303, and `provideRouter([])` makes the success-path navigation reject with NG04002 as an unhandled rejection.

## Not included

`backend/src/apis/shared/skills/models.py:5` and `__init__.py:4` still describe a skill as binding "a curated set of existing" tools. Docstrings only, not user-facing, and out of scope here — but wrong post-D1 and worth a follow-up. (`skills/service.py:8` already has it right.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)