### PR TITLE
feat(skills): enable Skills v2 + admin-only capability gate (skills v2 PR-5)

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -107,6 +107,14 @@ jobs:
       # config.ts treats as the default (on). Set the `CDK_MEMORY_SPACES_ENABLED`
       # variable to "false" in an environment only to dark-stop the feature there.
       CDK_MEMORY_SPACES_ENABLED: ${{ vars.CDK_MEMORY_SPACES_ENABLED }}
+      # Skills v2 (knowledge bundles: admin catalog, My Skills authoring, and
+      # skill resolution on the invocation path). Default ON with a kill switch:
+      # unset resolves to empty string, which config.ts treats as the default
+      # (on). Set the `CDK_SKILLS_ENABLED` variable to "false" in an environment
+      # only to dark-stop the feature there. NOTE this gates feature *existence*;
+      # who sees the user-facing surfaces is the `skills` RBAC capability, which
+      # keeps them admin-only until GA (one role grant, no redeploy).
+      CDK_SKILLS_ENABLED: ${{ vars.CDK_SKILLS_ENABLED }}
       # Agent Designer /agents surface. Default OFF (opt-in) until the Phase-4
       # Designer UI ships — a headless API helps no forker. Set the
       # `CDK_AGENTS_API_ENABLED` variable to "true" in an environment (e.g. dev)

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -871,18 +871,27 @@ S3_SKILL_RESOURCES_BUCKET_NAME=
 # =============================================================================
 # SKILLS (OPTIONAL)
 # =============================================================================
-# The Skills feature (admin skills catalog + user-facing skills picker) is gated
-# by SKILLS_ENABLED. Skills are pure knowledge bundles (Skills v2) — they bind
-# no tools and are opt-in per turn, not a mode. While off, app-api leaves the
-# user + admin skills routes unmounted (404) and inference-api never routes a
-# turn through the SkillAgent. All skills data and code remain intact, so the
-# feature can be turned back on by flipping this flag. Set it on BOTH app-api
-# and inference-api containers when enabling.
+# The Skills feature (admin catalog, My Skills authoring, and skill resolution
+# on the invocation path) is gated by SKILLS_ENABLED. Skills are pure knowledge
+# bundles (Skills v2) — they bind no tools and are opt-in per turn, not a mode.
+# While off, app-api leaves the user + admin skills routes unmounted (404) and
+# inference-api resolves no skills. All skills data and code remain intact, so
+# the feature can be turned back off by flipping this flag. Set it on BOTH the
+# app-api and inference-api containers.
+#
+# TWO INDEPENDENT CONTROLS. This flag gates feature *existence* per environment.
+# *Who* sees the user-facing surfaces is the `skills` RBAC capability
+# (apis.shared.rbac.capabilities), granted through the tools axis: system_admin
+# holds it implicitly via its "*" grant, so the surfaces are admin-only out of
+# the box. GA = grant `skills` to the `default` role — one config change, no
+# redeploy. The capability deliberately does NOT gate the runtime, so an Agent
+# shared to an ordinary user still resolves its bound skills (invoke-through).
 
 # Enable the skills feature (OPTIONAL)
-# Purpose: Feature gate. When "true", the skills surfaces are mounted.
-# Default: false
-SKILLS_ENABLED=false
+# Purpose: Feature gate. Default ON with a kill switch — unset or empty resolves
+#   to enabled; only the literal "false" (case-insensitive) disables.
+# Default: true
+SKILLS_ENABLED=true
 
 # =============================================================================
 # FINE-TUNING (OPTIONAL)

