### PR TITLE
fix: don't render empty "Thinking" blocks from signature-only reasoning

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -334,6 +334,38 @@ describe('AssistantMessageComponent', () => {
       expect(blocks[2].type).toBe('tool_group');
       expect(blocks[2].group!.calls.length).toBe(1);
     });
+
+    it('should not render a reasoning block with empty text and no redaction', () => {
+      // Signature-only / empty thinking blocks (e.g. Sonnet 5) are kept in the
+      // message for API correctness but must not paint an empty "Thinking"
+      // collapsible.
+      fixture.componentRef.setInput('message', makeMessage([
+        {
+          type: 'reasoningContent',
+          reasoningContent: { reasoningText: { text: '', signature: 'abc123' } },
+        },
+        { type: 'text', text: 'Here is your answer.' },
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('text');
+    });
+
+    it('should render a reasoning block that has only redacted content', () => {
+      fixture.componentRef.setInput('message', makeMessage([
+        {
+          type: 'reasoningContent',
+          reasoningContent: { redactedContent: 'encrypted-blob' },
+        },
+      ]));
+      fixture.detectChanges();
+
+      const blocks = component.displayBlocks();
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].type).toBe('reasoningContent');
+    });
   });
 
   describe('tool call data mapping', () => {

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -351,8 +351,16 @@ export class AssistantMessageComponent {
     };
 
     for (const block of blocks) {
-      // Handle reasoning content
-      if (block.type === 'reasoningContent' && block.reasoningContent) {
+      // Handle reasoning content. Only render a "Thinking" block when it has
+      // something to show -- reasoning text or a redacted notice. A block with
+      // an empty `reasoningText.text` and no `redactedContent` (e.g. a
+      // signature-only thinking block that some models, like Sonnet 5, still
+      // emit/persist) would otherwise render an empty collapsible header. The
+      // block is kept in the persisted message for API correctness (the
+      // signature is required on subsequent Bedrock calls); we just don't paint
+      // it. This mirrors the live stream parser's `reasoningText` guard, which
+      // the history-rehydration path bypasses.
+      if (block.type === 'reasoningContent' && this.hasRenderableReasoning(block)) {
         flushToolGroup();
         result.push({ type: 'reasoningContent', data: block });
         continue;
@@ -466,6 +474,20 @@ export class AssistantMessageComponent {
    */
   private toResultData(toolUse: ToolUseData): ToolResultData {
     return toolUse.result ?? { content: [], status: 'success' };
+  }
+
+  /**
+   * Whether a reasoningContent block has anything worth rendering as a
+   * "Thinking" section: actual reasoning text or a redacted-content notice.
+   * Signature-only / empty-text blocks are kept in the message (the signature
+   * is required for subsequent Bedrock calls) but paint nothing, so they must
+   * not produce an empty collapsible. Mirrors ReasoningContentComponent's own
+   * `hasReasoningText || hasRedactedContent` visibility checks.
+   */
+  private hasRenderableReasoning(block: ContentBlock): boolean {
+    const data = block.reasoningContent;
+    if (!data) return false;
+    return !!data.reasoningText?.text || !!data.redactedContent;
   }
 
   /**


### PR DESCRIPTION
## Problem

Sonnet 5 sometimes leaves an empty **"Thinking"** collapsible in the chat UI — a header with no body — even when there was no visible reasoning.

## Root cause

Sonnet 5 occasionally persists a `reasoningContent` block whose `reasoningText.text` is empty and which has no `redactedContent` (a **signature-only** thinking block). The signature must stay in the message because Bedrock requires it on subsequent Converse calls, but the block has nothing to display.

The **live** stream parser already guards on `reasoningText` (`stream-parser-core.ts`, `stream-parser.service.ts`), so live turns are fine. The **history-rehydration** path (`GET /messages` → `<app-assistant-message>`) bypasses those guards and lands at `displayBlocks`, which pushed a Thinking display block for *any* truthy `reasoningContent` object. `reasoning-content.component` then renders its "Thinking" header unconditionally → empty collapsible on reload.

## Fix

Guard the render decision in `assistant-message.component.ts` with a `hasRenderableReasoning()` check: a `reasoningContent` block is only painted when it has reasoning text **or** redacted content — mirroring the component's own `hasReasoningText || hasRedactedContent` visibility logic and the live parser's guard.

**Display-only.** The block is left untouched in the persisted message, so the reasoning signature (and the prompt-cache / history byte-stability contract) is preserved. This is purely "don't paint an empty block."

## Tests

Two regression tests added to `assistant-message.component.spec.ts`:
- empty-text + signature block is dropped from `displayBlocks`
- redacted-only block still renders

All 20 tests in the file pass; TypeScript typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)