### PR TITLE
feat(skills): user-authored skills tier (Skills v2 PR-3)

### DIFF
--- a/backend/scripts/backfill_skill_bundles.py
+++ b/backend/scripts/backfill_skill_bundles.py
@@ -1,0 +1,292 @@
+"""Backfill: bring v1 skill rows up to the agentskills.io bundle layout (Skills v2).
+
+Skills authored before Skills v2 PR-2 predate two things:
+
+1. **The ``SKILL.md`` write-through projection.** Their S3 prefix holds only
+   resource bytes, so the prefix is not a valid, portable agentskills.io
+   bundle — it cannot be handed to a managed Harness (``{"s3": {"uri": ...}}``)
+   or exported as-is.
+2. **The standard bundle layout.** v1 stored resources content-addressed
+   (``skills/{id}/{sha256}``) with no ``kind``; v2 stores them at
+   ``skills/{id}/{references|scripts|assets}/{filename}``.
+
+This script fixes both, per skill: it copies each legacy content-hash object to
+its standard path, rewrites the row's ``resources`` manifest to point there
+(adding ``kind``), and writes the ``SKILL.md`` projection generated from the
+row. The DynamoDB row stays the source of truth throughout — nothing here
+invents metadata.
+
+It does NOT touch ``instructions``, ``description`` or any other authored
+field. A skill whose prose is stale is a content problem, not a layout one.
+
+SAFETY
+------
+* **Dry-run by default.** Pass ``--apply`` to actually write.
+* **Idempotent + re-runnable.** A skill already in the standard layout has its
+  projection rewritten (cheap, byte-identical) and its objects left alone.
+  Legacy objects are *copied*, never moved, and only deleted with
+  ``--delete-legacy`` once the copy is verified present.
+* **Throttled.** ``--sleep`` between skills (default 50ms).
+* **Scoped.** ``--skill`` limits the run to one skill id.
+
+Run against dev first, then prod::
+
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_skill_bundles.py \\
+        --table dev-boisestateai-v2-app-roles \\
+        --bucket dev-boisestateai-v2-skill-resources            # dry-run
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_skill_bundles.py \\
+        --table dev-boisestateai-v2-app-roles \\
+        --bucket dev-boisestateai-v2-skill-resources --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3
+from botocore.exceptions import ClientError
+
+# The generator and the layout rules are shared with the live write path, so a
+# backfilled bundle is byte-identical to one the app would write today.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from apis.shared.skills.bundle import generate_skill_md  # noqa: E402
+from apis.shared.skills.resource_store import (  # noqa: E402
+    resource_key,
+    skill_md_key,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_skill_bundles")
+
+
+def is_legacy_key(s3_key: str, skill_id: str) -> bool:
+    """True if a manifest entry still uses the v1 content-addressed key.
+
+    v1 wrote ``skills/{id}/{sha256}`` — a flat key with no bundle subdirectory.
+    v2 always writes ``skills/{id}/{references|scripts|assets}/{filename}``, so
+    the presence of a subdirectory is the discriminator.
+    """
+    prefix = f"skills/{skill_id}/"
+    if not s3_key.startswith(prefix):
+        # Unrecognized shape — treat as legacy so it gets normalized.
+        return True
+    return "/" not in s3_key[len(prefix) :]
+
+
+def scan_skills(table, skill_id: Optional[str]) -> List[Dict[str, Any]]:
+    """Return the skill rows to process (all, or just the one named)."""
+    if skill_id:
+        response = table.get_item(Key={"PK": f"SKILL#{skill_id}", "SK": "METADATA"})
+        item = response.get("Item")
+        return [item] if item else []
+
+    filter_expr = "begins_with(PK, :pk_prefix) AND SK = :sk"
+    expr_values = {":pk_prefix": "SKILL#", ":sk": "METADATA"}
+
+    response = table.scan(
+        FilterExpression=filter_expr, ExpressionAttributeValues=expr_values
+    )
+    items = list(response.get("Items", []))
+    while "LastEvaluatedKey" in response:
+        response = table.scan(
+            FilterExpression=filter_expr,
+            ExpressionAttributeValues=expr_values,
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        items.extend(response.get("Items", []))
+    return items
+
+
+def object_exists(s3, bucket: str, key: str) -> bool:
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] in ("404", "NoSuchKey", "NotFound"):
+            return False
+        raise
+
+
+def migrate_resources(
+    s3,
+    bucket: str,
+    skill_id: str,
+    resources: List[Dict[str, Any]],
+    *,
+    apply: bool,
+    delete_legacy: bool,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Copy legacy objects into the standard layout and rewrite the manifest.
+
+    Returns the (possibly rewritten) manifest and the number of entries moved.
+    """
+    migrated: List[Dict[str, Any]] = []
+    moved = 0
+
+    for ref in resources:
+        entry = dict(ref)
+        filename = entry.get("filename") or ""
+        old_key = entry.get("s3Key") or ""
+        # v1 rows carry no `kind`; everything it could store was a reference doc.
+        kind = entry.get("kind") or "reference"
+        entry["kind"] = kind
+
+        if not filename or not is_legacy_key(old_key, skill_id):
+            migrated.append(entry)
+            continue
+
+        new_key = resource_key(skill_id, kind, filename)
+        entry["s3Key"] = new_key
+        moved += 1
+
+        if not apply:
+            logger.info("  [dry-run] copy %s -> %s", old_key, new_key)
+            migrated.append(entry)
+            continue
+
+        if object_exists(s3, bucket, new_key):
+            logger.info("  %s already present, skipping copy", new_key)
+        elif not object_exists(s3, bucket, old_key):
+            # The manifest points at bytes that are gone. Rewriting the key
+            # would be a lie, so leave the entry untouched and shout.
+            logger.warning(
+                "  MISSING legacy object %s for %s/%s — manifest left as-is",
+                old_key,
+                skill_id,
+                filename,
+            )
+            entry["s3Key"] = old_key
+            moved -= 1
+            migrated.append(entry)
+            continue
+        else:
+            s3.copy_object(
+                Bucket=bucket,
+                CopySource={"Bucket": bucket, "Key": old_key},
+                Key=new_key,
+                ContentType=entry.get("contentType") or "application/octet-stream",
+                MetadataDirective="REPLACE",
+                ServerSideEncryption="AES256",
+            )
+            logger.info("  copied %s -> %s", old_key, new_key)
+
+        if delete_legacy and object_exists(s3, bucket, new_key):
+            s3.delete_object(Bucket=bucket, Key=old_key)
+            logger.info("  deleted legacy %s", old_key)
+
+        migrated.append(entry)
+
+    return migrated, moved
+
+
+def write_projection(
+    s3, bucket: str, row: Dict[str, Any], *, apply: bool
+) -> None:
+    """Write the row's ``SKILL.md`` projection into the bundle prefix."""
+    skill_id = row["skillId"]
+    content = generate_skill_md(
+        skill_id=skill_id,
+        description=row.get("description") or "",
+        instructions=row.get("instructions") or "",
+        allowed_tools=[str(t) for t in (row.get("allowedTools") or [])],
+        skill_metadata=dict(row.get("skillMetadata") or {}),
+    )
+    key = skill_md_key(skill_id)
+
+    if not apply:
+        logger.info("  [dry-run] write %s (%d bytes)", key, len(content.encode()))
+        return
+
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=content.encode("utf-8"),
+        ContentType="text/markdown",
+        ServerSideEncryption="AES256",
+    )
+    logger.info("  wrote %s", key)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", required=True, help="app-roles DynamoDB table")
+    parser.add_argument("--bucket", required=True, help="skill-resources S3 bucket")
+    parser.add_argument("--skill", help="Only process this skill id")
+    parser.add_argument(
+        "--apply", action="store_true", help="Actually write (default: dry-run)"
+    )
+    parser.add_argument(
+        "--delete-legacy",
+        action="store_true",
+        help="Delete the old content-hash objects after a verified copy",
+    )
+    parser.add_argument("--sleep", type=float, default=0.05)
+    args = parser.parse_args()
+
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(args.table)
+    s3 = boto3.client("s3")
+
+    rows = scan_skills(table, args.skill)
+    if not rows:
+        logger.warning("No skills found (table=%s skill=%s)", args.table, args.skill)
+        return 1
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info("%s: %d skill(s) to inspect", mode, len(rows))
+
+    projections = 0
+    moves = 0
+
+    for row in rows:
+        skill_id = row.get("skillId")
+        if not skill_id:
+            logger.warning("Row without skillId, skipping: PK=%s", row.get("PK"))
+            continue
+
+        logger.info("skill %s", skill_id)
+        resources = [dict(r) for r in (row.get("resources") or [])]
+
+        migrated, moved = migrate_resources(
+            s3,
+            args.bucket,
+            skill_id,
+            resources,
+            apply=args.apply,
+            delete_legacy=args.delete_legacy,
+        )
+        moves += moved
+
+        if moved and args.apply:
+            table.update_item(
+                Key={"PK": f"SKILL#{skill_id}", "SK": "METADATA"},
+                UpdateExpression="SET #r = :r",
+                ExpressionAttributeNames={"#r": "resources"},
+                ExpressionAttributeValues={":r": migrated},
+            )
+            logger.info("  manifest rewritten (%d entr(y|ies))", moved)
+
+        write_projection(s3, args.bucket, row, apply=args.apply)
+        projections += 1
+
+        time.sleep(args.sleep)
+
+    logger.info(
+        "%s complete: %d projection(s), %d resource(s) relocated",
+        mode,
+        projections,
+        moves,
+    )
+    if not args.apply:
+        logger.info("Re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import sys
 import uuid
 from dataclasses import dataclass, field
@@ -835,12 +836,72 @@ EXAMPLE_SKILL_INSTRUCTIONS = (
 )
 
 
+def _skill_slug(skill_id: str) -> str:
+    """agentskills.io-valid skill name from a catalog id.
+
+    Mirrors ``apis/shared/skills/bundle.py::slugify_skill_name``. Duplicated
+    rather than imported because this script is standalone — ``seed.sh`` runs it
+    straight after infra deploy, without the app package on the path.
+    """
+    slug = skill_id.strip().lower().replace("_", "-")
+    slug = re.sub(r"[^a-z0-9-]+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug[:64].strip("-") or "skill"
+
+
+def _write_skill_md(
+    skill_id: str, description: str, instructions: str, region: str
+) -> None:
+    """Write the skill's ``SKILL.md`` projection so the prefix is a real bundle.
+
+    Mirrors ``apis/shared/skills/bundle.py::generate_skill_md`` for the subset
+    the seed uses (no advisory tools, no frontmatter passthrough). Without this
+    the seeded prefix holds only resource bytes and is not a valid
+    agentskills.io bundle — it could not be handed to a managed Harness or
+    exported as-is. Best-effort, like the reference upload.
+    """
+    bucket = os.environ.get("S3_SKILL_RESOURCES_BUCKET_NAME", "")
+    if not bucket:
+        return
+
+    content = (
+        "---\n"
+        f"name: {_skill_slug(skill_id)}\n"
+        f"description: {description}\n"
+        "---\n"
+        "\n"
+        f"{instructions.strip()}\n"
+    )
+    key = f"skills/{skill_id}/SKILL.md"
+    try:
+        s3 = boto3.Session(region_name=region).client("s3")
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=content.encode("utf-8"),
+            ContentType="text/markdown",
+            ServerSideEncryption="AES256",
+        )
+    except ClientError as e:
+        logger.warning(
+            "Could not write SKILL.md for skill '%s' to %s — seeding without "
+            "the projection: %s",
+            skill_id,
+            bucket,
+            e,
+        )
+        return
+
+    logger.info("Wrote SKILL.md for skill '%s' to s3://%s/%s", skill_id, bucket, key)
+
+
 def _upload_skill_reference(
     skill_id: str, filename: str, content: bytes, content_type: str, region: str
 ) -> Optional[dict[str, Any]]:
     """Upload a reference file's bytes to the skill-resources bucket.
 
-    Content-addressed (``skills/{skill_id}/{sha256}``), mirroring
+    Stored in the standard agentskills.io bundle layout
+    (``skills/{skill_id}/references/{filename}``), mirroring
     ``apis/shared/skills/resource_store.py``. Best-effort: returns the manifest
     entry on success, or ``None`` (with a warning) when the bucket is not
     configured or the put fails, so the skill still seeds without the bytes.
@@ -856,7 +917,7 @@ def _upload_skill_reference(
         return None
 
     digest = hashlib.sha256(content).hexdigest()
-    key = f"skills/{skill_id}/{digest}"
+    key = f"skills/{skill_id}/references/{filename}"
     try:
         s3 = boto3.Session(region_name=region).client("s3")
         s3.put_object(
@@ -884,6 +945,7 @@ def _upload_skill_reference(
         "size": len(content),
         "contentType": content_type,
         "s3Key": key,
+        "kind": "reference",
     }
 
 
@@ -991,6 +1053,8 @@ def seed_example_skills(
 
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
+    description = "Fetch web pages and turn them into accurate, citable notes."
+
     item: dict[str, Any] = {
         "PK": pk,
         "SK": sk,
@@ -999,7 +1063,7 @@ def seed_example_skills(
         "GSI4SK": f"SKILL#{skill_id}",
         "skillId": skill_id,
         "displayName": "Web Research Assistant",
-        "description": "Fetch web pages and turn them into accurate, citable notes.",
+        "description": description,
         "instructions": EXAMPLE_SKILL_INSTRUCTIONS,
         "compose": [],
         "resources": resources,
@@ -1026,6 +1090,9 @@ def seed_example_skills(
         result.failed += 1
         result.details.append(msg)
         return result
+
+    # Projection last: the row is the source of truth, so it must exist first.
+    _write_skill_md(skill_id, description, EXAMPLE_SKILL_INSTRUCTIONS, region)
 
     _grant_skill_to_default_role(table, skill_id)
     return result

--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -1,25 +1,45 @@
-"""User-facing skills API: list accessible skills + per-skill preferences.
+"""User-facing skills API: accessible skills, preferences, and My Skills CRUD.
 
-The skills parallel of ``apis/app_api/tools/routes.py``. Returns only the
-ACTIVE skills the user's RBAC roles grant — the same resolution
-(``apis.shared.skills.access``) and the same ACTIVE filter the SkillAgent
-applies at runtime, so what the user sees in the picker is exactly what the
-agent can activate. Preferences are a global per-user map (skill_id ->
-enabled); a skill absent from the map is enabled by default.
+Two surfaces live here:
 
-Admin skill management routes are in ``apis.app_api.admin.skills.routes``.
+1. **Picker** (``GET /skills/``, ``PUT /skills/preferences``). Returns the
+   ACTIVE skills the user can reach — RBAC-granted catalog skills **union**
+   the skills they authored themselves — via the same resolution the runtime
+   uses (``apis.shared.skills.access``), so what the user sees in the picker
+   is exactly what the agent can activate. Preferences are a global per-user
+   map (skill_id -> enabled).
+
+2. **My Skills** (``/skills/mine/*``, Skills v2 PR-3). Owner-scoped CRUD over
+   the user-authored tier: create/edit/delete your own skills and upload the
+   supporting files of their agentskills.io bundle. Every route resolves
+   ownership through ``UserSkillService``; a skill you do not own is
+   indistinguishable from one that does not exist.
+
+Admin catalog management routes are in ``apis.app_api.admin.skills.routes``.
 """
 
 import logging
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
 from pydantic import BaseModel, Field
 
 from apis.shared.auth import User, get_current_user_from_session
 from apis.shared.skills.access import resolve_accessible_skill_ids
-from apis.shared.skills.models import SkillStatus
+from apis.shared.skills.models import (
+    SkillDefinition,
+    SkillResourceRef,
+    SkillResourcesResponse,
+    SkillStatus,
+)
 from apis.shared.skills.repository import get_skill_catalog_repository
+
+from .user_service import (
+    UserSkillError,
+    UserSkillLimitError,
+    UserSkillNotFoundError,
+    get_user_skill_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,3 +134,288 @@ async def update_skill_preferences(
     repo = get_skill_catalog_repository()
     await repo.save_user_preferences(user.user_id, request.preferences)
     return {"message": "Preferences saved successfully"}
+
+
+# =============================================================================
+# My Skills — the user-authored tier (Skills v2 PR-3)
+# =============================================================================
+
+
+class MySkillResponse(BaseModel):
+    """One skill the caller authored, as shown on the My Skills page."""
+
+    skill_id: str = Field(..., alias="skillId")
+    display_name: str = Field(..., alias="displayName")
+    description: str
+    instructions: str = ""
+    allowed_tools: List[str] = Field(default_factory=list, alias="allowedTools")
+    skill_metadata: Dict = Field(default_factory=dict, alias="skillMetadata")
+    resources: List[SkillResourceRef] = Field(default_factory=list)
+    status: str = SkillStatus.ACTIVE.value
+    category: Optional[str] = None
+    created_at: Optional[str] = Field(None, alias="createdAt")
+    updated_at: Optional[str] = Field(None, alias="updatedAt")
+
+    model_config = {"populate_by_name": True}
+
+    @classmethod
+    def from_skill(cls, skill: SkillDefinition) -> "MySkillResponse":
+        return cls(
+            skill_id=skill.skill_id,
+            display_name=skill.display_name,
+            description=skill.description,
+            instructions=skill.instructions,
+            allowed_tools=list(skill.allowed_tools),
+            skill_metadata=dict(skill.skill_metadata),
+            resources=list(skill.resources),
+            status=str(skill.status.value if hasattr(skill.status, "value") else skill.status),
+            category=skill.category,
+            created_at=skill.created_at.isoformat() if skill.created_at else None,
+            updated_at=skill.updated_at.isoformat() if skill.updated_at else None,
+        )
+
+
+class MySkillListResponse(BaseModel):
+    """Response model for GET /skills/mine."""
+
+    skills: List[MySkillResponse]
+    total_count: int = Field(..., alias="totalCount")
+
+    model_config = {"populate_by_name": True}
+
+
+class CreateMySkillRequest(BaseModel):
+    """Request body for POST /skills/mine.
+
+    No ``skillId``: ids are allocated server-side from the display name so a
+    user never has to invent one — or collide with a catalog skill they cannot
+    see. ``allowedTools`` is advisory metadata only and never grants a tool
+    (spec D1/D4).
+    """
+
+    display_name: str = Field(..., alias="displayName", max_length=200)
+    description: str = Field(..., max_length=2000)
+    instructions: str = ""
+    allowed_tools: List[str] = Field(default_factory=list, alias="allowedTools")
+    skill_metadata: Dict = Field(default_factory=dict, alias="skillMetadata")
+    category: Optional[str] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateMySkillRequest(BaseModel):
+    """Request body for PUT /skills/mine/{skill_id}.
+
+    Only authored fields are writable. ``ownerId``, ``visibility`` and the
+    audit fields are deliberately absent — a user cannot re-home their skill
+    into the admin catalog or onto another account.
+    """
+
+    display_name: Optional[str] = Field(None, alias="displayName", max_length=200)
+    description: Optional[str] = Field(None, max_length=2000)
+    instructions: Optional[str] = None
+    allowed_tools: Optional[List[str]] = Field(None, alias="allowedTools")
+    skill_metadata: Optional[Dict] = Field(None, alias="skillMetadata")
+    category: Optional[str] = None
+    status: Optional[SkillStatus] = None
+
+    model_config = {"populate_by_name": True}
+
+
+def _user_skill_error(e: UserSkillError) -> HTTPException:
+    """Map a user-tier service error to its HTTP status."""
+    if isinstance(e, UserSkillNotFoundError):
+        return HTTPException(status_code=404, detail=str(e))
+    if isinstance(e, UserSkillLimitError):
+        return HTTPException(status_code=409, detail=str(e))
+    return HTTPException(status_code=400, detail=str(e))
+
+
+def _resource_value_error(e: ValueError) -> HTTPException:
+    """Map a resource-file validation error to its HTTP status."""
+    status = 404 if "not found" in str(e).lower() else 400
+    return HTTPException(status_code=status, detail=str(e))
+
+
+@router.get("/mine", response_model=MySkillListResponse)
+async def list_my_skills(
+    user: User = Depends(get_current_user_from_session),
+) -> MySkillListResponse:
+    """List every skill the current user authored (any status)."""
+    logger.info(f"User {user.name} listing authored skills")
+
+    skills = await get_user_skill_service().list_my_skills(user)
+    return MySkillListResponse(
+        skills=[MySkillResponse.from_skill(s) for s in skills],
+        total_count=len(skills),
+    )
+
+
+@router.post("/mine", response_model=MySkillResponse)
+async def create_my_skill(
+    request: CreateMySkillRequest,
+    user: User = Depends(get_current_user_from_session),
+) -> MySkillResponse:
+    """Create a skill owned by the current user."""
+    logger.info(f"User {user.name} creating an authored skill")
+
+    try:
+        skill = await get_user_skill_service().create_my_skill(
+            user,
+            display_name=request.display_name,
+            description=request.description,
+            instructions=request.instructions,
+            allowed_tools=request.allowed_tools,
+            skill_metadata=request.skill_metadata,
+            category=request.category,
+        )
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+
+    return MySkillResponse.from_skill(skill)
+
+
+@router.get("/mine/{skill_id}", response_model=MySkillResponse)
+async def get_my_skill(
+    skill_id: str,
+    user: User = Depends(get_current_user_from_session),
+) -> MySkillResponse:
+    """Get one of the current user's authored skills."""
+    try:
+        skill = await get_user_skill_service().get_my_skill(skill_id, user)
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+
+    return MySkillResponse.from_skill(skill)
+
+
+@router.put("/mine/{skill_id}", response_model=MySkillResponse)
+async def update_my_skill(
+    skill_id: str,
+    request: UpdateMySkillRequest,
+    user: User = Depends(get_current_user_from_session),
+) -> MySkillResponse:
+    """Update one of the current user's authored skills."""
+    logger.info(f"User {user.name} updating an authored skill")
+
+    updates = request.model_dump(exclude_unset=True, exclude_none=True)
+    try:
+        skill = await get_user_skill_service().update_my_skill(skill_id, updates, user)
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+
+    return MySkillResponse.from_skill(skill)
+
+
+@router.delete("/mine/{skill_id}")
+async def delete_my_skill(
+    skill_id: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """Delete one of the current user's authored skills and its bundle files."""
+    logger.info(f"User {user.name} deleting an authored skill")
+
+    try:
+        await get_user_skill_service().delete_my_skill(skill_id, user)
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+
+    return {"message": f"Skill '{skill_id}' deleted"}
+
+
+# -----------------------------------------------------------------------------
+# My Skills — bundle files
+# -----------------------------------------------------------------------------
+
+
+@router.get("/mine/{skill_id}/resources", response_model=SkillResourcesResponse)
+async def list_my_skill_resources(
+    skill_id: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """List an owned skill's supporting-file manifest (no bytes)."""
+    try:
+        resources = await get_user_skill_service().list_resources(skill_id, user)
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)
+
+
+@router.post("/mine/{skill_id}/resources", response_model=SkillResourcesResponse)
+async def upload_my_skill_resource(
+    skill_id: str,
+    file: UploadFile = File(...),
+    kind: str = Form("reference"),
+    user: User = Depends(get_current_user_from_session),
+):
+    """Upload (or replace) one supporting file on an owned skill.
+
+    Bytes land in the standard agentskills.io bundle layout (``references/`` |
+    ``scripts/`` | ``assets/`` per ``kind``). ``script`` files are stored inert
+    — listed and readable, never executed (spec D5).
+    """
+    logger.info(f"User {user.name} uploading a skill bundle file")
+
+    content = await file.read()
+    try:
+        resources = await get_user_skill_service().add_resource(
+            skill_id,
+            filename=file.filename or "",
+            content=content,
+            content_type=file.content_type or "",
+            user=user,
+            kind=kind,
+        )
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)
+
+
+@router.get("/mine/{skill_id}/resources/{filename}")
+async def read_my_skill_resource(
+    skill_id: str,
+    filename: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """Return the raw bytes of one of an owned skill's supporting files."""
+    try:
+        ref, content = await get_user_skill_service().read_resource(
+            skill_id, filename, user
+        )
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return Response(
+        content=content,
+        media_type=ref.content_type or "application/octet-stream",
+        headers={"Content-Disposition": f'inline; filename="{ref.filename}"'},
+    )
+
+
+@router.delete(
+    "/mine/{skill_id}/resources/{filename}", response_model=SkillResourcesResponse
+)
+async def delete_my_skill_resource(
+    skill_id: str,
+    filename: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """Delete one supporting file from an owned skill. Returns the manifest."""
+    logger.info(f"User {user.name} deleting a skill bundle file")
+
+    try:
+        resources = await get_user_skill_service().delete_resource(
+            skill_id, filename, user
+        )
+    except UserSkillError as e:
+        raise _user_skill_error(e)
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return SkillResourcesResponse(skill_id=skill_id, resources=resources)

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -20,6 +20,7 @@ from apis.shared.rbac.admin_service import (
 )
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
 from apis.shared.skills.models import (
+    SYSTEM_OWNER_ID,
     SkillDefinition,
     SkillResourceRef,
     SkillRoleAssignment,
@@ -82,7 +83,12 @@ class SkillCatalogService:
         self, status: Optional[str] = None, include_roles: bool = True
     ) -> List[SkillDefinition]:
         """
-        Get all skills in the catalog.
+        Get all skills in the admin catalog.
+
+        Scoped to ``owner_id == "system"``: user-authored skills (Skills v2
+        PR-3) live in the same table but are governed by ownership, not by RBAC
+        role grants, so they are not part of the catalog an admin curates and
+        must not appear on the admin skills page.
 
         Args:
             status: Optional status filter
@@ -91,7 +97,9 @@ class SkillCatalogService:
         Returns:
             List of SkillDefinition objects
         """
-        skills = await self.repository.list_skills(status=status)
+        skills = await self.repository.list_skills(
+            status=status, owner_id=SYSTEM_OWNER_ID
+        )
 
         if include_roles:
             for skill in skills:
@@ -407,6 +415,15 @@ class SkillCatalogService:
             skill_id, {"resources": resources}, admin_user_id=admin.user_id
         )
 
+    def write_skill_md(self, skill: SkillDefinition) -> None:
+        """Write the skill's SKILL.md projection to S3 (best-effort).
+
+        Public entry point for the user-authored tier (``UserSkillService``),
+        which reuses this bundle machinery so both tiers emit identical
+        agentskills.io layouts.
+        """
+        self._write_skill_md(skill)
+
     def _write_skill_md(self, skill: SkillDefinition) -> None:
         """Write the skill's SKILL.md projection to S3 (best-effort).
 
@@ -517,9 +534,7 @@ class SkillCatalogService:
             app_role_ids: AppRole IDs that should grant this skill
             admin: Admin user performing the action
         """
-        skill = await self.get_skill(skill_id)
-        if not skill:
-            raise ValueError(f"Skill '{skill_id}' not found")
+        await self._require_catalog_skill(skill_id)
 
         current_roles = await self.get_roles_for_skill(skill_id)
         current_role_ids = {
@@ -550,6 +565,7 @@ class SkillCatalogService:
         self, skill_id: str, app_role_ids: List[str], admin: User
     ) -> None:
         """Add AppRoles to skill access (preserves existing)."""
+        await self._require_catalog_skill(skill_id)
         for role_id in app_role_ids:
             await self._add_skill_to_role(role_id, skill_id, admin)
 
@@ -557,8 +573,28 @@ class SkillCatalogService:
         self, skill_id: str, app_role_ids: List[str], admin: User
     ) -> None:
         """Remove AppRoles from skill access."""
+        await self._require_catalog_skill(skill_id)
         for role_id in app_role_ids:
             await self._remove_skill_from_role(role_id, skill_id, admin)
+
+    async def _require_catalog_skill(self, skill_id: str) -> SkillDefinition:
+        """Assert a skill exists AND belongs to the admin catalog.
+
+        Role grants are the catalog's governance mechanism. A user-authored
+        skill (Skills v2 PR-3) is reached through ownership — and, once PR-4
+        lands, through invoke-through on a shared Agent. Granting one to an
+        AppRole would hand a private, user-owned document to a whole role, so
+        the role endpoints refuse to touch anything outside the catalog.
+        """
+        skill = await self.get_skill(skill_id)
+        if not skill:
+            raise ValueError(f"Skill '{skill_id}' not found")
+        if skill.owner_id != SYSTEM_OWNER_ID:
+            raise ValueError(
+                f"Skill '{skill_id}' is user-authored and cannot be granted to "
+                "AppRoles. Only admin catalog skills carry role grants."
+            )
+        return skill
 
     async def _add_skill_to_role(
         self, role_id: str, skill_id: str, admin: User

--- a/backend/src/apis/app_api/skills/user_service.py
+++ b/backend/src/apis/app_api/skills/user_service.py
@@ -1,0 +1,338 @@
+"""User-authored skills service (Skills v2 PR-3).
+
+The owner-scoped half of the skill catalog. Admin catalog skills
+(``owner_id == "system"``, governed by RBAC ``granted_skills``) and
+user-authored skills (``owner_id == <user_id>``, governed by ownership) are
+the same record type in the same table — two authorship tiers, one store
+(spec D8). This service is the ownership-governed entry point; every method
+resolves the record and refuses to touch one the caller does not own.
+
+Resource-file handling (caps, manifest, S3 bundle layout, orphan GC) is
+*not* reimplemented here — it is delegated to :class:`SkillCatalogService`
+after the ownership check, so both tiers write identical agentskills.io
+bundles through one code path.
+"""
+
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+from apis.shared.auth.models import User
+from apis.shared.skills.models import (
+    SKILL_ID_PATTERN,
+    SkillDefinition,
+    SkillResourceRef,
+    SkillStatus,
+    SkillVisibility,
+)
+from apis.shared.skills.repository import (
+    SkillCatalogRepository,
+    get_skill_catalog_repository,
+)
+
+from .service import SkillCatalogService, get_skill_catalog_service
+
+logger = logging.getLogger(__name__)
+
+# A user may author this many skills. Generous enough that nobody legitimate
+# hits it; low enough that one account cannot inflate the shared catalog table
+# (every admin catalog list still scans over these rows).
+MAX_SKILLS_PER_USER = 50
+
+# Fallback stem when a display name slugifies to nothing usable (e.g. a name
+# written entirely in a non-Latin script).
+_FALLBACK_STEM = "skill"
+_SKILL_ID_RE = re.compile(SKILL_ID_PATTERN)
+
+
+class UserSkillError(Exception):
+    """Base class for user-tier skill failures (400)."""
+
+
+class UserSkillNotFoundError(UserSkillError):
+    """The skill does not exist, or is not visible to this caller (404)."""
+
+
+class UserSkillLimitError(UserSkillError):
+    """The caller is at their authored-skill cap (409)."""
+
+
+def slugify_skill_id(display_name: str) -> str:
+    """Derive a ``skill_id`` stem from a human display name.
+
+    Produces the ``SKILL_ID_PATTERN`` shape: lowercase, underscore-separated,
+    leading letter, 3-50 chars. This is the *stem* only — uniqueness is
+    settled by :meth:`UserSkillService._allocate_skill_id`.
+    """
+    stem = re.sub(r"[^a-z0-9]+", "_", (display_name or "").lower()).strip("_")
+    # The pattern demands a leading letter, so a name like "3d modeling" needs
+    # a prefix rather than a truncation that would change its meaning.
+    if not stem or not stem[0].isalpha():
+        stem = f"{_FALLBACK_STEM}_{stem}".strip("_") if stem else _FALLBACK_STEM
+    # Leave room for a disambiguating suffix (see _allocate_skill_id).
+    stem = stem[:45].rstrip("_")
+    while len(stem) < 3:
+        stem = f"{stem}_x" if stem else _FALLBACK_STEM
+    return stem
+
+
+class UserSkillService:
+    """Owner-scoped CRUD over the user-authored skill tier."""
+
+    def __init__(
+        self,
+        repository: Optional[SkillCatalogRepository] = None,
+        catalog_service: Optional[SkillCatalogService] = None,
+    ):
+        self.repository = repository or get_skill_catalog_repository()
+        # Reused purely for its resource-file machinery (caps, manifest,
+        # SKILL.md projection, orphan GC) — never for its role-sync methods,
+        # which are admin-only by construction.
+        self.catalog_service = catalog_service or get_skill_catalog_service()
+
+    # =========================================================================
+    # Ownership
+    # =========================================================================
+
+    async def require_owned(self, skill_id: str, user: User) -> SkillDefinition:
+        """Load a skill and assert the caller authored it.
+
+        Raises:
+            UserSkillNotFoundError: No such skill, or it belongs to the admin
+                catalog / another user. Both collapse to "not found" so this
+                surface never confirms the existence of someone else's skill.
+        """
+        skill = await self.repository.get_skill(skill_id)
+        if skill is None or skill.owner_id != user.user_id:
+            raise UserSkillNotFoundError(f"Skill '{skill_id}' not found")
+        return skill
+
+    # =========================================================================
+    # CRUD
+    # =========================================================================
+
+    async def list_my_skills(self, user: User) -> List[SkillDefinition]:
+        """Every skill the caller authored, any status (GSI4 partition query)."""
+        return await self.repository.list_skills_by_owner(user.user_id)
+
+    async def get_my_skill(self, skill_id: str, user: User) -> SkillDefinition:
+        """One owned skill, including its resource manifest."""
+        return await self.require_owned(skill_id, user)
+
+    async def create_my_skill(
+        self,
+        user: User,
+        *,
+        display_name: str,
+        description: str,
+        instructions: str = "",
+        allowed_tools: Optional[List[str]] = None,
+        skill_metadata: Optional[Dict] = None,
+        category: Optional[str] = None,
+    ) -> SkillDefinition:
+        """Create a skill owned by ``user``.
+
+        The ``skill_id`` is allocated server-side from the display name — users
+        never type one. Ids are globally unique across both tiers on purpose:
+        the runtime activation key is the (slugified) id, so two same-named
+        skills in one turn would be ambiguous to the model.
+
+        Raises:
+            UserSkillLimitError: Caller is at ``MAX_SKILLS_PER_USER``.
+            UserSkillError: Display name or description is blank.
+        """
+        display_name = (display_name or "").strip()
+        description = (description or "").strip()
+        if not display_name:
+            raise UserSkillError("A skill needs a name.")
+        if not description:
+            raise UserSkillError(
+                "A skill needs a description — it is the one line the agent "
+                "reads when deciding whether to use the skill."
+            )
+
+        existing = await self.repository.list_skills_by_owner(user.user_id)
+        if len(existing) >= MAX_SKILLS_PER_USER:
+            raise UserSkillLimitError(
+                f"You already have the maximum of {MAX_SKILLS_PER_USER} skills. "
+                "Delete one before creating another."
+            )
+
+        skill_id = await self._allocate_skill_id(display_name)
+        skill = SkillDefinition(
+            skill_id=skill_id,
+            display_name=display_name,
+            description=description,
+            instructions=instructions or "",
+            allowed_tools=list(allowed_tools or []),
+            skill_metadata=dict(skill_metadata or {}),
+            category=category,
+            status=SkillStatus.ACTIVE,
+            owner_id=user.user_id,
+            visibility=SkillVisibility.PRIVATE,
+            created_by=user.user_id,
+            updated_by=user.user_id,
+        )
+
+        created = await self.repository.create_skill(skill)
+        self.catalog_service.write_skill_md(created)
+        self._invalidate(skill_id)
+
+        logger.info(
+            f"User {user.email} created skill: {skill_id}",
+            extra={
+                "event": "user_skill_created",
+                "skill_id": skill_id,
+                "owner_user_id": user.user_id,
+            },
+        )
+        return created
+
+    async def update_my_skill(
+        self, skill_id: str, updates: Dict, user: User
+    ) -> SkillDefinition:
+        """Update an owned skill's authored fields.
+
+        ``updates`` is already narrowed to the caller-writable fields by the
+        route DTO — ``owner_id``, ``visibility`` and audit fields are never
+        routed through here.
+        """
+        await self.require_owned(skill_id, user)
+
+        updated = await self.repository.update_skill(
+            skill_id, updates, admin_user_id=user.user_id
+        )
+        if updated is None:
+            raise UserSkillNotFoundError(f"Skill '{skill_id}' not found")
+
+        self.catalog_service.write_skill_md(updated)
+        self._invalidate(skill_id)
+
+        logger.info(
+            f"User {user.email} updated skill: {skill_id}",
+            extra={
+                "event": "user_skill_updated",
+                "skill_id": skill_id,
+                "owner_user_id": user.user_id,
+                "changes": list(updates.keys()),
+            },
+        )
+        return updated
+
+    async def delete_my_skill(self, skill_id: str, user: User) -> None:
+        """Hard-delete an owned skill and purge its bundle objects.
+
+        Deliberately a *hard* delete, unlike the admin catalog's default soft
+        delete: an admin skill may be referenced by role grants worth auditing,
+        whereas a user deleting their own draft expects it gone. Bundle objects
+        are removed first so a failed row delete cannot strand a live skill
+        pointing at missing files.
+        """
+        skill = await self.require_owned(skill_id, user)
+
+        for ref in skill.resources:
+            self.catalog_service.resource_store.delete(ref.s3_key)
+        self._delete_skill_md(skill_id)
+
+        await self.repository.delete_skill(skill_id)
+        self._invalidate(skill_id)
+
+        logger.info(
+            f"User {user.email} deleted skill: {skill_id}",
+            extra={
+                "event": "user_skill_deleted",
+                "skill_id": skill_id,
+                "owner_user_id": user.user_id,
+            },
+        )
+
+    # =========================================================================
+    # Bundle files — delegated to the shared catalog service post-ownership
+    # =========================================================================
+
+    async def list_resources(
+        self, skill_id: str, user: User
+    ) -> List[SkillResourceRef]:
+        skill = await self.require_owned(skill_id, user)
+        return list(skill.resources)
+
+    async def add_resource(
+        self,
+        skill_id: str,
+        filename: str,
+        content: bytes,
+        content_type: str,
+        user: User,
+        kind: str = "reference",
+    ) -> List[SkillResourceRef]:
+        await self.require_owned(skill_id, user)
+        refs = await self.catalog_service.add_resource(
+            skill_id, filename, content, content_type, user, kind=kind
+        )
+        self._invalidate(skill_id)
+        return refs
+
+    async def read_resource(
+        self, skill_id: str, filename: str, user: User
+    ) -> Tuple[SkillResourceRef, bytes]:
+        await self.require_owned(skill_id, user)
+        return await self.catalog_service.read_resource(skill_id, filename)
+
+    async def delete_resource(
+        self, skill_id: str, filename: str, user: User
+    ) -> List[SkillResourceRef]:
+        await self.require_owned(skill_id, user)
+        refs = await self.catalog_service.delete_resource(skill_id, filename, user)
+        self._invalidate(skill_id)
+        return refs
+
+    # =========================================================================
+    # Internals
+    # =========================================================================
+
+    async def _allocate_skill_id(self, display_name: str) -> str:
+        """Pick a globally-unique ``skill_id`` from a display-name stem.
+
+        Collisions are resolved by suffixing rather than rejected, so a user
+        naming their skill "docx" when the catalog already has one succeeds
+        (as ``docx_2``) instead of hitting a 409 that would also disclose the
+        existence of a skill they cannot see.
+        """
+        stem = slugify_skill_id(display_name)
+        candidate = stem
+        for suffix in range(2, 100):
+            if not await self.repository.skill_exists(candidate):
+                return candidate
+            candidate = f"{stem}_{suffix}"
+
+        # Astronomically unlikely; fall back to a random tail rather than loop.
+        import uuid
+
+        candidate = f"{stem}_{uuid.uuid4().hex[:6]}"
+        if not _SKILL_ID_RE.match(candidate):
+            candidate = f"{_FALLBACK_STEM}_{uuid.uuid4().hex[:8]}"
+        return candidate
+
+    def _delete_skill_md(self, skill_id: str) -> None:
+        """Best-effort removal of the SKILL.md projection for a deleted skill."""
+        from apis.shared.skills.resource_store import skill_md_key
+
+        self.catalog_service.resource_store.delete(skill_md_key(skill_id))
+
+    @staticmethod
+    def _invalidate(skill_id: str) -> None:
+        """Drop the freshness caches so the change is visible on the next turn."""
+        from apis.shared.skills.freshness import invalidate
+
+        invalidate(skill_id)
+
+
+_user_service_instance: Optional[UserSkillService] = None
+
+
+def get_user_skill_service() -> UserSkillService:
+    """Get or create the global UserSkillService instance."""
+    global _user_service_instance
+    if _user_service_instance is None:
+        _user_service_instance = UserSkillService()
+    return _user_service_instance

--- a/backend/src/apis/shared/skills/__init__.py
+++ b/backend/src/apis/shared/skills/__init__.py
@@ -14,6 +14,7 @@ from .freshness import (
 )
 from .models import (
     SKILL_ID_PATTERN,
+    SYSTEM_OWNER_ID,
     AddRemoveSkillRolesRequest,
     AdminSkillListResponse,
     AdminSkillResponse,
@@ -28,7 +29,7 @@ from .models import (
     SkillUpdateRequest,
     SkillVisibility,
 )
-from .access import resolve_accessible_skill_ids
+from .access import resolve_accessible_skill_ids, resolve_owned_skill_ids
 from .models import UserSkillPreference
 from .repository import SkillCatalogRepository, get_skill_catalog_repository
 from .resource_store import (
@@ -39,6 +40,7 @@ from .resource_store import (
 
 __all__ = [
     "SKILL_ID_PATTERN",
+    "SYSTEM_OWNER_ID",
     "SkillDefinition",
     "SkillResourceRef",
     "SkillResourcesResponse",
@@ -62,5 +64,6 @@ __all__ = [
     "get_skill_updated_at",
     "invalidate",
     "resolve_accessible_skill_ids",
+    "resolve_owned_skill_ids",
     "UserSkillPreference",
 ]

--- a/backend/src/apis/shared/skills/access.py
+++ b/backend/src/apis/shared/skills/access.py
@@ -1,9 +1,19 @@
 """Per-user skill access resolution shared by app_api and the runtime.
 
-Single source of truth for "which skills do this user's RBAC roles grant",
-so the user-facing skills API (``app_api/skills``) and the inference path
+Single source of truth for "which skills can this user reach", so the
+user-facing skills API (``app_api/skills``) and the inference path
 (``inference_api/chat``) can never drift. Lives in ``apis.shared`` per the
 import-boundary rule (both consume it; neither may import the other).
+
+Two tiers feed the result (Skills v2 §5):
+
+- **catalog** — admin-authored skills the user's RBAC roles grant
+  (``granted_skills``, ``"*"`` honored over the catalog only).
+- **own** — skills the user authored themselves (``owner_id == user_id``,
+  resolved through the ``SkillOwnerIndex`` GSI). Ownership is its own grant;
+  it needs no role.
+
+Selection (``enabled_skills``) narrows this set per turn; it never widens it.
 """
 
 import logging
@@ -14,21 +24,51 @@ from apis.shared.auth.models import User
 logger = logging.getLogger(__name__)
 
 
-async def resolve_accessible_skill_ids(user: User) -> List[str]:
-    """Resolve the skills a user's RBAC roles grant (admin/DB-backed).
+async def resolve_owned_skill_ids(user: User) -> List[str]:
+    """Resolve the ACTIVE skills a user authored (the user-authored tier).
 
-    A ``"*"`` wildcard grant expands to every known skill id. Never raises —
-    on any failure the user simply gets no skills (the SkillAgent degrades
-    to chat, the skills list renders empty).
+    Ownership is the grant — a user always reaches their own skills without
+    any RBAC role. Never raises; on failure the user simply sees none.
     """
+    if not getattr(user, "user_id", None):
+        return []
+    try:
+        from apis.shared.skills.models import SkillStatus
+        from apis.shared.skills.repository import get_skill_catalog_repository
+
+        skills = await get_skill_catalog_repository().list_skills_by_owner(
+            user.user_id, status=SkillStatus.ACTIVE.value
+        )
+        return [s.skill_id for s in skills]
+    except Exception:
+        logger.warning("Failed to resolve owned skills", exc_info=True)
+        return []
+
+
+async def resolve_accessible_skill_ids(user: User) -> List[str]:
+    """Resolve every skill a user can reach: RBAC-granted catalog ∪ own.
+
+    A ``"*"`` wildcard grant expands to every *catalog* skill id — never to
+    another user's authored skills (see ``freshness.get_all_skill_ids``).
+    Never raises — on any failure the user simply gets no skills (the agent
+    runs without the disclosure plugin, the skills list renders empty).
+    """
+    catalog: List[str] = []
     try:
         from apis.shared.rbac.service import get_app_role_service
         from apis.shared.skills.freshness import get_all_skill_ids
 
         skills = await get_app_role_service().get_accessible_skills(user)
         if "*" in skills:
-            return sorted(await get_all_skill_ids())
-        return list(skills)
+            catalog = sorted(await get_all_skill_ids())
+        else:
+            catalog = list(skills)
     except Exception:
         logger.warning("Failed to resolve accessible skills", exc_info=True)
-        return []
+
+    owned = await resolve_owned_skill_ids(user)
+
+    # Preserve catalog order, then append owned ids the catalog didn't already
+    # grant (a user may hold a role that grants a skill they also authored).
+    seen = set(catalog)
+    return catalog + [sid for sid in owned if sid not in seen]

--- a/backend/src/apis/shared/skills/freshness.py
+++ b/backend/src/apis/shared/skills/freshness.py
@@ -9,9 +9,11 @@ here, both backed by DynamoDB reads of the skill catalog:
    the freshness hash in a cache key causes the next build to miss and
    rebuild with the fresh config (the runtime ``skills_hash`` in spec §8.3).
 
-2. **All-known-skill-ids snapshot** (``get_all_skill_ids``). The set of
-   skill IDs known to the catalog — the source of truth that RBAC's
-   wildcard (``"*"``) skill access needs to enumerate.
+2. **Catalog-skill-ids snapshot** (``get_all_skill_ids``). The set of
+   ADMIN-CATALOG skill IDs — the source of truth that RBAC's wildcard
+   (``"*"``) skill access needs to enumerate. User-authored skills are
+   deliberately excluded: a ``"*"`` grant is a grant over the catalog an
+   admin curates, never over other users' private skills (Skills v2 PR-3).
 
 Reads are TTL-cached so the per-turn overhead is bounded to at most one
 DynamoDB read per cache key per TTL window, per process. Admin routes call
@@ -98,12 +100,17 @@ async def get_freshness_hash(skill_ids: List[str]) -> str:
 
 
 async def get_all_skill_ids() -> FrozenSet[str]:
-    """Return the set of all known skill IDs, TTL-cached per process.
+    """Return the set of ADMIN-CATALOG skill IDs, TTL-cached per process.
 
     Listed once per TTL window via `repository.list_skills()` and reused
     across that window. Used by RBAC skill access to enumerate "every skill
-    the system knows about" (e.g. expanding a `"*"` wildcard grant) without
+    the catalog offers" (e.g. expanding a `"*"` wildcard grant) without
     scanning DynamoDB on every chat turn.
+
+    User-authored skills (``owner_id != "system"``) are excluded: a wildcard
+    RBAC grant must never sweep in another user's private skills. Owned
+    skills reach their author through ``access.resolve_accessible_skill_ids``
+    instead, via the ownership union.
 
     On a repository error, returns the last-known set if available, else an
     empty frozenset — never raises (auth must not break on a transient DB
@@ -114,11 +121,12 @@ async def get_all_skill_ids() -> FrozenSet[str]:
     if cached is not None and now - cached[1] < _TTL_SECONDS:
         return cached[0]
 
+    from apis.shared.skills.models import SYSTEM_OWNER_ID
     from apis.shared.skills.repository import get_skill_catalog_repository
 
     try:
         repo = get_skill_catalog_repository()
-        skills = await repo.list_skills()
+        skills = await repo.list_skills(owner_id=SYSTEM_OWNER_ID)
         ids = frozenset(s.skill_id for s in skills)
     except Exception:
         logger.exception("Failed to list skill IDs for catalog snapshot")

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -25,6 +25,10 @@ from pydantic import BaseModel, Field
 # Regex for a skill_id — identical shape to tool_id (see ToolCreateRequest).
 SKILL_ID_PATTERN = r"^[a-z][a-z0-9_]{2,49}$"
 
+# ``owner_id`` of an admin-catalog skill. Anything else is a user-authored
+# skill (Skills v2 PR-3): governed by ownership, not by RBAC ``granted_skills``.
+SYSTEM_OWNER_ID = "system"
+
 
 class SkillStatus(str, Enum):
     """Availability status of a skill (mirrors ToolStatus)."""

--- a/backend/src/apis/shared/skills/repository.py
+++ b/backend/src/apis/shared/skills/repository.py
@@ -8,9 +8,10 @@ DynamoDB operations for the admin-managed Skill catalog. Mirrors
   - Skill: PK=SKILL#{skill_id}, SK=METADATA
 
 ``SkillOwnerIndex`` (GSI4: GSI4PK=OWNER#{owner_id}, GSI4SK=SKILL#{skill_id})
-is provisioned for a Phase-2 "list my skills" query; v1 admin lists scan by
-``begins_with(PK, "SKILL#")``. See
-``docs/specs/admin-skills-rbac-tool-binding.md`` (§5).
+backs the user-authored tier's "list my skills" query
+(``list_skills_by_owner``). Admin catalog lists still scan by
+``begins_with(PK, "SKILL#")`` and narrow to ``owner_id == "system"``. See
+``docs/specs/skills-as-agent-primitive.md`` (§4, PR-3).
 """
 
 import logging
@@ -19,11 +20,15 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import boto3
+from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
-from .models import SkillDefinition, SkillStatus, UserSkillPreference
+from .models import SYSTEM_OWNER_ID, SkillDefinition, SkillStatus, UserSkillPreference
 
 logger = logging.getLogger(__name__)
+
+# GSI4 — see module docstring. Provisioned in the CDK auth-tables construct.
+SKILL_OWNER_INDEX = "SkillOwnerIndex"
 
 
 class SkillCatalogRepository:
@@ -69,13 +74,17 @@ class SkillCatalogRepository:
             raise
 
     async def list_skills(
-        self, status: Optional[str] = None
+        self, status: Optional[str] = None, owner_id: Optional[str] = None
     ) -> List[SkillDefinition]:
         """
-        List all skills, optionally filtered by status.
+        List all skills, optionally filtered by status and/or owner.
 
         Args:
             status: Optional status filter (active, draft, disabled)
+            owner_id: Optional owner filter. Pass ``"system"`` to get only the
+                admin catalog (excluding every user-authored skill); pass a user
+                id to get that user's skills — though ``list_skills_by_owner``
+                is the cheap GSI-backed path for the latter.
 
         Returns:
             List of SkillDefinition objects
@@ -105,6 +114,9 @@ class SkillCatalogRepository:
             if status:
                 skills = [s for s in skills if s.status == status]
 
+            if owner_id is not None:
+                skills = [s for s in skills if s.owner_id == owner_id]
+
             # Sort by category then display_name
             skills.sort(key=lambda s: (s.category or "", s.display_name))
 
@@ -112,6 +124,52 @@ class SkillCatalogRepository:
 
         except ClientError as e:
             logger.error(f"Error listing skills: {e}")
+            raise
+
+    async def list_skills_by_owner(
+        self, owner_id: str, status: Optional[str] = None
+    ) -> List[SkillDefinition]:
+        """
+        List the skills authored by one owner, via the ``SkillOwnerIndex`` GSI.
+
+        This is the "list my skills" query for the user-authored tier — a
+        partition query, not a table scan, so it stays cheap as the catalog
+        grows. Passing ``"system"`` returns the admin catalog.
+
+        Args:
+            owner_id: Author identity (a user id, or ``"system"``)
+            status: Optional status filter (active, draft, disabled)
+
+        Returns:
+            List of SkillDefinition objects, sorted by display name
+        """
+        try:
+            key_condition = Key("GSI4PK").eq(f"OWNER#{owner_id}")
+
+            response = self._table.query(
+                IndexName=SKILL_OWNER_INDEX,
+                KeyConditionExpression=key_condition,
+            )
+            items = response.get("Items", [])
+
+            while "LastEvaluatedKey" in response:
+                response = self._table.query(
+                    IndexName=SKILL_OWNER_INDEX,
+                    KeyConditionExpression=key_condition,
+                    ExclusiveStartKey=response["LastEvaluatedKey"],
+                )
+                items.extend(response.get("Items", []))
+
+            skills = [SkillDefinition.from_dynamo_item(item) for item in items]
+
+            if status:
+                skills = [s for s in skills if s.status == status]
+
+            skills.sort(key=lambda s: s.display_name.lower())
+            return skills
+
+        except ClientError as e:
+            logger.error(f"Error listing skills for owner {owner_id}: {e}")
             raise
 
     async def create_skill(self, skill: SkillDefinition) -> SkillDefinition:

--- a/backend/tests/apis/app_api/skills/conftest.py
+++ b/backend/tests/apis/app_api/skills/conftest.py
@@ -122,6 +122,41 @@ def skill_service(app_roles_table, skill_resource_store):
 
 
 @pytest.fixture()
+def user_skill_service(skill_service):
+    """UserSkillService sharing the moto-backed catalog service + repository."""
+    from apis.app_api.skills.user_service import UserSkillService
+
+    return UserSkillService(
+        repository=skill_service.repository,
+        catalog_service=skill_service,
+    )
+
+
+@pytest.fixture()
+def author_user() -> User:
+    """A plain (non-admin) user who authors their own skills."""
+    return User(
+        user_id="user-author",
+        email="author@example.com",
+        name="Author",
+        roles=["user"],
+        raw_token="test-token",
+    )
+
+
+@pytest.fixture()
+def other_user() -> User:
+    """A second plain user — used to prove owner isolation."""
+    return User(
+        user_id="user-other",
+        email="other@example.com",
+        name="Other",
+        roles=["user"],
+        raw_token="test-token",
+    )
+
+
+@pytest.fixture()
 def admin_user() -> User:
     return User(
         user_id="admin-1",

--- a/backend/tests/apis/app_api/skills/test_my_skill_routes.py
+++ b/backend/tests/apis/app_api/skills/test_my_skill_routes.py
@@ -1,0 +1,170 @@
+"""HTTP surface of the My Skills routes (Skills v2 PR-3).
+
+Asserts the contract the SPA depends on: camelCase DTOs, session-cookie auth
+(never Bearer-only), and the status mapping for the owner-scoped errors.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.skills import routes as skill_routes
+from apis.shared.auth import get_current_user_from_session
+
+
+@pytest.fixture()
+def client(user_skill_service, author_user, monkeypatch):
+    monkeypatch.setattr(
+        skill_routes, "get_user_skill_service", lambda: user_skill_service
+    )
+    app = FastAPI()
+    app.include_router(skill_routes.router)
+    app.dependency_overrides[get_current_user_from_session] = lambda: author_user
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def other_client(user_skill_service, other_user, monkeypatch):
+    """Same app, authenticated as a different user."""
+    monkeypatch.setattr(
+        skill_routes, "get_user_skill_service", lambda: user_skill_service
+    )
+    app = FastAPI()
+    app.include_router(skill_routes.router)
+    app.dependency_overrides[get_current_user_from_session] = lambda: other_user
+    with TestClient(app) as c:
+        yield c
+
+
+def test_my_skills_routes_use_session_auth_not_bearer():
+    """A Bearer-only dependency here would 401-loop the cookie-bearing SPA."""
+    paths = [
+        r
+        for r in skill_routes.router.routes
+        if getattr(r, "path", "").startswith("/skills/mine")
+    ]
+    assert paths, "expected /mine routes to be registered"
+
+    for route in paths:
+        deps = [d.call for d in route.dependant.dependencies]
+        assert get_current_user_from_session in deps, route.path
+
+
+def test_create_list_get_roundtrip(client):
+    created = client.post(
+        "/skills/mine",
+        json={
+            "displayName": "Grant Writing",
+            "description": "How we write grant narratives.",
+            "instructions": "Start with the abstract.",
+        },
+    )
+    assert created.status_code == 200
+    body = created.json()
+    assert body["skillId"] == "grant_writing"
+    assert body["displayName"] == "Grant Writing"
+
+    listed = client.get("/skills/mine")
+    assert listed.status_code == 200
+    assert listed.json()["totalCount"] == 1
+    assert listed.json()["skills"][0]["skillId"] == "grant_writing"
+
+    fetched = client.get("/skills/mine/grant_writing")
+    assert fetched.status_code == 200
+    assert fetched.json()["instructions"] == "Start with the abstract."
+
+
+def test_create_rejects_a_blank_description(client):
+    resp = client.post(
+        "/skills/mine", json={"displayName": "Named", "description": "   "}
+    )
+    assert resp.status_code == 400
+
+
+def test_update_and_delete(client):
+    client.post(
+        "/skills/mine", json={"displayName": "Notes", "description": "Old."}
+    )
+
+    updated = client.put("/skills/mine/notes", json={"description": "New."})
+    assert updated.status_code == 200
+    assert updated.json()["description"] == "New."
+
+    deleted = client.delete("/skills/mine/notes")
+    assert deleted.status_code == 200
+    assert client.get("/skills/mine/notes").status_code == 404
+
+
+def test_update_cannot_rehome_ownership(client, user_skill_service, author_user):
+    """``ownerId``/``visibility`` are absent from the DTO, so they're ignored."""
+    client.post("/skills/mine", json={"displayName": "Notes", "description": "d"})
+
+    resp = client.put(
+        "/skills/mine/notes",
+        json={"description": "d2", "ownerId": "system", "visibility": "admin"},
+    )
+    assert resp.status_code == 200
+
+    stored = client.get("/skills/mine/notes")
+    assert stored.status_code == 200
+    # Still owned by the author — proven by it still being reachable as theirs.
+    mine = client.get("/skills/mine").json()
+    assert [s["skillId"] for s in mine["skills"]] == ["notes"]
+
+
+def test_another_users_skill_is_404_everywhere(client, other_client):
+    client.post("/skills/mine", json={"displayName": "Notes", "description": "d"})
+
+    assert other_client.get("/skills/mine/notes").status_code == 404
+    assert other_client.put("/skills/mine/notes", json={"description": "x"}).status_code == 404
+    assert other_client.delete("/skills/mine/notes").status_code == 404
+    assert other_client.get("/skills/mine/notes/resources").status_code == 404
+    assert other_client.get("/skills/mine").json()["totalCount"] == 0
+
+
+def test_resource_upload_read_and_delete(client):
+    client.post("/skills/mine", json={"displayName": "Notes", "description": "d"})
+
+    uploaded = client.post(
+        "/skills/mine/notes/resources",
+        files={"file": ("forms.md", b"# Forms", "text/markdown")},
+    )
+    assert uploaded.status_code == 200
+    refs = uploaded.json()["resources"]
+    assert refs[0]["filename"] == "forms.md"
+    assert refs[0]["s3Key"] == "skills/notes/references/forms.md"
+
+    read = client.get("/skills/mine/notes/resources/forms.md")
+    assert read.status_code == 200
+    assert read.content == b"# Forms"
+
+    removed = client.delete("/skills/mine/notes/resources/forms.md")
+    assert removed.status_code == 200
+    assert removed.json()["resources"] == []
+
+
+def test_script_uploads_are_accepted_and_stored_inert(client):
+    client.post("/skills/mine", json={"displayName": "Notes", "description": "d"})
+
+    uploaded = client.post(
+        "/skills/mine/notes/resources",
+        files={"file": ("build.py", b"print(1)", "text/x-python")},
+        data={"kind": "script"},
+    )
+
+    assert uploaded.status_code == 200
+    ref = uploaded.json()["resources"][0]
+    assert ref["kind"] == "script"
+    assert ref["s3Key"] == "skills/notes/scripts/build.py"
+
+
+def test_resource_upload_rejects_a_traversal_filename(client):
+    client.post("/skills/mine", json={"displayName": "Notes", "description": "d"})
+
+    resp = client.post(
+        "/skills/mine/notes/resources",
+        files={"file": ("../../etc/passwd", b"x", "text/plain")},
+    )
+
+    assert resp.status_code == 400

--- a/backend/tests/apis/app_api/skills/test_user_skill_service.py
+++ b/backend/tests/apis/app_api/skills/test_user_skill_service.py
@@ -1,0 +1,376 @@
+"""UserSkillService — the owner-scoped user-authored tier (Skills v2 PR-3).
+
+Covers the two things that make this tier safe: ids are allocated server-side
+without ever colliding across tiers, and ownership is checked on every path.
+"""
+
+import pytest
+
+from apis.app_api.skills.user_service import (
+    MAX_SKILLS_PER_USER,
+    UserSkillError,
+    UserSkillLimitError,
+    UserSkillNotFoundError,
+    slugify_skill_id,
+)
+from apis.shared.skills.models import (
+    SYSTEM_OWNER_ID,
+    SkillDefinition,
+    SkillStatus,
+    SkillVisibility,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# slugify_skill_id
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "display_name,expected",
+    [
+        ("Docx", "docx"),
+        ("PDF Workflows", "pdf_workflows"),
+        ("  Grant   Writing!  ", "grant_writing"),
+        ("Weekly-Report/Builder", "weekly_report_builder"),
+        # Pattern demands a leading letter, so a digit-led name gets a prefix
+        # rather than a truncation that would change its meaning.
+        ("3D Modeling", "skill_3d_modeling"),
+        # Non-Latin script slugifies to nothing usable → the fallback stem.
+        ("日本語", "skill"),
+        ("", "skill"),
+        # Minimum length is 3.
+        ("Q", "q_x"),
+    ],
+)
+def test_slugify_skill_id_shapes(display_name, expected):
+    assert slugify_skill_id(display_name) == expected
+
+
+def test_slugify_skill_id_always_matches_the_id_pattern():
+    import re
+
+    from apis.shared.skills.models import SKILL_ID_PATTERN
+
+    names = ["Docx", "3D", "日本語", "", "Q", "A" * 200, "--- ??? ---"]
+    for name in names:
+        assert re.match(SKILL_ID_PATTERN, slugify_skill_id(name)), name
+
+
+# =============================================================================
+# create
+# =============================================================================
+
+
+async def test_create_allocates_id_and_stamps_ownership(
+    user_skill_service, author_user
+):
+    skill = await user_skill_service.create_my_skill(
+        author_user,
+        display_name="Grant Writing",
+        description="How we write grant narratives.",
+        instructions="# Grant Writing\n\nStart with the abstract.",
+    )
+
+    assert skill.skill_id == "grant_writing"
+    assert skill.owner_id == author_user.user_id
+    assert skill.visibility == SkillVisibility.PRIVATE
+    assert skill.status == SkillStatus.ACTIVE
+    assert skill.created_by == author_user.user_id
+
+
+async def test_create_suffixes_around_a_catalog_collision(
+    user_skill_service, skill_service, admin_user, author_user
+):
+    """A user naming their skill after a catalog skill succeeds, suffixed.
+
+    Rejecting with a 409 would also disclose the existence of a catalog skill
+    the user may not be granted.
+    """
+    await skill_service.create_skill(
+        SkillDefinition(
+            skill_id="docx",
+            display_name="Docx",
+            description="Admin catalog docx skill.",
+            instructions="body",
+        ),
+        admin_user,
+    )
+
+    mine = await user_skill_service.create_my_skill(
+        author_user, display_name="Docx", description="My own docx notes."
+    )
+
+    assert mine.skill_id == "docx_2"
+    assert mine.owner_id == author_user.user_id
+
+
+async def test_create_suffixes_around_another_users_skill(
+    user_skill_service, author_user, other_user
+):
+    first = await user_skill_service.create_my_skill(
+        author_user, display_name="Docx", description="Mine."
+    )
+    second = await user_skill_service.create_my_skill(
+        other_user, display_name="Docx", description="Theirs."
+    )
+
+    assert first.skill_id == "docx"
+    assert second.skill_id == "docx_2"
+
+
+async def test_create_requires_name_and_description(user_skill_service, author_user):
+    with pytest.raises(UserSkillError):
+        await user_skill_service.create_my_skill(
+            author_user, display_name="   ", description="Has a description."
+        )
+    with pytest.raises(UserSkillError):
+        await user_skill_service.create_my_skill(
+            author_user, display_name="Named", description="  "
+        )
+
+
+async def test_create_enforces_the_per_user_cap(
+    user_skill_service, author_user, monkeypatch
+):
+    monkeypatch.setattr(
+        "apis.app_api.skills.user_service.MAX_SKILLS_PER_USER", 2, raising=False
+    )
+    # The service reads the module-level constant at call time.
+    import apis.app_api.skills.user_service as mod
+
+    monkeypatch.setattr(mod, "MAX_SKILLS_PER_USER", 2)
+
+    await user_skill_service.create_my_skill(
+        author_user, display_name="One", description="d"
+    )
+    await user_skill_service.create_my_skill(
+        author_user, display_name="Two", description="d"
+    )
+
+    with pytest.raises(UserSkillLimitError):
+        await user_skill_service.create_my_skill(
+            author_user, display_name="Three", description="d"
+        )
+
+    assert MAX_SKILLS_PER_USER == 50  # the shipped default is unchanged
+
+
+# =============================================================================
+# ownership isolation
+# =============================================================================
+
+
+async def test_list_my_skills_returns_only_own(
+    user_skill_service, skill_service, admin_user, author_user, other_user
+):
+    await user_skill_service.create_my_skill(
+        author_user, display_name="Mine A", description="d"
+    )
+    await user_skill_service.create_my_skill(
+        author_user, display_name="Mine B", description="d"
+    )
+    await user_skill_service.create_my_skill(
+        other_user, display_name="Theirs", description="d"
+    )
+    await skill_service.create_skill(
+        SkillDefinition(
+            skill_id="catalog_one",
+            display_name="Catalog",
+            description="d",
+            instructions="",
+        ),
+        admin_user,
+    )
+
+    mine = await user_skill_service.list_my_skills(author_user)
+
+    assert [s.display_name for s in mine] == ["Mine A", "Mine B"]
+
+
+async def test_another_users_skill_is_not_found_not_forbidden(
+    user_skill_service, author_user, other_user
+):
+    """404, not 403 — this surface never confirms someone else's skill exists."""
+    theirs = await user_skill_service.create_my_skill(
+        other_user, display_name="Theirs", description="d"
+    )
+
+    with pytest.raises(UserSkillNotFoundError):
+        await user_skill_service.get_my_skill(theirs.skill_id, author_user)
+    with pytest.raises(UserSkillNotFoundError):
+        await user_skill_service.update_my_skill(
+            theirs.skill_id, {"description": "hijacked"}, author_user
+        )
+    with pytest.raises(UserSkillNotFoundError):
+        await user_skill_service.delete_my_skill(theirs.skill_id, author_user)
+
+
+async def test_catalog_skills_are_not_editable_through_the_user_tier(
+    user_skill_service, skill_service, admin_user, author_user
+):
+    await skill_service.create_skill(
+        SkillDefinition(
+            skill_id="catalog_one",
+            display_name="Catalog",
+            description="d",
+            instructions="",
+        ),
+        admin_user,
+    )
+
+    with pytest.raises(UserSkillNotFoundError):
+        await user_skill_service.update_my_skill(
+            "catalog_one", {"instructions": "hijacked"}, author_user
+        )
+
+
+# =============================================================================
+# update / delete
+# =============================================================================
+
+
+async def test_update_writes_authored_fields(user_skill_service, author_user):
+    skill = await user_skill_service.create_my_skill(
+        author_user, display_name="Notes", description="Old."
+    )
+
+    updated = await user_skill_service.update_my_skill(
+        skill.skill_id,
+        {"description": "New.", "instructions": "# Notes", "allowed_tools": ["web"]},
+        author_user,
+    )
+
+    assert updated.description == "New."
+    assert updated.instructions == "# Notes"
+    assert updated.allowed_tools == ["web"]
+    # Ownership is untouched by an update.
+    assert updated.owner_id == author_user.user_id
+    assert updated.visibility == SkillVisibility.PRIVATE
+
+
+async def test_delete_is_hard_and_purges_bundle_objects(
+    user_skill_service, skill_resource_store, author_user
+):
+    skill = await user_skill_service.create_my_skill(
+        author_user, display_name="Notes", description="d"
+    )
+    refs = await user_skill_service.add_resource(
+        skill.skill_id, "forms.md", b"# Forms", "text/markdown", author_user
+    )
+    s3_key = refs[0].s3_key
+    assert skill_resource_store.get(s3_key) == b"# Forms"
+
+    await user_skill_service.delete_my_skill(skill.skill_id, author_user)
+
+    assert await user_skill_service.repository.get_skill(skill.skill_id) is None
+    from apis.shared.skills.resource_store import SkillResourceStoreError
+
+    with pytest.raises(SkillResourceStoreError):
+        skill_resource_store.get(s3_key)
+
+
+# =============================================================================
+# bundle files
+# =============================================================================
+
+
+async def test_resources_land_in_the_standard_bundle_layout(
+    user_skill_service, author_user
+):
+    skill = await user_skill_service.create_my_skill(
+        author_user, display_name="Notes", description="d"
+    )
+
+    await user_skill_service.add_resource(
+        skill.skill_id, "forms.md", b"# Forms", "text/markdown", author_user
+    )
+    refs = await user_skill_service.add_resource(
+        skill.skill_id, "build.py", b"print(1)", "text/x-python", author_user,
+        kind="script",
+    )
+
+    by_name = {r.filename: r for r in refs}
+    assert by_name["forms.md"].s3_key == f"skills/{skill.skill_id}/references/forms.md"
+    assert by_name["build.py"].s3_key == f"skills/{skill.skill_id}/scripts/build.py"
+    assert by_name["build.py"].kind == "script"
+
+
+async def test_resource_routes_enforce_ownership(
+    user_skill_service, author_user, other_user
+):
+    skill = await user_skill_service.create_my_skill(
+        author_user, display_name="Notes", description="d"
+    )
+    await user_skill_service.add_resource(
+        skill.skill_id, "forms.md", b"# Forms", "text/markdown", author_user
+    )
+
+    for call in (
+        user_skill_service.list_resources(skill.skill_id, other_user),
+        user_skill_service.read_resource(skill.skill_id, "forms.md", other_user),
+        user_skill_service.delete_resource(skill.skill_id, "forms.md", other_user),
+    ):
+        with pytest.raises(UserSkillNotFoundError):
+            await call
+
+
+async def test_skill_md_projection_is_written_for_user_skills(
+    user_skill_service, skill_resource_store, author_user
+):
+    """A user skill's S3 prefix must be a valid, portable agentskills.io bundle."""
+    skill = await user_skill_service.create_my_skill(
+        author_user,
+        display_name="Grant Writing",
+        description="How we write grant narratives.",
+        instructions="Start with the abstract.",
+    )
+
+    content = skill_resource_store.get(f"skills/{skill.skill_id}/SKILL.md").decode()
+
+    assert content.startswith("---")
+    assert "How we write grant narratives." in content
+    assert "Start with the abstract." in content
+
+
+# =============================================================================
+# tier boundaries
+# =============================================================================
+
+
+async def test_admin_catalog_list_excludes_user_skills(
+    user_skill_service, skill_service, admin_user, author_user
+):
+    await skill_service.create_skill(
+        SkillDefinition(
+            skill_id="catalog_one",
+            display_name="Catalog",
+            description="d",
+            instructions="",
+        ),
+        admin_user,
+    )
+    await user_skill_service.create_my_skill(
+        author_user, display_name="Mine", description="d"
+    )
+
+    catalog = await skill_service.get_all_skills(include_roles=False)
+
+    assert [s.skill_id for s in catalog] == ["catalog_one"]
+    assert all(s.owner_id == SYSTEM_OWNER_ID for s in catalog)
+
+
+async def test_user_skills_cannot_be_granted_to_app_roles(
+    user_skill_service, skill_service, admin_user, author_user
+):
+    """Granting a private user skill to a role would leak it to that role."""
+    mine = await user_skill_service.create_my_skill(
+        author_user, display_name="Mine", description="d"
+    )
+
+    with pytest.raises(ValueError, match="user-authored"):
+        await skill_service.set_roles_for_skill(mine.skill_id, ["some_role"], admin_user)
+    with pytest.raises(ValueError, match="user-authored"):
+        await skill_service.add_roles_to_skill(mine.skill_id, ["some_role"], admin_user)

--- a/backend/tests/shared/test_skills_access.py
+++ b/backend/tests/shared/test_skills_access.py
@@ -53,3 +53,65 @@ class TestResolveAccessibleSkillIds:
         ):
             result = await resolve_accessible_skill_ids(_user())
         assert result == []
+
+
+def _owned(*skill_ids):
+    """Patch the owner-index query to return skills with these ids."""
+    records = [MagicMock(skill_id=sid) for sid in skill_ids]
+    repo = MagicMock()
+    repo.list_skills_by_owner = AsyncMock(return_value=records)
+    return patch(
+        "apis.shared.skills.repository.get_skill_catalog_repository",
+        return_value=repo,
+    )
+
+
+class TestOwnedSkillUnion:
+    """Ownership is its own grant — a user always reaches skills they authored."""
+
+    async def test_owned_skills_are_unioned_onto_catalog_grants(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(return_value=["pdf_workflows"])
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ), _owned("my_notes"):
+            result = await resolve_accessible_skill_ids(_user())
+
+        assert result == ["pdf_workflows", "my_notes"]
+
+    async def test_owned_skills_reach_a_user_with_no_role_grants(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(return_value=[])
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ), _owned("my_notes"):
+            result = await resolve_accessible_skill_ids(_user())
+
+        assert result == ["my_notes"]
+
+    async def test_a_skill_both_granted_and_owned_appears_once(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(return_value=["my_notes"])
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ), _owned("my_notes"):
+            result = await resolve_accessible_skill_ids(_user())
+
+        assert result == ["my_notes"]
+
+    async def test_owner_lookup_failure_still_yields_catalog_grants(self):
+        role_service = MagicMock()
+        role_service.get_accessible_skills = AsyncMock(return_value=["pdf_workflows"])
+        with patch(
+            "apis.shared.rbac.service.get_app_role_service",
+            return_value=role_service,
+        ), patch(
+            "apis.shared.skills.repository.get_skill_catalog_repository",
+            side_effect=RuntimeError("dynamo down"),
+        ):
+            result = await resolve_accessible_skill_ids(_user())
+
+        assert result == ["pdf_workflows"]

--- a/backend/tests/shared/test_skills_repository.py
+++ b/backend/tests/shared/test_skills_repository.py
@@ -48,6 +48,54 @@ class TestSkillCatalogRepository:
         assert {s.skill_id for s in skills} == {"skill_one", "skill_two"}
 
     @pytest.mark.asyncio
+    async def test_list_skills_filters_by_owner(self, skill_repository):
+        await skill_repository.create_skill(_make_skill("catalog_one"))
+        await skill_repository.create_skill(_make_skill("mine", owner_id="user-1"))
+
+        catalog = await skill_repository.list_skills(owner_id="system")
+        mine = await skill_repository.list_skills(owner_id="user-1")
+
+        assert {s.skill_id for s in catalog} == {"catalog_one"}
+        assert {s.skill_id for s in mine} == {"mine"}
+
+    @pytest.mark.asyncio
+    async def test_list_skills_by_owner_uses_the_owner_index(self, skill_repository):
+        """GSI4 partition query — the 'list my skills' path for the user tier."""
+        await skill_repository.create_skill(_make_skill("catalog_one"))
+        await skill_repository.create_skill(
+            _make_skill("mine_b", display_name="Bravo", owner_id="user-1")
+        )
+        await skill_repository.create_skill(
+            _make_skill("mine_a", display_name="Alpha", owner_id="user-1")
+        )
+        await skill_repository.create_skill(_make_skill("theirs", owner_id="user-2"))
+
+        mine = await skill_repository.list_skills_by_owner("user-1")
+
+        # Sorted by display name, and scoped strictly to that owner.
+        assert [s.skill_id for s in mine] == ["mine_a", "mine_b"]
+
+    @pytest.mark.asyncio
+    async def test_list_skills_by_owner_filters_status(self, skill_repository):
+        await skill_repository.create_skill(_make_skill("active_one", owner_id="user-1"))
+        await skill_repository.create_skill(
+            _make_skill("draft_one", owner_id="user-1", status=SkillStatus.DRAFT)
+        )
+
+        active = await skill_repository.list_skills_by_owner(
+            "user-1", status=SkillStatus.ACTIVE.value
+        )
+
+        assert [s.skill_id for s in active] == ["active_one"]
+
+    @pytest.mark.asyncio
+    async def test_list_skills_by_owner_is_empty_for_an_unknown_owner(
+        self, skill_repository
+    ):
+        await skill_repository.create_skill(_make_skill("catalog_one"))
+        assert await skill_repository.list_skills_by_owner("nobody") == []
+
+    @pytest.mark.asyncio
     async def test_list_does_not_pick_up_other_pk_items(
         self, skill_repository, role_repository
     ):

--- a/backend/tests/test_backfill_skill_bundles.py
+++ b/backend/tests/test_backfill_skill_bundles.py
@@ -1,0 +1,257 @@
+"""Tests for the skill-bundle backfill script (Skills v2 PR-3 follow-up).
+
+The script's job is to make a v1 skill's S3 prefix a valid agentskills.io
+bundle: a ``SKILL.md`` projection plus resources in the standard directory
+layout, with the manifest pointing at the new keys.
+"""
+
+import os
+import sys
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from backfill_skill_bundles import (  # noqa: E402
+    is_legacy_key,
+    migrate_resources,
+    scan_skills,
+    write_projection,
+)
+
+REGION = "us-east-1"
+TABLE = "test-app-roles"
+BUCKET = "test-skill-resources"
+
+LEGACY_HASH = "1b6af35536890b2d21fbe1be58b2155d869f20a73acec0d16afeee71dda3fd92"
+LEGACY_KEY = f"skills/web_research/{LEGACY_HASH}"
+STANDARD_KEY = "skills/web_research/references/extraction_tips.md"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def table(aws):
+    ddb = boto3.client("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+@pytest.fixture()
+def s3(aws):
+    client = boto3.client("s3", region_name=REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+def _legacy_row():
+    return {
+        "PK": "SKILL#web_research",
+        "SK": "METADATA",
+        "skillId": "web_research",
+        "displayName": "Web Research Assistant",
+        "description": "Research a topic and produce citable notes.",
+        "instructions": "# Web Research Assistant\n\nFetch, extract, cite.",
+        "resources": [
+            {
+                "filename": "extraction_tips.md",
+                "contentHash": LEGACY_HASH,
+                "size": 824,
+                "contentType": "text/markdown",
+                "s3Key": LEGACY_KEY,
+                # NB: no `kind` — v1 rows predate the field.
+            }
+        ],
+    }
+
+
+# =============================================================================
+# is_legacy_key
+# =============================================================================
+
+
+def test_content_hash_keys_are_legacy():
+    assert is_legacy_key(LEGACY_KEY, "web_research") is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "skills/web_research/references/extraction_tips.md",
+        "skills/web_research/scripts/build.py",
+        "skills/web_research/assets/logo.png",
+    ],
+)
+def test_standard_layout_keys_are_not_legacy(key):
+    assert is_legacy_key(key, "web_research") is False
+
+
+def test_unrecognized_prefix_is_treated_as_legacy():
+    """A key from another skill's prefix gets normalized rather than trusted."""
+    assert is_legacy_key("skills/other/refs/x.md", "web_research") is True
+
+
+# =============================================================================
+# migrate_resources
+# =============================================================================
+
+
+def test_dry_run_touches_nothing(s3):
+    s3.put_object(Bucket=BUCKET, Key=LEGACY_KEY, Body=b"# Tips")
+
+    migrated, moved = migrate_resources(
+        s3, BUCKET, "web_research", _legacy_row()["resources"],
+        apply=False, delete_legacy=False,
+    )
+
+    assert moved == 1
+    assert migrated[0]["s3Key"] == STANDARD_KEY  # what *would* be written
+    # ...but S3 is untouched.
+    listing = s3.list_objects_v2(Bucket=BUCKET).get("Contents", [])
+    assert [o["Key"] for o in listing] == [LEGACY_KEY]
+
+
+def test_apply_copies_into_the_standard_layout(s3):
+    s3.put_object(Bucket=BUCKET, Key=LEGACY_KEY, Body=b"# Tips")
+
+    migrated, moved = migrate_resources(
+        s3, BUCKET, "web_research", _legacy_row()["resources"],
+        apply=True, delete_legacy=False,
+    )
+
+    assert moved == 1
+    assert migrated[0]["s3Key"] == STANDARD_KEY
+    assert migrated[0]["kind"] == "reference"
+    assert s3.get_object(Bucket=BUCKET, Key=STANDARD_KEY)["Body"].read() == b"# Tips"
+    # Legacy object survives by default — the copy is non-destructive.
+    assert s3.head_object(Bucket=BUCKET, Key=LEGACY_KEY)
+
+
+def test_delete_legacy_removes_the_old_object(s3):
+    s3.put_object(Bucket=BUCKET, Key=LEGACY_KEY, Body=b"# Tips")
+
+    migrate_resources(
+        s3, BUCKET, "web_research", _legacy_row()["resources"],
+        apply=True, delete_legacy=True,
+    )
+
+    assert s3.get_object(Bucket=BUCKET, Key=STANDARD_KEY)["Body"].read() == b"# Tips"
+    with pytest.raises(s3.exceptions.ClientError):
+        s3.head_object(Bucket=BUCKET, Key=LEGACY_KEY)
+
+
+def test_missing_legacy_object_leaves_the_manifest_alone(s3):
+    """Rewriting a key to bytes that don't exist would be a lie."""
+    migrated, moved = migrate_resources(
+        s3, BUCKET, "web_research", _legacy_row()["resources"],
+        apply=True, delete_legacy=False,
+    )
+
+    assert moved == 0
+    assert migrated[0]["s3Key"] == LEGACY_KEY
+
+
+def test_is_idempotent(s3):
+    s3.put_object(Bucket=BUCKET, Key=LEGACY_KEY, Body=b"# Tips")
+
+    once, _ = migrate_resources(
+        s3, BUCKET, "web_research", _legacy_row()["resources"],
+        apply=True, delete_legacy=True,
+    )
+    twice, moved_again = migrate_resources(
+        s3, BUCKET, "web_research", once, apply=True, delete_legacy=True,
+    )
+
+    assert moved_again == 0
+    assert twice == once
+
+
+# =============================================================================
+# write_projection
+# =============================================================================
+
+
+def test_projection_is_a_valid_bundle_head(s3):
+    write_projection(s3, BUCKET, _legacy_row(), apply=True)
+
+    body = s3.get_object(Bucket=BUCKET, Key="skills/web_research/SKILL.md")[
+        "Body"
+    ].read().decode()
+
+    assert body.startswith("---")
+    assert "name: web-research" in body
+    assert "Research a topic and produce citable notes." in body
+    assert "Fetch, extract, cite." in body
+
+
+def test_projection_carries_frontmatter_passthrough(s3):
+    row = _legacy_row()
+    row["allowedTools"] = ["fetch_url_content"]
+    row["skillMetadata"] = {"license": "MIT"}
+
+    write_projection(s3, BUCKET, row, apply=True)
+    body = s3.get_object(Bucket=BUCKET, Key="skills/web_research/SKILL.md")[
+        "Body"
+    ].read().decode()
+
+    assert "fetch_url_content" in body
+    assert "license: MIT" in body
+
+
+def test_projection_dry_run_writes_nothing(s3):
+    write_projection(s3, BUCKET, _legacy_row(), apply=False)
+
+    assert s3.list_objects_v2(Bucket=BUCKET).get("Contents", []) == []
+
+
+# =============================================================================
+# scan_skills
+# =============================================================================
+
+
+def test_scan_can_target_one_skill(table):
+    table.put_item(Item=_legacy_row())
+    table.put_item(
+        Item={
+            "PK": "SKILL#other",
+            "SK": "METADATA",
+            "skillId": "other",
+            "description": "d",
+            "instructions": "i",
+        }
+    )
+
+    assert [r["skillId"] for r in scan_skills(table, "web_research")] == ["web_research"]
+    assert len(scan_skills(table, None)) == 2
+
+
+def test_scan_ignores_non_skill_rows(table):
+    table.put_item(Item=_legacy_row())
+    table.put_item(Item={"PK": "ROLE#admin", "SK": "METADATA", "roleId": "admin"})
+
+    assert [r["skillId"] for r in scan_skills(table, None)] == ["web_research"]
+
+
+def test_scan_returns_empty_for_a_missing_skill(table):
+    assert scan_skills(table, "nope") == []

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -319,7 +319,43 @@ class TestSeedExampleSkills:
         assert len(item["resources"]) == 1
         ref = item["resources"][0]
         assert ref["filename"] == "extraction_tips.md"
-        assert ref["s3Key"].startswith(f"skills/{EXAMPLE_SKILL_ID}/")
-        # Bytes really landed in S3 at the content-addressed key.
+        # Standard agentskills.io bundle layout, not the v1 content-hash key —
+        # a seeded prefix must be a portable bundle on day one (Skills v2).
+        assert ref["s3Key"] == f"skills/{EXAMPLE_SKILL_ID}/references/extraction_tips.md"
+        assert ref["kind"] == "reference"
         body = s3.get_object(Bucket=bucket, Key=ref["s3Key"])["Body"].read()
         assert b"Extraction Tips" in body
+
+    def test_writes_the_skill_md_projection(self, dynamodb_table, monkeypatch):
+        """The seeded prefix must be a valid bundle, not just loose bytes.
+
+        Without SKILL.md the prefix cannot be handed to a managed Harness
+        (``{"s3": {"uri": ...}}``) or exported as-is.
+        """
+        bucket = "test-skill-resources"
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=bucket)
+        monkeypatch.setenv("S3_SKILL_RESOURCES_BUCKET_NAME", bucket)
+        seed_default_role(TABLE_NAME, REGION)
+
+        seed_example_skills(TABLE_NAME, REGION)
+
+        body = s3.get_object(
+            Bucket=bucket, Key=f"skills/{EXAMPLE_SKILL_ID}/SKILL.md"
+        )["Body"].read().decode()
+
+        assert body.startswith("---")
+        assert "name: web-research" in body
+        assert "Fetch web pages and turn them into accurate, citable notes." in body
+        assert "# Web Research Assistant" in body
+
+    def test_seeded_instructions_name_no_retired_v1_tools(self):
+        """The v1 disclosure meta-tools were deleted in Skills v2 PR-1/PR-2.
+
+        Seed prose naming them would tell the model to call tools that no
+        longer exist — the exact drift that stranded dev's row.
+        """
+        from seed_bootstrap_data import EXAMPLE_SKILL_INSTRUCTIONS
+
+        assert "skill_executor" not in EXAMPLE_SKILL_INSTRUCTIONS
+        assert "skill_dispatcher" not in EXAMPLE_SKILL_INSTRUCTIONS

--- a/docs/specs/skills-as-agent-primitive.md
+++ b/docs/specs/skills-as-agent-primitive.md
@@ -319,8 +319,26 @@ access can use this agent's skills and knowledge."*
   `skill_registry` / `skill_tools` retired (`"skill"` is now a ChatAgent alias);
   agentskills.io S3 bundle layout + `SKILL.md` write-through projection;
   `allowed_tools`/`skill_metadata` + resource `kind` on the model.
-- **PR-3 — User-authored tier.** Owner-scoped `/skills` CRUD + upload routes
-  (session auth), GSI4 list-my-skills, My Skills page.
+- **PR-3 — User-authored tier. ✅ DONE** (branch `feature/skills-v2-user-tier`).
+  Owner-scoped `/skills/mine` CRUD + bundle-upload routes (session auth),
+  `list_skills_by_owner` over GSI4, `UserSkillService` (ownership resolved on
+  every path; a skill you don't own is 404, never 403), and the My Skills SPA
+  page (list + form, SKILL.md import prefill, reference/script/asset upload).
+  Two tier boundaries were closed along the way, both of which would have
+  leaked private skills:
+  1. `get_all_skill_ids` (the RBAC `"*"` wildcard expansion) now lists **only
+     catalog skills** — a wildcard grant must never sweep in other users'
+     authored skills.
+  2. The admin role-grant endpoints refuse a user-authored skill
+     (`_require_catalog_skill`), since granting one to an AppRole would hand a
+     private document to a whole role. The admin catalog list is likewise
+     scoped to `owner_id == "system"`.
+  `resolve_accessible_skill_ids` now returns **catalog ∪ own**, which is what
+  makes an authored skill reachable at runtime at all. Skill ids are allocated
+  server-side from the display name and suffixed on collision (`docx` →
+  `docx_2`), keeping ids globally unique — the runtime activation key is the
+  slugified id, so same-named skills in one turn would be ambiguous to the
+  model — without a 409 that would disclose an invisible skill's existence.
 - **PR-4 — Selection surfaces.** Chat opt-in picker; Designer palette union;
   invoke-through predicate in the binding resolver + `read_skill_file`;
   share-dialog copy.

--- a/frontend/ai.client/src/app/admin/skills/models/skill-import.util.spec.ts
+++ b/frontend/ai.client/src/app/admin/skills/models/skill-import.util.spec.ts
@@ -98,3 +98,55 @@ describe('isValidSkillId', () => {
     (id) => expect(isValidSkillId(id)).toBe(false)
   );
 });
+
+describe('parseSkillMarkdown — frontmatter passthrough (Skills v2 D2/D4)', () => {
+  it('carries non-reserved frontmatter into metadata', () => {
+    const parsed = parseSkillMarkdown(
+      ['---', 'name: Docx', 'description: Word docs.', 'license: MIT', 'version: 2.1', '---', '', 'Body.'].join('\n'),
+    );
+
+    expect(parsed.metadata).toEqual({ license: 'MIT', version: '2.1' });
+  });
+
+  it('excludes the reserved keys from metadata', () => {
+    const parsed = parseSkillMarkdown(
+      ['---', 'name: Docx', 'description: Word docs.', 'allowed-tools: Read', '---', '', 'Body.'].join('\n'),
+    );
+
+    expect(parsed.metadata).toEqual({});
+    expect(parsed.name).toBe('Docx');
+    expect(parsed.description).toBe('Word docs.');
+  });
+
+  it('splits a comma-separated allowed-tools scalar', () => {
+    const parsed = parseSkillMarkdown(
+      ['---', 'name: Docx', 'allowed-tools: Read, Write, Bash', '---', '', 'Body.'].join('\n'),
+    );
+
+    expect(parsed.allowedTools).toEqual(['Read', 'Write', 'Bash']);
+  });
+
+  it('splits an inline-array allowed-tools value', () => {
+    const parsed = parseSkillMarkdown(
+      ['---', 'name: Docx', 'allowed-tools: [Read, "Write"]', '---', '', 'Body.'].join('\n'),
+    );
+
+    expect(parsed.allowedTools).toEqual(['Read', 'Write']);
+  });
+
+  it('returns empty passthrough when there is no frontmatter', () => {
+    const parsed = parseSkillMarkdown('Just a body.');
+
+    expect(parsed.allowedTools).toEqual([]);
+    expect(parsed.metadata).toEqual({});
+    expect(parsed.instructions).toBe('Just a body.');
+  });
+
+  it('returns empty allowedTools when the key is absent', () => {
+    const parsed = parseSkillMarkdown(
+      ['---', 'name: Docx', '---', '', 'Body.'].join('\n'),
+    );
+
+    expect(parsed.allowedTools).toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/admin/skills/models/skill-import.util.ts
+++ b/frontend/ai.client/src/app/admin/skills/models/skill-import.util.ts
@@ -22,7 +22,27 @@ export interface ParsedSkillMarkdown {
   description: string;
   /** The markdown body after the frontmatter (→ instructions). */
   instructions: string;
+  /**
+   * Frontmatter `allowed-tools`, split into names. **Advisory only** — the
+   * platform never grants a tool because a skill names it (Skills v2 D1/D4).
+   * Empty when the key is absent.
+   */
+  allowedTools: string[];
+  /**
+   * Every other frontmatter key (license, compatibility, arbitrary keys),
+   * carried verbatim so an imported bundle round-trips (D2). `name`,
+   * `description` and `allowed-tools` are excluded — they have their own
+   * fields above, and the backend regenerates them into the SKILL.md
+   * projection.
+   */
+  metadata: Record<string, string>;
 }
+
+/**
+ * Frontmatter keys that map to first-class fields rather than metadata
+ * passthrough. Mirrors the backend `_RESERVED_METADATA_KEYS`.
+ */
+const RESERVED_KEYS = new Set(['name', 'description', 'allowed-tools', 'instructions']);
 
 /**
  * Parse a SKILL.md into prefill fields.
@@ -37,13 +57,46 @@ export function parseSkillMarkdown(text: string): ParsedSkillMarkdown {
   const normalized = text.replace(/\r\n/g, '\n');
   const fm = extractFrontmatter(normalized);
   if (!fm) {
-    return { name: '', description: '', instructions: normalized.trim() };
+    return {
+      name: '',
+      description: '',
+      instructions: normalized.trim(),
+      allowedTools: [],
+      metadata: {},
+    };
   }
+
+  const metadata: Record<string, string> = {};
+  for (const [key, value] of Object.entries(fm.fields)) {
+    if (!RESERVED_KEYS.has(key)) {
+      metadata[key] = value;
+    }
+  }
+
   return {
     name: fm.fields['name'] ?? '',
     description: fm.fields['description'] ?? '',
     instructions: fm.body.trim(),
+    allowedTools: parseToolList(fm.fields['allowed-tools'] ?? ''),
+    metadata,
   };
+}
+
+/**
+ * Split an `allowed-tools` frontmatter value into tool names.
+ *
+ * The ecosystem writes this either as a comma-separated scalar
+ * (`allowed-tools: Read, Write`) or as an inline YAML array
+ * (`allowed-tools: [Read, Write]`). Both collapse to the same list; a
+ * block-sequence form (one `- item` per line) is not a `key: value` scalar and
+ * so never reaches here.
+ */
+function parseToolList(value: string): string[] {
+  const inner = value.trim().replace(/^\[/, '').replace(/\]$/, '');
+  return inner
+    .split(',')
+    .map((tool) => stripQuotes(tool.trim()))
+    .filter((tool) => tool.length > 0);
 }
 
 interface Frontmatter {

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -80,6 +80,21 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'my-skills/new',
+        loadComponent: () => import('./my-skills/my-skill-form.page').then(m => m.MySkillFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'my-skills/:skillId/edit',
+        loadComponent: () => import('./my-skills/my-skill-form.page').then(m => m.MySkillFormPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'my-skills',
+        loadComponent: () => import('./my-skills/my-skills.page').then(m => m.MySkillsPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'memories',
         loadComponent: () => import('./memory/memory-dashboard.page').then(m => m.MemoryDashboardPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -62,6 +62,22 @@
                 <span class="ml-auto rounded-full bg-amber-100 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-amber-700 dark:bg-amber-400/15 dark:text-amber-300">Preview</span>
             </a>
         }
+
+        <!-- My Skills (user-authored skill bundles; hidden while SKILLS_ENABLED is off) -->
+        @if (showMySkills()) {
+            <a
+                routerLink="/my-skills"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">My Skills</span>
+            </a>
+        }
     </div>
 
     <nav class="flex-1 overflow-y-auto px-3 pb-4">

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -9,6 +9,7 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
+import { MySkillService } from '../../my-skills/services/my-skill.service';
 
 @Component({
   selector: 'app-sidenav',
@@ -22,6 +23,7 @@ export class Sidenav {
   private bffSession = inject(BffSessionService);
   private memorySpaceService = inject(MemorySpaceService);
   private agentService = inject(AgentService);
+  private mySkillService = inject(MySkillService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -59,6 +61,14 @@ export class Sidenav {
    */
   readonly showAgents = computed(() => this.agentService.accessible$() === true);
 
+  /**
+   * Whether to show the "My Skills" nav entry. Rides the authored-skills list
+   * the same way the two above ride theirs: the `/skills` router is only
+   * mounted when `SKILLS_ENABLED` is on, so a 404 flips `accessible$` false
+   * and the entry stays hidden. `null` (unresolved) also hides it.
+   */
+  readonly showMySkills = computed(() => this.mySkillService.accessible$() === true);
+
   constructor() {
     // Kick off the accessibility probes once the user is authenticated —
     // mirrors UserService's own permissions-fetch gating.
@@ -66,6 +76,7 @@ export class Sidenav {
       if (this.userService.currentUser()) {
         void this.memorySpaceService.loadSpaces();
         void this.agentService.loadAgents();
+        void this.mySkillService.loadSkills().catch(() => undefined);
       }
     });
   }

--- a/frontend/ai.client/src/app/my-skills/models/my-skill.model.ts
+++ b/frontend/ai.client/src/app/my-skills/models/my-skill.model.ts
@@ -1,0 +1,111 @@
+/**
+ * My Skills models — the TypeScript mirror of the backend
+ * `apis/app_api/skills/routes.py` My Skills DTOs (`MySkillResponse`,
+ * `CreateMySkillRequest`, `UpdateMySkillRequest`). Shapes must stay in sync
+ * with that module (CLAUDE.md cross-package contract).
+ *
+ * A skill here is a *pure knowledge bundle* in the agentskills.io format —
+ * instructions plus supporting files, no tool bindings (Skills v2 D1). Tools,
+ * models and knowledge bind on the Agent, never on a skill.
+ */
+
+import { SkillStatus } from '../../admin/skills/models/admin-skill.model';
+
+export type { SkillStatus };
+
+/**
+ * Which directory of the bundle a supporting file lives in. `script` files are
+ * accept-and-inert: stored and readable by the agent, never executed (D5).
+ */
+export type SkillResourceKind = 'reference' | 'script' | 'asset';
+
+/**
+ * Manifest entry for one supporting file. Bytes live in S3; this is the
+ * lightweight pointer carried on the skill row.
+ */
+export interface MySkillResourceRef {
+  filename: string;
+  contentHash: string;
+  size: number;
+  contentType: string;
+  s3Key: string;
+  kind: SkillResourceKind;
+}
+
+/**
+ * One skill the current user authored.
+ */
+export interface MySkill {
+  skillId: string;
+  displayName: string;
+  description: string;
+  instructions: string;
+  /** Advisory only — parsed from SKILL.md frontmatter, never enforced (D4). */
+  allowedTools: string[];
+  /** agentskills.io frontmatter passthrough (license, compatibility, ...). */
+  skillMetadata: Record<string, unknown>;
+  resources: MySkillResourceRef[];
+  status: SkillStatus;
+  category: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface MySkillListResponse {
+  skills: MySkill[];
+  totalCount: number;
+}
+
+export interface MySkillResourcesResponse {
+  skillId: string;
+  resources: MySkillResourceRef[];
+}
+
+/**
+ * Request body for POST /skills/mine. No `skillId` — the backend allocates one
+ * from the display name, so two users can both name a skill "Docx".
+ */
+export interface CreateMySkillRequest {
+  displayName: string;
+  description: string;
+  instructions?: string;
+  allowedTools?: string[];
+  skillMetadata?: Record<string, unknown>;
+  category?: string | null;
+}
+
+/**
+ * Request body for PUT /skills/mine/{id}. All fields optional (partial update).
+ */
+export interface UpdateMySkillRequest {
+  displayName?: string;
+  description?: string;
+  instructions?: string;
+  allowedTools?: string[];
+  skillMetadata?: Record<string, unknown>;
+  category?: string | null;
+  status?: SkillStatus;
+}
+
+/**
+ * Bundle directory labels, used for the upload picker and file list grouping.
+ */
+export const RESOURCE_KINDS: { value: SkillResourceKind; label: string; hint: string }[] = [
+  {
+    value: 'reference',
+    label: 'Reference',
+    hint: 'Markdown or text the agent can read on demand.',
+  },
+  {
+    value: 'script',
+    label: 'Script',
+    hint: 'Stored for reference — never executed on this platform.',
+  },
+  { value: 'asset', label: 'Asset', hint: 'Images, templates and other binaries.' },
+];
+
+/** Per-file upload ceiling, mirroring the backend `MAX_RESOURCE_BYTES`. */
+export const MAX_RESOURCE_BYTES = 1_048_576;
+
+/** Per-skill file ceiling, mirroring the backend `MAX_RESOURCES_PER_SKILL`. */
+export const MAX_RESOURCES_PER_SKILL = 50;

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
@@ -106,6 +106,26 @@
         </p>
       </div>
 
+      <!-- Advisory allowed-tools (D4: displayed, never enforced) -->
+      @if (allowedTools().length > 0) {
+        <div class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+          <h2 class="text-sm/6 font-medium text-gray-900 dark:text-white">Tools this skill mentions</h2>
+          <ul role="list" class="mt-2 flex flex-wrap gap-2">
+            @for (tool of allowedTools(); track tool) {
+              <li
+                class="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+              >
+                {{ tool }}
+              </li>
+            }
+          </ul>
+          <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-400">
+            Carried over from the imported bundle for reference. Skills never grant tools — the
+            agent you bind this to decides which tools are available.
+          </p>
+        </div>
+      }
+
       <!-- Supporting files -->
       <fieldset class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
         <legend class="px-1 text-sm/6 font-medium text-gray-900 dark:text-white">
@@ -192,8 +212,8 @@
               <li class="flex items-center justify-between gap-3 py-2">
                 <span class="min-w-0 text-sm/6 text-gray-900 dark:text-white">
                   <span class="truncate">{{ pending.filename }}</span>
-                  <span class="ml-2 text-xs text-gray-500 capitalize dark:text-gray-500">
-                    {{ pending.kind }} · uploads when you save
+                  <span class="ml-2 text-xs text-gray-500 dark:text-gray-500">
+                    <span class="capitalize">{{ pending.kind }}</span> · uploads when you save
                   </span>
                 </span>
                 <button

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
@@ -1,0 +1,255 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <a
+      routerLink="/my-skills"
+      class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+    >
+      <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+      My Skills
+    </a>
+
+    <h1 class="mt-4 text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">
+      {{ isEdit() ? 'Edit skill' : 'New skill' }}
+    </h1>
+
+    @if (error()) {
+      <div
+        role="alert"
+        class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400"
+      >
+        {{ error() }}
+      </div>
+    }
+
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" class="mt-8 space-y-6">
+      <!-- Import from SKILL.md -->
+      @if (!isEdit()) {
+        <div class="rounded-2xl border border-dashed border-gray-300 p-4 dark:border-gray-700">
+          <label
+            for="skill-md-import"
+            class="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <ng-icon name="heroArrowUpTray" class="size-4" aria-hidden="true" />
+            Import a SKILL.md
+          </label>
+          <input
+            id="skill-md-import"
+            type="file"
+            class="sr-only"
+            accept=".md,.markdown,text/markdown,text/plain"
+            (change)="onImportSelected($event)"
+          />
+          <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-400">
+            Already have a skill in the
+            <code class="text-xs">agentskills.io</code> format? Import it to prefill this form.
+          </p>
+          @if (importNotice()) {
+            <p role="status" class="mt-2 text-sm/6 text-blue-700 dark:text-blue-400">
+              {{ importNotice() }}
+            </p>
+          }
+        </div>
+      }
+
+      <!-- Name -->
+      <div>
+        <label for="displayName" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+          Name
+        </label>
+        <input
+          id="displayName"
+          type="text"
+          formControlName="displayName"
+          required
+          class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        />
+        @if (form.controls.displayName.touched && form.controls.displayName.invalid) {
+          <p class="mt-1 text-sm/6 text-red-700 dark:text-red-400">A name is required.</p>
+        }
+      </div>
+
+      <!-- Description -->
+      <div>
+        <label for="description" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+          Description
+        </label>
+        <textarea
+          id="description"
+          rows="2"
+          formControlName="description"
+          required
+          class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        ></textarea>
+        <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+          One line explaining when to use this skill. This is what the agent reads when deciding
+          whether the skill is relevant — make it specific.
+        </p>
+        @if (form.controls.description.touched && form.controls.description.invalid) {
+          <p class="mt-1 text-sm/6 text-red-700 dark:text-red-400">A description is required.</p>
+        }
+      </div>
+
+      <!-- Instructions -->
+      <div>
+        <label for="instructions" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+          Instructions
+        </label>
+        <textarea
+          id="instructions"
+          rows="14"
+          formControlName="instructions"
+          class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 font-mono text-sm/6 text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        ></textarea>
+        <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+          Markdown. The agent loads this only after it decides the skill applies, so length here
+          costs nothing until it's used.
+        </p>
+      </div>
+
+      <!-- Supporting files -->
+      <fieldset class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+        <legend class="px-1 text-sm/6 font-medium text-gray-900 dark:text-white">
+          Supporting files
+        </legend>
+
+        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
+          Optional. The agent can read these on demand once the skill is active — up to
+          {{ maxFiles }} files, 1 MB each.
+        </p>
+
+        <div class="mt-4 flex flex-wrap items-center gap-3">
+          <label for="file-kind" class="text-sm/6 text-gray-700 dark:text-gray-300">Add as</label>
+          <select
+            id="file-kind"
+            [value]="uploadKind()"
+            (change)="setUploadKind($any($event.target).value)"
+            class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          >
+            @for (kind of resourceKinds; track kind.value) {
+              <option [value]="kind.value">{{ kind.label }}</option>
+            }
+          </select>
+
+          <label
+            for="resource-upload"
+            class="inline-flex cursor-pointer items-center gap-2 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <ng-icon name="heroArrowUpTray" class="size-4" aria-hidden="true" />
+            {{ uploading() ? 'Uploading…' : 'Choose files' }}
+          </label>
+          <input
+            id="resource-upload"
+            type="file"
+            multiple
+            class="sr-only"
+            [disabled]="uploading()"
+            (change)="onFilesSelected($event)"
+          />
+        </div>
+
+        <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-400">
+          {{ kindHint(uploadKind()) }}
+        </p>
+
+        <!-- Uploaded (edit mode) -->
+        @if (resources().length > 0) {
+          <ul role="list" class="mt-4 divide-y divide-gray-100 dark:divide-gray-700">
+            @for (resource of resources(); track resource.filename) {
+              <li class="flex items-center justify-between gap-3 py-2">
+                <span class="min-w-0 text-sm/6 text-gray-900 dark:text-white">
+                  <span class="truncate">{{ resource.filename }}</span>
+                  <span class="ml-2 text-xs text-gray-500 capitalize dark:text-gray-500">
+                    {{ resource.kind }}
+                  </span>
+                </span>
+                <span class="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    (click)="viewResource(resource.filename)"
+                    [attr.aria-label]="'View ' + resource.filename"
+                    class="rounded-2xl p-1.5 text-gray-600 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-700"
+                  >
+                    <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    (click)="deleteResource(resource.filename)"
+                    [attr.aria-label]="'Delete ' + resource.filename"
+                    class="rounded-2xl p-1.5 text-red-700 hover:bg-red-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-red-400 dark:hover:bg-red-900/20"
+                  >
+                    <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                  </button>
+                </span>
+              </li>
+            }
+          </ul>
+        }
+
+        <!-- Staged (create mode) -->
+        @if (pendingList().length > 0) {
+          <ul role="list" class="mt-4 divide-y divide-gray-100 dark:divide-gray-700">
+            @for (pending of pendingList(); track pending.filename) {
+              <li class="flex items-center justify-between gap-3 py-2">
+                <span class="min-w-0 text-sm/6 text-gray-900 dark:text-white">
+                  <span class="truncate">{{ pending.filename }}</span>
+                  <span class="ml-2 text-xs text-gray-500 capitalize dark:text-gray-500">
+                    {{ pending.kind }} · uploads when you save
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  (click)="removePending(pending.filename)"
+                  [attr.aria-label]="'Remove ' + pending.filename"
+                  class="shrink-0 rounded-2xl p-1.5 text-red-700 hover:bg-red-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:text-red-400 dark:hover:bg-red-900/20"
+                >
+                  <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                </button>
+              </li>
+            }
+          </ul>
+        }
+
+        <!-- Inline viewer -->
+        @if (viewing(); as preview) {
+          <div class="mt-4 rounded-2xl border border-gray-200 dark:border-gray-700">
+            <div
+              class="flex items-center justify-between gap-3 border-b border-gray-200 px-3 py-2 dark:border-gray-700"
+            >
+              <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                {{ preview.filename }}
+              </span>
+              <button
+                type="button"
+                (click)="closeViewer()"
+                class="rounded-2xl px-2 py-1 text-sm/6 text-gray-600 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-700"
+              >
+                Close
+              </button>
+            </div>
+            <pre
+              class="max-h-80 overflow-auto p-3 font-mono text-xs whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              >{{ preview.content }}</pre
+            >
+          </div>
+        }
+      </fieldset>
+
+      <!-- Actions -->
+      <div class="flex items-center gap-3">
+        <button
+          type="submit"
+          [disabled]="saving()"
+          class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          {{ saving() ? 'Saving…' : isEdit() ? 'Save changes' : 'Create skill' }}
+        </button>
+        <a
+          routerLink="/my-skills"
+          class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          Cancel
+        </a>
+      </div>
+    </form>
+  </div>
+</div>

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
@@ -62,6 +62,14 @@ export class MySkillFormPage {
   protected readonly uploading = signal(false);
   protected readonly viewing = signal<{ filename: string; content: string } | null>(null);
 
+  /**
+   * Frontmatter carried through from an import (or a loaded skill) that has no
+   * form control of its own. Preserved verbatim on save so a bundle
+   * round-trips (D2); `allowedTools` is advisory display metadata (D4).
+   */
+  protected readonly allowedTools = signal<string[]>([]);
+  private readonly skillMetadata = signal<Record<string, unknown>>({});
+
   protected readonly form = this.fb.nonNullable.group({
     displayName: ['', [Validators.required, Validators.maxLength(200)]],
     description: ['', [Validators.required, Validators.maxLength(2000)]],
@@ -97,6 +105,8 @@ export class MySkillFormPage {
         instructions: skill.instructions,
       });
       this.resources.set(skill.resources);
+      this.allowedTools.set(skill.allowedTools ?? []);
+      this.skillMetadata.set(skill.skillMetadata ?? {});
     } catch {
       this.error.set("We couldn't load that skill. It may have been deleted.");
     }
@@ -119,6 +129,9 @@ export class MySkillFormPage {
       description: parsed.description || this.form.controls.description.value,
       instructions: parsed.instructions,
     });
+    // Everything the form has no control for still round-trips (D2/D4).
+    this.allowedTools.set(parsed.allowedTools);
+    this.skillMetadata.set(parsed.metadata);
     this.importNotice.set(
       parsed.name || parsed.description
         ? `Prefilled from ${file.name}. Review the name and description before saving.`
@@ -237,7 +250,11 @@ export class MySkillFormPage {
 
     this.saving.set(true);
     this.error.set(null);
-    const value = this.form.getRawValue();
+    const value = {
+      ...this.form.getRawValue(),
+      allowedTools: this.allowedTools(),
+      skillMetadata: this.skillMetadata(),
+    };
 
     try {
       const id = this.skillId();

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
@@ -1,0 +1,260 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroArrowUpTray,
+  heroEye,
+  heroTrash,
+} from '@ng-icons/heroicons/outline';
+import { parseSkillMarkdown } from '../admin/skills/models/skill-import.util';
+import {
+  MAX_RESOURCE_BYTES,
+  MAX_RESOURCES_PER_SKILL,
+  MySkillResourceRef,
+  RESOURCE_KINDS,
+  SkillResourceKind,
+} from './models/my-skill.model';
+import { MySkillService } from './services/my-skill.service';
+
+/**
+ * Create / edit one user-authored skill (Skills v2 PR-3).
+ *
+ * Two modes, mirroring the admin skill form:
+ * - **Create** — supporting files are *staged* client-side and uploaded after
+ *   the skill exists (uploads need a skill id).
+ * - **Edit** — each file uploads immediately and the returned manifest is
+ *   authoritative.
+ *
+ * The skill id is allocated by the backend from the display name, so unlike
+ * the admin form there is no id field to fill in or validate.
+ */
+@Component({
+  selector: 'app-my-skill-form',
+  imports: [ReactiveFormsModule, RouterLink, NgIcon],
+  templateUrl: './my-skill-form.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [provideIcons({ heroArrowLeft, heroArrowUpTray, heroEye, heroTrash })],
+})
+export class MySkillFormPage {
+  private fb = inject(FormBuilder);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private skillService = inject(MySkillService);
+
+  protected readonly resourceKinds = RESOURCE_KINDS;
+  protected readonly maxFiles = MAX_RESOURCES_PER_SKILL;
+
+  protected readonly skillId = signal<string | null>(null);
+  protected readonly isEdit = computed(() => this.skillId() !== null);
+  protected readonly saving = signal(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly importNotice = signal<string | null>(null);
+
+  /** Manifest of files already on the skill (edit mode). */
+  protected readonly resources = signal<MySkillResourceRef[]>([]);
+  /** Files staged for upload after create (create mode), keyed by filename. */
+  protected readonly pendingFiles = signal<Map<string, { file: File; kind: SkillResourceKind }>>(
+    new Map(),
+  );
+  protected readonly uploadKind = signal<SkillResourceKind>('reference');
+  protected readonly uploading = signal(false);
+  protected readonly viewing = signal<{ filename: string; content: string } | null>(null);
+
+  protected readonly form = this.fb.nonNullable.group({
+    displayName: ['', [Validators.required, Validators.maxLength(200)]],
+    description: ['', [Validators.required, Validators.maxLength(2000)]],
+    instructions: [''],
+  });
+
+  protected readonly pendingList = computed(() =>
+    [...this.pendingFiles().entries()].map(([filename, staged]) => ({
+      filename,
+      kind: staged.kind,
+      size: staged.file.size,
+    })),
+  );
+
+  protected readonly fileCount = computed(
+    () => this.resources().length + this.pendingFiles().size,
+  );
+
+  constructor() {
+    const id = this.route.snapshot.paramMap.get('skillId');
+    if (id) {
+      this.skillId.set(id);
+      void this.loadSkill(id);
+    }
+  }
+
+  private async loadSkill(id: string): Promise<void> {
+    try {
+      const skill = await this.skillService.getSkill(id);
+      this.form.patchValue({
+        displayName: skill.displayName,
+        description: skill.description,
+        instructions: skill.instructions,
+      });
+      this.resources.set(skill.resources);
+    } catch {
+      this.error.set("We couldn't load that skill. It may have been deleted.");
+    }
+  }
+
+  // ---- SKILL.md import ---------------------------------------------------
+
+  protected async onImportSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const text = await file.text();
+    const parsed = parseSkillMarkdown(text);
+
+    this.form.patchValue({
+      displayName: parsed.name || this.form.controls.displayName.value,
+      description: parsed.description || this.form.controls.description.value,
+      instructions: parsed.instructions,
+    });
+    this.importNotice.set(
+      parsed.name || parsed.description
+        ? `Prefilled from ${file.name}. Review the name and description before saving.`
+        : `${file.name} had no frontmatter, so its whole body became the instructions.`,
+    );
+
+    // Let the same file be re-picked if the user wants to redo the import.
+    input.value = '';
+  }
+
+  // ---- bundle files ------------------------------------------------------
+
+  protected setUploadKind(kind: string): void {
+    this.uploadKind.set(kind as SkillResourceKind);
+  }
+
+  protected async onFilesSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const files = [...(input.files ?? [])];
+    input.value = '';
+    if (files.length === 0) {
+      return;
+    }
+
+    const oversized = files.filter((f) => f.size > MAX_RESOURCE_BYTES);
+    if (oversized.length > 0) {
+      this.error.set(
+        `${oversized.map((f) => f.name).join(', ')} exceeds the 1 MB per-file limit.`,
+      );
+      return;
+    }
+    if (this.fileCount() + files.length > this.maxFiles) {
+      this.error.set(`A skill can hold at most ${this.maxFiles} supporting files.`);
+      return;
+    }
+
+    this.error.set(null);
+    const kind = this.uploadKind();
+    const id = this.skillId();
+
+    if (!id) {
+      // Create mode — stage until the skill exists.
+      this.pendingFiles.update((current) => {
+        const next = new Map(current);
+        for (const file of files) {
+          next.set(file.name, { file, kind });
+        }
+        return next;
+      });
+      return;
+    }
+
+    this.uploading.set(true);
+    try {
+      for (const file of files) {
+        this.resources.set(await this.skillService.uploadResource(id, file, kind));
+      }
+    } catch {
+      this.error.set(this.skillService.error$() ?? 'Failed to upload the file.');
+    } finally {
+      this.uploading.set(false);
+    }
+  }
+
+  protected removePending(filename: string): void {
+    this.pendingFiles.update((current) => {
+      const next = new Map(current);
+      next.delete(filename);
+      return next;
+    });
+  }
+
+  protected async viewResource(filename: string): Promise<void> {
+    const id = this.skillId();
+    if (!id) {
+      return;
+    }
+    try {
+      const content = await this.skillService.readResource(id, filename);
+      this.viewing.set({ filename, content });
+    } catch {
+      this.error.set(`Couldn't read ${filename}.`);
+    }
+  }
+
+  protected closeViewer(): void {
+    this.viewing.set(null);
+  }
+
+  protected async deleteResource(filename: string): Promise<void> {
+    const id = this.skillId();
+    if (!id) {
+      return;
+    }
+    try {
+      this.resources.set(await this.skillService.deleteResource(id, filename));
+      if (this.viewing()?.filename === filename) {
+        this.viewing.set(null);
+      }
+    } catch {
+      this.error.set(`Couldn't delete ${filename}.`);
+    }
+  }
+
+  protected kindHint(kind: SkillResourceKind): string {
+    return this.resourceKinds.find((k) => k.value === kind)?.hint ?? '';
+  }
+
+  // ---- save --------------------------------------------------------------
+
+  protected async onSubmit(): Promise<void> {
+    if (this.form.invalid || this.saving()) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.saving.set(true);
+    this.error.set(null);
+    const value = this.form.getRawValue();
+
+    try {
+      const id = this.skillId();
+      if (id) {
+        await this.skillService.updateSkill(id, value);
+      } else {
+        const created = await this.skillService.createSkill(value);
+        // Uploads need a skill id, so staged files go up now.
+        for (const [, staged] of this.pendingFiles()) {
+          await this.skillService.uploadResource(created.skillId, staged.file, staged.kind);
+        }
+      }
+      await this.router.navigate(['/my-skills']);
+    } catch {
+      this.error.set(this.skillService.error$() ?? 'Failed to save the skill.');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/my-skills/my-skills.page.html
+++ b/frontend/ai.client/src/app/my-skills/my-skills.page.html
@@ -1,0 +1,142 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">
+          My Skills
+        </h1>
+        <p class="mt-2 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+          A skill is a set of instructions — plus any reference files it needs — that an agent
+          can pull in when it's relevant. Write one once, then turn it on in chat or bind it to
+          an agent.
+        </p>
+      </div>
+
+      @if (accessible() === true) {
+        <a
+          routerLink="/my-skills/new"
+          class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+          New skill
+        </a>
+      }
+    </div>
+
+    <!-- Error -->
+    @if (error()) {
+      <div
+        role="alert"
+        class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm/6 text-red-800 dark:bg-red-900/20 dark:text-red-400"
+      >
+        {{ error() }}
+      </div>
+    }
+
+    <!-- Feature disabled -->
+    @if (accessible() === false) {
+      <div
+        class="mt-8 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800"
+      >
+        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
+          Skills aren't enabled for this environment yet.
+        </p>
+      </div>
+    }
+
+    <!-- Loading -->
+    @if (loading() && skills().length === 0) {
+      <div class="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        @for (placeholder of [1, 2, 3]; track placeholder) {
+          <div class="h-40 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700"></div>
+        }
+      </div>
+    }
+
+    <!-- Empty -->
+    @if (isEmpty()) {
+      <div
+        class="mt-8 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800"
+      >
+        <ng-icon
+          name="heroSparkles"
+          class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <h2 class="mt-3 text-sm/6 font-medium text-gray-900 dark:text-white">No skills yet</h2>
+        <p class="mx-auto mt-1 max-w-md text-sm/6 text-gray-600 dark:text-gray-400">
+          Write down something you explain to the assistant over and over — a house style, a
+          process, a checklist — and it becomes a skill you can reuse.
+        </p>
+        <a
+          routerLink="/my-skills/new"
+          class="mt-6 inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+          Create your first skill
+        </a>
+      </div>
+    }
+
+    <!-- List -->
+    @if (skills().length > 0) {
+      <ul role="list" class="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        @for (skill of skills(); track skill.skillId) {
+          <li
+            class="flex flex-col rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                <a
+                  [routerLink]="['/my-skills', skill.skillId, 'edit']"
+                  class="hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  {{ skill.displayName }}
+                </a>
+              </h2>
+
+              @if (skill.status !== 'active') {
+                <span
+                  class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 capitalize dark:bg-gray-700 dark:text-gray-300"
+                >
+                  {{ skill.status }}
+                </span>
+              }
+            </div>
+
+            <p class="mt-2 line-clamp-3 grow text-sm/6 text-gray-600 dark:text-gray-400">
+              {{ skill.description }}
+            </p>
+
+            <p
+              class="mt-4 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-500"
+            >
+              <ng-icon name="heroDocumentText" class="size-4" aria-hidden="true" />
+              {{ fileCountLabel(skill.resources.length) }}
+            </p>
+
+            <div class="mt-4 flex items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700">
+              <a
+                [routerLink]="['/my-skills', skill.skillId, 'edit']"
+                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                Edit
+              </a>
+              <button
+                type="button"
+                [disabled]="deleting() === skill.skillId"
+                (click)="confirmDelete(skill.skillId, skill.displayName)"
+                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-red-700 hover:bg-red-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                {{ deleting() === skill.skillId ? 'Deleting…' : 'Delete' }}
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/my-skills/my-skills.page.ts
+++ b/frontend/ai.client/src/app/my-skills/my-skills.page.ts
@@ -1,0 +1,86 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { Router, RouterLink } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroPlus, heroSparkles, heroPencilSquare, heroTrash, heroDocumentText } from '@ng-icons/heroicons/outline';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../components/confirmation-dialog/confirmation-dialog.component';
+import { MySkillService } from './services/my-skill.service';
+
+/**
+ * "My Skills" — the user-authored half of the skill catalog (Skills v2 PR-3).
+ *
+ * A skill is a pure knowledge bundle: instructions the agent can pull in on
+ * demand, plus supporting files. Skills authored here are private to their
+ * author until bound to an Agent (sharing an Agent shares the use of its
+ * skills — spec §6 invoke-through).
+ */
+@Component({
+  selector: 'app-my-skills',
+  imports: [RouterLink, NgIcon],
+  templateUrl: './my-skills.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [
+    provideIcons({ heroPlus, heroSparkles, heroPencilSquare, heroTrash, heroDocumentText }),
+  ],
+})
+export class MySkillsPage {
+  private skillService = inject(MySkillService);
+  private dialog = inject(Dialog);
+  private router = inject(Router);
+
+  protected readonly skills = this.skillService.skills$;
+  protected readonly loading = this.skillService.loading$;
+  protected readonly error = this.skillService.error$;
+  protected readonly accessible = this.skillService.accessible$;
+
+  /** Only render "you have no skills yet" once the list has actually resolved. */
+  protected readonly isEmpty = computed(
+    () => this.accessible() === true && !this.loading() && this.skills().length === 0,
+  );
+
+  protected readonly deleting = signal<string | null>(null);
+
+  constructor() {
+    void this.skillService.loadSkills();
+  }
+
+  protected fileCountLabel(count: number): string {
+    if (count === 0) {
+      return 'No supporting files';
+    }
+    return count === 1 ? '1 supporting file' : `${count} supporting files`;
+  }
+
+  protected async confirmDelete(skillId: string, displayName: string): Promise<void> {
+    const data: ConfirmationDialogData = {
+      title: 'Delete this skill?',
+      message: `"${displayName}" and its supporting files will be permanently deleted. Agents that use it will stop seeing it.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    };
+
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, { data });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) {
+      return;
+    }
+
+    this.deleting.set(skillId);
+    try {
+      await this.skillService.deleteSkill(skillId);
+    } catch {
+      // The service surfaces the message on `error$`; the banner renders it.
+    } finally {
+      this.deleting.set(null);
+    }
+  }
+
+  protected openSkill(skillId: string): void {
+    void this.router.navigate(['/my-skills', skillId, 'edit']);
+  }
+}

--- a/frontend/ai.client/src/app/my-skills/services/my-skill.service.spec.ts
+++ b/frontend/ai.client/src/app/my-skills/services/my-skill.service.spec.ts
@@ -1,0 +1,174 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigService } from '../../services/config.service';
+import { MySkill } from '../models/my-skill.model';
+import { MySkillService } from './my-skill.service';
+
+const BASE = 'http://localhost:8000/skills/mine';
+
+function stubSkill(overrides: Partial<MySkill> = {}): MySkill {
+  return {
+    skillId: 'grant_writing',
+    displayName: 'Grant Writing',
+    description: 'How we write grant narratives.',
+    instructions: '# Grant Writing',
+    allowedTools: [],
+    skillMetadata: {},
+    resources: [],
+    status: 'active',
+    category: null,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('MySkillService', () => {
+  let service: MySkillService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+        MySkillService,
+      ],
+    });
+    service = TestBed.inject(MySkillService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  it('loads skills and marks the feature accessible', async () => {
+    const promise = service.loadSkills();
+
+    const req = httpMock.expectOne(BASE);
+    expect(req.request.method).toBe('GET');
+    req.flush({ skills: [stubSkill()], totalCount: 1 });
+    await promise;
+
+    expect(service.skills$()).toHaveLength(1);
+    expect(service.accessible$()).toBe(true);
+    expect(service.error$()).toBeNull();
+  });
+
+  it('treats a 404 as the kill switch, not an error', async () => {
+    const promise = service.loadSkills();
+
+    httpMock.expectOne(BASE).flush('Not found', { status: 404, statusText: 'Not Found' });
+    await promise;
+
+    expect(service.accessible$()).toBe(false);
+    expect(service.skills$()).toEqual([]);
+    expect(service.error$()).toBeNull();
+  });
+
+  it('surfaces a non-404 failure as an error and rethrows', async () => {
+    const promise = service.loadSkills();
+
+    httpMock.expectOne(BASE).flush('Boom', { status: 500, statusText: 'Server Error' });
+
+    await expect(promise).rejects.toBeDefined();
+    expect(service.error$()).toBeTruthy();
+    expect(service.accessible$()).toBeNull();
+  });
+
+  it('prefers the backend detail message over a generic HTTP error', async () => {
+    const promise = service.createSkill({ displayName: 'X', description: 'd' });
+
+    httpMock
+      .expectOne(BASE)
+      .flush(
+        { detail: 'You already have the maximum of 50 skills.' },
+        { status: 409, statusText: 'Conflict' },
+      );
+
+    await expect(promise).rejects.toBeDefined();
+    expect(service.error$()).toBe('You already have the maximum of 50 skills.');
+  });
+
+  it('appends a created skill to local state', async () => {
+    const promise = service.createSkill({ displayName: 'Grant Writing', description: 'd' });
+
+    const req = httpMock.expectOne(BASE);
+    expect(req.request.method).toBe('POST');
+    // No skillId is sent — the backend allocates it.
+    expect(req.request.body.skillId).toBeUndefined();
+    req.flush(stubSkill());
+    await promise;
+
+    expect(service.skills$().map((s) => s.skillId)).toEqual(['grant_writing']);
+  });
+
+  it('replaces the updated skill in local state', async () => {
+    const load = service.loadSkills();
+    httpMock.expectOne(BASE).flush({ skills: [stubSkill()], totalCount: 1 });
+    await load;
+
+    const promise = service.updateSkill('grant_writing', { description: 'New.' });
+    const req = httpMock.expectOne(`${BASE}/grant_writing`);
+    expect(req.request.method).toBe('PUT');
+    req.flush(stubSkill({ description: 'New.' }));
+    await promise;
+
+    expect(service.skills$()[0].description).toBe('New.');
+  });
+
+  it('drops a deleted skill from local state', async () => {
+    const load = service.loadSkills();
+    httpMock.expectOne(BASE).flush({ skills: [stubSkill()], totalCount: 1 });
+    await load;
+
+    const promise = service.deleteSkill('grant_writing');
+    httpMock.expectOne(`${BASE}/grant_writing`).flush({ message: 'ok' });
+    await promise;
+
+    expect(service.skills$()).toEqual([]);
+  });
+
+  it('posts an upload as multipart with the resource kind', async () => {
+    const file = new File(['print(1)'], 'build.py', { type: 'text/x-python' });
+    const promise = service.uploadResource('grant_writing', file, 'script');
+
+    const req = httpMock.expectOne(`${BASE}/grant_writing/resources`);
+    expect(req.request.method).toBe('POST');
+    const body = req.request.body as FormData;
+    expect(body.get('kind')).toBe('script');
+    expect((body.get('file') as File).name).toBe('build.py');
+
+    req.flush({
+      skillId: 'grant_writing',
+      resources: [
+        {
+          filename: 'build.py',
+          contentHash: 'abc',
+          size: 8,
+          contentType: 'text/x-python',
+          s3Key: 'skills/grant_writing/scripts/build.py',
+          kind: 'script',
+        },
+      ],
+    });
+
+    expect((await promise)[0].kind).toBe('script');
+  });
+
+  it('encodes the filename when reading and deleting a resource', async () => {
+    void service.readResource('grant_writing', 'my notes.md');
+    httpMock.expectOne(`${BASE}/grant_writing/resources/my%20notes.md`).flush('body');
+
+    void service.deleteResource('grant_writing', 'my notes.md');
+    const del = httpMock.expectOne(`${BASE}/grant_writing/resources/my%20notes.md`);
+    expect(del.request.method).toBe('DELETE');
+    del.flush({ skillId: 'grant_writing', resources: [] });
+  });
+});

--- a/frontend/ai.client/src/app/my-skills/services/my-skill.service.ts
+++ b/frontend/ai.client/src/app/my-skills/services/my-skill.service.ts
@@ -1,0 +1,171 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import {
+  CreateMySkillRequest,
+  MySkill,
+  MySkillListResponse,
+  MySkillResourceRef,
+  MySkillResourcesResponse,
+  SkillResourceKind,
+  UpdateMySkillRequest,
+} from '../models/my-skill.model';
+
+/**
+ * Signal-based state for the user-authored skills tier (Skills v2 PR-3).
+ *
+ * Mirrors the memory-spaces / schedules facades: private mutable signals,
+ * readonly public views, async methods that keep local state in sync.
+ *
+ * `accessible$` rides the list call the way `MemorySpaceService.accessible$`
+ * rides spaces: a successful (even empty) list means the `SKILLS_ENABLED` kill
+ * switch is on; a 404 flips it false so the nav entry and page hide gracefully
+ * rather than surfacing an error. `null` (unresolved) also hides, so nothing
+ * flashes in before disappearing.
+ */
+@Injectable({ providedIn: 'root' })
+export class MySkillService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/skills/mine`);
+
+  private skills = signal<MySkill[]>([]);
+  private loading = signal<boolean>(false);
+  private error = signal<string | null>(null);
+  private accessible = signal<boolean | null>(null);
+
+  readonly skills$ = this.skills.asReadonly();
+  readonly loading$ = this.loading.asReadonly();
+  readonly error$ = this.error.asReadonly();
+  readonly accessible$ = this.accessible.asReadonly();
+
+  async loadSkills(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.http.get<MySkillListResponse>(this.baseUrl(), { withCredentials: true }),
+      );
+      this.skills.set(response?.skills ?? []);
+      this.accessible.set(true);
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 404) {
+        // Kill switch off — fail gracefully rather than surfacing an error.
+        this.accessible.set(false);
+        this.skills.set([]);
+        return;
+      }
+      this.error.set(this.messageFor(err, 'Failed to load your skills'));
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  getSkill(skillId: string): Promise<MySkill> {
+    return firstValueFrom(
+      this.http.get<MySkill>(`${this.baseUrl()}/${skillId}`, { withCredentials: true }),
+    );
+  }
+
+  async createSkill(request: CreateMySkillRequest): Promise<MySkill> {
+    this.error.set(null);
+    try {
+      const skill = await firstValueFrom(
+        this.http.post<MySkill>(this.baseUrl(), request, { withCredentials: true }),
+      );
+      this.skills.update((current) => [...current, skill]);
+      return skill;
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to create the skill'));
+      throw err;
+    }
+  }
+
+  async updateSkill(skillId: string, request: UpdateMySkillRequest): Promise<MySkill> {
+    this.error.set(null);
+    try {
+      const skill = await firstValueFrom(
+        this.http.put<MySkill>(`${this.baseUrl()}/${skillId}`, request, {
+          withCredentials: true,
+        }),
+      );
+      this.skills.update((current) =>
+        current.map((s) => (s.skillId === skillId ? skill : s)),
+      );
+      return skill;
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to save the skill'));
+      throw err;
+    }
+  }
+
+  async deleteSkill(skillId: string): Promise<void> {
+    this.error.set(null);
+    try {
+      await firstValueFrom(
+        this.http.delete(`${this.baseUrl()}/${skillId}`, { withCredentials: true }),
+      );
+      this.skills.update((current) => current.filter((s) => s.skillId !== skillId));
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to delete the skill'));
+      throw err;
+    }
+  }
+
+  // ---- bundle files ------------------------------------------------------
+
+  async uploadResource(
+    skillId: string,
+    file: File,
+    kind: SkillResourceKind = 'reference',
+  ): Promise<MySkillResourceRef[]> {
+    const form = new FormData();
+    form.append('file', file, file.name);
+    form.append('kind', kind);
+
+    const response = await firstValueFrom(
+      this.http.post<MySkillResourcesResponse>(
+        `${this.baseUrl()}/${skillId}/resources`,
+        form,
+        { withCredentials: true },
+      ),
+    );
+    return response?.resources ?? [];
+  }
+
+  async readResource(skillId: string, filename: string): Promise<string> {
+    return firstValueFrom(
+      this.http.get(`${this.baseUrl()}/${skillId}/resources/${encodeURIComponent(filename)}`, {
+        withCredentials: true,
+        responseType: 'text',
+      }),
+    );
+  }
+
+  async deleteResource(skillId: string, filename: string): Promise<MySkillResourceRef[]> {
+    const response = await firstValueFrom(
+      this.http.delete<MySkillResourcesResponse>(
+        `${this.baseUrl()}/${skillId}/resources/${encodeURIComponent(filename)}`,
+        { withCredentials: true },
+      ),
+    );
+    return response?.resources ?? [];
+  }
+
+  /**
+   * Prefer the backend's own message (FastAPI puts it on `error.detail`) so a
+   * cap or validation failure reads as written, not as a generic HTTP error.
+   */
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } } | null)?.error?.detail;
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail;
+    }
+    return err instanceof Error ? err.message : fallback;
+  }
+}


### PR DESCRIPTION
Implements **PR-3** of `docs/specs/skills-as-agent-primitive.md`: the user-authored tier. Any user can now write their own agentskills.io knowledge bundles and reach them at runtime, without an admin RBAC grant.

Builds on PR-1 (#680, the great deletion) and PR-2 (#681, the runtime swap). `SKILLS_ENABLED` stays **off** — PR-5 flips it.

## What changed

**Backend — the owner-scoped half of the catalog**

- `list_skills_by_owner` finally *uses* the `SkillOwnerIndex` GSI4 that v1 provisioned and never queried. `list_skills` gains an `owner_id` filter.
- `UserSkillService` — owner-scoped CRUD. Ownership resolves on every path; a skill you don't own returns **404, not 403**, so the surface never confirms someone else's skill exists. Resource handling (caps, manifest, bundle layout, orphan GC) delegates to `SkillCatalogService`, so both tiers emit identical bundles through one code path.
- `/skills/mine/*` routes ride the existing session-auth router, inheriting the `SKILLS_ENABLED` mount gate.
- `resolve_accessible_skill_ids` now returns **catalog ∪ own**. Ownership is its own grant — this is what makes an authored skill reachable at all.
- Skill ids are allocated server-side from the display name and suffixed on collision (`docx` → `docx_2`). Ids stay globally unique because the runtime activation key is the slugified id, so same-named skills in one turn would be ambiguous to the model; a 409 would also disclose the existence of a skill the user can't see.

**Frontend**

- My Skills page (list + create/edit form), SKILL.md import prefill, reference/script/asset uploads with scripts labeled non-executable.
- Nav entry gated on the same 404 accessibility probe Memory Spaces uses.

## Two leaks closed

Neither was called out in the spec; both would have exposed private user skills the moment the tier existed.

1. **`get_all_skill_ids` fed the RBAC `"*"` wildcard from a full `SKILL#` scan.** Once users author into that same table, any role holding `"*"` would sweep in every user's private skills. Now scoped to `owner_id == "system"`.
2. **Admin role-grant endpoints accepted any skill id.** Granting a user-authored skill to an AppRole would hand a private document to a whole role. `_require_catalog_skill` now refuses. The admin catalog list is likewise scoped to system-owned.

## Follow-on fixes found during live testing

- **Frontmatter was being dropped on import.** A SKILL.md carrying `license: MIT` round-tripped back out of S3 without it, violating spec D2. The backend already had `skill_metadata`/`allowed_tools` columns — the client import just never populated them, leaving both fields dead on the user tier. `parseSkillMarkdown` now returns `allowedTools` and `metadata`; the form carries them through create *and* update. Advisory tools render as chips with the D1 disclaimer.
- **`backfill_skill_bundles.py`** — v1 skills have neither the SKILL.md projection nor the standard layout (resources were content-addressed, no `kind`), so their S3 prefix isn't a valid agentskills.io bundle. Dry-run by default, idempotent, throttled, scopeable. Copies are non-destructive; a manifest entry whose bytes are missing is left alone rather than repointed at nothing.
- **The seeder emitted v1 shapes**, so every fresh environment reproduced exactly what the backfill repairs. Now writes the standard layout + projection, with a test guarding that seed prose never again names the retired `skill_executor` / `skill_dispatcher`.

## Verification

- Backend **4702 passed**, 3 skipped. SPA **1463 passed** across 127 spec files. `tsc --noEmit` and `ng build` clean.
- Full clickthrough on localhost against the dev backend: create → import → staged upload → edit → preview → delete, all green; no console or network errors on the skills routes.
- Confirmed live: user skill absent from the admin catalog; `GET /skills/` returns an owned skill with zero role grants; hard delete purges the whole S3 prefix.
- `dev-ai` backfilled and instructions synced — `web_research` is now a clean bundle, verified 200 through the app.

## Reviewer notes

- **`prod-ai` needs nothing.** Inventoried it: zero skill rows, empty bucket, no dangling grants. `seed_example_skills` never ran there. Whether prod should get the example skill seeded at all is a separate decision, deliberately not made here.
- **Existing environments aren't self-healing.** Seeders are skip-if-exists, so the seeder fix only helps *new* environments; existing ones need the backfill script.
- **Known drift risk:** `bundle.py` and the seeder now carry duplicated slug/frontmatter rules, because `seed.sh` runs the seeder standalone without the app package on the path. Nothing enforces they stay in step.
- **Not verified against live AWS:** the admin role-grant refusal. CORS blocks a cross-origin PUT from the page, so it's covered by moto tests only.
- Invoke-through sharing (spec §6) is **PR-4**. Until then an authored skill only reaches its own author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)