### PR TITLE
refactor(artifacts): collapse the two artifact catalog rows into one Artifacts toggle

### DIFF
--- a/backend/scripts/backfill_artifact_tool_merge.py
+++ b/backend/scripts/backfill_artifact_tool_merge.py
@@ -1,0 +1,327 @@
+"""Backfill: collapse the two artifact catalog rows into one "Artifacts" toggle.
+
+Artifacts shipped as two independent ``protocol: local`` catalog rows —
+``create_artifact`` and ``update_artifact`` — so the tool picker listed them as
+two unrelated entries. They are now a single capability following the
+Word-document idiom: one catalog row (``create_artifact``, displayName
+"Artifacts") whose id is the gate key, and enabling it injects *both* the
+create and update tools at runtime. See ``ARTIFACT_TOOL_IDS`` /
+``_build_artifact_tools`` in ``apis/inference_api/chat/routes.py``.
+
+``seed_default_tools`` is create-only (it skips rows that already exist), so a
+seed run does nothing to an environment that was seeded before this change.
+This script performs the migration:
+
+1. **Retitle** ``TOOL#create_artifact`` to the merged displayName/description.
+2. **Promote** every role that grants ``update_artifact`` so it also grants
+   ``create_artifact`` — a role holding *only* the retired id would otherwise
+   silently lose artifact access. Both representations are updated: the
+   ``TOOL_GRANT#`` mapping item (GSI2/ToolRoleMappingIndex) and the
+   ``grantedTools`` / ``effectivePermissions.tools`` arrays on ``DEFINITION``.
+3. **Promote** user tool preferences the same way. ``toolPreferences`` is a
+   sparse override map: an explicit *enable* of the retired id carries over to
+   ``create_artifact`` (create wins when both keys are set), and the retired
+   key is dropped either way. An explicit *disable* does not carry over —
+   someone who switched update off while leaving create at its default-on never
+   asked to lose artifacts entirely.
+4. **Promote** assistant tool bindings (``kind == "tool"``, ``ref ==
+   "update_artifact"``) to ``create_artifact``, de-duplicating.
+5. **Delete** the ``TOOL#update_artifact`` catalog row and every
+   ``TOOL_GRANT#update_artifact`` mapping item.
+
+Note the promote-before-delete ordering: nothing is removed until its
+replacement is in place, so an aborted run degrades to "both ids granted",
+never to "neither".
+
+OUT OF SCOPE
+------------
+Schedule snapshots (``enabledTools`` on the sessions-metadata table) are left
+alone. A stale ``update_artifact`` entry there is an inert no-op — the runtime
+only reads ``create_artifact`` — and any snapshot taken while both rows were
+seeded default-on already carries ``create_artifact`` alongside it.
+
+SAFETY
+------
+* **Dry-run by default.** Pass ``--apply`` to actually write.
+* **Idempotent + re-runnable.** A second run finds nothing to do.
+* **Scoped.** ``--assistants-table`` is optional; omit it to skip step 4.
+
+Run against dev first, then prod::
+
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_artifact_tool_merge.py \\
+        --table dev-boisestateai-v2-app-roles \\
+        --assistants-table dev-boisestateai-v2-assistants          # dry-run
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_artifact_tool_merge.py \\
+        --table dev-boisestateai-v2-app-roles \\
+        --assistants-table dev-boisestateai-v2-assistants --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_artifact_tool_merge")
+
+KEEP_ID = "create_artifact"
+RETIRED_ID = "update_artifact"
+
+MERGED_DISPLAY_NAME = "Artifacts"
+MERGED_DESCRIPTION = (
+    "Save standalone HTML or Markdown documents as versioned artifacts the "
+    "user can open and iterate on. Updates create a new immutable version."
+)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def retitle_catalog_row(table: Any, apply: bool) -> int:
+    """Point TOOL#create_artifact at the merged name/description."""
+    resp = table.get_item(Key={"PK": f"TOOL#{KEEP_ID}", "SK": "METADATA"})
+    item = resp.get("Item")
+    if not item:
+        logger.warning(f"TOOL#{KEEP_ID} not found — nothing to retitle")
+        return 0
+    if item.get("displayName") == MERGED_DISPLAY_NAME:
+        logger.info(f"TOOL#{KEEP_ID} already retitled — skipped")
+        return 0
+
+    logger.info(
+        f"retitle TOOL#{KEEP_ID}: {item.get('displayName')!r} -> {MERGED_DISPLAY_NAME!r}"
+    )
+    if apply:
+        table.update_item(
+            Key={"PK": f"TOOL#{KEEP_ID}", "SK": "METADATA"},
+            UpdateExpression=(
+                "SET displayName = :dn, description = :d, updatedAt = :u"
+            ),
+            ExpressionAttributeValues={
+                ":dn": MERGED_DISPLAY_NAME,
+                ":d": MERGED_DESCRIPTION,
+                ":u": _now(),
+            },
+        )
+    return 1
+
+
+def _roles_granting(table: Any, tool_id: str) -> List[Dict[str, Any]]:
+    """Every TOOL_GRANT mapping item for a tool, via ToolRoleMappingIndex."""
+    items: List[Dict[str, Any]] = []
+    kwargs: Dict[str, Any] = {
+        "IndexName": "ToolRoleMappingIndex",
+        "KeyConditionExpression": Key("GSI2PK").eq(f"TOOL#{tool_id}"),
+    }
+    while True:
+        resp = table.query(**kwargs)
+        items.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            return items
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def promote_role_grants(table: Any, apply: bool) -> int:
+    """Ensure every role granting the retired id also grants the keeper."""
+    changed = 0
+    for mapping in _roles_granting(table, RETIRED_ID):
+        role_pk = mapping["PK"]
+        role_id = mapping.get("roleId", role_pk)
+
+        definition = table.get_item(Key={"PK": role_pk, "SK": "DEFINITION"}).get("Item")
+        if not definition:
+            logger.warning(f"{role_pk}: grant exists but DEFINITION missing — skipped")
+            continue
+
+        granted: List[str] = list(definition.get("grantedTools") or [])
+        effective = definition.get("effectivePermissions") or {}
+        effective_tools: List[str] = list(effective.get("tools") or [])
+
+        # A wildcard already covers the keeper; only the arrays need pruning.
+        needs_keeper = KEEP_ID not in granted and "*" not in granted
+
+        if needs_keeper:
+            logger.info(f"{role_id}: grant {KEEP_ID} (held only {RETIRED_ID})")
+            if apply:
+                table.put_item(
+                    Item={
+                        "PK": role_pk,
+                        "SK": f"TOOL_GRANT#{KEEP_ID}",
+                        "GSI2PK": f"TOOL#{KEEP_ID}",
+                        "GSI2SK": role_pk,
+                        "roleId": mapping.get("roleId"),
+                        "displayName": mapping.get("displayName"),
+                        "enabled": mapping.get("enabled", True),
+                    }
+                )
+            granted.append(KEEP_ID)
+            if "*" not in effective_tools:
+                effective_tools.append(KEEP_ID)
+
+        new_granted = [t for t in granted if t != RETIRED_ID]
+        new_effective = [t for t in effective_tools if t != RETIRED_ID]
+
+        if new_granted != (definition.get("grantedTools") or []) or new_effective != (
+            effective.get("tools") or []
+        ):
+            logger.info(f"{role_id}: grantedTools -> {new_granted}")
+            if apply:
+                effective["tools"] = new_effective
+                table.update_item(
+                    Key={"PK": role_pk, "SK": "DEFINITION"},
+                    UpdateExpression=(
+                        "SET grantedTools = :g, effectivePermissions = :e, updatedAt = :u"
+                    ),
+                    ExpressionAttributeValues={
+                        ":g": new_granted,
+                        ":e": effective,
+                        ":u": _now(),
+                    },
+                )
+            changed += 1
+
+        logger.info(f"{role_id}: delete TOOL_GRANT#{RETIRED_ID}")
+        if apply:
+            table.delete_item(Key={"PK": role_pk, "SK": f"TOOL_GRANT#{RETIRED_ID}"})
+    return changed
+
+
+def _scan(table: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    while True:
+        resp = table.scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            return items
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def promote_user_preferences(table: Any, apply: bool) -> int:
+    """Carry an explicit opinion on the retired id over to the keeper."""
+    changed = 0
+    # `contains` matches strings/sets only, never Map keys — toolPreferences is
+    # a Map, so this has to be a nested-path existence check.
+    rows = _scan(
+        table,
+        FilterExpression=Attr("SK").eq("TOOL_PREFERENCES")
+        & Attr(f"toolPreferences.{RETIRED_ID}").exists(),
+    )
+    for row in rows:
+        prefs: Dict[str, Any] = dict(row.get("toolPreferences") or {})
+        if RETIRED_ID not in prefs:
+            continue
+
+        retired_value = prefs.pop(RETIRED_ID)
+        # Create wins when the user has an opinion on both. Otherwise only a
+        # *True* carries over: someone who turned update off while leaving
+        # create at its default-on never asked to lose artifacts, so dropping
+        # the key (falling back to enabledByDefault) is the faithful read.
+        if KEEP_ID not in prefs and retired_value:
+            prefs[KEEP_ID] = True
+
+        logger.info(f"{row['PK']}: toolPreferences -> {prefs}")
+        if apply:
+            table.update_item(
+                Key={"PK": row["PK"], "SK": "TOOL_PREFERENCES"},
+                UpdateExpression="SET toolPreferences = :p, updatedAt = :u",
+                ExpressionAttributeValues={":p": prefs, ":u": _now()},
+            )
+        changed += 1
+    return changed
+
+
+def promote_assistant_bindings(table: Any, apply: bool) -> int:
+    """Rewrite tool bindings on the retired id to the keeper, de-duplicated."""
+    changed = 0
+    rows = _scan(table, FilterExpression=Attr("SK").eq("METADATA") & Attr("bindings").exists())
+    for row in rows:
+        bindings: List[Dict[str, Any]] = list(row.get("bindings") or [])
+        if not any(
+            b.get("kind") == "tool" and b.get("ref") == RETIRED_ID for b in bindings
+        ):
+            continue
+
+        has_keeper = any(
+            b.get("kind") == "tool" and b.get("ref") == KEEP_ID for b in bindings
+        )
+        new_bindings: List[Dict[str, Any]] = []
+        for b in bindings:
+            if b.get("kind") == "tool" and b.get("ref") == RETIRED_ID:
+                if has_keeper:
+                    continue  # keeper already bound — just drop the retired one
+                new_bindings.append({**b, "ref": KEEP_ID})
+                has_keeper = True
+                continue
+            new_bindings.append(b)
+
+        logger.info(f"{row['PK']}: bindings {RETIRED_ID} -> {KEEP_ID}")
+        if apply:
+            table.update_item(
+                Key={"PK": row["PK"], "SK": "METADATA"},
+                UpdateExpression="SET bindings = :b, updatedAt = :u",
+                ExpressionAttributeValues={":b": new_bindings, ":u": _now()},
+            )
+        changed += 1
+    return changed
+
+
+def delete_retired_catalog_row(table: Any, apply: bool) -> int:
+    resp = table.get_item(Key={"PK": f"TOOL#{RETIRED_ID}", "SK": "METADATA"})
+    if "Item" not in resp:
+        logger.info(f"TOOL#{RETIRED_ID} already absent — skipped")
+        return 0
+    logger.info(f"delete TOOL#{RETIRED_ID}")
+    if apply:
+        table.delete_item(Key={"PK": f"TOOL#{RETIRED_ID}", "SK": "METADATA"})
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", required=True, help="app-roles table name")
+    parser.add_argument(
+        "--assistants-table",
+        help="assistants table name; omit to skip the binding rewrite",
+    )
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--apply", action="store_true", help="actually write")
+    args = parser.parse_args()
+
+    if not args.apply:
+        logger.info("DRY RUN — pass --apply to write")
+
+    dynamodb = boto3.Session(region_name=args.region).resource("dynamodb")
+    table = dynamodb.Table(args.table)
+
+    try:
+        retitled = retitle_catalog_row(table, args.apply)
+        roles = promote_role_grants(table, args.apply)
+        prefs = promote_user_preferences(table, args.apply)
+        bindings = 0
+        if args.assistants_table:
+            bindings = promote_assistant_bindings(
+                dynamodb.Table(args.assistants_table), args.apply
+            )
+        else:
+            logger.info("--assistants-table not given — skipping binding rewrite")
+        deleted = delete_retired_catalog_row(table, args.apply)
+    except ClientError as e:
+        logger.error(f"aborted: {e}")
+        return 1
+
+    logger.info(
+        f"done: retitled={retitled} roles={roles} prefs={prefs} "
+        f"bindings={bindings} deleted={deleted}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -413,19 +413,14 @@ DEFAULT_TOOLS: list[dict[str, Any]] = [
         "forwardAuthToken": False,
     },
     {
+        # Single catalog entry / toggle that provisions the whole artifact
+        # toolset. Enabling this one id injects create/update at runtime — see
+        # ARTIFACT_TOOL_IDS and _build_artifact_tools in
+        # apis/inference_api/chat/routes.py. Keep the toolId as
+        # "create_artifact": it is the gate key.
         "toolId": "create_artifact",
-        "displayName": "Create Artifact",
-        "description": "Save standalone HTML or Markdown documents as versioned artifacts the user can open and iterate on.",
-        "category": "document",
-        "protocol": "local",
-        "enabledByDefault": True,
-        "isPublic": True,
-        "forwardAuthToken": False,
-    },
-    {
-        "toolId": "update_artifact",
-        "displayName": "Update Artifact",
-        "description": "Replace an existing artifact's content, creating a new immutable version.",
+        "displayName": "Artifacts",
+        "description": "Save standalone HTML or Markdown documents as versioned artifacts the user can open and iterate on. Updates create a new immutable version.",
         "category": "document",
         "protocol": "local",
         "enabledByDefault": True,

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -415,7 +415,7 @@ def _build_spreadsheet_tools(
 # Artifact Authoring Tool Injection
 # ============================================================
 
-ARTIFACT_TOOL_IDS = {"create_artifact", "update_artifact"}
+ARTIFACT_TOOL_IDS = {"create_artifact"}
 
 
 def _build_artifact_tools(
@@ -424,23 +424,23 @@ def _build_artifact_tools(
     user_id: str,
 ) -> list:
     """Create context-bound artifact authoring tools if enabled by the user."""
-    if not enabled_tools:
+    if not enabled_tools or not ARTIFACT_TOOL_IDS.intersection(enabled_tools):
         return []
 
-    requested = ARTIFACT_TOOL_IDS.intersection(enabled_tools)
-    if not requested:
-        return []
-
+    # Artifacts are a single toggle: enabling create_artifact provisions the
+    # full authoring toolset (create + update) so the model can iterate on a
+    # document without a second admin catalog entry. The legacy
+    # "update_artifact" catalog row is retired — see
+    # backend/scripts/backfill_artifact_tool_merge.py.
     from agents.builtin_tools.artifacts import (
         make_create_artifact_tool,
         make_update_artifact_tool,
     )
 
-    tools = []
-    if "create_artifact" in requested:
-        tools.append(make_create_artifact_tool(session_id, user_id))
-    if "update_artifact" in requested:
-        tools.append(make_update_artifact_tool(session_id, user_id))
+    tools = [
+        make_create_artifact_tool(session_id, user_id),
+        make_update_artifact_tool(session_id, user_id),
+    ]
 
     logger.info(f"Created {len(tools)} artifact authoring tools")
     return tools

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -231,7 +231,10 @@ def test_record_satisfies_minter(aws) -> None:
 
 @pytest.mark.parametrize(
     "enabled,expected",
-    [(None, 0), ([], 0), (["other"], 0), (["create_artifact"], 1),
+    # create_artifact is the single gate key: it provisions create + update.
+    # A stale "update_artifact" preference on its own grants nothing.
+    [(None, 0), ([], 0), (["other"], 0), (["update_artifact"], 0),
+     (["create_artifact"], 2),
      (["create_artifact", "update_artifact"], 2)],
 )
 def test_routes_gating(enabled, expected) -> None:

--- a/backend/tests/test_backfill_artifact_tool_merge.py
+++ b/backend/tests/test_backfill_artifact_tool_merge.py
@@ -1,0 +1,333 @@
+"""Tests for the artifact tool-merge backfill script.
+
+The script collapses the two artifact catalog rows (``create_artifact`` +
+``update_artifact``) into a single "Artifacts" toggle keyed on
+``create_artifact``. Its real job is not the rename but the promotion: every
+place the retired id could be the *only* thing granting artifact access must
+be moved onto the keeper before the retired id is deleted, or a role/user/
+assistant silently loses the capability.
+"""
+
+import os
+import sys
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from backfill_artifact_tool_merge import (  # noqa: E402
+    delete_retired_catalog_row,
+    promote_assistant_bindings,
+    promote_role_grants,
+    promote_user_preferences,
+    retitle_catalog_row,
+)
+
+REGION = "us-east-1"
+ROLES_TABLE = "test-app-roles"
+ASSISTANTS_TABLE = "test-assistants"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def roles(aws):
+    """app-roles table, including the GSI2 the grant lookup queries."""
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=ROLES_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "ToolRoleMappingIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table = ddb.Table(ROLES_TABLE)
+    table.put_item(
+        Item={
+            "PK": "TOOL#create_artifact",
+            "SK": "METADATA",
+            "toolId": "create_artifact",
+            "displayName": "Create Artifact",
+        }
+    )
+    table.put_item(
+        Item={
+            "PK": "TOOL#update_artifact",
+            "SK": "METADATA",
+            "toolId": "update_artifact",
+            "displayName": "Update Artifact",
+        }
+    )
+    return table
+
+
+@pytest.fixture()
+def assistants(aws):
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=ASSISTANTS_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return ddb.Table(ASSISTANTS_TABLE)
+
+
+def _put_role(table, role_id, granted):
+    table.put_item(
+        Item={
+            "PK": f"ROLE#{role_id}",
+            "SK": "DEFINITION",
+            "roleId": role_id,
+            "grantedTools": list(granted),
+            "effectivePermissions": {"tools": list(granted)},
+        }
+    )
+    for tool_id in granted:
+        table.put_item(
+            Item={
+                "PK": f"ROLE#{role_id}",
+                "SK": f"TOOL_GRANT#{tool_id}",
+                "GSI2PK": f"TOOL#{tool_id}",
+                "GSI2SK": f"ROLE#{role_id}",
+                "roleId": role_id,
+                "displayName": role_id.upper(),
+                "enabled": True,
+            }
+        )
+
+
+def _definition(table, role_id):
+    return table.get_item(Key={"PK": f"ROLE#{role_id}", "SK": "DEFINITION"})["Item"]
+
+
+def _has(table, pk, sk):
+    return "Item" in table.get_item(Key={"PK": pk, "SK": sk})
+
+
+def _put_prefs(table, user_id, prefs):
+    table.put_item(
+        Item={"PK": f"USER#{user_id}", "SK": "TOOL_PREFERENCES", "toolPreferences": prefs}
+    )
+
+
+def _prefs(table, user_id):
+    return table.get_item(Key={"PK": f"USER#{user_id}", "SK": "TOOL_PREFERENCES"})[
+        "Item"
+    ]["toolPreferences"]
+
+
+class TestCatalogRow:
+    def test_retitles_keeper_and_deletes_retired(self, roles):
+        assert retitle_catalog_row(roles, apply=True) == 1
+        assert delete_retired_catalog_row(roles, apply=True) == 1
+
+        item = roles.get_item(Key={"PK": "TOOL#create_artifact", "SK": "METADATA"})[
+            "Item"
+        ]
+        assert item["displayName"] == "Artifacts"
+        assert not _has(roles, "TOOL#update_artifact", "METADATA")
+
+    def test_dry_run_does_not_mutate(self, roles):
+        retitle_catalog_row(roles, apply=False)
+        delete_retired_catalog_row(roles, apply=False)
+
+        item = roles.get_item(Key={"PK": "TOOL#create_artifact", "SK": "METADATA"})[
+            "Item"
+        ]
+        assert item["displayName"] == "Create Artifact"
+        assert _has(roles, "TOOL#update_artifact", "METADATA")
+
+    def test_rerun_is_a_noop(self, roles):
+        retitle_catalog_row(roles, apply=True)
+        delete_retired_catalog_row(roles, apply=True)
+
+        assert retitle_catalog_row(roles, apply=True) == 0
+        assert delete_retired_catalog_row(roles, apply=True) == 0
+
+
+class TestRoleGrants:
+    def test_role_holding_only_retired_id_is_promoted(self, roles):
+        """The case that would otherwise silently revoke artifact access."""
+        _put_role(roles, "a", ["update_artifact", "other"])
+
+        promote_role_grants(roles, apply=True)
+
+        definition = _definition(roles, "a")
+        assert sorted(definition["grantedTools"]) == ["create_artifact", "other"]
+        assert sorted(definition["effectivePermissions"]["tools"]) == [
+            "create_artifact",
+            "other",
+        ]
+        assert _has(roles, "ROLE#a", "TOOL_GRANT#create_artifact")
+        assert not _has(roles, "ROLE#a", "TOOL_GRANT#update_artifact")
+
+    def test_role_holding_both_is_just_pruned(self, roles):
+        _put_role(roles, "b", ["create_artifact", "update_artifact"])
+
+        promote_role_grants(roles, apply=True)
+
+        assert _definition(roles, "b")["grantedTools"] == ["create_artifact"]
+        assert _has(roles, "ROLE#b", "TOOL_GRANT#create_artifact")
+        assert not _has(roles, "ROLE#b", "TOOL_GRANT#update_artifact")
+
+    def test_wildcard_role_gains_no_explicit_grant(self, roles):
+        """`*` already covers the keeper — don't narrow it to a concrete list."""
+        _put_role(roles, "c", ["*"])
+        roles.put_item(
+            Item={
+                "PK": "ROLE#c",
+                "SK": "TOOL_GRANT#update_artifact",
+                "GSI2PK": "TOOL#update_artifact",
+                "GSI2SK": "ROLE#c",
+                "roleId": "c",
+                "enabled": True,
+            }
+        )
+
+        promote_role_grants(roles, apply=True)
+
+        assert _definition(roles, "c")["grantedTools"] == ["*"]
+        assert not _has(roles, "ROLE#c", "TOOL_GRANT#create_artifact")
+        assert not _has(roles, "ROLE#c", "TOOL_GRANT#update_artifact")
+
+    def test_dry_run_does_not_mutate(self, roles):
+        _put_role(roles, "a", ["update_artifact"])
+
+        promote_role_grants(roles, apply=False)
+
+        assert _definition(roles, "a")["grantedTools"] == ["update_artifact"]
+        assert _has(roles, "ROLE#a", "TOOL_GRANT#update_artifact")
+
+
+class TestUserPreferences:
+    def test_explicit_enable_carries_over(self, roles):
+        _put_prefs(roles, "u1", {"update_artifact": True})
+
+        promote_user_preferences(roles, apply=True)
+
+        assert _prefs(roles, "u1") == {"create_artifact": True}
+
+    def test_create_wins_when_both_are_set(self, roles):
+        _put_prefs(roles, "u2", {"create_artifact": False, "update_artifact": True})
+
+        promote_user_preferences(roles, apply=True)
+
+        assert _prefs(roles, "u2") == {"create_artifact": False}
+
+    def test_explicit_disable_does_not_carry_over(self, roles):
+        """Turning update off never meant "disable artifacts entirely" — the
+        user left create at its default-on, so the key just drops."""
+        _put_prefs(roles, "u3", {"update_artifact": False})
+
+        promote_user_preferences(roles, apply=True)
+
+        assert _prefs(roles, "u3") == {}
+
+    def test_unrelated_prefs_untouched(self, roles):
+        _put_prefs(roles, "u4", {"other": True})
+
+        assert promote_user_preferences(roles, apply=True) == 0
+        assert _prefs(roles, "u4") == {"other": True}
+
+    def test_dry_run_does_not_mutate(self, roles):
+        _put_prefs(roles, "u1", {"update_artifact": True})
+
+        promote_user_preferences(roles, apply=False)
+
+        assert _prefs(roles, "u1") == {"update_artifact": True}
+
+
+class TestAssistantBindings:
+    def test_sole_retired_binding_is_promoted(self, assistants):
+        assistants.put_item(
+            Item={
+                "PK": "AST#1",
+                "SK": "METADATA",
+                "bindings": [{"kind": "tool", "ref": "update_artifact"}],
+            }
+        )
+
+        promote_assistant_bindings(assistants, apply=True)
+
+        item = assistants.get_item(Key={"PK": "AST#1", "SK": "METADATA"})["Item"]
+        assert item["bindings"] == [{"kind": "tool", "ref": "create_artifact"}]
+
+    def test_binding_pair_is_deduped(self, assistants):
+        assistants.put_item(
+            Item={
+                "PK": "AST#2",
+                "SK": "METADATA",
+                "bindings": [
+                    {"kind": "tool", "ref": "create_artifact"},
+                    {"kind": "tool", "ref": "update_artifact"},
+                    {"kind": "skill", "ref": "s"},
+                ],
+            }
+        )
+
+        promote_assistant_bindings(assistants, apply=True)
+
+        item = assistants.get_item(Key={"PK": "AST#2", "SK": "METADATA"})["Item"]
+        assert item["bindings"] == [
+            {"kind": "tool", "ref": "create_artifact"},
+            {"kind": "skill", "ref": "s"},
+        ]
+
+    def test_unrelated_bindings_untouched(self, assistants):
+        assistants.put_item(
+            Item={
+                "PK": "AST#3",
+                "SK": "METADATA",
+                "bindings": [{"kind": "tool", "ref": "other"}],
+            }
+        )
+
+        assert promote_assistant_bindings(assistants, apply=True) == 0
+
+    def test_dry_run_does_not_mutate(self, assistants):
+        assistants.put_item(
+            Item={
+                "PK": "AST#1",
+                "SK": "METADATA",
+                "bindings": [{"kind": "tool", "ref": "update_artifact"}],
+            }
+        )
+
+        promote_assistant_bindings(assistants, apply=False)
+
+        item = assistants.get_item(Key={"PK": "AST#1", "SK": "METADATA"})["Item"]
+        assert item["bindings"] == [{"kind": "tool", "ref": "update_artifact"}]

--- a/backend/tests/test_seed_system_admin_jwt.py
+++ b/backend/tests/test_seed_system_admin_jwt.py
@@ -131,7 +131,7 @@ class TestSeedDefaultTools:
         """Creates the default tool entries."""
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 7
+        assert result.created == 6
         assert result.failed == 0
 
         # Verify fetch_url_content
@@ -187,7 +187,7 @@ class TestSeedDefaultTools:
         )
         item = resp["Item"]
         assert item["toolId"] == "create_artifact"
-        assert item["displayName"] == "Create Artifact"
+        assert item["displayName"] == "Artifacts"
         assert item["category"] == "document"
         assert item["protocol"] == "local"
         assert item["enabledByDefault"] is True
@@ -195,17 +195,12 @@ class TestSeedDefaultTools:
         assert item["GSI1PK"] == "CATEGORY#document"
         assert item["GSI1SK"] == "TOOL#create_artifact"
 
-        # Verify update_artifact
+        # update_artifact is no longer its own catalog row: create_artifact is
+        # the single gate key that provisions the whole artifact toolset.
         resp = dynamodb_table.get_item(
             Key={"PK": "TOOL#update_artifact", "SK": "METADATA"}
         )
-        item = resp["Item"]
-        assert item["toolId"] == "update_artifact"
-        assert item["displayName"] == "Update Artifact"
-        assert item["category"] == "document"
-        assert item["protocol"] == "local"
-        assert item["enabledByDefault"] is True
-        assert item["isPublic"] is True
+        assert "Item" not in resp
 
         # Verify create_word_document (single toggle for the whole Word toolset)
         resp = dynamodb_table.get_item(
@@ -227,7 +222,7 @@ class TestSeedDefaultTools:
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.skipped == 7
+        assert result.skipped == 6
         assert result.created == 0
 
     def test_partial_skip(self, dynamodb_table):
@@ -241,7 +236,7 @@ class TestSeedDefaultTools:
 
         result = seed_default_tools(TABLE_NAME, REGION)
 
-        assert result.created == 6
+        assert result.created == 5
         assert result.skipped == 1
 
 


### PR DESCRIPTION
## What

Artifacts shipped as two independent `protocol: local` catalog rows — `create_artifact` and `update_artifact` — so the tool picker listed **Create Artifact** and **Update Artifact** as two unrelated entries.

This collapses them into a single **Artifacts** toggle keyed on `create_artifact`, and adds a backfill script to migrate already-seeded environments.

## Why

The picker only nests children under a parent for MCP protocols — the grouping is gated on `protocol === 'mcp' | 'mcp_external'` and driven by `serverTools`, which is populated from `mcp_config`/`mcp_gateway_config`. Artifact tools are local, so there was no parent to nest them under. The flat listing was a data-model fact, not a template gap.

The fix adopts the idiom the repo already uses one entry below in the same seed list: `create_word_document` / "Word Documents" is a single catalog row whose id is the gate key, injecting create/modify/list/read at runtime. `create_artifact` is now that key for artifacts and provisions both tools.

## Changes

| File | What |
|---|---|
| `backend/scripts/seed_bootstrap_data.py` | Two rows → one, displayName "Artifacts", gate-key comment matching Word Documents |
| `backend/src/apis/inference_api/chat/routes.py` | `ARTIFACT_TOOL_IDS = {"create_artifact"}`; injects create + update |
| `backend/scripts/backfill_artifact_tool_merge.py` | **New** — migration for already-seeded environments |
| `backend/tests/test_backfill_artifact_tool_merge.py` | **New** — 16 tests |
| `backend/tests/test_seed_system_admin_jwt.py` | Asserts `TOOL#update_artifact` is now absent; tool counts 7→6 |
| `backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py` | `["create_artifact"]` → 2 tools; a lone stale `["update_artifact"]` → 0 |

## Reviewer notes

**⚠️ The migration is required, not optional.** `seed_default_tools` skips rows that already exist, so a seed run does nothing to dev-ai/prod-ai — they'd keep both entries and the old "Create Artifact" label. The script has to run per environment after the backend ships. It's dry-run by default:

```bash
AWS_PROFILE=dev-ai python backend/scripts/backfill_artifact_tool_merge.py \
    --table dev-boisestateai-v2-app-roles \
    --assistants-table dev-boisestateai-v2-assistants        # then --apply
```

**⚠️ Live behavior change:** anyone with create enabled but update disabled silently gains update. Inherent to collapsing the toggle.

**The migration promotes before it deletes.** A grant can hide in four places, and any of them could be the *only* thing granting artifact access — so all four are moved onto the keeper before the retired row is removed. An aborted run degrades to "both granted", never "neither":

- role `TOOL_GRANT#` mapping items (GSI2/`ToolRoleMappingIndex`)
- the `grantedTools` **and** `effectivePermissions.tools` arrays on `DEFINITION`
- user `toolPreferences`
- assistant `bindings`

**Two judgement calls worth a second opinion:**

1. **User prefs only carry over an explicit *enable*.** `toolPreferences` is a sparse override map. Someone who switched update off while leaving create at its default-on never asked to lose artifacts entirely, so an explicit *disable* just drops the key and falls back to `enabledByDefault`. (My first pass carried any value over, which would have silently disabled artifacts for those users.)
2. **A role granting `*` gains no concrete grant.** The wildcard already covers the keeper; materializing an explicit list would be a silent scope change.

**Deliberately out of scope:** schedule snapshots (`enabledTools` on the sessions-metadata table). A stale `update_artifact` there is an inert no-op — the runtime only reads `create_artifact` — and any snapshot taken while both rows were seeded default-on already carries `create_artifact` alongside it.

**Left alone on purpose:** `STREAMING_CONTENT_TOOLS` in `stream-parser.service.ts` still lists both names. Those are *runtime* tool names, and the update tool is still called `update_artifact` when it executes — only the catalog id is retired.

## Testing

- Full backend suite: **4678 passed, 3 skipped**
- 16 new migration tests against moto, covering promote / dedupe / wildcard / no-op, dry-run-doesn't-mutate, and rerun-is-a-no-op

The new test file follows the convention already set by `test_backfill_skill_bundles.py` and `test_backfill_session_static_sk.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)