### PR TITLE
feat(skills): drop the `skills` capability gate from user-facing routes

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -111,9 +111,10 @@ jobs:
       # skill resolution on the invocation path). Default ON with a kill switch:
       # unset resolves to empty string, which config.ts treats as the default
       # (on). Set the `CDK_SKILLS_ENABLED` variable to "false" in an environment
-      # only to dark-stop the feature there. NOTE this gates feature *existence*;
-      # who sees the user-facing surfaces is the `skills` RBAC capability, which
-      # keeps them admin-only until GA (one role grant, no redeploy).
+      # only to dark-stop the feature there. NOTE this is the ONLY gate on the
+      # user-facing surfaces — with it on, any signed-in user can author skills
+      # and see the ones their role grants. Which skills a cohort gets is a
+      # role's `grantedSkills`, managed in the admin roles UI.
       CDK_SKILLS_ENABLED: ${{ vars.CDK_SKILLS_ENABLED }}
       # Agent Designer /agents surface. Default OFF (opt-in) until the Phase-4
       # Designer UI ships — a headless API helps no forker. Set the

--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -16,6 +16,22 @@ Two surfaces live here:
    indistinguishable from one that does not exist.
 
 Admin catalog management routes are in ``apis.app_api.admin.skills.routes``.
+
+**Access model.** These routes require only an authenticated session. There is
+no per-user capability gate: ``SKILLS_ENABLED`` decides whether the feature
+exists in this environment, and a role's ``grantedSkills`` decides *which*
+catalog skills a user can reach. Both surfaces are already self-limiting —
+``GET /skills/`` returns only what ``resolve_accessible_skill_ids`` grants
+(so a user with no grants gets an empty list and the SPA renders no picker),
+and every ``/skills/mine/*`` route is owner-scoped, so a user only ever sees
+skills they authored.
+
+The ``skills`` RBAC capability that used to gate these routes was removed: it
+kept the surfaces admin-only during the v2 rollout, but it could not be granted
+from the admin roles UI (that form builds ``grantedTools`` from the tool
+catalog, and a capability id is not a tool), so an admin who granted a catalog
+skill to a role would find it silently invisible to that role's users with no
+way to fix it in-product.
 """
 
 import logging
@@ -25,7 +41,6 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, Upl
 from pydantic import BaseModel, Field
 
 from apis.shared.auth import User, get_current_user_from_session
-from apis.shared.rbac.capabilities import SKILLS_CAPABILITY, user_has_capability
 from apis.shared.skills.access import resolve_accessible_skill_ids
 from apis.shared.skills.models import (
     SkillDefinition,
@@ -45,29 +60,6 @@ from .user_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/skills", tags=["skills"])
-
-
-async def require_skills_capability(
-    current: User = Depends(get_current_user_from_session),
-) -> User:
-    """Gate the user-facing skills surfaces on the ``skills`` RBAC capability.
-
-    ``SKILLS_ENABLED`` says the feature *exists* here; this says *who* sees it.
-    During the initial rollout only ``system_admin`` holds it (implicitly, via
-    the ``"*"`` tools grant); GA is one grant of ``skills`` to the ``default``
-    role — no redeploy (see ``apis.shared.rbac.capabilities``).
-
-    Raises **404, not 403**, on purpose. The SPA hides the "My Skills" nav entry
-    by riding this list call — a 404 flips ``accessible$`` false and the entry
-    stays hidden, exactly as it already behaves when the router is unmounted. A
-    403 would surface an error toast instead of hiding the surface, and the
-    scheduled-runs capability gate was reverted in prod for precisely that class
-    of problem. Not a security boundary: the runtime is deliberately ungated so
-    invoke-through keeps working for ordinary users.
-    """
-    if not await user_has_capability(current, SKILLS_CAPABILITY):
-        raise HTTPException(status_code=404, detail="Not found")
-    return current
 
 
 class UserSkillResponse(BaseModel):
@@ -102,7 +94,7 @@ class SkillPreferencesRequest(BaseModel):
 
 @router.get("/", response_model=UserSkillsResponse)
 async def get_user_skills(
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ) -> UserSkillsResponse:
     """
     Get the ACTIVE skills the current user's roles grant, with the user's
@@ -143,7 +135,7 @@ async def get_user_skills(
 @router.put("/preferences")
 async def update_skill_preferences(
     request: SkillPreferencesRequest,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """
     Save the user's per-skill enabled/disabled preferences.
@@ -268,7 +260,7 @@ def _resource_value_error(e: ValueError) -> HTTPException:
 
 @router.get("/mine", response_model=MySkillListResponse)
 async def list_my_skills(
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ) -> MySkillListResponse:
     """List every skill the current user authored (any status)."""
     logger.info(f"User {user.name} listing authored skills")
@@ -283,7 +275,7 @@ async def list_my_skills(
 @router.post("/mine", response_model=MySkillResponse)
 async def create_my_skill(
     request: CreateMySkillRequest,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ) -> MySkillResponse:
     """Create a skill owned by the current user."""
     logger.info(f"User {user.name} creating an authored skill")
@@ -307,7 +299,7 @@ async def create_my_skill(
 @router.get("/mine/{skill_id}", response_model=MySkillResponse)
 async def get_my_skill(
     skill_id: str,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ) -> MySkillResponse:
     """Get one of the current user's authored skills."""
     try:
@@ -322,7 +314,7 @@ async def get_my_skill(
 async def update_my_skill(
     skill_id: str,
     request: UpdateMySkillRequest,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ) -> MySkillResponse:
     """Update one of the current user's authored skills."""
     logger.info(f"User {user.name} updating an authored skill")
@@ -339,7 +331,7 @@ async def update_my_skill(
 @router.delete("/mine/{skill_id}")
 async def delete_my_skill(
     skill_id: str,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """Delete one of the current user's authored skills and its bundle files."""
     logger.info(f"User {user.name} deleting an authored skill")
@@ -360,7 +352,7 @@ async def delete_my_skill(
 @router.get("/mine/{skill_id}/resources", response_model=SkillResourcesResponse)
 async def list_my_skill_resources(
     skill_id: str,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """List an owned skill's supporting-file manifest (no bytes)."""
     try:
@@ -376,7 +368,7 @@ async def upload_my_skill_resource(
     skill_id: str,
     file: UploadFile = File(...),
     kind: str = Form("reference"),
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """Upload (or replace) one supporting file on an owned skill.
 
@@ -408,7 +400,7 @@ async def upload_my_skill_resource(
 async def read_my_skill_resource(
     skill_id: str,
     filename: str,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """Return the raw bytes of one of an owned skill's supporting files."""
     try:
@@ -433,7 +425,7 @@ async def read_my_skill_resource(
 async def delete_my_skill_resource(
     skill_id: str,
     filename: str,
-    user: User = Depends(require_skills_capability),
+    user: User = Depends(get_current_user_from_session),
 ):
     """Delete one supporting file from an owned skill. Returns the manifest."""
     logger.info(f"User {user.name} deleting a skill bundle file")

--- a/backend/src/apis/shared/rbac/capabilities.py
+++ b/backend/src/apis/shared/rbac/capabilities.py
@@ -18,8 +18,17 @@ Consequences to be aware of:
   a real tool in practice (no tool in the catalog is named like a feature),
   and a granted capability id simply matches no tool at agent-build time —
   but pick ids that read as features, not tools.
-* GA for a capability = grant its id to the ``default`` role. One config
-  change, no redeploy (scheduled-agent-runs.md §6, "GA path").
+* GA for a capability is **not** one grant to the ``default`` role, despite
+  what earlier comments here claimed. ``default`` is a *fallback* — resolution
+  falls back to it only when a user matches zero roles (``service.py``
+  "Step 3"), and in prod it carries no JWT mappings at all. Granting a
+  capability there reaches only unmapped users. Reaching everyone means
+  granting to each cohort role (prod: ``faculty``/``staff``/``student``/
+  ``demo_day``), or changing ``default`` to merge as a baseline.
+* A capability id cannot be granted from the admin roles UI: that form builds
+  ``grantedTools`` from the tool catalog, and a capability is not a tool. Any
+  capability gate is therefore operable only by hand-writing DynamoDB items —
+  weigh that before adding one.
 
 If capabilities outgrow this (per-capability metadata, UI surfacing), the
 RBAC gap ledger already names the real fix: extend the grant vocabulary
@@ -31,22 +40,20 @@ from __future__ import annotations
 from apis.shared.auth.models import User
 from apis.shared.rbac.service import get_app_role_service
 
-#: Gates the headless-runs surface ("Run now" today; schedule CRUD in
-#: Phase B). Granted to the beta cohort's role; GA = grant to ``default``.
+#: Was intended to gate the headless-runs surface. **Currently unused**: the
+#: RBAC gate on ``/schedules`` + ``/runs`` was dropped (it 403'd in prod), so
+#: scheduled runs ship kill-switch-only. Kept as the worked example for the
+#: grant mechanism above — note the GA caveats in the module docstring before
+#: wiring it, or anything like it, to a route.
 SCHEDULED_RUNS_CAPABILITY = "scheduled-runs"
 
-#: Gates the user-facing Skills *surfaces* — the chat picker (``GET /skills/``,
-#: ``PUT /skills/preferences``) and My Skills authoring (``/skills/mine/*``).
-#: Skills v2 PR-5 turns ``SKILLS_ENABLED`` on everywhere but keeps the surfaces
-#: to admins first: ``system_admin``'s ``"*"`` tools grant satisfies this
-#: implicitly, so no seeding is needed for the admin cohort. **GA = grant
-#: ``skills`` to the ``default`` role — one config change, no redeploy.**
-#:
-#: Deliberately does NOT gate the runtime. An Agent shared to an ordinary user
-#: must still resolve its bound skills for them (invoke-through, §6/D7), and a
-#: capability check there would break exactly that path. Authoring and
-#: selection are gated; invocation through someone else's Agent is not.
-SKILLS_CAPABILITY = "skills"
+#: NOTE: there is deliberately no ``skills`` capability. The user-facing skills
+#: surfaces were gated on one during the v2 rollout and it was removed — see the
+#: "Access model" note in ``apis.app_api.skills.routes``. The short version: a
+#: capability id cannot be granted from the admin roles UI (that form builds
+#: ``grantedTools`` from the tool catalog), so the gate was unoperable in
+#: product. Skills are governed by ``SKILLS_ENABLED`` per environment and by a
+#: role's ``grantedSkills`` per cohort, which is a complete model on its own.
 
 
 async def user_has_capability(user: User, capability_id: str) -> bool:

--- a/backend/tests/apis/app_api/skills/test_my_skill_routes.py
+++ b/backend/tests/apis/app_api/skills/test_my_skill_routes.py
@@ -20,12 +20,6 @@ def client(user_skill_service, author_user, monkeypatch):
     app = FastAPI()
     app.include_router(skill_routes.router)
     app.dependency_overrides[get_current_user_from_session] = lambda: author_user
-    # PR-5: routes hang off the `skills` capability gate, which would otherwise
-    # resolve RBAC against DynamoDB. Ownership — what this file tests — is
-    # enforced inside UserSkillService, independently of the gate.
-    app.dependency_overrides[skill_routes.require_skills_capability] = (
-        lambda: author_user
-    )
     with TestClient(app) as c:
         yield c
 
@@ -39,9 +33,6 @@ def other_client(user_skill_service, other_user, monkeypatch):
     app = FastAPI()
     app.include_router(skill_routes.router)
     app.dependency_overrides[get_current_user_from_session] = lambda: other_user
-    app.dependency_overrides[skill_routes.require_skills_capability] = (
-        lambda: other_user
-    )
     with TestClient(app) as c:
         yield c
 
@@ -50,12 +41,12 @@ def test_my_skills_routes_use_session_auth_not_bearer():
     """A Bearer-only dependency here would 401-loop the cookie-bearing SPA.
 
     Walks the TRANSITIVE dependency tree, not just each route's direct
-    dependencies: since PR-5 the routes depend on ``require_skills_capability``,
-    which in turn depends on the session. The invariant being pinned is "the
-    session dependency is reachable from every /mine route", which is what
-    actually keeps the cookie-bearing SPA off the 401-redirect loop — asserting
-    the flat shape instead would break on any future gate wrapper while proving
-    less.
+    dependencies. The routes depend on the session directly today (the
+    ``require_skills_capability`` wrapper they used to nest under was removed),
+    but the invariant being pinned is "the session dependency is reachable from
+    every /mine route", which is what actually keeps the cookie-bearing SPA off
+    the 401-redirect loop — asserting the flat shape instead would break on any
+    future wrapper while proving less.
     """
     paths = [
         r

--- a/backend/tests/apis/app_api/test_skills_feature_flag.py
+++ b/backend/tests/apis/app_api/test_skills_feature_flag.py
@@ -9,9 +9,9 @@ the literal ``"false"`` disables. These tests pin three things:
   which must NOT read as disabled,
 * that the admin skills subrouter mounts with the flag on and unmounts with it
   explicitly off, and
-* that the ``skills`` capability — not the flag — is what gates *who* sees the
-  user-facing surfaces, and that it 404s (never 403s) so the SPA hides the nav
-  entry rather than surfacing an error.
+* that the flag is now the *only* gate on the user-facing surfaces — every
+  route requires a session, and the removed ``skills`` capability gate has not
+  crept back.
 
 The admin subrouter mounts conditionally at import time, so — like the
 fine-tuning gate in tests/routes/test_admin_lows.py — these reload the module
@@ -100,75 +100,67 @@ def test_admin_skills_mounted_when_enabled(admin_router_paths):
 # ---------------------------------------------------------------------------
 
 
-class TestSkillsCapabilityGate:
-    """PR-5 keeps the surfaces admin-only while the flag itself is on.
+class TestSkillsRouteAuth:
+    """``SKILLS_ENABLED`` is the only gate on *whether* these routes exist.
 
-    Two independent controls: ``SKILLS_ENABLED`` says the feature exists in this
-    environment, the ``skills`` capability says who sees it. GA is one grant of
-    ``skills`` to the ``default`` role — no redeploy.
+    The per-user ``skills`` capability that used to gate them was removed (see
+    the "Access model" note in ``apis.app_api.skills.routes``): it could not be
+    granted from the admin roles UI, so an admin granting a catalog skill to a
+    role had no in-product way to make it visible. Access is now governed by
+    ``grantedSkills`` per role, which the roles UI *can* edit.
+
+    What still has to hold is that every route requires a session.
     """
 
-    @pytest.mark.asyncio
-    async def test_holder_passes_through(self, monkeypatch):
-        from apis.app_api.skills import routes as skills_routes
+    def test_every_user_facing_route_requires_a_session(self):
+        """No skills route may be reachable unauthenticated.
 
-        user = _user()
-        monkeypatch.setattr(
-            skills_routes, "user_has_capability", _capability_stub(True)
-        )
-        assert await skills_routes.require_skills_capability(current=user) is user
-
-    @pytest.mark.asyncio
-    async def test_non_holder_gets_404_not_403(self, monkeypatch):
-        """404 on purpose: the SPA hides the nav entry by riding this call.
-
-        A 403 would surface an error toast instead of hiding the surface — the
-        failure mode that got the scheduled-runs capability gate reverted in
-        prod. Pin the status so a well-meaning "403 is more correct" change
-        can't silently reintroduce it.
-        """
-        from fastapi import HTTPException
-
-        from apis.app_api.skills import routes as skills_routes
-
-        monkeypatch.setattr(
-            skills_routes, "user_has_capability", _capability_stub(False)
-        )
-        with pytest.raises(HTTPException) as exc:
-            await skills_routes.require_skills_capability(current=_user())
-        assert exc.value.status_code == 404
-
-    def test_every_user_facing_route_is_gated(self):
-        """No user-facing skills route may depend on the session directly.
-
-        A new route added with the bare session dependency would be reachable
-        by the whole org the moment the flag went on — the gate has to be the
-        default, not a thing each route remembers.
+        The capability gate is gone, so ``get_current_user_from_session`` is the
+        only thing standing between these routes and an anonymous caller. A new
+        route added without it would expose authoring and preferences to the
+        internet, so assert the dependency is present on every one rather than
+        trusting each route to remember it.
         """
         from apis.app_api.skills import routes as skills_routes
 
-        ungated = []
+        unauthenticated = []
         for route in skills_routes.router.routes:
             deps = getattr(route, "dependant", None)
-            names = {
-                sub.call.__name__
-                for sub in getattr(deps, "dependencies", [])
-                if getattr(sub, "call", None)
-            }
-            if "require_skills_capability" not in names:
-                ungated.append(getattr(route, "path", "?"))
+            names = _dependency_names(deps)
+            if "get_current_user_from_session" not in names:
+                unauthenticated.append(getattr(route, "path", "?"))
 
-        assert ungated == [], f"ungated skills routes: {ungated}"
+        assert unauthenticated == [], (
+            f"skills routes missing session auth: {unauthenticated}"
+        )
+
+    def test_no_capability_gate_remains(self):
+        """Pin the removal.
+
+        Re-adding a capability dependency here would silently re-break the
+        admin flow (grant a skill to a role → users still can't see it, with no
+        UI to fix it). If a future change genuinely needs one, it has to make
+        the capability grantable from the roles UI first.
+        """
+        from apis.app_api.skills import routes as skills_routes
+
+        assert not hasattr(skills_routes, "require_skills_capability")
+
+        gated = [
+            getattr(route, "path", "?")
+            for route in skills_routes.router.routes
+            if any(
+                "capability" in name
+                for name in _dependency_names(getattr(route, "dependant", None))
+            )
+        ]
+        assert gated == [], f"capability-gated skills routes reintroduced: {gated}"
 
 
-def _user():
-    from apis.shared.auth.models import User
-
-    return User(email="u@example.edu", user_id="u-1", name="u", roles=[])
-
-
-def _capability_stub(result: bool):
-    async def _stub(user, capability_id):
-        return result
-
-    return _stub
+def _dependency_names(dependant) -> set:
+    """Names of a route's sub-dependency callables (empty set if none)."""
+    return {
+        sub.call.__name__
+        for sub in getattr(dependant, "dependencies", [])
+        if getattr(sub, "call", None)
+    }

--- a/backend/tests/apis/app_api/test_user_skills_routes.py
+++ b/backend/tests/apis/app_api/test_user_skills_routes.py
@@ -69,11 +69,6 @@ def _make_client(
     app = FastAPI()
     app.include_router(skills_routes.router)
     app.dependency_overrides[get_current_user_from_session] = _user
-    # The routes hang off `require_skills_capability` (PR-5), which resolves the
-    # `skills` RBAC capability against DynamoDB. These tests are about the route
-    # behavior, not the gate — the gate has its own tests in
-    # tests/apis/app_api/test_skills_feature_flag.py.
-    app.dependency_overrides[skills_routes.require_skills_capability] = _user
     return TestClient(app)
 
 

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -181,10 +181,10 @@ export interface MemorySpacesConfig {
  * app-api and inference-api; the skills data lives in the shared app-roles
  * table, so this only gates route mounting and skill resolution at runtime.
  *
- * This gates *feature existence* per environment. *Who* sees the user-facing
- * surfaces is the separate `skills` RBAC capability
- * (backend `apis.shared.rbac.capabilities`), which keeps them admin-only during
- * rollout — GA is one grant of `skills` to the `default` role, no redeploy.
+ * This gates *feature existence* per environment, and is now the only gate on
+ * the user-facing surfaces: the `skills` RBAC capability that used to keep them
+ * admin-only was removed (it could not be granted from the admin roles UI). Who
+ * can reach *which* skills is a role's `grantedSkills`, edited in that UI.
  */
 export interface SkillsConfig {
   enabled: boolean;


### PR DESCRIPTION
## Why

The user-facing skills surfaces hung off `require_skills_capability`, which 404'd anyone not holding the `skills` RBAC capability. Its purpose was to keep skills admin-only during the v2 rollout, with GA documented as *"one grant of `skills` to the `default` role — one config change, no redeploy."*

**That GA path does not work**, for two independent reasons:

1. **`default` is a fallback role, not a universal one.** `resolve_user_permissions` consults it only when a user matches *zero* AppRoles ([service.py "Step 3"](backend/src/apis/shared/rbac/service.py)); it is not merged alongside a matched role. Prod's `default` carries no JWT mappings at all, so granting there reaches only unmapped users — never faculty/staff/student.
2. **A capability id cannot be granted from the admin roles UI anyway.** That form builds `grantedTools` from the tool catalog ([role-form.page.ts](frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts)), and a capability is not a tool — no way to select it, no free-text entry.

Net effect: an admin who granted a catalog skill to a role would find it **silently invisible** to that role's users, with no in-product way to fix it.

Verified against prod (`boisestateai-v2-app-roles`, 6 role definitions):

| roleId | Entra groups | tools | skills |
|---|---|---|---|
| `system_admin` | `DotNetDevelopers`, `system_admin` | `*` | — |
| `faculty` | `Faculty` | 27 | `[]` |
| `staff` | `Staff` | 28 | `[]` |
| `student` | `PSSTUCURTERM` | 13 | `[]` |
| `demo_day` | `demo-users` | `[]` | — |
| `default` | **none** | `[]` | `['web_research']` |

## What changed

Removed the gate from all 12 user-facing routes. Skills are now governed by `SKILLS_ENABLED` per environment and a role's `grantedSkills` per cohort — a complete model the admin UI can actually operate.

Safe to remove because both surfaces are already self-limiting:
- `GET /skills/` returns only what `resolve_accessible_skill_ids` grants, so a user with no grants gets an empty list and the SPA renders no picker
- every `/skills/mine/*` route is owner-scoped inside `UserSkillService`

## Controls

The route-coverage test is **kept, not dropped** — retargeted from "every route is capability-gated" to "every route requires a session," which is the invariant that still matters now that the session dependency is the only thing between these routes and an anonymous caller. A second test pins the removal, so the gate can't creep back without first making capabilities grantable from the roles UI.

## Also

Corrects the "GA = grant to `default`" claim in `capabilities.py`, `infrastructure/lib/config.ts`, and `platform.yml`. Notes that `SCHEDULED_RUNS_CAPABILITY` is itself unused (that gate was dropped after 403ing in prod) — which leaves `capabilities.py` with **no consumers at all**. Deleting it is deliberately left to a follow-up, since its docstring holds findings that need relocating first.

No SPA changes: the three frontend comments referencing the gate only ever mentioned `SKILLS_ENABLED`, and are now unambiguous rather than stale.

## Testing

Full backend suite: **4693 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)