### PR TITLE
fix(observability): first cache write after below-threshold calls is first_write, not miss_avoidable

### DIFF
--- a/backend/src/apis/shared/observability/prompt_cache.py
+++ b/backend/src/apis/shared/observability/prompt_cache.py
@@ -52,15 +52,18 @@ CACHE_TTL_SECONDS = 300
 class CacheStatus(str, Enum):
     """Derived per-call prompt-cache outcome.
 
-    - ``first_write``: no previous call row for the session — the initial,
-      expected cache population.
+    - ``first_write``: the initial, expected cache population — either no
+      previous call row for the session, or every activity-bearing signal
+      says no cache existed yet (the previous call was ``uncached``, e.g.
+      the prompt was below the model's minimum cacheable prefix, so there
+      was nothing to read from).
     - ``hit``: tokens were read from cache (``cacheReadInputTokens > 0``).
       Partial re-writes of a changed suffix still count as hits.
     - ``miss_ttl_expired``: nothing read, cache re-written, and the gap since
       the previous call exceeded the cache TTL — unavoidable.
-    - ``miss_avoidable``: nothing read, cache re-written, previous call was
-      within the TTL — the prefix must have changed. This is the bug class
-      the fingerprints exist to diagnose.
+    - ``miss_avoidable``: nothing read, cache re-written, previous call had a
+      live cache entry within the TTL — the prefix must have changed. This is
+      the bug class the fingerprints exist to diagnose.
     - ``uncached``: no cache activity at all (caching disabled, non-Bedrock
       provider, or prompt below the minimum cacheable length).
     """
@@ -94,6 +97,7 @@ def classify_cache_status(
     cache_write_tokens: int,
     previous_call_exists: bool,
     gap_seconds: Optional[float],
+    previous_cached_prefix_tokens: Optional[int] = None,
 ) -> CacheStatus:
     """Classify one model call's cache outcome.
 
@@ -103,12 +107,22 @@ def classify_cache_status(
         previous_call_exists: Whether the session has an earlier call row.
         gap_seconds: Seconds since the previous call row's timestamp; None
             when unknown (treated conservatively as expired, not avoidable).
+        previous_cached_prefix_tokens: Previous call's cacheRead + cacheWrite
+            token total, or None when unknown. Zero means the previous call
+            was uncached (e.g. prompt below the model's minimum cacheable
+            prefix), so no cache entry existed for this call to read.
     """
     if cache_read_tokens > 0:
         return CacheStatus.HIT
     if cache_write_tokens <= 0:
         return CacheStatus.UNCACHED
     if not previous_call_exists:
+        return CacheStatus.FIRST_WRITE
+    if previous_cached_prefix_tokens is not None and previous_cached_prefix_tokens <= 0:
+        # The previous call wrote nothing to the cache, so there was no entry
+        # to read from — this write is the session's first real population
+        # (typically the first prompt to cross the minimum cacheable length),
+        # not a miss of any kind.
         return CacheStatus.FIRST_WRITE
     if gap_seconds is None or gap_seconds > CACHE_TTL_SECONDS:
         return CacheStatus.MISS_TTL_EXPIRED

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -437,6 +437,7 @@ def _derive_cache_observability(
             cache_write_tokens=cache_write,
             previous_call_exists=prev_row is not None,
             gap_seconds=gap_seconds,
+            previous_cached_prefix_tokens=prev_cached_prefix,
         )
         wasted_usd = compute_wasted_usd(
             cache_status=status,

--- a/backend/tests/shared/test_metadata_cache_derivation.py
+++ b/backend/tests/shared/test_metadata_cache_derivation.py
@@ -121,6 +121,17 @@ class TestDeriveCacheObservability:
         result = self._derive(table, _metadata())
         assert result["cacheStatus"] == "uncached"
 
+    def test_first_write_after_below_threshold_uncached_call(self):
+        # Session whose prior calls were all below the minimum cacheable
+        # prefix: the previous row shows zero cache activity, so this call's
+        # write (crossing the threshold) is the expected first population —
+        # not miss_avoidable, and never priced as waste.
+        table = _FakeTable([_prev_row(seconds_ago=30)])
+        result = self._derive(table, _metadata(cache_write=4122))
+        assert result["cacheStatus"] == "first_write"
+        assert result["wastedUsd"] == 0.0
+        assert result["cacheGapSeconds"] == 30
+
     def test_query_targets_previous_row_descending_limit_1(self):
         table = _FakeTable()
         self._derive(table, _metadata(cache_write=100))

--- a/backend/tests/shared/test_prompt_cache_observability.py
+++ b/backend/tests/shared/test_prompt_cache_observability.py
@@ -78,6 +78,35 @@ class TestClassifyCacheStatus:
             is CacheStatus.UNCACHED
         )
 
+    def test_below_threshold_then_crossing_is_first_write(self):
+        # Prior calls were below the minimum cacheable prefix (uncached), so
+        # no cache entry existed — the first call that crosses the threshold
+        # is the expected initial population, not an avoidable miss.
+        assert (
+            classify_cache_status(
+                0,
+                4122,
+                previous_call_exists=True,
+                gap_seconds=45,
+                previous_cached_prefix_tokens=0,
+            )
+            is CacheStatus.FIRST_WRITE
+        )
+
+    def test_unknown_previous_prefix_stays_avoidable(self):
+        # None means we couldn't see the previous call's cache split — keep
+        # the pre-existing (avoidable) classification rather than masking.
+        assert (
+            classify_cache_status(
+                0,
+                5000,
+                previous_call_exists=True,
+                gap_seconds=45,
+                previous_cached_prefix_tokens=None,
+            )
+            is CacheStatus.MISS_AVOIDABLE
+        )
+
 
 class TestComputeWastedUsd:
     def test_avoidable_miss_priced_at_write_read_premium(self):


### PR DESCRIPTION
## Problem

The prompt-cache classifier (PR #697) produces a false positive: in a session where every prior call was `uncached` (prompt below the model's minimum cacheable prefix — e.g. ~4096 tokens for Claude Haiku 4.5), the first call that crosses the threshold does `cacheWrite>0 / cacheRead=0` within the TTL window and gets classified `miss_avoidable`. That inflates the **AvoidableMiss** and **WastedUsd** EMF metrics and the admin Session Cost Anatomy page.

Verified live in dev-ai session `9a1f25b2-8ea4-487f-b0e7-80a60deff945`: calls 1–5 uncached at 3.5–4k tokens, call 6 falsely flagged `miss_avoidable` with write=4122/read=0, calls 7–8 clean hits.

## Fix

`classify_cache_status` gains an optional `previous_cached_prefix_tokens` parameter (the previous call's cacheRead + cacheWrite total, which `_derive_cache_observability` already computed for waste pricing). When the immediately preceding call had **zero cache activity**, there was no cache entry to read from — so the threshold-crossing write is classified `first_write` (the expected initial population) and excluded from waste pricing.

Reusing `first_write` (rather than adding a new status) keeps the EMF schema, dashboard, and admin anatomy page enums unchanged. `None` (unknown split) preserves the previous behavior.

## Tests

- Classifier: below-threshold-then-crossing → `first_write`; unknown previous prefix stays `miss_avoidable`.
- Derivation: previous row with zero cache activity → `first_write`, `wastedUsd == 0.0`.
- Full backend suite: **4771 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)