### PR TITLE
feat(marketplace): phase 2 — store browse API, Discover page, categories admin

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -1,13 +1,13 @@
-"""Admin API routes for the Agent Marketplace (Phase 1).
+"""Admin API routes for the Agent Marketplace (Phases 1-2).
 
 Mounted under ``/admin/agents`` per the CLAUDE.md route convention — admin CRUD lives at
 ``/admin/resource/``, never ``/resource/admin/``. Every route is ``Depends(require_admin)``
 (= ``require_app_roles("system_admin")``); D2 is explicit that a granular "marketplace
 curator" permission is a deliberate follow-up, so do not open a second permission axis here.
 
-Phase 1 covers two of D10's six surfaces — **Review queue** and **Listings** — plus the
-**Publishers** records they depend on. Store front, categories and default pins are
-Phases 5, 2 and 6.
+Covers three of D10's seven surfaces — **Review queue**, **Listings** and **Categories**
+— plus the **Publishers** records they depend on. Store front, default pins and the
+reports queue are Phases 5, 6 and 8.
 """
 
 import logging
@@ -24,11 +24,20 @@ from apis.app_api.agent_designer.services.listing_service import (
     review_listing,
     takedown_listing,
 )
-from apis.shared.assistants.listing import DEFAULT_CATEGORIES
+from apis.shared.assistants.categories import (
+    category_in_use,
+    delete_category,
+    ensure_seeded,
+    get_category,
+    put_category,
+)
 from apis.shared.assistants.models import (
     AdminListingPatchRequest,
     AdminListingsResponse,
     AgentCategoriesResponse,
+    AgentCategory,
+    AgentCategoryCreateRequest,
+    AgentCategoryUpdateRequest,
     AgentListing,
     PublisherCreateRequest,
     PublisherEligibilityRequest,
@@ -171,14 +180,105 @@ async def patch_agent_listing(
         raise HTTPException(status_code=500, detail=f"Failed to patch listing: {str(e)}")
 
 
+# ── categories (D10) ─────────────────────────────────────────────────────────────────
+# Admin-managed records rather than a build-time constant: a category set that requires a
+# deploy to change will not be maintained. ``ensure_seeded`` writes the defaults on the
+# first read in a fresh environment so the store is never category-less.
 @router.get("/categories", response_model=AgentCategoriesResponse)
-async def list_categories(admin: User = Depends(require_marketplace_admin)):
-    """The category set a listing may reference.
+async def list_agent_categories(admin: User = Depends(require_marketplace_admin)):
+    """The category set a listing may reference, in browse order."""
+    try:
+        return AgentCategoriesResponse(categories=await ensure_seeded())
+    except Exception as e:
+        logger.error(f"Error listing agent categories: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list categories: {str(e)}")
 
-    Phase 1 serves the ``DEFAULT_CATEGORIES`` constant. Phase 2 replaces the source with
-    admin-managed records (D10) and serves the same shape from the same route.
+
+@router.post("/categories", response_model=AgentCategory, status_code=201)
+async def create_agent_category(
+    request: AgentCategoryCreateRequest, admin: User = Depends(require_marketplace_admin)
+):
+    """Create a category.
+
+    The id defaults to the label and is **immutable** thereafter — it is half of
+    ``GSI5_PK = LISTED#{category}``, so changing it would strand every listing in that
+    category in a partition browse no longer queries. Rename the label instead.
     """
