### PR TITLE
feat(observability): prompt-cache CloudWatch dashboard + alarms

### DIFF
--- a/infrastructure/lib/constructs/observability/prompt-cache-observability-construct.ts
+++ b/infrastructure/lib/constructs/observability/prompt-cache-observability-construct.ts
@@ -1,0 +1,198 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { Construct } from 'constructs';
+
+import { AppConfig, getResourceName } from '../../config';
+
+export interface PromptCacheObservabilityConstructProps {
+  config: AppConfig;
+}
+
+/**
+ * PromptCacheObservabilityConstruct — fleet-wide dashboard + alarms for
+ * the prompt-cache EMF metrics emitted by
+ * `backend/src/apis/shared/observability/emf.py` (PR #697).
+ *
+ * The metrics arrive as raw EMF JSON on stdout from BOTH compute
+ * surfaces (inference-api via the AgentCore Runtime log group, app-api
+ * via ECS awslogs) into the shared `AgentCoreStack/PromptCache`
+ * namespace — the default of the `EMF_NAMESPACE` env var, which is
+ * deliberately NOT set in CDK (dev and prod are separate AWS accounts,
+ * so the unscoped namespace never collides). All metrics are
+ * dimension-less and designed for `Sum`; per-call detail (`modelId`,
+ * `sessionId`, `cacheStatus`) rides as queryable EMF log properties,
+ * hence the Logs Insights widget below rather than dimension fan-out.
+ *
+ * This is the first cross-service dashboard, so it lives in its own
+ * construct area instead of inside the inference-api construct. The
+ * per-session drill-down counterpart is the cost-anatomy admin endpoint
+ * (`GET /admin/costs/sessions/{id}/calls`).
+ *
+ * Alarms are console-only — no SNS topics exist in the stack yet (same
+ * posture as kb-sync and scheduled-runs). They use NOT_BREACHING for
+ * missing data because the `PROMPT_CACHE_OBSERVABILITY_ENABLED=false`
+ * kill switch (or simply zero traffic) makes the metrics absent
+ * entirely.
+ */
+export class PromptCacheObservabilityConstruct extends Construct {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: PromptCacheObservabilityConstructProps,
+  ) {
+    super(scope, id);
+
+    const { config } = props;
+
+    // Must match the default of EMF_NAMESPACE in emf.py.
+    const namespace = 'AgentCoreStack/PromptCache';
+
+    const cacheReadTokensMetric = new cloudwatch.Metric({
+      namespace,
+      metricName: 'CacheReadTokens',
+      statistic: 'Sum',
+      period: cdk.Duration.minutes(5),
+    });
+
+    const cacheWriteTokensMetric = new cloudwatch.Metric({
+      namespace,
+      metricName: 'CacheWriteTokens',
+      statistic: 'Sum',
+      period: cdk.Duration.minutes(5),
+    });
+
+    const avoidableMissMetric = new cloudwatch.Metric({
+      namespace,
+      metricName: 'AvoidableMiss',
+      statistic: 'Sum',
+      period: cdk.Duration.minutes(5),
+    });
+
+    const wastedUsdMetric = new cloudwatch.Metric({
+      namespace,
+      metricName: 'WastedUsd',
+      statistic: 'Sum',
+      period: cdk.Duration.minutes(5),
+    });
+
+    // Cache efficiency: fraction of cache traffic served from cache.
+    // Healthy steady-state conversations read far more than they write,
+    // so this should sit near 100%; a prefix-stability regression shows
+    // up as a sustained drop (writes displacing reads).
+    const cacheEfficiencyExpression = new cloudwatch.MathExpression({
+      expression: '100 * reads / (reads + writes)',
+      usingMetrics: {
+        reads: cacheReadTokensMetric,
+        writes: cacheWriteTokensMetric,
+      },
+      label: 'Cache efficiency (%)',
+      period: cdk.Duration.minutes(5),
+    });
+
+    // ============================================================
+    // Dashboard
+    // ============================================================
+
+    const dashboard = new cloudwatch.Dashboard(this, 'PromptCacheDashboard', {
+      dashboardName: getResourceName(config, 'prompt-cache-observability'),
+      defaultInterval: cdk.Duration.hours(3),
+    });
+
+    dashboard.addWidgets(
+      new cloudwatch.TextWidget({
+        markdown: `# Prompt Cache Observability\n**Project:** ${config.projectPrefix} | **Region:** ${config.awsRegion} — fleet-wide EMF metrics from app-api + inference-api. Per-session drill-down: \`GET /admin/costs/sessions/{id}/calls\`.`,
+        width: 24,
+        height: 1,
+      }),
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: 'Cache Tokens (Read vs Write)',
+        left: [cacheReadTokensMetric, cacheWriteTokensMetric],
+        width: 12,
+        height: 6,
+      }),
+      new cloudwatch.GraphWidget({
+        title: 'Cache Efficiency (reads / total cache traffic)',
+        left: [cacheEfficiencyExpression],
+        leftYAxis: { min: 0, max: 100 },
+        width: 12,
+        height: 6,
+      }),
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: 'Avoidable Cache Misses',
+        left: [avoidableMissMetric],
+        width: 12,
+        height: 6,
+      }),
+      new cloudwatch.GraphWidget({
+        title: 'Wasted USD (avoidable re-writes)',
+        left: [wastedUsdMetric],
+        width: 12,
+        height: 6,
+      }),
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.LogQueryWidget({
+        title: 'Model Calls by cacheStatus (inference-api)',
+        // The runtime log group is defined by the inference-api
+        // construct with this deterministic name; referenced by name
+        // (not typed ref) since a dashboard widget creates no CFN
+        // dependency. app-api's ECS log group is auto-named, so its
+        // (much smaller) share of emissions isn't queried here.
+        logGroupNames: [`/aws/bedrock-agentcore/runtimes/${config.projectPrefix}`],
+        queryLines: [
+          'filter ispresent(cacheStatus)',
+          'stats count(*) as calls by cacheStatus',
+          'sort calls desc',
+        ],
+        width: 24,
+        height: 6,
+      }),
+    );
+
+    // ============================================================
+    // Alarms (console-only; no SNS wiring yet)
+    // ============================================================
+
+    // AvoidableMiss is the nominated alarm target (see emf.py): a
+    // prefix-stability regression flips a large share of calls to
+    // `miss_avoidable`, showing up as a step change in this sum.
+    new cloudwatch.Alarm(this, 'PromptCacheAvoidableMissAlarm', {
+      alarmName: getResourceName(config, 'prompt-cache-avoidable-miss'),
+      alarmDescription:
+        'Avoidable prompt-cache misses exceeded threshold — likely a prompt-prefix stability regression',
+      metric: avoidableMissMetric,
+      threshold: config.production ? 10 : 50,
+      evaluationPeriods: 3,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    new cloudwatch.Alarm(this, 'PromptCacheWastedUsdAlarm', {
+      alarmName: getResourceName(config, 'prompt-cache-wasted-usd'),
+      alarmDescription:
+        'Dollars wasted on avoidable prompt-cache re-writes exceeded threshold',
+      metric: wastedUsdMetric,
+      threshold: config.production ? 1 : 5,
+      evaluationPeriods: 3,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // ============================================================
+    // Outputs
+    // ============================================================
+
+    new cdk.CfnOutput(this, 'PromptCacheDashboardName', {
+      value: dashboard.dashboardName,
+      description: 'CloudWatch Dashboard for prompt-cache observability',
+      exportName: `${config.projectPrefix}-PromptCacheDashboard`,
+    });
+  }
+}

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -70,6 +70,9 @@ import { AgentCoreGatewayConstruct } from './constructs/gateway/agentcore-gatewa
 import { McpSandboxBucketConstruct } from './constructs/mcp-sandbox/mcp-sandbox-bucket-construct';
 import { McpSandboxDistributionConstruct } from './constructs/mcp-sandbox/mcp-sandbox-distribution-construct';
 
+// Observability (cross-service dashboards + alarms)
+import { PromptCacheObservabilityConstruct } from './constructs/observability/prompt-cache-observability-construct';
+
 // Fine-tuning (data half lives in Platform)
 import { FineTuningDataConstruct } from './constructs/fine-tuning/fine-tuning-data-construct';
 
@@ -629,6 +632,15 @@ export class PlatformStack extends cdk.Stack {
       config: this._config,
       frontendUrl,
       documentsBucket: this.ragDocumentsBucket,
+    });
+
+    // ============================================================
+    // Prompt-cache observability — cross-service dashboard + alarms
+    // over the EMF metrics both APIs emit (PR #697 follow-up).
+    // Metric-namespace-based, so no typed refs are needed.
+    // ============================================================
+    new PromptCacheObservabilityConstruct(this, 'PromptCacheObservability', {
+      config,
     });
   }
 

