### PR TITLE
Set S3_USER_FILES_BUCKET_NAME on inference-api runtime

### DIFF
--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -310,6 +310,12 @@ export class InferenceAgentCoreConstruct extends Construct {
         DYNAMODB_MANAGED_MODELS_TABLE_NAME: managedModelsTableName,
         DYNAMODB_USER_SETTINGS_TABLE_NAME: userSettingsTableName,
         DYNAMODB_USER_FILES_TABLE_NAME: userFilesTableName,
+        // Bucket the runtime writes generated Word docs to (create/modify
+        // word-document tools). Without this the tool falls back to the
+        // literal "user-files" default and PutObject is AccessDenied. The
+        // runtime role's UserFilesBucketAccess statement already grants
+        // Get/Put/Delete/List on this bucket.
+        S3_USER_FILES_BUCKET_NAME: props.refs.fileUploadBucket.bucketName,
         DYNAMODB_SYSTEM_PROMPTS_TABLE_NAME: systemPromptsTableName,
 
         // Auth providers


### PR DESCRIPTION
Fixes AccessDenied on PutObject when creating/saving Word documents in the deployed dev environment. The AgentCore Runtime env block set DYNAMODB_USER_FILES_TABLE_NAME but never S3_USER_FILES_BUCKET_NAME, so the word-document tools fell back to the literal 'user-files' default bucket (no access) — surfacing as PermanentRedirect and then, after the region fix (#674), AccessDenied. The runtime role's UserFilesBucketAccess statement already grants Get/Put/Delete/List on the real file-upload bucket; this points the runtime at it via props.refs.fileUploadBucket.bucketName. Infra change: ships via platform.yml on merge. tsc build passes.