### PR TITLE
feat: add a loading state to the Agent Designer form

### DIFF
--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -11,7 +11,7 @@
         </h1>
       </div>
       <div class="flex items-center gap-2">
-        @if (mode() === 'edit' && userPermission() === 'owner') {
+        @if (!loading() && mode() === 'edit' && userPermission() === 'owner') {
           <button type="button" (click)="openShareDialog()" class="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700">
             <ng-icon name="heroShare" class="size-4" aria-hidden="true" />
             Share
@@ -20,7 +20,7 @@
         <button type="button" (click)="onCancel()" class="rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800">
           Cancel
         </button>
-        <button type="button" (click)="onSubmit()" [disabled]="saving() || isViewer()" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-xs transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50">
+        <button type="button" (click)="onSubmit()" [disabled]="loading() || saving() || isViewer()" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-xs transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50">
           <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
           {{ saving() ? 'Saving…' : 'Save Agent' }}
         </button>
@@ -31,6 +31,63 @@
   <main class="flex min-h-0 flex-1">
     <!-- Left: the editor form (independently scrollable) -->
     <div class="min-w-0 flex-1 overflow-y-auto lg:border-r lg:border-gray-200/80 dark:lg:border-gray-700/60">
+  @if (loading()) {
+    <!-- Form skeleton: mirrors the section rhythm below so the real form lands in place -->
+    <div class="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6" role="status" aria-live="polite" aria-busy="true">
+      <span class="sr-only">Loading agent…</span>
+
+      <!-- Persona -->
+      <div class="animate-pulse rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700"></div>
+        <div class="mt-2 h-3 w-2/3 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+        <div class="mt-5 flex items-start gap-4">
+          <div class="size-10 shrink-0 rounded-2xl bg-gray-100 dark:bg-gray-700/50"></div>
+          <div class="h-10 flex-1 rounded-lg bg-gray-100 dark:bg-gray-700/50"></div>
+        </div>
+        <div class="mt-4 h-10 rounded-lg bg-gray-100 dark:bg-gray-700/50"></div>
+        <div class="mt-4 h-32 rounded-lg bg-gray-100 dark:bg-gray-700/50"></div>
+        <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div class="h-10 rounded-lg bg-gray-100 dark:bg-gray-700/50"></div>
+          <div class="h-10 rounded-lg bg-gray-100 dark:bg-gray-700/50"></div>
+        </div>
+      </div>
+
+      <!-- Model -->
+      <div class="animate-pulse rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+        <div class="flex items-center gap-2">
+          <div class="size-5 rounded bg-gray-200 dark:bg-gray-700"></div>
+          <div class="h-4 w-20 rounded bg-gray-200 dark:bg-gray-700"></div>
+        </div>
+        <div class="mt-2 h-3 w-3/5 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+        <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          @for (i of [1, 2, 3, 4]; track i) {
+            <div class="rounded-xl border border-gray-200 px-3 py-2.5 dark:border-gray-700">
+              <div class="h-3.5 w-1/3 rounded bg-gray-200 dark:bg-gray-700"></div>
+              <div class="mt-1.5 h-3 w-3/4 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Tools / skills (pill rows) -->
+      @for (section of [1, 2]; track section) {
+        <div class="animate-pulse rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80">
+          <div class="flex items-center gap-2">
+            <div class="size-5 rounded bg-gray-200 dark:bg-gray-700"></div>
+            <div class="h-4 w-16 rounded bg-gray-200 dark:bg-gray-700"></div>
+          </div>
+          <div class="mt-2 h-3 w-1/2 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+          <div class="mt-4 flex flex-wrap gap-2">
+            <div class="h-8 w-24 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="h-8 w-32 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="h-8 w-20 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="h-8 w-28 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="h-8 w-24 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+          </div>
+        </div>
+      }
+    </div>
+  } @else {
   <form [formGroup]="form" (ngSubmit)="onSubmit()" class="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6">
     @if (isViewer()) {
       <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800/50 dark:bg-amber-900/20 dark:text-amber-300">
@@ -316,10 +373,33 @@
       [createDraft]="createDraftAgent"
     />
   </form>
+  }
     </div>
 
     <!-- Right: live preview (lg+, independently scrollable) -->
     <aside class="hidden shrink-0 flex-col bg-gray-50 p-4 lg:flex lg:w-[30rem] lg:min-h-0 xl:w-[34rem] dark:bg-gray-900">
+      @if (loading()) {
+        <!-- Hold the preview back too: it resolves from the saved record, and mounting
+             it against a half-hydrated form flashes an empty agent card. -->
+        <div class="flex h-full animate-pulse flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800" aria-hidden="true">
+          <div class="shrink-0 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div class="h-4 w-20 rounded bg-gray-200 dark:bg-gray-700"></div>
+            <div class="mt-2 h-3 w-3/4 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="mt-3 flex gap-1.5">
+              <div class="h-5 w-24 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+              <div class="h-5 w-16 rounded-full bg-gray-100 dark:bg-gray-700/50"></div>
+            </div>
+          </div>
+          <div class="flex flex-1 flex-col items-center justify-center gap-3 p-6">
+            <div class="size-14 rounded-2xl bg-gray-100 dark:bg-gray-700/50"></div>
+            <div class="h-4 w-40 rounded bg-gray-200 dark:bg-gray-700"></div>
+            <div class="h-3 w-56 rounded bg-gray-100 dark:bg-gray-700/50"></div>
+          </div>
+          <div class="shrink-0 border-t border-gray-200 p-4 dark:border-gray-700">
+            <div class="h-12 rounded-xl bg-gray-100 dark:bg-gray-700/50"></div>
+          </div>
+        </div>
+      } @else {
       <app-agent-preview
         [agentId]="agentId()"
         [name]="liveFormName()"
@@ -337,6 +417,7 @@
         (save)="onPreviewSave()"
         (openFull)="testInChat()"
       />
+      }
     </aside>
   </main>
 </div>

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
@@ -42,6 +42,16 @@ class StubKnowledgeBaseComponent {
   createDraft = input<unknown>(null);
 }
 
+/**
+ * Drain the microtask queue so the load promises' `.finally` handlers (which clear
+ * the loading flags) have run, then render. `whenStable()` alone can resolve ahead
+ * of them and leave the fixture showing its skeleton.
+ */
+async function settle(fixture: ComponentFixture<AgentFormPage>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  fixture.detectChanges();
+}
+
 describe('AgentFormPage — invalid submit feedback', () => {
   let component: AgentFormPage;
   let fixture: ComponentFixture<AgentFormPage>;
@@ -89,7 +99,7 @@ describe('AgentFormPage — invalid submit feedback', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     await fixture.whenStable();
-    fixture.detectChanges();
+    await settle(fixture);
   });
 
   /** Fill every required control except the one named, so it is the first invalid. */
@@ -150,5 +160,88 @@ describe('AgentFormPage — invalid submit feedback', () => {
 
     expect(mockAgentService.createAgent).toHaveBeenCalled();
     expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it('is done loading once the palettes resolve', () => {
+    expect(component.loading()).toBe(false);
+    expect(fixture.nativeElement.querySelector('form')).toBeTruthy();
+  });
+});
+
+describe('AgentFormPage — loading state', () => {
+  let fixture: ComponentFixture<AgentFormPage>;
+  let component: AgentFormPage;
+  /** Resolve to let the in-flight palette + agent fetches settle. */
+  let releasePalettes: () => void;
+  let releaseAgent: () => void;
+
+  const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() };
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+
+    const palettes = new Promise<[]>((resolve) => {
+      releasePalettes = () => resolve([]);
+    });
+    const agent = new Promise<Record<string, unknown>>((resolve) => {
+      releaseAgent = () => resolve({ name: 'Loaded', userPermission: 'owner' });
+    });
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      providers: [
+        provideRouter([{ path: 'agents', children: [] }]),
+        {
+          provide: AgentService,
+          useValue: {
+            loadBindable: vi.fn().mockReturnValue(palettes),
+            getAgent: vi.fn().mockReturnValue(agent),
+          },
+        },
+        { provide: ToastService, useValue: mockToast },
+        { provide: SidenavService, useValue: { hide: vi.fn(), show: vi.fn() } },
+        { provide: ThemeService, useValue: { isDark: () => false } },
+        // Edit mode: an :id on the route, so the record fetch runs too.
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => 'agt-1' } } } },
+      ],
+    });
+
+    TestBed.overrideComponent(AgentFormPage, {
+      remove: { imports: [AgentPreviewComponent, KnowledgeBaseSectionComponent] },
+      add: { imports: [StubPreviewComponent, StubKnowledgeBaseComponent] },
+    });
+
+    fixture = TestBed.createComponent(AgentFormPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('shows a skeleton instead of the form while the page loads', () => {
+    expect(component.loading()).toBe(true);
+    expect(fixture.nativeElement.querySelector('form')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.animate-pulse')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain(
+      'Loading agent',
+    );
+  });
+
+  it('disables Save while loading', () => {
+    const save: HTMLButtonElement | null = fixture.nativeElement.querySelector(
+      'header button[type="button"]:last-of-type',
+    );
+    expect(save?.disabled).toBe(true);
+  });
+
+  it('stays on the skeleton until BOTH the palettes and the record settle', async () => {
+    releasePalettes();
+    await settle(fixture);
+    expect(component.loading()).toBe(true);
+    expect(fixture.nativeElement.querySelector('form')).toBeNull();
+
+    releaseAgent();
+    await settle(fixture);
+    expect(component.loading()).toBe(false);
+    expect(fixture.nativeElement.querySelector('form')).toBeTruthy();
   });
 });

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -139,6 +139,15 @@ export class AgentFormPage implements OnInit, OnDestroy {
   readonly agentId = signal<string | null>(null);
   readonly saving = signal(false);
   readonly loadingAgent = signal(false);
+  /** The RBAC-filtered binding palettes are fetched on every entry (create + edit). */
+  readonly loadingPalettes = signal(true);
+  /**
+   * The page is still assembling. Both fetches feed sections of the same form
+   * (the palettes render the Model/Tools/Skills/Memory pickers; the record fills
+   * the persona + selections), so the editor stays behind a skeleton until both
+   * settle — otherwise the form paints empty and then visibly rewrites itself.
+   */
+  readonly loading = computed(() => this.loadingPalettes() || this.loadingAgent());
   readonly userPermission = signal<'owner' | 'editor' | 'viewer'>('owner');
   /**
    * Whether {@link userPermission} reflects a value loaded from the server.
@@ -241,7 +250,7 @@ export class AgentFormPage implements OnInit, OnDestroy {
     this.formSub = this.form.valueChanges.subscribe(() => this.syncFormToSignals());
 
     // Load the RBAC-filtered palettes in parallel; then hydrate an existing agent.
-    void this.loadPalettes();
+    void this.loadPalettes().finally(() => this.loadingPalettes.set(false));
 
     const id = this.route.snapshot.paramMap.get('id');
     this.agentId.set(id);
@@ -273,16 +282,23 @@ export class AgentFormPage implements OnInit, OnDestroy {
   }
 
   private async loadPalettes(): Promise<void> {
-    const [models, tools, skills, spaces] = await Promise.all([
-      this.agentService.loadBindable('model'),
-      this.agentService.loadBindable('tool'),
-      this.agentService.loadBindable('skill'),
-      this.agentService.loadBindable('memory_space'),
-    ]);
-    this.models.set(models);
-    this.tools.set(tools);
-    this.skills.set(skills);
-    this.spaces.set(spaces);
+    try {
+      const [models, tools, skills, spaces] = await Promise.all([
+        this.agentService.loadBindable('model'),
+        this.agentService.loadBindable('tool'),
+        this.agentService.loadBindable('skill'),
+        this.agentService.loadBindable('memory_space'),
+      ]);
+      this.models.set(models);
+      this.tools.set(tools);
+      this.skills.set(skills);
+      this.spaces.set(spaces);
+    } catch (err) {
+      // Don't let a palette failure strand the page on its skeleton — fall through
+      // to the form with empty pickers (the Model section renders its own empty state).
+      console.error('Error loading bindable palettes:', err);
+      this.toast.error('Could not load the available models, tools and skills.');
+    }
   }
 
   private async loadAgent(id: string): Promise<void> {


### PR DESCRIPTION
## What

The Agents edit view (`/agents/:id`) had no loading state. It painted an empty form immediately, then visibly rewrote itself as the bindable palettes and the agent record landed. The `loadingAgent` signal already existed on the component but nothing in the template read it.

This adds a skeleton for the whole authoring surface — form column and live preview — held until every fetch the page depends on has settled.

## Changes

**`agent-form.page.ts`**
- New `loadingPalettes` signal (the RBAC-filtered palettes are fetched on *every* entry, create and edit) plus a `loading` computed that ORs it with the existing `loadingAgent`. Both fetches feed sections of the same form — the palettes render the Model/Tools/Skills/Memory pickers, the record fills the persona and the selections — so gating on either alone still leaves a form that rewrites itself.
- `loadPalettes()` is now wrapped in try/catch. It was an unhandled rejection before; more importantly a palette failure must not strand the page on its skeleton. On failure it toasts and falls through to the form, where the Model section renders its own "No models are available to your role" empty state.

**`agent-form.page.html`**
- Skeleton in place of the `<form>`, laid out on the form's own section rhythm (persona card → model grid → two pill rows) so the real content lands roughly in place rather than jumping. Carries `role="status"` / `aria-live="polite"` / `aria-busy="true"` with an sr-only "Loading agent…".
- The preview aside gets a matching skeleton. It resolves bindings from the *saved* record, so mounting it against a half-hydrated form flashed an empty agent card.
- Save is disabled while loading. Share is now gated on `!loading()` — it was rendering off the default `userPermission()` guess of `'owner'`, so on a viewer's agent it appeared and then disappeared once the record came back.

## Testing

`ng test --include='**/agents/**/*.spec.ts'` → 15 passed.

New cases: skeleton renders and no `<form>` is present while loading; Save is disabled; the page stays on the skeleton until **both** the palettes and the record settle (releases them one at a time and asserts in between).

The existing suite needed a `settle()` helper — `fixture.whenStable()` can resolve ahead of the load promises' `.finally` handlers, leaving the fixture showing its skeleton. The pre-existing tests only passed because each happened to call `detectChanges()` before touching the DOM.

Verified visually in light and dark against the app's live stylesheet.

## Notes for the reviewer

Purely presentational — no API, contract, or model-call-path changes.

One adjacent issue I did **not** fix, since it's in the data rather than the render: `loadAgent()` and `loadPalettes()` race, so a memory-space binding whose palette entry hasn't arrived yet is snapshotted with its raw `ref` as the label and `role: 'viewer'` (which disables the Read+write toggle). Gating the render doesn't address it. The small fix is to `await` the palettes promise inside `loadAgent` just before building `memorySelections`, which keeps both requests in flight. Happy to fold that in here or file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)