--- a/infrastructure/test/prompt-cache-observability.test.ts
+++ b/infrastructure/test/prompt-cache-observability.test.ts
@@ -1,0 +1,86 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+
+import { PromptCacheObservabilityConstruct } from '../lib/constructs/observability/prompt-cache-observability-construct';
+import { createMockConfig, MOCK_ACCOUNT, MOCK_PREFIX, MOCK_REGION } from './helpers/mock-config';
+
+function synth(production: boolean): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'Test', {
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  const config = createMockConfig({ production });
+  new PromptCacheObservabilityConstruct(stack, 'PromptCacheObservability', {
+    config,
+  });
+  return Template.fromStack(stack);
+}
+
+describe('PromptCacheObservabilityConstruct', () => {
+  let t: Template;
+  beforeAll(() => {
+    t = synth(false);
+  });
+
+  it('creates the dashboard with the conventional name', () => {
+    t.hasResourceProperties('AWS::CloudWatch::Dashboard', {
+      DashboardName: `${MOCK_PREFIX}-prompt-cache-observability`,
+    });
+  });
+
+  it('dashboard graphs the EMF namespace metrics and queries the runtime log group', () => {
+    const dashboards = t.findResources('AWS::CloudWatch::Dashboard');
+    const body = JSON.stringify(Object.values(dashboards)[0].Properties.DashboardBody);
+    for (const metric of ['CacheReadTokens', 'CacheWriteTokens', 'AvoidableMiss', 'WastedUsd']) {
+      expect(body).toContain(metric);
+    }
+    expect(body).toContain('AgentCoreStack/PromptCache');
+    expect(body).toContain(`/aws/bedrock-agentcore/runtimes/${MOCK_PREFIX}`);
+    expect(body).toContain('cacheStatus');
+  });
+
+  it('creates exactly two alarms, both NOT_BREACHING on missing data (kill-switch tolerant)', () => {
+    t.resourceCountIs('AWS::CloudWatch::Alarm', 2);
+    const alarms = Object.values(t.findResources('AWS::CloudWatch::Alarm'));
+    for (const alarm of alarms) {
+      expect(alarm.Properties.TreatMissingData).toBe('notBreaching');
+      expect(alarm.Properties.Namespace).toBe('AgentCoreStack/PromptCache');
+      expect(alarm.Properties.Statistic).toBe('Sum');
+      // Console-only: no SNS wiring yet anywhere in the stack.
+      expect(alarm.Properties.AlarmActions).toBeUndefined();
+    }
+  });
+
+  it('alarms on AvoidableMiss (the nominated target) and WastedUsd', () => {
+    t.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `${MOCK_PREFIX}-prompt-cache-avoidable-miss`,
+      MetricName: 'AvoidableMiss',
+      Threshold: 50,
+      EvaluationPeriods: 3,
+      ComparisonOperator: 'GreaterThanThreshold',
+    });
+    t.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `${MOCK_PREFIX}-prompt-cache-wasted-usd`,
+      MetricName: 'WastedUsd',
+      Threshold: 5,
+    });
+  });
+
+  it('uses stricter thresholds in production', () => {
+    const prod = synth(true);
+    prod.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      MetricName: 'AvoidableMiss',
+      Threshold: 10,
+    });
+    prod.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      MetricName: 'WastedUsd',
+      Threshold: 1,
+    });
+  });
+
+  it('exports the dashboard name', () => {
+    t.hasOutput('*', {
+      Export: { Name: `${MOCK_PREFIX}-PromptCacheDashboard` },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up #1 from #697 (deliberately excluded there to keep it backend-only): CDK dashboard + alarms for the prompt-cache EMF metrics already emitting in prod from `backend/src/apis/shared/observability/emf.py`.

- New cross-service construct area `infrastructure/lib/constructs/observability/` with `PromptCacheObservabilityConstruct`, composed into `PlatformStack` (metric-namespace-based — no typed refs needed).
- **Dashboard** `{prefix}-prompt-cache-observability` over the `AgentCoreStack/PromptCache` namespace:
  - Cache read vs write tokens (Sum)
  - Cache efficiency as a `MathExpression` — `100 * reads / (reads + writes)`
  - AvoidableMiss and WastedUsd sums
  - Logs Insights widget over the AgentCore Runtime log group grouped by the `cacheStatus` EMF log property
- **Alarms** (console-only — no SNS topics exist in the stack yet, same posture as kb-sync/scheduled-runs):
  - `AvoidableMiss` Sum — the alarm target nominated in emf.py — >10 (prod) / >50 (dev) per 5-min period, 3 evaluation periods
  - `WastedUsd` Sum — >$1 (prod) / >$5 (dev) per 5-min period, 3 evaluation periods
  - Both `TreatMissingData.NOT_BREACHING` so the `PROMPT_CACHE_OBSERVABILITY_ENABLED=false` kill switch (or zero traffic) never pages
- CfnOutput for the dashboard name.
- Unit tests: dashboard body coverage, alarm count/thresholds/missing-data posture, prod-vs-dev thresholds, export name.

The per-session drill-down counterpart to this fleet view is `GET /admin/costs/sessions/{id}/calls`.

## Verification

- `npx tsc --noEmit` clean
- `npx jest` — 475 tests / 24 suites pass
- `npx cdk synth` clean; dashboard + both alarms confirmed in the synthesized template

Deploys via platform.yml (CDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)