### PR TITLE
fix(infra): allow the mcp-sandbox origin in the SPA frame-src CSP

### DIFF
--- a/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
+++ b/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
@@ -25,6 +25,14 @@ export interface SpaDistributionConstructProps {
    * the resolved string.
    */
   appApiUrl: string;
+  /**
+   * MCP Apps sandbox-proxy origin (`https://mcp-sandbox.{domainName}` on
+   * domained deploys). Included in the `frame-src` CSP directive so the
+   * SPA can frame MCP App UIs; without it CloudFront's CSP blocks the
+   * sandbox iframe (localhost dev bypasses CloudFront, so the block only
+   * shows up on deployed environments).
+   */
+  mcpSandboxOrigin: string;
 }
 
 /**
@@ -46,8 +54,9 @@ export interface SpaDistributionConstructProps {
  *     embedding), Referrer-Policy=strict-origin-when-cross-origin, HSTS
  *     1y w/ subdomains, X-XSS-Protection.
  *   - The `frame-src` CSP directive opens `https://artifacts.{domainName}`
- *     so the SPA can embed artifact iframes. Other resource types remain unrestricted
- *     by CSP (defended by the other security headers).
+ *     and the MCP Apps sandbox-proxy origin (`https://mcp-sandbox.{domainName}`)
+ *     so the SPA can embed artifact and MCP App iframes. Other resource types
+ *     remain unrestricted by CSP (defended by the other security headers).
  *
  * Custom domain: if `config.domainName` and
  * `config.frontend.certificateArn` are both set, the distribution
@@ -70,7 +79,7 @@ export class SpaDistributionConstruct extends Construct {
   ) {
     super(scope, id);
 
-    const { config, bucket, appApiUrl } = props;
+    const { config, bucket, appApiUrl, mcpSandboxOrigin } = props;
 
     // OAC for CloudFront → S3 access (S3 bucket has block-public-access).
     new cloudfront.CfnOriginAccessControl(this, 'FrontendOAC', {
@@ -129,7 +138,7 @@ export class SpaDistributionConstruct extends Construct {
           ...(artifactsOrigin
             ? {
                 contentSecurityPolicy: {
-                  contentSecurityPolicy: `frame-src 'self' ${artifactsOrigin}`,
+                  contentSecurityPolicy: `frame-src 'self' ${artifactsOrigin} ${mcpSandboxOrigin}`,
                   override: true,
                 },
               }

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -617,6 +617,7 @@ export class PlatformStack extends cdk.Stack {
       config,
       bucket: this.spaBucket,
       appApiUrl: this._albDns.albUrl,
+      mcpSandboxOrigin: this.mcpSandboxProxyOrigin,
     });
     this.spaDistribution = spaDist.distribution;
     this.spaDistributionDomainName = spaDist.distributionDomainName;

--- a/infrastructure/test/spa-frame-src-csp.test.ts
+++ b/infrastructure/test/spa-frame-src-csp.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression cover for the SPA distribution's `frame-src` CSP.
+ *
+ * The SPA frames two cross-origin iframes on domained deploys: artifact
+ * previews (`artifacts.{domain}`) and MCP App UIs via the sandbox proxy
+ * (`mcp-sandbox.{domain}`). The sandbox side's `frame-ancestors` was
+ * locked to the SPA origin from the start, but the SPA side's
+ * `frame-src` originally listed only the artifacts origin — so deployed
+ * environments blocked every MCP App iframe with a CSP violation while
+ * localhost dev (which bypasses CloudFront's response headers) worked,
+ * masking the gap through live verification.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { loadConfig } from '../lib/config';
+import { PlatformStack } from '../lib/platform-stack';
+import { mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+const SHARED_CF_CERT = 'arn:aws:acm:us-east-1:123456789012:certificate/shared-wildcard';
+
+/** Seed every context value loadConfig requires for a domained deploy. */
+function seedRequiredContext(app: cdk.App): void {
+  app.node.setContext('projectPrefix', 'test-project');
+  app.node.setContext('awsRegion', MOCK_REGION);
+  app.node.setContext('awsAccount', MOCK_ACCOUNT);
+  app.node.setContext('vpcCidr', '10.0.0.0/16');
+  app.node.setContext('production', false);
+  app.node.setContext('retainDataOnDelete', false);
+  app.node.setContext('domainName', 'example.com');
+  app.node.setContext('infrastructureHostedZoneDomain', 'example.com');
+  app.node.setContext('frontend', { cloudFrontPriceClass: 'PriceClass_100' });
+  app.node.setContext('appApi', { cpu: 256, memory: 512, desiredCount: 1, maxCapacity: 2 });
+  app.node.setContext('inferenceApi', {});
+  app.node.setContext('fineTuning', {});
+  app.node.setContext('artifacts', { retentionDays: 90, extraFrameAncestors: [] });
+  app.node.setContext('mcpSandbox', { extraFrameAncestors: [] });
+  app.node.setContext('ragIngestion', {
+    additionalCorsOrigins: '',
+    lambdaMemorySize: 10240,
+    lambdaTimeout: 900,
+    embeddingModel: 'amazon.titan-embed-text-v2',
+    vectorDimension: 1024,
+    vectorDistanceMetric: 'cosine',
+  });
+}
+
+describe('SPA distribution frame-src CSP', () => {
+  const PREV = process.env.CDK_CLOUDFRONT_CERTIFICATE_ARN;
+
+  afterAll(() => {
+    if (PREV === undefined) {
+      delete process.env.CDK_CLOUDFRONT_CERTIFICATE_ARN;
+    } else {
+      process.env.CDK_CLOUDFRONT_CERTIFICATE_ARN = PREV;
+    }
+  });
+
+  it('allows both the artifacts and mcp-sandbox origins on a domained deploy', () => {
+    delete process.env.CDK_FRONTEND_CERTIFICATE_ARN;
+    delete process.env.CDK_ARTIFACTS_CERTIFICATE_ARN;
+    delete process.env.CDK_MCP_SANDBOX_CERTIFICATE_ARN;
+    process.env.CDK_CLOUDFRONT_CERTIFICATE_ARN = SHARED_CF_CERT;
+
+    const app = new cdk.App();
+    seedRequiredContext(app);
+    const config = loadConfig(app);
+    mockSsmContext(app, config);
+
+    const stack = new PlatformStack(app, 'FrameSrcCspPlatformStack', {
+      config,
+      env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+    });
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: {
+        Name: 'test-project-frontend-headers',
+        SecurityHeadersConfig: {
+          ContentSecurityPolicy: {
+            ContentSecurityPolicy:
+              "frame-src 'self' https://artifacts.example.com https://mcp-sandbox.example.com",
+            Override: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/infrastructure/test/transport-security.test.ts
+++ b/infrastructure/test/transport-security.test.ts
@@ -59,6 +59,7 @@ describe('Transport security baseline', () => {
         config,
         bucket: bucket.bucket,
         appApiUrl: 'https://api.example.com',
+        mcpSandboxOrigin: 'https://mcp-sandbox.example.com',
       });
 
       const t = Template.fromStack(stack);


### PR DESCRIPTION
## Problem

Demoing MCP Apps (Excalidraw) on boisestate.ai failed with:

```
Framing 'https://mcp-sandbox.boisestate.ai/' violates the following Content Security Policy directive: "frame-src 'self' https://artifacts.boisestate.ai". The request has been blocked.
```

The SPA distribution's CloudFront `ResponseHeadersPolicy` only ever opened `frame-src` to `'self'` and the artifacts origin — the `mcp-sandbox.{domain}` origin was never included in any commit. The original MCP Apps PR sequence wired the *inbound* direction (the sandbox proxy's `frame-ancestors` is locked to the SPA origin), but the SPA side's *outbound* `frame-src` was never extended, so **every domained deploy CSP-blocks every MCP App iframe**.

This never surfaced in live verification because it all ran on localhost:4200, which bypasses CloudFront's response headers entirely.

## Fix

- Thread the already-computed `mcpSandboxProxyOrigin` from `PlatformStack` into `SpaDistributionConstruct` (new required `mcpSandboxOrigin` prop) and append it to the `frame-src` directive. On domained deploys this is always `https://mcp-sandbox.{domain}` — the sandbox construct's fail-loud cert guard guarantees the custom domain.
- New regression test `infrastructure/test/spa-frame-src-csp.test.ts` synthesizes a domained `PlatformStack` and asserts the frontend headers policy emits `frame-src 'self' https://artifacts.example.com https://mcp-sandbox.example.com`.

## Verification

- `npx tsc --noEmit` clean; full infra jest suite green (476 tests) against this change.

## Deploy notes

- Ships via `platform.yml` (CloudFront `ResponseHeadersPolicy` update only — quick, low-risk).
- Reaching prod (boisestate.ai) requires a release/hotfix from `main`; merging here fixes dev.boisestate.ai, which has the same latent break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)