### PR TITLE
fix(chat-input): make the textarea scrollable and reset it after submit

### DIFF
--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.css
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.css
@@ -6,26 +6,4 @@
   transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
 
-.chat-textarea {
-  min-height: 3rem;
-  max-height: 12rem;
-  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  font-family: inherit;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
-/* Auto-resize textarea */
-.chat-textarea {
-  field-sizing: content;
-}
-
-@supports not (field-sizing: content) {
-  .chat-textarea {
-    height: auto;
-  }
-}
-
-
-
 

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -60,7 +60,7 @@
         (focus)="onFocus()"
         (blur)="onBlur()"
         placeholder="How can I help you today?"
-        class="block w-full resize-none bg-transparent px-6 py-4 text-base text-gray-900 placeholder:text-gray-500 dark:text-gray-100 dark:placeholder:text-gray-400 focus:outline-hidden overflow-hidden"
+        class="block w-full resize-none bg-transparent px-6 py-4 text-base text-gray-900 placeholder:text-gray-500 dark:text-gray-100 dark:placeholder:text-gray-400 focus:outline-hidden overflow-y-auto"
         style="min-height: 60px; max-height: 200px;"
       ></textarea>
 

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -38,6 +38,11 @@ import { ToolService } from '../../../services/tool/tool.service';
 import { VoiceChatService, type VoiceStatus } from '../../services/voice';
 import { SystemPromptsService } from '../../../services/system-prompts/system-prompts.service';
 
+// Must stay in sync with the inline min-height/max-height on the textarea in
+// chat-input.component.html.
+const MIN_TEXTAREA_HEIGHT_PX = 60;
+const MAX_TEXTAREA_HEIGHT_PX = 200;
+
 interface Message {
   content: string;
   timestamp: Date;
@@ -97,7 +102,6 @@ export class ChatInputComponent {
 
   // Signals for state management
   userInput = signal('');
-  isExpanded = signal(false);
   isFocused = signal(false);
   isDraggingOver = signal(false);
 
@@ -219,7 +223,7 @@ export class ChatInputComponent {
 
     // Clear input and pending uploads
     this.userInput.set('');
-    this.isExpanded.set(false);
+    this.resetTextareaHeight();
     this.fileUploadService.clearReadyUploads();
   }
 
@@ -296,10 +300,29 @@ export class ChatInputComponent {
   onTextareaInput(event: Event) {
     const textarea = event.target as HTMLTextAreaElement;
     this.userInput.set(textarea.value);
-    
-    // Auto-expand based on content
+    this.autoResize(textarea);
+  }
+
+  /**
+   * Grow the textarea with its content up to MAX_TEXTAREA_HEIGHT_PX, past which
+   * it scrolls internally (the template sets overflow-y-auto). Without the clamp
+   * the inline height keeps growing past max-height and the scrollbar never
+   * becomes usable.
+   */
+  private autoResize(textarea: HTMLTextAreaElement): void {
     textarea.style.height = 'auto';
-    textarea.style.height = textarea.scrollHeight + 'px';
+    const height = Math.min(textarea.scrollHeight, MAX_TEXTAREA_HEIGHT_PX);
+    textarea.style.height = `${height}px`;
+  }
+
+  /** Collapse the textarea back to a single row (after submit or clear). */
+  private resetTextareaHeight(): void {
+    const textarea = this.messageInput()?.nativeElement;
+    if (!textarea) {
+      return;
+    }
+    textarea.style.height = `${MIN_TEXTAREA_HEIGHT_PX}px`;
+    textarea.scrollTop = 0;
   }
 
   onKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Problem

The chat input got awkward once the message grew long: you couldn't scroll inside the textarea, the expansion felt clunky, and it stayed expanded after sending.

Three separate causes:

1. **No scrolling** — the textarea carried `overflow-hidden`, so once content exceeded the visible area there was no way to reach it.
2. **Clunky expansion** — `onTextareaInput` set `height = scrollHeight` with no clamp. Past 200px the inline height kept growing while `max-height: 200px` capped the *rendered* height, leaving the element's real and displayed heights diverged and the scrollbar unreachable.
3. **No reset after submit** — `submitChatRequest` cleared the value but left the stale inline height behind.

## Changes

- `overflow-hidden` → `overflow-y-auto` on the textarea.
- Growth clamped to the max in a shared `autoResize()`.
- New `resetTextareaHeight()` called on submit.
- Removes the `.chat-textarea` CSS block — it declared its own `min-height`/`max-height`/`field-sizing: content`, but the class is applied nowhere in the template, so the rules were dead while contradicting the real inline styles. The JS path is now the sole sizing authority, with the inline `min-height`/`max-height` as the CSS backstop.
- Removes the `isExpanded` signal — written on submit, never read.

## Verification

Verified live against the dev backend on `localhost:4200`:

| Check | Result |
|---|---|
| Grow → clamp at max | inline height `200px`, content `992px` — no longer overruns |
| Scroll inside textarea | `overflow-y: auto`, scrollTop moves 0 → 792 |
| Reset after submit | inline height `152px` → `60px`, scrollTop 0 |
| Shrink while deleting | 200 → 104 → 60 |

`npx tsc --noEmit` clean.

⚠️ Worth knowing for anyone re-testing: the **first** submit from the home screen creates a session and *remounts* the component, so the input collapses whether or not the fix works. The reset was confirmed on a **second, in-session** submit where the component instance is reused (inline height lands on an explicit `60px` rather than empty string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)