-    return AgentCategoriesResponse(categories=list(DEFAULT_CATEGORIES))
+    try:
+        await ensure_seeded()
+        category_id = (request.id or request.label).strip()
+        if not category_id:
+            raise HTTPException(status_code=400, detail="Category id cannot be empty")
+        if await get_category(category_id):
+            raise HTTPException(status_code=409, detail=f"Category '{category_id}' already exists")
+
+        now = _now()
+        return await put_category(
+            AgentCategory(
+                id=category_id,
+                label=request.label,
+                order=request.order,
+                enabled=request.enabled,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating agent category: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to create category: {str(e)}")
+
+
+@router.patch("/categories/{category_id}", response_model=AgentCategory)
+async def update_agent_category(
+    category_id: str,
+    request: AgentCategoryUpdateRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Rename, reorder, or disable a category. The id cannot change (see create)."""
+    try:
+        existing = await get_category(category_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Category not found: {category_id}")
+        changes = request.model_dump(exclude_none=True)
+        return await put_category(existing.model_copy(update={**changes, "updated_at": _now()}))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating agent category: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update category: {str(e)}")
+
+
+@router.delete("/categories/{category_id}", status_code=204)
+async def delete_agent_category(
+    category_id: str, admin: User = Depends(require_marketplace_admin)
+):
+    """Delete a category, but only while nothing references it.
+
+    A referenced category cannot be deleted because its listings would point at a
+    partition with no label to render. Disable it instead: it leaves the pickers and the
+    browse header while its listings keep working — which is almost always what the admin
+    actually meant.
+    """
+    try:
+        if not await get_category(category_id):
+            raise HTTPException(status_code=404, detail=f"Category not found: {category_id}")
+        if await category_in_use(category_id):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"'{category_id}' still has listings in it. Disable it instead — that "
+                    "removes it from the pickers and the browse header while the agents "
+                    "already in it keep working."
+                ),
+            )
+        await delete_category(category_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting agent category: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to delete category: {str(e)}")
 
 
 # ── publishers (D12) ─────────────────────────────────────────────────────────────────

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -20,7 +20,7 @@ Phase-4 concern when the Designer consumes it.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from apis.app_api.agent_designer.services.bindable_catalog import (
     BINDABLE_KINDS,
@@ -64,8 +64,15 @@ from apis.app_api.agent_designer.services.listing_service import (
     submit_listing,
     withdraw_listing,
 )
+from apis.app_api.agent_designer.services.store_service import (
+    browse_all,
+    browse_category,
+    store_front,
+)
 from apis.shared.assistants.models import (
     AgentListing,
+    AgentStoreFrontResponse,
+    AgentStoreResponse,
     ListingSubmissionResponse,
     SubmitListingRequest,
 )
@@ -193,6 +200,50 @@ async def list_agents_endpoint(
     except Exception as e:
         logger.error(f"Error listing agents: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list agents: {str(e)}")
+
+
+# --------------------------------------------------------------------------- store (D4)
+# Declared BEFORE ``/{agent_id}`` so the literal paths are not captured by the path param.
+@router.get("/store/front", response_model=AgentStoreFrontResponse)
+async def agent_store_front_endpoint(current_user: User = Depends(require_marketplace_enabled)):
+    """The browse header: the featured row plus the categories to render (D10).
+
+    ``featured`` is empty until the store-front admin ships in Phase 5; the field is
+    present now so the SPA contract does not change when it fills in.
+    """
+    try:
+        featured, categories = await store_front()
+        return AgentStoreFrontResponse(featured=featured, categories=categories)
+    except Exception as e:
+        logger.error(f"Error loading agent store front: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to load store front: {str(e)}")
+
+
+@router.get("/store", response_model=AgentStoreResponse)
+async def agent_store_endpoint(
+    category: Optional[str] = None,
+    cursor: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=100),
+    current_user: User = Depends(require_marketplace_enabled),
+):
+    """Browse published Agents, newest-first (D4).
+
+    A pure sparse-GSI5 read: it cannot return an unpublished Agent because an unpublished
+    Agent has no key in the index. The response carries icon, name, tagline, publisher and
+    category — no ``instructions``, no binding refs, no owner id.
+
+    ``cursor`` paginates within a single ``category`` (one partition). Without a category
+    the whole store is merged newest-first and no cursor is returned — see
+    ``store_service.browse_all`` for why a half-cursor would be worse than none.
+    """
+    try:
+        if category:
+            listings, next_cursor = await browse_category(category, limit=limit, cursor=cursor)
+            return AgentStoreResponse(listings=listings, next_cursor=next_cursor)
+        return AgentStoreResponse(listings=await browse_all(limit=limit), next_cursor=None)
+    except Exception as e:
+        logger.error(f"Error browsing agent store: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to browse the store: {str(e)}")
 
 
 # --------------------------------------------------------------------------- palette

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -30,11 +30,8 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 from apis.shared.assistants.compat import effective_bindings
-from apis.shared.assistants.listing import (
-    DEFAULT_CATEGORIES,
-    ListingTransitionError,
-    assert_transition,
-)
+from apis.shared.assistants.categories import ensure_seeded
+from apis.shared.assistants.listing import ListingTransitionError, assert_transition
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
 from apis.shared.assistants.models import (
     AdminEdit,
@@ -94,11 +91,26 @@ def _current_state(assistant: Assistant) -> Optional[str]:
     return assistant.listing.state if assistant.listing else None
 
 
-def _validate_category(category: str) -> None:
-    if category not in DEFAULT_CATEGORIES:
+async def _validate_category(category: str) -> None:
+    """Check a category against the admin-managed set (D10, Phase 2).
+
+    Phase 1 checked a constant; the records are the source now. ``ensure_seeded`` makes
+    the first call in a fresh environment write the defaults rather than reject every
+    submission, so an unseeded environment is never an unusable one.
+
+    Disabled categories are refused for *new* submissions while listings already in them
+    keep working — that is the whole point of disable-instead-of-delete.
+    """
+    categories = await ensure_seeded()
+    match = next((c for c in categories if c.id == category), None)
+    if match is None:
+        available = ", ".join(c.id for c in categories if c.enabled)
         raise ListingError(
-            f"Unknown category '{category}'. Expected one of: {', '.join(DEFAULT_CATEGORIES)}.",
-            status_code=400,
+            f"Unknown category '{category}'. Expected one of: {available}.", status_code=400
+        )
+    if not match.enabled:
+        raise ListingError(
+            f"The category '{match.label}' is no longer accepting new listings.", status_code=400
         )
 
 
@@ -222,7 +234,7 @@ async def submit_listing(
 ) -> Tuple[AgentListing, List[SkillExposure]]:
     """Author submits an Agent for review (D2), after the D7 checks pass."""
     assistant = await _load_for_author(agent_id, user)
-    _validate_category(request.category)
+    await _validate_category(request.category)
 
     try:
         assert_transition(_current_state(assistant), "in_review")
@@ -311,7 +323,7 @@ async def review_listing(
         raise ListingError(str(e), status_code=400) from e
 
     if category is not None:
-        _validate_category(category)
+        await _validate_category(category)
     if publisher_id is not None:
         # No eligibility check: an admin may attribute any listing to any publisher (D12).
         # That is how the store gets its day-one set of official Agents without those
@@ -383,7 +395,7 @@ async def patch_listing_presentation(
     if not changes:
         raise ListingError("No presentation fields supplied.", status_code=400)
     if "category" in changes:
-        _validate_category(changes["category"])
+        await _validate_category(changes["category"])
     if "publisher_id" in changes and not await get_publisher(changes["publisher_id"]):
         raise ListingError(f"Unknown publisher '{changes['publisher_id']}'.", status_code=400)
 

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -1,0 +1,130 @@
+"""Agent Marketplace Phase 2 — the browse read (D4, D10).
+
+The user-facing half of the marketplace. Everything here reads the sparse GSI5 index and
+projects into ``AgentListingResponse``, which carries icon, name, tagline, publisher and
+category — and nothing else.
+
+Two properties are worth stating because they are easy to erode later:
+
+* **The query cannot return an unpublished agent.** Not because it filters, but because
+  an unpublished agent has no GSI5 key. Any future change that starts filtering
+  ``listing.state`` in here is a sign the index has stopped being sparse, which is a
+  bug in the write path, not something to compensate for on read.
+* **The store read never carries behavior.** No ``instructions``, no binding refs, no
+  owner id. ``AgentResponse`` exists for the surfaces that legitimately need those; the
+  shelf is seen by every browsing user and gets the narrowest projection that renders.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from apis.shared.assistants.categories import ensure_seeded, list_categories
+from apis.shared.assistants.listing_repository import query_store
+from apis.shared.assistants.models import (
+    AgentCategory,
+    AgentListingResponse,
+    Assistant,
+    ListingPublisher,
+    PublisherProfile,
+)
+from apis.shared.assistants.publishers import list_publishers
+
+logger = logging.getLogger(__name__)
+
+# How many shelves the no-category browse will sweep. Guards against a future category
+# set large enough to turn one page load into dozens of queries.
+_MAX_FANOUT_CATEGORIES = 12
+
+
+def _to_listing_response(
+    assistant: Assistant, publishers: dict
+) -> Optional[AgentListingResponse]:
+    """Project a stored agent into the shelf shape, or ``None`` if it cannot render."""
+    listing = assistant.listing
+    if not listing:
+        # Only reachable if a GSI5 key outlived its listing block, which the single-write
+        # invariant in listing_repository is designed to prevent. Skip rather than crash
+        # the whole shelf for one bad row.
+        logger.warning(f"Indexed agent {assistant.assistant_id} has no listing block; skipping")
+        return None
+
+    profile: Optional[PublisherProfile] = publishers.get(listing.publisher_id)
+    return AgentListingResponse(
+        agent_id=assistant.assistant_id,
+        name=assistant.name,
+        tagline=assistant.tagline,
+        emoji=assistant.emoji,
+        # icon_url stays absent until Phase 4; the SPA renders the generated fallback.
+        publisher=(
+            ListingPublisher(label=profile.label, kind=profile.kind, verified=profile.verified)
+            if profile
+            else None
+        ),
+        category=listing.category,
+    )
+
+
+def _project(items: list, publishers: dict) -> List[AgentListingResponse]:
+    responses = []
+    for item in items:
+        try:
+            assistant = Assistant.model_validate(item)
+        except Exception:
+            logger.warning("Skipping unparseable store row", exc_info=True)
+            continue
+        projected = _to_listing_response(assistant, publishers)
+        if projected:
+            responses.append(projected)
+    return responses
+
+
+async def browse_category(
+    category: str, *, limit: int = 50, cursor: Optional[str] = None
+) -> Tuple[List[AgentListingResponse], Optional[str]]:
+    """One category's shelf, newest-first, with a real cursor (single GSI5 partition)."""
+    publishers = {p.id: p for p in await list_publishers()}
+    items, next_cursor = await query_store(category, limit=limit, cursor=cursor)
+    return _project(items, publishers), next_cursor
+
+
+async def browse_all(*, limit: int = 50) -> List[AgentListingResponse]:
+    """The whole store, newest-first across every enabled category.
+
+    Fans out one query per category and merge-sorts. **No cursor** — paging a merge
+    across N partitions means carrying N cursors, and the honest options were a
+    misleading half-cursor or none at all. Callers that need to page ask for a category,
+    which is a single partition and pages properly.
+
+    The Discover page renders per-category sections and does not use this path; it exists
+    for search and for "everything" views.
+    """
+    categories = [c for c in await list_categories(enabled_only=True)]
+    if len(categories) > _MAX_FANOUT_CATEGORIES:
+        logger.warning(
+            f"Store fan-out capped at {_MAX_FANOUT_CATEGORIES} of {len(categories)} categories; "
+            "browse-all is no longer showing the whole store"
+        )
+        categories = categories[:_MAX_FANOUT_CATEGORIES]
+
+    publishers = {p.id: p for p in await list_publishers()}
+
+    merged: List[Tuple[str, AgentListingResponse]] = []
+    for category in categories:
+        items, _ = await query_store(category.id, limit=limit)
+        for item, response in zip(items, _project(items, publishers)):
+            merged.append((str(item.get("createdAt", "")), response))
+
+    # Newest-first across the merged set, matching the per-category ordering.
+    merged.sort(key=lambda pair: pair[0], reverse=True)
+    return [response for _created, response in merged[:limit]]
+
+
+async def store_front() -> Tuple[List[AgentListingResponse], List[AgentCategory]]:
+    """The browse header: the featured row and the categories to render.
+
+    ``featured`` is empty until the store-front admin ships in Phase 5. Returning the
+    field now — rather than adding it later — keeps the SPA contract stable across that
+    phase, and an empty list renders as "no featured row" rather than as a broken one.
+    """
+    categories = await ensure_seeded()
+    return [], [c for c in categories if c.enabled]

--- a/backend/src/apis/shared/assistants/categories.py
+++ b/backend/src/apis/shared/assistants/categories.py
@@ -1,0 +1,134 @@
+"""Admin-managed store categories (Agent Marketplace D10, Phase 2).
+
+Phase 1 validated ``listing.category`` against a constant. This replaces the source with
+per-item records — the ``UserMenuLink`` precedent: a fixed partition, an explicit
+``order``, sorted on read — because a category set that requires a deploy to change will
+not be maintained.
+
+    PK = "AGENT_CATEGORIES", SK = "CAT#{id}"   { id, label, order, enabled }
+
+⚠️ **A category id is immutable, because it is half of the directory partition key.**
+``GSI5_PK = LISTED#{category}`` is written from ``listing.category``, so renaming an id
+would strand every published listing in a partition the browse query no longer asks for.
+Renaming is therefore a ``label`` change only; the id a listing stores never moves. This
+is why the ids seeded below are the exact strings Phase 1 wrote — changing them now would
+require rewriting GSI5 keys on live listings for no user-visible gain.
+
+Disabling a category is the soft alternative to deleting one: it drops out of the pickers
+and the browse header while its listings keep their partition intact.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .listing import DEFAULT_CATEGORIES
+from .models import AgentCategory
+
+logger = logging.getLogger(__name__)
+
+_PARTITION = "AGENT_CATEGORIES"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _strip_keys(item: dict) -> dict:
+    return {k: v for k, v in item.items() if k not in ("PK", "SK")}
+
+
+async def list_categories(enabled_only: bool = False) -> List[AgentCategory]:
+    """All categories, ordered by ``(order, label)``."""
+    from boto3.dynamodb.conditions import Key
+
+    kwargs: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(_PARTITION) & Key("SK").begins_with("CAT#")
+    }
+    table = _table()
+    response = table.query(**kwargs)
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
+        items.extend(response.get("Items", []))
+
+    categories = [AgentCategory.model_validate(_strip_keys(i)) for i in items]
+    if enabled_only:
+        categories = [c for c in categories if c.enabled]
+    categories.sort(key=lambda c: (c.order, c.label.lower()))
+    return categories
+
+
+async def get_category(category_id: str) -> Optional[AgentCategory]:
+    response = _table().get_item(Key={"PK": _PARTITION, "SK": f"CAT#{category_id}"})
+    item = response.get("Item")
+    return AgentCategory.model_validate(_strip_keys(item)) if item else None
+
+
+async def put_category(category: AgentCategory) -> AgentCategory:
+    item = category.model_dump(by_alias=True, exclude_none=True)
+    item["PK"] = _PARTITION
+    item["SK"] = f"CAT#{category.id}"
+    _table().put_item(Item=item)
+    return category
+
+
+async def delete_category(category_id: str) -> None:
+    """Hard-delete a category record.
+
+    The caller is responsible for refusing this while listings still reference it —
+    see ``category_in_use``. Deleting a referenced category would leave those listings
+    pointing at a partition with no label to render.
+    """
+    _table().delete_item(Key={"PK": _PARTITION, "SK": f"CAT#{category_id}"})
+
+
+async def ensure_seeded() -> List[AgentCategory]:
+    """Write the default category set once, if no categories exist yet.
+
+    Idempotent bootstrap rather than a migration: the store must never be
+    category-less (an author cannot submit without one), and the alternative — a
+    deploy-time seeding step per environment — is one more thing to forget. Runs on
+    the admin list and store-front reads, both of which are already round trips.
+
+    Seeds the exact strings Phase 1 validated against, so any listing submitted before
+    this shipped still resolves and its GSI5 partition is unchanged.
+    """
+    existing = await list_categories()
+    if existing:
+        return existing
+
+    now = _now()
+    seeded = [
+        AgentCategory(id=label, label=label, order=index * 10, enabled=True, created_at=now)
+        for index, label in enumerate(DEFAULT_CATEGORIES)
+    ]
+    for category in seeded:
+        await put_category(category)
+    logger.info(f"🗂️ Seeded {len(seeded)} default agent categories")
+    return seeded
+
+
+async def category_in_use(category_id: str) -> bool:
+    """Whether any agent's listing still references this category.
+
+    Guards delete. A scan is right here for the same reason it is on the admin listings
+    table: the caller is a human clicking a button, and the alternative is a stranded
+    reference the browse header cannot label.
+    """
+    from .listing_repository import list_by_state
+
+    return any(
+        (item.get("listing") or {}).get("category") == category_id
+        for item in await list_by_state()
+    )

--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -19,9 +19,11 @@ two can never disagree — a published listing always has keys and an unpublishe
 does, with no window in between.
 """
 
+import base64
+import json
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from .listing import gsi5_keys
 from .models import AgentListing
@@ -151,6 +153,59 @@ async def clear_listing(agent_id: str) -> None:
             raise ValueError(f"Agent not found: {agent_id}") from e
         logger.error(f"Failed to clear listing for {agent_id}: {e}")
         raise
+
+
+async def query_store(
+    category: str, *, limit: int = 50, cursor: Optional[str] = None
+) -> Tuple[list, Optional[str]]:
+    """Browse one category's shelf, newest first (Phase 2).
+
+    The *only* user-facing read of the marketplace, and it is a pure GSI5 query — no
+    scan, no filter, and no state check. It cannot return an unpublished agent because
+    an unpublished agent has no key in this index; that is the whole point of keeping
+    the index sparse rather than filtering on ``listing.state`` after the fact.
+
+    ``ScanIndexForward=False`` gives newest-first, since ``GSI5_SK`` is
+    ``CREATED#{created_at}``. There is no popularity sort — the store front is the
+    manual ranking lever instead (see the spec's ranking caveat).
+    """
+    from boto3.dynamodb.conditions import Key
+
+    params: Dict[str, Any] = {
+        "IndexName": "AgentDirectoryIndex",
+        "KeyConditionExpression": Key("GSI5_PK").eq(f"LISTED#{category}"),
+        "ScanIndexForward": False,
+        "Limit": limit,
+    }
+    if cursor:
+        decoded = _decode_cursor(cursor)
+        if decoded:
+            params["ExclusiveStartKey"] = decoded
+
+    response = _table().query(**params)
+    items = [from_ddb(item) for item in response.get("Items", [])]
+    next_cursor = _encode_cursor(response.get("LastEvaluatedKey"))
+    return items, next_cursor
+
+
+def _encode_cursor(key: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Opaque pagination cursor over a DynamoDB LastEvaluatedKey."""
+    if not key:
+        return None
+    return base64.urlsafe_b64encode(json.dumps(key, default=str).encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> Optional[Dict[str, Any]]:
+    """Decode a cursor, treating anything malformed as "start from the beginning".
+
+    A bad cursor is a client bug or a hand-edited URL, not something worth 500ing over —
+    the honest degradation is the first page.
+    """
+    try:
+        return json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    except Exception:
+        logger.warning("Ignoring malformed store cursor")
+        return None
 
 
 async def list_by_state(state: Optional[str] = None) -> list:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -560,16 +560,118 @@ class PublisherEligibilityResponse(BaseModel):
     user_ids: List[str] = Field(default_factory=list, alias="userIds", description="Eligible user ids")
 
 
-class AgentCategoriesResponse(BaseModel):
-    """The category set a listing may reference.
+class AgentCategory(BaseModel):
+    """An admin-managed store category (D10).
 
-    Phase 1 serves the ``DEFAULT_CATEGORIES`` constant; Phase 2 serves admin-managed
-    records from the same route with no shape change.
+    ⚠️ ``id`` is immutable — it is half of ``GSI5_PK = LISTED#{category}``, so renaming
+    it would strand every published listing in a partition browse no longer queries.
+    Renaming a category changes ``label`` only.
     """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    categories: List[str] = Field(default_factory=list, description="Category ids in browse order")
+    id: str = Field(..., description="Immutable category id; the GSI5 partition suffix")
+    label: str = Field(..., description="Display name, renameable")
+    order: int = Field(0, description="Browse order")
+    enabled: bool = Field(True, description="Disabled categories hide from pickers and browse")
+    created_at: Optional[str] = Field(None, alias="createdAt", description="ISO 8601 creation timestamp")
+    updated_at: Optional[str] = Field(None, alias="updatedAt", description="ISO 8601 update timestamp")
+
+
+class AgentCategoryCreateRequest(BaseModel):
+    """Create a store category (D10)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., min_length=1, max_length=60, description="Display name")
+    id: Optional[str] = Field(
+        None, description="Optional explicit id; defaults to the label. Immutable once set."
+    )
+    order: int = Field(0, description="Browse order")
+    enabled: bool = Field(True, description="Whether the category is offered")
+
+
+class AgentCategoryUpdateRequest(BaseModel):
+    """Update a store category. ``id`` is deliberately absent — it cannot change."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: Optional[str] = Field(None, min_length=1, max_length=60, description="Display name")
+    order: Optional[int] = Field(None, description="Browse order")
+    enabled: Optional[bool] = Field(None, description="Whether the category is offered")
+
+
+class AgentCategoriesResponse(BaseModel):
+    """The category set a listing may reference (D10)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    categories: List[AgentCategory] = Field(default_factory=list, description="Categories in browse order")
+
+
+class ListingPublisher(BaseModel):
+    """The publisher as the store renders it — label, kind, and the verified mark.
+
+    A narrowed projection of ``PublisherProfile``: browse has no use for ``order``,
+    ``enabled`` or timestamps, and the less the store read carries the less there is to
+    leak.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., description="Display name")
+    kind: PublisherKind = Field(..., description="institution | department | individual")
+    verified: bool = Field(False, description="Check mark: a university team stands behind this")
+
+
+class AgentListingResponse(BaseModel):
+    """The shelf read-shape (D4).
+
+    ⚠️ Deliberately **not** ``AgentResponse``. This carries no ``instructions``, no
+    binding ``ref`` values, no binding ids, and no ``ownerId`` — a store row's job is to
+    make you tap, and everything else is an unnecessary disclosure to every browsing
+    user. The detail read (Phase 3) adds description, starters and capability *names*,
+    and gates ``instructions`` to owner/editor.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    name: str = Field(..., description="Agent display name")
+    tagline: Optional[str] = Field(None, description="One-line subtitle (D4)")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_url: Optional[str] = Field(
+        None,
+        alias="iconUrl",
+        description="Square icon URL; absent until icons ship in Phase 4, then the SPA falls back to the generated gradient",
+    )
+    publisher: Optional[ListingPublisher] = Field(None, description="Attribution (D12), display only")
+    category: str = Field(..., description="Category id")
+
+
+class AgentStoreResponse(BaseModel):
+    """One page of a category's shelf, newest-first."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    listings: List[AgentListingResponse] = Field(default_factory=list, description="Published agents")
+    next_cursor: Optional[str] = Field(
+        None, alias="nextCursor", description="Opaque pagination cursor; absent at the end of the shelf"
+    )
+
+
+class AgentStoreFrontResponse(BaseModel):
+    """The browse header: the featured row plus the categories to render (D10)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    featured: List[AgentListingResponse] = Field(
+        default_factory=list,
+        description="Curated store-front row; empty until the store-front admin ships in Phase 5",
+    )
+    categories: List[AgentCategory] = Field(
+        default_factory=list, description="Enabled categories in browse order"
+    )
 
 
 class AssistantTestChatRequest(BaseModel):

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -61,6 +61,26 @@ def _flag_on(monkeypatch):
     monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
 
 
+def _default_categories():
+    """The seeded category set, as ``ensure_seeded`` would return it."""
+    from apis.shared.assistants.listing import DEFAULT_CATEGORIES
+    from apis.shared.assistants.models import AgentCategory
+
+    return [
+        AgentCategory(id=label, label=label, order=i * 10, enabled=True)
+        for i, label in enumerate(DEFAULT_CATEGORIES)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _categories():
+    """Category validation reads admin-managed records (Phase 2); stub the store."""
+    with patch(
+        f"{SERVICE_MODULE}.ensure_seeded", new_callable=AsyncMock, side_effect=_default_categories
+    ):
+        yield
+
+
 @pytest.fixture
 def _no_writes():
     with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write:
@@ -382,6 +402,15 @@ class TestAdminTables:
         assert resp.json()["listings"][0]["publisher"] is None
 
     def test_categories_are_served_for_the_pickers(self, app):
-        resp = TestClient(app).get("/admin/agents/categories")
+        with patch(
+            f"{ADMIN_MODULE}.ensure_seeded",
+            new_callable=AsyncMock,
+            side_effect=_default_categories,
+        ):
+            resp = TestClient(app).get("/admin/agents/categories")
+
         assert resp.status_code == 200
-        assert "Administration" in resp.json()["categories"]
+        categories = resp.json()["categories"]
+        assert [c["id"] for c in categories][0] == "Administration"
+        # Ids double as the GSI5 partition suffix, so they must survive as written.
+        assert all(c["id"] == c["label"] for c in categories)

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -52,6 +52,26 @@ def _flags_on(monkeypatch):
     monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
 
 
+def _default_categories():
+    """The seeded category set, as ``ensure_seeded`` would return it."""
+    from apis.shared.assistants.listing import DEFAULT_CATEGORIES
+    from apis.shared.assistants.models import AgentCategory
+
+    return [
+        AgentCategory(id=label, label=label, order=i * 10, enabled=True)
+        for i, label in enumerate(DEFAULT_CATEGORIES)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _categories():
+    """Category validation reads admin-managed records (Phase 2); stub the store."""
+    with patch(
+        f"{SERVICE_MODULE}.ensure_seeded", new_callable=AsyncMock, side_effect=_default_categories
+    ):
+        yield
+
+
 @pytest.fixture
 def _no_writes():
     """Stub the persistence + publisher resolution so tests exercise decisions, not I/O."""

--- a/backend/tests/shared/test_agent_store.py
+++ b/backend/tests/shared/test_agent_store.py
@@ -1,0 +1,320 @@
+"""Agent Marketplace Phase 2 — the browse read and the category records (D4, D10).
+
+The point of these is that the store's safety property is *structural*: browse cannot
+return an unpublished agent because an unpublished agent has no key in GSI5. So the tests
+go through a real (moto) table and index rather than mocking the query — a mock would
+happily assert whatever filtering logic we wrote, which is exactly the thing that must not
+be load-bearing.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.agent_designer.services.store_service import (
+    browse_all,
+    browse_category,
+    store_front,
+)
+from apis.shared.assistants.categories import (
+    category_in_use,
+    delete_category,
+    ensure_seeded,
+    get_category,
+    list_categories,
+    put_category,
+)
+from apis.shared.assistants.listing import DEFAULT_CATEGORIES
+from apis.shared.assistants.listing_repository import query_store, write_listing
+from apis.shared.assistants.models import AgentCategory, AgentListing, PublisherProfile
+from apis.shared.assistants.publishers import put_publisher
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_PK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "AgentDirectoryIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI5_PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI5_SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+def _seed_agent(table, agent_id: str, *, created_at: str, name: str = "An Agent", **extra):
+    item = {
+        "PK": f"AST#{agent_id}",
+        "SK": "METADATA",
+        "assistantId": agent_id,
+        "ownerId": "user-author",
+        "ownerName": "Ada Author",
+        "name": name,
+        "description": "A description the shelf must not show",
+        "instructions": "SECRET SYSTEM PROMPT",
+        "vectorIndexId": "assistants-index",
+        "visibility": "PRIVATE",
+        "usageCount": 7,
+        "createdAt": created_at,
+        "updatedAt": created_at,
+        "status": "COMPLETE",
+        "emoji": "📋",
+        "tagline": "Find and cite university policy",
+    }
+    item.update(extra)
+    table.put_item(Item=item)
+    return item
+
+
+async def _publish(agent_id: str, category: str, created_at: str, publisher_id="pub-registrar"):
+    await write_listing(
+        agent_id,
+        AgentListing(state="published", category=category, publisher_id=publisher_id),
+        created_at,
+    )
+
+
+# ── the structural guarantee ─────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_browse_returns_published_agents(table):
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z", name="Policy Lookup")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
+
+    listings, cursor = await browse_category("Administration")
+
+    assert [row.name for row in listings] == ["Policy Lookup"]
+    assert cursor is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["in_review", "changes_requested", "taken_down", "private"])
+async def test_browse_cannot_see_an_unpublished_agent(table, state):
+    """Not filtered out — never indexed. The safety property is structural."""
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
+    await write_listing(
+        "ast-001",
+        AgentListing(state=state, category="Administration", publisher_id="pub-registrar"),
+        "2026-07-01T00:00:00Z",
+    )
+
+    listings, _ = await browse_category("Administration")
+    assert listings == []
+
+
+@pytest.mark.asyncio
+async def test_an_agent_that_was_never_submitted_is_invisible(table):
+    _seed_agent(table, "ast-002", created_at="2026-07-01T00:00:00Z")
+
+    listings, _ = await browse_category("Administration")
+    assert listings == []
+
+
+# ── the read shape ───────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_the_shelf_never_carries_behavior(table):
+    """D4: a store row is icon, name and one line — not a spec sheet, and not a leak.
+
+    ``instructions`` in particular is returned by ``GET /agents/{id}`` today; the store is
+    seen by every browsing user, so it gets the narrowest projection that renders.
+    """
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
+
+    listings, _ = await browse_category("Administration")
+    payload = listings[0].model_dump(by_alias=True)
+
+    for leaked in ("instructions", "description", "bindings", "modelConfig", "ownerId", "ownerName"):
+        assert leaked not in payload
+    assert set(payload) == {"agentId", "name", "tagline", "emoji", "iconUrl", "publisher", "category"}
+
+
+@pytest.mark.asyncio
+async def test_publisher_is_projected_to_label_kind_and_verified(table):
+    await put_publisher(
+        PublisherProfile(
+            id="pub-registrar", label="Office of the Registrar", kind="department", verified=True
+        )
+    )
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
+
+    listings, _ = await browse_category("Administration")
+
+    assert listings[0].publisher.label == "Office of the Registrar"
+    assert listings[0].publisher.verified is True
+    # No publisher id on the shelf — it is an internal reference, not display content.
+    assert "id" not in listings[0].publisher.model_dump(by_alias=True)
+
+
+@pytest.mark.asyncio
+async def test_a_listing_whose_publisher_was_deleted_still_renders(table):
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z", publisher_id="pub-gone")
+
+    listings, _ = await browse_category("Administration")
+    assert listings[0].publisher is None
+
+
+# ── ordering + pagination ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_browse_is_newest_first(table):
+    for idx, created in enumerate(["2026-01-01Z", "2026-04-01Z", "2026-07-01Z"]):
+        _seed_agent(table, f"ast-{idx}", created_at=created, name=f"Agent {idx}")
+        await _publish(f"ast-{idx}", "Research", created)
+
+    listings, _ = await browse_category("Research")
+    assert [row.name for row in listings] == ["Agent 2", "Agent 1", "Agent 0"]
+
+
+@pytest.mark.asyncio
+async def test_cursor_pages_through_a_category(table):
+    for idx, created in enumerate(["2026-01-01Z", "2026-04-01Z", "2026-07-01Z"]):
+        _seed_agent(table, f"ast-{idx}", created_at=created, name=f"Agent {idx}")
+        await _publish(f"ast-{idx}", "Research", created)
+
+    first, cursor = await browse_category("Research", limit=2)
+    assert [row.name for row in first] == ["Agent 2", "Agent 1"]
+    assert cursor
+
+    second, next_cursor = await browse_category("Research", limit=2, cursor=cursor)
+    assert [row.name for row in second] == ["Agent 0"]
+    assert next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_cursor_degrades_to_the_first_page(table):
+    """A hand-edited URL is a client bug, not a 500."""
+    _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
+    await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
+
+    items, _ = await query_store("Administration", cursor="not-a-real-cursor")
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_browse_all_merges_categories_newest_first(table):
+    await ensure_seeded()
+    _seed_agent(table, "ast-a", created_at="2026-01-01Z", name="Old Admin")
+    await _publish("ast-a", "Administration", "2026-01-01Z")
+    _seed_agent(table, "ast-b", created_at="2026-07-01Z", name="New Research")
+    await _publish("ast-b", "Research", "2026-07-01Z")
+
+    listings = await browse_all()
+    assert [row.name for row in listings] == ["New Research", "Old Admin"]
+
+
+# ── categories (D10) ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_seeding_is_idempotent_and_uses_the_phase_1_ids(table):
+    """Seeded ids must equal the Phase 1 constants — they are GSI5 partition suffixes."""
+    first = await ensure_seeded()
+    second = await ensure_seeded()
+
+    assert [c.id for c in first] == list(DEFAULT_CATEGORIES)
+    assert [c.id for c in second] == list(DEFAULT_CATEGORIES)
+    assert len(await list_categories()) == len(DEFAULT_CATEGORIES)
+
+
+@pytest.mark.asyncio
+async def test_categories_sort_by_order_then_label(table):
+    await put_category(AgentCategory(id="c", label="Ceramics", order=2))
+    await put_category(AgentCategory(id="a", label="Astronomy", order=1))
+    await put_category(AgentCategory(id="b", label="Botany", order=1))
+
+    assert [c.id for c in await list_categories()] == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_renaming_changes_the_label_and_never_the_id(table):
+    """The id is half of GSI5_PK, so a rename must not move a listing's partition."""
+    await put_category(AgentCategory(id="Administration", label="Administration"))
+    _seed_agent(table, "ast-001", created_at="2026-07-01Z")
+    await _publish("ast-001", "Administration", "2026-07-01Z")
+
+    existing = await get_category("Administration")
+    await put_category(existing.model_copy(update={"label": "University Operations"}))
+
+    renamed = await get_category("Administration")
+    assert renamed.id == "Administration"
+    assert renamed.label == "University Operations"
+    # The shelf still resolves under the original partition.
+    listings, _ = await browse_category("Administration")
+    assert len(listings) == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_categories_drop_out_of_the_browse_header(table):
+    await ensure_seeded()
+    existing = await get_category("Teaching")
+    await put_category(existing.model_copy(update={"enabled": False}))
+
+    _featured, categories = await store_front()
+    assert "Teaching" not in [c.id for c in categories]
+
+
+@pytest.mark.asyncio
+async def test_disabling_a_category_leaves_its_listings_queryable(table):
+    """Disable is the soft alternative to delete; existing listings keep working."""
+    await ensure_seeded()
+    _seed_agent(table, "ast-001", created_at="2026-07-01Z")
+    await _publish("ast-001", "Teaching", "2026-07-01Z")
+
+    existing = await get_category("Teaching")
+    await put_category(existing.model_copy(update={"enabled": False}))
+
+    listings, _ = await browse_category("Teaching")
+    assert len(listings) == 1
+
+
+@pytest.mark.asyncio
+async def test_category_in_use_detects_a_referencing_listing(table):
+    await ensure_seeded()
+    _seed_agent(table, "ast-001", created_at="2026-07-01Z")
+    await _publish("ast-001", "Teaching", "2026-07-01Z")
+
+    assert await category_in_use("Teaching") is True
+    assert await category_in_use("Research") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_an_unreferenced_category(table):
+    await ensure_seeded()
+    await delete_category("Research")
+    assert await get_category("Research") is None
+
+
+@pytest.mark.asyncio
+async def test_store_front_seeds_and_returns_no_featured_row_yet(table):
+    """``featured`` is present but empty until Phase 5 — a stable contract, not a stub."""
+    featured, categories = await store_front()
+
+    assert featured == []
+    assert [c.id for c in categories] == list(DEFAULT_CATEGORIES)

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -210,13 +210,14 @@ pins assigned to `default` therefore reach only users who match nothing else —
 nobody. The admin UI must label that chip *"fallback only — does not apply to users with any other
 role"* or admins will assume it means "everyone" and quietly seed no one.
 
-## D10 — Admin owns six levers, in one console
+## D10 — Admin owns seven levers, in one console
 
 Every store behavior needs a surface, or it becomes a code deploy:
 
 | Surface | Controls |
 |---|---|
 | **Review queue** | Approve / request changes, with a reason. Pending count badges the nav. |
+| **Reports** | User-submitted problem reports (D15): resolve or dismiss, with the reporter visible. Open count badges the nav alongside submissions. |
 | **Listings** | All published Agents: promote to store front, reassign category, take down. |
 | **Store front** | The Featured row as an explicitly ordered list, with slots. |
 | **Categories** | Fixed set in browse order: add, rename, reorder. Empty categories auto-hide. |
@@ -307,6 +308,51 @@ applies here too: granting the capability to `default` does **not** reach everyo
 
 ---
 
+## D15 — Users report problems; the report is private and lands in the admin queue
+
+A store with no way to say "this one is wrong" pushes that signal into email, or nowhere.
+Any user who can run a published Agent can **report a problem with it** from the detail
+page, and the report joins the admin console as a second work stream beside submissions.
+
+**This is not a review, and the distinction is the whole design.** The non-goal below
+still stands: no stars, no public comments, no visible counts. A report is a *private
+message to the curator*, never shelf content, and nothing a reporter writes is ever
+rendered to another browsing user. Ratings would make the store a popularity contest we
+have deliberately declined to run (see the ranking caveat); reports make it maintainable.
+Five decisions:
+
+**1. Reports are triaged, never auto-forwarded to the author.** The reviewer decides what
+reaches the person who built the thing. Piping raw user text straight to an author is how
+you get one bad message ending a volunteer's willingness to publish — and the author
+cannot act on "this is stupid" anyway. When a report is actionable the reviewer uses the
+existing **request changes** or **takedown** path, whose reason field is already the
+author-facing channel. Reports are the *evidence* for that reason, not a substitute for it.
+
+**2. The reporter is visible to the admin and never to the author.** Admins need identity
+to spot a brigade or a grudge; authors need the substance, not the name. This is the
+narrowest split that serves both.
+
+**3. Reportable means published.** You may report what the store offered you. Reporting a
+`private` or `in_review` Agent is not a thing — nobody outside the author was invited to
+it, and a takedown is not available as a remedy for something that was never listed.
+
+**4. A reporter gets one open report per Agent.** A second submission while the first is
+still open updates it rather than stacking. Without this the queue is trivially floodable
+and the count at the top of the nav stops meaning anything.
+
+**5. Reports have their own tiny lifecycle: `open → resolved | dismissed`.** Deliberately
+not a mirror of the listing state machine — the report is a note about an Agent, not a
+state of it. Resolving a report never changes `listing.state`; if a report warrants
+delisting, the admin takes the Agent down and that is a separate, recorded act.
+
+`reason` is a small fixed set (`inaccurate`, `broken`, `inappropriate`, `other`) plus free
+text. The set exists so the queue can be sorted by severity without reading every note;
+`inappropriate` is the one that should page a human rather than wait for a sweep.
+
+⚠️ **A report is not a permission signal and not a ranking input.** It must not feed
+`usageCount`, the store front, or any ordering. The moment report volume influences
+placement, reporting becomes a way to bury a competitor's Agent.
+
 ## Data model
 
 ### Agent record (additive — no new table, per Designer D2)
@@ -347,6 +393,34 @@ Unpublication is enforced by physics: no key, so the query cannot return it.
 **Ranking caveat, stated plainly:** `GSI5_SK` is `created_at`, so browse is **newest-first**. A
 popularity sort needs a mutable sort key (hot-item rewrite per use) or a periodic recompute; v1 does
 neither. The store front (D10) is the manual override. Deferred to F6b, not silently approximated.
+
+### Reports (D15)
+
+Child rows under the Agent, so a report is deleted with the Agent it concerns and never
+outlives it:
+
+```
+PK = AST#{agent_id}, SK = "REPORT#{created_at}#{report_id}"
+{ reporterId, reporterName, reason, note, state, createdAt,
+  resolvedAt?, resolvedBy?, resolutionNote? }
+```
+
+**Sparse open-report index (GSI6 on `rag-assistants`)**, written only while
+`state == 'open'`, exactly as GSI5 is written only while published:
+
+```
+GSI6_PK = "REPORTS#OPEN"
+GSI6_SK = CREATED#{created_at}
+```
+
+A single partition is correct here and would not be for the directory: the open queue is
+bounded by how fast admins work, it is read only by the admin console, and it wants one
+chronological sweep rather than per-category slices. If the queue ever outgrows a hot
+partition, that is a *product* signal (nobody is triaging) before it is a capacity one.
+
+D15.4's one-open-report-per-reporter rule needs a lookup by `(agent, reporter)`; do it
+with a conditional write on a deterministic `report_id` derived from the reporter id,
+not a second index — the write already knows both halves of the key.
 
 ### Store front, categories, publishers
 
@@ -432,6 +506,8 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `POST /agents/{id}/listing/submit` | Author submits. Runs D7 checks; 400 on a `memory_space` binding. |
 | `DELETE /agents/{id}/listing` | Author unpublishes. |
 | `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). |
+| `POST /agents/{id}/report` | Report a problem with a published Agent (D15). One open report per reporter. |
+| `GET /admin/agents/reports` · `POST /admin/agents/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). |
 | `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes (D2). |
 | `GET /admin/agents/listings` · `POST /admin/agents/{id}/takedown` | Listings table; delist with a reason. |
 | `PATCH /admin/agents/{id}/listing` | Edit presentation only — `name`, `tagline`, `iconKey`, `category`, `publisherId` (D13). Rejects any behavior field. |
@@ -460,7 +536,7 @@ persisted on the Agent.
   access" with the D6 availability line.
 - **My Agents** — listing-state badge per card (`Draft` / `Private` / `In review` /
   `Changes requested` / `Published`), the reviewer's note inline, Icon and Submit actions.
-- **Admin** — left sub-nav over the five D10 surfaces.
+- **Admin** — left sub-nav over the seven D10 surfaces.
 - **`@` menu** — grouped "Your agents" / "Pinned", publisher as secondary text, "Browse all →" last.
 
 Reuse the list-page token idiom (`rounded-2xl`, `text-sm/6`, flat), `@angular/cdk/dialog` for every
@@ -472,18 +548,23 @@ Working mockup of all of the above: the `agent-marketplace` artifact (v2, admin 
 ## Phasing
 
 ```
-Phase 0  This spec
+Phase 0  This spec                                                          ✅ shipped
 Phase 1  listing block + state machine + sparse GSI5 + submit/review/takedown API
          + publisher profiles (D12) + admin Review queue & Listings
-         + backfill (no listing block)                                          ← first PR
-Phase 2  GET /agents/store + the Discover page + categories admin
+         + backfill (no listing block)                               ✅ shipped (PR #731)
+Phase 2  GET /agents/store + the Discover page + categories admin           ← in progress
 Phase 3  Detail page + runnability + the instructions gate
 Phase 4  Icons: upload, S3, generated fallback, all four render sizes
 Phase 5  Pins: user pin state + Pinned tab + store front admin
 Phase 6  Default pins by role (D9) + the assignment-time runnability check
 Phase 7  @-mention in the composer
+Phase 8  Problem reports (D15): report action + admin Reports queue   ← depends on 3
 Later    Ranking + full-corpus search via the Registry catalog (F6b)
 ```
+
+Phase 8 sits after the detail page because that is where the report action lives — there
+is no other surface a user is looking at when they decide something is wrong. It is
+otherwise independent of 4–7 and can run alongside them.
 
 Phase 1 is the smallest thing that is independently useful: authors can submit, admins can approve
 and take down, and nothing is user-visible until Phase 2. Phases 4–7 are independent of each other
@@ -496,6 +577,8 @@ and parallelizable once 1–3 land.
 - **No re-review on edit** (D2). The listing is reviewed, not every subsequent change.
 - **No pin fan-out job** (D9.1). Role pins resolve live.
 - **No ratings, reviews, or comments.** Social proof is the store front and the publisher.
+  D15's problem reports are the deliberate exception that proves this: they are private to
+  admins, never rendered to another browsing user, and never an input to ranking.
 - **No popularity ranking.** Newest-first plus a curated front, honestly labeled.
 - **No cross-tenant or external publishing.** The store is institution-scoped.
 - **No agent versioning or changelogs.** A published Agent is a live pointer; updates are immediate.

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -22,6 +22,7 @@ import {
   heroSparkles,
   heroInbox,
   heroRectangleStack,
+  heroTag,
 } from '@ng-icons/heroicons/outline';
 
 interface NavItem {
@@ -56,6 +57,7 @@ interface NavGroup {
       heroSparkles,
       heroInbox,
       heroRectangleStack,
+      heroTag,
     }),
   ],
   host: { class: 'block' },
@@ -160,12 +162,13 @@ export class AdminLayout {
       ],
     },
     {
-      // Agent Marketplace (Phase 1). Two of D10's six surfaces; store front, categories
-      // and default pins join this group as their phases land.
+      // Agent Marketplace. Three of D10's seven surfaces; store front, default pins and
+      // the reports queue join this group as their phases land.
       label: 'Agent Marketplace',
       items: [
         { label: 'Review Queue', icon: 'heroInbox', route: '/admin/marketplace/review' },
         { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
+        { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories' },
       ],
     },
     {

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -85,8 +85,8 @@ export const adminRoutes: Routes = [
     path: 'skills/edit/:skillId',
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
-  // Agent Marketplace (docs/specs/agent-marketplace.md) — Phase 1 ships two of the six
-  // admin surfaces. Store front, categories and default pins arrive in later phases.
+  // Agent Marketplace (docs/specs/agent-marketplace.md) — three of D10's seven admin
+  // surfaces. Store front, default pins and the reports queue arrive in later phases.
   {
     path: 'marketplace/review',
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
@@ -94,6 +94,10 @@ export const adminRoutes: Routes = [
   {
     path: 'marketplace/listings',
     loadComponent: () => import('./marketplace/pages/listings.page').then(m => m.MarketplaceListingsPage),
+  },
+  {
+    path: 'marketplace/categories',
+    loadComponent: () => import('./marketplace/pages/categories.page').then(m => m.MarketplaceCategoriesPage),
   },
   {
     path: 'marketplace',

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -91,6 +91,21 @@ export interface ListingPatchRequest {
   publisherId?: string;
 }
 
+/**
+ * An admin-managed store category (D10).
+ *
+ * `id` is immutable — it is half of the directory partition key, so renaming a category
+ * changes `label` only. That is why the form offers no id field after creation.
+ */
+export interface AgentCategory {
+  id: string;
+  label: string;
+  order: number;
+  enabled: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 /** Display metadata for each listing state, used by the badge component. */
 export const LISTING_STATE_LABELS: Record<ListingState, string> = {
   private: 'Private',

--- a/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
@@ -1,0 +1,237 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  OnInit,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroPlus, heroTrash, heroTag } from '@ng-icons/heroicons/outline';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AgentCategory } from '../models/marketplace.model';
+
+/**
+ * Categories — the browse order of the store (D10).
+ *
+ * Admin-managed records rather than a build-time constant: a category set that needs a
+ * deploy to change will not be maintained.
+ *
+ * Two rules the UI has to make legible, because both are surprising otherwise:
+ *
+ * - **A category cannot be renamed into a different id.** The id is half of the directory
+ *   partition key, so it is fixed at creation; editing changes the label only. The row
+ *   shows the id when it differs from the label so the difference is visible rather than
+ *   discovered.
+ * - **Disable, don't delete.** Deleting is refused (409) while listings reference the
+ *   category. Disabling drops it from the pickers and the browse header while the agents
+ *   already in it keep working — nearly always what was actually meant.
+ */
+@Component({
+  selector: 'app-marketplace-categories',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [provideIcons({ heroPlus, heroTrash, heroTag })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Categories</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            The shelves of the store, in browse order. Empty categories hide themselves on
+            Discover, so it is safe to add one before anything is published into it.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        <!-- Add -->
+        <div
+          class="mb-6 flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-end dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div class="flex-1">
+            <label for="new-category" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+              New category
+            </label>
+            <input
+              type="text"
+              id="new-category"
+              [value]="newLabel()"
+              (input)="onNewLabelInput($event)"
+              placeholder="e.g. Student Support"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+            />
+          </div>
+          <button
+            type="button"
+            [disabled]="!newLabel().trim() || busy()"
+            (click)="addCategory()"
+            class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+            Add
+          </button>
+        </div>
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading categories</span>
+          </div>
+        } @else if (categories().length === 0) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroTag"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              No categories yet
+            </h2>
+          </div>
+        } @else {
+          <ul class="flex flex-col gap-2">
+            @for (category of categories(); track category.id) {
+              <li
+                class="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div class="min-w-0 flex-1">
+                  <label [for]="'label-' + category.id" class="sr-only">
+                    Label for {{ category.label }}
+                  </label>
+                  <input
+                    type="text"
+                    [id]="'label-' + category.id"
+                    [value]="category.label"
+                    (change)="renameCategory(category, $event)"
+                    class="block w-full rounded-2xl border border-transparent bg-transparent px-2 py-1 text-sm/6 font-medium text-gray-900 hover:border-gray-300 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white dark:hover:border-gray-600 dark:focus:bg-gray-900"
+                  />
+                  @if (category.id !== category.label) {
+                    <p class="px-2 text-xs text-gray-400 dark:text-gray-500">
+                      id: {{ category.id }} — fixed at creation
+                    </p>
+                  }
+                </div>
+
+                <div class="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    [disabled]="busy()"
+                    (click)="toggleEnabled(category)"
+                    class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    [appTooltip]="
+                      category.enabled
+                        ? 'Hide from the pickers and the browse header. Agents already in it keep working.'
+                        : 'Offer this category again'
+                    "
+                    appTooltipPosition="top"
+                  >
+                    {{ category.enabled ? 'Enabled' : 'Disabled' }}
+                  </button>
+                  <button
+                    type="button"
+                    [disabled]="busy()"
+                    (click)="removeCategory(category)"
+                    class="rounded-2xl p-2 text-gray-500 hover:bg-rose-50 hover:text-rose-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-rose-900/20 dark:hover:text-rose-400"
+                    [appTooltip]="'Delete category'"
+                    appTooltipPosition="top"
+                  >
+                    <ng-icon name="heroTrash" class="size-5" aria-hidden="true" />
+                    <span class="sr-only">Delete {{ category.label }}</span>
+                  </button>
+                </div>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class MarketplaceCategoriesPage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+
+  readonly categories = signal<AgentCategory[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busy = signal(false);
+  readonly newLabel = signal('');
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  onNewLabelInput(event: Event): void {
+    this.newLabel.set((event.target as HTMLInputElement).value);
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.categories.set(await this.service.loadCategories());
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load categories.'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async addCategory(): Promise<void> {
+    const label = this.newLabel().trim();
+    if (!label) return;
+    await this.mutate(async () => {
+      await this.service.createCategory({ label, order: this.categories().length * 10 });
+      this.newLabel.set('');
+    });
+  }
+
+  async renameCategory(category: AgentCategory, event: Event): Promise<void> {
+    const label = (event.target as HTMLInputElement).value.trim();
+    if (!label || label === category.label) return;
+    await this.mutate(() => this.service.updateCategory(category.id, { label }));
+  }
+
+  async toggleEnabled(category: AgentCategory): Promise<void> {
+    await this.mutate(() =>
+      this.service.updateCategory(category.id, { enabled: !category.enabled }),
+    );
+  }
+
+  async removeCategory(category: AgentCategory): Promise<void> {
+    await this.mutate(() => this.service.deleteCategory(category.id));
+  }
+
+  /** Run a mutation, surface its message, and reload so the list matches the server. */
+  private async mutate(action: () => Promise<unknown>): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      await action();
+      await this.reload();
+    } catch (err) {
+      // The in-use delete refusal (409) explains itself and suggests disabling instead,
+      // so surface the server's message rather than a generic one.
+      this.error.set(this.messageFor(err, 'That change could not be saved.'));
+      await this.reload();
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
   AdminListingRow,
+  AgentCategory,
   AdminListingsResponse,
   ListingPatchRequest,
   ListingState,
@@ -16,7 +17,7 @@ interface PublishersResponse {
 }
 
 interface CategoriesResponse {
-  categories: string[];
+  categories: AgentCategory[];
 }
 
 /**
@@ -93,11 +94,44 @@ export class AdminMarketplaceService {
     return response.publishers ?? [];
   }
 
-  async loadCategories(): Promise<string[]> {
+  async loadCategories(): Promise<AgentCategory[]> {
     const response = await firstValueFrom(
       this.http.get<CategoriesResponse>(`${this.baseUrl()}/categories`),
     );
     return response.categories ?? [];
+  }
+
+  /**
+   * Create a category. The id defaults to the label server-side and is immutable after —
+   * it is half of the directory partition key, so a rename changes the label only.
+   */
+  async createCategory(request: {
+    label: string;
+    order?: number;
+    enabled?: boolean;
+  }): Promise<AgentCategory> {
+    return firstValueFrom(
+      this.http.post<AgentCategory>(`${this.baseUrl()}/categories`, request),
+    );
+  }
+
+  async updateCategory(
+    categoryId: string,
+    changes: { label?: string; order?: number; enabled?: boolean },
+  ): Promise<AgentCategory> {
+    return firstValueFrom(
+      this.http.patch<AgentCategory>(
+        `${this.baseUrl()}/categories/${encodeURIComponent(categoryId)}`,
+        changes,
+      ),
+    );
+  }
+
+  /** Deleting is refused server-side (409) while listings still reference the category. */
+  async deleteCategory(categoryId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.delete(`${this.baseUrl()}/categories/${encodeURIComponent(categoryId)}`),
+    );
   }
 
   private messageFor(err: unknown, fallback: string): string {

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -1,7 +1,10 @@
 <div class="min-h-dvh">
   <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Marketplace hub tabs (spec phase 2) -->
+    <app-agents-tabs />
+
     <!-- Header -->
-    <div class="mb-10">
+    <div class="mb-10 mt-6">
       <div class="flex items-center justify-between gap-4">
         <div>
           <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -20,6 +20,7 @@ import {
 } from '../components/confirmation-dialog/confirmation-dialog.component';
 import { ShareAssistantDialogComponent, ShareAssistantDialogData } from '../assistants/components/share-assistant-dialog.component';
 import { TooltipDirective } from '../components/tooltip/tooltip.directive';
+import { AgentsTabsComponent } from './components/agents-tabs.component';
 
 /**
  * Agent Designer — the list surface. A sibling of the Assistants list page but
@@ -32,7 +33,7 @@ import { TooltipDirective } from '../components/tooltip/tooltip.directive';
   templateUrl: './agents.page.html',
   styleUrl: './agents.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, TooltipDirective],
+  imports: [NgIcon, TooltipDirective, AgentsTabsComponent],
   providers: [
     provideIcons({
       heroPlus,

--- a/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
@@ -1,0 +1,63 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckBadge } from '@ng-icons/heroicons/outline';
+import { AgentListing } from '../models/store.model';
+import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+
+/**
+ * One shelf row: icon, name, one line (D4).
+ *
+ * Deliberately carries no model chip, no tool/skill counts, no chat count and no
+ * runnability badge. A row's job is to make you tap; everything else lives on the detail
+ * page and in admin reporting.
+ *
+ * The icon is the emoji on a neutral tile for now — D5's uploaded icon and generated
+ * gradient fallback are Phase 4.
+ */
+@Component({
+  selector: 'app-agent-listing-row',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [provideIcons({ heroCheckBadge })],
+  template: `
+    <div class="flex items-center gap-3 rounded-2xl px-3 py-2.5">
+      <span
+        class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-xl dark:bg-gray-700"
+        aria-hidden="true"
+      >
+        {{ listing().emoji || '✦' }}
+      </span>
+      <div class="min-w-0 flex-1">
+        <p
+          class="flex items-center gap-1.5 truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+        >
+          {{ listing().name }}
+          @if (listing().publisher?.verified) {
+            <ng-icon
+              name="heroCheckBadge"
+              class="size-4 shrink-0 text-blue-600 dark:text-blue-400"
+              [appTooltip]="verifiedTooltip()"
+              appTooltipPosition="top"
+            />
+          }
+        </p>
+        <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
+          {{ subtitle() }}
+        </p>
+      </div>
+    </div>
+  `,
+})
+export class AgentListingRowComponent {
+  readonly listing = input.required<AgentListing>();
+
+  /** The tagline is the subtitle; the publisher is the fallback when there isn't one. */
+  subtitle(): string {
+    return this.listing().tagline || this.listing().publisher?.label || '';
+  }
+
+  verifiedTooltip(): string {
+    const label = this.listing().publisher?.label ?? 'a university team';
+    return `Published by ${label} — a verified university team`;
+  }
+}

--- a/frontend/ai.client/src/app/agents/components/agents-tabs.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agents-tabs.component.ts
@@ -1,0 +1,37 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+
+/**
+ * The `/agents` hub tab strip.
+ *
+ * Phase 2 has two tabs. **Pinned** joins in Phase 5 — deliberately not rendered now,
+ * because a tab that leads to an empty page teaches people not to click tabs.
+ */
+@Component({
+  selector: 'app-agents-tabs',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, RouterLinkActive],
+  template: `
+    <nav
+      class="inline-flex gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
+      aria-label="Agent views"
+    >
+      <a
+        routerLink="/agents/discover"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        Discover
+      </a>
+      <a
+        routerLink="/agents"
+        [routerLinkActiveOptions]="{ exact: true }"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        My Agents
+      </a>
+    </nav>
+  `,
+})
+export class AgentsTabsComponent {}

--- a/frontend/ai.client/src/app/agents/discover/discover.page.ts
+++ b/frontend/ai.client/src/app/agents/discover/discover.page.ts
@@ -1,0 +1,184 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  computed,
+  OnInit,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroMagnifyingGlass, heroSparkles } from '@ng-icons/heroicons/outline';
+import { AgentStoreService } from '../services/agent-store.service';
+import { AgentListing, CategoryShelf } from '../models/store.model';
+import { AgentsTabsComponent } from '../components/agents-tabs.component';
+import { AgentListingRowComponent } from '../components/agent-listing-row.component';
+
+/**
+ * Discover — the browse surface over published Agents (D4, Phase 2).
+ *
+ * Rows carry an icon, a name and one line, and nothing else: no model chip, no tool or
+ * skill counts, no chat counts, no runnability badge. Those numbers are still collected
+ * and still surfaced — on the detail page and in admin reporting — but a store row that
+ * reports its own dependency list is a spec sheet, and it scans like one.
+ *
+ * Search filters what has been loaded rather than issuing a query per keystroke. The
+ * store is small enough that this is honest; a real full-corpus search arrives with the
+ * Registry catalog, and pretending to have one now would mean silently missing results
+ * past the first page.
+ *
+ * Not here yet, by phase: the featured row renders only once the store-front admin can
+ * populate it (Phase 5), and rows are not yet clickable because the detail page is
+ * Phase 3.
+ */
+@Component({
+  selector: 'app-agent-discover',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, AgentsTabsComponent, AgentListingRowComponent],
+  providers: [provideIcons({ heroMagnifyingGlass, heroSparkles })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <app-agents-tabs />
+
+        <div class="mt-6 mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Discover agents</h1>
+          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+            Agents published by teams across the university.
+          </p>
+        </div>
+
+        <div class="relative mb-8 max-w-md">
+          <ng-icon
+            name="heroMagnifyingGlass"
+            class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <label for="agent-search" class="sr-only">Search agents</label>
+          <input
+            type="search"
+            id="agent-search"
+            [value]="query()"
+            (input)="onSearch($event)"
+            placeholder="Search agents…"
+            class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+          />
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading agents</span>
+          </div>
+        } @else if (isEmpty()) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroSparkles"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              {{ query() ? 'No agents match your search' : 'No published agents yet' }}
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              {{
+                query()
+                  ? 'Try a different word, or clear the search to browse everything.'
+                  : 'Agents appear here once their authors submit them and an admin approves.'
+              }}
+            </p>
+          </div>
+        } @else if (query()) {
+          <!-- Search collapses the category sections into one flat result list. -->
+          <section>
+            <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">
+              {{ searchResults().length }}
+              {{ searchResults().length === 1 ? 'result' : 'results' }}
+            </h2>
+            <ul class="grid gap-x-8 sm:grid-cols-2">
+              @for (listing of searchResults(); track listing.agentId) {
+                <li>
+                  <app-agent-listing-row [listing]="listing" />
+                </li>
+              }
+            </ul>
+          </section>
+        } @else {
+          @for (shelf of shelves(); track shelf.category.id) {
+            <section class="mb-8">
+              <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">
+                {{ shelf.category.label }}
+              </h2>
+              <ul class="grid gap-x-8 sm:grid-cols-2">
+                @for (listing of shelf.listings; track listing.agentId) {
+                  <li>
+                    <app-agent-listing-row [listing]="listing" />
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+        }
+      </div>
+    </div>
+
+  `,
+})
+export class AgentDiscoverPage implements OnInit {
+  private store = inject(AgentStoreService);
+
+  readonly shelves = signal<CategoryShelf[]>([]);
+  readonly featured = signal<AgentListing[]>([]);
+  readonly query = signal('');
+  readonly loading = this.store.loading;
+  readonly error = this.store.error;
+
+  /** Everything loaded, flattened — the corpus search filters over. */
+  private readonly allListings = computed(() =>
+    this.shelves().flatMap((shelf) => shelf.listings),
+  );
+
+  readonly searchResults = computed(() => {
+    const needle = this.query().trim().toLowerCase();
+    if (!needle) return [];
+    return this.allListings().filter((listing) =>
+      [listing.name, listing.tagline, listing.publisher?.label]
+        .filter(Boolean)
+        .some((field) => (field as string).toLowerCase().includes(needle)),
+    );
+  });
+
+  readonly isEmpty = computed(() =>
+    this.query() ? this.searchResults().length === 0 : this.shelves().length === 0,
+  );
+
+  ngOnInit(): void {
+    void this.load();
+  }
+
+  async load(): Promise<void> {
+    try {
+      const { featured, shelves } = await this.store.loadDiscover();
+      this.featured.set(featured);
+      this.shelves.set(shelves);
+    } catch {
+      // The service already captured a user-facing message in `error`.
+    }
+  }
+
+  onSearch(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
+}

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -1,0 +1,53 @@
+/**
+ * Agent Marketplace store types (Phase 2).
+ *
+ * Mirrors `AgentListingResponse` / `AgentStoreFrontResponse` on the backend. Note what is
+ * *absent*: no `instructions`, no bindings, no owner. A shelf row is icon, name and one
+ * line (D4), and the narrow shape is the point — this is the payload every browsing user
+ * receives.
+ */
+
+/** How the store renders a publisher: a name, a kind, and the verified mark. */
+export interface ListingPublisher {
+  label: string;
+  kind: 'institution' | 'department' | 'individual';
+  verified: boolean;
+}
+
+/** One row on a shelf. */
+export interface AgentListing {
+  agentId: string;
+  name: string;
+  tagline?: string;
+  emoji?: string;
+  /** Absent until icons ship (Phase 4); the SPA renders the generated fallback. */
+  iconUrl?: string;
+  publisher?: ListingPublisher | null;
+  category: string;
+}
+
+/** An admin-managed store category. `id` is immutable; `label` is what renders. */
+export interface AgentCategory {
+  id: string;
+  label: string;
+  order: number;
+  enabled: boolean;
+}
+
+export interface AgentStoreResponse {
+  listings: AgentListing[];
+  /** Opaque cursor; only returned when browsing a single category. */
+  nextCursor?: string | null;
+}
+
+export interface AgentStoreFrontResponse {
+  /** Curated row; empty until the store-front admin ships in Phase 5. */
+  featured: AgentListing[];
+  categories: AgentCategory[];
+}
+
+/** A category plus the listings currently on its shelf, for the Discover sections. */
+export interface CategoryShelf {
+  category: AgentCategory;
+  listings: AgentListing[];
+}

--- a/frontend/ai.client/src/app/agents/services/agent-store.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-store.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, inject, computed, signal } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import {
+  AgentCategory,
+  AgentListing,
+  AgentStoreFrontResponse,
+  AgentStoreResponse,
+  CategoryShelf,
+} from '../models/store.model';
+
+/**
+ * The user-facing marketplace read (Phase 2).
+ *
+ * Discover renders per-category shelves, so the load is one store-front call for the
+ * header plus one call per enabled category. That maps 1:1 onto the backend's single
+ * partition-per-category GSI query — the alternative (one big call, sliced client-side)
+ * would page badly and hide empty categories only after fetching them.
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentStoreService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/agents/store`);
+
+  private _loading = signal(false);
+  private _error = signal<string | null>(null);
+
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  /** The browse header: the featured row plus the categories to render. */
+  async loadStoreFront(): Promise<AgentStoreFrontResponse> {
+    return firstValueFrom(this.http.get<AgentStoreFrontResponse>(`${this.baseUrl()}/front`));
+  }
+
+  /** One category's shelf, newest-first. */
+  async browseCategory(categoryId: string, limit = 12): Promise<AgentListing[]> {
+    const params = new HttpParams().set('category', categoryId).set('limit', String(limit));
+    const response = await firstValueFrom(
+      this.http.get<AgentStoreResponse>(this.baseUrl(), { params }),
+    );
+    return response.listings ?? [];
+  }
+
+  /** Everything, newest-first across categories. Used for search. */
+  async browseAll(limit = 100): Promise<AgentListing[]> {
+    const params = new HttpParams().set('limit', String(limit));
+    const response = await firstValueFrom(
+      this.http.get<AgentStoreResponse>(this.baseUrl(), { params }),
+    );
+    return response.listings ?? [];
+  }
+
+  /**
+   * Load the whole Discover view: the header, then every category's shelf in parallel.
+   *
+   * Empty categories are dropped rather than rendered as empty headings — D10 says
+   * empty categories auto-hide, and a store whose shelves are mostly labels reads as
+   * broken rather than as new.
+   */
+  async loadDiscover(): Promise<{ featured: AgentListing[]; shelves: CategoryShelf[] }> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const front = await this.loadStoreFront();
+      const shelves = await Promise.all(
+        (front.categories ?? []).map(async (category: AgentCategory) => ({
+          category,
+          listings: await this.browseCategory(category.id),
+        })),
+      );
+      return {
+        featured: front.featured ?? [],
+        shelves: shelves.filter((shelf) => shelf.listings.length > 0),
+      };
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this._error.set(typeof detail === 'string' ? detail : 'Failed to load the agent store.');
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -60,6 +60,14 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        // Marketplace Discover (spec phase 2). Sits under the same preview gate as the
+        // rest of /agents — the sidenav entry is system-admin only until Agents are
+        // unveiled, so this is not user-visible yet.
+        path: 'agents/discover',
+        loadComponent: () => import('./agents/discover/discover.page').then(m => m.AgentDiscoverPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'agents',
         loadComponent: () => import('./agents/agents.page').then(m => m.AgentsPage),
         canActivate: [authGuard],


### PR DESCRIPTION
Implements **phase 2** of [`docs/specs/agent-marketplace.md`](docs/specs/agent-marketplace.md), on top of [#731](https://github.com/Boise-State-Development/agentcore-public-stack/pull/731).

Also adds **D15** to the spec (first commit): users can report a problem with a published Agent, and the report lands in the admin console as a second work stream beside submissions. Sequenced as phase 8 because the report action lives on the detail page (phase 3).

## Browse is safe by structure, not by filtering

`GET /agents/store` is a pure GSI5 query. It cannot return an unpublished agent because an unpublished agent **has no key in the index** — there is no `listing.state` check anywhere on the read path, and there shouldn't be. A test asserts this for all four unpublished states by publishing and then unpublishing through the real (moto) index rather than mocking the query, because a mock would happily confirm whatever filtering logic we wrote, which is exactly the thing that must not be load-bearing.

`AgentListingResponse` is a deliberately narrow projection — `agentId`, `name`, `tagline`, `emoji`, `iconUrl`, `publisher`, `category`. `test_the_shelf_never_carries_behavior` pins the **exact key set**, since this payload reaches every browsing user and `instructions` is returned by `GET /agents/{id}` today.

## The category-id constraint

A category id is **half of `GSI5_PK = LISTED#{category}`**, so it is immutable:

- Renaming changes `label` only; a test publishes, renames, and asserts the shelf still resolves under the original partition.
- Seeded ids are the **exact phase 1 strings**, so nothing needs a migration or a GSI rewrite.
- Delete is refused with a 409 while listings reference the category, and the message points at disable instead — which drops it from the pickers and browse header while its agents keep working.

Seeding is idempotent and runs on first read, so no environment is ever category-less (an author cannot submit without a category).

## Honest limits, stated rather than papered over

- **Cursor pagination works within a category** (one partition). Browse-all merges across categories newest-first and returns **no cursor** — carrying N cursors for a merge would be a worse lie than none. A malformed cursor degrades to the first page rather than 500ing.
- **Discover's search filters what's loaded**, it isn't a corpus query. The store is small enough that this is honest; real full-corpus search arrives with the Registry catalog, and faking it now would silently miss results past the first page.
- **The featured row is returned but always empty** until the store-front admin ships in phase 5. The field is present now so the SPA contract doesn't change under it.
- **Rows aren't clickable yet** — the detail page is phase 3. No dead affordances.

## Gating

The `/agents` sidenav entry is **already preview-gated to system-admins**, so Discover inherits that gate and nothing here is user-visible. That also means D14's RBAC capability isn't blocking this phase — it becomes the real question when Agents are unveiled, and the underlying problem (a capability id can't be granted from the roles UI) is its own piece of work.

## Deployment

**`backend.yml` only** — no CDK change. GSI5 shipped in phase 1 and phase 2 adds no index.

## Verification

Backend **4982 passed** / 3 skipped (+26) · SPA **1492 passed** · `ng build` clean · `version.ts` reverted.

Not verified in a browser: the routes aren't deployed to dev yet, and localhost talks to the dev backend, so a clickthrough would 404. The store behaviour is covered against a real DynamoDB index via moto instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
