### PR TITLE
refactor(rbac): remove dead AppRoleService.can_access_skill

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -12,7 +12,7 @@ Resolution scope:
   re-resolves each bound tool against the *invoker* (``AppRoleService.can_access_tool``, D5).
 - ``skill``          → feature-flagged; author must have the skill in the ``/agents/bindable``
   palette (``resolve_accessible_skill_ids``, the SAME source the picker fetches). Run-time then
-  re-resolves each bound skill against the *invoker* (``AppRoleService.can_access_skill``, D5).
+  re-resolves each bound skill against the *invoker* (``resolve_invocable_skill_ids``, D5).
 - ``memory_space``   → feature-flagged; author needs viewer+ (read) / editor+ (readwrite).
 - ``knowledge_base`` → **managed implicitly** (the KB is welded to the agent and its index
   is not user-configurable), so it is NOT author-settable; the compat layer synthesizes it
@@ -202,7 +202,7 @@ def _validate_skill(binding: AgentBinding, accessible_skill_ids: set) -> None:
         raise BindingValidationError("skill binding requires a non-empty 'ref'.", status_code=400)
     # The skill id must be in the author's palette (resolve_accessible_skill_ids) — the exact
     # source the Designer picker fetches. Run-time re-resolves against the invoker via
-    # AppRoleService.can_access_skill (D5).
+    # resolve_invocable_skill_ids (D5), which adds the Agent-owner invoke-through clause.
     if ref not in accessible_skill_ids:
         raise BindingValidationError(
             f"You do not have access to skill '{ref}'.", status_code=403

--- a/backend/src/apis/inference_api/chat/agent_binding_resolver.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_resolver.py
@@ -182,10 +182,10 @@ async def _resolve_skills(assistant: Assistant, invoker: User) -> Optional[Resol
     this resolver only after ``get_assistant_with_access_check`` has admitted the
     invoker — so the predicate only re-tests the owner-match half.
 
-    Replaces the previous ``AppRoleService.can_access_skill`` check, which was wrong on
-    two axes: it had no ownership clause (an author binding their *own* authored skill
-    was blocked on their own invocation), and its ``"*"`` wildcard matched any id at all,
-    including another user's private authored skill.
+    Replaced the previous ``AppRoleService.can_access_skill`` check (since removed),
+    which was wrong on two axes: it had no ownership clause (an author binding their
+    *own* authored skill was blocked on their own invocation), and its ``"*"`` wildcard
+    matched any id at all, including another user's private authored skill.
     """
     skill_bindings = [b for b in (assistant.bindings or []) if b.kind == "skill"]
     if not skill_bindings:

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -199,16 +199,6 @@ class AppRoleService:
 
         return model_id in permissions.models
 
-    async def can_access_skill(self, user: User, skill_id: str) -> bool:
-        """Check if user can access a specific skill."""
-        permissions = await self.resolve_user_permissions(user)
-
-        # Wildcard grants access to all
-        if "*" in permissions.skills:
-            return True
-
-        return skill_id in permissions.skills
-
     async def get_accessible_tools(self, user: User) -> List[str]:
         """Get list of tool IDs user can access."""
         permissions = await self.resolve_user_permissions(user)

--- a/backend/src/apis/shared/skills/access.py
+++ b/backend/src/apis/shared/skills/access.py
@@ -95,11 +95,12 @@ async def resolve_invocable_skill_ids(
        share-access to the Agent.
 
     Clauses 1+2 are exactly ``resolve_accessible_skill_ids``. Note this is
-    deliberately NOT ``AppRoleService.can_access_skill``: that returns ``True``
-    for a ``"*"`` wildcard role against *any* id, including another user's
-    private authored skill, and it has no ownership clause at all (so an author
-    binding their own skill was blocked on their own invocation). Routing
-    through the shared resolver expands ``"*"`` over the catalog only.
+    deliberately NOT a bare RBAC permission check (the removed
+    ``AppRoleService.can_access_skill``): that returned ``True`` for a ``"*"``
+    wildcard role against *any* id, including another user's private authored
+    skill, and it had no ownership clause at all (so an author binding their own
+    skill was blocked on their own invocation). Routing through the shared
+    resolver expands ``"*"`` over the catalog only.
 
     Clause 3's **share-access half is the caller's precondition**: this is
     reached only after ``get_assistant_with_access_check`` has already admitted

--- a/backend/tests/rbac/test_app_role_skills.py
+++ b/backend/tests/rbac/test_app_role_skills.py
@@ -4,7 +4,6 @@ Mirrors the tool/model coverage in test_app_role_service.py and
 test_app_role_admin_service.py:
 - skills union merge across roles (service)
 - wildcard skills (service)
-- can_access_skill: wildcard / match / no-match (service)
 - only enabled roles contribute skills (service)
 - inheritance merge of granted_skills (admin _compute_effective_permissions)
 - add_skill_to_role / remove_skill_from_role (admin)
@@ -87,42 +86,6 @@ async def test_wildcard_in_skills(service, mock_app_role_repo, make_app_role, us
     perms = await service.resolve_user_permissions(user)
 
     assert "*" in perms.skills
-
-
-@pytest.mark.asyncio
-async def test_can_access_skill_with_wildcard(service, mock_app_role_repo, make_app_role, user):
-    role_a = make_app_role(role_id="editor", skills=["*"], priority=1)
-    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
-        "Editor": ["editor"],
-        "Viewer": [],
-    }.get(r, [])
-    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
-
-    assert await service.can_access_skill(user, "any_skill") is True
-
-
-@pytest.mark.asyncio
-async def test_can_access_skill_with_match(service, mock_app_role_repo, make_app_role, user):
-    role_a = make_app_role(role_id="editor", skills=["pdf_workflows"], priority=1)
-    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
-        "Editor": ["editor"],
-        "Viewer": [],
-    }.get(r, [])
-    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
-
-    assert await service.can_access_skill(user, "pdf_workflows") is True
-
-
-@pytest.mark.asyncio
-async def test_can_access_skill_with_no_match(service, mock_app_role_repo, make_app_role, user):
-    role_a = make_app_role(role_id="editor", skills=["pdf_workflows"], priority=1)
-    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: {
-        "Editor": ["editor"],
-        "Viewer": [],
-    }.get(r, [])
-    mock_app_role_repo.get_role.side_effect = lambda rid: {"editor": role_a}.get(rid)
-
-    assert await service.can_access_skill(user, "other_skill") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`AppRoleService.can_access_skill` has had **zero production callers** since Skills v2 PR-4. All references in `backend/src` were comments/docstrings — three of which explicitly warned against using it.

It is wrong on two axes for anything user-tier:
- **No ownership clause** — an author binding their *own* authored skill was blocked on their own invocation.
- **`"*"` wildcard over-expansion** — a wildcard role matched ANY skill id, including another user's private authored skill.

The correct replacements already exist and are used everywhere:
- `apis/shared/skills/access.py::resolve_accessible_skill_ids` — catalog ∪ own
- `resolve_invocable_skill_ids` — adds the Agent-owner invoke-through clause

## Changes

- **Delete** `can_access_skill` from `apis/shared/rbac/service.py`.
- **Delete** its three tests in `tests/rbac/test_app_role_skills.py` plus the module-docstring bullet. Notably `test_can_access_skill_with_wildcard` asserted `can_access_skill(user, "any_skill") is True` — it actively enshrined the wildcard over-expansion bug as expected behavior, which is the main reason to remove rather than keep.
- **Fix two stale doc references** in `agent_designer/services/binding_validation.py` (module docstring + inline comment) that still named `AppRoleService.can_access_skill` as the live run-time mechanism. Since PR-4 that is `resolve_invocable_skill_ids`.
- **Reword** the intentional "deliberately NOT `can_access_skill`" rationale in `skills/access.py` and `inference_api/chat/agent_binding_resolver.py` to past tense. Those explanations document *why* the replacement exists and stay useful — they just shouldn't imply the function still exists.

No behavior change: nothing called it.

## Test plan

`cd backend && uv run python -m pytest tests/ -q` → **4686 passed, 3 skipped** (baseline minus the 3 deleted tests).

## Note for reviewers

There is a **separate, also-apparently-dead** `SkillAccessService.can_access_skill` in `apis/app_api/admin/services/skill_access.py`. Grepping `SkillAccessService|get_skill_access_service` across `src` turns up only a *comment* in `admin/skills/routes.py:100` — no live callers of the class at all. Left untouched here to keep this PR scoped; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)