### PR TITLE
fix: render markdown artifacts authored under the default HTML type

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -43,6 +43,7 @@ _DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8"
 # for a Markdown artifact: a self-contained HTML render wrapper.
 _RENDERED_CONTENT_TYPE = "text/html; charset=utf-8"
 _MARKDOWN_MIME_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+_HTML_MIME_TYPES = frozenset({"text/html", "application/xhtml+xml"})
 
 # Markdown is base64-embedded so no character ever needs HTML/JS escaping
 # and there is no second network fetch (the artifact-origin CSP sets
@@ -132,10 +133,47 @@ _MARKDOWN_RENDER_TEMPLATE = """<!doctype html>
 """
 
 
+def _bare_type(content_type: Optional[str]) -> str:
+    """MIME type with any `; charset=` suffix stripped, lowercased."""
+    return (content_type or "").split(";")[0].strip().lower()
+
+
 def _is_markdown(content_type: Optional[str]) -> bool:
     """True for a Markdown MIME type, ignoring any `; charset=` suffix."""
-    bare = (content_type or "").split(";")[0].strip().lower()
-    return bare in _MARKDOWN_MIME_TYPES
+    return _bare_type(content_type) in _MARKDOWN_MIME_TYPES
+
+
+def _looks_like_html_document(content: str) -> bool:
+    """True if `content` opens like a full standalone HTML document.
+
+    The create_artifact contract requires HTML artifacts to be a complete
+    document (`<!doctype html>` + a full `<html>…</html>`), which is what
+    the sandboxed iframe needs to render.
+    """
+    head = content.lstrip()[:1024].lower()
+    return head.startswith("<!doctype html") or head.startswith("<html")
+
+
+def _coerce_content_type(content: str, content_type: str) -> str:
+    """Safety net for HTML-typed content that isn't an HTML document.
+
+    `content_type` defaults to `text/html`, so a request like "make a
+    markdown recipe" easily produces raw Markdown authored under the HTML
+    type. Stored verbatim as HTML, that renders as run-together `#`/`**`
+    source instead of a formatted document. When HTML-typed content lacks
+    the required document shell it is almost always Markdown the model
+    forgot to type, so reclassify it as Markdown (which the writer wraps
+    into a proper render document). Markdown and non-HTML types pass
+    through untouched.
+    """
+    if _bare_type(content_type) not in _HTML_MIME_TYPES:
+        return content_type
+    if _looks_like_html_document(content):
+        return content_type
+    logger.info(
+        "reclassifying HTML-typed artifact as markdown (no HTML document shell)"
+    )
+    return "text/markdown"
 
 
 def _wrap_markdown(title: str, markdown: str) -> str:
@@ -265,7 +303,7 @@ def create_artifact_record(
     """Create v1 of a new artifact. Returns (artifact_id, version)."""
     artifact_id = uuid.uuid4().hex
     version = 1
-    content_type = content_type or _DEFAULT_CONTENT_TYPE
+    content_type = _coerce_content_type(content, content_type or _DEFAULT_CONTENT_TYPE)
     now = _now_iso()
     content_key = _put_object(
         user_id, artifact_id, version, content, content_type, title
@@ -337,7 +375,9 @@ def update_artifact_record(
     current = int(head["version"])
     version = current + 1
     title = title or head.get("title", "")
-    content_type = content_type or head.get("content_type") or _DEFAULT_CONTENT_TYPE
+    content_type = _coerce_content_type(
+        content, content_type or head.get("content_type") or _DEFAULT_CONTENT_TYPE
+    )
     now = _now_iso()
     content_key = _put_object(
         user_id, artifact_id, version, content, content_type, title

--- a/backend/src/agents/builtin_tools/artifacts/tools.py
+++ b/backend/src/agents/builtin_tools/artifacts/tools.py
@@ -32,6 +32,13 @@ def make_create_artifact_tool(session_id: str, user_id: str):
         will want to view, keep, or iterate on — an HTML page, a chart,
         an interactive widget, a formatted report, or a written document.
 
+        Choosing a mode: if the deliverable is prose — a report, an
+        article, notes, documentation, a recipe, any mostly-text
+        document — author it as Markdown (`content_type="text/markdown"`),
+        NOT HTML. Only reach for HTML when you genuinely need custom
+        layout, styling, charts, or interactivity. When the user asks for
+        "markdown", always use the Markdown mode.
+
         Two authoring modes:
 
         - HTML (default): `content` MUST be a complete standalone HTML

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -188,6 +188,60 @@ def test_markdown_update_rewraps_inherited_type(aws) -> None:
     assert _embedded_markdown(body) == new_md
 
 
+def test_markdown_content_under_default_type_is_reclassified(aws) -> None:
+    """Regression: raw Markdown authored under the default HTML type (the
+    model forgot content_type="text/markdown") must be treated as Markdown
+    so it renders, not stored verbatim as run-together HTML source."""
+    ddb, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "Recipe", MD, "")
+
+    # Row is corrected to Markdown → card badge reads "MD", not "HTML".
+    assert _item(ddb, aid, "V#00001")["content_type"] == "text/markdown"
+
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode()
+    assert body.lstrip().startswith("<!doctype html>")
+    assert "https://esm.sh/marked@14.1.4" in body
+    assert _embedded_markdown(body) == MD
+
+
+def test_markdown_content_under_explicit_html_type_is_reclassified(aws) -> None:
+    ddb, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "Recipe", MD, "text/html")
+    assert _item(ddb, aid, "V#00001")["content_type"] == "text/markdown"
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode()
+    assert _embedded_markdown(body) == MD
+
+
+def test_full_html_document_not_reclassified(aws) -> None:
+    """A genuine standalone HTML document keeps its HTML type and is
+    stored verbatim (the safety net must not touch real HTML)."""
+    ddb, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "Page", DOC, "text/html")
+    assert _item(ddb, aid, "V#00001")["content_type"] == "text/html"
+    assert s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v1/index.html"
+    )["Body"].read().decode() == DOC
+
+
+def test_update_reclassifies_markdown_under_inherited_html_type(aws) -> None:
+    """An HTML artifact updated with raw Markdown (content_type omitted →
+    inherits HTML from HEAD) is reclassified so the new version renders."""
+    ddb, s3 = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "Page", DOC, "text/html")
+    new_md = "# Rewritten\n\nNow it's **markdown**.\n"
+    ver = service.update_artifact_record(USER, aid, new_md, None, None)
+    assert ver == 2
+    assert _item(ddb, aid, "V#00002")["content_type"] == "text/markdown"
+    body = s3.get_object(
+        Bucket=BUCKET, Key=f"{USER}/{aid}/v2/index.html"
+    )["Body"].read().decode()
+    assert _embedded_markdown(body) == new_md
+
+
 def test_html_artifact_not_wrapped(aws) -> None:
     _, s3 = aws
     aid, _ = service.create_artifact_record(USER, SESSION, "Page", DOC, "text/html")


