### PR TITLE
feat(admin-costs): per-session cost-anatomy drill-down page

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -12,6 +12,10 @@ export const adminRoutes: Routes = [
     loadComponent: () => import('./costs/admin-costs.page').then(m => m.AdminCostsPage),
   },
   {
+    path: 'costs/sessions/:id',
+    loadComponent: () => import('./costs/pages/session-cost-anatomy.page').then(m => m.SessionCostAnatomyPage),
+  },
+  {
     path: 'quota',
     loadChildren: () => import('./quota-tiers/quota-routing.module').then(m => m.quotaRoutes),
   },

--- a/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/admin-costs.page.ts
@@ -7,10 +7,12 @@ import {
   signal,
 } from '@angular/core';
 import { Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
   heroArrowDownTray,
+  heroMagnifyingGlass,
 } from '@ng-icons/heroicons/outline';
 import { AdminCostStateService } from './services';
 import { PeriodSelectorComponent } from './components/period-selector.component';
@@ -28,6 +30,7 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
 @Component({
   selector: 'app-admin-costs',
   imports: [
+    FormsModule,
     NgIcon,
     PeriodSelectorComponent,
     SystemSummaryCardComponent,
@@ -35,7 +38,7 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
     CostTrendsChartComponent,
     ModelBreakdownComponent,
   ],
-  providers: [provideIcons({ heroArrowLeft, heroArrowDownTray })],
+  providers: [provideIcons({ heroArrowLeft, heroArrowDownTray, heroMagnifyingGlass })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div>
@@ -66,6 +69,46 @@ import { ModelBreakdownComponent } from './components/model-breakdown.component'
             </button>
           </div>
         </div>
+        <!-- Session cost anatomy lookup -->
+        <form
+          (ngSubmit)="onInspectSession()"
+          class="mb-6 flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div>
+            <label for="session-lookup" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              Session Cost Anatomy
+            </label>
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              Look up per-call cache diagnostics for a session ID.
+            </p>
+          </div>
+          <div class="flex items-center gap-2 sm:w-96">
+            <div class="relative flex-1">
+              <ng-icon
+                name="heroMagnifyingGlass"
+                class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                id="session-lookup"
+                name="sessionLookup"
+                [ngModel]="sessionLookupId()"
+                (ngModelChange)="sessionLookupId.set($event)"
+                placeholder="Session ID…"
+                class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 font-mono text-sm/6 text-gray-900 placeholder:font-sans placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              />
+            </div>
+            <button
+              type="submit"
+              [disabled]="!sessionLookupId().trim()"
+              class="shrink-0 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              Inspect
+            </button>
+          </div>
+        </form>
+
         @if (loading()) {
           <!-- Loading State -->
           <div class="flex items-center justify-center h-64">
@@ -177,6 +220,9 @@ export class AdminCostsPage implements OnInit {
   trends = this.stateService.trends;
   modelUsage = this.stateService.modelUsage;
 
+  // Session-id lookup for the cost-anatomy drill-down
+  sessionLookupId = signal('');
+
   // Track pagination state for top users
   private topUsersLimit = signal(20);
   hasMoreUsers = computed(
@@ -236,6 +282,13 @@ export class AdminCostsPage implements OnInit {
 
   onUserClick(userId: string): void {
     this.router.navigate(['/admin/users', userId]);
+  }
+
+  onInspectSession(): void {
+    const sessionId = this.sessionLookupId().trim();
+    if (sessionId) {
+      this.router.navigate(['/admin/costs/sessions', sessionId]);
+    }
   }
 
   async onLoadMoreUsers(): Promise<void> {

--- a/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
+++ b/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
@@ -91,6 +91,59 @@ export interface AdminCostDashboard {
   dailyTrends?: CostTrend[];
 }
 
+// ========== Session Cost Anatomy ==========
+
+/**
+ * Derived prompt-cache status for one model call.
+ * Null on rows persisted before the cache-observability feature.
+ */
+export type CacheStatus =
+  | 'first_write'
+  | 'hit'
+  | 'miss_ttl_expired'
+  | 'miss_avoidable'
+  | 'uncached';
+
+/** Prompt-cache prefix hashes for one model call. */
+export interface PrefixFingerprints {
+  toolConfigHash?: string | null;
+  systemPromptHash?: string | null;
+  historyHash?: string | null;
+  messageCount?: number | null;
+}
+
+/** One model call within a session's cost anatomy. */
+export interface SessionCallRow {
+  timestamp: string;
+  messageId?: number | null;
+  modelId?: string | null;
+
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+
+  cost: number;
+  cacheStatus?: CacheStatus | null;
+  cacheGapSeconds?: number | null;
+  wastedUsd: number;
+  prefixFingerprints?: PrefixFingerprints | null;
+}
+
+/** Per-call cost anatomy for one session (admin cache-miss forensics). */
+export interface SessionCostAnatomy {
+  sessionId: string;
+  calls: SessionCallRow[];
+
+  totalCost: number;
+  totalCacheReadTokens: number;
+  totalCacheWriteTokens: number;
+  avoidableMissCount: number;
+  wastedUsd: number;
+  /** cacheRead / (cacheRead + cacheWrite); null until any cache activity. */
+  cacheEfficiency: number | null;
+}
+
 // ========== API Request Options ==========
 
 export interface DashboardRequestOptions {

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { SessionCostAnatomyPage } from './session-cost-anatomy.page';
+import { AdminCostHttpService } from '../services/admin-cost-http.service';
+import { SessionCostAnatomy } from '../models';
+
+const MOCK_ANATOMY: SessionCostAnatomy = {
+  sessionId: 'sess-1',
+  totalCost: 0.42,
+  totalCacheReadTokens: 20_000,
+  totalCacheWriteTokens: 5_000,
+  avoidableMissCount: 1,
+  wastedUsd: 0.03,
+  cacheEfficiency: 0.8,
+  calls: [
+    {
+      timestamp: '2026-07-19T10:00:00Z',
+      messageId: 1,
+      modelId: 'us.anthropic.claude-sonnet-5',
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 5_000,
+      cost: 0.1,
+      cacheStatus: 'first_write',
+      cacheGapSeconds: null,
+      wastedUsd: 0,
+      prefixFingerprints: { toolConfigHash: 'aaaa1111', systemPromptHash: 'bbbb2222', historyHash: 'cccc3333', messageCount: 2 },
+    },
+    {
+      timestamp: '2026-07-19T10:01:00Z',
+      messageId: 2,
+      modelId: 'us.anthropic.claude-sonnet-5',
+      inputTokens: 120,
+      outputTokens: 60,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 5_200,
+      cost: 0.12,
+      cacheStatus: 'miss_avoidable',
+      cacheGapSeconds: 60,
+      wastedUsd: 0.03,
+      prefixFingerprints: { toolConfigHash: 'DIFFERENT', systemPromptHash: 'bbbb2222', historyHash: 'cccc3333', messageCount: 4 },
+    },
+  ],
+};
+
+describe('SessionCostAnatomyPage', () => {
+  let getSessionCostAnatomy: ReturnType<typeof vi.fn>;
+
+  function setup(mock: ReturnType<typeof vi.fn>) {
+    getSessionCostAnatomy = mock;
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AdminCostHttpService, useValue: { getSessionCostAnatomy } },
+      ],
+    });
+    TestBed.overrideComponent(SessionCostAnatomyPage, {
+      set: { template: '<div></div>' },
+    });
+    const fixture = TestBed.createComponent(SessionCostAnatomyPage);
+    fixture.componentRef.setInput('id', 'sess-1');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('loads the anatomy for the routed session id and annotates fingerprint diffs', async () => {
+    const fixture = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY)));
+    const page = fixture.componentInstance;
+
+    await vi.waitFor(() => {
+      expect(page.anatomyResource.hasValue()).toBe(true);
+    });
+
+    expect(getSessionCostAnatomy).toHaveBeenCalledWith('sess-1');
+    const rows = page.rows();
+    expect(rows).toHaveLength(2);
+    expect(rows[0].changed).toEqual([]);
+    // The flipped toolConfigHash is the diagnosis on the miss_avoidable row.
+    expect(rows[1].changed).toEqual(['toolConfigHash']);
+    expect(page.notFound()).toBe(false);
+  });
+
+  it('treats a 404 as "session has no cost rows"', async () => {
+    const fixture = setup(
+      vi.fn().mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }))
+      )
+    );
+    const page = fixture.componentInstance;
+
+    await vi.waitFor(() => {
+      expect(page.anatomyResource.error()).toBeTruthy();
+    });
+    expect(page.notFound()).toBe(true);
+  });
+
+  it('does not report notFound for other errors', async () => {
+    const fixture = setup(
+      vi.fn().mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' }))
+      )
+    );
+    const page = fixture.componentInstance;
+
+    await vi.waitFor(() => {
+      expect(page.anatomyResource.error()).toBeTruthy();
+    });
+    expect(page.notFound()).toBe(false);
+  });
+
+  it('toggles row expansion', () => {
+    const fixture = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY)));
+    const page = fixture.componentInstance;
+
+    expect(page.isExpanded(0)).toBe(false);
+    page.toggleExpand(0);
+    expect(page.isExpanded(0)).toBe(true);
+    page.toggleExpand(0);
+    expect(page.isExpanded(0)).toBe(false);
+  });
+
+  it('formats cache efficiency, handling null', () => {
+    const fixture = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY)));
+    const page = fixture.componentInstance;
+
+    expect(page.formatEfficiency(null)).toBe('—');
+    expect(page.formatEfficiency(0.8)).toBe('80.0%');
+  });
+
+  it('formats cache gaps, handling null', () => {
+    const fixture = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY)));
+    const page = fixture.componentInstance;
+
+    expect(page.formatGap(null)).toBe('—');
+    expect(page.formatGap(undefined)).toBe('—');
+    expect(page.formatGap(42)).toBe('42s');
+    expect(page.formatGap(60)).toBe('1m');
+    expect(page.formatGap(312)).toBe('5m 12s');
+  });
+
+  it('maps cache statuses to color-coded badge classes', () => {
+    const fixture = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY)));
+    const page = fixture.componentInstance;
+
+    expect(page.getStatusClass('hit')).toContain('bg-green-100');
+    expect(page.getStatusClass('first_write')).toContain('bg-blue-100');
+    expect(page.getStatusClass('miss_ttl_expired')).toContain('bg-yellow-100');
+    expect(page.getStatusClass('miss_avoidable')).toContain('bg-red-100');
+    expect(page.getStatusClass('uncached')).toContain('bg-gray-100');
+  });
+});

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
@@ -1,0 +1,469 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  resource,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { RouterLink } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowLeft, heroChevronDown } from '@ng-icons/heroicons/outline';
+import { AdminCostHttpService } from '../services/admin-cost-http.service';
+import { CacheStatus, SessionCallRow } from '../models';
+import {
+  AnatomyRow,
+  FINGERPRINT_KEYS,
+  FINGERPRINT_LABELS,
+  FingerprintKey,
+  buildAnatomyRows,
+  truncateHash,
+} from './session-cost-anatomy.util';
+
+/**
+ * Admin drill-down: per-model-call cost anatomy for one session.
+ *
+ * The forensic view for prompt-cache diagnostics — each call row carries its
+ * cache status and prefix-fingerprint hashes, and the hash that flipped
+ * between consecutive calls names the cache-buster (the diagnosis on
+ * `miss_avoidable` rows).
+ */
+@Component({
+  selector: 'app-session-cost-anatomy',
+  imports: [RouterLink, NgIcon, DatePipe],
+  providers: [provideIcons({ heroArrowLeft, heroChevronDown })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div>
+      <!-- Back link -->
+      <a
+        routerLink="/admin/costs"
+        class="mb-6 inline-flex items-center gap-2 rounded-2xl text-sm/6 font-medium text-gray-600 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+        Back to Cost Analytics
+      </a>
+
+      <!-- Page Header -->
+      <div class="mb-6">
+        <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Session Cost Anatomy</h1>
+        <p class="mt-1 truncate font-mono text-sm/6 text-gray-600 dark:text-gray-400" [title]="id()">
+          {{ id() }}
+        </p>
+      </div>
+
+      @if (anatomyResource.isLoading()) {
+        <!-- Loading State -->
+        <div class="flex h-64 items-center justify-center">
+          <div class="flex flex-col items-center gap-4">
+            <div
+              class="size-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading session cost anatomy…</p>
+          </div>
+        </div>
+      } @else if (notFound()) {
+        <!-- 404: session has no cost rows -->
+        <div
+          class="rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800"
+        >
+          <p class="text-sm/6 font-medium text-gray-900 dark:text-white">No cost rows for this session</p>
+          <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+            Nothing has been recorded under this session ID — check the ID, or the session may predate
+            cost tracking.
+          </p>
+        </div>
+      } @else if (anatomyResource.error()) {
+        <!-- Error State -->
+        <div
+          class="rounded-2xl border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200"
+        >
+          <p class="text-sm/6">Failed to load session cost anatomy. Please try again.</p>
+          <button
+            type="button"
+            (click)="anatomyResource.reload()"
+            class="mt-2 text-sm/6 font-medium underline hover:no-underline"
+          >
+            Retry
+          </button>
+        </div>
+      } @else if (anatomyResource.hasValue()) {
+        <!-- Summary Header -->
+        <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-6">
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Total Cost
+            </p>
+            <p class="mt-1 text-lg/7 font-semibold text-gray-900 dark:text-white">
+              {{ formatCurrency(anatomyResource.value().totalCost) }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Cache Efficiency
+            </p>
+            <p class="mt-1 text-lg/7 font-semibold text-gray-900 dark:text-white">
+              {{ formatEfficiency(anatomyResource.value().cacheEfficiency) }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Avoidable Misses
+            </p>
+            <p
+              class="mt-1 text-lg/7 font-semibold"
+              [class]="
+                anatomyResource.value().avoidableMissCount > 0
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-gray-900 dark:text-white'
+              "
+            >
+              {{ anatomyResource.value().avoidableMissCount }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Wasted
+            </p>
+            <p
+              class="mt-1 text-lg/7 font-semibold"
+              [class]="
+                anatomyResource.value().wastedUsd > 0
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-gray-900 dark:text-white'
+              "
+            >
+              {{ formatCurrency(anatomyResource.value().wastedUsd, 4) }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Cache Read
+            </p>
+            <p class="mt-1 text-lg/7 font-semibold text-gray-900 dark:text-white">
+              {{ formatTokens(anatomyResource.value().totalCacheReadTokens) }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Cache Write
+            </p>
+            <p class="mt-1 text-lg/7 font-semibold text-gray-900 dark:text-white">
+              {{ formatTokens(anatomyResource.value().totalCacheWriteTokens) }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Calls Table -->
+        <div
+          class="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead>
+                <tr class="text-left text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <th scope="col" class="px-3 py-3 sm:pl-4"><span class="sr-only">Expand</span></th>
+                  <th scope="col" class="px-3 py-3">Time</th>
+                  <th scope="col" class="px-3 py-3">Model</th>
+                  <th scope="col" class="px-3 py-3 text-right">In</th>
+                  <th scope="col" class="px-3 py-3 text-right">Read</th>
+                  <th scope="col" class="px-3 py-3 text-right">Write</th>
+                  <th scope="col" class="px-3 py-3 text-right">Out</th>
+                  <th scope="col" class="px-3 py-3 text-right">Cost</th>
+                  <th scope="col" class="px-3 py-3">Cache Status</th>
+                  <th scope="col" class="px-3 py-3 text-right">Gap</th>
+                  <th scope="col" class="px-3 py-3 text-right">Wasted</th>
+                  <th scope="col" class="px-3 py-3">Fingerprints</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                @for (row of rows(); track row.index) {
+                  <tr
+                    class="text-sm/6 text-gray-700 dark:text-gray-300"
+                    [class.bg-red-50]="row.call.cacheStatus === 'miss_avoidable'"
+                    [class.dark:bg-red-900/10]="row.call.cacheStatus === 'miss_avoidable'"
+                  >
+                    <td class="px-3 py-2 sm:pl-4">
+                      <button
+                        type="button"
+                        (click)="toggleExpand(row.index)"
+                        [attr.aria-expanded]="isExpanded(row.index)"
+                        [attr.aria-controls]="'call-detail-' + row.index"
+                        [attr.aria-label]="(isExpanded(row.index) ? 'Hide' : 'Show') + ' details for call ' + (row.index + 1)"
+                        class="flex size-7 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                      >
+                        <ng-icon
+                          name="heroChevronDown"
+                          class="size-4 transition-transform duration-150"
+                          [class.rotate-180]="isExpanded(row.index)"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 tabular-nums" [title]="row.call.timestamp">
+                      {{ row.call.timestamp | date: 'MMM d, HH:mm:ss' }}
+                    </td>
+                    <td class="max-w-48 truncate px-3 py-2 font-mono text-xs/5" [title]="row.call.modelId ?? ''">
+                      {{ row.call.modelId ?? '—' }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                      {{ formatTokens(row.call.inputTokens) }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums text-green-700 dark:text-green-400">
+                      {{ formatTokens(row.call.cacheReadTokens) }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums text-blue-700 dark:text-blue-400">
+                      {{ formatTokens(row.call.cacheWriteTokens) }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                      {{ formatTokens(row.call.outputTokens) }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                      {{ formatCurrency(row.call.cost, 4) }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2">
+                      @if (row.call.cacheStatus; as status) {
+                        <span [class]="getStatusClass(status)">{{ getStatusLabel(status) }}</span>
+                      } @else {
+                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                      }
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                      {{ formatGap(row.call.cacheGapSeconds) }}
+                    </td>
+                    <td
+                      class="whitespace-nowrap px-3 py-2 text-right tabular-nums"
+                      [class.text-red-600]="row.call.wastedUsd > 0"
+                      [class.dark:text-red-400]="row.call.wastedUsd > 0"
+                    >
+                      {{ row.call.wastedUsd > 0 ? formatCurrency(row.call.wastedUsd, 4) : '—' }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2">
+                      @if (row.call.prefixFingerprints; as fp) {
+                        <div class="flex items-center gap-1.5">
+                          @for (key of fingerprintKeys; track key) {
+                            <span
+                              [class]="getFingerprintClass(row, key)"
+                              [title]="
+                                fingerprintLabels[key] +
+                                ': ' +
+                                (fp[key] ?? 'not recorded') +
+                                (isChanged(row, key) ? ' — changed since previous call' : '')
+                              "
+                            >
+                              {{ fingerprintLabels[key] }} {{ truncateHash(fp[key]) }}
+                            </span>
+                          }
+                        </div>
+                      } @else {
+                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                      }
+                    </td>
+                  </tr>
+                  @if (isExpanded(row.index)) {
+                    <tr [id]="'call-detail-' + row.index" class="bg-gray-50 dark:bg-gray-900/40">
+                      <td colspan="12" class="px-4 py-3 sm:pl-14">
+                        <dl class="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
+                          <div>
+                            <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                              Timestamp
+                            </dt>
+                            <dd class="mt-0.5 font-mono text-xs/5 text-gray-700 dark:text-gray-300">
+                              {{ row.call.timestamp }}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                              Message ID
+                            </dt>
+                            <dd class="mt-0.5 font-mono text-xs/5 text-gray-700 dark:text-gray-300">
+                              {{ row.call.messageId ?? '—' }}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                              Message Count
+                            </dt>
+                            <dd class="mt-0.5 font-mono text-xs/5 text-gray-700 dark:text-gray-300">
+                              {{ row.call.prefixFingerprints?.messageCount ?? '—' }}
+                            </dd>
+                          </div>
+                          @for (key of fingerprintKeys; track key) {
+                            <div>
+                              <dt class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                {{ fingerprintLabels[key] }} Hash
+                                @if (isChanged(row, key)) {
+                                  <span class="ml-1 normal-case text-red-600 dark:text-red-400">(changed)</span>
+                                }
+                              </dt>
+                              <dd
+                                class="mt-0.5 break-all font-mono text-xs/5"
+                                [class]="
+                                  isChanged(row, key)
+                                    ? 'text-red-600 dark:text-red-400'
+                                    : 'text-gray-700 dark:text-gray-300'
+                                "
+                              >
+                                {{ row.call.prefixFingerprints?.[key] ?? '—' }}
+                              </dd>
+                            </div>
+                          }
+                        </dl>
+                      </td>
+                    </tr>
+                  }
+                } @empty {
+                  <tr>
+                    <td colspan="12" class="px-4 py-8 text-center text-sm/6 text-gray-500 dark:text-gray-400">
+                      No model calls recorded for this session.
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+})
+export class SessionCostAnatomyPage {
+  private costHttp = inject(AdminCostHttpService);
+
+  /** Session ID from the `costs/sessions/:id` route (component input binding). */
+  readonly id = input.required<string>();
+
+  readonly fingerprintKeys = FINGERPRINT_KEYS;
+  readonly fingerprintLabels = FINGERPRINT_LABELS;
+  readonly truncateHash = truncateHash;
+
+  readonly anatomyResource = resource({
+    params: () => ({ id: this.id() }),
+    loader: ({ params }) => firstValueFrom(this.costHttp.getSessionCostAnatomy(params.id)),
+  });
+
+  /** Chronological call rows annotated with fingerprint diffs. */
+  readonly rows = computed<AnatomyRow[]>(() =>
+    this.anatomyResource.hasValue() ? buildAnatomyRows(this.anatomyResource.value().calls) : []
+  );
+
+  /** True when the backend returned 404 — the session has no cost rows. */
+  readonly notFound = computed(() => this.errorStatus(this.anatomyResource.error()) === 404);
+
+  private expandedRows = signal<ReadonlySet<number>>(new Set());
+
+  isExpanded(index: number): boolean {
+    return this.expandedRows().has(index);
+  }
+
+  toggleExpand(index: number): void {
+    this.expandedRows.update((current) => {
+      const next = new Set(current);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  }
+
+  isChanged(row: AnatomyRow, key: FingerprintKey): boolean {
+    return row.changed.includes(key);
+  }
+
+  getFingerprintClass(row: AnatomyRow, key: FingerprintKey): string {
+    const base = 'inline-flex items-center rounded-2xl px-2 py-0.5 font-mono text-xs/5';
+    if (this.isChanged(row, key)) {
+      return `${base} bg-red-100 font-semibold text-red-700 ring-1 ring-inset ring-red-300 dark:bg-red-900/40 dark:text-red-300 dark:ring-red-700`;
+    }
+    return `${base} bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400`;
+  }
+
+  getStatusClass(status: CacheStatus): string {
+    const base = 'inline-flex items-center rounded-2xl px-2.5 py-0.5 text-xs/5 font-medium';
+    switch (status) {
+      case 'hit':
+        return `${base} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300`;
+      case 'first_write':
+        return `${base} bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300`;
+      case 'miss_ttl_expired':
+        return `${base} bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300`;
+      case 'miss_avoidable':
+        return `${base} bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300`;
+      case 'uncached':
+      default:
+        return `${base} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300`;
+    }
+  }
+
+  getStatusLabel(status: CacheStatus): string {
+    switch (status) {
+      case 'hit':
+        return 'Hit';
+      case 'first_write':
+        return 'First Write';
+      case 'miss_ttl_expired':
+        return 'Miss (TTL)';
+      case 'miss_avoidable':
+        return 'Miss (Avoidable)';
+      case 'uncached':
+        return 'Uncached';
+      default:
+        return status;
+    }
+  }
+
+  formatCurrency(value: number, maxFractionDigits = 2): string {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: maxFractionDigits,
+    }).format(value);
+  }
+
+  formatTokens(tokens: number): string {
+    if (tokens >= 1_000_000) {
+      return `${(tokens / 1_000_000).toFixed(1)}M`;
+    } else if (tokens >= 1_000) {
+      return `${(tokens / 1_000).toFixed(1)}K`;
+    }
+    return tokens.toString();
+  }
+
+  formatEfficiency(efficiency: number | null): string {
+    if (efficiency === null) {
+      return '—';
+    }
+    return `${(efficiency * 100).toFixed(1)}%`;
+  }
+
+  formatGap(seconds: number | null | undefined): string {
+    if (seconds == null) {
+      return '—';
+    }
+    if (seconds >= 60) {
+      const minutes = Math.floor(seconds / 60);
+      const rest = seconds % 60;
+      return rest > 0 ? `${minutes}m ${rest}s` : `${minutes}m`;
+    }
+    return `${seconds}s`;
+  }
+
+  private errorStatus(error: unknown): number | undefined {
+    if (error instanceof HttpErrorResponse) {
+      return error.status;
+    }
+    // resource() may wrap loader errors; check the cause chain.
+    const cause = (error as { cause?: unknown } | null | undefined)?.cause;
+    if (cause instanceof HttpErrorResponse) {
+      return cause.status;
+    }
+    return undefined;
+  }
+}

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.util.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.util.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { buildAnatomyRows, truncateHash } from './session-cost-anatomy.util';
+import { SessionCallRow } from '../models';
+
+function makeCall(overrides: Partial<SessionCallRow> = {}): SessionCallRow {
+  return {
+    timestamp: '2026-07-19T10:00:00Z',
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cost: 0.01,
+    wastedUsd: 0,
+    ...overrides,
+  };
+}
+
+describe('buildAnatomyRows', () => {
+  it('never flags the first call', () => {
+    const rows = buildAnatomyRows([
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].changed).toEqual([]);
+  });
+
+  it('flags exactly the hash that flipped between consecutive calls', () => {
+    const rows = buildAnatomyRows([
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'XXX', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+    ]);
+    expect(rows[1].changed).toEqual(['toolConfigHash']);
+  });
+
+  it('flags multiple flipped hashes', () => {
+    const rows = buildAnatomyRows([
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'YYY', historyHash: 'ZZZ' },
+      }),
+    ]);
+    expect(rows[1].changed).toEqual(['systemPromptHash', 'historyHash']);
+  });
+
+  it('skips rows without fingerprints as comparison baselines', () => {
+    const rows = buildAnatomyRows([
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+      makeCall({ prefixFingerprints: null }),
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'XXX', systemPromptHash: 'bbb', historyHash: 'ccc' },
+      }),
+    ]);
+    // Row 1 has nothing to diff; row 2 diffs against row 0, not the null row.
+    expect(rows[1].changed).toEqual([]);
+    expect(rows[2].changed).toEqual(['toolConfigHash']);
+  });
+
+  it('does not flag a hash when either side is missing', () => {
+    const rows = buildAnatomyRows([
+      makeCall({ prefixFingerprints: { toolConfigHash: 'aaa', historyHash: 'ccc' } }),
+      makeCall({
+        prefixFingerprints: { toolConfigHash: 'aaa', systemPromptHash: 'now-present', historyHash: 'ccc' },
+      }),
+    ]);
+    expect(rows[1].changed).toEqual([]);
+  });
+
+  it('does not flag identical fingerprints', () => {
+    const fp = { toolConfigHash: 'aaa', systemPromptHash: 'bbb', historyHash: 'ccc' };
+    const rows = buildAnatomyRows([
+      makeCall({ prefixFingerprints: fp }),
+      makeCall({ prefixFingerprints: { ...fp } }),
+    ]);
+    expect(rows[1].changed).toEqual([]);
+  });
+});
+
+describe('truncateHash', () => {
+  it('truncates to the first 8 chars', () => {
+    expect(truncateHash('0123456789abcdef')).toBe('01234567');
+  });
+
+  it('returns an em dash for missing hashes', () => {
+    expect(truncateHash(null)).toBe('—');
+    expect(truncateHash(undefined)).toBe('—');
+    expect(truncateHash('')).toBe('—');
+  });
+});

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.util.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.util.ts
@@ -1,0 +1,62 @@
+import { PrefixFingerprints, SessionCallRow } from '../models';
+
+export type FingerprintKey = 'toolConfigHash' | 'systemPromptHash' | 'historyHash';
+
+export const FINGERPRINT_KEYS: readonly FingerprintKey[] = [
+  'toolConfigHash',
+  'systemPromptHash',
+  'historyHash',
+];
+
+export const FINGERPRINT_LABELS: Record<FingerprintKey, string> = {
+  toolConfigHash: 'Tools',
+  systemPromptHash: 'System',
+  historyHash: 'History',
+};
+
+/** One call row annotated with fingerprint-diff results against the previous fingerprinted call. */
+export interface AnatomyRow {
+  call: SessionCallRow;
+  index: number;
+  /** Fingerprint hashes that flipped vs. the nearest previous call that has fingerprints. */
+  changed: FingerprintKey[];
+}
+
+/**
+ * Annotate chronological call rows with which prefix-fingerprint hashes
+ * changed since the previous fingerprinted call — on a `miss_avoidable`
+ * row, the flipped hash names the cache-buster.
+ *
+ * A hash is flagged only when both rows carry a value for it and the values
+ * differ; rows predating the fingerprint feature (null fingerprints) are
+ * skipped as comparison baselines.
+ */
+export function buildAnatomyRows(calls: SessionCallRow[]): AnatomyRow[] {
+  let previous: PrefixFingerprints | undefined;
+
+  return calls.map((call, index) => {
+    const fingerprints = call.prefixFingerprints ?? undefined;
+    const changed: FingerprintKey[] = [];
+
+    if (fingerprints && previous) {
+      for (const key of FINGERPRINT_KEYS) {
+        const current = fingerprints[key];
+        const before = previous[key];
+        if (current != null && before != null && current !== before) {
+          changed.push(key);
+        }
+      }
+    }
+
+    if (fingerprints) {
+      previous = fingerprints;
+    }
+
+    return { call, index, changed };
+  });
+}
+
+/** First 8 chars of a fingerprint hash, or an em dash when absent. */
+export function truncateHash(hash: string | null | undefined): string {
+  return hash ? hash.slice(0, 8) : '—';
+}

--- a/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.spec.ts
@@ -65,6 +65,35 @@ describe('AdminCostHttpService', () => {
     req.flush(mockSummary);
   });
 
+  it('should get session cost anatomy', () => {
+    const mockAnatomy = {
+      sessionId: 'sess-1',
+      calls: [],
+      totalCost: 1.23,
+      totalCacheReadTokens: 1000,
+      totalCacheWriteTokens: 500,
+      avoidableMissCount: 0,
+      wastedUsd: 0,
+      cacheEfficiency: 2 / 3,
+    };
+
+    service.getSessionCostAnatomy('sess-1').subscribe(anatomy => {
+      expect(anatomy).toEqual(mockAnatomy);
+    });
+
+    const req = httpMock.expectOne('http://localhost:8000/admin/costs/sessions/sess-1/calls');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockAnatomy);
+  });
+
+  it('should URL-encode the session id in the anatomy request', () => {
+    service.getSessionCostAnatomy('a/b c').subscribe();
+
+    const req = httpMock.expectOne('http://localhost:8000/admin/costs/sessions/a%2Fb%20c/calls');
+    expect(req.request.method).toBe('GET');
+    req.flush({ sessionId: 'a/b c', calls: [] });
+  });
+
   it('should export data', () => {
     const mockBlob = new Blob(['csv data'], { type: 'text/csv' });
 

--- a/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.ts
+++ b/frontend/ai.client/src/app/admin/costs/services/admin-cost-http.service.ts
@@ -12,6 +12,7 @@ import {
   DashboardRequestOptions,
   TopUsersRequestOptions,
   TrendsRequestOptions,
+  SessionCostAnatomy,
 } from '../models';
 
 /**
@@ -126,6 +127,17 @@ export class AdminCostHttpService {
       .set('endDate', options.endDate);
 
     return this.http.get<CostTrend[]>(`${this.baseUrl()}/trends`, { params });
+  }
+
+  /**
+   * Get the per-model-call cost anatomy for one session.
+   * Returns chronological call rows with cache status, prefix fingerprints,
+   * and session-level cache rollups. 404 when the session has no cost rows.
+   */
+  getSessionCostAnatomy(sessionId: string): Observable<SessionCostAnatomy> {
+    return this.http.get<SessionCostAnatomy>(
+      `${this.baseUrl()}/sessions/${encodeURIComponent(sessionId)}/calls`
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

SPA follow-up #2 from backend PR #697 — the admin page consuming `GET /admin/costs/sessions/{session_id}/calls`. Frontend-only; the backend contract is already live.

- **Models**: `SessionCostAnatomy`, `SessionCallRow`, `PrefixFingerprints`, and the `CacheStatus` union in `admin-cost.models.ts` (exported via the existing models barrel).
- **Service**: `AdminCostHttpService.getSessionCostAnatomy(sessionId)` (URL-encodes the id).
- **Route**: `/admin/costs/sessions/:id` (lazy `loadComponent`, route param via component input binding). No sidebar entry — drill-down only, mirroring `/admin/users/:userId`.
- **Entry point**: session-id lookup form on the Cost Analytics dashboard that navigates to the drill-down.

## The page

- **Summary header**: total cost, cache efficiency (`—` when null), avoidable-miss count (red when > 0), wasted USD, cache read/write token totals.
- **Calls table** (chronological): timestamp, model, in/read/write/out tokens, cost, color-coded `cacheStatus` badge (hit=green, first_write=blue, miss_ttl_expired=yellow, miss_avoidable=red, uncached=gray, null=`—`), cache gap, wasted USD.
- **Fingerprint diffing**: each row's `prefixFingerprints` are compared against the nearest previous fingerprinted call; a flipped hash (Tools / System / History) is highlighted red in the truncated 8-char chips — on a `miss_avoidable` row, that flipped hash names the cache-buster. Rows with null fingerprints (predating the feature) are skipped as baselines. Expandable rows show full hashes, `messageCount`, `messageId`, and the raw timestamp.
- 404 renders a distinct "no cost rows for this session" empty state; loading + generic error (with retry) handled via `resource()`.

Follows the newer admin idiom (skills pages): `resource()`-backed loading, rounded-2xl containers/badges, `text-sm/6` / `text-xs/5`, blue-600 primary actions, focus-visible outlines, dark mode.

## Testing

- `ng test`: 41 specs pass across the costs feature, including new specs for the fingerprint-diff util (baseline skipping, partial hashes), the HTTP method (URL + encoding), and page states (load, 404 vs other errors, expansion, formatters, badge mapping).
- `ng build` passes (pre-existing bundle-budget warning only).

## Manual test script

1. Sign in as an admin → **Admin → Cost Analytics**.
2. In the new "Session Cost Anatomy" card, paste a session id from a cost investigation and hit **Inspect**.
3. Verify the summary rollups match the API response, and that rows render chronologically with status badges.
4. On a `miss_avoidable` row, confirm exactly the flipped fingerprint chip is highlighted red and matches the changed hash in the expanded detail.
5. Enter a bogus session id → expect the "No cost rows for this session" empty state (not a raw error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)