### PR TITLE
feat(marketplace): phase 3 — detail page, runnability, and the instructions gate

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -26,6 +26,11 @@ from apis.app_api.agent_designer.services.bindable_catalog import (
     BINDABLE_KINDS,
     list_bindable,
 )
+from apis.app_api.agent_designer.services.agent_detail import (
+    resolve_capabilities,
+    resolve_listing_display,
+    resolve_runnability,
+)
 from apis.app_api.agent_designer.services.binding_validation import (
     BindingValidationError,
     validate_agent_write,
@@ -33,6 +38,7 @@ from apis.app_api.agent_designer.services.binding_validation import (
 from apis.shared.assistants.compat import to_agent_view
 from apis.shared.assistants.models import (
     AgentResponse,
+    AgentRunnabilityResponse,
     AgentSharesResponse,
     AgentsListResponse,
     BindableListResponse,
@@ -111,10 +117,22 @@ async def require_marketplace_enabled(
     return user
 
 
+# Permissions that may read an Agent's ``instructions`` (Marketplace Phase 3).
+# ⚠️ Behaviour change: this used to be returned to any PUBLIC viewer. Under link-sharing
+# that exposure was bounded by who had the link; under a store, "PUBLIC" means the whole
+# institution can browse to it, so the system prompt is gated to the people who may edit
+# it. Viewers get ``capabilities`` — names, not behaviour — instead.
+INSTRUCTIONS_PERMISSIONS = ("owner", "editor")
+
+
 def _agent_response(assistant, *, permission: Optional[str] = None,
                     is_shared_with_me: Optional[bool] = None) -> AgentResponse:
     """Project an Assistant into the Agent read-shape, layering share metadata."""
     view = to_agent_view(assistant)
+    if permission not in INSTRUCTIONS_PERMISSIONS:
+        # Dropped rather than blanked: every route here serves the model with
+        # ``response_model_exclude_none``, so the key is simply absent for a viewer.
+        view.pop("instructions", None)
     if permission is not None:
         view["userPermission"] = permission
     if is_shared_with_me is not None:
@@ -275,7 +293,17 @@ async def list_bindable_endpoint(
 
 @router.get("/{agent_id}", response_model=AgentResponse, response_model_exclude_none=True)
 async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require_agents_enabled)):
-    """Retrieve an Agent by id with visibility-based access control."""
+    """Retrieve an Agent by id with visibility-based access control.
+
+    This is the marketplace **detail read** (Phase 3). Two things beyond Phase 1:
+
+    * ``instructions`` is gated to owner/editor — see ``INSTRUCTIONS_PERMISSIONS``.
+    * ``capabilities`` + ``modelLabel`` are resolved, so the detail page can say what the
+      Agent reaches by *name* rather than making the SPA dereference binding refs.
+
+    Capability resolution is best-effort: it is presentation, and a catalog hiccup should
+    not turn a readable Agent into a 500. The list route does not resolve them at all.
+    """
     try:
         if not await assistant_exists(agent_id):
             raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
@@ -284,12 +312,51 @@ async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require
         )
         if not assistant:
             raise HTTPException(status_code=403, detail="Access denied: you do not have permission to access this agent")
-        return _agent_response(assistant, permission=permission)
+
+        response = _agent_response(assistant, permission=permission)
+        try:
+            capabilities, model_label = await resolve_capabilities(assistant, current_user)
+            response.capabilities = capabilities
+            response.model_label = model_label
+            response.publisher, response.category_label = await resolve_listing_display(assistant)
+        except Exception:
+            logger.warning(f"Failed to resolve capabilities for agent {agent_id}", exc_info=True)
+        return response
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error retrieving agent: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to retrieve agent: {str(e)}")
+
+
+@router.get("/{agent_id}/runnability", response_model=AgentRunnabilityResponse)
+async def get_agent_runnability_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """Will this Agent run for the requesting user? (D6)
+
+    Resolves the Agent's ``modelConfig`` + ``bindings`` against the **viewer's** own
+    RBAC-filtered ``/agents/bindable`` results and answers ``ready`` / ``limits`` /
+    ``blocked``, naming what is missing. Access-gated exactly like the detail read: you
+    can only ask about an Agent you can already see.
+
+    D6's stated cost: with no badge on the shelf (D4), a user only learns an Agent will
+    not run for them after tapping into it. This route is where that lands.
+    """
+    try:
+        if not await assistant_exists(agent_id):
+            raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
+        assistant, permission = await get_assistant_with_access_check(
+            assistant_id=agent_id, user_id=current_user.user_id, user_email=current_user.email
+        )
+        if not assistant:
+            raise HTTPException(status_code=403, detail="Access denied: you do not have permission to access this agent")
+        return await resolve_runnability(assistant, current_user)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error resolving agent runnability: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to resolve runnability: {str(e)}")
 
 
 @router.put("/{agent_id}", response_model=AgentResponse, response_model_exclude_none=True)

--- a/backend/src/apis/app_api/agent_designer/services/agent_detail.py
+++ b/backend/src/apis/app_api/agent_designer/services/agent_detail.py
@@ -1,0 +1,328 @@
+"""Agent Marketplace Phase 3 — the detail read and the runnability preview (D4, D6).
+
+Two reads over one Agent record, with one thing in common: **they speak in names.**
+
+* ``resolve_capabilities`` answers *what does this Agent reach?* — the bound primitives
+  projected to ``{label, kind}``. Labels come from the **unfiltered** catalog, on
+  purpose: D6 has to be able to name a capability the viewer lacks, and a viewer-filtered
+  lookup would silently drop exactly the entries that matter most.
+* ``resolve_runnability`` answers *will it run for me?* — the Agent's ``modelConfig`` +
+  ``bindings`` diffed against the viewer's own ``bindable_catalog.list_bindable``
+  results. It **composes the five existing per-primitive access services** and adds no
+  sixth (Agent Designer D4); every ``list_bindable`` call here is the same call the
+  Designer's picker makes, so "what you may bind" and "what will run for you" can never
+  drift apart.
+
+Two rules in here are load-bearing and easy to erode:
+
+**1. ``knowledge_base`` is never gated.** ``compat.effective_bindings`` synthesizes a
+``knowledge_base`` binding on *every* legacy Agent, while ``list_bindable`` returns an
+empty list for that kind (the KB is welded to the Agent and is not user-configurable).
+A naive diff therefore marks every legacy Agent *blocked*. The KB is excluded from both
+reads instead — it is not a capability the viewer can lack.
+
+**2. ``limits`` requires an explicitly optional binding.** ``agent_binding_resolver`` is
+block-with-message for *every* kind it resolves — a missing model, tool, skill or memory
+space raises rather than degrading. So a gap only downgrades to "Runs with limits for
+you" when the binding declares ``config.optional == true``; anything else missing is
+``blocked``, because telling a user an Agent "runs with limits" when the next turn will
+raise would be a preview that lies. No surface writes ``optional`` yet — the flag is the
+seam for when the resolver grows a degrade path, not a live feature.
+"""
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from apis.shared.assistants.categories import get_category
+from apis.shared.assistants.compat import effective_bindings
+from apis.shared.assistants.models import (
+    AgentCapability,
+    AgentRunnabilityResponse,
+    Assistant,
+    ListingPublisher,
+    MissingCapability,
+)
+from apis.shared.assistants.publishers import get_publisher
+from apis.shared.auth.models import User
+from apis.shared.models.managed_models import list_all_managed_models
+from apis.shared.skills.repository import get_skill_catalog_repository
+from apis.shared.tools.scoped_ids import base_tool_id
+from apis.shared.memory.service import MemorySpaceService
+
+from apis.app_api.agent_designer.services.bindable_catalog import list_bindable
+from apis.app_api.tools.service import ToolCatalogService, get_tool_catalog_service
+
+logger = logging.getLogger(__name__)
+
+# Kinds a viewer can be denied, in the order the detail page lists them. ``knowledge_base``
+# is deliberately absent (rule 1 above) and so is any kind this deployment does not know —
+# the run-time resolver ignores unknown kinds, so previewing a block on one would be wrong.
+GATED_KINDS = ("tool", "skill", "memory_space")
+
+# Fallbacks for a ref whose primitive no longer resolves. Never fall back to the ref
+# itself: a capability label is rendered to every viewer, and refs are not display content.
+_KIND_FALLBACK_LABELS = {
+    "tool": "A tool",
+    "skill": "A skill",
+    "memory_space": "A memory space",
+    "model": "A model",
+}
+
+
+def _fallback(kind: str) -> str:
+    return _KIND_FALLBACK_LABELS.get(kind, "A capability")
+
+
+def _is_optional(binding) -> bool:
+    """Whether this binding degrades rather than blocks when the viewer lacks it."""
+    return (binding.config or {}).get("optional") is True
+
+
+def _binding_key(binding) -> str:
+    """The identity a binding is looked up and diffed by.
+
+    Tool refs may be *scoped* (``toolId::mcpToolName``) to bind a subset of an MCP
+    server's tools, while both the catalog and the RBAC gate key on the bare catalog id
+    — so a scoped ref must collapse to its base before either lookup.
+    """
+    return base_tool_id(binding.ref) if binding.kind == "tool" else binding.ref
+
+
+def _gated_bindings(assistant: Assistant) -> List:
+    """The Agent's bindings that a viewer can actually be denied, KB excluded."""
+    return [b for b in effective_bindings(assistant) if b.kind in GATED_KINDS]
+
+
+# ------------------------------------------------------------------ label resolution
+async def _tool_labels(refs: List[str], svc: ToolCatalogService) -> Dict[str, str]:
+    labels: Dict[str, str] = {}
+    for ref in refs:
+        try:
+            tool = await svc.get_tool(ref)
+        except Exception:
+            logger.warning(f"Failed to resolve tool label for '{ref}'", exc_info=True)
+            tool = None
+        if tool is not None:
+            labels[ref] = tool.display_name
+    return labels
+
+
+async def _skill_labels(refs: List[str]) -> Dict[str, str]:
+    if not refs:
+        return {}
+    try:
+        skills = await get_skill_catalog_repository().batch_get_skills(refs)
+    except Exception:
+        logger.warning("Failed to resolve skill labels", exc_info=True)
+        return {}
+    return {s.skill_id: s.display_name for s in skills}
+
+
+def _memory_labels(refs: List[str], user: User, svc: MemorySpaceService) -> Dict[str, str]:
+    """Memory-space names, resolved through the viewer.
+
+    Unlike tools and skills there is no unfiltered name lookup for a space, and there
+    should not be — a space is personal data. That is tolerable precisely because D7
+    blocks submission on a ``memory_space`` binding, so a *published* Agent never has
+    one; this path is reached by an author looking at their own Agent, where the lookup
+    resolves. Anything unresolved falls back to the generic kind label.
+    """
+    labels: Dict[str, str] = {}
+    for ref in refs:
+        try:
+            space, _role = svc.resolve_permission(ref, user.user_id, user.email)
+        except Exception:
+            logger.warning(f"Failed to resolve memory space label for '{ref}'", exc_info=True)
+            space = None
+        if space is not None:
+            labels[ref] = space.name
+    return labels
+
+
+async def _model_label(model_id: str) -> Optional[str]:
+    """The managed model's display name, unfiltered by the viewer's access."""
+    try:
+        model = next((m for m in await list_all_managed_models() if m.model_id == model_id), None)
+    except Exception:
+        logger.warning(f"Failed to resolve model label for '{model_id}'", exc_info=True)
+        return None
+    return model.model_name if model else None
+
+
+async def _labels_by_kind(
+    assistant: Assistant,
+    user: User,
+    *,
+    tool_service: Optional[ToolCatalogService] = None,
+    memory_service: Optional[MemorySpaceService] = None,
+) -> Dict[str, Dict[str, str]]:
+    """``{kind: {ref: label}}`` for every gated binding on the Agent.
+
+    Each per-kind lookup runs only when that kind is actually bound, mirroring the lazy
+    fetching in ``binding_validation.validate_agent_write``.
+    """
+    by_kind: Dict[str, List[str]] = {kind: [] for kind in GATED_KINDS}
+    for binding in _gated_bindings(assistant):
+        key = _binding_key(binding)
+        if key not in by_kind[binding.kind]:
+            by_kind[binding.kind].append(key)
+
+    labels: Dict[str, Dict[str, str]] = {kind: {} for kind in GATED_KINDS}
+    if by_kind["tool"]:
+        labels["tool"] = await _tool_labels(by_kind["tool"], tool_service or get_tool_catalog_service())
+    if by_kind["skill"]:
+        labels["skill"] = await _skill_labels(by_kind["skill"])
+    if by_kind["memory_space"]:
+        labels["memory_space"] = _memory_labels(
+            by_kind["memory_space"], user, memory_service or MemorySpaceService()
+        )
+    return labels
+
+
+# --------------------------------------------------------------------- capabilities
+async def resolve_capabilities(
+    assistant: Assistant,
+    user: User,
+    *,
+    tool_service: Optional[ToolCatalogService] = None,
+    memory_service: Optional[MemorySpaceService] = None,
+) -> Tuple[List[AgentCapability], Optional[str]]:
+    """Return ``(capabilities, model_label)`` for the detail read.
+
+    Capabilities are de-duplicated by ``(kind, label)``: two scoped bindings into the
+    same MCP server are one line on the page, not two identical ones. ``model_label`` is
+    ``None`` when the Agent pins no model, which means "resolve the model as today" —
+    the detail page renders an em dash rather than inventing a name.
+    """
+    labels = await _labels_by_kind(
+        assistant, user, tool_service=tool_service, memory_service=memory_service
+    )
+
+    capabilities: List[AgentCapability] = []
+    seen = set()
+    for binding in _gated_bindings(assistant):
+        label = labels.get(binding.kind, {}).get(_binding_key(binding)) or _fallback(binding.kind)
+        if (binding.kind, label) in seen:
+            continue
+        seen.add((binding.kind, label))
+        capabilities.append(AgentCapability(label=label, kind=binding.kind))
+
+    model_label = None
+    if assistant.model_settings is not None:
+        model_label = await _model_label(assistant.model_settings.model_id)
+
+    return capabilities, model_label
+
+
+# ------------------------------------------------------------------ listing display
+async def resolve_listing_display(
+    assistant: Assistant,
+) -> Tuple[Optional[ListingPublisher], Optional[str]]:
+    """Return ``(publisher, category_label)`` for the detail page's Details panel.
+
+    Both halves exist because **the stored listing holds ids, and ids are not display
+    content**: ``listing.publisherId`` references a ``PublisherProfile`` (D12) and
+    ``listing.category`` is a category id that an admin may since have renamed. Rendering
+    either raw would put an internal reference on a page every browsing user sees, and in
+    the publisher's case would also skip the ``verified`` mark that the whole attribution
+    decision hangs on.
+
+    ⚠️ This is the *only* thing ``publisherId`` is ever used for. It is display-only and
+    must never reach an access check — ``ownerId`` governs edit rights and Skills v2
+    invoke-through resolution, and re-attributing a listing changes neither.
+
+    A deleted publisher or category yields ``None`` rather than an error: a listing whose
+    attribution was removed still renders, exactly as the shelf does.
+    """
+    listing = assistant.listing
+    if listing is None:
+        return None, None
+
+    publisher = None
+    try:
+        profile = await get_publisher(listing.publisher_id)
+        if profile is not None:
+            publisher = ListingPublisher(
+                label=profile.label, kind=profile.kind, verified=profile.verified
+            )
+    except Exception:
+        logger.warning(
+            f"Failed to resolve publisher '{listing.publisher_id}' for detail read", exc_info=True
+        )
+
+    category_label = listing.category
+    try:
+        category = await get_category(listing.category)
+        if category is not None:
+            category_label = category.label
+    except Exception:
+        logger.warning(
+            f"Failed to resolve category '{listing.category}' for detail read", exc_info=True
+        )
+
+    return publisher, category_label
+
+
+# ---------------------------------------------------------------------- runnability
+async def resolve_runnability(
+    assistant: Assistant,
+    user: User,
+    *,
+    tool_service: Optional[ToolCatalogService] = None,
+    memory_service: Optional[MemorySpaceService] = None,
+) -> AgentRunnabilityResponse:
+    """Diff the Agent's model + bindings against the viewer's own catalog (D6).
+
+    ``ready`` when nothing is missing, ``limits`` when only optional bindings are, and
+    ``blocked`` the moment something the run-time resolver would raise on is absent.
+    """
+    missing: List[MissingCapability] = []
+    labels = await _labels_by_kind(
+        assistant, user, tool_service=tool_service, memory_service=memory_service
+    )
+
+    # The pinned model. Not a binding and never optional — ``agent_binding_resolver``
+    # blocks the turn outright when the invoker cannot access it.
+    if assistant.model_settings is not None:
+        model_id = assistant.model_settings.model_id
+        available_models = {item.ref for item in await list_bindable("model", user)}
+        if model_id not in available_models:
+            missing.append(
+                MissingCapability(
+                    label=await _model_label(model_id) or _fallback("model"),
+                    kind="model",
+                    optional=False,
+                )
+            )
+
+    bindings = _gated_bindings(assistant)
+    for kind in GATED_KINDS:
+        of_kind = [b for b in bindings if b.kind == kind]
+        if not of_kind:
+            continue
+        # One catalog fetch per bound kind — the same RBAC-filtered list the Designer
+        # picker shows the viewer. An empty list is a legitimate answer (the primitive's
+        # feature flag is off in this environment), and it correctly blocks, matching
+        # the run-time resolver's behaviour in the same situation.
+        available = {item.ref for item in await list_bindable(kind, user)}
+        for binding in of_kind:
+            key = _binding_key(binding)
+            if key in available:
+                continue
+            label = labels.get(kind, {}).get(key) or _fallback(kind)
+            if any(m.kind == kind and m.label == label for m in missing):
+                continue
+            missing.append(
+                MissingCapability(label=label, kind=kind, optional=_is_optional(binding))
+            )
+
+    if not missing:
+        state = "ready"
+    elif all(item.optional for item in missing):
+        state = "limits"
+    else:
+        state = "blocked"
+
+    return AgentRunnabilityResponse(
+        agent_id=assistant.assistant_id, state=state, missing=missing
+    )

--- a/backend/src/apis/shared/assistants/compat.py
+++ b/backend/src/apis/shared/assistants/compat.py
@@ -51,6 +51,10 @@ def to_agent_view(assistant: Assistant) -> dict:
     Returns a plain dict (camelCase keys) — the HTTP response model is a route concern
     (Phase 3). ``agentId`` aliases ``assistantId``; legacy ids remain valid. ``owner_id``
     is deliberately omitted (never returned to clients), matching ``AssistantResponse``.
+
+    ``instructions`` is projected here and **dropped by the route** for anyone who is not
+    an owner or editor (Marketplace Phase 3). The gate lives at the route because that is
+    where the caller's permission is known; this function stays a pure record projection.
     """
     return {
         "agentId": assistant.assistant_id,
@@ -69,4 +73,11 @@ def to_agent_view(assistant: Assistant) -> dict:
         "status": assistant.status,
         "createdAt": assistant.created_at,
         "updatedAt": assistant.updated_at,
+        # Marketplace (Phase 1 fields, projected in Phase 3 when the detail page first
+        # needed them). All three are ``None`` on an agent that was never submitted —
+        # the D3 backfill default — and every route serving ``AgentResponse`` uses
+        # ``response_model_exclude_none``, so that payload is unchanged.
+        "tagline": assistant.tagline,
+        "iconKey": assistant.icon_key,
+        "listing": assistant.listing.model_dump(by_alias=True) if assistant.listing else None,
     }

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -270,6 +270,59 @@ class AssistantsListResponse(BaseModel):
     next_token: Optional[str] = Field(None, alias="nextToken", description="Pagination token for next page")
 
 
+class AgentCapability(BaseModel):
+    """One thing an Agent can reach, as the detail page names it (Phase 3, D4/D6).
+
+    ⚠️ **Names, never refs.** A capability is rendered to anyone who can see the Agent,
+    so it carries the primitive's display name and its kind — not the ``binding.ref``,
+    not a tool id, not a skill id. That is the same reasoning as the shelf projection in
+    ``AgentListingResponse``, one level less narrow.
+
+    Labels resolve against the **unfiltered** catalog rather than the viewer's, because
+    D6 has to be able to name a capability the viewer *lacks*. Availability is the
+    separate ``/runnability`` read; this list is what the Agent binds, full stop.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., description="Display name of the bound primitive")
+    kind: str = Field(..., description="Binding kind (tool | skill | memory_space)")
+
+
+RunnabilityState = Literal["ready", "limits", "blocked"]
+
+
+class MissingCapability(BaseModel):
+    """A capability the viewer cannot reach, named for the D6 availability line."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(..., description="Display name of the unavailable primitive")
+    kind: str = Field(..., description="'model' or a binding kind")
+    optional: bool = Field(
+        False,
+        description="Whether the binding was declared optional; only optional gaps degrade to 'limits'",
+    )
+
+
+class AgentRunnabilityResponse(BaseModel):
+    """Whether this Agent will run for the requesting user (D6).
+
+    Resolved by diffing the Agent's ``modelConfig`` + ``bindings`` against the viewer's
+    own RBAC-filtered ``list_bindable`` results — composing the five existing
+    per-primitive checks, never a sixth access service (Designer D4).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    state: RunnabilityState = Field(
+        ..., description="ready | limits | blocked — the D6 three-way outcome"
+    )
+    missing: List[MissingCapability] = Field(
+        default_factory=list, description="What the viewer cannot reach; empty when ready"
+    )
+
 class AgentResponse(BaseModel):
     """Agent read-shape (D3) — the projection served by the ``/agents/*`` surface.
 
@@ -284,7 +337,14 @@ class AgentResponse(BaseModel):
     owner_name: str = Field(..., alias="ownerName", description="Owner display name")
     name: str = Field(..., description="Agent display name")
     description: str = Field(..., description="Short summary")
-    instructions: str = Field(..., description="System prompt")
+    instructions: Optional[str] = Field(
+        None,
+        description=(
+            "System prompt. ⚠️ Marketplace Phase 3: gated to permission in ('owner', 'editor') "
+            "and omitted otherwise. Under link-sharing, exposing it to any PUBLIC viewer was "
+            "bounded; under a store it is not."
+        ),
+    )
     model_settings: Optional[AgentModelConfig] = Field(None, alias="modelConfig", description="Governed single-select model")
     bindings: List[AgentBinding] = Field(default_factory=list, description="Resolved bindings (legacy KB synthesized)")
     visibility: Literal["PRIVATE", "PUBLIC", "SHARED"] = Field(..., description="Access control")
@@ -304,10 +364,36 @@ class AgentResponse(BaseModel):
     icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon (D5)")
     listing: Optional[AgentListing] = Field(None, description="Publication state (D2); absent = never submitted")
 
+    # Marketplace Phase 3 — the detail read. Both are populated only by GET /agents/{id};
+    # the list route leaves them None (and serves ``response_model_exclude_none``), so
+    # listing payloads are unchanged and no N-agent label fan-out happens on a list read.
+    capabilities: Optional[List[AgentCapability]] = Field(
+        None, description="What the Agent can reach, by display name (D4/D6)"
+    )
+    model_label: Optional[str] = Field(
+        None,
+        alias="modelLabel",
+        description="Display name of the pinned model, for the detail Details panel; absent when no model is pinned",
+    )
+    publisher: Optional["ListingPublisher"] = Field(
+        None,
+        description=(
+            "Attribution as the detail page renders it (D12), resolved from "
+            "``listing.publisherId``. DISPLAY ONLY — the id itself is never returned and "
+            "never gates access."
+        ),
+    )
+    category_label: Optional[str] = Field(
+        None,
+        alias="categoryLabel",
+        description="Human-readable category name; ``listing.category`` is an id an admin may have renamed",
+    )
+
     # Share metadata (parity with AssistantResponse; set post-projection)
     first_interacted: Optional[bool] = Field(None, alias="firstInteracted")
     is_shared_with_me: Optional[bool] = Field(None, alias="isSharedWithMe")
     user_permission: Optional[Literal["owner", "editor", "viewer"]] = Field(None, alias="userPermission")
+
 
 
 class AgentsListResponse(BaseModel):

--- a/backend/tests/routes/test_agent_detail.py
+++ b/backend/tests/routes/test_agent_detail.py
@@ -1,0 +1,299 @@
+"""Agent Marketplace Phase 3 — the detail read, the instructions gate, and runnability.
+
+The gate is a **behaviour change to an endpoint that already shipped**: ``GET /agents/{id}``
+returned ``instructions`` to any PUBLIC viewer, which was tolerable while PUBLIC meant
+"anyone with the link" and is not once a store puts the link in front of the institution.
+These tests pin it per permission level, because the failure mode — a regression that
+restores the field for viewers — is silent and invisible in the UI.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.agent_designer.routes import router
+from apis.shared.assistants.models import (
+    AgentBinding,
+    AgentCapability,
+    AgentModelConfig,
+    AgentRunnabilityResponse,
+    Assistant,
+    MissingCapability,
+)
+from tests.routes.conftest import mock_auth_user
+
+ROUTES_MODULE = "apis.app_api.agent_designer.routes"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Finds and cites university policy",
+        instructions="SECRET SYSTEM PROMPT",
+        vectorIndexId="idx-001",
+        visibility="PUBLIC",
+        tags=["policy"],
+        starters=["What is the travel reimbursement deadline?"],
+        emoji="📋",
+        usageCount=12,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-20T00:00:00Z",
+        status="COMPLETE",
+        tagline="Find and cite university policy",
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    return _app
+
+
+@pytest.fixture
+def _flags_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+def _get_agent(app, permission, *, capabilities=None, model_label=None, agent=None):
+    """Drive ``GET /agents/{id}`` with the access check resolved to ``permission``."""
+    with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True), patch(
+        f"{ROUTES_MODULE}.get_assistant_with_access_check",
+        new_callable=AsyncMock,
+        return_value=(agent or _make_assistant(), permission),
+    ), patch(
+        f"{ROUTES_MODULE}.resolve_capabilities",
+        new_callable=AsyncMock,
+        return_value=(capabilities or [], model_label),
+    ):
+        return TestClient(app).get("/agents/ast-001")
+
+
+# ── the instructions gate ────────────────────────────────────────────────────────────
+class TestInstructionsGate:
+    @pytest.mark.parametrize("permission", ["owner", "editor"])
+    def test_owner_and_editor_still_read_instructions(self, app, make_user, _flags_on, permission):
+        """The people who may *edit* the system prompt keep reading it — the Designer
+        loads the Agent through this exact route to populate its form."""
+        mock_auth_user(app, make_user())
+        resp = _get_agent(app, permission)
+
+        assert resp.status_code == 200
+        assert resp.json()["instructions"] == "SECRET SYSTEM PROMPT"
+
+    def test_a_viewer_does_not_receive_instructions(self, app, make_user, _flags_on):
+        """The store case: a PUBLIC agent every browsing user can reach."""
+        mock_auth_user(app, make_user())
+        resp = _get_agent(app, "viewer")
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert "instructions" not in body
+        # The rest of the detail read is intact — this is a gate, not a truncation.
+        assert body["description"] == "Finds and cites university policy"
+        assert body["starters"] == ["What is the travel reimbursement deadline?"]
+        assert body["updatedAt"] == "2026-07-20T00:00:00Z"
+
+    def test_the_prompt_text_appears_nowhere_in_a_viewers_payload(self, app, make_user, _flags_on):
+        """Guards the whole response, not one key: a future field that happens to echo
+        the prompt (a summary, a preview) re-opens the exact hole this closed."""
+        mock_auth_user(app, make_user())
+        resp = _get_agent(app, "viewer")
+
+        assert "SECRET SYSTEM PROMPT" not in resp.text
+
+    def test_the_list_read_is_gated_the_same_way(self, app, make_user, _flags_on):
+        """An agent shared read-only shows up in ``GET /agents`` too; one gate, both reads."""
+        mock_auth_user(app, make_user())
+        shared = _make_assistant()
+        shared.user_permission = "viewer"
+        with patch(
+            f"{ROUTES_MODULE}.list_user_assistants", new_callable=AsyncMock, return_value=([], None)
+        ), patch(f"{ROUTES_MODULE}.list_shared_with_user", new_callable=AsyncMock, return_value=[shared]):
+            resp = TestClient(app).get("/agents")
+
+        assert resp.status_code == 200
+        assert "instructions" not in resp.json()["agents"][0]
+
+
+# ── the detail shape ─────────────────────────────────────────────────────────────────
+class TestDetailShape:
+    def test_capabilities_and_model_label_are_layered_on(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        resp = _get_agent(
+            app,
+            "viewer",
+            capabilities=[
+                AgentCapability(label="Document Search", kind="tool"),
+                AgentCapability(label="Policy Citation Format", kind="skill"),
+            ],
+            model_label="Claude Sonnet 4.5",
+        )
+
+        body = resp.json()
+        assert body["capabilities"] == [
+            {"label": "Document Search", "kind": "tool"},
+            {"label": "Policy Citation Format", "kind": "skill"},
+        ]
+        assert body["modelLabel"] == "Claude Sonnet 4.5"
+
+    def test_a_capability_lookup_failure_does_not_500_the_page(self, app, make_user, _flags_on):
+        """Capabilities are presentation. A catalog hiccup degrades the panel; it must
+        not turn a readable Agent into an error page."""
+        mock_auth_user(app, make_user())
+        with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check",
+            new_callable=AsyncMock,
+            return_value=(_make_assistant(), "viewer"),
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_capabilities",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("catalog down"),
+        ):
+            resp = TestClient(app).get("/agents/ast-001")
+
+        assert resp.status_code == 200
+        assert "capabilities" not in resp.json()
+
+    def test_the_publisher_renders_by_name_and_never_by_id(self, app, make_user, _flags_on):
+        """D12: attribution is display-only, so the page gets label/kind/verified and the
+        ``publisherId`` it was resolved from stays server-side."""
+        from apis.shared.assistants.models import AgentListing, ListingPublisher
+
+        mock_auth_user(app, make_user())
+        listed = _make_assistant(
+            listing=AgentListing(
+                state="published", category="Administration", publisher_id="pub-registrar"
+            )
+        )
+        with patch(f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check",
+            new_callable=AsyncMock,
+            return_value=(listed, "viewer"),
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_capabilities", new_callable=AsyncMock, return_value=([], None)
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_listing_display",
+            new_callable=AsyncMock,
+            return_value=(
+                ListingPublisher(
+                    label="Office of the Registrar", kind="department", verified=True
+                ),
+                "University Operations",
+            ),
+        ):
+            resp = TestClient(app).get("/agents/ast-001")
+
+        body = resp.json()
+        assert body["publisher"] == {
+            "label": "Office of the Registrar",
+            "kind": "department",
+            "verified": True,
+        }
+        assert body["categoryLabel"] == "University Operations"
+        # The id is still on the listing block for owner-facing surfaces, but it is never
+        # what the page renders — and it is not a permission.
+        assert body["listing"]["publisherId"] == "pub-registrar"
+
+    def test_an_unlisted_agent_carries_no_listing_block(self, app, make_user, _flags_on):
+        """D3's backfill default: absent listing means never submitted, and stays absent."""
+        mock_auth_user(app, make_user())
+        resp = _get_agent(app, "owner")
+
+        assert "listing" not in resp.json()
+
+
+# ── runnability (D6) ─────────────────────────────────────────────────────────────────
+class TestRunnabilityRoute:
+    def _call(self, app, *, result=None, permission="viewer", exists=True, access=True):
+        agent = _make_assistant(
+            bindings=[AgentBinding(kind="tool", ref="workday_query")],
+            model_settings=AgentModelConfig(model_id="claude-opus"),
+        )
+        with patch(
+            f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=exists
+        ), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check",
+            new_callable=AsyncMock,
+            return_value=(agent, permission) if access else (None, None),
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_runnability",
+            new_callable=AsyncMock,
+            return_value=result
+            or AgentRunnabilityResponse(agent_id="ast-001", state="ready", missing=[]),
+        ):
+            return TestClient(app).get("/agents/ast-001/runnability")
+
+    def test_ready(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        resp = self._call(app)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"agentId": "ast-001", "state": "ready", "missing": []}
+
+    def test_limits_names_the_optional_binding(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        resp = self._call(
+            app,
+            result=AgentRunnabilityResponse(
+                agent_id="ast-001",
+                state="limits",
+                missing=[
+                    MissingCapability(label="Grants.gov Search", kind="tool", optional=True)
+                ],
+            ),
+        )
+
+        body = resp.json()
+        assert body["state"] == "limits"
+        assert body["missing"] == [
+            {"label": "Grants.gov Search", "kind": "tool", "optional": True}
+        ]
+
+    def test_blocked_names_what_is_missing(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        resp = self._call(
+            app,
+            result=AgentRunnabilityResponse(
+                agent_id="ast-001",
+                state="blocked",
+                missing=[MissingCapability(label="Workday Query", kind="tool")],
+            ),
+        )
+
+        body = resp.json()
+        assert body["state"] == "blocked"
+        assert body["missing"][0]["label"] == "Workday Query"
+
+    def test_runnability_never_leaks_instructions_or_refs(self, app, make_user, _flags_on):
+        """It answers one question. The Agent's prompt and its binding refs are not part
+        of the answer, and the agent record is right there in the handler."""
+        mock_auth_user(app, make_user())
+        resp = self._call(app)
+
+        assert "SECRET SYSTEM PROMPT" not in resp.text
+        assert "workday_query" not in resp.text
+
+    def test_404_for_an_agent_that_does_not_exist(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        assert self._call(app, exists=False).status_code == 404
+
+    def test_403_when_the_caller_cannot_see_the_agent(self, app, make_user, _flags_on):
+        """You may only ask about runnability for an Agent you can already reach."""
+        mock_auth_user(app, make_user())
+        assert self._call(app, access=False).status_code == 403
+
+    def test_404_when_the_marketplace_kill_switch_is_off(self, app, make_user, monkeypatch):
+        monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+        monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+        mock_auth_user(app, make_user())
+
+        assert self._call(app).status_code == 404

--- a/backend/tests/shared/test_agent_compat.py
+++ b/backend/tests/shared/test_agent_compat.py
@@ -67,6 +67,33 @@ class TestCompatMapping:
         assert view["agentId"] == "ast_123"
         assert "ownerId" not in view and "owner_id" not in view
 
+    def test_agent_view_projects_the_listing_block(self):
+        """Marketplace Phase 3: the detail read carries ``listing``, so the projection
+        has to actually emit it — the field existed on the response model from Phase 1
+        but nothing populated it."""
+        from apis.shared.assistants.models import AgentListing
+
+        a = _legacy_assistant(
+            tagline="Find and cite university policy",
+            listing=AgentListing(
+                state="published", category="Administration", publisher_id="pub-registrar"
+            ),
+        )
+        view = to_agent_view(a)
+
+        assert view["tagline"] == "Find and cite university policy"
+        assert view["listing"]["state"] == "published"
+        assert view["listing"]["publisherId"] == "pub-registrar"
+
+    def test_an_unsubmitted_agents_marketplace_fields_are_all_none(self):
+        """``response_model_exclude_none`` then drops them, so the payload for an agent
+        that was never submitted is byte-identical to before the marketplace shipped."""
+        view = to_agent_view(_legacy_assistant())
+
+        assert view["listing"] is None
+        assert view["tagline"] is None
+        assert view["iconKey"] is None
+
 
 class TestModelContract:
     def test_modelconfig_alias_roundtrip(self):

--- a/backend/tests/shared/test_agent_runnability.py
+++ b/backend/tests/shared/test_agent_runnability.py
@@ -1,0 +1,362 @@
+"""Agent Marketplace Phase 3 — the capability projection and the D6 diff.
+
+Two properties are under test, and both are the kind that quietly rot:
+
+* **Capabilities carry names, never refs.** The detail page is seen by anyone who can
+  reach the Agent, so a tool id or skill id appearing in that list is a leak of exactly
+  the sort ``AgentListingResponse`` was narrowed to prevent.
+* **Runnability composes ``list_bindable`` and nothing else.** Every assertion here goes
+  through the real ``resolve_runnability`` with a stubbed catalog, so a future change
+  that grows a sixth access service instead of composing the five fails loudly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apis.app_api.agent_designer.services.agent_detail import (
+    resolve_capabilities,
+    resolve_listing_display,
+    resolve_runnability,
+)
+from apis.shared.assistants.models import (
+    AgentBinding,
+    AgentModelConfig,
+    Assistant,
+    BindableItem,
+)
+from apis.shared.auth.models import User
+
+MODULE = "apis.app_api.agent_designer.services.agent_detail"
+
+
+def _agent(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Finds policy",
+        instructions="SECRET SYSTEM PROMPT",
+        vectorIndexId="idx-001",
+        visibility="PUBLIC",
+        usageCount=3,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+def _user(user_id="user-viewer") -> User:
+    return User(user_id=user_id, email=f"{user_id}@x.edu", name="A Viewer", roles=[])
+
+
+class _Tools:
+    """Stands in for ToolCatalogService's unfiltered ``get_tool`` lookup."""
+
+    def __init__(self, labels: dict):
+        self._labels = labels
+
+    async def get_tool(self, tool_id):
+        label = self._labels.get(tool_id)
+        return SimpleNamespace(tool_id=tool_id, display_name=label) if label else None
+
+
+def _catalog(**by_kind):
+    """A fake ``list_bindable`` returning the viewer's catalog per kind."""
+
+    async def _list_bindable(kind, user, **_kwargs):
+        return [
+            BindableItem(kind=kind, ref=ref, label=label)
+            for ref, label in by_kind.get(kind, {}).items()
+        ]
+
+    return _list_bindable
+
+
+def _skills(labels: dict):
+    repo = SimpleNamespace(
+        batch_get_skills=AsyncMock(
+            return_value=[
+                SimpleNamespace(skill_id=ref, display_name=label) for ref, label in labels.items()
+            ]
+        )
+    )
+    return patch(f"{MODULE}.get_skill_catalog_repository", return_value=repo)
+
+
+def _models(*pairs):
+    return patch(
+        f"{MODULE}.list_all_managed_models",
+        new_callable=AsyncMock,
+        return_value=[SimpleNamespace(model_id=mid, model_name=name) for mid, name in pairs],
+    )
+
+
+# ── capabilities: names, not refs ────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_capabilities_carry_display_names_never_refs():
+    agent = _agent(
+        bindings=[
+            AgentBinding(kind="tool", ref="document_search"),
+            AgentBinding(kind="skill", ref="skl_9f2c"),
+        ],
+        model_settings=AgentModelConfig(model_id="us.anthropic.claude-sonnet"),
+    )
+    with _skills({"skl_9f2c": "Policy Citation Format"}), _models(
+        ("us.anthropic.claude-sonnet", "Claude Sonnet 4.5")
+    ):
+        capabilities, model_label = await resolve_capabilities(
+            agent, _user(), tool_service=_Tools({"document_search": "Document Search"})
+        )
+
+    assert [(c.label, c.kind) for c in capabilities] == [
+        ("Document Search", "tool"),
+        ("Policy Citation Format", "skill"),
+    ]
+    assert model_label == "Claude Sonnet 4.5"
+
+    # The refs themselves must appear nowhere in the projection.
+    rendered = [c.model_dump() for c in capabilities]
+    assert not any("document_search" in str(row) or "skl_9f2c" in str(row) for row in rendered)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_omit_the_synthesized_knowledge_base():
+    """A legacy Agent's KB binding is welded plumbing, not a capability to advertise."""
+    with _models():
+        capabilities, model_label = await resolve_capabilities(_agent(), _user())
+
+    assert capabilities == []
+    assert model_label is None
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_ref_falls_back_to_a_kind_label_not_the_ref():
+    """A deleted tool must not leak its id into the page as a 'name'."""
+    agent = _agent(bindings=[AgentBinding(kind="tool", ref="tool_that_was_deleted")])
+    with _models():
+        capabilities, _ = await resolve_capabilities(agent, _user(), tool_service=_Tools({}))
+
+    assert [c.label for c in capabilities] == ["A tool"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_tool_bindings_collapse_to_one_named_capability():
+    """Two sub-tools of one MCP server are one line on the page, resolved by base id."""
+    agent = _agent(
+        bindings=[
+            AgentBinding(kind="tool", ref="wikipedia::search"),
+            AgentBinding(kind="tool", ref="wikipedia::fetch"),
+        ]
+    )
+    with _models():
+        capabilities, _ = await resolve_capabilities(
+            agent, _user(), tool_service=_Tools({"wikipedia": "Wikipedia"})
+        )
+
+    assert [(c.label, c.kind) for c in capabilities] == [("Wikipedia", "tool")]
+
+
+# ── listing display: ids resolved to names ───────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_listing_display_resolves_publisher_and_category_to_names():
+    from apis.shared.assistants.models import AgentListing, AgentCategory, PublisherProfile
+
+    agent = _agent(
+        listing=AgentListing(
+            state="published", category="Administration", publisher_id="pub-registrar"
+        )
+    )
+    profile = PublisherProfile(
+        id="pub-registrar", label="Office of the Registrar", kind="department", verified=True
+    )
+    with patch(f"{MODULE}.get_publisher", new_callable=AsyncMock, return_value=profile), patch(
+        f"{MODULE}.get_category",
+        new_callable=AsyncMock,
+        return_value=AgentCategory(id="Administration", label="University Operations"),
+    ):
+        publisher, category_label = await resolve_listing_display(agent)
+
+    assert (publisher.label, publisher.kind, publisher.verified) == (
+        "Office of the Registrar",
+        "department",
+        True,
+    )
+    # The renamed label renders, not the immutable partition id.
+    assert category_label == "University Operations"
+    # And the publisher id never rides along — it is an internal reference.
+    assert "id" not in publisher.model_dump(by_alias=True)
+
+
+@pytest.mark.asyncio
+async def test_listing_display_survives_a_deleted_publisher():
+    from apis.shared.assistants.models import AgentListing
+
+    agent = _agent(
+        listing=AgentListing(state="published", category="Research", publisher_id="pub-gone")
+    )
+    with patch(f"{MODULE}.get_publisher", new_callable=AsyncMock, return_value=None), patch(
+        f"{MODULE}.get_category", new_callable=AsyncMock, return_value=None
+    ):
+        publisher, category_label = await resolve_listing_display(agent)
+
+    assert publisher is None
+    assert category_label == "Research"  # falls back to the id, which is also the seeded label
+
+
+@pytest.mark.asyncio
+async def test_an_agent_that_was_never_submitted_has_no_listing_display():
+    publisher, category_label = await resolve_listing_display(_agent())
+
+    assert publisher is None
+    assert category_label is None
+
+
+# ── runnability: the three-way outcome (D6) ──────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_ready_when_the_viewer_holds_everything():
+    agent = _agent(
+        bindings=[AgentBinding(kind="tool", ref="document_search")],
+        model_settings=AgentModelConfig(model_id="claude-sonnet"),
+    )
+    catalog = _catalog(
+        model={"claude-sonnet": "Claude Sonnet 4.5"}, tool={"document_search": "Document Search"}
+    )
+    with patch(f"{MODULE}.list_bindable", side_effect=catalog), _models():
+        result = await resolve_runnability(
+            agent, _user(), tool_service=_Tools({"document_search": "Document Search"})
+        )
+
+    assert result.state == "ready"
+    assert result.missing == []
+    assert result.agent_id == "ast-001"
+
+
+@pytest.mark.asyncio
+async def test_blocked_when_a_required_tool_is_not_in_the_viewers_catalog():
+    """Names what is missing — by label, because the SPA renders this line verbatim."""
+    agent = _agent(bindings=[AgentBinding(kind="tool", ref="workday_query")])
+    with patch(f"{MODULE}.list_bindable", side_effect=_catalog(tool={})), _models():
+        result = await resolve_runnability(
+            agent, _user(), tool_service=_Tools({"workday_query": "Workday Query"})
+        )
+
+    assert result.state == "blocked"
+    assert [(m.label, m.kind, m.optional) for m in result.missing] == [
+        ("Workday Query", "tool", False)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_limits_when_only_an_optional_binding_is_missing():
+    """The one gap that degrades instead of blocking — see the module docstring."""
+    agent = _agent(
+        bindings=[
+            AgentBinding(kind="tool", ref="document_search"),
+            AgentBinding(kind="tool", ref="grants_gov", config={"optional": True}),
+        ]
+    )
+    catalog = _catalog(tool={"document_search": "Document Search"})
+    with patch(f"{MODULE}.list_bindable", side_effect=catalog), _models():
+        result = await resolve_runnability(
+            agent,
+            _user(),
+            tool_service=_Tools(
+                {"document_search": "Document Search", "grants_gov": "Grants.gov Search"}
+            ),
+        )
+
+    assert result.state == "limits"
+    assert [(m.label, m.optional) for m in result.missing] == [("Grants.gov Search", True)]
+
+
+@pytest.mark.asyncio
+async def test_one_required_gap_outranks_any_number_of_optional_ones():
+    agent = _agent(
+        bindings=[
+            AgentBinding(kind="tool", ref="grants_gov", config={"optional": True}),
+            AgentBinding(kind="tool", ref="workday_query"),
+        ]
+    )
+    with patch(f"{MODULE}.list_bindable", side_effect=_catalog(tool={})), _models():
+        result = await resolve_runnability(
+            agent,
+            _user(),
+            tool_service=_Tools(
+                {"grants_gov": "Grants.gov Search", "workday_query": "Workday Query"}
+            ),
+        )
+
+    assert result.state == "blocked"
+    assert {m.label for m in result.missing} == {"Grants.gov Search", "Workday Query"}
+
+
+@pytest.mark.asyncio
+async def test_a_model_the_viewer_cannot_access_blocks_and_is_named():
+    """The pinned model is never optional — the run-time resolver raises outright."""
+    agent = _agent(model_settings=AgentModelConfig(model_id="claude-opus"))
+    with patch(f"{MODULE}.list_bindable", side_effect=_catalog(model={})), _models(
+        ("claude-opus", "Claude Opus 4.5")
+    ):
+        result = await resolve_runnability(agent, _user())
+
+    assert result.state == "blocked"
+    assert [(m.label, m.kind) for m in result.missing] == [("Claude Opus 4.5", "model")]
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_agent_with_no_bindings_is_ready():
+    """The trap: compat synthesizes a knowledge_base binding on *every* legacy row while
+    ``list_bindable('knowledge_base')`` is empty by design. Diffing it would mark the
+    entire back catalogue unrunnable."""
+    called_kinds = []
+
+    async def _tracking(kind, user, **_kwargs):
+        called_kinds.append(kind)
+        return []
+
+    with patch(f"{MODULE}.list_bindable", side_effect=_tracking), _models():
+        result = await resolve_runnability(_agent(), _user())
+
+    assert result.state == "ready"
+    assert result.missing == []
+    assert "knowledge_base" not in called_kinds
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_binding_kind_does_not_block():
+    """Storage tolerates kinds newer code wrote; the run-time resolver ignores them, so
+    previewing a block on one would be a preview of something that will not happen."""
+    agent = _agent(bindings=[AgentBinding(kind="quantum_flux", ref="qf-1")])
+    with patch(f"{MODULE}.list_bindable", side_effect=_catalog()), _models():
+        result = await resolve_runnability(agent, _user())
+
+    assert result.state == "ready"
+
+
+@pytest.mark.asyncio
+async def test_publisher_is_never_consulted_when_deciding_runnability():
+    """D12: ``publisherId`` is display-only. Re-attributing a listing changes the name on
+    the shelf and nothing about who can run it."""
+    from apis.shared.assistants.models import AgentListing
+
+    bindings = [AgentBinding(kind="tool", ref="document_search")]
+    catalog = _catalog(tool={"document_search": "Document Search"})
+    tools = _Tools({"document_search": "Document Search"})
+
+    results = []
+    for publisher_id in ("pub-registrar", "pub-institution"):
+        agent = _agent(
+            bindings=bindings,
+            listing=AgentListing(
+                state="published", category="Administration", publisher_id=publisher_id
+            ),
+        )
+        with patch(f"{MODULE}.list_bindable", side_effect=catalog), _models():
+            results.append(await resolve_runnability(agent, _user(), tool_service=tools))
+
+    assert [r.state for r in results] == ["ready", "ready"]

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -308,7 +308,10 @@ export class AgentFormPage implements OnInit, OnDestroy {
       this.form.patchValue({
         name: agent.name,
         description: agent.description,
-        instructions: agent.instructions,
+        // Marketplace Phase 3 gates `instructions` to owner/editor. Reaching this form
+        // means one of those, so the fallback is defensive, not an expected path — the
+        // field's own `required` validator surfaces it if the gate ever changes.
+        instructions: agent.instructions ?? '',
         visibility: agent.visibility,
         tags: agent.tags ?? [],
         emoji: agent.emoji ?? '',

--- a/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroCheckBadge } from '@ng-icons/heroicons/outline';
 import { AgentListing } from '../models/store.model';
@@ -13,14 +14,20 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
  *
  * The icon is the emoji on a neutral tile for now — D5's uploaded icon and generated
  * gradient fallback are Phase 4.
+ *
+ * The whole row routes to the detail page (Phase 3). A `+` add affordance sits beside it
+ * in the mockup; that is Phase 5's pin, so the row has exactly one destination today.
  */
 @Component({
   selector: 'app-agent-listing-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, TooltipDirective],
+  imports: [NgIcon, RouterLink, TooltipDirective],
   providers: [provideIcons({ heroCheckBadge })],
   template: `
-    <div class="flex items-center gap-3 rounded-2xl px-3 py-2.5">
+    <a
+      [routerLink]="['/agents', listing().agentId]"
+      class="flex w-full items-center gap-3 rounded-2xl px-3 py-2.5 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:hover:bg-gray-800"
+    >
       <span
         class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-xl dark:bg-gray-700"
         aria-hidden="true"
@@ -45,7 +52,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
           {{ subtitle() }}
         </p>
       </div>
-    </div>
+    </a>
   `,
 })
 export class AgentListingRowComponent {

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -1,0 +1,396 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroArrowRight,
+  heroCheckBadge,
+  heroCheckCircle,
+  heroExclamationTriangle,
+  heroNoSymbol,
+} from '@ng-icons/heroicons/outline';
+import { AgentApiService } from '../services/agent-api.service';
+import { Agent, AgentRunnability } from '../models/agent.model';
+import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+
+/**
+ * Agent detail — the page a shelf row taps through to (Marketplace Phase 3).
+ *
+ * The shelf deliberately carries icon, name and one line (D4), which means this page
+ * is where everything else has to land: what the Agent is, what it can reach, and —
+ * the one thing D4's shelf cannot tell you — whether it will run for *you* (D6).
+ *
+ * Two loads, deliberately not one: the identity half paints from `GET /agents/{id}`
+ * immediately, while runnability fans out across the viewer's model/tool/skill catalogs
+ * and settles into the sidebar when it arrives. Blocking the whole page on the slower
+ * question would trade a fast page for a spinner.
+ *
+ * Not here yet, by phase: "Add to my agents" (pins, Phase 5), the uploaded icon and its
+ * generated gradient fallback (Phase 4), and "Report a problem" (Phase 8). Rendering an
+ * affordance whose backing lever does not exist is how a store starts lying, so the
+ * header carries Start chat alone.
+ */
+@Component({
+  selector: 'app-agent-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroArrowRight,
+      heroCheckBadge,
+      heroCheckCircle,
+      heroExclamationTriangle,
+      heroNoSymbol,
+    }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <button
+          type="button"
+          (click)="onBack()"
+          class="mb-6 inline-flex items-center gap-1.5 text-sm/6 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Back
+        </button>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        } @else if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading agent</span>
+          </div>
+        } @else if (agent(); as a) {
+          <!-- Identity -->
+          <div class="flex flex-wrap items-start gap-5">
+            <span
+              class="flex size-21 shrink-0 items-center justify-center rounded-3xl bg-gray-100 text-4xl dark:bg-gray-700"
+              aria-hidden="true"
+            >
+              {{ a.emoji || '✦' }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">{{ a.name }}</h1>
+              @if (a.tagline) {
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">{{ a.tagline }}</p>
+              }
+              <p
+                class="mt-2 flex flex-wrap items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400"
+              >
+                <span>{{ publisherLabel() }}</span>
+                @if (a.publisher?.verified) {
+                  <span class="inline-flex items-center gap-1 font-semibold text-blue-600 dark:text-blue-400">
+                    <ng-icon
+                      name="heroCheckBadge"
+                      class="size-4"
+                      [appTooltip]="verifiedTooltip()"
+                      appTooltipPosition="top"
+                    />
+                    University team
+                  </span>
+                }
+                @if (a.categoryLabel) {
+                  <span aria-hidden="true">·</span>
+                  <span>{{ a.categoryLabel }}</span>
+                }
+              </p>
+            </div>
+            <button
+              type="button"
+              (click)="onStartChat()"
+              [disabled]="isBlocked()"
+              [appTooltip]="startChatTooltip()"
+              appTooltipPosition="top"
+              class="rounded-full bg-blue-600 px-4 py-2 text-sm/6 font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-45 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              Start chat
+            </button>
+          </div>
+
+          <!--
+            Hero: the @-mention prompt this agent answers to. Display-only — the
+            composer has no prompt-prefill entry point, and @-mention itself is
+            Phase 7, so a clickable pill here would be an affordance with no lever
+            behind it. It shows the shape of the thing; Start chat performs it.
+          -->
+          <div
+            class="mt-6 grid place-items-center rounded-3xl bg-linear-to-br from-blue-700 to-sky-500 px-6 py-12 dark:from-blue-900 dark:to-sky-700"
+          >
+            <p
+              class="flex w-full max-w-xl items-center gap-4 rounded-full bg-white/95 px-5 py-3.5 text-sm/6 text-gray-900 shadow-md"
+            >
+              <span class="min-w-0 flex-1">
+                <span class="font-semibold text-blue-700">{{ mention() }}</span>
+                {{ heroSuffix() }}
+              </span>
+              <span
+                class="grid size-7 shrink-0 place-items-center rounded-full bg-gray-900 text-white"
+                aria-hidden="true"
+              >
+                <ng-icon name="heroArrowRight" class="size-3.5" />
+              </span>
+            </p>
+          </div>
+
+          <div class="mt-8 grid gap-8 lg:grid-cols-[1fr_300px]">
+            <div>
+              <section class="mb-8">
+                <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">About</h2>
+                <p class="max-w-prose text-sm/6 text-gray-600 dark:text-gray-400">
+                  {{ a.description }}
+                </p>
+              </section>
+
+              @if (a.starters.length) {
+                <section class="mb-8">
+                  <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">
+                    Try asking
+                  </h2>
+                  <!-- The author's starters, shown as examples. Not buttons: sending one
+                       needs composer prefill, which does not exist yet. -->
+                  <ul class="flex flex-col gap-2">
+                    @for (starter of a.starters; track starter) {
+                      <li
+                        class="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm/6 text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                      >
+                        {{ starter }}
+                      </li>
+                    }
+                  </ul>
+                </section>
+              }
+            </div>
+
+            <div class="flex flex-col gap-3">
+              <section
+                class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800"
+              >
+                <h2
+                  class="mb-2.5 text-xs/5 font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  Details
+                </h2>
+                <dl class="flex flex-col gap-1">
+                  @for (row of details(); track row.label) {
+                    <div class="flex items-baseline justify-between gap-3 py-1 text-sm/6">
+                      <dt class="text-gray-500 dark:text-gray-400">{{ row.label }}</dt>
+                      <dd class="text-right font-semibold text-gray-900 dark:text-white">
+                        {{ row.value }}
+                      </dd>
+                    </div>
+                  }
+                </dl>
+              </section>
+
+              <section
+                class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800"
+              >
+                <h2
+                  class="mb-2.5 text-xs/5 font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  What it can access
+                </h2>
+                @if (a.capabilities?.length) {
+                  <ul class="flex flex-col gap-1">
+                    @for (capability of a.capabilities; track capability.label) {
+                      <li class="flex items-center gap-2 py-1 text-sm/6 text-gray-700 dark:text-gray-300">
+                        <span class="min-w-0 flex-1 truncate">{{ capability.label }}</span>
+                        <span class="shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">
+                          {{ kindLabel(capability.kind) }}
+                        </span>
+                      </li>
+                    }
+                  </ul>
+                } @else {
+                  <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                    Nothing beyond its own knowledge.
+                  </p>
+                }
+
+                <!-- D6: the one line the shelf deliberately does not carry. -->
+                @if (runnability(); as r) {
+                  <p
+                    class="mt-3 flex items-start gap-1.5 border-t border-gray-200 pt-3 text-sm/6 dark:border-gray-700"
+                    [class]="
+                      r.state === 'ready'
+                        ? 'text-emerald-700 dark:text-emerald-400'
+                        : r.state === 'limits'
+                          ? 'text-amber-700 dark:text-amber-400'
+                          : 'text-rose-700 dark:text-rose-400'
+                    "
+                  >
+                    <ng-icon [name]="availabilityIcon()" class="mt-1 size-4 shrink-0" aria-hidden="true" />
+                    <span>{{ availabilityText() }}</span>
+                  </p>
+                }
+              </section>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class AgentDetailPage {
+  private api = inject(AgentApiService);
+  private router = inject(Router);
+
+  /** Bound from the `agents/:id` route via `withComponentInputBinding`. */
+  readonly id = input.required<string>();
+
+  readonly agent = signal<Agent | null>(null);
+  readonly runnability = signal<AgentRunnability | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  constructor() {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.agent.set(await firstValueFrom(this.api.getAgent(this.id())));
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load this agent.'));
+      return;
+    } finally {
+      this.loading.set(false);
+    }
+
+    // Runnability is advisory: the page is fully usable without it, so a failure here
+    // leaves the availability line absent rather than erroring the whole detail view.
+    try {
+      this.runnability.set(await firstValueFrom(this.api.getRunnability(this.id())));
+    } catch {
+      this.runnability.set(null);
+    }
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+
+  readonly isBlocked = computed(() => this.runnability()?.state === 'blocked');
+
+  readonly publisherLabel = computed(
+    () => this.agent()?.publisher?.label || this.agent()?.ownerName || 'Unknown',
+  );
+
+  readonly mention = computed(() => `@${this.agent()?.name ?? ''}`);
+
+  /**
+   * The hero band carries the `@Agent` prompt an author's first starter suggests,
+   * lower-cased so it reads as one sentence after the mention.
+   */
+  readonly heroSuffix = computed(() => {
+    const starter = this.agent()?.starters?.[0];
+    if (!starter) return 'help me get started';
+    return starter.charAt(0).toLowerCase() + starter.slice(1);
+  });
+
+  readonly details = computed(() => {
+    const a = this.agent();
+    if (!a) return [];
+    return [
+      { label: 'Publisher', value: this.publisherLabel() },
+      { label: 'Category', value: a.categoryLabel || '—' },
+      { label: 'Model', value: a.modelLabel || '—' },
+      { label: 'Last updated', value: this.formatDate(a.updatedAt) },
+    ];
+  });
+
+  readonly availabilityIcon = computed(() => {
+    switch (this.runnability()?.state) {
+      case 'ready':
+        return 'heroCheckCircle';
+      case 'limits':
+        return 'heroExclamationTriangle';
+      default:
+        return 'heroNoSymbol';
+    }
+  });
+
+  /**
+   * D6's three lines, each naming what is unavailable rather than saying "something".
+   * A user who cannot act on the sentence has been told nothing useful.
+   */
+  readonly availabilityText = computed(() => {
+    const r = this.runnability();
+    if (!r) return '';
+    if (r.state === 'ready') return 'Ready to run for you.';
+
+    const names = r.missing.map((m) => `“${m.label}”`).join(', ');
+    const verb = r.missing.length === 1 ? "isn't" : "aren't";
+    const lead = r.state === 'limits' ? 'Runs with limits for you' : 'Not available to you';
+    return names ? `${lead} — ${names} ${verb} granted to your role.` : `${lead}.`;
+  });
+
+  startChatTooltip(): string {
+    return this.isBlocked()
+      ? 'This agent needs access your account does not have'
+      : `Start a chat with ${this.agent()?.name ?? 'this agent'}`;
+  }
+
+  verifiedTooltip(): string {
+    const label = this.agent()?.publisher?.label ?? 'a university team';
+    return `Published by ${label} — a verified university team`;
+  }
+
+  kindLabel(kind: string): string {
+    switch (kind) {
+      case 'tool':
+        return 'tool';
+      case 'skill':
+        return 'skill';
+      case 'memory_space':
+        return 'memory';
+      default:
+        return kind;
+    }
+  }
+
+  private formatDate(iso: string): string {
+    const parsed = new Date(iso);
+    if (Number.isNaN(parsed.getTime())) return '—';
+    return parsed.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  onBack(): void {
+    void this.router.navigate(['/agents/discover']);
+  }
+
+  /**
+   * Reuses the existing chat entry point — `assistantId` on the root route — because
+   * `agentId === assistantId` and a store-launched run is an ordinary run (the invoker
+   * pays, per the existing per-user model).
+   */
+  onStartChat(): void {
+    if (this.isBlocked()) return;
+    void this.router.navigate(['/'], { queryParams: { assistantId: this.id() } });
+  }
+}

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -1,4 +1,5 @@
 import { ShareEntry, UserPermission } from '../../assistants/models/assistant.model';
+import { ListingPublisher } from './store.model';
 
 /**
  * Agent Designer contract (Phase 4). Mirrors the backend `/agents` surface
@@ -52,12 +53,27 @@ export interface AgentBinding {
   config?: Record<string, unknown>;
 }
 
+/**
+ * One thing an Agent can reach, as the detail page names it (Marketplace Phase 3).
+ * Names, never refs — the backend resolves binding refs to display names so this
+ * payload can be rendered to anyone who may see the Agent.
+ */
+export interface AgentCapability {
+  label: string;
+  kind: string;
+}
+
 export interface Agent {
   agentId: string;
   ownerName: string;
   name: string;
   description: string;
-  instructions: string;
+  /**
+   * The system prompt. **Absent unless you are the owner or an editor** (Marketplace
+   * Phase 3): under a store, a PUBLIC agent is browsable by the whole institution, so
+   * viewers get `capabilities` instead of behaviour.
+   */
+  instructions?: string;
   modelConfig?: AgentModelConfig;
   bindings: AgentBinding[];
   visibility: 'PRIVATE' | 'PUBLIC' | 'SHARED';
@@ -70,10 +86,44 @@ export interface Agent {
   createdAt: string;
   updatedAt: string;
 
+  // Marketplace listing (Phase 1) + the detail read (Phase 3). All are absent on the
+  // list route and on an agent that was never submitted.
+  tagline?: string;
+  listing?: AgentListingBlock;
+  /** Resolved on `GET /agents/{id}` only. */
+  capabilities?: AgentCapability[];
+  modelLabel?: string;
+  /** Attribution as the page renders it; `listing.publisherId` is an id and never shown. */
+  publisher?: ListingPublisher | null;
+  categoryLabel?: string;
+
   // Share metadata (present for shared agents)
   firstInteracted?: boolean;
   isSharedWithMe?: boolean;
   userPermission?: UserPermission;
+}
+
+/** The marketplace publication state carried on an Agent (D2). */
+export interface AgentListingBlock {
+  state: 'private' | 'in_review' | 'published' | 'changes_requested' | 'taken_down';
+  category: string;
+  publisherId: string;
+  reviewNote?: string;
+}
+
+/** D6's three-way answer to "will this run for me?". */
+export type RunnabilityState = 'ready' | 'limits' | 'blocked';
+
+export interface MissingCapability {
+  label: string;
+  kind: string;
+  optional: boolean;
+}
+
+export interface AgentRunnability {
+  agentId: string;
+  state: RunnabilityState;
+  missing: MissingCapability[];
 }
 
 export interface CreateAgentDraftRequest {

--- a/frontend/ai.client/src/app/agents/services/agent-api.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-api.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { ConfigService } from '../../services/config.service';
 import {
   Agent,
+  AgentRunnability,
   AgentsListResponse,
   AgentSharesResponse,
   BindableKind,
@@ -48,6 +49,17 @@ export class AgentApiService {
 
   getAgent(id: string): Observable<Agent> {
     return this.http.get<Agent>(`${this.baseUrl()}/${id}`);
+  }
+
+  /**
+   * Will this Agent run for the signed-in user? (D6)
+   *
+   * A separate call from `getAgent` on purpose: the detail page paints identity,
+   * description and starters immediately, and this answer — which fans out across the
+   * viewer's model/tool/skill catalogs — resolves into the sidebar when it arrives.
+   */
+  getRunnability(id: string): Observable<AgentRunnability> {
+    return this.http.get<AgentRunnability>(`${this.baseUrl()}/${id}/runnability`);
   }
 
   updateAgent(id: string, request: UpdateAgentRequest): Observable<Agent> {

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -68,6 +68,15 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        // Marketplace detail (spec phase 3). Declared AFTER `agents/discover` so the
+        // literal path is not captured by `:id`, and after `agents/:id/edit` so the
+        // deeper route still wins. `id` binds to the page's `input.required` via
+        // `withComponentInputBinding()`.
+        path: 'agents/:id',
+        loadComponent: () => import('./agents/detail/agent-detail.page').then(m => m.AgentDetailPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'agents',
         loadComponent: () => import('./agents/agents.page').then(m => m.AgentsPage),
         canActivate: [authGuard],


### PR DESCRIPTION
Phase 3 of [`docs/specs/agent-marketplace.md`](docs/specs/agent-marketplace.md): **detail page + runnability + the instructions gate**. Follows #731 (phase 1) and #732 (phase 2).

## ⚠️ Behaviour change: `instructions` is now gated

`GET /agents/{id}` returned `instructions` to any **PUBLIC** viewer. That was bounded while PUBLIC meant "anyone with the link" and it is not once a store puts the link in front of the institution. It is now gated to `permission in ("owner", "editor")` and dropped otherwise; the routes already serve the model with `response_model_exclude_none`, so a viewer's payload simply omits the key.

Worth stating plainly: **no existing test asserted the field was present on a read.** In `backend/tests/routes/test_agents.py` it appears only in the `_make_assistant` defaults and in two `POST` bodies, and `test_get_exposes_bindings_and_modelconfig` exercises the `owner` path, so it stays green on its own merits. Nothing needed correcting. `test_agent_detail.py` pins the new behaviour per permission level — including a whole-payload assertion, so a future field that happens to echo the prompt cannot quietly re-open the hole.

**Deliberate non-change:** the spec's ⚠️ names only `instructions`. `bindings[]` still ships raw refs to PUBLIC viewers. Narrowing that isn't in this phase's scope and the Designer consumes it, but `capabilities[]` is arguably the viewer-facing replacement, so it's worth a look in a later phase.

## Detail read

`capabilities[]` of `{label, kind}` — **display names, never ids or refs** — plus `modelLabel`, `publisher` and `categoryLabel`.

Labels resolve against the **unfiltered** catalog on purpose: D6 has to be able to name a capability the viewer *lacks*, and a viewer-filtered lookup would silently drop exactly the entries that matter most. `publisher` and `categoryLabel` exist because the stored listing holds ids — `listing.publisherId` is an internal reference (and D12 display-only: it stays out of every access check, `ownerId` still governs edit rights and Skills v2 invoke-through), and `listing.category` is an id an admin may since have renamed.

Also fixes a **phase 1 gap**: `listing`, `tagline` and `iconKey` were declared on `AgentResponse` but `compat.to_agent_view` never projected them, so `listing` was always absent from the very read the spec says should carry it. An unsubmitted agent's payload is unchanged (all `None`, excluded).

## Runnability (D6)

`GET /agents/{id}/runnability` composes `bindable_catalog.list_bindable` per kind and diffs — no sixth access service (Designer D4). Two rules are load-bearing and both have tests:

1. **`knowledge_base` is never gated.** `compat.effective_bindings` synthesizes a KB binding on *every* legacy agent while `list_bindable` returns `[]` for that kind. A naive diff marks the entire back catalogue blocked.
2. **`limits` requires an explicitly optional binding.** `inference_api/chat/agent_binding_resolver.py` is block-with-message for every kind it resolves — a missing model, tool, skill or memory space raises rather than degrading. So a gap only downgrades to "Runs with limits for you" when the binding declares `config.optional == true`; anything else missing is `blocked`.

On (2) — this is the one place the implementation reads the spec against the current runtime rather than the mockup. D6 presupposes optional bindings; none exist today. Calling a missing *tool* "limits" would match the mockup and mislead: the resolver raises, so the user would tap Start chat and get an error turn. `config.optional` is the seam for when the resolver grows a degrade path, and nothing writes it yet — so in practice real agents return `ready` or `blocked` today. Flagging it explicitly because it means the middle state is dormant on merge.

## SPA

`/agents/:id` — 84px icon, publisher with the verified check mark, tagline, Start chat; a hero band carrying the `@Agent` prompt; About; "Try asking" from `starters[]`; a Details panel (Publisher / Category / Model / Last updated); and "What it can access" with the D6 availability line. Discover rows route through — they were inert by design in phase 2.

Identity and runnability load separately: the page paints from `GET /agents/{id}` while the catalog fan-out settles into the sidebar. Runnability failing leaves the availability line absent rather than erroring the page.

**Not rendered, by phase:** "Add to my agents" (pins, 5), icons (4), report a problem (8). The hero band and the "Try asking" starters are **display-only** — the composer has no prompt-prefill entry point, and `@`-mention is phase 7, so making them clickable would be an affordance with no lever behind it. Same reasoning that kept the store-front star, the inline category select and the mockup's Preview button out of phases 1–2.

## Deployment

**`backend.yml` + `frontend-deploy.yml`; no `platform.yml`** — verified, not assumed: GSI5 and `AGENT_MARKETPLACE_ENABLED` both landed in CDK in phase 1 (`rag-data-construct.ts:173`, `app-api-environment.ts:311`), this phase adds no index, no table, no env var, and no IAM (runnability composes services app-api already calls). `git status` shows no `infrastructure/` changes. (The SPA half still needs `frontend-deploy.yml`, as phase 2's Discover page did.)

**No flags to set.** `config.agents.enabled` and `config.agentMarketplace.enabled` both default ON (`?? true`, empty-string-safe), so neither `CDK_AGENTS_API_ENABLED` nor `CDK_AGENT_MARKETPLACE_ENABLED` needs setting in an environment. Two pre-existing nits spotted while verifying, neither blocking: `CDK_AGENT_MARKETPLACE_ENABLED` is read by `config.ts` but never threaded through `platform.yml`, so its kill switch is currently unreachable from GitHub environment variables; and `platform.yml`'s comment on `CDK_AGENTS_API_ENABLED` still says "Default OFF (opt-in)", which stopped being true when `agents.enabled` flipped to default-on. D14's `agent-marketplace` RBAC capability is not implemented in phases 1–3 either — the routes gate on the env flags alone — so there is no grant to make.

## Tests

- Backend: **5014 passed**, 3 skipped. New: `tests/routes/test_agent_detail.py` (16), `tests/shared/test_agent_runnability.py` (15), plus two `test_agent_compat.py` cases for the listing projection.
- SPA: **1492 passed** across 130 files; `npm run build` clean (`src/version.ts` reverted).

## Not verified live

No `backend/.env` in this checkout, so app-api can't run locally and the SPA dev environment points at `localhost:8000` — an end-to-end clickthrough of the detail page isn't available pre-deploy. Manual test script after deploy: open `/agents/discover`, tap a published row through to `/agents/:id`, confirm (a) a non-owner sees no `instructions` in the network response, (b) the Details panel shows resolved publisher/category/model **names**, and (c) the availability line reads "Ready to run for you" — then revoke a bound tool from your role and confirm it flips to "Not available to you" naming that tool, with Start chat disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