### PR DESCRIPTION
## Problem

Asking the agent to "create a banana bread recipe **markdown** artifact" produced an artifact that rendered as run-together raw Markdown source (`#`, `##`, `**` …) with a card badge reading **HTML** — not a formatted document. Repro conversation (prod): `33cb39eb-4d3c-4e72-94a9-904400243d4f`.

## Root cause

The Markdown pipeline works end-to-end (the writer wraps Markdown in an HTML render document via `marked`, the badge shows "MD", the render Lambda maps the type). The failure is at authoring time: `create_artifact`'s `content_type` **defaults to `text/html`**. The model wrote raw Markdown as `content` but never set `content_type="text/markdown"`, so `service._put_object` stored the Markdown verbatim as HTML — which the sandboxed iframe renders as plain text, and the DynamoDB row records `text/html` (hence the "HTML" badge).

## Fix

**Server-side safety net (the guarantee).** HTML-typed content that lacks a standalone HTML document shell (`<!doctype html>` / `<html>`) is reclassified to `text/markdown` before storage, so it's wrapped into a proper render document and the DynamoDB row (badge + render-Lambda mapping) stays truthful. Real HTML documents, Markdown, and other MIME types pass through untouched. Applied in **both** `create_artifact_record` and `update_artifact_record` — the update path covers the inherited-type case, where there's no argument for the model to get right at all.

**Docstring nudge (reduces how often the backstop fires).** `create_artifact`'s description now steers the model to author prose (reports, docs, recipes, mostly-text) as Markdown and to honor an explicit "markdown" request.

### Why a content-based net rather than making `content_type` required
The bug was a **type/content mismatch** (HTML type declared over Markdown body), not an omitted value. A required argument forces the model to state *a* value, not a *correct* one, removes a genuinely good default for the majority-HTML case, and still can't help the `update_artifact` inherited-type path. The coercion validates the invariant we actually care about — declared type matches content shape — deterministically.

### Cost note
The docstring adds ~60 tokens to the `create_artifact` description, which lives in the cacheable `toolConfig` prefix — only when the artifact tool is enabled, and it's a one-time-per-session prefix cost, not per-turn growth.

## Tests
Added 4 regression tests; full artifact suite green (26 artifact-tool + 29 app-api artifact tests):
- Markdown under the default type → reclassified + wrapped
- Markdown under explicit `text/html` → reclassified
- a genuine full HTML document → **not** touched, stored verbatim
- an HTML artifact updated with Markdown (inherited type) → reclassified on the new version

## Notes
- Backend/authoring-path change only (no dev-server-observable surface) — verified via the test suite, not the browser preview.
- Existing artifacts already stored as HTML won't retroactively change, but any new create/update — including an `update_artifact` on the banana-bread artifact — now renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)