### PR TITLE
chore(kaizen): weekly research scan 2026-07-24

### DIFF
--- a/docs/kaizen/research/2026-07-24.md
+++ b/docs/kaizen/research/2026-07-24.md
@@ -1,0 +1,222 @@
+# Kaizen Research — Friday, July 24, 2026
+> Scan window: July 17 – July 24, 2026 (7 days)
+> Web budget: ~52/50 used (modest overage — 10 subagents + an 11-dep version-pin sweep; see Web Budget block).
+
+## TL;DR
+
+**Two things went from "conditional" to "confirmed and actionable" this week, and the keystone bump we've queued for seven weeks is *still* on the shelf.** First: **GPT-5.6 (Sol / Terra / Luna) is now GA on Bedrock via Mantle** — the item flagged last week as "conflicting, verify before acting" is confirmed by AWS's own What's New page. Terra and Luna are in **us-west-2, our region**, they ride the **exact `apiMode=responses` Mantle path we already built for gpt-5.4**, and they add explicit-breakpoint prompt caching at a 90% cached-input discount — a mechanical catalog add plus a caching-wire. Second: the **MCP 2026-07-28 spec finalizes in 4 days** and confirms **SEP-2575 removes the `initialize` handshake our MCP Apps host reads for the App-frame `serverName`/`icon`** — a near-term migration, no longer a watch-item. Against both, the **`bedrock-agentcore` 1.9.1 → 1.18.1 bump remains unshipped** (Strands got bumped to 1.48.0; the SDK did not), and **Nightly went red Jul 23–24 on a stuck `DELETE_FAILED` ephemeral stack**, so the dep-bump safety gate is itself untrustworthy right now. **The #1 idea is unchanged — bump `bedrock-agentcore`** — but **GPT-5.6-on-Bedrock is the new capability story of the week.**
+
+## External Scan
+
+### What's moving this week
+
+The shape of the week is **the ecosystem cashing two checks it wrote earlier.** GPT-5.6-on-Bedrock (rumored/unverified last Friday) is now GA and — crucially — lands on the Mantle Responses path we already own, so it's adoption, not architecture. The MCP 07-28 spec (locked since May, GA in 4 days) confirms the two changes that touch our MCP Apps host: SEP-2575 (handshake removal — the `initialize` `serverInfo` we read disappears) and SEP-2567 (stateless transport), while MCP Apps itself **graduates to a first-class official extension** and a new **Tasks extension** (long-running work) graduates from experimental. AWS shipped a cluster of AgentCore ops maturity — **unified per-agent observability** (spans to the agent's own log group, gated by `UNIFIED_TRACES_DESTINATION_ENABLED`), the **`ActiveSessionCount`** metric (already queued), an **"Evaluating AI Agents" production blueprint on our exact Strands+AgentCore stack**, and **Agentic retrieval for Managed KB** (`AgenticRetrieveStream`). On the harness side the theme was **cost-of-context hygiene**: Claude Code 2.1.217 fixed an **MCP tool-output memory leak** ("full untruncated results no longer retained") and auto-compact for Opus 4.8 on Bedrock, and an HN post ("The Subagent Tax") put numbers on fan-out cost (2–6× input tokens, never faster) — both squarely on the token-cost tenet we just wrote into CLAUDE.md. Strands is current at 1.48.0; FastMCP holds at 3.4.4 (a v4 alpha is in flight, not production); LibreChat and the reference repo were silent (ref-repo now **3 consecutive dormant weeks**).
+
+### Notable items by source
+
+> **Annotation conventions:**
+> - `*relevance*:` — impact-on-existing-code lens (what construct/file it affects, replaces, or obsoletes).
+> - `*unlocks*:` — capability-unlock lens (new primitive / new product surface).
+>
+> Bug-fixes and dep-bumps usually only need `*relevance*`. New platform features, SDK primitives, spec capabilities, and UX patterns deserve both.
+
+#### AWS Bedrock / AgentCore
+- **GPT-5.6 (Sol / Terra / Luna) GA on Amazon Bedrock via the Mantle Responses API** — OpenAI's newest family is Bedrock-served through the `bedrock-mantle` endpoint (Responses API), with prompt caching via explicit cache breakpoints at a **90% cached-input discount**; pricing matches OpenAI first-party. Sol = advanced reasoning (coding/research/cyber); Terra = GPT-5.5-level at half cost; Luna = cheapest/fastest. — https://aws.amazon.com/about-aws/whats-new/2026/07/openai-gpt-sol-terra/ (posted Jul 13, carried in the Jul 20 AWS Weekly Roundup — in-window) — *relevance*: **confirms and closes** last week's "GPT-5.6-on-Bedrock — verify" flag. **Terra + Luna are in us-west-2 (our region); Sol is us-east-1/us-east-2 only.** They reach us through the same `apiMode=responses` Mantle path we wired for gpt-5.4 (`_create_mantle_model` / per-model region routing) — a mechanical model-catalog add. — *unlocks*: a materially cheaper non-Claude tier (Terra at half GPT-5.5 cost, Luna as a fast/cheap default) **and** explicit-breakpoint prompt caching on the Mantle leg (see idea #2 + the caching audit #3).
+- **AgentCore unified observability — per-agent span log group** — Runtime now delivers spans to the agent's own `/aws/bedrock-agentcore/runtimes/<agent_id>-<endpoint>` group (`spans` stream) instead of shared `aws/spans`; default for new agents from Jul 20, gated by `UNIFIED_TRACES_DESTINATION_ENABLED`, needs ADOT ≥ 0.18.0. — https://aws.amazon.com/about-aws/whats-new/2026/07/amazon-bedrock-agentcore-unified-observability-single-log-group/ (Jul 23 — in-window) — *relevance*: this is the exact log-group pattern our runtime debugging leans on (the `424 → container 500` traceback path; prod-ai `/aws/bedrock-agentcore/runtimes/boisestateai_v2_*`); per-agent scoping changes *where you look* and could clean up the prompt-cache EMF metrics we just shipped (PR #697/#699). — *unlocks*: per-agent trace isolation for the observability layer without shared-log-group grep.
+- **Blog: "Evaluating AI Agents — a production blueprint with Strands + AgentCore" (Jul 23)** — End-to-end eval methodology on our *exact* runtime + Strands stack, claiming incorrect-result rate cut 1-in-8 → 1-in-50. — https://aws.amazon.com/blogs/machine-learning/evaluating-ai-agents-a-production-blueprint-with-strands-and-agentcore/ — *relevance*: complementary to the cost/cache observability just built; a reference pattern for evaluating `agents/main_agent` answer quality (the "quality wins when it conflicts with cost" half of the token-cost tenet). — *unlocks*: an agent-eval harness — net-new surface, but a spike/monitor, not a near-term ship.
+- **`ActiveSessionCount` CloudWatch metric (AWS/Bedrock-AgentCore)** — Per-minute active-session gauge dimensioned by `Service` (Runtime / CodeInterpreter / Browser). — https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html — *relevance*: **already queued** as the [2026-07-10] "wire an `ActiveSessionCount` alarm" item; feeds the session single-flight lease + quota-cooldown work. No change to that item's disposition.
+- **Blog: "Agentic retrieval for Amazon Bedrock Managed Knowledge Base" (Jul 23)** — Walks the new `AgenticRetrieveStream` API (hybrid search, ranking, multi-step queries) now that Managed KB is GA. — https://aws.amazon.com/blogs/machine-learning/agentic-retrieval-for-amazon-bedrock-managed-knowledge-base/ — *relevance*: bears directly on the drafted `project_bedrock_managed_kb_spec` (KB-per-assistant replacement) + `project_kb_sync_design`; a managed pipeline + native connectors could displace the custom RAG-ingestion path. Monitor for the KB-replacement design, not this week's ship.
+
+#### Strands Agents
+**Latest `strands-agents==1.48.0`; we pin 1.48.0 — current, zero lag.** The Strands bump shipped in-window (commit `060375c7`, "bump strands-agents to 1.48.0 for cachePoint-attachment fix"). No newer Python release in-window (TS side at v1.10.0).
+- **#3348 — rolling pair of message cachePoints (OPEN, updated Jul 24)** — Our filed issue; thread now frames it around parallel tool fan-outs defeating Anthropic's ~20-block cache lookback. **No fix in 1.48.0.** — https://github.com/strands-agents/sdk-python/issues/3348 — *relevance*: `to_bedrock_config` 3-cachePoint budget; **already queued** [2026-07-19] as track-gated-on-dashboard-evidence. The PR #697 prompt-cache dashboard (now shipped in 1.9.0) is the evidence source that gates the local workaround.
+- **#3144 — `CacheConfig(strategy="auto")` never caches the system prompt (OPEN)** — validates keeping our manual cache-point injection; do NOT switch to `strategy="auto"` expecting system-prompt caching. — https://github.com/strands-agents/sdk-python/issues/3144 — *relevance*: feeds the multi-provider caching audit (idea #3).
+
+#### Reference repo (aws-samples/sample-strands-agent-with-agentcore)
+- **No commits Jul 17–24 — third consecutive dormant week.** Latest activity remains Jul 1 (Sonnet 5 `NO_TEMPERATURE_MODELS` + Tailwind v4 / React 19 modernization). — https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main — *applicability*: nothing to port. **Reinforces last week's cadence recommendation: drop this source to bi-weekly** (skill-hygiene subtraction, flagged for a skill-maintenance PR — not this run's scope).
+
+#### AgentCore SDK / starter-toolkit (issues + releases)
+- **`bedrock-agentcore` 1.18.1 (patch, Jul 17)** — Only change over 1.18.0: tightened package-specifier validation in `install_packages()` + security dep bumps (Starlette→1.3.1, cryptography→48.0.1, PyJWT→2.13.0, python-multipart→0.0.31). No Memory/tool_filter behavior change. — https://github.com/aws/bedrock-agentcore-sdk-python/releases/tag/v1.18.1 — *relevance*: **retargets idea #1 from 1.18.0 → 1.18.1** — same keystone bump, now also carrying the security patches (we're on 1.9.1, exposed to #482 + #571 today).
+- **#547 — restored history with `filter_restored_tool_context` can be Converse-invalid (OPEN, updated Jul 21)** — Filtering tool content out of restored history can orphan a `tool_use`/`tool_result` pair Bedrock rejects — **the exact failure class our hand-rolled `_repair_tool_pairing` defends against.** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/547 — *relevance*: `TurnBasedSessionManager` tool-content truncation; watch their fix pattern (a library-native replacement for our repair shim would be a subtraction).
+- **#456 / #346 — Memory session-manager defects (OPEN, updated Jul 21)** — #456: OTEL context token detached across the asyncio/thread boundary in the memory client + Strands session_manager; #346: incorrect pagination in `list_messages`. — https://github.com/aws/bedrock-agentcore-sdk-python/issues/456 — *relevance*: the Memory + session-manager seam we run custom on; #456 pairs with the AgentCore unified-observability item (trace-context correctness).
+- **#580 — Search Tool plugin must honor an allow-list (OPEN, design-stage)** — the native `tool_filters` primitive we hand-rolled in `FilteredMCPClient` is still unsettled; **no shippable replacement this week.** — https://github.com/aws/bedrock-agentcore-sdk-python/issues/580 — *relevance*: `FilteredMCPClient` subtraction candidate when it lands. Not yet actionable.
+
+#### MCP ecosystem
+- **The 2026-07-28 spec is still an RC today (Jul 24) — final in 4 days; no early GA this week.** — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ — *relevance*: **next Friday is the GA-cutover scan.** Plan the migration now (idea #4).
+- **SEP-2575 (handshake removal) confirmed in the RC** — the `initialize`/`initialized` handshake and `Mcp-Session-Id` are removed; protocolVersion/clientInfo/capabilities ride in `_meta` on every request, plus a new **`server/discover`** method fetches capabilities on demand. — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ — *relevance*: **high — our MCP Apps host reads `initialize` `serverInfo` for the App-frame `serverName`/`icon` (per CLAUDE.md); that source disappears.** Migrate to `server/discover` (or lean on the `manifest.json` fallback we already have). See idea #4. — *unlocks*: RC-conformant negotiation with future spec-final hosts/servers.
+- **SEP-2567 stateless transport + SEP-2322 multi-round-trip elicitation** — servers return `InputRequiredResult`; clients re-issue with the answer, so any instance handles the retry (no sticky sessions). New `Mcp-Method`/`Mcp-Name` headers enable gateway routing without body inspection; `ttlMs`/`cacheScope` on list responses enable client-side caching. — same RC URL — *relevance*: our Gateway + MCP Apps host; the multi-round-trip elicitation is the App user-input flow (request/echo state instead of a held-open SSE).
+- **MCP Apps (SEP-1865) graduates to a first-class official extension; new Tasks extension graduates from experimental; roots/sampling/logging enter a 12-month deprecation window.** — https://modelcontextprotocol.io/extensions/apps/overview — *relevance*: our SEP-1865 host stays on-spec; the formal extensions framework (reverse-DNS ids, independent versioning) is the context for the [2026-05-29] "align capability advertisement to `io.modelcontextprotocol/ui`" item, now folded into idea #4. — *unlocks*: the **Tasks extension** is a net-new primitive for long-running MCP work — monitor for fit with our scheduled-runs / headless lane.
+
+#### FastMCP
+- **Stable holds at v3.4.4 (Jul 9); v4.0.0 alphas (a1/a2) now in flight — pre-release only.** The v4 line documents v3→v4 removals, protocol-type/import restructuring, revised lifespan/timeout semantics; not production-ready. — https://github.com/jlowin/fastmcp/releases — *implications for our MCP servers*: **≥3.4.4 remains the safe floor** for externally-hosted Lambda-behind-Gateway servers; hold on v4 until it exits alpha. No breaking change in-window.
+
+#### Agentic UI/UX patterns
+- **Linear Loops — event-triggered recurring agent jobs with an inspectable per-run activity log (Jul 20)** — Describe a recurring job in plain language; the Linear Agent runs it on a schedule OR **in response to workspace events**, then acts directly (opens issues, starts a coding session, edits a doc + leaves a note). Every Loop is inspectable — anyone with access reviews instructions, config, and a per-run "what happened" log. — https://linear.app/blog/introducing-loops — *what it is*: scheduled/evented agent runs with a shared audit trail. — *fit*: pattern-only (Angular) — we already have scheduled-runs (ungated) + MCP scheduled-tasks; the novel conventions are the **event trigger** and the **shared, inspectable per-run activity log**. — *where it'd land*: extend `/schedules` + `/runs` with an event-trigger type and a run-detail activity view (a run-history component, not a new SSE event). — *unlocks*: event-driven proactive agents + per-run transparency (the trust surface a scheduled run currently lacks).
+- **Vercel AI SDK — policy-based tool approvals** — Human-in-the-loop tool gating driven by a declarative *policy* (auto-approve safe tools, prompt only on sensitive ones) rather than all-or-nothing consent. — https://ai-sdk.dev/docs/ai-sdk-ui — *fit*: pattern-only — a policy layer above our per-provider `oauth_required` approval. — *where it'd land*: a pre-execution `tool_approval_required` SSE event + a tool-approval card; policy config sits alongside RBAC `granted*` lists. **Reinforces the queued [2026-07-03]/[2026-07-10] tool-approval item — not a fresh finding, a third datapoint.**
+- **Cursor — Side Chats + Router (Router Jul 22)** — Side Chats spawn a scoped sub-conversation off the main thread without losing context; Router auto-picks a model per request. — https://www.cursor.com/blog — *fit*: pattern-only — a branch/fork affordance over our concurrent-streaming-per-session architecture (parser/loading/abort already keyed by `sessionId`). — *where it'd land*: SPA conversation model + sidebar (child session linked to parent); no new SSE event. **Queue-worthy pattern, not a near-term port** (Side Chats itself predates the window).
+- **assistant-ui + Anthropic news — quiet on new UX this window.** assistant-ui's Jul 16 releases were bugfix/SSE-parser/Firefox-animation only (covered last week); Anthropic's Jul 20–22 posts are economic-research/grants, no artifact/UI/design content. NN/g not fetched (budget) — pick up next scan. — https://github.com/Yonom/assistant-ui/releases
+
+#### Frontier model announcements
+- **GPT-5.6 Sol/Terra/Luna — ON-BEDROCK (see AWS section, idea #2).** The one actionable frontier item this week.
+- **Gemini 3.5 Pro — rumored Jul 17 launch did NOT happen (third missed deadline); still limited Vertex-only enterprise preview, GA now rumored August.** 2M-context + Deep Think remain unconfirmed by any official model card. — https://www.techtimes.com/articles/320736/20260716/rebuilt-gemini-35-pro-misses-third-deadline-google-eyes-stopgap-release.htm — *relevance*: **watchlist, off-Bedrock** — recheck August.
+- **Anthropic / Meta — no in-window model or API-capability announcement.** Opus 4.8 / Sonnet 5 / Fable 5 lineup unchanged. — https://www.anthropic.com/news
+
+#### Agent harness patterns
+- **Claude Code 2.1.217 — MCP tool-output memory leak fixed ("full untruncated results no longer retained") + auto-compact fixed for Opus 4.8 on Bedrock** — https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md — *relevance*: **cost-effectiveness → our token-cost tenet directly** (MCP responses must be bounded/offloaded, not unbounded pass-through — the exact motivation for the queued [2026-07-19] `ContextOffloader` spike); the Opus-4.8-on-Bedrock auto-compact fix maps to our compaction path.
+- **Claude Code 2.1.218 — context hygiene: overflow-retry loop eliminated, accurate `/context` post-compaction, fork-session lineage preserved across compaction in headless/SDK sessions** — same CHANGELOG — *relevance*: context-engineering → the headless-SDK "fork lineage byte-stable across a compaction" invariant is the same as our `TurnBasedSessionManager` truncation-anchor byte-stability contract (PR #697).
+- **Claude Code 2.1.216 / 2.1.214 — MCP re-auth no longer revokes working credentials before new sign-in; worktree-subagents can't redirect git to shared checkout; subagent model-overrides persist on resume; Gateway spend metering fixed for Bedrock application-inference-profile ARNs** — same CHANGELOG — *relevance*: the MCP re-auth fix mirrors our "cold `oauth_token_cache`" re-auth gotcha; the inference-profile spend-metering fix maps to our `/admin/costs` metering (we de-prefix `us.*` for CountTokens — same ARN-shape class).
+- **opencode v1.18.4 (Jul 20) — adaptive thinking controls for Kimi on Anthropic-compatible providers; respect provider-defined reasoning options instead of wrong fallback controls** — https://github.com/anomalyco/opencode/releases — *relevance*: cost-effectiveness → validates our per-model bedrock config; guards against applying one provider's reasoning controls to another (the same class as our per-model temperature-suppression guard). No sub-agent/context-pinning change in-window.
+
+#### Pricing / quota
+- **No change Jul 17–24.** Sonnet 5 promo **$2/$10** per 1M in/out holds through Aug 31 (reverts $3/$15 on Sep 1 — the one scheduled shift to plan for); Opus 4.8 $6/$30. GPT-5.6 pricing matches OpenAI first-party (Terra ≈ half GPT-5.5). — https://aws.amazon.com/bedrock/pricing/
+
+#### Community + Cookbook
+- **HN: "The Subagent Tax" (Jul 23)** — measured parallel subagents at "2 to (almost) 6× the input tokens and never faster on any task." — https://systima.ai/blog/subagent-tax — *relevance*: direct evidence for our token-cost tenet — a caution against fan-out subagent designs *in the agent loop* (parallelism buys latency only when work is genuinely independent and context isn't duplicated). Not a code change; a design guardrail.
+- **Anthropic cookbook — subagent live-streaming example (Jul 22) + crop-tool rewrite around a *measured zoom* region (Jul 23)** — https://github.com/anthropics/anthropic-cookbook/commits/main — *relevance*: the zoom-tool rewrite is a concrete "bounded tool result" pattern that fits the token-cost tenet; subagent-streaming is a reference if we ever surface sub-agent progress via SSE. No caching/prefill change in-window (last week's prefill-400 note still stands as an ungated cheap grep).
+- **HN "bedrock agentcore": zero in-window threads.**
+
+#### opencode / LibreChat (light references)
+- **opencode**: covered under Agent harness (reasoning-controls per model).
+- **LibreChat: no new release; holds at v0.8.7 (Jun 24).** Nothing to evaluate. — https://github.com/danny-avila/LibreChat/releases
+
+#### Seasonal
+- Out of window — none scanned this week. (re:Invent is late Nov / early Dec; MCP 07-28 spec-final is next week's non-seasonal event to watch.)
+
+### Patterns worth considering
+
+- **Cost-of-context hygiene is converging into a first-class harness concern** — Claude Code (2.1.217 MCP-output leak fix; 2.1.218 context accounting) + the "Subagent Tax" HN measurement + the cookbook "measured zoom / bounded tool result" rewrite all landed the same week, all saying the same thing: **unbounded tool output and duplicated fan-out context are the dominant avoidable cost.**
+  - **Where**: Claude Code CHANGELOG, systima.ai, anthropic-cookbook.
+  - **Fit**: we already wrote this into CLAUDE.md as the token-cost tenet and queued the [2026-07-19] `ContextOffloader` spike (bound tool results at ingestion → S3). The external week is a strong second signal to *act* on that spike, not just track it.
+  - **Verdict**: Worth trying (the queued ContextOffloader spike is the concrete vehicle).
+- **Evented + auditable proactive agents** — Linear Loops pairs an *event trigger* with a *shared, inspectable per-run log*; it's the productized version of our scheduled-runs.
+  - **Where**: Linear Loops (Jul 20).
+  - **Fit**: our scheduled-runs are schedule-only and deliberately low-key (no per-run activity surface). The event-trigger + run-history-transparency conventions are the gap.
+  - **Verdict**: Monitor (queue-worthy pattern; sequence behind the reliability + model-catalog work).
+
+## Internal Audit
+
+### Activity (last 7 days)
+- **Commits on develop**: 54 non-merge (window overlaps releases 1.7.0 → 1.10.0) — Excel spreadsheet tools + shared `office/_storage.py`; **prompt-cache observability cluster** (PrefixFingerprintHook, `cacheStatus`, Session Cost Anatomy page, CloudWatch dashboard + alarms, 3-cachePoint fix, byte-stable restored history, deterministic skill ordering); **Skills v2** (pure knowledge bundles, user-authored tier, invoke-through, `read_skill_file`, capability-gate removal); **issue #175** session-metadata static-SK migration (Phases 0–3 + backfills); Word doc tools + storage fixes; **MCP-sandbox CSP fix** (#714); **Strands 1.48.0 bump** (cachePoint-attachment). High velocity.
+- **PRs opened against develop**: 0 open (last week's kaizen PR #616 merged; no open PRs this scan). **merged**: the 1.7.0–1.10.0 release train. **reverted**: 0.
+- **Issues opened (7d)**: 7 — **#718** quota-assignment edit bug (400, `QuotaAssignment has no field tierId`); a **product-enhancement cluster** #703–#712 (pin/unpin assistants, pin/unpin conversations, copy prompt, list/grid assistant view, prompt-panel scrollbar, duplicate assistants). — **closed**: n/a.
+- **CI failures (workflow → count)**: **Nightly Build & Test → 2 (Jul 23–24, on `main`)** — regressed after being green Jul 14–17; **CI → 1** (Jul 21, `feature/session-workspace-tools` — the active branch). No Backend Deploy failures in-window (the curl-pin cluster from last week did not recur).
+
+### Repeated friction signals
+- **Nightly is red again (Jul 23–24) on a stuck ephemeral CloudFormation stack** — `Stack .../nightly-develop-PlatformStack is in DELETE_FAILED state and can not be updated.` (run 30083857845). The nightly deploy-pipeline stands up an ephemeral `nightly-develop-PlatformStack`, runs, and tears it down; a **failed teardown left the stack in `DELETE_FAILED`**, and every subsequent run can neither update nor delete it — so nightly stays red until the stack is manually cleared.
+  - **Hypothesis**: a resource in the ephemeral stack fails to delete (retained/non-empty S3 bucket, an ENI/security-group with a lingering dependency, or a custom resource) → `DELETE_FAILED` → the stack wedges. This is a *different* failure from the June `exit 127` install-stage nightly cluster and the July curl-pin deploy cluster — it's a teardown-idempotency gap, not an install gap.
+  - **Fix candidate**: (1) immediate — manually delete/retry-delete the wedged `nightly-develop-PlatformStack` (skip the un-deletable resource) so nightly can go green; (2) durable — make the nightly teardown resilient: `--no-fail-on-empty-changeset`-style handling plus a pre-deploy step that force-deletes a leftover `DELETE_FAILED`/`ROLLBACK_COMPLETE` stack of that name before re-creating, and mark retained buckets/log-groups `autoDeleteObjects`/`RemovalPolicy.DESTROY` in the *nightly* context so teardown can't wedge. **See idea #5.** **This matters extra this week: nightly is the dep-bump safety gate for idea #1, and a red gate can't vouch for the `bedrock-agentcore` bump.**
+- **Product-enhancement cluster #703–#712 (assistant/conversation UX)** — six small, coherent requests filed Jul 20–21 (pin/unpin, copy prompt, list/grid, duplicate). Not a friction/bug signal — a **product-owner backlog batch**; noted for review-prep's awareness, out of kaizen ecosystem-scan scope (routine SPA backlog, not an ecosystem-driven change).
+
+### Version-pin lag
+| Dep | Pinned | Latest | Lag | Notes |
+|---|---|---|---|---|
+| bedrock-agentcore | **1.9.1** | **1.18.1 (Jul 17)** | ~9 minor lines | **Still exposed to #482 (SSE deadlock, fixed 1.17.0) + #571 (cross-process Memory reorder, fixed 1.18.0); 1.18.1 adds security dep bumps.** Keystone bump — idea #1, retargeted 1.18.1. |
+| strands-agents | **1.48.0** | 1.48.0 | 0 | **Current** — bumped in-window (`060375c7`, cachePoint-attachment fix). |
+| boto3 | 1.43.9 | 1.43.55 (Jul 23) | ~46 patches | routine; coupled to the agentcore bump — bump together. |
+| fastapi | 0.136.1 | 0.139.2 (Jul 16) | ~3 minors | routine. |
+| mcp | (latest) | 1.28.1 | — | informational; 07-28 spec-final may move this next week. |
+| pydantic | (latest) | 2.13.4 | — | informational. |
+| fastmcp (unpinned) | — | 3.4.4 (Jul 9) | — | not pinned; ≥3.4.4 safe floor; hold on the v4 alpha. |
+| @angular/core | 21.2.17 | 22.0.8 | **1 major** | Angular 22 — hold; major migration, not a kaizen bump. |
+| vitest | 4.1.5 | 4.1.10 | 5 patches | routine. |
+| aws-cdk-lib | 2.260.0 | 2.262.0 | 2 minors | routine. |
+| constructs | 10.6.0 | 10.7.1 | 1 minor + patch | routine. |
+
+### Retirement candidates
+- **Reference-repo source → bi-weekly cadence** — `aws-samples/sample-strands-agent-with-agentcore` is now dormant **3 consecutive weekly windows** (no commits Jul 3–24). A fortnightly check saves web budget with negligible miss risk. Skill-hygiene subtraction (edit `kaizen-research/SKILL.md` source 3 cadence note — flag for a skill-maintenance PR, not this run's scope). **Carried from last week — the dormancy streak lengthened, strengthening the case.**
+- **Hand-rolled `_repair_tool_pairing` / tool-content truncation — watch AgentCore #547** — if the SDK ships a Converse-valid restored-history filter, our repair shim becomes a subtraction candidate. Not yet actionable.
+- **Hand-rolled `FilteredMCPClient` — watch AgentCore #580** — native `tool_filters` still design-stage. Not yet actionable.
+- **`agent_type="skill"` ChatAgent alias** — a temporary shim from Skills v2 PR-2; deprecation is already tracked in `project_skills_v2_followups`. Not a kaizen finding; noted for completeness.
+- No dormant skills flagged (all `.claude/skills/*` referenced in recent PRs or actively maintained).
+
+### Risks introduced this week
+- **Still exposed to #482 (SSE deadlock) + #571 (cross-process Memory reorder) at 1.9.1** — https://github.com/aws/bedrock-agentcore-sdk-python/releases — the 1.6.0 reliability work (single-flight lease, `_repair_tool_pairing`) reduces the *symptom* surface, but the SDK-level bugs persist and Scheduled Runs + Memory Spaces + conversation-sharing keep Memory load high. Seven weeks queued, still unshipped.
+- **Nightly (the dep-bump gate) is red on a wedged `DELETE_FAILED` stack** — the safety net for idea #1 can't vouch for a bump while it's failing on teardown, not on tests.
+- **SEP-2575 removes the `initialize` handshake our MCP Apps host reads for `serverName`/`icon` — spec-final in 4 days** — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ — the icon/title-resolution path needs the `server/discover` (or `manifest.json`-fallback) migration before adopting spec-final SDKs. Near-term now, not a watch-item.
+- **GPT-5.6 Sol is us-east-only** — if Sol is added to the catalog without a region guard, a us-west-2 invocation fails; Terra/Luna are in-region. Gate on per-model region (the routing already exists).
+
+## Ideas — Top 5 (ranked)
+
+| # | Idea | Surface | Effort | Impact | Subtracts? | Unlocks? |
+|---|---|---|---|---|---|---|
+| 1 | Bump `bedrock-agentcore` 1.9.1 → 1.18.1 (closes #482 + #571; +security patches) | backend | M | H | Retires the queued [2026-05-22] hand-written #482 guard; complements `_repair_tool_pairing` | — |
+| 2 | Add GPT-5.6 Terra + Luna to the model catalog via the existing Mantle Responses path | backend / cross-cutting | L–M | M–H | Addition — justified: rides the built gpt-5.4 `apiMode=responses` wiring; a cheaper non-Claude tier | Terra (½ GPT-5.5 cost) + Luna (fast/cheap) tiers; explicit-breakpoint Mantle caching (90% discount) |
+| 3 | Multi-provider prompt-caching audit — now doubly-motivated by GPT-5.6 explicit-breakpoint caching | backend | L–M | M–H | Consolidates per-provider cache logic; kills silent Mantle/OpenAI token-cost regression | Captures GPT-5.6's 90% cached-input discount instead of leaving it on the table |
+| 4 | Prep the MCP Apps host for the 07-28 spec (`serverInfo` → `server/discover`; SEP-2575) | backend | M | M–H | Retires the pre-standard `initialize`-serverInfo dependency + `experimental.ui` id | RC-conformant negotiation with spec-final MCP hosts/servers |
+| 5 | Fix the nightly `DELETE_FAILED` stuck ephemeral stack + make teardown resilient | infra / CI | L | M–H | Removes a recurring nightly-wedge class; restores the dep-bump safety gate | — |
+
+### 1. Bump `bedrock-agentcore` 1.9.1 → 1.18.1 (closes #482 + #571; + security patches)
+- **Source**: https://github.com/aws/bedrock-agentcore-sdk-python/releases (1.18.1, Jul 17 — security patch over 1.18.0's #571 Memory-reorder fix; #482 SSE-deadlock fix in 1.17.0); internal 1.6.0 reliability cluster + Memory-heavy features (Scheduled Runs, Memory Spaces, sharing).
+- **Surface area**: `backend/pyproject.toml` (coupled `boto3` bump), inference-api chat router + `TurnBasedSessionManager` flush ordering; full local pytest suite (the PR gate as of #490) — **but note the Nightly gate is red (idea #5), so lean on local pytest + a green Nightly before merge.**
+- **Change**: bump the pin to `1.18.1`; verify (a) the async→sync streaming-bridge fix on `/invocations`, and (b) the millisecond event-flooring (#571) against our Memory flush ordering; keep the agent-cache continuity path primary (#564 read-gap unfixed).
+- **Subtracts**: retires the queued [2026-05-22] hand-written #482 guard (library-native); the #571 ordering fix complements — does not replace — `_repair_tool_pairing` (belt-and-suspenders on a corruption class the product leaned harder into).
+- **Effort × Impact**: Med × High.
+- **Verdict**: Worth trying — **highest priority; active exposure, now seven weeks queued while the release keeps advancing (1.18.1).** SUPERSEDES the [2026-07-17] "→ 1.18.0" queue item (retarget 1.18.1). Sequence *after* Nightly is green (idea #5) so the gate can vouch for it.
+
+### 2. Add GPT-5.6 Terra + Luna to the model catalog via the existing Mantle Responses path
+- **Source**: GPT-5.6 Sol/Terra/Luna GA on Bedrock via Mantle — https://aws.amazon.com/about-aws/whats-new/2026/07/openai-gpt-sol-terra/ (confirms last week's flagged-for-verification item). Rides the gpt-5.4 Mantle wiring (`_create_mantle_model`, `apiMode=responses`, per-model region routing).
+- **Surface area**: inference-api model config + admin model catalog; `_create_mantle_model` / `ModelProvider.MANTLE`; per-model region routing (Terra/Luna → us-west-2; **Sol → us-east only, gate or omit**); frontend model picker; `CountTokensBedrockModel` de-prefix path (Mantle has no native CountTokens — confirm context-attribution behaves as it does for gpt-5.4).
+- **Change**: add Terra + Luna as curated model cards on the existing Responses-API Mantle lane (mechanical — same shape as gpt-5.4); wire the explicit cache-breakpoint on the Mantle leg (see idea #3); region-gate Sol until it reaches us-west-2. Confirm the temperature/reasoning-controls handling (opencode's in-window fix is a reminder: don't apply Claude's controls to the OpenAI path).
+- **Subtracts**: addition only — justified: it exercises the already-scaffolded non-Claude Mantle lane (the [2026-07-06] Mantle-watchlist item noted this lane as "dark scaffolding"; Terra/Luna make it a first-class peer) and adds a materially cheaper tier for non-Claude workloads.
+- **Unlocks**: Terra (GPT-5.5-level at half cost) as a cheaper agent/default tier; Luna as a fast/cheap tier; explicit-breakpoint prompt caching on the Mantle leg at a 90% cached-input discount.
+- **Effort × Impact**: Low–Med × Med–High.
+- **Verdict**: Worth trying — **the new capability story of the week; low-effort because the path exists.** Pair with idea #3 so the caching discount is actually captured. Gate Sol on region availability.
+
+### 3. Multi-provider prompt-caching audit (issue #642 + Strands #3144) — now doubly-motivated by GPT-5.6 explicit-breakpoint caching
+- **Source**: internal issue #642 (provider-agnostic prompt caching); Strands #3144 (`strategy="auto"` never caches the system prompt); **new this week** — GPT-5.6 on Mantle uses explicit cache breakpoints at a 90% discount, so adding Terra/Luna (idea #2) without wiring breakpoints leaves that discount unclaimed.
+- **Surface area**: `to_bedrock_config` cache-point injection (Bedrock); the Mantle Responses builder (`build_mantle_model` / `_create_mantle_model`) — **now the load-bearing case, not a hypothetical**; `CountTokensBedrockModel` / the PR #697 `cacheStatus` + fingerprint observability (which now *measures* this — the audit is nearly free).
+- **Change**: instrument `cache_read`/`cache_write` ratios per provider (the 1.9.0 observability layer surfaces them); confirm the Bedrock manual cache-point still engages post-1.48; wire explicit cache breakpoints on the Mantle Responses leg for gpt-5.x models; consolidate the per-provider cache decision behind one predicate rather than provider-scattered logic.
+- **Subtracts**: consolidates per-provider cache plumbing; kills a silent full-input-token cost regression if a Mantle/OpenAI turn caches nothing.
+- **Unlocks**: captures GPT-5.6's 90% cached-input discount as Terra/Luna land.
+- **Effort × Impact**: Low–Med × Med–High.
+- **Verdict**: Worth trying — **strongest internal-signal fit after the bump, and now coupled to idea #2's cost story.** SUPERSEDES the [2026-07-17] caching-audit item (adds the GPT-5.6 explicit-breakpoint motivation). Do NOT switch to `strategy="auto"` expecting system-prompt caching.
+
+### 4. Prep the MCP Apps host for the 2026-07-28 spec (`serverInfo` → `server/discover`; SEP-2575 handshake removal)
+- **Source**: MCP 07-28 RC (final in 4 days) — SEP-2575 removes the `initialize`/`initialized` handshake + `Mcp-Session-Id`; a new `server/discover` method fetches capabilities on demand; MCP Apps (SEP-1865) graduates to a first-class official extension. — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ · https://modelcontextprotocol.io/extensions/apps/overview
+- **Surface area**: inference-api MCP Apps host — the `initialize` `serverInfo` read that resolves the App-frame `serverName`/`icon` (per CLAUDE.md), the capability advertisement (`experimental.ui` → spec-canonical `io.modelcontextprotocol/ui`), and the `ui_resource` SSE header path; the `manifest.json`-fallback icon resolution we already have (becomes primary if `server/discover` isn't yet universal).
+- **Change**: migrate `serverName`/`icon` resolution off `initialize` `serverInfo` to `server/discover` (with the existing `manifest.json` fetch as fallback); rename the capability advertisement to the spec-canonical id; diff the merged 07-28 draft for any change to the declare-templates-ahead / tool-list-prefetch shape. Sequence *after* the spec goes final next week (don't build against a moving RC).
+- **Subtracts**: retires the pre-standard `initialize`-serverInfo dependency and the `experimental.ui` identifier.
+- **Unlocks**: RC-conformant negotiation with spec-final MCP hosts/servers; readiness for the SEP-2567 stateless transport + SEP-2322 multi-round-trip elicitation (the App user-input flow).
+- **Effort × Impact**: Med × Med–High.
+- **Verdict**: Worth trying — **near-term (spec-final in 4 days); absorbs the [2026-05-29] "align MCP Apps capability advertisement" item and sharpens it with the SEP-2575 handshake-removal detail.** Confirm final-spec details next Friday before building.
+
+### 5. Fix the nightly `DELETE_FAILED` stuck ephemeral stack + make teardown resilient
+- **Source**: internal friction — Nightly Build & Test red Jul 23–24 (run 30083857845): `nightly-develop-PlatformStack is in DELETE_FAILED state and can not be updated.` Green Jul 14–17 before; a *new* failure class (teardown-idempotency), distinct from the June `exit 127` install cluster and the July curl-pin deploy cluster.
+- **Surface area**: `.github/workflows/nightly-deploy-pipeline.yml` (the ephemeral deploy/teardown lane) + the PlatformStack constructs' `RemovalPolicy`/`autoDeleteObjects` in the *nightly* context (retained buckets, log groups, or a custom resource are the usual `DELETE_FAILED` culprits).
+- **Change**: (1) immediate — manually force-delete the wedged `nightly-develop-PlatformStack` (skip the un-deletable resource) so Nightly goes green; (2) durable — add a pre-deploy step that detects and force-deletes a leftover `DELETE_FAILED`/`ROLLBACK_COMPLETE` stack of that name before re-creating, and set nightly-context removal policies so retained resources can't wedge teardown.
+- **Subtracts**: removes a recurring nightly-wedge class; **restores the dep-bump safety gate** (idea #1 needs a green Nightly to vouch for the SDK bump).
+- **Effort × Impact**: Low × Med–High.
+- **Verdict**: Worth trying — **cheapest win with outsized leverage: it unblocks the #1 keystone bump's safety net.** Do the immediate cleanup first; the teardown-resilience guard is the durable follow-on.
+
+## Take
+
+The system is trending firmly *toward* the ecosystem: Strands is current, the prompt-cache observability we shipped this fortnight is the exact instrument the multi-provider caching audit needs, and the one net-new capability (GPT-5.6) lands on a Mantle path we already built rather than a new one. The single change that matters most is *still* the **`bedrock-agentcore` 1.18.1 bump** — seven weeks queued, a subtraction and a two-bug reliability fix in one line — but this week it has a precondition: **fix the wedged Nightly first (idea #5) so the gate can vouch for the bump.** What Phil would notice first as an operator is idea #2 — GPT-5.6 Terra/Luna showing up as cheaper model cards that "just work" because the Mantle wiring was already there — with the caching audit (#3) quietly making sure that cheaper tier is actually cheap. The MCP spec finalizes in four days; idea #4 is the one clock-driven item that graduates from watch-list to near-term next Friday. The through-line of the external week — bounded tool output, no wasteful fan-out, capture the cache discount — is the token-cost tenet we just wrote down, now echoed back by Claude Code, the cookbook, and a viral "Subagent Tax" post in the same seven days.
+
+---
+
+## Sources Scanned
+
+| # | Source | URL | Accessed | Items |
+|---|---|---|---|---|
+| 1 | AWS Bedrock/AgentCore What's New + release notes + ML blog | https://aws.amazon.com/about-aws/whats-new/recent/feed/ | 2026-07-24 | 5 |
+| 2 | Strands Agents releases + issues | https://github.com/strands-agents/sdk-python/releases | 2026-07-24 | 2 |
+| 3 | Reference repo commits | https://github.com/aws-samples/sample-strands-agent-with-agentcore/commits/main | 2026-07-24 | 0 (dormant 3 wks) |
+| 4 | MCP blog / RC / apps overview / servers | https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ | 2026-07-24 | 4 |
+| 4a | FastMCP releases + PyPI | https://github.com/jlowin/fastmcp/releases | 2026-07-24 | 1 (holds 3.4.4) |
+| 4b | Agentic UI/UX (Linear, Vercel AI SDK, Cursor, assistant-ui, Anthropic) | https://linear.app/blog/introducing-loops | 2026-07-24 | 4 |
+| 5 | Frontier models (Anthropic/Google/OpenAI-on-Bedrock/Meta) | https://aws.amazon.com/about-aws/whats-new/2026/07/openai-gpt-sol-terra/ | 2026-07-24 | 3 |
+| 6 | Agent harness (Claude Code CHANGELOG + Anthropic eng) | https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md | 2026-07-24 | 4 |
+| 6a | opencode releases | https://github.com/anomalyco/opencode/releases | 2026-07-24 | 1 |
+| 7 | Bedrock pricing | https://aws.amazon.com/bedrock/pricing/ | 2026-07-24 | 0 (no change) |
+| 8 | AgentCore SDK / starter-toolkit issues + releases | https://github.com/aws/bedrock-agentcore-sdk-python/releases | 2026-07-24 | 4 |
+| 9 | Community (HN) | https://hn.algolia.com/ | 2026-07-24 | 1 |
+| 10 | Anthropic cookbook commits | https://github.com/anthropics/anthropic-cookbook/commits/main | 2026-07-24 | 1 |
+| 12 | LibreChat releases | https://github.com/danny-avila/LibreChat/releases | 2026-07-24 | 0 (holds v0.8.7) |
+| 19 | Version pins (PyPI + npm registry JSON) | https://pypi.org/pypi/bedrock-agentcore/json | 2026-07-24 | 11 deps |
+
+## Web Budget
+
+Used: **~52 / 50 requests** (modest overage).
+Skipped (unreachable / rate-limited): NN/g AI topic page (not fetched — UI/UX subagent budget exhausted at ~6 requests; pick up next scan); OpenAI blog (not fetched — GPT-5.6 confirmed via AWS's own What's New, the only Bedrock-relevant source); Meta Llama blog (not scanned — no Bedrock-reaching signal surfaced incidentally); Reddit (domain-blocked, per decisions.md 2026-05-18).
+Skipped (other): none material.
+Notes: overage driven by the 11-dep version-pin sweep (registry JSON, ~15 tool calls with retries) + a second cross-check confirming GPT-5.6's Bedrock/region availability (the highest-value confirmation of the run — it converts last week's flagged-uncertain item into an actionable Top-5 idea).

--- a/docs/kaizen/review-queue.md
+++ b/docs/kaizen/review-queue.md
@@ -5,6 +5,44 @@ Items added by `kaizen-research`, consumed by `kaizen-review-prep`.
 ## Open
 <!-- Newest at top. -->
 
+### [2026-07-24] Bump `bedrock-agentcore` 1.9.1 → 1.18.1 (closes #482 SSE deadlock + #571 Memory reorder; + security patches)
+- **Source**: research/2026-07-24.md ▸ Top 5 #1 — bedrock-agentcore 1.18.1 (Jul 17, security patch over 1.18.0's #571 fix; #482 fix in 1.17.0) — https://github.com/aws/bedrock-agentcore-sdk-python/releases
+- **Surface**: backend (`backend/pyproject.toml` + coupled `boto3`; inference-api chat router + `TurnBasedSessionManager` flush ordering; full local pytest suite)
+- **Effort × Impact**: M × H
+- **Subtracts**: yes — retires the queued [2026-05-22] hand-written #482 guard (library-native); the #571 ordering fix complements (not replaces) `_repair_tool_pairing`
+- **Status**: open — **highest priority; now SEVEN weeks queued while the release keeps advancing (1.18.1).** SUPERSEDES the [2026-07-17] "→ 1.18.0" item (retarget 1.18.1). We're on 1.9.1, exposed to #482 + #571 today. Validate ms event-flooring vs our flush ordering; #564 (eventual-consistency read gap) stays unfixed — keep agent-cache continuity primary. **Sequence AFTER Nightly is green (the [2026-07-24] nightly-stack item below) so the dep-bump gate can vouch for it.**
+
+### [2026-07-24] Add GPT-5.6 Terra + Luna to the model catalog via the existing Mantle Responses path
+- **Source**: research/2026-07-24.md ▸ Top 5 #2 — GPT-5.6 Sol/Terra/Luna GA on Bedrock via Mantle (confirms last week's flagged-for-verification item) — https://aws.amazon.com/about-aws/whats-new/2026/07/openai-gpt-sol-terra/
+- **Surface**: backend / cross-cutting (inference-api model config + admin catalog; `_create_mantle_model` / `ModelProvider.MANTLE`; per-model region routing — Terra/Luna→us-west-2, **Sol→us-east only, gate or omit**; `CountTokensBedrockModel` de-prefix; frontend model picker)
+- **Effort × Impact**: L–M × M–H
+- **Subtracts**: addition only — justified: rides the built gpt-5.4 `apiMode=responses` wiring (exercises the "dark scaffolding" non-Claude Mantle lane the [2026-07-06] watchlist flagged) + adds a cheaper non-Claude tier
+- **Unlocks**: Terra (½ GPT-5.5 cost) as a cheaper agent/default tier + Luna (fast/cheap); explicit-breakpoint Mantle prompt caching at a 90% cached-input discount
+- **Status**: open — **new capability story of the week; low-effort because the path exists.** Pair with the caching-audit item below so the discount is captured. Gate Sol on region availability; confirm reasoning/temperature-controls handling on the OpenAI path (don't apply Claude's controls).
+
+### [2026-07-24] Multi-provider prompt-caching audit — now doubly-motivated by GPT-5.6 explicit-breakpoint caching
+- **Source**: research/2026-07-24.md ▸ Top 5 #3 — internal issue #642; Strands #3144 (`strategy="auto"` never caches system prompt); **new**: GPT-5.6 on Mantle uses explicit cache breakpoints at a 90% discount
+- **Surface**: backend (`to_bedrock_config` cache-point injection; Mantle Responses builder `build_mantle_model`/`_create_mantle_model` — now the load-bearing case; the PR #697 `cacheStatus`+fingerprint observability that now *measures* this)
+- **Effort × Impact**: L–M × M–H
+- **Subtracts**: yes — consolidates per-provider cache logic; kills a silent full-input-token cost regression if a Mantle/OpenAI path caches nothing
+- **Unlocks**: captures GPT-5.6's 90% cached-input discount instead of leaving it on the table
+- **Status**: open — SUPERSEDES the [2026-07-17] caching-audit item (adds the GPT-5.6 explicit-breakpoint motivation). Instrument `cache_read`/`cache_write` per provider (1.9.0 observability surfaces them); wire explicit breakpoints on the Mantle leg; confirm the Bedrock manual cache-point still engages post-1.48; do NOT switch to `strategy="auto"`. Coupled to the GPT-5.6 item above.
+
+### [2026-07-24] Prep the MCP Apps host for the 2026-07-28 spec (`serverInfo` → `server/discover`; SEP-2575 handshake removal)
+- **Source**: research/2026-07-24.md ▸ Top 5 #4 — MCP 07-28 RC final in 4 days; SEP-2575 removes the `initialize`/`initialized` handshake + `Mcp-Session-Id`, adds `server/discover`; MCP Apps (SEP-1865) graduates to a first-class official extension — https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+- **Surface**: backend (inference-api MCP Apps host — the `initialize` `serverInfo` read that resolves App-frame `serverName`/`icon`; capability advertisement `experimental.ui` → `io.modelcontextprotocol/ui`; `ui_resource` SSE header path; existing `manifest.json`-fallback icon resolution)
+- **Effort × Impact**: M × M–H
+- **Subtracts**: yes — retires the pre-standard `initialize`-serverInfo dependency + the `experimental.ui` id
+- **Unlocks**: RC-conformant negotiation with spec-final MCP hosts/servers; readiness for SEP-2567 stateless transport + SEP-2322 multi-round-trip elicitation (the App user-input flow)
+- **Status**: open — **near-term (spec-final in 4 days); ABSORBS the [2026-05-29] "align MCP Apps capability advertisement" item and sharpens it with the SEP-2575 handshake-removal detail.** Migrate `serverName`/`icon` off `serverInfo` to `server/discover` (manifest.json fallback stays); confirm final-spec details next Friday before building (don't build against a moving RC).
+
+### [2026-07-24] Fix the nightly `DELETE_FAILED` stuck ephemeral stack + make teardown resilient
+- **Source**: research/2026-07-24.md ▸ Top 5 #5 — internal friction: Nightly red Jul 23–24 (run 30083857845), `nightly-develop-PlatformStack is in DELETE_FAILED state and can not be updated`; green Jul 14–17 before (a new teardown-idempotency failure class, distinct from the June exit-127 + July curl-pin clusters)
+- **Surface**: infra/CI (`.github/workflows/nightly-deploy-pipeline.yml` ephemeral deploy/teardown lane + PlatformStack `RemovalPolicy`/`autoDeleteObjects` in the nightly context — retained buckets/log-groups/custom resources are the usual `DELETE_FAILED` culprits)
+- **Effort × Impact**: L × M–H
+- **Subtracts**: yes — removes a recurring nightly-wedge class; restores the dep-bump safety gate
+- **Status**: open — **cheapest win with outsized leverage: unblocks the #1 keystone bump's safety net.** (1) immediate — manually force-delete the wedged stack (skip the un-deletable resource) so Nightly goes green; (2) durable — pre-deploy step that force-deletes a leftover `DELETE_FAILED`/`ROLLBACK_COMPLETE` stack of that name before re-creating + nightly-context removal policies.
+
 ### [2026-07-19] Track harness-sdk#3348 (rolling pair of message cachePoints) — local workaround gated on dashboard evidence
 - **Source**: Phil-initiated (PR #697 follow-up) — https://github.com/strands-agents/harness-sdk/issues/3348 (filed by philmerrell, open, no maintainer response yet); prod session aecd387d (18-way parallel tool fan-out → cacheRead=0 / cacheWrite=134k mid-turn, the ~20-block Anthropic lookback miss mode documented in `model_config.py:366`)
 - **Surface**: backend (`agents/main_agent/core/model_config.py` 3-cachePoint budget). If built locally: strands 1.48's `_inject_cache_point` **strips any pre-existing message-level cachePoints**, so a rolling pair requires dropping `CacheConfig(strategy="auto")` and hand-placing both points via a hook — the 4th Bedrock cachePoint slot is free. Position tests in `tests/agents/main_agent/core/test_bedrock_cache_points.py` are the safety net.


### PR DESCRIPTION
## Summary
- External scan: AWS Bedrock/AgentCore, Strands, FastMCP, reference repo, MCP (07-28 spec-final in 4 days), agentic UI/UX, frontier models (GPT-5.6 now GA on Bedrock via Mantle), agent-harness patterns, pricing.
- Internal audit: 54 commits (releases 1.7.0→1.10.0 — Skills v2, prompt-cache observability, Excel tools), version-pin lag (bedrock-agentcore still 1.9.1 vs 1.18.1), a red Nightly on a wedged `DELETE_FAILED` ephemeral stack, and a product-enhancement issue cluster.
- Top 5 ideas in `docs/kaizen/research/2026-07-24.md`, queued in `docs/kaizen/review-queue.md`.

## Top 5 (ranked)
1. **Bump `bedrock-agentcore` 1.9.1 → 1.18.1** (M×H) — keystone, 7 weeks queued; closes #482 + #571; sequence after Nightly is green.
2. **Add GPT-5.6 Terra + Luna to the model catalog** (L–M × M–H) — confirmed GA on Bedrock, us-west-2, rides the existing gpt-5.4 Mantle Responses path; cheaper non-Claude tier + 90% cached-input discount.
3. **Multi-provider prompt-caching audit** (L–M × M–H) — now doubly-motivated by GPT-5.6 explicit-breakpoint caching; captures the discount instead of leaving it on the table.
4. **Prep the MCP Apps host for the 07-28 spec** (M × M–H) — SEP-2575 removes the `initialize` handshake our App-frame header reads; migrate `serverInfo` → `server/discover`. Near-term (spec-final in 4 days).
5. **Fix the nightly `DELETE_FAILED` stuck ephemeral stack** (L × M–H) — cheapest win; restores the dep-bump safety gate that idea #1 needs.

## Review
- Read the research doc.
- Comment with reactions and any weekend POC findings — these become first-class signal for next Friday's `kaizen-review-prep`.
- POC promising ideas over the weekend.

## Decision
Ship the doc to `develop`. Ranking into decisions happens in the kaizen-review-prep PR opened later this morning. Action on individual ideas happens in separate PRs the following week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)