### PR TITLE
feat(marketplace): Agent Marketplace phase 1 — listing lifecycle, sparse GSI5, admin review

### DIFF
--- a/backend/src/apis/app_api/admin/agents/__init__.py
+++ b/backend/src/apis/app_api/admin/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Admin surfaces for the Agent Marketplace (Phase 1): review queue, listings, publishers."""

--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -1,0 +1,305 @@
+"""Admin API routes for the Agent Marketplace (Phase 1).
+
+Mounted under ``/admin/agents`` per the CLAUDE.md route convention — admin CRUD lives at
+``/admin/resource/``, never ``/resource/admin/``. Every route is ``Depends(require_admin)``
+(= ``require_app_roles("system_admin")``); D2 is explicit that a granular "marketplace
+curator" permission is a deliberate follow-up, so do not open a second permission axis here.
+
+Phase 1 covers two of D10's six surfaces — **Review queue** and **Listings** — plus the
+**Publishers** records they depend on. Store front, categories and default pins are
+Phases 5, 2 and 6.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from apis.app_api.agent_designer.services.listing_service import (
+    ListingError,
+    list_admin_listings,
+    patch_listing_presentation,
+    review_listing,
+    takedown_listing,
+)
+from apis.shared.assistants.listing import DEFAULT_CATEGORIES
+from apis.shared.assistants.models import (
+    AdminListingPatchRequest,
+    AdminListingsResponse,
+    AgentCategoriesResponse,
+    AgentListing,
+    PublisherCreateRequest,
+    PublisherEligibilityRequest,
+    PublisherEligibilityResponse,
+    PublisherProfile,
+    PublishersResponse,
+    PublisherUpdateRequest,
+    ReviewListingRequest,
+    TakedownRequest,
+)
+from apis.shared.assistants.publishers import (
+    delete_publisher,
+    get_publisher,
+    list_eligibility,
+    list_publishers,
+    put_publisher,
+    set_eligibility,
+)
+from apis.shared.auth import User, require_admin
+from apis.shared.feature_flags import agent_marketplace_enabled
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/agents", tags=["admin-agent-marketplace"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+async def require_marketplace_admin(admin: User = Depends(require_admin)) -> User:
+    """Admin auth + the environment kill switch (404 when off, so it reads as unmounted)."""
+    if not agent_marketplace_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return admin
+
+
+# ── review queue + listings (D10) ────────────────────────────────────────────────────
+@router.get("/submissions", response_model=AdminListingsResponse)
+async def list_submissions(admin: User = Depends(require_marketplace_admin)):
+    """The Review queue: every submission awaiting a decision (D2)."""
+    try:
+        rows, pending = await list_admin_listings(state="in_review")
+        return AdminListingsResponse(listings=rows, pending_count=pending)
+    except Exception as e:
+        logger.error(f"Error listing agent submissions: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list submissions: {str(e)}")
+
+
+@router.get("/listings", response_model=AdminListingsResponse)
+async def list_listings(
+    state: Optional[str] = Query(None, description="Filter by listing state"),
+    admin: User = Depends(require_marketplace_admin),
+):
+    """The Listings table: every Agent that has ever been submitted (D10).
+
+    ``updatedAt`` is on every row on purpose — D2 accepts that an approved listing can
+    drift from what was reviewed, and the mitigation is this audit trail rather than a
+    re-review gate that would make iteration miserable.
+    """
+    try:
+        rows, pending = await list_admin_listings(state=state)
+        return AdminListingsResponse(listings=rows, pending_count=pending)
+    except Exception as e:
+        logger.error(f"Error listing agent listings: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list listings: {str(e)}")
+
+
+@router.post("/{agent_id}/review", response_model=AgentListing)
+async def review_agent_listing(
+    agent_id: str,
+    request: ReviewListingRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Approve a submission, or return it with a reason (D2).
+
+    Approving writes the sparse directory key and the Agent appears in the store
+    immediately. Requesting changes requires a reason, which renders on the author's own
+    card so they never have to ask what happened.
+    """
+    try:
+        return await review_listing(
+            agent_id,
+            admin,
+            decision=request.decision,
+            note=request.note,
+            category=request.category,
+            publisher_id=request.publisher_id,
+        )
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error reviewing agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to review listing: {str(e)}")
+
+
+@router.post("/{agent_id}/takedown", response_model=AgentListing)
+async def takedown_agent_listing(
+    agent_id: str,
+    request: TakedownRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Delist a published Agent, with a reason sent to the author (D2).
+
+    A delisting, not a revocation: existing pins keep working, conversations underway keep
+    running, and the Agent stays reachable by direct link — ``visibility`` is a separate
+    axis. Clearing the directory key is all this does.
+    """
+    try:
+        return await takedown_listing(agent_id, admin, request.reason)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error taking down agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to take down listing: {str(e)}")
+
+
+@router.patch("/{agent_id}/listing", response_model=AgentListing)
+async def patch_agent_listing(
+    agent_id: str,
+    request: AdminListingPatchRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Edit a listing's presentation — and only its presentation (D13).
+
+    Accepts ``name``, ``tagline``, ``iconKey``, ``category``, ``publisherId``. Behavior
+    fields (``instructions``, ``bindings``, ``modelConfig``, ``starters``, ``visibility``)
+    are refused at the model boundary with a 422 naming the rule: an admin editing
+    behavior would be responsible for something they did not write and cannot test.
+
+    Every edit is appended to ``listing.adminEdits`` and surfaced to the author. Editing
+    someone's listing quietly is how you lose authors.
+    """
+    try:
+        return await patch_listing_presentation(agent_id, admin, request)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error patching agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to patch listing: {str(e)}")
+
+
+@router.get("/categories", response_model=AgentCategoriesResponse)
+async def list_categories(admin: User = Depends(require_marketplace_admin)):
+    """The category set a listing may reference.
+
+    Phase 1 serves the ``DEFAULT_CATEGORIES`` constant. Phase 2 replaces the source with
+    admin-managed records (D10) and serves the same shape from the same route.
+    """
+    return AgentCategoriesResponse(categories=list(DEFAULT_CATEGORIES))
+
+
+# ── publishers (D12) ─────────────────────────────────────────────────────────────────
+@router.get("/publishers", response_model=PublishersResponse)
+async def list_publisher_profiles(admin: User = Depends(require_marketplace_admin)):
+    """Every publisher profile, ordered."""
+    try:
+        return PublishersResponse(publishers=await list_publishers())
+    except Exception as e:
+        logger.error(f"Error listing publishers: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list publishers: {str(e)}")
+
+
+@router.post("/publishers", response_model=PublisherProfile, status_code=201)
+async def create_publisher_profile(
+    request: PublisherCreateRequest, admin: User = Depends(require_marketplace_admin)
+):
+    """Create a publisher profile.
+
+    ``verified`` is settable only here and on update — it is the admin-only mark meaning
+    "a university team stands behind this", which is why individual profiles (auto-created
+    at submission) are never created verified.
+    """
+    try:
+        now = _now()
+        profile = PublisherProfile(
+            id=f"pub-{uuid.uuid4().hex[:12]}",
+            label=request.label,
+            kind=request.kind,
+            verified=request.verified,
+            icon_key=request.icon_key,
+            order=request.order,
+            enabled=request.enabled,
+            created_at=now,
+            updated_at=now,
+        )
+        return await put_publisher(profile)
+    except Exception as e:
+        logger.error(f"Error creating publisher: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to create publisher: {str(e)}")
+
+
+@router.patch("/publishers/{publisher_id}", response_model=PublisherProfile)
+async def update_publisher_profile(
+    publisher_id: str,
+    request: PublisherUpdateRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Update a publisher profile, including the admin-only ``verified`` mark."""
+    try:
+        existing = await get_publisher(publisher_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Publisher not found: {publisher_id}")
+        changes = request.model_dump(exclude_none=True)
+        updated = existing.model_copy(update={**changes, "updated_at": _now()})
+        return await put_publisher(updated)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating publisher: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update publisher: {str(e)}")
+
+
+@router.delete("/publishers/{publisher_id}", status_code=204)
+async def delete_publisher_profile(
+    publisher_id: str, admin: User = Depends(require_marketplace_admin)
+):
+    """Delete a publisher profile and its eligibility items.
+
+    Listings already attributed to it keep the id; the admin Listings table renders them
+    without a resolved publisher so the gap is visible and can be reassigned. Deleting an
+    attribution must never change who can run an Agent (D12).
+    """
+    try:
+        if not await get_publisher(publisher_id):
+            raise HTTPException(status_code=404, detail=f"Publisher not found: {publisher_id}")
+        await delete_publisher(publisher_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting publisher: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to delete publisher: {str(e)}")
+
+
+@router.get("/publishers/{publisher_id}/eligibility", response_model=PublisherEligibilityResponse)
+async def get_publisher_eligibility(
+    publisher_id: str, admin: User = Depends(require_marketplace_admin)
+):
+    """Who may *propose* this publisher at submission (D12)."""
+    try:
+        if not await get_publisher(publisher_id):
+            raise HTTPException(status_code=404, detail=f"Publisher not found: {publisher_id}")
+        return PublisherEligibilityResponse(
+            publisher_id=publisher_id, user_ids=await list_eligibility(publisher_id)
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error reading publisher eligibility: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to read eligibility: {str(e)}")
+
+
+@router.put("/publishers/{publisher_id}/eligibility", response_model=PublisherEligibilityResponse)
+async def put_publisher_eligibility(
+    publisher_id: str,
+    request: PublisherEligibilityRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Replace the set of users who may propose this publisher (D12).
+
+    A *proposal* allowlist for the submit dialog and nothing more. An admin may attribute
+    any listing to any publisher regardless of eligibility, so this list never appears in
+    an access check — it decides what an author is offered, not what anyone may run.
+    """
+    try:
+        if not await get_publisher(publisher_id):
+            raise HTTPException(status_code=404, detail=f"Publisher not found: {publisher_id}")
+        user_ids = await set_eligibility(publisher_id, request.user_ids)
+        return PublisherEligibilityResponse(publisher_id=publisher_id, user_ids=user_ids)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error setting publisher eligibility: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to set eligibility: {str(e)}")

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -884,6 +884,14 @@ if skills_enabled():
 
     router.include_router(skills_router)
 
+# ========== Include Agent Marketplace Admin Subrouter ==========
+# Mounted unconditionally; every route depends on ``require_marketplace_admin``, which
+# 404s while AGENT_MARKETPLACE_ENABLED is off (the ``/agents`` surface pattern) rather
+# than being unmounted at import time.
+from .agents.routes import router as agent_marketplace_admin_router
+
+router.include_router(agent_marketplace_admin_router)
+
 # ========== Include OAuth Admin Subrouter ==========
 from .oauth.routes import router as oauth_admin_router
 

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -59,9 +59,19 @@ from apis.shared.assistants.service import (
     update_assistant,
     update_share_permission,
 )
+from apis.app_api.agent_designer.services.listing_service import (
+    ListingError,
+    submit_listing,
+    withdraw_listing,
+)
+from apis.shared.assistants.models import (
+    AgentListing,
+    ListingSubmissionResponse,
+    SubmitListingRequest,
+)
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
-from apis.shared.feature_flags import agents_enabled
+from apis.shared.feature_flags import agent_marketplace_enabled, agents_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +87,19 @@ async def require_agents_enabled(
     (mirrors the memory-spaces / schedules pattern).
     """
     if not agents_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return user
+
+
+async def require_marketplace_enabled(
+    user: User = Depends(require_agents_enabled),
+) -> User:
+    """Cookie auth + both kill switches, for the marketplace listing routes.
+
+    The marketplace is a surface over the Agent record, so it is off whenever the Agent
+    surface itself is off. 404 rather than 403 so the routes behave as if unmounted.
+    """
+    if not agent_marketplace_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     return user
 
@@ -351,3 +374,47 @@ async def get_agent_shares_endpoint(agent_id: str, current_user: User = Depends(
     except Exception as e:
         logger.error(f"Error getting agent shares: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to get agent shares: {str(e)}")
+
+
+# ------------------------------------------------------------------- marketplace (D2)
+# The author's half of the listing lifecycle. The reviewer's half lives under
+# /admin/agents/* behind require_admin. Nothing here is user-visible in Phase 1 — the
+# SPA surfaces that call these ship with the Discover page in Phase 2.
+@router.post("/{agent_id}/listing/submit", response_model=ListingSubmissionResponse)
+async def submit_agent_listing_endpoint(
+    agent_id: str,
+    request: SubmitListingRequest,
+    current_user: User = Depends(require_marketplace_enabled),
+):
+    """Submit an Agent for marketplace review (owner only).
+
+    Runs the D7 checks first: a ``memory_space`` binding rejects the submission with 400,
+    and the response enumerates the author's own skills that publication would make
+    readable to anyone who runs the Agent.
+    """
+    try:
+        listing, exposed = await submit_listing(agent_id, current_user, request)
+        return ListingSubmissionResponse(agent_id=agent_id, listing=listing, exposed_skills=exposed)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error submitting agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to submit agent listing: {str(e)}")
+
+
+@router.delete("/{agent_id}/listing", response_model=AgentListing)
+async def withdraw_agent_listing_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """Unpublish an Agent or withdraw a pending submission (owner only).
+
+    Returns the listing to ``private``. This revokes nothing retroactively — pins keep
+    working and conversations underway keep running; it is a delisting, not a recall.
+    """
+    try:
+        return await withdraw_listing(agent_id, current_user)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error withdrawing agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to withdraw agent listing: {str(e)}")

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -1,0 +1,471 @@
+"""Agent Marketplace Phase 1 — submit / review / takedown orchestration (D2, D7, D12, D13).
+
+Where the authorization, the disclosure checks and the state machine meet. The machine
+itself is pure (``apis.shared.assistants.listing``) and the writes are isolated
+(``apis.shared.assistants.listing_repository``); this module decides *whether* a given
+caller may walk a given edge, and what has to be true first.
+
+Three rules are enforced here and nowhere else:
+
+* **Submission is the disclosure point (D7).** Publishing an Agent effectively publishes
+  the contents of every skill its author wrote and bound, because Skills v2 resolves a
+  ``skill`` binding on ``skill.owner_id == agent.owner_id``. The author is shown that list
+  before a reviewer's time is spent, and a ``memory_space`` binding blocks submission
+  outright — a memory space is personal data that re-resolution will deny to every other
+  viewer, so a published agent bound to one is a guaranteed failure for everyone.
+* **Approval is the only door into the store (D2).** ``in_review → published`` is the sole
+  edge that writes a directory key, and only ``require_admin`` routes reach it.
+* **Admins own presentation, authors own behavior (D13).** The patch path can reach
+  ``name``/``tagline``/``iconKey``/``category``/``publisherId`` and nothing else, and every
+  such edit is recorded on the listing so the author is told rather than surprised.
+
+⚠️ ``publisherId`` appears nowhere in an access decision in this file. Ownership
+(``resolve_assistant_permission``) is what gates the author paths; ``require_admin`` gates
+the rest. Publisher is a name on a shelf.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+from apis.shared.assistants.compat import effective_bindings
+from apis.shared.assistants.listing import (
+    DEFAULT_CATEGORIES,
+    ListingTransitionError,
+    assert_transition,
+)
+from apis.shared.assistants.listing_repository import list_by_state, write_listing
+from apis.shared.assistants.models import (
+    AdminEdit,
+    AdminListingPatchRequest,
+    AdminListingRow,
+    AgentListing,
+    Assistant,
+    PublisherProfile,
+    SkillExposure,
+    SubmitListingRequest,
+)
+from apis.shared.assistants.publishers import (
+    ensure_individual_profile,
+    get_publisher,
+    list_publishers,
+    list_publishers_for_user,
+)
+from apis.shared.assistants.service import (
+    _get_assistant_cloud_without_ownership_check,
+    resolve_assistant_permission,
+)
+from apis.shared.auth.models import User
+from apis.shared.feature_flags import skills_enabled
+from apis.shared.memory.service import MemorySpaceService
+from apis.shared.skills.repository import get_skill_catalog_repository
+
+logger = logging.getLogger(__name__)
+
+
+class ListingError(Exception):
+    """A listing operation the caller may not perform, or that is not yet valid.
+
+    ``status_code`` maps to the HTTP response: 403 for an authorization denial, 404 for a
+    missing agent, 400 for a request the current state or bindings do not permit.
+    """
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+# The author reads these ("An admin updated the category on Jul 24"), so record the field
+# by the name they'd recognize rather than the internal attribute.
+_EDIT_FIELD_LABELS = {
+    "icon_key": "icon",
+    "publisher_id": "publisher",
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _current_state(assistant: Assistant) -> Optional[str]:
+    """The listing state, or ``None`` for a record that has never been submitted (D3)."""
+    return assistant.listing.state if assistant.listing else None
+
+
+def _validate_category(category: str) -> None:
+    if category not in DEFAULT_CATEGORIES:
+        raise ListingError(
+            f"Unknown category '{category}'. Expected one of: {', '.join(DEFAULT_CATEGORIES)}.",
+            status_code=400,
+        )
+
+
+async def _load_for_author(agent_id: str, user: User) -> Assistant:
+    """Load an Agent the caller owns, or raise.
+
+    Submission and withdrawal are owner-only. An *editor* may change what an agent does,
+    but putting the institution's name on it is the owner's act — and the owner is who
+    D7's skill exposure actually concerns, since invoke-through resolves against
+    ``agent.owner_id``.
+    """
+    assistant, permission = await resolve_assistant_permission(
+        assistant_id=agent_id, user_id=user.user_id, user_email=user.email
+    )
+    if not assistant:
+        raise ListingError(f"Agent not found: {agent_id}", status_code=404)
+    if permission != "owner":
+        raise ListingError(
+            "Only the owner of an agent can manage its marketplace listing.", status_code=403
+        )
+    return assistant
+
+
+async def _load_any(agent_id: str) -> Assistant:
+    """Load an Agent without an ownership check — for admin paths (D13).
+
+    ``update_assistant``/``get_assistant`` both gate on ``owner_id``, which a reviewer
+    fails by definition; D13 exists so an admin can fix a tagline without the author.
+    """
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    assistant = await _get_assistant_cloud_without_ownership_check(agent_id, table_name)
+    if not assistant:
+        raise ListingError(f"Agent not found: {agent_id}", status_code=404)
+    return assistant
+
+
+# ── D7 disclosure ────────────────────────────────────────────────────────────────────
+async def _memory_space_block(assistant: Assistant, user: User) -> None:
+    """Block submission on any ``memory_space`` binding, naming the space (D7.2).
+
+    Not a warning. A memory space is personal data; Designer D5's run-time re-resolve
+    already denies it to anyone who lacks access, so publishing an agent bound to one
+    ships a listing that cannot work for a single other person.
+    """
+    bound = [b for b in effective_bindings(assistant) if b.kind == "memory_space"]
+    if not bound:
+        return
+
+    # Resolve a human name for the message. The id alone tells the author nothing.
+    label = bound[0].ref
+    try:
+        spaces = MemorySpaceService().list_spaces_for_user(user.user_id, user.email)
+        by_id = {space.space_id: space.name for space, _role in spaces}
+        label = by_id.get(bound[0].ref, bound[0].ref)
+    except Exception:
+        logger.warning("Could not resolve memory space name for submission block", exc_info=True)
+
+    raise ListingError(
+        f"This agent can't be published while it's bound to the memory space “{label}”. "
+        "A memory space is personal data — it won't resolve for anyone else, so the agent "
+        "would fail for every person who ran it. Remove the binding and submit again.",
+        status_code=400,
+    )
+
+
+async def _exposed_skills(assistant: Assistant) -> List[SkillExposure]:
+    """Skills the author wrote that publication makes readable (D7.1).
+
+    Matches the invoke-through rule exactly: a ``skill`` binding resolves when
+    ``skill.owner_id == agent.owner_id``, so those — and only those — are the skills whose
+    contents publication exposes. Skills the author merely has access to belong to someone
+    else and are not the author's to disclose.
+    """
+    refs = [b.ref for b in effective_bindings(assistant) if b.kind == "skill"]
+    if not refs or not skills_enabled():
+        return []
+    try:
+        skills = await get_skill_catalog_repository().batch_get_skills(refs)
+    except Exception:
+        logger.warning("Could not resolve skill names for submission disclosure", exc_info=True)
+        return [SkillExposure(ref=r, label=r) for r in refs]
+
+    return [
+        SkillExposure(ref=s.skill_id, label=s.display_name)
+        for s in skills
+        if s.owner_id == assistant.owner_id
+    ]
+
+
+# ── publisher resolution (D12) ───────────────────────────────────────────────────────
+async def _resolve_proposed_publisher(user: User, publisher_id: Optional[str]) -> str:
+    """The publisher an author may propose, defaulting to their own individual profile.
+
+    Eligibility is checked *here*, on the author's proposal path only. An admin may set
+    any publisher on any listing regardless of it (D12) — see ``patch_listing_presentation``,
+    which deliberately does not call this.
+    """
+    if not publisher_id:
+        profile = await ensure_individual_profile(user.user_id, user.name)
+        return profile.id
+
+    profile = await get_publisher(publisher_id)
+    if not profile or not profile.enabled:
+        raise ListingError(f"Unknown publisher '{publisher_id}'.", status_code=400)
+
+    eligible = await list_publishers_for_user(user.user_id)
+    if publisher_id not in eligible:
+        raise ListingError(
+            f"You aren't eligible to publish as “{profile.label}”. "
+            "An admin can grant that, or you can submit under your own name.",
+            status_code=403,
+        )
+    return publisher_id
+
+
+# ── author transitions ───────────────────────────────────────────────────────────────
+async def submit_listing(
+    agent_id: str, user: User, request: SubmitListingRequest
+) -> Tuple[AgentListing, List[SkillExposure]]:
+    """Author submits an Agent for review (D2), after the D7 checks pass."""
+    assistant = await _load_for_author(agent_id, user)
+    _validate_category(request.category)
+
+    try:
+        assert_transition(_current_state(assistant), "in_review")
+    except ListingTransitionError as e:
+        raise ListingError(str(e), status_code=400) from e
+
+    # Order matters: block before disclosing. An author whose agent cannot be published
+    # at all should not first be walked through a skill-exposure confirmation.
+    await _memory_space_block(assistant, user)
+    exposed = await _exposed_skills(assistant)
+    publisher_id = await _resolve_proposed_publisher(user, request.publisher_id)
+
+    now = _now()
+    previous = assistant.listing
+    listing = AgentListing(
+        state="in_review",
+        category=request.category,
+        publisher_id=publisher_id,
+        submitted_at=now,
+        submitted_by=user.user_id,
+        # A resubmission carries its review history forward; the note stays visible until
+        # the reviewer replaces it, so the author keeps the context they are acting on.
+        reviewed_at=previous.reviewed_at if previous else None,
+        reviewed_by=previous.reviewed_by if previous else None,
+        review_note=request.note or (previous.review_note if previous else None),
+        admin_edits=previous.admin_edits if previous else [],
+    )
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    logger.info(f"📨 Agent {agent_id} submitted for review by {user.user_id}")
+    return listing, exposed
+
+
+async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
+    """Author unpublishes or withdraws a submission — back to ``private`` (D2).
+
+    Unpublishing revokes nothing retroactively: people who pinned it keep their pin,
+    conversations underway keep running, and the agent stays reachable by direct link
+    because ``visibility`` is a separate axis. It is a delisting, not a recall.
+    """
+    assistant = await _load_for_author(agent_id, user)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+
+    try:
+        assert_transition(assistant.listing.state, "private")
+    except ListingTransitionError as e:
+        raise ListingError(str(e), status_code=400) from e
+
+    now = _now()
+    listing = assistant.listing.model_copy(update={"state": "private"})
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    logger.info(f"📭 Agent {agent_id} unpublished by its owner")
+    return listing
+
+
+# ── admin transitions ────────────────────────────────────────────────────────────────
+async def review_listing(
+    agent_id: str,
+    admin: User,
+    *,
+    decision: str,
+    note: Optional[str] = None,
+    category: Optional[str] = None,
+    publisher_id: Optional[str] = None,
+) -> AgentListing:
+    """Approve a submission, or return it with a reason (D2).
+
+    Approval is where an attribution becomes authoritative, so the reviewer may adjust
+    category and publisher in the same act (D12) without a second round trip.
+    """
+    assistant = await _load_any(agent_id)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing to review.", status_code=404)
+
+    target = "published" if decision == "approve" else "changes_requested"
+    if decision == "request_changes" and not (note or "").strip():
+        raise ListingError(
+            "Requesting changes needs a reason — it renders on the author's card so they "
+            "never have to ask what happened.",
+            status_code=400,
+        )
+
+    try:
+        assert_transition(assistant.listing.state, target)
+    except ListingTransitionError as e:
+        raise ListingError(str(e), status_code=400) from e
+
+    if category is not None:
+        _validate_category(category)
+    if publisher_id is not None:
+        # No eligibility check: an admin may attribute any listing to any publisher (D12).
+        # That is how the store gets its day-one set of official Agents without those
+        # Agents carrying a staff member's personal name.
+        if not await get_publisher(publisher_id):
+            raise ListingError(f"Unknown publisher '{publisher_id}'.", status_code=400)
+
+    now = _now()
+    listing = assistant.listing.model_copy(
+        update={
+            "state": target,
+            "category": category or assistant.listing.category,
+            "publisher_id": publisher_id or assistant.listing.publisher_id,
+            "reviewed_at": now,
+            "reviewed_by": admin.user_id,
+            "review_note": note or None,
+        }
+    )
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    logger.info(f"⚖️ Agent {agent_id} review by {admin.user_id}: {decision} → {target}")
+    return listing
+
+
+async def takedown_listing(agent_id: str, admin: User, reason: str) -> AgentListing:
+    """Delist a published Agent, clearing its directory key (D2).
+
+    A **delisting, not a revocation**: existing pins keep working, conversations underway
+    keep running, and the Agent stays reachable by direct link because ``visibility`` is
+    the separate access axis. All this changes is whether the store can find it.
+    """
+    assistant = await _load_any(agent_id)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+
+    try:
+        assert_transition(assistant.listing.state, "taken_down")
+    except ListingTransitionError as e:
+        raise ListingError(str(e), status_code=400) from e
+
+    now = _now()
+    listing = assistant.listing.model_copy(
+        update={
+            "state": "taken_down",
+            "reviewed_at": now,
+            "reviewed_by": admin.user_id,
+            "review_note": reason,
+        }
+    )
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    logger.info(f"🚫 Agent {agent_id} taken down by {admin.user_id}")
+    return listing
+
+
+async def patch_listing_presentation(
+    agent_id: str, admin: User, patch: AdminListingPatchRequest
+) -> AgentListing:
+    """Edit the presentation fields of a listing, recording each change (D13).
+
+    Everything the store renders is admin-editable without the author's involvement; an
+    admin fixing a typo or swapping an off-brand icon should not need a round trip. What
+    an admin cannot touch is behavior — ``AdminListingPatchRequest`` refuses those fields
+    at the model boundary, so by the time we are here the request is presentation-only.
+    """
+    assistant = await _load_any(agent_id)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+
+    changes = patch.model_dump(exclude_none=True)
+    if not changes:
+        raise ListingError("No presentation fields supplied.", status_code=400)
+    if "category" in changes:
+        _validate_category(changes["category"])
+    if "publisher_id" in changes and not await get_publisher(changes["publisher_id"]):
+        raise ListingError(f"Unknown publisher '{changes['publisher_id']}'.", status_code=400)
+
+    now = _now()
+    edits = list(assistant.listing.admin_edits) + [
+        AdminEdit(field=_EDIT_FIELD_LABELS.get(field, field), at=now, by=admin.name or admin.user_id)
+        for field in sorted(changes)
+    ]
+    listing = assistant.listing.model_copy(
+        update={
+            "category": changes.get("category", assistant.listing.category),
+            "publisher_id": changes.get("publisher_id", assistant.listing.publisher_id),
+            "admin_edits": edits,
+        }
+    )
+    # ``name``/``tagline``/``iconKey`` live on the Agent record, not the listing block, so
+    # they ride the same single write rather than racing a second update.
+    await write_listing(
+        agent_id,
+        listing,
+        assistant.created_at,
+        tagline=changes.get("tagline"),
+        icon_key=changes.get("icon_key"),
+        name=changes.get("name"),
+        updated_at=now,
+    )
+    logger.info(f"✏️ Admin {admin.user_id} edited listing presentation for {agent_id}: {sorted(changes)}")
+    return listing
+
+
+# ── admin reads ──────────────────────────────────────────────────────────────────────
+async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminListingRow], int]:
+    """Rows for the Review queue / Listings tables, plus the pending-review count.
+
+    The count badges the admin nav so the queue is visible rather than discovered — the
+    operational half of D2's answer to "a review queue makes publication stop".
+    """
+    raw = await list_by_state(state)
+    publishers = {p.id: p for p in await list_publishers()}
+
+    rows: List[AdminListingRow] = []
+    for item in raw:
+        try:
+            assistant = Assistant.model_validate(item)
+        except Exception:
+            logger.warning(f"Skipping unparseable assistant row {item.get('PK')}", exc_info=True)
+            continue
+        if not assistant.listing:
+            continue
+        rows.append(_to_row(assistant, publishers.get(assistant.listing.publisher_id)))
+
+    rows.sort(key=lambda r: (r.submitted_at or r.updated_at), reverse=True)
+
+    # The badge counts the review queue, not whatever slice the caller asked for — an
+    # admin filtering the Listings table to "published" still needs to see work waiting.
+    # When the fetched rows already cover the queue, count them instead of re-scanning.
+    if state is None or state == "in_review":
+        pending = len([r for r in rows if r.state == "in_review"])
+    else:
+        pending = len(await list_by_state("in_review"))
+
+    return rows, pending
+
+
+def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> AdminListingRow:
+    listing = assistant.listing
+    if listing is None:  # callers filter; belt-and-braces rather than a stripped assert
+        raise ValueError(f"Agent {assistant.assistant_id} has no listing to project")
+    return AdminListingRow(
+        agent_id=assistant.assistant_id,
+        name=assistant.name,
+        tagline=assistant.tagline,
+        emoji=assistant.emoji,
+        icon_key=assistant.icon_key,
+        owner_name=assistant.owner_name,
+        publisher=publisher,
+        category=listing.category,
+        state=listing.state,
+        usage_count=assistant.usage_count,
+        submitted_at=listing.submitted_at,
+        reviewed_at=listing.reviewed_at,
+        review_note=listing.review_note,
+        updated_at=assistant.updated_at,
+        admin_edits=listing.admin_edits,
+    )

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -1,0 +1,161 @@
+"""Agent Marketplace Phase 1 — the listing state machine and the sparse directory key.
+
+Pure functions over the ``listing`` block on an Agent record. No I/O: the repository
+layer (``listing_repository``) turns a validated target state into a DynamoDB write, and
+the service layer (``agent_designer.services.listing_service``) owns the authorization
+and disclosure rules. Keeping the machine pure is what makes every transition — legal
+and illegal — cheap to test.
+
+Two invariants live here, and both are load-bearing:
+
+1. **Publication is an explicit forward act** (spec D3). A record with no ``listing``
+   block has never been submitted, and no amount of ``visibility == "PUBLIC"`` creates
+   one. ``visibility`` is the access gate; ``listing.state`` is the publication state.
+   They are separate axes and this module never reads the former.
+2. **The directory index is written only while published** (spec Data model). ``gsi5_keys``
+   returns keys for exactly one state, so unpublication is enforced by physics rather
+   than by a filter someone can forget: no key, so the browse query cannot return it.
+"""
+
+from typing import Dict, Optional, Set, Tuple
+
+# ── Categories (spec D10) ────────────────────────────────────────────────────────────
+# Phase 1 validates ``listing.category`` against this constant set. Phase 2 replaces the
+# source with admin-managed ``AGENT_CATEGORIES`` records (the ``UserMenuLink`` precedent:
+# a fixed partition, per-item records with an explicit ``order``). The stored shape does
+# NOT change — ``listing.category`` is a category id string either way — so that swap is
+# a source change with no data migration.
+#
+# D10 is explicit that categories must not stay a build-time constant ("a category set
+# that requires a deploy to change will not be maintained"). This is a one-phase
+# expedient while nothing is user-visible, not the end state.
+DEFAULT_CATEGORIES: Tuple[str, ...] = (
+    "Administration",
+    "Teaching",
+    "Research",
+    "Student Support",
+    "IT & Operations",
+    "Communications",
+)
+
+# ── States (spec D2) ─────────────────────────────────────────────────────────────────
+LISTING_STATES: Tuple[str, ...] = (
+    "private",
+    "in_review",
+    "published",
+    "changes_requested",
+    "taken_down",
+)
+
+# The transition table. ``None`` is the pre-state of a record that has never been
+# submitted (no ``listing`` block at all) — the D3 backfill default.
+#
+# Each edge and the actor that walks it:
+#
+#   None              → in_review          author submits for the first time
+#   private           → in_review          author submits
+#   changes_requested → in_review          author resubmits after addressing the note
+#   taken_down        → in_review          author resubmits after addressing the takedown
+#                                          (the takedown dialog promises exactly this)
+#   in_review         → published          admin approves
+#   in_review         → changes_requested  admin requests changes, with a reason
+#   published         → taken_down         admin delists, with a reason
+#   published         → changes_requested  admin requests changes on a live listing
+#   taken_down        → changes_requested  admin annotates an already-delisted listing
+#   in_review         → private            author withdraws a pending submission
+#   changes_requested → private            author withdraws
+#   published         → private            author unpublishes (DELETE /agents/{id}/listing)
+#
+# Deliberately absent: anything → published other than from in_review. Approval is the
+# only door into the store, so a bug elsewhere cannot publish by accident.
+ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
+    None: {"in_review"},
+    "private": {"in_review"},
+    "in_review": {"published", "changes_requested", "private"},
+    "changes_requested": {"in_review", "private"},
+    "published": {"taken_down", "changes_requested", "private"},
+    "taken_down": {"in_review", "changes_requested"},
+}
+
+# States an author may drive. Everything else is the reviewer's (``require_admin``).
+AUTHOR_TARGET_STATES: Set[str] = {"in_review", "private"}
+
+
+class ListingTransitionError(ValueError):
+    """An attempted listing state change that the machine does not allow."""
+
+    def __init__(self, current: Optional[str], target: str, message: Optional[str] = None):
+        self.current = current
+        self.target = target
+        super().__init__(message or self._default_message(current, target))
+
+    @staticmethod
+    def _default_message(current: Optional[str], target: str) -> str:
+        if target not in LISTING_STATES:
+            return (
+                f"Unknown listing state '{target}'. Expected one of: "
+                f"{', '.join(LISTING_STATES)}."
+            )
+        if current is None:
+            return (
+                f"This agent has never been submitted, so it cannot move to '{target}'. "
+                "Submit it for review first."
+            )
+        allowed = ALLOWED_TRANSITIONS.get(current, set())
+        allowed_text = ", ".join(sorted(allowed)) if allowed else "nothing"
+        return (
+            f"Cannot move a listing from '{current}' to '{target}'. "
+            f"From '{current}' the allowed next states are: {allowed_text}."
+        )
+
+
+def assert_transition(current: Optional[str], target: str) -> None:
+    """Raise ``ListingTransitionError`` unless ``current → target`` is a legal edge.
+
+    ``current`` is ``None`` for a record with no ``listing`` block (never submitted).
+    """
+    if target not in LISTING_STATES:
+        raise ListingTransitionError(current, target)
+    if current is not None and current not in LISTING_STATES:
+        # A state written by newer code that this deployment does not know. Refuse rather
+        # than guess — the record is the source of truth and a wrong guess could publish.
+        raise ListingTransitionError(
+            current,
+            target,
+            f"This agent's listing is in an unrecognized state '{current}'. "
+            "It may have been changed by a newer version; reload before retrying.",
+        )
+    if target not in ALLOWED_TRANSITIONS.get(current, set()):
+        raise ListingTransitionError(current, target)
+
+
+def is_published(state: Optional[str]) -> bool:
+    """Whether a listing state means "visible in the store"."""
+    return state == "published"
+
+
+def gsi5_keys(state: Optional[str], category: Optional[str], created_at: str) -> Optional[Dict[str, str]]:
+    """The sparse ``AgentDirectoryIndex`` (GSI5) key pair, or ``None`` when unlisted.
+
+    ``GSI5_PK = LISTED#{category}`` / ``GSI5_SK = CREATED#{created_at}``, written **only**
+    while ``state == "published"`` — the ``DueSyncIndex`` precedent on this same table.
+
+    Returning ``None`` is the caller's signal to REMOVE both attributes, not to skip the
+    write: leaving a stale key behind would keep a delisted agent queryable in the store,
+    which is the exact failure the sparse index exists to prevent.
+
+    ``created_at`` makes browse newest-first. A popularity sort would need a mutable sort
+    key (a hot-item rewrite per use) and is deferred, not approximated — the store front
+    is the manual ranking lever instead.
+    """
+    if not is_published(state):
+        return None
+    if not category:
+        # Defensive: a published listing with no category has no shelf to sit on. The
+        # service validates category at submit and at admin PATCH, so this is a
+        # can't-happen that we refuse to paper over with a "LISTED#None" partition.
+        raise ValueError("A published listing must carry a category.")
+    return {
+        "GSI5_PK": f"LISTED#{category}",
+        "GSI5_SK": f"CREATED#{created_at}",
+    }

--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -1,0 +1,191 @@
+"""Persistence for the Agent Marketplace ``listing`` block and the sparse GSI5 keys.
+
+This is deliberately a *separate* write path from ``service.update_assistant``, for two
+reasons that both bite if ignored:
+
+1. **The generic update cannot own the directory keys.** ``Assistant`` is ``extra="allow"``
+   and reads hydrate straight from the raw DynamoDB item, so ``GSI_PK``/``GSI2_SK``/… come
+   back as extra model fields and ``_update_assistant_cloud`` re-writes every attribute
+   not in its ``immutable_fields`` set. GSI5 is listed there precisely so a routine author
+   edit can never resurrect a directory key on a delisted agent. Only this module writes
+   them.
+2. **Admin edits are not owner edits.** ``update_assistant`` gates on
+   ``get_assistant(id, owner_id)``, an ownership check a reviewer fails by definition
+   (D13 exists so an admin can fix a tagline without the author). The authorization for
+   these writes lives in the service layer, not in an ownership check here.
+
+Every write puts the listing state and its index keys in **one** ``update_item``, so the
+two can never disagree — a published listing always has keys and an unpublished one never
+does, with no window in between.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from .listing import gsi5_keys
+from .models import AgentListing
+from .serialization import from_ddb, to_ddb_safe
+
+logger = logging.getLogger(__name__)
+
+# Attributes this module owns. Nothing else writes them.
+_GSI5_ATTRS = ("GSI5_PK", "GSI5_SK")
+
+
+def _table():
+    """Bind the assistants table, or raise if the environment is not configured."""
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _key(agent_id: str) -> Dict[str, str]:
+    return {"PK": f"AST#{agent_id}", "SK": "METADATA"}
+
+
+async def write_listing(
+    agent_id: str,
+    listing: AgentListing,
+    created_at: str,
+    *,
+    tagline: Optional[str] = None,
+    icon_key: Optional[str] = None,
+    name: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> None:
+    """Persist a listing block and reconcile the sparse directory keys in one write.
+
+    ``created_at`` is the Agent's own creation timestamp — it is the GSI5 sort key, which
+    is why browse is newest-first. The optional presentation fields let an admin D13 edit
+    ride along in the same call rather than racing a second update.
+
+    Raises ``ValueError`` (via the conditional check) if the agent no longer exists.
+    """
+    from botocore.exceptions import ClientError
+
+    keys = gsi5_keys(listing.state, listing.category, created_at)
+
+    set_parts = ["listing = :listing"]
+    values: Dict[str, Any] = {
+        ":listing": to_ddb_safe(listing.model_dump(by_alias=True, exclude_none=True))
+    }
+    names: Dict[str, str] = {}
+    remove_parts = []
+
+    if updated_at is not None:
+        set_parts.append("updatedAt = :updated_at")
+        values[":updated_at"] = updated_at
+
+    if tagline is not None:
+        set_parts.append("tagline = :tagline")
+        values[":tagline"] = tagline
+    if icon_key is not None:
+        set_parts.append("iconKey = :icon_key")
+        values[":icon_key"] = icon_key
+    if name is not None:
+        # ``name`` is a DynamoDB reserved word.
+        set_parts.append("#name = :name")
+        names["#name"] = "name"
+        values[":name"] = name
+
+    if keys:
+        for attr, value in keys.items():
+            set_parts.append(f"{attr} = :{attr.lower()}")
+            values[f":{attr.lower()}"] = value
+    else:
+        # Not published → the keys must not exist. REMOVE is unconditional on purpose:
+        # a stale key would keep a delisted agent answerable by the store query, which is
+        # the single failure the sparse index is there to make impossible.
+        remove_parts.extend(_GSI5_ATTRS)
+
+    expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        expression += " REMOVE " + ", ".join(remove_parts)
+
+    params: Dict[str, Any] = {
+        "Key": _key(agent_id),
+        "UpdateExpression": expression,
+        "ExpressionAttributeValues": values,
+        "ConditionExpression": "attribute_exists(PK)",
+        "ReturnValues": "NONE",
+    }
+    if names:
+        params["ExpressionAttributeNames"] = names
+
+    try:
+        _table().update_item(**params)
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise ValueError(f"Agent not found: {agent_id}") from e
+        logger.error(f"Failed to write listing for {agent_id}: {e}")
+        raise
+
+    logger.info(
+        f"📇 Listing for {agent_id} → {listing.state} "
+        f"({'indexed ' + keys['GSI5_PK'] if keys else 'not indexed'})"
+    )
+
+
+async def clear_listing(agent_id: str) -> None:
+    """Remove the listing block and the directory keys entirely.
+
+    Only for an agent whose listing should return to "never submitted". Not used by the
+    author's unpublish path — that moves to ``private``, which is a different thing: a
+    record that *has* been through review and carries its history.
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        _table().update_item(
+            Key=_key(agent_id),
+            UpdateExpression="REMOVE listing, " + ", ".join(_GSI5_ATTRS),
+            ConditionExpression="attribute_exists(PK)",
+            ReturnValues="NONE",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise ValueError(f"Agent not found: {agent_id}") from e
+        logger.error(f"Failed to clear listing for {agent_id}: {e}")
+        raise
+
+
+async def list_by_state(state: Optional[str] = None) -> list:
+    """Every agent carrying a listing block, optionally filtered to one state.
+
+    Backs the admin Review queue and Listings tables. This is a table scan with a filter
+    on ``attribute_exists(listing)`` — correct for the admin surface, where the population
+    is the handful of agents anyone has ever submitted and the caller is a human clicking
+    a nav item. The *user-facing* browse query is the GSI5 read (Phase 2) and never scans.
+    """
+    from botocore.exceptions import ClientError
+
+    filter_expr = "attribute_exists(listing) AND SK = :sk"
+    values: Dict[str, Any] = {":sk": "METADATA"}
+    if state:
+        filter_expr += " AND listing.#st = :state"
+        values[":state"] = state
+
+    params: Dict[str, Any] = {
+        "FilterExpression": filter_expr,
+        "ExpressionAttributeValues": values,
+    }
+    if state:
+        params["ExpressionAttributeNames"] = {"#st": "state"}
+
+    items = []
+    try:
+        table = _table()
+        response = table.scan(**params)
+        items.extend(response.get("Items", []))
+        while "LastEvaluatedKey" in response:
+            response = table.scan(**params, ExclusiveStartKey=response["LastEvaluatedKey"])
+            items.extend(response.get("Items", []))
+    except ClientError as e:
+        logger.error(f"Failed to list listings: {e}")
+        raise
+
+    return [from_ddb(item) for item in items]

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -2,13 +2,18 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # Agent Designer Phase 1 (D3): the uniform binding kinds. Requests validate against
 # this set; storage tolerates unknown kinds on read so records written by newer code
 # survive a read/write round trip through older code (forward + rollback compat).
 KNOWN_BINDING_KINDS = ("knowledge_base", "tool", "skill", "memory_space")
 BindingKind = Literal["knowledge_base", "tool", "skill", "memory_space"]
+
+# Agent Marketplace Phase 1 (D2): the listing lifecycle. The transition table and the
+# sparse-index key derivation live in ``assistants.listing`` — this is only the wire type.
+ListingState = Literal["private", "in_review", "published", "changes_requested", "taken_down"]
+PublisherKind = Literal["institution", "department", "individual"]
 
 
 class AgentModelConfig(BaseModel):
@@ -44,6 +49,86 @@ class AgentBinding(BaseModel):
     kind: str = Field(..., description="Binding kind (see KNOWN_BINDING_KINDS)")
     ref: str = Field(..., description="Primitive identifier this binding points at")
     config: Dict[str, Any] = Field(default_factory=dict, description="Kind-specific configuration")
+
+
+class AdminEdit(BaseModel):
+    """One admin edit to a listing's presentation fields (D13).
+
+    Recorded so the author can be told what changed and when — "An admin updated the
+    category on Jul 24" on their My Agents card. Editing someone's listing quietly is
+    how you lose authors, so this list is append-only and never pruned on write.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    field: str = Field(..., description="Presentation field that was edited")
+    at: str = Field(..., description="ISO 8601 timestamp of the edit")
+    by: str = Field(..., description="Display name of the admin who made the edit")
+
+
+class AgentListing(BaseModel):
+    """The publication state of an Agent in the marketplace (D2).
+
+    **Absent means never submitted** — that is the D3 backfill default and the reason
+    this is optional on ``Assistant``. Publication is an explicit forward act; nothing
+    derives a listing from ``visibility``, which stays the independent access gate.
+
+    ``extra="allow"`` mirrors ``Assistant``: a block written by newer code (a state or
+    field this deployment does not know) survives a read/write round trip intact.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    state: ListingState = Field(..., description="Publication state (see assistants.listing)")
+    category: str = Field(..., description="Category id; the GSI5 partition while published")
+    publisher_id: str = Field(
+        ...,
+        alias="publisherId",
+        description=(
+            "PublisherProfile this listing is attributed to (D12). DISPLAY ONLY — never "
+            "consult this in an access check; ownerId governs edit rights and Skills v2 "
+            "invoke-through resolution."
+        ),
+    )
+    submitted_at: Optional[str] = Field(None, alias="submittedAt", description="ISO 8601 submission timestamp")
+    submitted_by: Optional[str] = Field(None, alias="submittedBy", description="User id of the submitting author")
+    reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
+    reviewed_by: Optional[str] = Field(None, alias="reviewedBy", description="User id of the reviewing admin")
+    review_note: Optional[str] = Field(
+        None,
+        alias="reviewNote",
+        description="Reviewer's reason; rendered on the author's own card so they never have to ask",
+    )
+    admin_edits: List[AdminEdit] = Field(
+        default_factory=list, alias="adminEdits", description="Append-only log of admin presentation edits (D13)"
+    )
+
+
+class PublisherProfile(BaseModel):
+    """A display identity a listing can be attributed to (D12).
+
+    Separate from ``ownerId`` on purpose: an institutional store needs Agents that speak
+    as the institution rather than as whoever on staff built them. An individual profile
+    is auto-created from the author's display name on their first submission.
+
+    ⚠️ Publisher is display-only. ``verified`` drives a check mark, not a permission, and
+    eligibility (below) is a *proposal* allowlist — an admin may set any publisher on any
+    listing regardless of it. Neither ever appears in an access check.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(..., description="Publisher identifier")
+    label: str = Field(..., description="Display name shown on the shelf and detail page")
+    kind: PublisherKind = Field(..., description="institution | department | individual")
+    verified: bool = Field(
+        False, description="Admin-only check mark meaning 'a university team stands behind this'"
+    )
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the publisher icon")
+    order: int = Field(0, description="Sort order in admin pickers")
+    enabled: bool = Field(True, description="Whether this profile may be proposed or assigned")
+    created_at: Optional[str] = Field(None, alias="createdAt", description="ISO 8601 creation timestamp")
+    updated_at: Optional[str] = Field(None, alias="updatedAt", description="ISO 8601 update timestamp")
 
 
 class Assistant(BaseModel):
@@ -83,6 +168,18 @@ class Assistant(BaseModel):
         None, description="Uniform primitive bindings (D3); absent = synthesize legacy KB binding via compat"
     )
 
+    # Agent Marketplace Phase 1: additive, optional, absent on every existing row. There
+    # is no backfill — an absent ``listing`` IS the D3 default and means "never submitted".
+    tagline: Optional[str] = Field(
+        None, max_length=80, description="Shelf subtitle (D4); distinct from description, which is a summary"
+    )
+    icon_key: Optional[str] = Field(
+        None, alias="iconKey", description="S3 object key for the square icon (D5); absent → generated fallback"
+    )
+    listing: Optional[AgentListing] = Field(
+        None, description="Marketplace publication state (D2); absent = never submitted (D3)"
+    )
+
 
 class CreateAssistantDraftRequest(BaseModel):
     """Request body for creating a draft assistant (minimal fields)"""
@@ -108,6 +205,7 @@ class CreateAssistantRequest(BaseModel):
     # Agent Designer Phase 1 (D3): additive, optional. Validated by binding_validation.
     model_settings: Optional[AgentModelConfig] = Field(None, alias="modelConfig", description="Governed single-select model")
     bindings: Optional[List[AgentBinding]] = Field(None, description="Uniform primitive bindings")
+    tagline: Optional[str] = Field(None, max_length=80, description="Shelf subtitle (D4)")
 
 
 class UpdateAssistantRequest(BaseModel):
@@ -127,6 +225,9 @@ class UpdateAssistantRequest(BaseModel):
     # Agent Designer Phase 1 (D3): additive, optional. Validated by binding_validation.
     model_settings: Optional[AgentModelConfig] = Field(None, alias="modelConfig", description="Governed single-select model")
     bindings: Optional[List[AgentBinding]] = Field(None, description="Uniform primitive bindings")
+    # Marketplace: the author owns their own tagline. Admins may also edit it, but only
+    # through PATCH /admin/agents/{id}/listing, which records the edit (D13).
+    tagline: Optional[str] = Field(None, max_length=80, description="Shelf subtitle (D4)")
 
 
 class AssistantResponse(BaseModel):
@@ -196,6 +297,13 @@ class AgentResponse(BaseModel):
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 creation timestamp")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 update timestamp")
 
+    # Marketplace Phase 1. All three are ``None`` on an agent that has never been
+    # submitted, and the routes serve this model with ``response_model_exclude_none``,
+    # so an unsubmitted agent's payload is byte-identical to before this shipped.
+    tagline: Optional[str] = Field(None, description="Shelf subtitle (D4)")
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon (D5)")
+    listing: Optional[AgentListing] = Field(None, description="Publication state (D2); absent = never submitted")
+
     # Share metadata (parity with AssistantResponse; set post-projection)
     first_interacted: Optional[bool] = Field(None, alias="firstInteracted")
     is_shared_with_me: Optional[bool] = Field(None, alias="isSharedWithMe")
@@ -247,6 +355,221 @@ class BindableListResponse(BaseModel):
 
     kind: str = Field(..., description="The requested primitive kind")
     items: List[BindableItem] = Field(default_factory=list, description="Primitives the caller may bind")
+
+
+# ─────────────────────────────────────────────────────── Agent Marketplace (Phase 1)
+# Behavior fields, named once so the D13 guard and its test agree on the list. An admin
+# may edit everything the store *renders*; an admin may never edit what the agent *does*
+# — that would make the reviewer responsible for behavior they did not write and cannot
+# test, and would silently break an Agent its author still maintains.
+BEHAVIOR_FIELDS = ("instructions", "bindings", "modelConfig", "model_settings", "starters", "visibility")
+
+# Presentation fields an admin may edit on someone else's listing (D13).
+ADMIN_EDITABLE_FIELDS = ("name", "tagline", "iconKey", "category", "publisherId")
+
+
+class SubmitListingRequest(BaseModel):
+    """Author submits an Agent for review (D2). Runs the D7 disclosure checks."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    category: str = Field(..., description="Category id; must be a known category")
+    publisher_id: Optional[str] = Field(
+        None,
+        alias="publisherId",
+        description=(
+            "Proposed PublisherProfile (D12). Omit to use the author's own individual "
+            "profile, which is auto-created on first submission."
+        ),
+    )
+    note: Optional[str] = Field(None, max_length=2000, description="Optional note to the reviewer")
+
+
+class SkillExposure(BaseModel):
+    """One skill that publication would make readable (D7.1)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    ref: str = Field(..., description="Skill identifier")
+    label: str = Field(..., description="Skill display name, for the submit dialog's enumeration")
+
+
+class ListingSubmissionResponse(BaseModel):
+    """The resulting listing plus the disclosures the author was shown (D7)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    listing: AgentListing = Field(..., description="The listing after the transition")
+    exposed_skills: List[SkillExposure] = Field(
+        default_factory=list,
+        alias="exposedSkills",
+        description="Skills the author wrote that become readable to anyone who runs this agent (D7.1)",
+    )
+
+
+class ReviewListingRequest(BaseModel):
+    """Admin approves a submission or returns it with a reason (D2)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    decision: Literal["approve", "request_changes"] = Field(..., description="Reviewer's decision")
+    note: Optional[str] = Field(
+        None, max_length=2000, description="Reason; required for request_changes, renders on the author's card"
+    )
+    category: Optional[str] = Field(None, description="Optionally recategorize at approval (D12/D13)")
+    publisher_id: Optional[str] = Field(
+        None, alias="publisherId", description="Optionally reattribute at approval — approval makes it authoritative (D12)"
+    )
+
+
+class TakedownRequest(BaseModel):
+    """Admin delists a published Agent (D2). A delisting, not a revocation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    reason: str = Field(..., min_length=1, max_length=2000, description="Reason sent to the author")
+
+
+class AdminListingPatchRequest(BaseModel):
+    """Presentation-only edit to a listing (D13).
+
+    Every field the browse and detail pages render must be admin-editable without the
+    author's involvement — a typo in a tagline or an off-brand icon should not require a
+    round trip. Behavior stays with the author, and this model is where that line is
+    enforced: ``extra="forbid"`` rejects anything not listed here, and the validator
+    below turns the specific behavior-field case into a message that says *why*.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: Optional[str] = Field(None, min_length=1, description="Agent display name")
+    tagline: Optional[str] = Field(None, max_length=80, description="Shelf subtitle")
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon")
+    category: Optional[str] = Field(None, description="Category id; rewrites the GSI5 partition while published")
+    publisher_id: Optional[str] = Field(
+        None, alias="publisherId", description="Attribution (D12) — display only, never an access grant"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_behavior_fields(cls, data: Any) -> Any:
+        """Name the behavior fields explicitly rather than leaving a bare 'extra inputs'.
+
+        ``extra="forbid"`` already blocks these; this exists so the reviewer is told the
+        rule instead of the symptom.
+        """
+        if isinstance(data, dict):
+            offending = [f for f in BEHAVIOR_FIELDS if f in data]
+            if offending:
+                raise ValueError(
+                    f"Cannot edit agent behavior from the listing surface: {', '.join(sorted(set(offending)))}. "
+                    "Admins may edit presentation only "
+                    f"({', '.join(ADMIN_EDITABLE_FIELDS)}); behavior belongs to the agent's author."
+                )
+        return data
+
+
+class AdminListingRow(BaseModel):
+    """One row in the admin Review queue or Listings table."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    name: str = Field(..., description="Agent display name")
+    tagline: Optional[str] = Field(None, description="Shelf subtitle")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon")
+    owner_name: str = Field(..., alias="ownerName", description="Author display name — who to talk to about behavior")
+    publisher: Optional[PublisherProfile] = Field(None, description="Resolved attribution (D12), display only")
+    category: str = Field(..., description="Category id")
+    state: ListingState = Field(..., description="Publication state")
+    usage_count: int = Field(0, alias="usageCount", description="Chats — admin reporting only, never shelf furniture (D4)")
+    submitted_at: Optional[str] = Field(None, alias="submittedAt", description="ISO 8601 submission timestamp")
+    reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
+    review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
+    updated_at: str = Field(..., alias="updatedAt", description="Audit trail for post-approval drift (D2)")
+    admin_edits: List[AdminEdit] = Field(default_factory=list, alias="adminEdits", description="Admin edit log (D13)")
+
+
+class AdminListingsResponse(BaseModel):
+    """Rows for the admin Review queue / Listings tables, plus the nav pending count."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    listings: List[AdminListingRow] = Field(default_factory=list, description="Matching listings")
+    pending_count: int = Field(
+        0, alias="pendingCount", description="Submissions awaiting review; badges the admin nav (D2)"
+    )
+
+
+class PublisherCreateRequest(BaseModel):
+    """Create an admin-managed publisher profile (D12)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., min_length=1, description="Display name")
+    kind: PublisherKind = Field("department", description="institution | department | individual")
+    verified: bool = Field(False, description="Admin-only check mark")
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key")
+    order: int = Field(0, description="Sort order")
+    enabled: bool = Field(True, description="Whether the profile may be proposed or assigned")
+
+
+class PublisherUpdateRequest(BaseModel):
+    """Update a publisher profile (D12). All fields optional."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: Optional[str] = Field(None, min_length=1, description="Display name")
+    kind: Optional[PublisherKind] = Field(None, description="institution | department | individual")
+    verified: Optional[bool] = Field(None, description="Admin-only check mark")
+    icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key")
+    order: Optional[int] = Field(None, description="Sort order")
+    enabled: Optional[bool] = Field(None, description="Whether the profile may be proposed or assigned")
+
+
+class PublishersResponse(BaseModel):
+    """All publisher profiles, ordered."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    publishers: List[PublisherProfile] = Field(default_factory=list, description="Publisher profiles")
+
+
+class PublisherEligibilityRequest(BaseModel):
+    """Replace the set of users who may *propose* a publisher (D12).
+
+    An allowlist for the submit dialog only. An admin may set any publisher on any
+    listing regardless of eligibility, so this never appears in an access check.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_ids: List[str] = Field(
+        default_factory=list, alias="userIds", description="Users who may propose this publisher at submission"
+    )
+
+
+class PublisherEligibilityResponse(BaseModel):
+    """Who may currently propose a publisher (D12)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    publisher_id: str = Field(..., alias="publisherId", description="Publisher identifier")
+    user_ids: List[str] = Field(default_factory=list, alias="userIds", description="Eligible user ids")
+
+
+class AgentCategoriesResponse(BaseModel):
+    """The category set a listing may reference.
+
+    Phase 1 serves the ``DEFAULT_CATEGORIES`` constant; Phase 2 serves admin-managed
+    records from the same route with no shape change.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    categories: List[str] = Field(default_factory=list, description="Category ids in browse order")
 
 
 class AssistantTestChatRequest(BaseModel):

--- a/backend/src/apis/shared/assistants/publishers.py
+++ b/backend/src/apis/shared/assistants/publishers.py
@@ -1,0 +1,201 @@
+"""Publisher profiles and per-user eligibility (Agent Marketplace D12).
+
+Attribution motivates publication — people build better Agents when their name is on them
+— but an institutional store also needs Agents that speak *as the institution*. Both are
+true, so publisher is its own record rather than a projection of ``ownerName``.
+
+Storage follows the ``UserMenuLink`` precedent on the assistants table: a fixed partition
+with per-item records carrying an explicit ``order``, sorted on read.
+
+    PK = "AGENT_PUBLISHERS", SK = "PUB#{id}"                    a PublisherProfile
+    PK = "AGENT_PUBLISHERS", SK = "ELIG#{publisherId}#{userId}" who may *propose* it
+
+⚠️ Nothing in this module is an access control. ``publisherId`` is display-only, and the
+eligibility items are a proposal allowlist for the submit dialog — an admin may set any
+publisher on any listing regardless of them (D12). ``ownerId`` continues to govern edit
+rights and Skills v2 invoke-through resolution. This is the same trap as ``allowedAppRoles``
+on a resource: a display projection that looks like a grant will eventually be read as one,
+so it must never reach an access check.
+"""
+
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .models import PublisherProfile
+
+logger = logging.getLogger(__name__)
+
+_PARTITION = "AGENT_PUBLISHERS"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _individual_id(user_id: str) -> str:
+    """Deterministic id for a user's own individual profile.
+
+    Deterministic so first-submission auto-creation is idempotent: a second submission
+    finds the existing profile instead of minting a duplicate under a new uuid. The user
+    id is slugified because it lands in a sort key.
+    """
+    slug = re.sub(r"[^a-zA-Z0-9_-]", "-", user_id).strip("-").lower()
+    return f"user-{slug}" if slug else f"user-{uuid.uuid4().hex[:12]}"
+
+
+# ── profiles ─────────────────────────────────────────────────────────────────────────
+async def list_publishers(enabled_only: bool = False) -> List[PublisherProfile]:
+    """All publisher profiles, ordered by ``(order, label)``."""
+    from boto3.dynamodb.conditions import Key
+
+    table = _table()
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(_PARTITION) & Key("SK").begins_with("PUB#")
+    }
+    response = table.query(**kwargs)
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
+        items.extend(response.get("Items", []))
+
+    profiles = [PublisherProfile.model_validate(_strip_keys(i)) for i in items]
+    if enabled_only:
+        profiles = [p for p in profiles if p.enabled]
+    profiles.sort(key=lambda p: (p.order, p.label.lower()))
+    return profiles
+
+
+def _strip_keys(item: dict) -> dict:
+    """Drop the DynamoDB key attributes before validating into the wire model."""
+    return {k: v for k, v in item.items() if k not in ("PK", "SK")}
+
+
+async def get_publisher(publisher_id: str) -> Optional[PublisherProfile]:
+    response = _table().get_item(Key={"PK": _PARTITION, "SK": f"PUB#{publisher_id}"})
+    item = response.get("Item")
+    return PublisherProfile.model_validate(_strip_keys(item)) if item else None
+
+
+async def put_publisher(profile: PublisherProfile) -> PublisherProfile:
+    """Create or replace a publisher profile."""
+    item = profile.model_dump(by_alias=True, exclude_none=True)
+    item["PK"] = _PARTITION
+    item["SK"] = f"PUB#{profile.id}"
+    _table().put_item(Item=item)
+    logger.info(f"📛 Wrote publisher profile {profile.id} ({profile.kind})")
+    return profile
+
+
+async def delete_publisher(publisher_id: str) -> None:
+    """Delete a publisher profile and every eligibility item pointing at it."""
+    table = _table()
+    table.delete_item(Key={"PK": _PARTITION, "SK": f"PUB#{publisher_id}"})
+    for user_id in await list_eligibility(publisher_id):
+        table.delete_item(Key={"PK": _PARTITION, "SK": f"ELIG#{publisher_id}#{user_id}"})
+
+
+async def ensure_individual_profile(user_id: str, display_name: str) -> PublisherProfile:
+    """Return the author's own individual profile, creating it on first submission (D12).
+
+    Created ``verified: False`` — individual profiles are never verified; that mark means
+    "a university team stands behind this". Comes with an eligibility item for that author
+    alone, so they can propose themselves and nobody else can propose as them.
+    """
+    publisher_id = _individual_id(user_id)
+    existing = await get_publisher(publisher_id)
+    if existing:
+        return existing
+
+    now = _now()
+    profile = PublisherProfile(
+        id=publisher_id,
+        label=display_name or user_id,
+        kind="individual",
+        verified=False,
+        order=100,  # individuals sort below curated institution/department profiles
+        enabled=True,
+        created_at=now,
+        updated_at=now,
+    )
+    await put_publisher(profile)
+    await add_eligibility(publisher_id, user_id)
+    return profile
+
+
+# ── eligibility (proposal allowlist only — never an access check) ────────────────────
+async def list_eligibility(publisher_id: str) -> List[str]:
+    """User ids who may *propose* this publisher at submission."""
+    from boto3.dynamodb.conditions import Key
+
+    prefix = f"ELIG#{publisher_id}#"
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(_PARTITION) & Key("SK").begins_with(prefix)
+    }
+    table = _table()
+    response = table.query(**kwargs)
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
+        items.extend(response.get("Items", []))
+    return sorted(str(i["SK"])[len(prefix):] for i in items)
+
+
+async def add_eligibility(publisher_id: str, user_id: str) -> None:
+    _table().put_item(
+        Item={
+            "PK": _PARTITION,
+            "SK": f"ELIG#{publisher_id}#{user_id}",
+            "publisherId": publisher_id,
+            "userId": user_id,
+            "createdAt": _now(),
+        }
+    )
+
+
+async def set_eligibility(publisher_id: str, user_ids: List[str]) -> List[str]:
+    """Replace the eligibility set for a publisher; returns the resulting ids."""
+    current = set(await list_eligibility(publisher_id))
+    target = {u for u in user_ids if u}
+    table = _table()
+
+    for user_id in target - current:
+        await add_eligibility(publisher_id, user_id)
+    for user_id in current - target:
+        table.delete_item(Key={"PK": _PARTITION, "SK": f"ELIG#{publisher_id}#{user_id}"})
+
+    return sorted(target)
+
+
+async def list_publishers_for_user(user_id: str) -> List[str]:
+    """Publisher ids this user may propose (their own, plus any an admin granted).
+
+    Used only to populate and validate the submit dialog's picker. An admin's assignment
+    path does not consult it.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(_PARTITION) & Key("SK").begins_with("ELIG#"),
+        "FilterExpression": "userId = :uid",
+        "ExpressionAttributeValues": {":uid": user_id},
+    }
+    table = _table()
+    response = table.query(**kwargs)
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
+        items.extend(response.get("Items", []))
+    return sorted({str(i["publisherId"]) for i in items if i.get("publisherId")})

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -91,6 +91,7 @@ async def create_assistant(
     emoji: Optional[str] = None,
     bindings: Optional[List[AgentBinding]] = None,
     model_settings: Optional[AgentModelConfig] = None,
+    tagline: Optional[str] = None,
 ) -> Assistant:
     """
     Create a complete assistant with all required fields
@@ -134,6 +135,7 @@ async def create_assistant(
         status="COMPLETE",
         bindings=bindings,
         model_settings=model_settings,
+        tagline=tagline,
     )
 
     # Store the assistant
@@ -466,6 +468,7 @@ async def update_assistant(
     image_url: Optional[str] = None,
     bindings: Optional[List[AgentBinding]] = None,
     model_settings: Optional[AgentModelConfig] = None,
+    tagline: Optional[str] = None,
 ) -> Optional[Assistant]:
     """
     Update assistant fields (deep merge)
@@ -520,6 +523,8 @@ async def update_assistant(
         updates["bindings"] = bindings
     if model_settings is not None:
         updates["model_settings"] = model_settings
+    if tagline is not None:
+        updates["tagline"] = tagline
 
     # Always update the updated_at timestamp
     updates["updated_at"] = _get_current_timestamp()
@@ -572,8 +577,21 @@ async def _update_assistant_cloud(assistant: Assistant, table_name: str) -> None
         expression_attribute_values = {}
         expression_attribute_names = {}
 
-        # Fields that should never be updated (immutable or composite keys)
-        immutable_fields = {"PK", "SK", "GSI_PK", "GSI_SK", "GSI2_PK", "GSI2_SK", "assistantId", "createdAt", "ownerId"}
+        # Fields that should never be updated (immutable or composite keys).
+        #
+        # GSI5_* and ``listing`` belong to the marketplace write path
+        # (``assistants.listing_repository``) and must NOT be rewritten from here.
+        # Reads hydrate ``Assistant`` (extra="allow") straight from the raw item, so the
+        # index keys round-trip as extra model fields; without this guard a routine author
+        # edit would re-write a stale GSI5 key onto a delisted agent and silently put it
+        # back in the store. ``listing`` is excluded for the same reason in the other
+        # direction: a stale in-memory copy must not clobber a concurrent review decision.
+        immutable_fields = {
+            "PK", "SK",
+            "GSI_PK", "GSI_SK", "GSI2_PK", "GSI2_SK", "GSI5_PK", "GSI5_SK",
+            "assistantId", "createdAt", "ownerId",
+            "listing",
+        }
 
         # Always update updatedAt
         update_parts.append("updatedAt = :updated_at")

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -109,3 +109,28 @@ def agents_enabled() -> bool:
     nav is separately preview-gated (system-admin) until Assistants are deprecated.
     """
     return os.environ.get("AGENTS_API_ENABLED", "").strip().lower() != "false"
+
+
+def agent_marketplace_enabled() -> bool:
+    """Whether the Agent Marketplace surface is enabled for this environment.
+
+    Covers the listing lifecycle (submit / review / takedown), publisher profiles, and
+    the admin Review queue + Listings pages. **Default ON with a kill switch** (house
+    style, mirroring ``agents_enabled``): unset or empty resolves to enabled; only the
+    literal ``"false"`` (case-insensitive) disables. The CDK side threads
+    ``config.agentMarketplace.enabled`` into this env var with the same empty-string-safe
+    ternary, so an unset GitHub Actions variable can never silently turn it off.
+
+    App-api only. The marketplace adds no inference-api routes — publication is a
+    catalog concern, and the inference API stays inference-only.
+
+    NOTE on the spec's D14: it also calls for an ``agent-marketplace`` RBAC *capability*
+    that 404s the routes for ungranted roles, "mirroring the ``skills`` gate from Skills
+    v2 PR-5". That gate no longer exists — it was removed because a capability id cannot
+    be granted from the admin roles UI (see ``skills_enabled`` above and
+    ``AppRoleService.resolve_user_permissions``), so copying it would ship a gate nobody
+    can open. Phase 1 is admin routes plus two author routes with no user-facing surface,
+    which ``require_admin`` and the per-agent ownership checks already cover. Revisit when
+    Phase 2 makes Discover user-visible and a real "who sees the store" control is needed.
+    """
+    return os.environ.get("AGENT_MARKETPLACE_ENABLED", "").strip().lower() != "false"

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -1,0 +1,387 @@
+"""Agent Marketplace Phase 1 — the admin review / listings surface (D2, D12, D13).
+
+The rule this file exists to hold in place is D13's split: an admin may edit everything
+the store *renders* and nothing about what the agent *does*. The second rule, quieter but
+more dangerous to lose, is that ``publisherId`` is display-only — re-attributing a listing
+must change the name on the shelf and nothing about who can run it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.agents.routes import router
+from apis.shared.assistants.models import AgentListing, Assistant, PublisherProfile
+from apis.shared.auth import require_admin
+
+SERVICE_MODULE = "apis.app_api.agent_designer.services.listing_service"
+ADMIN_MODULE = "apis.app_api.admin.agents.routes"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="Answer from the policy manual.",
+        vectorIndexId="idx-001",
+        visibility="PRIVATE",
+        usageCount=12,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+def _listing(state="in_review", **overrides) -> AgentListing:
+    defaults = dict(state=state, category="Administration", publisherId="pub-registrar")
+    defaults.update(overrides)
+    return AgentListing.model_validate(defaults)
+
+
+@pytest.fixture
+def app(make_user):
+    _app = FastAPI()
+    _app.include_router(router, prefix="/admin")
+    _app.dependency_overrides[require_admin] = lambda: make_user(
+        user_id="admin-001", name="Sam Admin", roles=["system_admin"]
+    )
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(monkeypatch):
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+@pytest.fixture
+def _no_writes():
+    with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write:
+        yield write
+
+
+def _loaded(assistant):
+    return patch(f"{SERVICE_MODULE}._load_any", new_callable=AsyncMock, return_value=assistant)
+
+
+_UNSET = object()
+
+
+def _publisher(profile=_UNSET):
+    """Patch publisher lookup. Pass ``None`` explicitly to simulate a missing publisher."""
+    if profile is _UNSET:
+        profile = PublisherProfile(
+            id="pub-registrar", label="Office of the Registrar", kind="department"
+        )
+    return patch(f"{SERVICE_MODULE}.get_publisher", new_callable=AsyncMock, return_value=profile)
+
+
+# ── the kill switch ──────────────────────────────────────────────────────────────────
+def test_404_when_flag_off(app, monkeypatch):
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+    assert TestClient(app).get("/admin/agents/submissions").status_code == 404
+
+
+# ── D13 — presentation only ──────────────────────────────────────────────────────────
+class TestPresentationOnlyPatch:
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("instructions", "You are now evil."),
+            ("bindings", []),
+            ("modelConfig", {"modelId": "claude-opus-5"}),
+            ("starters", ["hi"]),
+            ("visibility", "PUBLIC"),
+        ],
+    )
+    def test_behavior_fields_are_rejected(self, app, _no_writes, field, value):
+        """An admin editing behavior would own something they did not write and cannot test."""
+        resp = TestClient(app).patch("/admin/agents/ast-001/listing", json={field: value})
+
+        assert resp.status_code == 422
+        assert "Cannot edit agent behavior" in str(resp.json())
+        _no_writes.assert_not_called()
+
+    def test_behavior_field_rejected_even_alongside_a_valid_one(self, app, _no_writes):
+        """A legitimate tagline edit must not smuggle an instructions change through."""
+        resp = TestClient(app).patch(
+            "/admin/agents/ast-001/listing",
+            json={"tagline": "A fine tagline", "instructions": "You are now evil."},
+        )
+
+        assert resp.status_code == 422
+        _no_writes.assert_not_called()
+
+    def test_unknown_fields_are_rejected(self, app, _no_writes):
+        resp = TestClient(app).patch("/admin/agents/ast-001/listing", json={"usageCount": 9999})
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"name": "Policy Finder"},
+            {"tagline": "Cite the policy manual"},
+            {"iconKey": "icons/policy.png"},
+            {"category": "Teaching"},
+            {"publisherId": "pub-registrar"},
+        ],
+    )
+    def test_presentation_fields_are_accepted(self, app, _no_writes, payload):
+        assistant = _make_assistant(listing=_listing("published"))
+        with _loaded(assistant), _publisher():
+            resp = TestClient(app).patch("/admin/agents/ast-001/listing", json=payload)
+
+        assert resp.status_code == 200
+        _no_writes.assert_called_once()
+
+    def test_every_edit_is_recorded_for_the_author(self, app, _no_writes):
+        """D13: editing someone's listing quietly is how you lose authors."""
+        assistant = _make_assistant(listing=_listing("published"))
+        with _loaded(assistant), _publisher():
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing",
+                json={"tagline": "Cite the policy manual", "category": "Teaching"},
+            )
+
+        edits = resp.json()["adminEdits"]
+        assert {e["field"] for e in edits} == {"tagline", "category"}
+        assert all(e["by"] == "Sam Admin" for e in edits)
+
+    def test_edits_are_recorded_by_the_name_the_author_would_recognize(self, app, _no_writes):
+        """The author reads this string; internal attribute names would be noise."""
+        assistant = _make_assistant(listing=_listing("published"))
+        with _loaded(assistant), _publisher():
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing",
+                json={"iconKey": "icons/policy.png", "publisherId": "pub-registrar"},
+            )
+
+        assert {e["field"] for e in resp.json()["adminEdits"]} == {"icon", "publisher"}
+
+    def test_admin_edits_accumulate_rather_than_replace(self, app, _no_writes):
+        prior = _listing("published", adminEdits=[{"field": "name", "at": "2026-07-01Z", "by": "Prior"}])
+        with _loaded(_make_assistant(listing=prior)), _publisher():
+            resp = TestClient(app).patch("/admin/agents/ast-001/listing", json={"tagline": "New"})
+
+        assert [e["field"] for e in resp.json()["adminEdits"]] == ["name", "tagline"]
+
+    def test_unknown_category_is_rejected(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published"))):
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"category": "Miscellaneous"}
+            )
+        assert resp.status_code == 400
+
+    def test_empty_patch_is_rejected(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published"))):
+            resp = TestClient(app).patch("/admin/agents/ast-001/listing", json={})
+        assert resp.status_code == 400
+
+    def test_patching_an_unsubmitted_agent_is_404(self, app, _no_writes):
+        with _loaded(_make_assistant()):
+            resp = TestClient(app).patch("/admin/agents/ast-001/listing", json={"tagline": "x"})
+        assert resp.status_code == 404
+
+
+# ── D12 — publisher is display only ──────────────────────────────────────────────────
+class TestPublisherIsDisplayOnly:
+    def test_reattribution_does_not_touch_ownership(self, app, _no_writes):
+        """The trap this guards: a display projection that looks like a grant.
+
+        ``ownerId`` governs edit rights and Skills v2 invoke-through
+        (``skill.owner_id == agent.owner_id``). Changing the name on the shelf must leave
+        both untouched.
+        """
+        assistant = _make_assistant(listing=_listing("published"))
+        institution = PublisherProfile(id="pub-bsu", label="Boise State", kind="institution", verified=True)
+
+        with _loaded(assistant), _publisher(institution):
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"publisherId": "pub-bsu"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["publisherId"] == "pub-bsu"
+        # The agent record's owner is untouched, and the write carried no owner change.
+        assert assistant.owner_id == "user-author"
+        written_listing = _no_writes.call_args.args[1]
+        assert not hasattr(written_listing, "owner_id")
+
+    def test_admin_may_attribute_to_a_publisher_the_author_is_not_eligible_for(
+        self, app, _no_writes
+    ):
+        """D12: this is how the store gets official Agents without a staff member's name.
+
+        Eligibility is a *proposal* allowlist on the author's path only — the admin path
+        must not consult it, so ``list_publishers_for_user`` is never called here.
+        """
+        assistant = _make_assistant(listing=_listing("published"))
+        with _loaded(assistant), _publisher(), patch(
+            f"{SERVICE_MODULE}.list_publishers_for_user", new_callable=AsyncMock
+        ) as eligibility:
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"publisherId": "pub-registrar"}
+            )
+
+        assert resp.status_code == 200
+        eligibility.assert_not_called()
+
+    def test_unknown_publisher_is_rejected(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published"))), _publisher(None):
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"publisherId": "pub-ghost"}
+            )
+        assert resp.status_code == 400
+
+
+# ── D2 — review + takedown ───────────────────────────────────────────────────────────
+class TestReview:
+    def test_approve_publishes(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "approve"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "published"
+        assert resp.json()["reviewedBy"] == "admin-001"
+
+    def test_request_changes_requires_a_reason(self, app, _no_writes):
+        """The reason renders on the author's card so they never have to ask what happened."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "request_changes"}
+            )
+
+        assert resp.status_code == 400
+        assert "reason" in resp.json()["detail"]
+        _no_writes.assert_not_called()
+
+    def test_request_changes_with_a_reason(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "request_changes", "note": "Please add a tagline."},
+            )
+
+        assert resp.json()["state"] == "changes_requested"
+        assert resp.json()["reviewNote"] == "Please add a tagline."
+
+    def test_reviewer_may_recategorize_at_approval(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "approve", "category": "Teaching"},
+            )
+
+        assert resp.json()["category"] == "Teaching"
+
+    def test_cannot_approve_something_not_in_review(self, app, _no_writes):
+        """Approval is the only door into the store, and in_review is the only way to it."""
+        with _loaded(_make_assistant(listing=_listing("private"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "approve"}
+            )
+
+        assert resp.status_code == 400
+        _no_writes.assert_not_called()
+
+    def test_reviewing_an_unsubmitted_agent_is_404(self, app, _no_writes):
+        with _loaded(_make_assistant()):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "approve"}
+            )
+        assert resp.status_code == 404
+
+
+class TestTakedown:
+    def test_takedown_delists(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/takedown", json={"reason": "Off-brand icon."}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "taken_down"
+        assert resp.json()["reviewNote"] == "Off-brand icon."
+
+    def test_takedown_requires_a_reason(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published"))):
+            resp = TestClient(app).post("/admin/agents/ast-001/takedown", json={"reason": ""})
+        assert resp.status_code == 422
+
+    def test_cannot_take_down_something_not_published(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/takedown", json={"reason": "nope"}
+            )
+        assert resp.status_code == 400
+
+
+# ── the tables ───────────────────────────────────────────────────────────────────────
+class TestAdminTables:
+    def test_submissions_returns_the_queue_with_a_pending_count(self, app):
+        rows = [
+            {
+                "PK": "AST#ast-001",
+                **_make_assistant(listing=_listing("in_review", submittedAt="2026-07-20Z")).model_dump(
+                    by_alias=True, exclude_none=True
+                ),
+            }
+        ]
+        with patch(f"{SERVICE_MODULE}.list_by_state", new_callable=AsyncMock, return_value=rows), patch(
+            f"{SERVICE_MODULE}.list_publishers",
+            new_callable=AsyncMock,
+            return_value=[
+                PublisherProfile(id="pub-registrar", label="Office of the Registrar", kind="department")
+            ],
+        ):
+            resp = TestClient(app).get("/admin/agents/submissions")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["pendingCount"] == 1
+        row = body["listings"][0]
+        # The queue row carries who to talk to about behavior (the author) and the
+        # attribution separately — they are different people by design (D12).
+        assert row["ownerName"] == "Ada Author"
+        assert row["publisher"]["label"] == "Office of the Registrar"
+        assert row["state"] == "in_review"
+
+    def test_listings_ignores_records_that_were_never_submitted(self, app):
+        rows = [{"PK": "AST#ast-002", **_make_assistant().model_dump(by_alias=True, exclude_none=True)}]
+        with patch(f"{SERVICE_MODULE}.list_by_state", new_callable=AsyncMock, return_value=rows), patch(
+            f"{SERVICE_MODULE}.list_publishers", new_callable=AsyncMock, return_value=[]
+        ):
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"] == []
+
+    def test_row_renders_without_a_resolved_publisher(self, app):
+        """A deleted publisher leaves a visible gap to reassign, not a 500."""
+        rows = [
+            {
+                "PK": "AST#ast-001",
+                **_make_assistant(listing=_listing("published")).model_dump(
+                    by_alias=True, exclude_none=True
+                ),
+            }
+        ]
+        with patch(f"{SERVICE_MODULE}.list_by_state", new_callable=AsyncMock, return_value=rows), patch(
+            f"{SERVICE_MODULE}.list_publishers", new_callable=AsyncMock, return_value=[]
+        ):
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"][0]["publisher"] is None
+
+    def test_categories_are_served_for_the_pickers(self, app):
+        resp = TestClient(app).get("/admin/agents/categories")
+        assert resp.status_code == 200
+        assert "Administration" in resp.json()["categories"]

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -1,0 +1,311 @@
+"""Agent Marketplace Phase 1 — the author's submit / withdraw routes (D2, D7, D12).
+
+The load-bearing cases here are the D7 checks, because they are the only place the cost
+of publishing is made visible to the person paying it: a memory-space binding blocks
+submission outright, and skill exposure is enumerated before a reviewer's time is spent.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.agent_designer.routes import router
+from apis.shared.assistants.models import AgentBinding, AgentListing, Assistant
+from tests.routes.conftest import mock_auth_user
+
+ROUTES_MODULE = "apis.app_api.agent_designer.routes"
+SERVICE_MODULE = "apis.app_api.agent_designer.services.listing_service"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-001",
+        ownerName="Test User",
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="Answer from the policy manual.",
+        vectorIndexId="idx-001",
+        visibility="PRIVATE",
+        usageCount=0,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def _flags_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+@pytest.fixture
+def _no_writes():
+    """Stub the persistence + publisher resolution so tests exercise decisions, not I/O."""
+    with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write, patch(
+        f"{SERVICE_MODULE}.ensure_individual_profile",
+        new_callable=AsyncMock,
+        return_value=SimpleNamespace(id="user-user-001"),
+    ):
+        yield write
+
+
+def _owner(assistant):
+    return patch(
+        f"{SERVICE_MODULE}.resolve_assistant_permission",
+        new_callable=AsyncMock,
+        return_value=(assistant, "owner"),
+    )
+
+
+# ── the kill switch ──────────────────────────────────────────────────────────────────
+class TestFeatureGate:
+    def test_404_when_marketplace_flag_off(self, app, make_user, monkeypatch):
+        monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+        mock_auth_user(app, make_user())
+        resp = TestClient(app).post(
+            "/agents/ast-001/listing/submit", json={"category": "Administration"}
+        )
+        assert resp.status_code == 404
+
+    def test_404_when_the_agent_surface_itself_is_off(self, app, make_user, monkeypatch):
+        """The marketplace is a surface over Agents; it cannot outlive them."""
+        monkeypatch.setenv("AGENTS_API_ENABLED", "false")
+        mock_auth_user(app, make_user())
+        resp = TestClient(app).post(
+            "/agents/ast-001/listing/submit", json={"category": "Administration"}
+        )
+        assert resp.status_code == 404
+
+
+# ── D7.2 — memory spaces block submission ────────────────────────────────────────────
+class TestMemorySpaceBlock:
+    def test_memory_space_binding_blocks_submission_and_names_the_space(
+        self, app, make_user, _no_writes
+    ):
+        """A memory space is personal data — a published agent bound to one fails for everyone."""
+        assistant = _make_assistant(
+            bindings=[AgentBinding(kind="memory_space", ref="mem-042", config={})]
+        )
+        space = SimpleNamespace(space_id="mem-042", name="Oliver", owner_id="user-001")
+
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.MemorySpaceService") as svc:
+            svc.return_value.list_spaces_for_user.return_value = [(space, "owner")]
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "Oliver" in detail, "the message must name the space, not just its id"
+        assert "memory space" in detail.lower()
+
+    def test_block_falls_back_to_the_ref_when_the_name_cannot_be_resolved(
+        self, app, make_user, _no_writes
+    ):
+        assistant = _make_assistant(
+            bindings=[AgentBinding(kind="memory_space", ref="mem-042", config={})]
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.MemorySpaceService") as svc:
+            svc.return_value.list_spaces_for_user.side_effect = RuntimeError("boom")
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        assert resp.status_code == 400
+        assert "mem-042" in resp.json()["detail"]
+
+    def test_blocked_submission_writes_nothing(self, app, make_user, _no_writes):
+        """A blocked submission must not leave a half-built listing behind."""
+        assistant = _make_assistant(
+            bindings=[AgentBinding(kind="memory_space", ref="mem-042", config={})]
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.MemorySpaceService") as svc:
+            svc.return_value.list_spaces_for_user.return_value = []
+            TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        _no_writes.assert_not_called()
+
+
+# ── D7.1 — skill exposure is enumerated ──────────────────────────────────────────────
+class TestSkillDisclosure:
+    def test_submission_enumerates_the_authors_own_skills(self, app, make_user, _no_writes):
+        """Publishing publishes the contents of every skill the author wrote and bound."""
+        assistant = _make_assistant(
+            bindings=[
+                AgentBinding(kind="skill", ref="skill-a", config={}),
+                AgentBinding(kind="skill", ref="skill-b", config={}),
+            ]
+        )
+        skills = [
+            SimpleNamespace(skill_id="skill-a", display_name="Policy Citation Format", owner_id="user-001"),
+            SimpleNamespace(skill_id="skill-b", display_name="Someone Else's Skill", owner_id="user-999"),
+        ]
+
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.skills_enabled", return_value=True), patch(
+            f"{SERVICE_MODULE}.get_skill_catalog_repository"
+        ) as repo:
+            repo.return_value.batch_get_skills = AsyncMock(return_value=skills)
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        assert resp.status_code == 200
+        exposed = resp.json()["exposedSkills"]
+        # Invoke-through resolves on skill.owner_id == agent.owner_id, so only the
+        # author's own skills are theirs to disclose.
+        assert [s["label"] for s in exposed] == ["Policy Citation Format"]
+
+    def test_no_skill_bindings_discloses_nothing(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["exposedSkills"] == []
+
+
+# ── submission mechanics ─────────────────────────────────────────────────────────────
+class TestSubmit:
+    def test_submission_moves_to_in_review_and_is_not_indexed(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit",
+                json={"category": "Teaching", "note": "For the CTL team"},
+            )
+
+        assert resp.status_code == 200
+        listing = resp.json()["listing"]
+        assert listing["state"] == "in_review"
+        assert listing["category"] == "Teaching"
+        assert listing["reviewNote"] == "For the CTL team"
+
+    def test_unknown_category_is_rejected(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Miscellaneous"}
+            )
+
+        assert resp.status_code == 400
+        assert "Unknown category" in resp.json()["detail"]
+
+    def test_defaults_to_the_authors_own_individual_publisher(self, app, make_user, _no_writes):
+        """D12: an individual profile is auto-created from the display name on first submit."""
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Research"}
+            )
+
+        assert resp.json()["listing"]["publisherId"] == "user-user-001"
+
+    def test_editor_may_not_submit(self, app, make_user, _no_writes):
+        """Putting the institution's name on an agent is the owner's act, not an editor's."""
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{SERVICE_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(_make_assistant(), "editor"),
+        ):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Research"}
+            )
+
+        assert resp.status_code == 403
+
+    def test_missing_agent_is_404(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{SERVICE_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Research"}
+            )
+
+        assert resp.status_code == 404
+
+    def test_resubmission_after_changes_requested_keeps_the_review_note(
+        self, app, make_user, _no_writes
+    ):
+        """The author keeps the context they are acting on until a reviewer replaces it."""
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state="changes_requested",
+                category="Teaching",
+                publisherId="user-user-001",
+                reviewNote="Please add a tagline.",
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Teaching"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["listing"]["state"] == "in_review"
+        assert resp.json()["listing"]["reviewNote"] == "Please add a tagline."
+
+    def test_cannot_resubmit_an_agent_already_in_review(self, app, make_user, _no_writes):
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state="in_review", category="Teaching", publisherId="user-user-001"
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Teaching"}
+            )
+
+        assert resp.status_code == 400
+
+
+# ── withdraw ─────────────────────────────────────────────────────────────────────────
+class TestWithdraw:
+    def test_owner_unpublishes_back_to_private(self, app, make_user, _no_writes):
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="published", category="Teaching", publisherId="user-user-001"
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "private"
+
+    def test_withdrawing_an_unsubmitted_agent_is_404(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant()):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 404

--- a/backend/tests/shared/test_agent_listing_index.py
+++ b/backend/tests/shared/test_agent_listing_index.py
@@ -1,0 +1,300 @@
+"""Agent Marketplace Phase 1 — the sparse directory index against a real table.
+
+The state machine tests assert what the keys *should* be; these assert what actually
+lands in DynamoDB, because the failure this index exists to prevent — a delisted agent
+still answerable by the store query — is a persistence failure, not a logic one.
+
+The guard in ``test_routine_agent_edit_does_not_resurrect_the_directory_key`` is the one
+to keep: ``Assistant`` is ``extra="allow"`` and reads hydrate from the raw item, so the
+GSI keys round-trip as extra model fields and the generic update path would rewrite them
+if they were not listed immutable.
+"""
+
+import os
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.listing_repository import (
+    clear_listing,
+    list_by_state,
+    write_listing,
+)
+from apis.shared.assistants.models import AgentListing, Assistant
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT_ID = "ast-marketplace01"
+CREATED = "2026-07-01T00:00:00Z"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def table(aws):
+    """The assistants table, carrying the same GSI5 the CDK construct declares."""
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI5_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5_SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "AgentDirectoryIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5_PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5_SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    t = ddb.Table(TABLE)
+    t.put_item(
+        Item={
+            "PK": f"AST#{AGENT_ID}",
+            "SK": "METADATA",
+            "assistantId": AGENT_ID,
+            "ownerId": "user-author",
+            "ownerName": "Ada Author",
+            "name": "Policy Lookup",
+            "description": "Find and cite university policy",
+            "instructions": "Answer from the policy manual.",
+            "vectorIndexId": "assistants-index",
+            "visibility": "PRIVATE",
+            "usageCount": 0,
+            "createdAt": CREATED,
+            "updatedAt": CREATED,
+            "status": "COMPLETE",
+            "GSI_PK": "OWNER#user-author",
+            "GSI_SK": f"STATUS#COMPLETE#CREATED#{CREATED}",
+            "GSI2_PK": "VISIBILITY#PRIVATE",
+            "GSI2_SK": f"STATUS#COMPLETE#CREATED#{CREATED}",
+        }
+    )
+    return t
+
+
+def _listing(state: str, category: str = "Administration") -> AgentListing:
+    return AgentListing(
+        state=state, category=category, publisher_id="pub-registrar", submitted_at=CREATED
+    )
+
+
+def _item(table):
+    return table.get_item(Key={"PK": f"AST#{AGENT_ID}", "SK": "METADATA"})["Item"]
+
+
+def _query_store(table, category: str):
+    return table.query(
+        IndexName="AgentDirectoryIndex",
+        KeyConditionExpression=boto3.dynamodb.conditions.Key("GSI5_PK").eq(f"LISTED#{category}"),
+    )["Items"]
+
+
+# ── write / clear ────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_publishing_writes_the_directory_key(table):
+    await write_listing(AGENT_ID, _listing("published"), CREATED)
+
+    item = _item(table)
+    assert item["GSI5_PK"] == "LISTED#Administration"
+    assert item["GSI5_SK"] == f"CREATED#{CREATED}"
+    assert item["listing"]["state"] == "published"
+    assert len(_query_store(table, "Administration")) == 1
+
+
+@pytest.mark.asyncio
+async def test_submission_does_not_write_a_directory_key(table):
+    """in_review must never be reachable from the store."""
+    await write_listing(AGENT_ID, _listing("in_review"), CREATED)
+
+    item = _item(table)
+    assert "GSI5_PK" not in item
+    assert "GSI5_SK" not in item
+    assert item["listing"]["state"] == "in_review"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["taken_down", "private", "changes_requested"])
+async def test_leaving_published_clears_the_directory_key(table, state):
+    """The delisting path. A stale key here would keep a pulled agent in the store."""
+    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    assert _query_store(table, "Administration")
+
+    await write_listing(AGENT_ID, _listing(state), CREATED)
+
+    item = _item(table)
+    assert "GSI5_PK" not in item
+    assert "GSI5_SK" not in item
+    assert item["listing"]["state"] == state
+    assert _query_store(table, "Administration") == []
+
+
+@pytest.mark.asyncio
+async def test_recategorizing_a_published_listing_moves_its_partition(table):
+    await write_listing(AGENT_ID, _listing("published", "Administration"), CREATED)
+    await write_listing(AGENT_ID, _listing("published", "Teaching"), CREATED)
+
+    assert _query_store(table, "Administration") == []
+    assert len(_query_store(table, "Teaching")) == 1
+
+
+@pytest.mark.asyncio
+async def test_write_to_a_missing_agent_raises(table):
+    with pytest.raises(ValueError, match="not found"):
+        await write_listing("ast-nope", _listing("published"), CREATED)
+
+
+@pytest.mark.asyncio
+async def test_clear_listing_removes_block_and_keys(table):
+    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    await clear_listing(AGENT_ID)
+
+    item = _item(table)
+    assert "listing" not in item
+    assert "GSI5_PK" not in item
+
+
+@pytest.mark.asyncio
+async def test_presentation_fields_ride_the_same_write(table):
+    """D13 edits land atomically with the listing rather than racing a second update."""
+    await write_listing(
+        AGENT_ID,
+        _listing("published"),
+        CREATED,
+        name="Policy Finder",
+        tagline="Cite the policy manual",
+        icon_key="icons/policy.png",
+    )
+
+    item = _item(table)
+    assert item["name"] == "Policy Finder"
+    assert item["tagline"] == "Cite the policy manual"
+    assert item["iconKey"] == "icons/policy.png"
+
+
+# ── the immutable-fields guard ───────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_directory_keys_round_trip_onto_the_model(table):
+    """The premise of the two guards below, asserted directly.
+
+    ``Assistant`` is ``extra="allow"`` and ``_get_assistant_cloud`` validates the raw
+    DynamoDB item, so the index keys and the listing block come back as model fields and
+    are therefore candidates for rewrite by the generic update path. If this ever stops
+    being true the guards below become vacuous, so assert it rather than assume it.
+    """
+    from apis.shared.assistants.service import get_assistant
+
+    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    stale = await get_assistant(AGENT_ID, "user-author")
+
+    dumped = stale.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["GSI5_PK"] == "LISTED#Administration"
+    assert dumped["listing"]["state"] == "published"
+
+
+@pytest.mark.asyncio
+async def test_stale_edit_racing_a_takedown_does_not_resurrect_the_directory_key(table):
+    """A takedown must survive an in-flight author edit that began before it.
+
+    The real exposure, reproduced deterministically: the author's request reads the agent
+    while it is still published (so its in-memory copy carries GSI5_*), an admin takes it
+    down, and then the author's write lands. Without GSI5_* in ``immutable_fields`` that
+    write puts the directory key straight back and the pulled agent is in the store again.
+    """
+    from apis.shared.assistants.service import _update_assistant_cloud, get_assistant
+
+    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    stale = await get_assistant(AGENT_ID, "user-author")  # read while published
+
+    await write_listing(AGENT_ID, _listing("taken_down"), CREATED)  # admin pulls it
+    assert "GSI5_PK" not in _item(table)
+
+    stale.description = "An unrelated tweak"
+    await _update_assistant_cloud(stale, TABLE)  # the in-flight write lands
+
+    item = _item(table)
+    assert item["description"] == "An unrelated tweak"
+    assert "GSI5_PK" not in item, "a stale edit re-published a taken-down agent"
+    assert _query_store(table, "Administration") == []
+
+
+@pytest.mark.asyncio
+async def test_stale_edit_racing_a_review_does_not_clobber_the_decision(table):
+    """The same race in the other direction — the listing block itself.
+
+    An author editing their agent while a reviewer approves it must not roll the listing
+    back to the state their request happened to read.
+    """
+    from apis.shared.assistants.service import _update_assistant_cloud, get_assistant
+
+    await write_listing(AGENT_ID, _listing("in_review"), CREATED)
+    stale = await get_assistant(AGENT_ID, "user-author")  # read while in review
+
+    await write_listing(AGENT_ID, _listing("published"), CREATED)  # admin approves
+
+    stale.name = "Renamed"
+    await _update_assistant_cloud(stale, TABLE)
+
+    item = _item(table)
+    assert item["name"] == "Renamed"
+    assert item["listing"]["state"] == "published", "a stale edit reverted an approval"
+    assert len(_query_store(table, "Administration")) == 1
+
+
+# ── the D3 backfill default ──────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_existing_records_carry_no_listing_block(table):
+    """The whole backfill: an untouched record has no listing, and PUBLIC never implies one."""
+    item = _item(table)
+    assert "listing" not in item
+    assert "GSI5_PK" not in item
+
+    assistant = Assistant.model_validate(item)
+    assert assistant.listing is None
+
+
+@pytest.mark.asyncio
+async def test_public_visibility_never_produces_a_listing(table):
+    """D3's data-safety consequence: shipping this must not publish existing PUBLIC agents."""
+    from apis.shared.assistants.service import update_assistant
+
+    await update_assistant(assistant_id=AGENT_ID, owner_id="user-author", visibility="PUBLIC")
+
+    item = _item(table)
+    assert item["visibility"] == "PUBLIC"
+    assert "listing" not in item
+    assert "GSI5_PK" not in item
+    assert _query_store(table, "Administration") == []
+
+
+# ── admin reads ──────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_list_by_state_filters_and_ignores_unsubmitted_records(table):
+    assert await list_by_state() == []
+
+    await write_listing(AGENT_ID, _listing("in_review"), CREATED)
+
+    assert len(await list_by_state()) == 1
+    assert len(await list_by_state("in_review")) == 1
+    assert await list_by_state("published") == []

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -1,0 +1,141 @@
+"""Agent Marketplace Phase 1 — the listing state machine and the sparse GSI5 derivation.
+
+The machine is pure, so these are exhaustive rather than representative: every ordered
+pair of states is asserted legal or illegal, which is what keeps a later edit to the
+transition table from quietly opening a path into the store.
+"""
+
+import itertools
+
+import pytest
+
+from apis.shared.assistants.listing import (
+    ALLOWED_TRANSITIONS,
+    DEFAULT_CATEGORIES,
+    LISTING_STATES,
+    ListingTransitionError,
+    assert_transition,
+    gsi5_keys,
+    is_published,
+)
+
+CREATED = "2026-07-24T12:00:00.000000+00:00Z"
+
+
+# ── the happy paths from D2's diagram ────────────────────────────────────────────────
+def test_first_submission_from_no_listing_block():
+    """A record with no listing block (the D3 backfill default) may be submitted."""
+    assert_transition(None, "in_review")
+
+
+def test_full_lifecycle_submit_approve_takedown():
+    assert_transition(None, "in_review")
+    assert_transition("in_review", "published")
+    assert_transition("published", "taken_down")
+
+
+def test_request_changes_then_resubmit():
+    """The loop D2 draws: in_review → changes_requested → in_review."""
+    assert_transition("in_review", "changes_requested")
+    assert_transition("changes_requested", "in_review")
+
+
+def test_resubmit_after_takedown():
+    """The takedown dialog promises the author can resubmit once it's addressed."""
+    assert_transition("taken_down", "in_review")
+
+
+def test_author_may_withdraw_from_every_reachable_state():
+    for state in ("in_review", "changes_requested", "published"):
+        assert_transition(state, "private")
+
+
+# ── the edges that must not exist ────────────────────────────────────────────────────
+def test_approval_is_the_only_door_into_the_store():
+    """Only in_review may become published.
+
+    This is the load-bearing assertion of the whole machine: if any other state could
+    reach ``published``, a bug elsewhere could publish an agent nobody reviewed.
+    """
+    publishable = {s for s in ALLOWED_TRANSITIONS if "published" in ALLOWED_TRANSITIONS[s]}
+    assert publishable == {"in_review"}
+
+
+def test_private_cannot_jump_straight_to_published():
+    with pytest.raises(ListingTransitionError):
+        assert_transition("private", "published")
+
+
+def test_never_submitted_cannot_jump_straight_to_published():
+    with pytest.raises(ListingTransitionError) as exc:
+        assert_transition(None, "published")
+    assert "never been submitted" in str(exc.value)
+
+
+def test_taken_down_cannot_return_to_published_without_review():
+    with pytest.raises(ListingTransitionError):
+        assert_transition("taken_down", "published")
+
+
+def test_unknown_target_state_is_refused():
+    with pytest.raises(ListingTransitionError) as exc:
+        assert_transition("private", "listed")
+    assert "Unknown listing state" in str(exc.value)
+
+
+def test_unknown_current_state_is_refused_rather_than_guessed():
+    """A state written by newer code must not be interpreted optimistically."""
+    with pytest.raises(ListingTransitionError) as exc:
+        assert_transition("archived", "in_review")
+    assert "unrecognized state" in str(exc.value)
+
+
+@pytest.mark.parametrize("current,target", list(itertools.product(LISTING_STATES, LISTING_STATES)))
+def test_every_state_pair_matches_the_table(current, target):
+    """Exhaustive: the enforcement and the declared table never diverge."""
+    allowed = target in ALLOWED_TRANSITIONS.get(current, set())
+    if allowed:
+        assert_transition(current, target)
+    else:
+        with pytest.raises(ListingTransitionError):
+            assert_transition(current, target)
+
+
+def test_no_state_transitions_to_itself():
+    for state in LISTING_STATES:
+        assert state not in ALLOWED_TRANSITIONS.get(state, set())
+
+
+# ── the sparse index derivation ──────────────────────────────────────────────────────
+def test_published_yields_both_keys():
+    keys = gsi5_keys("published", "Teaching", CREATED)
+    assert keys == {"GSI5_PK": "LISTED#Teaching", "GSI5_SK": f"CREATED#{CREATED}"}
+
+
+@pytest.mark.parametrize("state", [s for s in LISTING_STATES if s != "published"] + [None])
+def test_every_unpublished_state_yields_no_keys(state):
+    """The sparse half of the sparse index — no key, so the store query can't see it."""
+    assert gsi5_keys(state, "Teaching", CREATED) is None
+
+
+def test_is_published_is_the_single_predicate():
+    assert is_published("published")
+    for state in [s for s in LISTING_STATES if s != "published"] + [None]:
+        assert not is_published(state)
+
+
+def test_published_without_a_category_refuses_rather_than_inventing_a_partition():
+    with pytest.raises(ValueError, match="must carry a category"):
+        gsi5_keys("published", None, CREATED)
+
+
+def test_sort_key_is_created_at_so_browse_is_newest_first():
+    older = gsi5_keys("published", "Research", "2026-01-01T00:00:00Z")
+    newer = gsi5_keys("published", "Research", "2026-07-24T00:00:00Z")
+    assert older["GSI5_PK"] == newer["GSI5_PK"]
+    assert older["GSI5_SK"] < newer["GSI5_SK"]
+
+
+def test_default_categories_are_non_empty_and_unique():
+    assert DEFAULT_CATEGORIES
+    assert len(set(DEFAULT_CATEGORIES)) == len(DEFAULT_CATEGORIES)

--- a/backend/tests/shared/test_agent_publishers.py
+++ b/backend/tests/shared/test_agent_publishers.py
@@ -1,0 +1,175 @@
+"""Agent Marketplace Phase 1 — publisher profiles and eligibility (D12).
+
+Two properties matter more than the CRUD: an individual profile is auto-created on first
+submission and is **never verified**, and eligibility is a *proposal* allowlist that never
+reaches an access decision.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.publishers import (
+    delete_publisher,
+    ensure_individual_profile,
+    get_publisher,
+    list_eligibility,
+    list_publishers,
+    list_publishers_for_user,
+    put_publisher,
+    set_eligibility,
+)
+from apis.shared.assistants.models import PublisherProfile
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+# ── auto-created individual profiles ─────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_individual_profile_is_created_on_first_submission(table):
+    profile = await ensure_individual_profile("user-001", "Ada Author")
+
+    assert profile.kind == "individual"
+    assert profile.label == "Ada Author"
+    assert await get_publisher(profile.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_individual_profiles_are_never_verified(table):
+    """``verified`` means 'a university team stands behind this' — never a single person."""
+    profile = await ensure_individual_profile("user-001", "Ada Author")
+    assert profile.verified is False
+
+
+@pytest.mark.asyncio
+async def test_auto_creation_is_idempotent(table):
+    """A second submission must find the profile, not mint a duplicate under a new id."""
+    first = await ensure_individual_profile("user-001", "Ada Author")
+    second = await ensure_individual_profile("user-001", "Ada Renamed")
+
+    assert first.id == second.id
+    assert second.label == "Ada Author"  # the existing record wins
+    assert len([p for p in await list_publishers() if p.kind == "individual"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_author_may_propose_their_own_profile_and_only_that(table):
+    await ensure_individual_profile("user-001", "Ada Author")
+    await ensure_individual_profile("user-002", "Bo Builder")
+
+    eligible = await list_publishers_for_user("user-001")
+    assert eligible == [(await ensure_individual_profile("user-001", "Ada Author")).id]
+
+
+@pytest.mark.asyncio
+async def test_user_ids_with_awkward_characters_produce_a_usable_id(table):
+    """The id lands in a sort key, so it is slugified."""
+    profile = await ensure_individual_profile("AzureAD\\ada.author@u.edu", "Ada Author")
+    assert "\\" not in profile.id
+    assert await get_publisher(profile.id) is not None
+
+
+# ── admin-managed profiles ───────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_profiles_sort_by_order_then_label(table):
+    await put_publisher(PublisherProfile(id="p-c", label="Comms", kind="department", order=2))
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department", order=1))
+    await put_publisher(PublisherProfile(id="p-b", label="Bursar", kind="department", order=1))
+
+    assert [p.id for p in await list_publishers()] == ["p-a", "p-b", "p-c"]
+
+
+@pytest.mark.asyncio
+async def test_enabled_only_filters_disabled_profiles(table):
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department"))
+    await put_publisher(
+        PublisherProfile(id="p-x", label="Retired", kind="department", enabled=False)
+    )
+
+    assert [p.id for p in await list_publishers(enabled_only=True)] == ["p-a"]
+
+
+@pytest.mark.asyncio
+async def test_verified_institution_profile_round_trips(table):
+    await put_publisher(
+        PublisherProfile(id="p-bsu", label="Boise State", kind="institution", verified=True)
+    )
+    profile = await get_publisher("p-bsu")
+
+    assert profile.verified is True
+    assert profile.kind == "institution"
+
+
+# ── eligibility is a proposal allowlist ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_set_eligibility_replaces_the_set(table):
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department"))
+
+    await set_eligibility("p-a", ["user-001", "user-002"])
+    assert await list_eligibility("p-a") == ["user-001", "user-002"]
+
+    await set_eligibility("p-a", ["user-002", "user-003"])
+    assert await list_eligibility("p-a") == ["user-002", "user-003"]
+
+
+@pytest.mark.asyncio
+async def test_eligibility_is_scoped_to_its_own_publisher(table):
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department"))
+    await put_publisher(PublisherProfile(id="p-b", label="Bursar", kind="department"))
+
+    await set_eligibility("p-a", ["user-001"])
+    await set_eligibility("p-b", ["user-002"])
+
+    assert await list_eligibility("p-a") == ["user-001"]
+    assert await list_publishers_for_user("user-001") == ["p-a"]
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_publisher_removes_its_eligibility_items(table):
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department"))
+    await set_eligibility("p-a", ["user-001", "user-002"])
+
+    await delete_publisher("p-a")
+
+    assert await get_publisher("p-a") is None
+    assert await list_eligibility("p-a") == []
+    assert await list_publishers_for_user("user-001") == []
+
+
+@pytest.mark.asyncio
+async def test_eligibility_records_carry_no_permission_semantics(table):
+    """Guard on the shape: an eligibility item is a pointer, not a grant.
+
+    If a role, scope or permission field ever appears here, someone has started treating
+    the proposal allowlist as an access control — which D12 explicitly forbids.
+    """
+    await put_publisher(PublisherProfile(id="p-a", label="Advising", kind="department"))
+    await set_eligibility("p-a", ["user-001"])
+
+    item = table.get_item(Key={"PK": "AGENT_PUBLISHERS", "SK": "ELIG#p-a#user-001"})["Item"]
+    assert set(item) == {"PK", "SK", "publisherId", "userId", "createdAt"}

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -111,7 +111,7 @@ between a summary and a subtitle matters.
 
 ## D5 — Agents get a square icon, with a generated fallback
 
-Authors upload a square icon (**512×512, PNG or JPG, ≤ 256 KB**, stored in the existing assistants
+Authors upload a square icon (**512×512, PNG or JPG, ≤ 400 KB**, stored in the existing assistants
 asset bucket with the object key on the record — **not** inline on the DynamoDB item, per the 400 KB
 item-limit lesson from MCP App icons).
 

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -20,6 +20,8 @@ import {
   heroFingerPrint,
   heroBars3,
   heroSparkles,
+  heroInbox,
+  heroRectangleStack,
 } from '@ng-icons/heroicons/outline';
 
 interface NavItem {
@@ -52,6 +54,8 @@ interface NavGroup {
       heroFingerPrint,
       heroBars3,
       heroSparkles,
+      heroInbox,
+      heroRectangleStack,
     }),
   ],
   host: { class: 'block' },
@@ -153,6 +157,15 @@ export class AdminLayout {
         { label: 'Tools', icon: 'heroWrenchScrewdriver', route: '/admin/tools' },
         { label: 'Skills', icon: 'heroSparkles', route: '/admin/skills' },
         { label: 'Connectors', icon: 'heroLink', route: '/admin/connectors' },
+      ],
+    },
+    {
+      // Agent Marketplace (Phase 1). Two of D10's six surfaces; store front, categories
+      // and default pins join this group as their phases land.
+      label: 'Agent Marketplace',
+      items: [
+        { label: 'Review Queue', icon: 'heroInbox', route: '/admin/marketplace/review' },
+        { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
       ],
     },
     {

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -85,6 +85,21 @@ export const adminRoutes: Routes = [
     path: 'skills/edit/:skillId',
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
+  // Agent Marketplace (docs/specs/agent-marketplace.md) — Phase 1 ships two of the six
+  // admin surfaces. Store front, categories and default pins arrive in later phases.
+  {
+    path: 'marketplace/review',
+    loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
+  },
+  {
+    path: 'marketplace/listings',
+    loadComponent: () => import('./marketplace/pages/listings.page').then(m => m.MarketplaceListingsPage),
+  },
+  {
+    path: 'marketplace',
+    redirectTo: 'marketplace/review',
+    pathMatch: 'full',
+  },
   {
     path: 'connectors',
     loadComponent: () => import('./connectors/pages/connector-list.page').then(m => m.ConnectorListPage),

--- a/frontend/ai.client/src/app/admin/marketplace/components/agent-tile.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/agent-tile.component.ts
@@ -1,0 +1,32 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+/**
+ * The small square that identifies an agent in the admin tables.
+ *
+ * Phase 1 renders the agent's emoji on a neutral tile. D5's real identity work — an
+ * uploaded 512×512 icon plus a *generated gradient* fallback derived from the agent id,
+ * at four render sizes — is Phase 4. Deliberately not approximating that here: a
+ * throwaway gradient would be one more thing Phase 4 has to unpick, and nothing in
+ * Phase 1 is user-visible.
+ */
+@Component({
+  selector: 'app-agent-tile',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span
+      class="flex shrink-0 items-center justify-center rounded-2xl bg-gray-100 dark:bg-gray-700"
+      [class]="sizeClass()"
+      aria-hidden="true"
+    >
+      {{ emoji() || '✦' }}
+    </span>
+  `,
+})
+export class AgentTileComponent {
+  readonly emoji = input<string | undefined>();
+  readonly size = input<'sm' | 'md'>('md');
+
+  sizeClass(): string {
+    return this.size() === 'sm' ? 'size-7 text-sm' : 'size-10 text-xl';
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/components/request-changes-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/request-changes-dialog.component.ts
@@ -1,0 +1,121 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { AdminListingRow } from '../models/marketplace.model';
+
+export interface RequestChangesDialogData {
+  listing: AdminListingRow;
+}
+
+/** The reason, or undefined if cancelled. */
+export type RequestChangesDialogResult = string | undefined;
+
+/**
+ * Returns a submission to its author with a reason.
+ *
+ * The reason is required, not optional: it renders on the author's own card, which is the
+ * whole point — the author never has to ask what happened. (The design mockup decided
+ * without one; the spec requires it, so this dialog exists.)
+ */
+@Component({
+  selector: 'app-request-changes-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="request-changes-title"
+        aria-describedby="request-changes-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="request-changes-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Request changes
+            </h2>
+            <p id="request-changes-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Returns <span class="font-medium">{{ data.listing.name }}</span> to
+              {{ data.listing.ownerName }}. Your note appears on their card, so they can
+              act on it without asking.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <label for="change-reason" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+            What needs to change?
+          </label>
+          <textarea
+            id="change-reason"
+            rows="4"
+            [value]="reason()"
+            (input)="onReasonInput($event)"
+            placeholder="Be specific — this is the whole message the author receives."
+            class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+          ></textarea>
+        </div>
+
+        <div class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            [disabled]="!reason().trim()"
+            (click)="onSubmit()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Send to author
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class RequestChangesDialogComponent {
+  private dialogRef = inject<DialogRef<RequestChangesDialogResult>>(DialogRef);
+  readonly data = inject<RequestChangesDialogData>(DIALOG_DATA);
+
+  readonly reason = signal('');
+
+  onReasonInput(event: Event): void {
+    this.reason.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onSubmit(): void {
+    const reason = this.reason().trim();
+    if (reason) {
+      this.dialogRef.close(reason);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/components/takedown-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/takedown-dialog.component.ts
@@ -1,0 +1,138 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { AdminListingRow } from '../models/marketplace.model';
+
+export interface TakedownDialogData {
+  listing: AdminListingRow;
+}
+
+/** The reason, or undefined if cancelled. */
+export type TakedownDialogResult = string | undefined;
+
+/**
+ * Delists a published agent.
+ *
+ * The callout is load-bearing copy, carried from the design mockup: a takedown is a
+ * *delisting, not a revocation*. Reviewers who believe it recalls the agent will use it
+ * for things it does not do.
+ */
+@Component({
+  selector: 'app-takedown-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="takedown-title"
+        aria-describedby="takedown-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="takedown-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Take down “{{ data.listing.name }}”?
+            </h2>
+            <p id="takedown-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              It leaves the store and stops appearing in search or the store front. The author
+              is notified with your reason and can resubmit once it's addressed.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <div class="rounded-2xl bg-amber-50 px-4 py-3 dark:bg-amber-900/20">
+            <h3 class="text-sm/6 font-semibold text-amber-800 dark:text-amber-300">
+              What a takedown does not do
+            </h3>
+            <p class="mt-1 text-sm/6 text-gray-700 dark:text-gray-300">
+              Conversations already underway keep running, existing pins keep working, and the
+              agent stays reachable by direct link. A takedown is a delisting, not a revocation.
+            </p>
+          </div>
+
+          <label
+            for="takedown-reason"
+            class="mt-4 block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            Reason sent to {{ publisherLabel() }}
+          </label>
+          <textarea
+            id="takedown-reason"
+            rows="3"
+            [value]="reason()"
+            (input)="onReasonInput($event)"
+            placeholder="What needs to change before this can be listed again?"
+            class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+          ></textarea>
+        </div>
+
+        <div class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            [disabled]="!reason().trim()"
+            (click)="onSubmit()"
+            class="rounded-2xl bg-rose-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-rose-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-rose-500 dark:hover:bg-rose-600"
+          >
+            Take down
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class TakedownDialogComponent {
+  private dialogRef = inject<DialogRef<TakedownDialogResult>>(DialogRef);
+  readonly data = inject<TakedownDialogData>(DIALOG_DATA);
+
+  readonly reason = signal('');
+
+  onReasonInput(event: Event): void {
+    this.reason.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  /** The attribution if there is one, else the author — never an empty "sent to". */
+  publisherLabel(): string {
+    return this.data.listing.publisher?.label || this.data.listing.ownerName;
+  }
+
+  onSubmit(): void {
+    const reason = this.reason().trim();
+    if (reason) {
+      this.dialogRef.close(reason);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -1,0 +1,118 @@
+/**
+ * Agent Marketplace admin types (Phase 1).
+ *
+ * Mirrors the backend wire models in `apis/shared/assistants/models.py`. Phase 1 covers
+ * two of the six admin surfaces — Review queue and Listings — plus the publisher profiles
+ * they read. Store front, categories and default pins arrive in later phases.
+ */
+
+/** Publication state of an agent's listing. Absent listing = never submitted. */
+export type ListingState =
+  | 'private'
+  | 'in_review'
+  | 'published'
+  | 'changes_requested'
+  | 'taken_down';
+
+export type PublisherKind = 'institution' | 'department' | 'individual';
+
+/**
+ * A display identity a listing is attributed to.
+ *
+ * Display only — never an access grant. `ownerName` on the row is who actually owns the
+ * agent and whose skills resolve when it runs.
+ */
+export interface PublisherProfile {
+  id: string;
+  label: string;
+  kind: PublisherKind;
+  verified: boolean;
+  iconKey?: string;
+  order: number;
+  enabled: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** One admin edit to a listing's presentation, surfaced back to the author. */
+export interface AdminEdit {
+  field: string;
+  at: string;
+  by: string;
+}
+
+/** A row in the Review queue or the Listings table. */
+export interface AdminListingRow {
+  agentId: string;
+  name: string;
+  tagline?: string;
+  emoji?: string;
+  iconKey?: string;
+  /** The author — who to talk to about behavior. Distinct from `publisher`. */
+  ownerName: string;
+  publisher?: PublisherProfile | null;
+  category: string;
+  state: ListingState;
+  usageCount: number;
+  submittedAt?: string;
+  reviewedAt?: string;
+  reviewNote?: string;
+  updatedAt: string;
+  adminEdits: AdminEdit[];
+}
+
+export interface AdminListingsResponse {
+  listings: AdminListingRow[];
+  /** Submissions awaiting review; badges the nav so the queue is visible, not discovered. */
+  pendingCount: number;
+}
+
+export interface ReviewListingRequest {
+  decision: 'approve' | 'request_changes';
+  note?: string;
+  category?: string;
+  publisherId?: string;
+}
+
+export interface TakedownRequest {
+  reason: string;
+}
+
+/**
+ * Presentation-only patch. The backend refuses behavior fields (`instructions`,
+ * `bindings`, `modelConfig`, `starters`, `visibility`) with a 422 — an admin editing
+ * behavior would own something they did not write and cannot test.
+ */
+export interface ListingPatchRequest {
+  name?: string;
+  tagline?: string;
+  iconKey?: string;
+  category?: string;
+  publisherId?: string;
+}
+
+/** Display metadata for each listing state, used by the badge component. */
+export const LISTING_STATE_LABELS: Record<ListingState, string> = {
+  private: 'Private',
+  in_review: 'In review',
+  published: 'Published',
+  changes_requested: 'Changes requested',
+  taken_down: 'Taken down',
+};
+
+/**
+ * Badge classes per state. Mirrors the mockup's palette: published reads as success,
+ * in-review as pending, and both "needs attention" states as stop.
+ */
+export const LISTING_STATE_CLASSES: Record<ListingState, string> = {
+  private:
+    'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+  in_review:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  published:
+    'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+  changes_requested:
+    'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+  taken_down:
+    'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+};

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -1,0 +1,253 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+  OnInit,
+} from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroRectangleStack, heroCheckBadge } from '@ng-icons/heroicons/outline';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import {
+  AdminListingRow,
+  LISTING_STATE_CLASSES,
+  LISTING_STATE_LABELS,
+  ListingState,
+} from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+import {
+  TakedownDialogComponent,
+  TakedownDialogData,
+  TakedownDialogResult,
+} from '../components/takedown-dialog.component';
+
+/**
+ * Listings — every agent that has ever been submitted (D10).
+ *
+ * The mockup's table lists only published agents; this one carries a state filter and a
+ * state badge because until the Discover page ships (Phase 2) this is the *only* view of
+ * the marketplace, and an admin needs to see the ones that are not live too.
+ *
+ * Two mockup columns are deliberately absent because their levers do not exist yet: the
+ * store-front star (Phase 5) and the inline category `<select>` (Phase 2's category CRUD).
+ * Category is shown as text here rather than rendered as a control that cannot be honored.
+ */
+@Component({
+  selector: 'app-marketplace-listings',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, AgentTileComponent, TooltipDirective],
+  providers: [provideIcons({ heroRectangleStack, heroCheckBadge })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Listings</h1>
+          <p class="mt-1 max-w-3xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Every agent that has been submitted to the store. Taking one down removes it from
+            the store but leaves it reachable by direct link for anyone mid-conversation.
+          </p>
+        </div>
+
+        <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <label for="state" class="sr-only">Filter by state</label>
+            <select
+              id="state"
+              [value]="stateFilter()"
+              (change)="onStateFilterChange($event)"
+              class="rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+              <option value="">All states</option>
+              @for (state of states; track state) {
+                <option [value]="state">{{ stateLabels[state] }}</option>
+              }
+            </select>
+          </div>
+          <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+            {{ listings().length }} {{ listings().length === 1 ? 'listing' : 'listings' }}
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading listings</span>
+          </div>
+        } @else if (listings().length === 0) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroRectangleStack"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              No listings yet
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Agents appear here once their authors submit them for review.
+            </p>
+          </div>
+        } @else {
+          <div
+            class="overflow-x-auto rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+          >
+            <table class="min-w-full text-sm/6">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-gray-700">
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Agent</th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Publisher</th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Category</th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">State</th>
+                  <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Chats</th>
+                  <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    <span class="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (row of listings(); track row.agentId) {
+                  <tr class="border-t border-gray-200 dark:border-gray-700">
+                    <td class="px-4 py-3">
+                      <div class="flex items-center gap-3">
+                        <app-agent-tile [emoji]="row.emoji" size="sm" />
+                        <div class="min-w-0">
+                          <p class="truncate font-medium text-gray-900 dark:text-white">
+                            {{ row.name }}
+                          </p>
+                          <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                            by {{ row.ownerName }}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="px-4 py-3 text-gray-600 dark:text-gray-300">
+                      @if (row.publisher) {
+                        <span class="inline-flex items-center gap-1">
+                          {{ row.publisher.label }}
+                          @if (row.publisher.verified) {
+                            <ng-icon
+                              name="heroCheckBadge"
+                              class="size-4 text-blue-600 dark:text-blue-400"
+                              [appTooltip]="'Verified publisher'"
+                              appTooltipPosition="top"
+                            />
+                          }
+                        </span>
+                      } @else {
+                        <span class="text-gray-400 dark:text-gray-500">Unattributed</span>
+                      }
+                    </td>
+                    <td class="px-4 py-3 text-gray-600 dark:text-gray-300">{{ row.category }}</td>
+                    <td class="px-4 py-3">
+                      <span
+                        class="inline-flex rounded-lg px-2 py-0.5 text-xs font-semibold"
+                        [class]="stateClasses[row.state]"
+                      >
+                        {{ stateLabels[row.state] }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3 text-right tabular-nums text-gray-600 dark:text-gray-300">
+                      {{ row.usageCount.toLocaleString() }}
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      @if (row.state === 'published') {
+                        <button
+                          type="button"
+                          [disabled]="busyId() === row.agentId"
+                          (click)="takedown(row)"
+                          class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-rose-700 hover:bg-rose-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-rose-400 dark:hover:bg-gray-700"
+                        >
+                          Take down
+                        </button>
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class MarketplaceListingsPage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+  private dialog = inject(Dialog);
+
+  readonly listings = signal<AdminListingRow[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busyId = signal<string | null>(null);
+  readonly stateFilter = signal<'' | ListingState>('');
+
+  readonly states: ListingState[] = [
+    'in_review',
+    'published',
+    'changes_requested',
+    'taken_down',
+    'private',
+  ];
+  readonly stateLabels = LISTING_STATE_LABELS;
+  readonly stateClasses = LISTING_STATE_CLASSES;
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  onStateFilterChange(event: Event): void {
+    this.stateFilter.set((event.target as HTMLSelectElement).value as '' | ListingState);
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const filter = this.stateFilter();
+      this.listings.set(await this.service.loadListings(filter || undefined));
+    } catch {
+      this.error.set(this.service.error() ?? 'Failed to load listings.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async takedown(row: AdminListingRow): Promise<void> {
+    const ref = this.dialog.open<TakedownDialogResult, TakedownDialogData>(
+      TakedownDialogComponent,
+      { data: { listing: row } },
+    );
+    const reason = await firstValueFrom(ref.closed);
+    if (!reason) return;
+
+    this.busyId.set(row.agentId);
+    this.error.set(null);
+    try {
+      await this.service.takedown(row.agentId, reason);
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(typeof detail === 'string' ? detail : 'Failed to take down the listing.');
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -1,0 +1,203 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  OnInit,
+} from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroInbox, heroCheck, heroArrowUturnLeft } from '@ng-icons/heroicons/outline';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminListingRow } from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+import {
+  RequestChangesDialogComponent,
+  RequestChangesDialogData,
+  RequestChangesDialogResult,
+} from '../components/request-changes-dialog.component';
+
+/**
+ * The Review queue — every submission awaiting a decision (D2).
+ *
+ * A card list rather than a table, matching the design mockup: each row is one decision,
+ * and the subtitle carries the three things a reviewer needs before making it (who wrote
+ * it, what shelf it wants, how long it has waited).
+ *
+ * The mockup's "Preview" action is deliberately absent: it opens the agent detail page,
+ * which is Phase 3. Rendering a dead button would be worse than not having one.
+ */
+@Component({
+  selector: 'app-review-queue',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, AgentTileComponent],
+  providers: [provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Review queue</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Every submission lands here. Approving publishes it to the store immediately;
+            requesting changes returns it to the author with your note attached to their card.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading submissions</span>
+          </div>
+        } @else if (submissions().length === 0) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroInbox"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              Nothing awaiting review
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Submissions from agent authors appear here.
+            </p>
+          </div>
+        } @else {
+          <ul class="flex flex-col gap-3">
+            @for (row of submissions(); track row.agentId) {
+              <li
+                class="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center dark:border-gray-700 dark:bg-gray-800"
+              >
+                <app-agent-tile [emoji]="row.emoji" />
+
+                <div class="min-w-0 flex-1">
+                  <h2 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+                    {{ row.name }}
+                  </h2>
+                  <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
+                    {{ row.ownerName }} · {{ row.category }} · submitted
+                    {{ relativeTime(row.submittedAt) }}
+                  </p>
+                  @if (row.tagline) {
+                    <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
+                      {{ row.tagline }}
+                    </p>
+                  }
+                </div>
+
+                <div class="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    [disabled]="busyId() === row.agentId"
+                    (click)="requestChanges(row)"
+                    class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <ng-icon name="heroArrowUturnLeft" class="size-4" aria-hidden="true" />
+                    Request changes
+                  </button>
+                  <button
+                    type="button"
+                    [disabled]="busyId() === row.agentId"
+                    (click)="approve(row)"
+                    class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                  >
+                    <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+                    Approve
+                  </button>
+                </div>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class ReviewQueuePage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+  private dialog = inject(Dialog);
+
+  readonly submissions = signal<AdminListingRow[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busyId = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.submissions.set(await this.service.loadSubmissions());
+    } catch {
+      this.error.set(this.service.error() ?? 'Failed to load submissions.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async approve(row: AdminListingRow): Promise<void> {
+    await this.decide(row, { decision: 'approve' });
+  }
+
+  async requestChanges(row: AdminListingRow): Promise<void> {
+    const ref = this.dialog.open<RequestChangesDialogResult, RequestChangesDialogData>(
+      RequestChangesDialogComponent,
+      { data: { listing: row } },
+    );
+    const note = await firstValueFrom(ref.closed);
+    if (note) {
+      await this.decide(row, { decision: 'request_changes', note });
+    }
+  }
+
+  private async decide(
+    row: AdminListingRow,
+    request: { decision: 'approve' | 'request_changes'; note?: string },
+  ): Promise<void> {
+    this.busyId.set(row.agentId);
+    this.error.set(null);
+    try {
+      await this.service.review(row.agentId, request);
+      // Reload rather than splice: approving writes the directory key server-side, and a
+      // reload is the only way the pending count stays honest.
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(typeof detail === 'string' ? detail : 'Failed to record the decision.');
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+
+  /** "yesterday" / "3 days ago", matching the mockup's queue subtitle. */
+  relativeTime(iso?: string): string {
+    if (!iso) return 'recently';
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return 'recently';
+
+    const days = Math.floor((Date.now() - then) / 86_400_000);
+    if (days <= 0) return 'today';
+    if (days === 1) return 'yesterday';
+    if (days < 7) return `${days} days ago`;
+    if (days < 14) return 'last week';
+    if (days < 60) return `${Math.floor(days / 7)} weeks ago`;
+    return `${Math.floor(days / 30)} months ago`;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import {
+  AdminListingRow,
+  AdminListingsResponse,
+  ListingPatchRequest,
+  ListingState,
+  PublisherProfile,
+  ReviewListingRequest,
+} from '../models/marketplace.model';
+
+interface PublishersResponse {
+  publishers: PublisherProfile[];
+}
+
+interface CategoriesResponse {
+  categories: string[];
+}
+
+/**
+ * Admin surface for the Agent Marketplace (Phase 1).
+ *
+ * Mirrors `AdminSkillService`: signal-backed state plus explicit reload, so the two
+ * pages can share the pending count without either owning the other's fetch.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminMarketplaceService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/admin/agents`);
+
+  private _loading = signal(false);
+  private _error = signal<string | null>(null);
+  private _pendingCount = signal(0);
+
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  /** Submissions awaiting review — badges the nav so the queue stays visible (D2). */
+  readonly pendingCount = this._pendingCount.asReadonly();
+
+  /** The Review queue: everything currently awaiting a decision. */
+  async loadSubmissions(): Promise<AdminListingRow[]> {
+    return this.fetchListings(`${this.baseUrl()}/submissions`);
+  }
+
+  /** The Listings table: every agent that has ever been submitted. */
+  async loadListings(state?: ListingState): Promise<AdminListingRow[]> {
+    const url = state ? `${this.baseUrl()}/listings?state=${state}` : `${this.baseUrl()}/listings`;
+    return this.fetchListings(url);
+  }
+
+  private async fetchListings(url: string): Promise<AdminListingRow[]> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const response = await firstValueFrom(this.http.get<AdminListingsResponse>(url));
+      this._pendingCount.set(response.pendingCount ?? 0);
+      return response.listings ?? [];
+    } catch (err) {
+      this._error.set(this.messageFor(err, 'Failed to load listings'));
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /** Approve a submission, or return it to the author with a reason. */
+  async review(agentId: string, request: ReviewListingRequest): Promise<void> {
+    await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/review`, request));
+  }
+
+  /**
+   * Delist a published agent. A delisting, not a revocation — pins keep working and
+   * conversations underway keep running.
+   */
+  async takedown(agentId: string, reason: string): Promise<void> {
+    await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/takedown`, { reason }));
+  }
+
+  /** Edit presentation only; the backend 422s any behavior field. */
+  async patchListing(agentId: string, patch: ListingPatchRequest): Promise<void> {
+    await firstValueFrom(this.http.patch(`${this.baseUrl()}/${agentId}/listing`, patch));
+  }
+
+  async loadPublishers(): Promise<PublisherProfile[]> {
+    const response = await firstValueFrom(
+      this.http.get<PublishersResponse>(`${this.baseUrl()}/publishers`),
+    );
+    return response.publishers ?? [];
+  }
+
+  async loadCategories(): Promise<string[]> {
+    const response = await firstValueFrom(
+      this.http.get<CategoriesResponse>(`${this.baseUrl()}/categories`),
+    );
+    return response.categories ?? [];
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -53,6 +53,7 @@ export interface AppConfig {
   memorySpaces: MemorySpacesConfig;
   skills: SkillsConfig;
   agents: AgentsConfig;
+  agentMarketplace: AgentMarketplaceConfig;
   fineTuning: FineTuningConfig;
   artifacts: ArtifactsConfig;
   mcpSandbox: McpSandboxConfig;
@@ -199,6 +200,18 @@ export interface SkillsConfig {
  * Assistants are deprecated.
  */
 export interface AgentsConfig {
+  enabled: boolean;
+}
+
+/**
+ * Agent Marketplace (docs/specs/agent-marketplace.md).
+ *
+ * Default ON with a kill switch: CDK_AGENT_MARKETPLACE_ENABLED=false (or an
+ * `agentMarketplace.enabled: false` cdk.json context) turns it off. Sets the
+ * AGENT_MARKETPLACE_ENABLED env var on **app-api only** — publication is a catalog
+ * concern and the marketplace adds no inference-api routes.
+ */
+export interface AgentMarketplaceConfig {
   enabled: boolean;
 }
 
@@ -418,6 +431,16 @@ export function loadConfig(scope: cdk.App): AppConfig {
       enabled: process.env.CDK_AGENTS_API_ENABLED
         ? process.env.CDK_AGENTS_API_ENABLED !== 'false'
         : scope.node.tryGetContext('agents')?.enabled ?? true,
+    },
+    agentMarketplace: {
+      // Default ON with a kill switch, same empty-string-safe ternary as `agents`
+      // above: the workflow forwards an EMPTY STRING when the variable is unset, so
+      // treat empty/unset as the default (on) and only the literal "false" as off.
+      // Phase 1 ships nothing user-visible — the author submit routes and the admin
+      // Review queue / Listings pages — so it is safe on everywhere from the start.
+      enabled: process.env.CDK_AGENT_MARKETPLACE_ENABLED
+        ? process.env.CDK_AGENT_MARKETPLACE_ENABLED !== 'false'
+        : scope.node.tryGetContext('agentMarketplace')?.enabled ?? true,
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -304,6 +304,11 @@ export function buildAppApiEnvironment(
     // Gates only whether the routes 404; the assistant store it reads is always
     // present, so no extra table/bucket wiring is needed here.
     AGENTS_API_ENABLED: config.agents.enabled ? 'true' : 'false',
+    // Kill switch for the Agent Marketplace (listing lifecycle, publisher profiles,
+    // admin Review queue + Listings). App-api only — the marketplace adds no
+    // inference-api routes. It reads and writes the same assistants table the Agent
+    // surface already uses, so there is no extra wiring beyond the flag.
+    AGENT_MARKETPLACE_ENABLED: config.agentMarketplace.enabled ? 'true' : 'false',
     VOICE_TICKET_REPLAY_TABLE_NAME: params.voiceTicketReplayTableName,
     VOICE_TICKET_SIGNING_SECRET_ARN: params.voiceTicketSigningSecretArn,
   };

--- a/infrastructure/lib/constructs/rag/rag-data-construct.ts
+++ b/infrastructure/lib/constructs/rag/rag-data-construct.ts
@@ -161,6 +161,21 @@ export class RagDataConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // Sparse marketplace directory index (docs/specs/agent-marketplace.md).
+    // Same shape and same reasoning as DueSyncIndex above: GSI5 keys are written
+    // only while listing.state == "published", so unpublication is enforced by
+    // physics — no key, so the browse query cannot return the agent. Written
+    // exclusively by apis/shared/assistants/listing_repository.py; the generic
+    // assistant update lists GSI5_* as immutable so a routine author edit can
+    // never resurrect a directory key on a delisted agent.
+    //   GSI5_PK = LISTED#{category}   GSI5_SK = CREATED#{created_at}  (newest-first)
+    this.assistantsTable.addGlobalSecondaryIndex({
+      indexName: 'AgentDirectoryIndex',
+      partitionKey: { name: 'GSI5_PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI5_SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // ── SSM publications (consumed by restore tooling, app-api/inference-api runtime) ──
     new ssm.StringParameter(this, 'RagAssistantsTableNameParameter', {
       parameterName: `/${config.projectPrefix}/rag/assistants-table-name`,

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -60,6 +60,9 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     agents: {
       enabled: false,
     },
+    agentMarketplace: {
+      enabled: false,
+    },
     fineTuning: {},
     artifacts: {
       retentionDays: 90,


### PR DESCRIPTION
Implements **phase 1** of [`docs/specs/agent-marketplace.md`](docs/specs/agent-marketplace.md) (included here as the first commit, superseding `agent-directory.md`).

Authors can submit an Agent for review; admins can approve, request changes, and take down. **Nothing is user-visible** — the Discover page is phase 2.

## What's in scope

| Spec item | Where |
|---|---|
| `listing` block + state machine | `assistants/listing.py` (pure), `listing_repository.py` (writes) |
| Sparse `AgentDirectoryIndex` (GSI5) | `rag-data-construct.ts`, following the `DueSyncIndex` precedent |
| Publisher profiles + eligibility (D12) | `assistants/publishers.py` |
| Submit / review / takedown API | `agent_designer/routes.py`, `admin/agents/routes.py` |
| Admin Review queue + Listings | `admin/marketplace/` |
| Backfill (D3) | Deliberately empty — see below |
| `AGENT_MARKETPLACE_ENABLED` | Default on, kill switch, **app-api only** |

GSI5 was confirmed to be the next free slot — `GSI_`/`GSI2`/`GSI3`/`GSI4` are `OwnerStatusIndex`, `VisibilityStatusIndex`, `SharedWithIndex`, `DueSyncIndex`, and nothing else references GSI5 in code or CDK.

## The bug this turned up

`Assistant` is `extra="allow"` and reads hydrate from the raw DynamoDB item, so `GSI5_PK`/`GSI5_SK` and the `listing` block round-trip as model fields — and `_update_assistant_cloud` rewrites every attribute not in its `immutable_fields` set.

The exposure isn't a routine edit (that rewrites identical values); it's a **stale read racing a takedown**: an author's request reads the agent while it's still published, an admin pulls it, and the author's write puts the directory key straight back — silently republishing a pulled agent. The same race in the other direction reverts an approval.

Both are now immutable in that path. `test_stale_edit_racing_a_takedown_does_not_resurrect_the_directory_key` and its sibling reproduce the race deterministically and **were verified to fail with the fix removed**. A third test asserts the round-trip premise, so the guards can't quietly become vacuous if that behaviour ever changes.

## Constraints held

- **D7 at submission** — skill exposure enumerates only skills where `skill.owner_id == agent.owner_id` (matching invoke-through exactly); a `memory_space` binding returns **400 naming the space**, and a blocked submission writes nothing.
- **`publisherId` is display-only** — it appears in no access check. One test asserts the eligibility lookup is *never called* on the admin path, which is what makes "an admin may publish as the institution" actually true. `ownerId` still governs edit rights and invoke-through.
- **D13** — the PATCH model refuses behavior fields at the boundary with a message naming the rule; tested per-field and in the mixed case where a legitimate tagline edit tries to smuggle `instructions` alongside it.
- **D3 backfill** — no record gets a `listing` block, and none is ever inferred from `visibility == 'PUBLIC'`. Two tests hold that line.
- Auth is `get_current_user_from_session` on author routes, `require_admin` on admin routes; the admin subrouter is registered like the others. No inference-api routes.

## Deviations, all deliberate

- **`tagline` is author-settable.** D13 lists it as admin-editable; admin-only would mean authors could never set their own.
- **Listings has a State column + filter** the mockup lacks — until Discover ships, this is the only view of the marketplace.
- **Omitted rather than rendered dead:** the mockup's `Preview` (needs the phase 3 detail page), the store-front star (phase 5), the inline category `<select>` (phase 2).
- **Request-changes gets a reason dialog** the mockup skips — the spec requires one.
- **Categories are a seeded constant** this phase; phase 2 swaps the source for admin-managed records with **no change to the stored shape**.
- **D14's RBAC capability is not built** — it says to mirror the `skills` gate, which was removed because a capability id can't be granted from the admin roles UI. Flag only; the reasoning is recorded in `feature_flags.py`. Worth revisiting when Discover makes the store user-visible.

## Deployment

Needs `platform.yml` — GSI5 is a new index on `rag-assistants`. No data migration and no seeding; the flag defaults on.

## Verification

Backend **4956 passed** / 3 skipped · SPA **1492 passed** · CDK **476 passed** · `tsc` + `ng build` clean · `version.ts` stamp reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