--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, Upl
 from pydantic import BaseModel, Field
 
 from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.rbac.capabilities import SKILLS_CAPABILITY, user_has_capability
 from apis.shared.skills.access import resolve_accessible_skill_ids
 from apis.shared.skills.models import (
     SkillDefinition,
@@ -44,6 +45,29 @@ from .user_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/skills", tags=["skills"])
+
+
+async def require_skills_capability(
+    current: User = Depends(get_current_user_from_session),
+) -> User:
+    """Gate the user-facing skills surfaces on the ``skills`` RBAC capability.
+
+    ``SKILLS_ENABLED`` says the feature *exists* here; this says *who* sees it.
+    During the initial rollout only ``system_admin`` holds it (implicitly, via
+    the ``"*"`` tools grant); GA is one grant of ``skills`` to the ``default``
+    role — no redeploy (see ``apis.shared.rbac.capabilities``).
+
+    Raises **404, not 403**, on purpose. The SPA hides the "My Skills" nav entry
+    by riding this list call — a 404 flips ``accessible$`` false and the entry
+    stays hidden, exactly as it already behaves when the router is unmounted. A
+    403 would surface an error toast instead of hiding the surface, and the
+    scheduled-runs capability gate was reverted in prod for precisely that class
+    of problem. Not a security boundary: the runtime is deliberately ungated so
+    invoke-through keeps working for ordinary users.
+    """
+    if not await user_has_capability(current, SKILLS_CAPABILITY):
+        raise HTTPException(status_code=404, detail="Not found")
+    return current
 
 
 class UserSkillResponse(BaseModel):
@@ -78,7 +102,7 @@ class SkillPreferencesRequest(BaseModel):
 
 @router.get("/", response_model=UserSkillsResponse)
 async def get_user_skills(
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ) -> UserSkillsResponse:
     """
     Get the ACTIVE skills the current user's roles grant, with the user's
@@ -119,7 +143,7 @@ async def get_user_skills(
 @router.put("/preferences")
 async def update_skill_preferences(
     request: SkillPreferencesRequest,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """
     Save the user's per-skill enabled/disabled preferences.
@@ -244,7 +268,7 @@ def _resource_value_error(e: ValueError) -> HTTPException:
 
 @router.get("/mine", response_model=MySkillListResponse)
 async def list_my_skills(
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ) -> MySkillListResponse:
     """List every skill the current user authored (any status)."""
     logger.info(f"User {user.name} listing authored skills")
@@ -259,7 +283,7 @@ async def list_my_skills(
 @router.post("/mine", response_model=MySkillResponse)
 async def create_my_skill(
     request: CreateMySkillRequest,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ) -> MySkillResponse:
     """Create a skill owned by the current user."""
     logger.info(f"User {user.name} creating an authored skill")
@@ -283,7 +307,7 @@ async def create_my_skill(
 @router.get("/mine/{skill_id}", response_model=MySkillResponse)
 async def get_my_skill(
     skill_id: str,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ) -> MySkillResponse:
     """Get one of the current user's authored skills."""
     try:
@@ -298,7 +322,7 @@ async def get_my_skill(
 async def update_my_skill(
     skill_id: str,
     request: UpdateMySkillRequest,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ) -> MySkillResponse:
     """Update one of the current user's authored skills."""
     logger.info(f"User {user.name} updating an authored skill")
@@ -315,7 +339,7 @@ async def update_my_skill(
 @router.delete("/mine/{skill_id}")
 async def delete_my_skill(
     skill_id: str,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """Delete one of the current user's authored skills and its bundle files."""
     logger.info(f"User {user.name} deleting an authored skill")
@@ -336,7 +360,7 @@ async def delete_my_skill(
 @router.get("/mine/{skill_id}/resources", response_model=SkillResourcesResponse)
 async def list_my_skill_resources(
     skill_id: str,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """List an owned skill's supporting-file manifest (no bytes)."""
     try:
@@ -352,7 +376,7 @@ async def upload_my_skill_resource(
     skill_id: str,
     file: UploadFile = File(...),
     kind: str = Form("reference"),
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """Upload (or replace) one supporting file on an owned skill.
 
@@ -384,7 +408,7 @@ async def upload_my_skill_resource(
 async def read_my_skill_resource(
     skill_id: str,
     filename: str,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """Return the raw bytes of one of an owned skill's supporting files."""
     try:
@@ -409,7 +433,7 @@ async def read_my_skill_resource(
 async def delete_my_skill_resource(
     skill_id: str,
     filename: str,
-    user: User = Depends(get_current_user_from_session),
+    user: User = Depends(require_skills_capability),
 ):
     """Delete one supporting file from an owned skill. Returns the manifest."""
     logger.info(f"User {user.name} deleting a skill bundle file")

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -16,15 +16,26 @@ import os
 
 
 def skills_enabled() -> bool:
-    """Whether the Skills feature is enabled for this environment.
+    """Whether the Skills feature exists in this environment.
 
-    Covers the admin skills catalog, the user-facing skills picker, and
-    skills mode (routing turns through the ``SkillAgent``). Defaults off;
-    set ``SKILLS_ENABLED=true`` to turn it on. While off, new turns are
-    forced through the plain ``ChatAgent`` and the skills surfaces are
-    unmounted / hidden, but all skills data and code remain intact.
+    Covers the admin skills catalog, the user-facing skills picker, My Skills
+    authoring, and skill resolution on the runtime path. **Default ON with a
+    kill switch** (house style, mirroring ``SCHEDULED_RUNS_ENABLED``): unset or
+    empty resolves to enabled; only the literal ``"false"`` (case-insensitive)
+    disables. The CDK side threads ``config.skills.enabled`` into this env var
+    with the same empty-string-safe ternary, so an unset GitHub Actions
+    variable can never silently turn the feature off.
+
+    Flipped from default-off in Skills v2 PR-5, once the epic was complete and
+    dogfooded end to end (a real agentskills.io bundle uploaded as a user skill,
+    bound to an Agent, exercised L1→L2→L3 including ``read_skill_file``).
+
+    Note this flag gates *feature existence* per environment; *who* may use it
+    is the ``skills`` RBAC capability (``apis.shared.rbac.capabilities``) — two
+    independent controls. The capability keeps the surfaces admin-only during
+    the initial rollout; GA is one role-grant change, no redeploy.
     """
-    return os.environ.get("SKILLS_ENABLED", "false").lower() == "true"
+    return os.environ.get("SKILLS_ENABLED", "").strip().lower() != "false"
 
 
 def scheduled_runs_enabled() -> bool:

--- a/backend/src/apis/shared/rbac/capabilities.py
+++ b/backend/src/apis/shared/rbac/capabilities.py
@@ -35,6 +35,19 @@ from apis.shared.rbac.service import get_app_role_service
 #: Phase B). Granted to the beta cohort's role; GA = grant to ``default``.
 SCHEDULED_RUNS_CAPABILITY = "scheduled-runs"
 
+#: Gates the user-facing Skills *surfaces* — the chat picker (``GET /skills/``,
+#: ``PUT /skills/preferences``) and My Skills authoring (``/skills/mine/*``).
+#: Skills v2 PR-5 turns ``SKILLS_ENABLED`` on everywhere but keeps the surfaces
+#: to admins first: ``system_admin``'s ``"*"`` tools grant satisfies this
+#: implicitly, so no seeding is needed for the admin cohort. **GA = grant
+#: ``skills`` to the ``default`` role — one config change, no redeploy.**
+#:
+#: Deliberately does NOT gate the runtime. An Agent shared to an ordinary user
+#: must still resolve its bound skills for them (invoke-through, §6/D7), and a
+#: capability check there would break exactly that path. Authoring and
+#: selection are gated; invocation through someone else's Agent is not.
+SKILLS_CAPABILITY = "skills"
+
 
 async def user_has_capability(user: User, capability_id: str) -> bool:
     """True iff ``user`` resolves the capability through their AppRoles.

--- a/backend/tests/apis/app_api/skills/test_my_skill_routes.py
+++ b/backend/tests/apis/app_api/skills/test_my_skill_routes.py
@@ -20,6 +20,12 @@ def client(user_skill_service, author_user, monkeypatch):
     app = FastAPI()
     app.include_router(skill_routes.router)
     app.dependency_overrides[get_current_user_from_session] = lambda: author_user
+    # PR-5: routes hang off the `skills` capability gate, which would otherwise
+    # resolve RBAC against DynamoDB. Ownership — what this file tests — is
+    # enforced inside UserSkillService, independently of the gate.
+    app.dependency_overrides[skill_routes.require_skills_capability] = (
+        lambda: author_user
+    )
     with TestClient(app) as c:
         yield c
 
@@ -33,12 +39,24 @@ def other_client(user_skill_service, other_user, monkeypatch):
     app = FastAPI()
     app.include_router(skill_routes.router)
     app.dependency_overrides[get_current_user_from_session] = lambda: other_user
+    app.dependency_overrides[skill_routes.require_skills_capability] = (
+        lambda: other_user
+    )
     with TestClient(app) as c:
         yield c
 
 
 def test_my_skills_routes_use_session_auth_not_bearer():
-    """A Bearer-only dependency here would 401-loop the cookie-bearing SPA."""
+    """A Bearer-only dependency here would 401-loop the cookie-bearing SPA.
+
+    Walks the TRANSITIVE dependency tree, not just each route's direct
+    dependencies: since PR-5 the routes depend on ``require_skills_capability``,
+    which in turn depends on the session. The invariant being pinned is "the
+    session dependency is reachable from every /mine route", which is what
+    actually keeps the cookie-bearing SPA off the 401-redirect loop — asserting
+    the flat shape instead would break on any future gate wrapper while proving
+    less.
+    """
     paths = [
         r
         for r in skill_routes.router.routes
@@ -46,9 +64,14 @@ def test_my_skills_routes_use_session_auth_not_bearer():
     ]
     assert paths, "expected /mine routes to be registered"
 
+    def _calls(dependant):
+        for sub in dependant.dependencies:
+            if sub.call is not None:
+                yield sub.call
+            yield from _calls(sub)
+
     for route in paths:
-        deps = [d.call for d in route.dependant.dependencies]
-        assert get_current_user_from_session in deps, route.path
+        assert get_current_user_from_session in set(_calls(route.dependant)), route.path
 
 
 def test_create_list_get_roundtrip(client):

--- a/backend/tests/apis/app_api/test_skills_feature_flag.py
+++ b/backend/tests/apis/app_api/test_skills_feature_flag.py
@@ -1,11 +1,17 @@
 """Tests for the SKILLS_ENABLED feature gate.
 
-The skills feature (admin catalog, user picker) is deferred and disabled by
-default. These tests pin two things:
+Skills v2 PR-5 flipped this to **default ON with a kill switch** (the
+``SCHEDULED_RUNS_ENABLED`` house style): unset or empty resolves enabled, only
+the literal ``"false"`` disables. These tests pin three things:
 
-* the ``skills_enabled()`` helper's parsing + default-off behavior, and
-* that the admin skills subrouter is unmounted while the flag is off and
-  mounted while it is on.
+* the ``skills_enabled()`` helper's parsing + default-ON behavior — including
+  the empty-string case, which an unset GitHub Actions variable produces and
+  which must NOT read as disabled,
+* that the admin skills subrouter mounts with the flag on and unmounts with it
+  explicitly off, and
+* that the ``skills`` capability — not the flag — is what gates *who* sees the
+  user-facing surfaces, and that it 404s (never 403s) so the SPA hides the nav
+  entry rather than surfacing an error.
 
 The admin subrouter mounts conditionally at import time, so — like the
 fine-tuning gate in tests/routes/test_admin_lows.py — these reload the module
@@ -29,24 +35,28 @@ from apis.shared.feature_flags import skills_enabled
 
 
 class TestSkillsEnabledFlag:
-    def test_defaults_off_when_unset(self, monkeypatch):
+    def test_defaults_on_when_unset(self, monkeypatch):
         monkeypatch.delenv("SKILLS_ENABLED", raising=False)
-        assert skills_enabled() is False
+        assert skills_enabled() is True
 
     @pytest.mark.parametrize(
         "value, expected",
         [
-            ("true", True),
-            ("True", True),
-            ("TRUE", True),
             ("false", False),
-            ("0", False),
-            ("1", False),
-            ("yes", False),
-            ("", False),
+            ("False", False),
+            ("FALSE", False),
+            (" false ", False),
+            ("true", True),
+            ("0", True),
+            ("no", True),
+            # An unset GitHub Actions variable forwards as the empty string.
+            # It must resolve ENABLED — reading it as "off" is how a kill
+            # switch silently dark-ships a live feature.
+            ("", True),
+            ("   ", True),
         ],
     )
-    def test_parses_env_value(self, monkeypatch, value, expected):
+    def test_only_literal_false_disables(self, monkeypatch, value, expected):
         monkeypatch.setenv("SKILLS_ENABLED", value)
         assert skills_enabled() is expected
 
@@ -63,10 +73,9 @@ def admin_router_paths():
     here can't leak mounted skills routes into later tests."""
 
     def _load(*, enabled: bool) -> set[str]:
-        if enabled:
-            os.environ["SKILLS_ENABLED"] = "true"
-        else:
-            os.environ.pop("SKILLS_ENABLED", None)
+        # Under the default-ON flag, "disabled" must be set EXPLICITLY —
+        # popping the var now means enabled.
+        os.environ["SKILLS_ENABLED"] = "true" if enabled else "false"
         importlib.reload(admin_routes_module)
         return {getattr(route, "path", "") for route in admin_routes_module.router.routes}
 
@@ -84,3 +93,82 @@ def test_admin_skills_unmounted_when_disabled(admin_router_paths):
 def test_admin_skills_mounted_when_enabled(admin_router_paths):
     paths = admin_router_paths(enabled=True)
     assert any("/skills" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# `skills` capability gate on the user-facing surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsCapabilityGate:
+    """PR-5 keeps the surfaces admin-only while the flag itself is on.
+
+    Two independent controls: ``SKILLS_ENABLED`` says the feature exists in this
+    environment, the ``skills`` capability says who sees it. GA is one grant of
+    ``skills`` to the ``default`` role — no redeploy.
+    """
+
+    @pytest.mark.asyncio
+    async def test_holder_passes_through(self, monkeypatch):
+        from apis.app_api.skills import routes as skills_routes
+
+        user = _user()
+        monkeypatch.setattr(
+            skills_routes, "user_has_capability", _capability_stub(True)
+        )
+        assert await skills_routes.require_skills_capability(current=user) is user
+
+    @pytest.mark.asyncio
+    async def test_non_holder_gets_404_not_403(self, monkeypatch):
+        """404 on purpose: the SPA hides the nav entry by riding this call.
+
+        A 403 would surface an error toast instead of hiding the surface — the
+        failure mode that got the scheduled-runs capability gate reverted in
+        prod. Pin the status so a well-meaning "403 is more correct" change
+        can't silently reintroduce it.
+        """
+        from fastapi import HTTPException
+
+        from apis.app_api.skills import routes as skills_routes
+
+        monkeypatch.setattr(
+            skills_routes, "user_has_capability", _capability_stub(False)
+        )
+        with pytest.raises(HTTPException) as exc:
+            await skills_routes.require_skills_capability(current=_user())
+        assert exc.value.status_code == 404
+
+    def test_every_user_facing_route_is_gated(self):
+        """No user-facing skills route may depend on the session directly.
+
+        A new route added with the bare session dependency would be reachable
+        by the whole org the moment the flag went on — the gate has to be the
+        default, not a thing each route remembers.
+        """
+        from apis.app_api.skills import routes as skills_routes
+
+        ungated = []
+        for route in skills_routes.router.routes:
+            deps = getattr(route, "dependant", None)
+            names = {
+                sub.call.__name__
+                for sub in getattr(deps, "dependencies", [])
+                if getattr(sub, "call", None)
+            }
+            if "require_skills_capability" not in names:
+                ungated.append(getattr(route, "path", "?"))
+
+        assert ungated == [], f"ungated skills routes: {ungated}"
+
+
+def _user():
+    from apis.shared.auth.models import User
+
+    return User(email="u@example.edu", user_id="u-1", name="u", roles=[])
+
+
+def _capability_stub(result: bool):
+    async def _stub(user, capability_id):
+        return result
+
+    return _stub

--- a/backend/tests/apis/app_api/test_user_skills_routes.py
+++ b/backend/tests/apis/app_api/test_user_skills_routes.py
@@ -69,6 +69,11 @@ def _make_client(
     app = FastAPI()
     app.include_router(skills_routes.router)
     app.dependency_overrides[get_current_user_from_session] = _user
+    # The routes hang off `require_skills_capability` (PR-5), which resolves the
+    # `skills` RBAC capability against DynamoDB. These tests are about the route
+    # behavior, not the gate — the gate has its own tests in
+    # tests/apis/app_api/test_skills_feature_flag.py.
+    app.dependency_overrides[skills_routes.require_skills_capability] = _user
     return TestClient(app)
 
 

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -51,6 +51,7 @@ export interface AppConfig {
   kbSync: KbSyncConfig;
   scheduledRuns: ScheduledRunsConfig;
   memorySpaces: MemorySpacesConfig;
+  skills: SkillsConfig;
   agents: AgentsConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
@@ -169,6 +170,23 @@ export interface ScheduledRunsConfig {
  * are provisioned unconditionally, so this only gates route mounting at runtime.
  */
 export interface MemorySpacesConfig {
+  enabled: boolean;
+}
+
+/**
+ * Skills feature flag (Skills v2). Default ON with a kill switch — the epic is
+ * complete and dogfooded, so it ships enabled for every deployer (opt-out),
+ * disabled per environment with CDK_SKILLS_ENABLED=false (or a
+ * `skills.enabled: false` cdk.json context). Sets the SKILLS_ENABLED env var on
+ * app-api and inference-api; the skills data lives in the shared app-roles
+ * table, so this only gates route mounting and skill resolution at runtime.
+ *
+ * This gates *feature existence* per environment. *Who* sees the user-facing
+ * surfaces is the separate `skills` RBAC capability
+ * (backend `apis.shared.rbac.capabilities`), which keeps them admin-only during
+ * rollout — GA is one grant of `skills` to the `default` role, no redeploy.
+ */
+export interface SkillsConfig {
   enabled: boolean;
 }
 
@@ -377,6 +395,18 @@ export function loadConfig(scope: cdk.App): AppConfig {
       enabled: process.env.CDK_MEMORY_SPACES_ENABLED
         ? process.env.CDK_MEMORY_SPACES_ENABLED !== 'false'
         : scope.node.tryGetContext('memorySpaces')?.enabled ?? true,
+    },
+    skills: {
+      // Default ON with a kill switch (house style, mirroring memorySpaces /
+      // scheduledRuns): the workflow forwards an EMPTY STRING when the variable is
+      // unset, so treat empty/unset as the default (on) and only the literal
+      // "false" as the kill switch. A `skills.enabled: false` cdk.json context can
+      // also force it off. Skills v2 is complete and dogfooded end to end, so it
+      // ships on everywhere; the user-facing surfaces stay admin-only via the
+      // separate `skills` RBAC capability until GA.
+      enabled: process.env.CDK_SKILLS_ENABLED
+        ? process.env.CDK_SKILLS_ENABLED !== 'false'
+        : scope.node.tryGetContext('skills')?.enabled ?? true,
     },
     agents: {
       // Default ON with a kill switch (house style, mirroring memorySpaces /

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -295,6 +295,11 @@ export function buildAppApiEnvironment(
     MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
     DYNAMODB_MEMORY_SPACES_TABLE_NAME: params.memorySpacesTableName,
     S3_MEMORY_SPACES_BUCKET_NAME: params.memorySpacesBucketName,
+    // Skills v2 (default ON with a kill switch per env). Skills live in the
+    // shared app-roles table, which is already wired, so this only gates route
+    // mounting. Cohort access is the separate `skills` RBAC capability — this
+    // flag only gates feature existence per environment.
+    SKILLS_ENABLED: config.skills.enabled ? 'true' : 'false',
     // Kill switch for the Agent Designer /agents surface (default off per env).
     // Gates only whether the routes 404; the assistant store it reads is always
     // present, so no extra table/bucket wiring is needed here.

--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -347,6 +347,14 @@ export class InferenceAgentCoreConstruct extends Construct {
         DYNAMODB_MEMORY_SPACES_TABLE_NAME: props.refs.memorySpacesTable.tableName,
         MEMORY_SPACES_ENABLED: config.memorySpaces.enabled ? 'true' : 'false',
 
+        // Skills v2 (default ON with a kill switch, mirroring the app-api flag).
+        // Gates skill resolution on the invocation path — the AgentSkills plugin's
+        // <available_skills> block, the `skills` activation tool, and
+        // `read_skill_file`. Must stay in step with app-api: design-time refuses to
+        // bind a skill while the flag is off there, so a mismatch would let an Agent
+        // be built with skills the runtime then blocks.
+        SKILLS_ENABLED: config.skills.enabled ? 'true' : 'false',
+
         // Agent Designer harness resolution (Phase 3): the runtime resolves an
         // Agent's bindings + modelConfig at invocation. Gates that resolution;
         // default off, mirrors the app-api flag. Without it the harness ignores

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -54,6 +54,9 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     memorySpaces: {
       enabled: false,
     },
+    skills: {
+      enabled: false,
+    },
     agents: {
       enabled: false,
     },


### PR DESCRIPTION
Final PR of the Skills v2 epic (spec `docs/specs/skills-as-agent-primitive.md` §8 — "PR-5 — Flip"). Follows #684.

## What this does

Flips `SKILLS_ENABLED` to **default ON with a kill switch** and adds the infrastructure wiring it never had.

`SKILLS_ENABLED` had **zero** CDK/workflow plumbing — a grep of `infrastructure/` and `.github/` returned nothing — so "enable it per environment" was not previously expressible at all. That plumbing is the bulk of this diff:

- `SkillsConfig` in `infrastructure/lib/config.ts`
- `SKILLS_ENABLED` threaded into **both** `app-api-environment.ts` and `inference-agentcore-construct.ts`
- `CDK_SKILLS_ENABLED` forwarded in `platform.yml`, with the empty-string-safe ternary an unset GitHub Actions variable requires
- the `skills` block in `test/helpers/mock-config.ts` (tsc fails without it)

Both compute constructs must stay in step: design-time refuses to bind a skill while the flag is off, so a mismatch would let an Agent be built with skills the runtime then blocks.

## Two independent controls

Feature *existence* and *audience* are separate:

| Control | Answers | Mechanism |
|---|---|---|
| `SKILLS_ENABLED` | Does this feature exist in this environment? | env var, default ON, kill switch |
| `skills` capability | Who sees the user-facing surfaces? | RBAC, `apis.shared.rbac.capabilities` |

`system_admin` holds the capability implicitly via its `"*"` tools grant, so the chat picker and My Skills stay **admin-only** during rollout with no seeding required. **GA is one grant of `skills` to the `default` role — no redeploy.**

Two deliberate design points, both load-bearing:

- **The gate raises 404, not 403.** The SPA hides the My Skills nav entry by riding the list call, so a 404 hides the surface while a 403 surfaces an error toast — the failure mode that got the scheduled-runs capability gate reverted in prod.
- **It does not gate the runtime.** An Agent shared to an ordinary user must still resolve its bound skills (invoke-through, §6/D7); a capability check there would break exactly that path.

A test pins that *every* user-facing skills route hangs off the gate, so a new route can't be added with the bare session dependency and become org-visible the moment the flag goes on.

## Verification

Dogfooded live against a real agentskills.io bundle (Anthropic's `docx`) uploaded as a **user** skill and bound to an Agent:

| Level | Mechanism | Context |
|---|---|---|
| L1 | `<available_skills>` name + description | 8,075 |
| L2 | `skills` tool → SKILL.md body | 9,835 |
| L3 | `read_skill_file` → `references/LICENSE.txt` | 10,737 |

SKILL.md frontmatter import prefills name/description and strips frontmatter from instructions.

**Invoke-through verified with a real second non-admin account** — the one thing #684 could not test:

- **Grant** — the invoker reaches the Agent owner's private skill through the shared Agent, full L1→L2→L3.
- **No leak** — that same skill is absent from the invoker's own `/skills/` picker and `/skills/mine`. Agent-scoped, as designed.
- **Chain-sharing block** — owner-match refuses a skill the Agent's owner doesn't author; the D5 block message fires through the real turn path.
- **System carve-out** — a `system`-owned Agent gets no clause 3.
- **`"*"` does not sweep user-authored skills** — confirmed live with an admin account, by flipping a skill's owner away and watching access disappear while the wildcard stayed unchanged.

## Test plan

- Backend: **4718 passed**, 3 skipped
- Infrastructure: `npx tsc --noEmit` clean, **469 jest passed**
- No SPA changes — the nav hides via the existing 404 path

## Notes for review

- **The code change alone activates skills at the next `backend.yml` deploy**, before any CDK deploy: deployed containers set no `SKILLS_ENABLED` today, and unset now reads as enabled. The CDK wiring makes it controllable, not active.
- **The capability gate is inert on dev-ai**, where `ROLE#default` carries `grantedTools: ["*"]` and capabilities ride the tools axis. prod-ai is properly enumerated, so the gate is real there. Tightening dev-ai's wildcard is separate, unscoped work.
- **prod-ai has been seeded** with the example `web_research` skill (only `seed_example_skills()` was run, not `main()` — the full bootstrap seeder would also create any model or tool prod deliberately lacks). It is inert until GA, since `default` holds no `skills` capability.
- **Known gap:** bundle storage is flat per kind with no path separators in filenames (50 files / 1 MiB each), so a nested real-world bundle like `docx` (61 files under `scripts/office/...`) cannot be uploaded faithfully. Relevant to the "harness-lane attachment of the same bundles" item in Later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)