### PR TITLE
chore(sidenav): hide the My Skills nav entry

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -63,21 +63,11 @@
             </a>
         }
 
-        <!-- My Skills (user-authored skill bundles; hidden while SKILLS_ENABLED is off) -->
-        @if (showMySkills()) {
-            <a
-                routerLink="/my-skills"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">My Skills</span>
-            </a>
-        }
+        <!--
+            No "My Skills" nav entry: the /my-skills route, page, and service are
+            live, but how users reach them is still undecided, so the link stays
+            out of the sidenav until that navigation path is settled.
+        -->
     </div>
 
     <nav class="flex-1 overflow-y-auto px-3 pb-4">

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -9,7 +9,6 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
-import { MySkillService } from '../../my-skills/services/my-skill.service';
 
 @Component({
   selector: 'app-sidenav',
@@ -23,7 +22,6 @@ export class Sidenav {
   private bffSession = inject(BffSessionService);
   private memorySpaceService = inject(MemorySpaceService);
   private agentService = inject(AgentService);
-  private mySkillService = inject(MySkillService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
 
@@ -61,14 +59,6 @@ export class Sidenav {
    */
   readonly showAgents = computed(() => this.agentService.accessible$() === true);
 
-  /**
-   * Whether to show the "My Skills" nav entry. Rides the authored-skills list
-   * the same way the two above ride theirs: the `/skills` router is only
-   * mounted when `SKILLS_ENABLED` is on, so a 404 flips `accessible$` false
-   * and the entry stays hidden. `null` (unresolved) also hides it.
-   */
-  readonly showMySkills = computed(() => this.mySkillService.accessible$() === true);
-
   constructor() {
     // Kick off the accessibility probes once the user is authenticated —
     // mirrors UserService's own permissions-fetch gating.
@@ -76,7 +66,6 @@ export class Sidenav {
       if (this.userService.currentUser()) {
         void this.memorySpaceService.loadSpaces();
         void this.agentService.loadAgents();
-        void this.mySkillService.loadSkills().catch(() => undefined);
       }
     });
   }


### PR DESCRIPTION
## Summary

Removes the **My Skills** entry from the sidenav. Everything behind it stays live — this only hides the link while we decide how users should navigate to their skills.

## What changed

- `sidenav.html` — removed the My Skills `<a>` block, leaving a comment explaining the deliberate absence.
- `sidenav.ts` — removed the now-dead `showMySkills` computed, the `MySkillService` injection/import, and its `loadSkills()` probe from the constructor effect. That probe existed solely to decide whether to render the link.

## What did *not* change

The `/my-skills` route, both pages, `MySkillService`, and the entire `/skills/mine` backend surface are untouched. Navigating directly to `/my-skills` still works normally.

## Note for whoever wires up the eventual entry point

The removed probe was the SPA's only signal for whether the skills API is reachable — a 404 when `SKILLS_ENABLED` is off flipped `accessible$` false and hid the link. Whatever entry point replaces it will need to re-establish that gate, or it will offer a link into a 404 in environments with skills disabled.

## Verification

- `tsc --noEmit` clean
- `sidenav.spec.ts` passes (10/10) — no test referenced the skills entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)