### PR TITLE
feat(marketplace): the author's Submit UI + a D7 preflight

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -67,6 +67,7 @@ from apis.shared.assistants.service import (
 )
 from apis.app_api.agent_designer.services.listing_service import (
     ListingError,
+    preflight_listing,
     submit_listing,
     withdraw_listing,
 )
@@ -79,6 +80,7 @@ from apis.shared.assistants.models import (
     AgentListing,
     AgentStoreFrontResponse,
     AgentStoreResponse,
+    ListingPreflightResponse,
     ListingSubmissionResponse,
     SubmitListingRequest,
 )
@@ -496,8 +498,29 @@ async def get_agent_shares_endpoint(agent_id: str, current_user: User = Depends(
 
 # ------------------------------------------------------------------- marketplace (D2)
 # The author's half of the listing lifecycle. The reviewer's half lives under
-# /admin/agents/* behind require_admin. Nothing here is user-visible in Phase 1 — the
-# SPA surfaces that call these ship with the Discover page in Phase 2.
+# /admin/agents/* behind require_admin.
+@router.get("/{agent_id}/listing/preflight", response_model=ListingPreflightResponse)
+async def agent_listing_preflight_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """What the submit dialog needs before the author commits (D7, owner only).
+
+    A read-only rehearsal of the submit checks: the skills publication would expose,
+    and the memory-space block if there is one. Declared before ``/listing/submit``
+    only for reading order — the paths are literal and do not collide.
+    """
+    try:
+        exposed, block_reason = await preflight_listing(agent_id, current_user)
+        return ListingPreflightResponse(
+            agent_id=agent_id, exposed_skills=exposed, block_reason=block_reason
+        )
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error preflighting agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to preflight agent listing: {str(e)}")
+
+
 @router.post("/{agent_id}/listing/submit", response_model=ListingSubmissionResponse)
 async def submit_agent_listing_endpoint(
     agent_id: str,

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -150,16 +150,16 @@ async def _load_any(agent_id: str) -> Assistant:
 
 
 # ── D7 disclosure ────────────────────────────────────────────────────────────────────
-async def _memory_space_block(assistant: Assistant, user: User) -> None:
-    """Block submission on any ``memory_space`` binding, naming the space (D7.2).
+async def _memory_space_block_reason(assistant: Assistant, user: User) -> Optional[str]:
+    """The D7.2 blocking message for a ``memory_space`` binding, or ``None`` if clear.
 
-    Not a warning. A memory space is personal data; Designer D5's run-time re-resolve
-    already denies it to anyone who lacks access, so publishing an agent bound to one
-    ships a listing that cannot work for a single other person.
+    Split from the raising path so ``preflight_listing`` can *show* the block without
+    attempting the transition. One function decides, two callers present it — a second
+    copy of this rule in the SPA would be the thing that eventually disagrees.
     """
     bound = [b for b in effective_bindings(assistant) if b.kind == "memory_space"]
     if not bound:
-        return
+        return None
 
     # Resolve a human name for the message. The id alone tells the author nothing.
     label = bound[0].ref
@@ -170,12 +170,23 @@ async def _memory_space_block(assistant: Assistant, user: User) -> None:
     except Exception:
         logger.warning("Could not resolve memory space name for submission block", exc_info=True)
 
-    raise ListingError(
+    return (
         f"This agent can't be published while it's bound to the memory space “{label}”. "
         "A memory space is personal data — it won't resolve for anyone else, so the agent "
-        "would fail for every person who ran it. Remove the binding and submit again.",
-        status_code=400,
+        "would fail for every person who ran it. Remove the binding and submit again."
     )
+
+
+async def _memory_space_block(assistant: Assistant, user: User) -> None:
+    """Block submission on any ``memory_space`` binding, naming the space (D7.2).
+
+    Not a warning. A memory space is personal data; Designer D5's run-time re-resolve
+    already denies it to anyone who lacks access, so publishing an agent bound to one
+    ships a listing that cannot work for a single other person.
+    """
+    reason = await _memory_space_block_reason(assistant, user)
+    if reason:
+        raise ListingError(reason, status_code=400)
 
 
 async def _exposed_skills(assistant: Assistant) -> List[SkillExposure]:
@@ -229,6 +240,26 @@ async def _resolve_proposed_publisher(user: User, publisher_id: Optional[str]) -
 
 
 # ── author transitions ───────────────────────────────────────────────────────────────
+async def preflight_listing(agent_id: str, user: User) -> Tuple[List[SkillExposure], Optional[str]]:
+    """Run the D7 checks **without** transitioning, for the submit dialog.
+
+    D7.1 asks the dialog to enumerate the exposed skills *before* the author commits,
+    and D7.2's block is more useful as a disabled button with a reason than as an error
+    after the click. Both answers come from the same helpers ``submit_listing`` uses, so
+    what the author is shown and what the transition enforces cannot drift apart.
+
+    Owner-only, like every other author path: the skill exposure is a statement about
+    what the *owner's* publication would reveal, and it is not an editor's to see.
+    """
+    assistant = await _load_for_author(agent_id, user)
+    block_reason = await _memory_space_block_reason(assistant, user)
+    # Order mirrors submit_listing: an agent that cannot be published at all is not first
+    # walked through a skill-exposure confirmation.
+    if block_reason:
+        return [], block_reason
+    return await _exposed_skills(assistant), None
+
+
 async def submit_listing(
     agent_id: str, user: User, request: SubmitListingRequest
 ) -> Tuple[AgentListing, List[SkillExposure]]:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -494,6 +494,30 @@ class ListingSubmissionResponse(BaseModel):
     )
 
 
+class ListingPreflightResponse(BaseModel):
+    """What the submit dialog shows before the author commits (D7).
+
+    The same two checks ``submit_listing`` runs, answered without a transition: the
+    skills publication would expose, and the memory-space block if there is one. A
+    ``blockReason`` means the Submit control is disabled and this text explains why —
+    the dialog never re-derives that rule for itself.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    exposed_skills: List[SkillExposure] = Field(
+        default_factory=list,
+        alias="exposedSkills",
+        description="Skills the author wrote that publication would make readable (D7.1)",
+    )
+    block_reason: Optional[str] = Field(
+        None,
+        alias="blockReason",
+        description="Why this agent cannot be submitted at all (D7.2); null when it can",
+    )
+
+
 class ReviewListingRequest(BaseModel):
     """Admin approves a submission or returns it with a reason (D2)."""
 

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -329,3 +329,90 @@ class TestWithdraw:
             resp = TestClient(app).delete("/agents/ast-001/listing")
 
         assert resp.status_code == 404
+
+
+# ── D7 preflight — the same checks, without the transition ───────────────────────────
+class TestPreflight:
+    """The submit dialog's read.
+
+    The point of this route is that the author sees the D7 answers *before* committing,
+    and that what they see comes from the same helpers the transition enforces. Each
+    test below therefore pairs with one in TestMemorySpaceBlock / TestSkillDisclosure.
+    """
+
+    def test_enumerates_the_authors_own_skills_without_submitting(
+        self, app, make_user, _no_writes
+    ):
+        assistant = _make_assistant(
+            bindings=[
+                AgentBinding(kind="skill", ref="skill-a", config={}),
+                AgentBinding(kind="skill", ref="skill-b", config={}),
+            ]
+        )
+        skills = [
+            SimpleNamespace(skill_id="skill-a", display_name="Policy Citation Format", owner_id="user-001"),
+            SimpleNamespace(skill_id="skill-b", display_name="Someone Else's Skill", owner_id="user-999"),
+        ]
+
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.skills_enabled", return_value=True), patch(
+            f"{SERVICE_MODULE}.get_skill_catalog_repository"
+        ) as repo:
+            repo.return_value.batch_get_skills = AsyncMock(return_value=skills)
+            resp = TestClient(app).get("/agents/ast-001/listing/preflight")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [s["label"] for s in body["exposedSkills"]] == ["Policy Citation Format"]
+        assert body["blockReason"] is None
+        # A preflight must never move the listing — it is a rehearsal, not the act.
+        _no_writes.assert_not_called()
+
+    def test_memory_space_returns_a_block_reason_rather_than_an_error(
+        self, app, make_user, _no_writes
+    ):
+        """A disabled Submit with an explanation beats a 400 after the click."""
+        assistant = _make_assistant(
+            bindings=[AgentBinding(kind="memory_space", ref="mem-042", config={})]
+        )
+        space = SimpleNamespace(space_id="mem-042", name="Oliver", owner_id="user-001")
+
+        mock_auth_user(app, make_user())
+        with _owner(assistant), patch(f"{SERVICE_MODULE}.MemorySpaceService") as svc:
+            svc.return_value.list_spaces_for_user.return_value = [(space, "owner")]
+            resp = TestClient(app).get("/agents/ast-001/listing/preflight")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "Oliver" in body["blockReason"]
+        # Blocked agents disclose nothing: an author who cannot publish at all should not
+        # first be walked through a skill-exposure confirmation. Mirrors submit_listing.
+        assert body["exposedSkills"] == []
+
+    def test_editor_may_not_preflight(self, app, make_user, _no_writes):
+        """Skill exposure is a statement about the owner's publication, not an editor's."""
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{SERVICE_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=(_make_assistant(), "editor"),
+        ):
+            resp = TestClient(app).get("/agents/ast-001/listing/preflight")
+
+        assert resp.status_code == 403
+
+    def test_404_when_marketplace_flag_off(self, app, make_user, monkeypatch):
+        monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+        mock_auth_user(app, make_user())
+        assert TestClient(app).get("/agents/ast-001/listing/preflight").status_code == 404
+
+    def test_preflight_is_not_captured_by_the_agent_id_path_param(
+        self, app, make_user, _no_writes
+    ):
+        """`/{agent_id}/listing/preflight` must not resolve as `GET /{agent_id}`."""
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).get("/agents/ast-001/listing/preflight")
+
+        assert resp.status_code == 200
+        assert "exposedSkills" in resp.json()

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -553,7 +553,10 @@ Phase 1  listing block + state machine + sparse GSI5 + submit/review/takedown AP
          + publisher profiles (D12) + admin Review queue & Listings
          + backfill (no listing block)                               ✅ shipped (PR #731)
 Phase 2  GET /agents/store + the Discover page + categories admin           ← in progress
-Phase 3  Detail page + runnability + the instructions gate
+Phase 3  Detail page + runnability + the instructions gate            ✅ shipped (PR #733)
+Phase 3.5 Author Submit UI: submit dialog (category, note, D7 disclosures),
+         listing-state badges + reviewer note + D13 edit trail on My Agents,
+         withdraw/unpublish, and GET /agents/{id}/listing/preflight
 Phase 4  Icons: upload, S3, generated fallback, all four render sizes
 Phase 5  Pins: user pin state + Pinned tab + store front admin
 Phase 6  Default pins by role (D9) + the assignment-time runnability check
@@ -569,6 +572,14 @@ otherwise independent of 4–7 and can run alongside them.
 Phase 1 is the smallest thing that is independently useful: authors can submit, admins can approve
 and take down, and nothing is user-visible until Phase 2. Phases 4–7 are independent of each other
 and parallelizable once 1–3 land.
+
+**Phase 3.5 is a gap this table originally left open.** Phases 1–3 shipped the submit and withdraw
+endpoints and the entire reviewer console, but no phase owned the *author's* half of the surface —
+so the SPA called `POST /agents/{id}/listing/submit` from nowhere and nothing could reach the store
+without a hand-rolled request. It also adds `GET /agents/{id}/listing/preflight`, because D7.1 asks
+the dialog to enumerate the exposed skills *before* the author commits and Phase 1's disclosures
+were only available in the submit response. The preflight reuses the submit path's own helpers
+rather than restating the checks.
 
 ## Non-goals (v1)
 

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -6,13 +6,21 @@
  * they read. Store front, categories and default pins arrive in later phases.
  */
 
-/** Publication state of an agent's listing. Absent listing = never submitted. */
-export type ListingState =
-  | 'private'
-  | 'in_review'
-  | 'published'
-  | 'changes_requested'
-  | 'taken_down';
+import {
+  AdminEdit,
+  ListingState,
+  LISTING_STATE_CLASSES,
+  LISTING_STATE_LABELS,
+} from '../../../agents/models/store.model';
+
+/**
+ * The listing-state vocabulary is shared with the author's own surface (My Agents) and
+ * is defined once, in the agents feature. Re-exported here so this file stays the one
+ * import the admin pages need — but never redefined, because a reviewer and an author
+ * looking at the same listing must read the same word for it.
+ */
+export type { AdminEdit, ListingState };
+export { LISTING_STATE_CLASSES, LISTING_STATE_LABELS };
 
 export type PublisherKind = 'institution' | 'department' | 'individual';
 
@@ -32,13 +40,6 @@ export interface PublisherProfile {
   enabled: boolean;
   createdAt?: string;
   updatedAt?: string;
-}
-
-/** One admin edit to a listing's presentation, surfaced back to the author. */
-export interface AdminEdit {
-  field: string;
-  at: string;
-  by: string;
 }
 
 /** A row in the Review queue or the Listings table. */
@@ -106,28 +107,3 @@ export interface AgentCategory {
   updatedAt?: string;
 }
 
-/** Display metadata for each listing state, used by the badge component. */
-export const LISTING_STATE_LABELS: Record<ListingState, string> = {
-  private: 'Private',
-  in_review: 'In review',
-  published: 'Published',
-  changes_requested: 'Changes requested',
-  taken_down: 'Taken down',
-};
-
-/**
- * Badge classes per state. Mirrors the mockup's palette: published reads as success,
- * in-review as pending, and both "needs attention" states as stop.
- */
-export const LISTING_STATE_CLASSES: Record<ListingState, string> = {
-  private:
-    'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
-  in_review:
-    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-  published:
-    'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
-  changes_requested:
-    'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
-  taken_down:
-    'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
-};

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -27,6 +27,15 @@
       </div>
     </div>
 
+    @if (listingError(); as message) {
+      <div
+        role="alert"
+        class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+      >
+        {{ message }}
+      </div>
+    }
+
     <!-- Content -->
     <main>
       @if (loading()) {
@@ -109,6 +118,49 @@
                   <span class="inline-flex items-center rounded-md bg-emerald-50 px-2 py-1 text-xs/5 font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">{{ n }} memory</span>
                 }
               </div>
+
+              <!-- Marketplace listing (D2) — state, the reviewer's note, the D13 edit trail -->
+              @if (agent.listing) {
+                <div class="mt-4">
+                  <app-listing-status [listing]="agent.listing" />
+                </div>
+              }
+
+              <!-- Publication controls. Owner-only, and hidden entirely when the
+                   marketplace routes are unmounted, so nothing offers a dead click. -->
+              @if (marketplaceAvailable() && isOwner(agent)) {
+                <div class="mt-3 flex flex-wrap items-center gap-2">
+                  @if (canSubmit(agent)) {
+                    <button
+                      type="button"
+                      (click)="onSubmitListing(agent)"
+                      [disabled]="listingBusyId() === agent.agentId"
+                      class="rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs/5 font-medium text-gray-700 transition hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      {{ submitLabel(agent) }}
+                    </button>
+                  }
+                  @if (isPublished(agent)) {
+                    <button
+                      type="button"
+                      (click)="onViewInStore(agent)"
+                      class="rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs/5 font-medium text-gray-700 transition hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      View in store
+                    </button>
+                  }
+                  @if (canWithdraw(agent)) {
+                    <button
+                      type="button"
+                      (click)="onWithdrawListing(agent)"
+                      [disabled]="listingBusyId() === agent.agentId"
+                      class="rounded-lg px-2.5 py-1 text-xs/5 font-medium text-gray-500 transition hover:bg-gray-100 hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+                    >
+                      {{ listingBusyId() === agent.agentId ? 'Working…' : withdrawLabel(agent) }}
+                    </button>
+                  }
+                </div>
+              }
 
               <!-- Actions -->
               <div class="mt-4 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-700/60">

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
@@ -13,7 +13,9 @@ import {
   heroSparkles,
 } from '@ng-icons/heroicons/outline';
 import { AgentService } from './services/agent.service';
+import { AgentListingService } from './services/agent-listing.service';
 import { Agent } from './models/agent.model';
+import { ListingState } from './models/store.model';
 import {
   ConfirmationDialogComponent,
   ConfirmationDialogData,
@@ -21,19 +23,32 @@ import {
 import { ShareAssistantDialogComponent, ShareAssistantDialogData } from '../assistants/components/share-assistant-dialog.component';
 import { TooltipDirective } from '../components/tooltip/tooltip.directive';
 import { AgentsTabsComponent } from './components/agents-tabs.component';
+import { ListingStatusComponent } from './components/listing-status.component';
+import {
+  SubmitListingDialogComponent,
+  SubmitListingDialogData,
+  SubmitListingDialogResult,
+} from './components/submit-listing-dialog.component';
 
 /**
- * Agent Designer — the list surface. A sibling of the Assistants list page but
- * over the `/agents` surface: each card carries the Agent's model + binding
- * summary (the whole point of an Agent vs. a legacy Assistant). Share reuses the
- * assistants share dialog since the records are the same (agentId == assistantId).
+ * Agent Designer — the list surface, and the author's half of publication.
+ *
+ * A sibling of the Assistants list page but over the `/agents` surface: each card
+ * carries the Agent's model + binding summary (the whole point of an Agent vs. a legacy
+ * Assistant). Share reuses the assistants share dialog since the records are the same
+ * (agentId == assistantId).
+ *
+ * This is also the **only** surface from which an Agent reaches the store (D2). The
+ * listing state, the reviewer's note and the D13 admin-edit trail all render on the
+ * author's own card, and the submit / withdraw controls sit beside them — an author
+ * should never have to go looking for the state of their own submission.
  */
 @Component({
   selector: 'app-agents',
   templateUrl: './agents.page.html',
   styleUrl: './agents.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, TooltipDirective, AgentsTabsComponent],
+  imports: [NgIcon, TooltipDirective, AgentsTabsComponent, ListingStatusComponent],
   providers: [
     provideIcons({
       heroPlus,
@@ -49,14 +64,28 @@ import { AgentsTabsComponent } from './components/agents-tabs.component';
 export class AgentsPage implements OnInit {
   private router = inject(Router);
   private agentService = inject(AgentService);
+  private listingService = inject(AgentListingService);
   private dialog = inject(Dialog);
 
   readonly agents = this.agentService.agents$;
   readonly loading = this.agentService.loading$;
   readonly error = this.agentService.error$;
 
+  /**
+   * Whether the marketplace is reachable at all. `null` until the probe resolves, so
+   * the publication controls appear once rather than flashing in and out, and stay
+   * hidden entirely when `AGENT_MARKETPLACE_ENABLED=false` 404s the routes.
+   */
+  readonly marketplaceAvailable = this.listingService.available;
+
+  /** Agent id whose listing is mid-write; disables that card's controls. */
+  readonly listingBusyId = signal<string | null>(null);
+  readonly listingError = signal<string | null>(null);
+
   ngOnInit(): void {
     void this.load();
+    // Doubles as the kill-switch probe — see `AgentListingService.available`.
+    void this.listingService.loadCategories();
   }
 
   private async load(): Promise<void> {
@@ -107,6 +136,106 @@ export class AgentsPage implements OnInit {
       } as unknown as ShareAssistantDialogData,
     });
     await firstValueFrom(dialogRef.closed);
+  }
+
+  // ── marketplace, the author's half (D2, D7.3) ──────────────────────────────────
+  /** Owner-only: an editor may change what an agent does, but not publish it. */
+  isOwner(agent: Agent): boolean {
+    return (agent.userPermission ?? 'owner') === 'owner';
+  }
+
+  private listingState(agent: Agent): ListingState | undefined {
+    return agent.listing?.state;
+  }
+
+  /**
+   * Submittable states, mirroring the backend transition table: never submitted,
+   * withdrawn (`private`), returned (`changes_requested`) or delisted (`taken_down`).
+   * `in_review` and `published` are deliberately absent — there is nothing to submit.
+   */
+  canSubmit(agent: Agent): boolean {
+    const state = this.listingState(agent);
+    return !state || state === 'private' || state === 'changes_requested' || state === 'taken_down';
+  }
+
+  submitLabel(agent: Agent): string {
+    return this.listingState(agent) ? 'Submit again' : 'Submit to marketplace';
+  }
+
+  /** `taken_down` is absent on purpose: the machine allows no author edge out of it. */
+  canWithdraw(agent: Agent): boolean {
+    const state = this.listingState(agent);
+    return state === 'in_review' || state === 'changes_requested' || state === 'published';
+  }
+
+  withdrawLabel(agent: Agent): string {
+    switch (this.listingState(agent)) {
+      case 'published':
+        return 'Unpublish';
+      case 'in_review':
+        return 'Withdraw submission';
+      default:
+        return 'Withdraw';
+    }
+  }
+
+  isPublished(agent: Agent): boolean {
+    return this.listingState(agent) === 'published';
+  }
+
+  onViewInStore(agent: Agent): void {
+    this.router.navigate(['/agents', agent.agentId]);
+  }
+
+  async onSubmitListing(agent: Agent): Promise<void> {
+    this.listingError.set(null);
+    const dialogRef = this.dialog.open<SubmitListingDialogResult>(SubmitListingDialogComponent, {
+      data: {
+        agentId: agent.agentId,
+        agentName: agent.name,
+        listing: agent.listing,
+      } satisfies SubmitListingDialogData,
+    });
+    // The dialog writes through `AgentListingService`, which patches the card itself;
+    // the result is awaited only so a failure inside the dialog stays inside it.
+    await firstValueFrom(dialogRef.closed);
+  }
+
+  async onWithdrawListing(agent: Agent): Promise<void> {
+    const published = this.isPublished(agent);
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: published ? 'Unpublish this agent?' : 'Withdraw this submission?',
+        // D7.3 — say plainly that this recalls nothing. An author who believes
+        // unpublishing revokes access will make a worse decision than one who knows.
+        message: published
+          ? `"${agent.name}" is removed from the store and no one new can find it there. ` +
+            'It revokes nothing retroactively: anyone who already added it keeps it, ' +
+            'conversations underway keep running, and it stays reachable by direct link. ' +
+            'You can submit it again later.'
+          : `"${agent.name}" is pulled from the review queue. You can submit it again at any time.`,
+        confirmText: published ? 'Unpublish' : 'Withdraw',
+        cancelText: 'Cancel',
+        destructive: published,
+      } as ConfirmationDialogData,
+    });
+
+    if (!(await firstValueFrom(dialogRef.closed))) return;
+
+    this.listingBusyId.set(agent.agentId);
+    this.listingError.set(null);
+    try {
+      await this.listingService.withdraw(agent.agentId);
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.listingError.set(
+        typeof detail === 'string'
+          ? detail
+          : `Failed to ${published ? 'unpublish' : 'withdraw'} "${agent.name}".`,
+      );
+    } finally {
+      this.listingBusyId.set(null);
+    }
   }
 
   async onDelete(agent: Agent): Promise<void> {

--- a/frontend/ai.client/src/app/agents/components/listing-status.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/listing-status.component.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ListingStatusComponent } from './listing-status.component';
+import { AgentListingBlock } from '../models/store.model';
+
+describe('ListingStatusComponent', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  function create(listing: AgentListingBlock | undefined) {
+    const fixture = TestBed.createComponent(ListingStatusComponent);
+    fixture.componentRef.setInput('listing', listing);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function block(overrides: Partial<AgentListingBlock> = {}): AgentListingBlock {
+    return {
+      state: 'published',
+      category: 'Teaching',
+      publisherId: 'user-user-001',
+      ...overrides,
+    };
+  }
+
+  it('renders nothing for an agent that was never submitted', () => {
+    const fixture = create(undefined);
+    expect(fixture.nativeElement.textContent.trim()).toBe('');
+  });
+
+  it('names the state in the same words the reviewer sees', () => {
+    const fixture = create(block({ state: 'changes_requested' }));
+    expect(fixture.nativeElement.textContent).toContain('Changes requested');
+  });
+
+  it('renders the reviewer note inline, so the author never has to ask', () => {
+    const fixture = create(
+      block({ state: 'changes_requested', reviewNote: 'Tighten the tagline.' }),
+    );
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('The reviewer asked for changes');
+    expect(text).toContain('Tighten the tagline.');
+  });
+
+  it('does not attribute an in-review note to a reviewer', () => {
+    // Submission stores the author's own note in the same field; calling it the
+    // reviewer's would be a lie the author can see through.
+    const fixture = create(block({ state: 'in_review', reviewNote: 'For the CTL team' }));
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Note on this submission');
+    expect(text).not.toContain('reviewer asked');
+  });
+
+  it('does not attribute a withdrawn listing note either way', () => {
+    // `private` is reached from both `in_review` (author's note survives) and
+    // `changes_requested` (the reviewer's does), so the heading cannot claim a voice.
+    const fixture = create(block({ state: 'private', reviewNote: 'Verification run.' }));
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Note on this listing');
+    expect(text).not.toContain('reviewer');
+  });
+
+  it('surfaces the D13 admin-edit trail with a date', () => {
+    const fixture = create(
+      block({ adminEdits: [{ field: 'category', at: '2026-07-24T10:00:00Z', by: 'Dana' }] }),
+    );
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('An admin updated the category');
+    expect(text).toContain('Jul 24');
+  });
+
+  it('tolerates the backend timestamp that carries both an offset and a Z', () => {
+    const fixture = create(
+      block({ adminEdits: [{ field: 'tagline', at: '2026-07-24T10:00:00+00:00Z', by: 'Dana' }] }),
+    );
+    expect(fixture.nativeElement.textContent).toContain('Jul 24');
+  });
+
+  it('drops the date rather than printing "Invalid Date"', () => {
+    const fixture = create(block({ adminEdits: [{ field: 'icon', at: 'not-a-date', by: 'Dana' }] }));
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('An admin updated the icon');
+    expect(text).not.toContain('Invalid');
+  });
+
+  it('collapses an append-only log to the latest edit per field, newest first', () => {
+    const component = create(
+      block({
+        adminEdits: [
+          { field: 'tagline', at: '2026-07-20T10:00:00Z', by: 'Dana' },
+          { field: 'tagline', at: '2026-07-22T10:00:00Z', by: 'Dana' },
+          { field: 'category', at: '2026-07-24T10:00:00Z', by: 'Sam' },
+        ],
+      }),
+    ).componentInstance;
+
+    expect(component.edits().map((e) => e.field)).toEqual(['category', 'tagline']);
+    expect(component.edits()[1].at).toBe('2026-07-22T10:00:00Z');
+  });
+});

--- a/frontend/ai.client/src/app/agents/components/listing-status.component.ts
+++ b/frontend/ai.client/src/app/agents/components/listing-status.component.ts
@@ -1,0 +1,123 @@
+import { Component, ChangeDetectionStrategy, computed, input } from '@angular/core';
+import {
+  AdminEdit,
+  AgentListingBlock,
+  LISTING_STATE_CLASSES,
+  LISTING_STATE_LABELS,
+} from '../models/store.model';
+import { formatShortDate } from '../../shared/utils/iso-date';
+
+/**
+ * The author's view of their own listing: the state, the reviewer's reason, and what
+ * an admin changed (D2, D13).
+ *
+ * Everything here exists so the author never has to ask what happened. "Changes
+ * requested" without the reason is worse than no badge at all, and D13 is explicit
+ * that admin edits to presentation are shown rather than made quietly.
+ */
+@Component({
+  selector: 'app-listing-status',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (listing(); as l) {
+      <span
+        class="inline-flex items-center rounded-full px-2 py-0.5 text-xs/5 font-medium"
+        [class]="badgeClass()"
+      >
+        {{ badgeLabel() }}
+      </span>
+
+      @if (note(); as text) {
+        <div
+          class="mt-2 rounded-2xl border px-3 py-2 text-xs/5"
+          [class]="noteClass()"
+        >
+          <p class="font-medium">{{ noteHeading() }}</p>
+          <p class="mt-0.5 whitespace-pre-line">{{ text }}</p>
+        </div>
+      }
+
+      @if (edits().length) {
+        <ul class="mt-2 space-y-0.5">
+          @for (edit of edits(); track edit.field + edit.at) {
+            <li class="text-xs/5 text-gray-500 dark:text-gray-400">
+              An admin updated the {{ edit.field }}@if (editedOn(edit); as on) {
+                <span> on {{ on }}</span>
+              }
+            </li>
+          }
+        </ul>
+      }
+    }
+  `,
+})
+export class ListingStatusComponent {
+  readonly listing = input.required<AgentListingBlock | undefined>();
+
+  readonly badgeLabel = computed(() => {
+    const state = this.listing()?.state;
+    return state ? LISTING_STATE_LABELS[state] : '';
+  });
+
+  readonly badgeClass = computed(() => {
+    const state = this.listing()?.state;
+    return state ? LISTING_STATE_CLASSES[state] : '';
+  });
+
+  readonly note = computed(() => this.listing()?.reviewNote?.trim() || null);
+
+  /**
+   * Who wrote the note depends on the state, and mislabelling it is worse than not
+   * saying. One field carries both voices: submission writes the author's note to the
+   * reviewer into `reviewNote`, and a review overwrites it with the reviewer's reason.
+   *
+   * Only the states a reviewer must have driven are attributed to one. `private` is
+   * the ambiguous case — withdrawing from `in_review` leaves the author's own note
+   * behind, withdrawing from `changes_requested` leaves the reviewer's — so it stays
+   * neutral rather than guessing.
+   */
+  readonly noteHeading = computed(() => {
+    switch (this.listing()?.state) {
+      case 'in_review':
+        return 'Note on this submission';
+      case 'changes_requested':
+        return 'The reviewer asked for changes';
+      case 'taken_down':
+        return 'Why this was taken down';
+      case 'published':
+        return 'Note from the reviewer';
+      default:
+        return 'Note on this listing';
+    }
+  });
+
+  readonly noteClass = computed(() => {
+    const state = this.listing()?.state;
+    return state === 'changes_requested' || state === 'taken_down'
+      ? 'border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-200'
+      : 'border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
+  });
+
+  /**
+   * The most recent edit per field, newest first.
+   *
+   * The log is append-only, so an admin who fixes a tagline three times produces three
+   * rows saying the same thing. Collapsing to the latest per field keeps the card
+   * readable while still naming everything that was touched.
+   */
+  readonly edits = computed<AdminEdit[]>(() => {
+    const all = this.listing()?.adminEdits ?? [];
+    const latest = new Map<string, AdminEdit>();
+    for (const edit of all) {
+      const seen = latest.get(edit.field);
+      if (!seen || (edit.at ?? '') > (seen.at ?? '')) {
+        latest.set(edit.field, edit);
+      }
+    }
+    return [...latest.values()].sort((a, b) => (b.at ?? '').localeCompare(a.at ?? ''));
+  });
+
+  editedOn(edit: AdminEdit): string {
+    return formatShortDate(edit.at);
+  }
+}

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -1,0 +1,279 @@
+import { Component, ChangeDetectionStrategy, OnInit, computed, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroExclamationTriangle, heroEye } from '@ng-icons/heroicons/outline';
+import { AgentListingService } from '../services/agent-listing.service';
+import {
+  AgentCategory,
+  AgentListingBlock,
+  SkillExposure,
+} from '../models/store.model';
+
+export interface SubmitListingDialogData {
+  agentId: string;
+  agentName: string;
+  /** Present on a resubmission; its category preselects the picker. */
+  listing?: AgentListingBlock;
+}
+
+/** The listing after submission, or `undefined` if cancelled. */
+export type SubmitListingDialogResult = AgentListingBlock | undefined;
+
+/**
+ * Submit an Agent to the marketplace (D2), with the D7 disclosures.
+ *
+ * The dialog does not decide anything. It asks `GET /agents/{id}/listing/preflight`,
+ * which runs the same two checks the transition enforces, and renders the answers:
+ *
+ * * **Skill exposure (D7.1)** — publishing an Agent effectively publishes the contents
+ *   of every skill its author wrote and bound, because Skills v2 resolves a `skill`
+ *   binding on `skill.owner_id == agent.owner_id`. The names are listed, not counted.
+ * * **Memory spaces (D7.2)** — a `memory_space` binding blocks submission outright, so
+ *   Submit is disabled and the backend's message (which names the space) explains why.
+ *   The author learns this before filling in a category, not after clicking.
+ */
+@Component({
+  selector: 'app-submit-listing-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark, heroExclamationTriangle, heroEye })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
+      <div
+        class="dialog-panel relative flex max-h-[90vh] w-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="submit-listing-title"
+        aria-describedby="submit-listing-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="submit-listing-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              {{ isResubmission() ? 'Submit again for review' : 'Submit to the marketplace' }}
+            </h2>
+            <p id="submit-listing-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              An admin reviews <span class="font-medium">{{ data.agentName }}</span> before it
+              appears in the store. You'll see their decision here.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-6 py-4">
+          @if (loading()) {
+            <div class="space-y-3" aria-live="polite">
+              <div class="h-4 w-1/3 animate-pulse rounded bg-gray-100 dark:bg-gray-700"></div>
+              <div class="h-9 animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-700"></div>
+              <span class="sr-only">Checking what publishing this agent would share…</span>
+            </div>
+          } @else if (blockReason(); as reason) {
+            <!-- D7.2 — not a warning. Nothing below it would help. -->
+            <div
+              role="alert"
+              class="flex gap-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-200"
+            >
+              <ng-icon name="heroExclamationTriangle" class="mt-0.5 size-5 shrink-0" aria-hidden="true" />
+              <p>{{ reason }}</p>
+            </div>
+          } @else {
+            <div>
+              <label for="listing-category" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Category
+              </label>
+              <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                Which shelf it sits on. A reviewer may move it.
+              </p>
+              <select
+                id="listing-category"
+                [value]="category()"
+                (change)="onCategoryChange($event)"
+                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+              >
+                <option value="" disabled>Choose a category…</option>
+                @for (option of categories(); track option.id) {
+                  <option [value]="option.id">{{ option.label }}</option>
+                }
+              </select>
+              @if (!categories().length) {
+                <p class="mt-2 text-xs/5 text-amber-700 dark:text-amber-400">
+                  No categories are open for new listings yet. An admin adds these under
+                  Admin → Marketplace → Categories.
+                </p>
+              }
+            </div>
+
+            <div class="mt-5">
+              <label for="listing-note" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Note to the reviewer <span class="font-normal text-gray-500 dark:text-gray-400">(optional)</span>
+              </label>
+              <textarea
+                id="listing-note"
+                rows="3"
+                [value]="note()"
+                (input)="onNoteInput($event)"
+                [placeholder]="notePlaceholder()"
+                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+              ></textarea>
+            </div>
+
+            <!-- D7.1 — enumerate, don't count. -->
+            @if (exposedSkills().length; as count) {
+              <div class="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-900/20">
+                <div class="flex gap-3">
+                  <ng-icon
+                    name="heroEye"
+                    class="mt-0.5 size-5 shrink-0 text-amber-700 dark:text-amber-400"
+                    aria-hidden="true"
+                  />
+                  <div class="min-w-0">
+                    <p class="text-sm/6 font-medium text-amber-900 dark:text-amber-200">
+                      {{ count === 1 ? '1 skill you wrote becomes' : count + ' skills you wrote become' }}
+                      readable by anyone who runs this agent
+                    </p>
+                    <ul class="mt-1.5 space-y-0.5">
+                      @for (skill of exposedSkills(); track skill.ref) {
+                        <li class="text-sm/6 text-amber-900 dark:text-amber-200">· {{ skill.label }}</li>
+                      }
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            }
+
+            <p class="mt-5 text-xs/5 text-gray-500 dark:text-gray-400">
+              You'll be credited as the publisher. An admin may reattribute the listing to a
+              department or the university at approval — that changes the name on the shelf and
+              nothing about who can run it.
+            </p>
+
+            @if (error(); as message) {
+              <p role="alert" class="mt-4 text-sm/6 text-rose-700 dark:text-rose-400">{{ message }}</p>
+            }
+          }
+        </div>
+
+        <div class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            {{ blockReason() ? 'Close' : 'Cancel' }}
+          </button>
+          @if (!blockReason()) {
+            <button
+              type="button"
+              [disabled]="!canSubmit()"
+              (click)="onSubmit()"
+              class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {{ submitting() ? 'Submitting…' : 'Submit for review' }}
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class SubmitListingDialogComponent implements OnInit {
+  private dialogRef = inject<DialogRef<SubmitListingDialogResult>>(DialogRef);
+  private listings = inject(AgentListingService);
+  readonly data = inject<SubmitListingDialogData>(DIALOG_DATA);
+
+  readonly categories = signal<AgentCategory[]>([]);
+  readonly exposedSkills = signal<SkillExposure[]>([]);
+  readonly blockReason = signal<string | null>(null);
+  readonly loading = signal(true);
+  readonly submitting = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly category = signal('');
+  readonly note = signal('');
+
+  readonly isResubmission = computed(() => !!this.data.listing);
+
+  readonly canSubmit = computed(
+    () => !!this.category() && !this.submitting() && !this.blockReason(),
+  );
+
+  /** A resubmission is answering a reviewer; a first submission is introducing itself. */
+  readonly notePlaceholder = computed(() =>
+    this.isResubmission()
+      ? 'What you changed since the last review.'
+      : 'Anything the reviewer should know — who it is for, what it draws on.',
+  );
+
+  async ngOnInit(): Promise<void> {
+    // Preselect the category the listing already had, so a resubmission is one click.
+    this.category.set(this.data.listing?.category ?? '');
+    try {
+      const [categories, preflight] = await Promise.all([
+        this.listings.loadCategories(),
+        this.listings.preflight(this.data.agentId),
+      ]);
+      this.categories.set(categories);
+      this.exposedSkills.set(preflight.exposedSkills ?? []);
+      this.blockReason.set(preflight.blockReason ?? null);
+      // Only preselect a category that is still open for new listings.
+      if (!categories.some((c) => c.id === this.category())) {
+        this.category.set('');
+      }
+    } catch (err) {
+      this.error.set(this.detail(err) ?? 'Could not check this agent for submission.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  onCategoryChange(event: Event): void {
+    this.category.set((event.target as HTMLSelectElement).value);
+  }
+
+  onNoteInput(event: Event): void {
+    this.note.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  async onSubmit(): Promise<void> {
+    if (!this.canSubmit()) return;
+    this.submitting.set(true);
+    this.error.set(null);
+    try {
+      const response = await this.listings.submit(this.data.agentId, {
+        category: this.category(),
+        note: this.note().trim() || undefined,
+      });
+      this.dialogRef.close(response.listing);
+    } catch (err) {
+      // The backend re-runs both D7 checks on the write, so a binding added since the
+      // preflight surfaces here rather than passing silently.
+      this.error.set(this.detail(err) ?? 'Failed to submit this agent for review.');
+      this.submitting.set(false);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+
+  private detail(err: unknown): string | null {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : null;
+  }
+}

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -1,5 +1,9 @@
 import { ShareEntry, UserPermission } from '../../assistants/models/assistant.model';
-import { ListingPublisher } from './store.model';
+import { AgentListingBlock, ListingPublisher } from './store.model';
+
+// `AgentListingBlock` lives with the other marketplace types in `store.model.ts` and is
+// re-exported here for the many callers that reach for it alongside `Agent`.
+export type { AgentListingBlock };
 
 /**
  * Agent Designer contract (Phase 4). Mirrors the backend `/agents` surface
@@ -101,14 +105,6 @@ export interface Agent {
   firstInteracted?: boolean;
   isSharedWithMe?: boolean;
   userPermission?: UserPermission;
-}
-
-/** The marketplace publication state carried on an Agent (D2). */
-export interface AgentListingBlock {
-  state: 'private' | 'in_review' | 'published' | 'changes_requested' | 'taken_down';
-  category: string;
-  publisherId: string;
-  reviewNote?: string;
 }
 
 /** D6's three-way answer to "will this run for me?". */

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -14,6 +14,103 @@ export interface ListingPublisher {
   verified: boolean;
 }
 
+/**
+ * Publication state of an agent's listing (D2). Absent listing = never submitted.
+ *
+ * This vocabulary lives here rather than in the admin feature because both halves of
+ * the flow render it: the reviewer's queue and the author's own card. A second copy
+ * would be the one that eventually says "In Review" while the other says "In review".
+ */
+export type ListingState =
+  | 'private'
+  | 'in_review'
+  | 'published'
+  | 'changes_requested'
+  | 'taken_down';
+
+/** One admin edit to a listing's presentation, surfaced back to the author (D13). */
+export interface AdminEdit {
+  /** Author-facing field name — the backend already maps `icon_key` → "icon". */
+  field: string;
+  at: string;
+  by: string;
+}
+
+/** Display metadata for each listing state, used by the badge components. */
+export const LISTING_STATE_LABELS: Record<ListingState, string> = {
+  private: 'Private',
+  in_review: 'In review',
+  published: 'Published',
+  changes_requested: 'Changes requested',
+  taken_down: 'Taken down',
+};
+
+/**
+ * Badge classes per state. Mirrors the mockup's palette: published reads as success,
+ * in-review as pending, and both "needs attention" states as stop.
+ */
+export const LISTING_STATE_CLASSES: Record<ListingState, string> = {
+  private: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+  in_review: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  published: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+  changes_requested: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+  taken_down: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+};
+
+/**
+ * The marketplace publication state carried on an Agent (D2).
+ *
+ * Present on `GET /agents` as well as the detail read, so an author's own card can
+ * render its state, the reviewer's note and the D13 edit trail without a second call.
+ */
+export interface AgentListingBlock {
+  state: ListingState;
+  category: string;
+  /** Display-only attribution (D12) — never an access grant, and never rendered raw. */
+  publisherId: string;
+  submittedAt?: string;
+  submittedBy?: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  /** The reviewer's reason. Renders inline on the author's card so they never have to ask. */
+  reviewNote?: string;
+  /** Append-only log of admin presentation edits (D13). */
+  adminEdits?: AdminEdit[];
+}
+
+/** Author submits an Agent for review (D2). */
+export interface SubmitListingRequest {
+  category: string;
+  /** Omit to publish under the author's own individual profile (D12). */
+  publisherId?: string;
+  note?: string;
+}
+
+/** One skill that publication would make readable (D7.1). */
+export interface SkillExposure {
+  ref: string;
+  label: string;
+}
+
+/**
+ * The D7 answers, before the author commits.
+ *
+ * `blockReason` non-null means submission is impossible (a `memory_space` binding,
+ * D7.2) and the text explains why. The dialog renders it; it never re-derives it.
+ */
+export interface ListingPreflight {
+  agentId: string;
+  exposedSkills: SkillExposure[];
+  blockReason?: string | null;
+}
+
+/** The listing after a submission, plus the disclosures the author was shown (D7). */
+export interface ListingSubmissionResponse {
+  agentId: string;
+  listing: AgentListingBlock;
+  exposedSkills: SkillExposure[];
+}
+
 /** One row on a shelf. */
 export interface AgentListing {
   agentId: string;

--- a/frontend/ai.client/src/app/agents/services/agent-api.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-api.service.ts
@@ -14,6 +14,12 @@ import {
   UpdateAgentRequest,
 } from '../models/agent.model';
 import {
+  AgentListingBlock,
+  ListingPreflight,
+  ListingSubmissionResponse,
+  SubmitListingRequest,
+} from '../models/store.model';
+import {
   ShareAssistantRequest,
   UnshareAssistantRequest,
   UpdateSharePermissionRequest,
@@ -90,5 +96,23 @@ export class AgentApiService {
 
   getAgentShares(id: string): Observable<AgentSharesResponse> {
     return this.http.get<AgentSharesResponse>(`${this.baseUrl()}/${id}/shares`);
+  }
+
+  // ── marketplace, the author's half (D2/D7) ─────────────────────────────────────
+  /** The D7 answers before the author commits: skill exposure and any block. */
+  getListingPreflight(id: string): Observable<ListingPreflight> {
+    return this.http.get<ListingPreflight>(`${this.baseUrl()}/${id}/listing/preflight`);
+  }
+
+  submitListing(id: string, request: SubmitListingRequest): Observable<ListingSubmissionResponse> {
+    return this.http.post<ListingSubmissionResponse>(
+      `${this.baseUrl()}/${id}/listing/submit`,
+      request,
+    );
+  }
+
+  /** Unpublish or withdraw. Returns the listing at `private`; revokes nothing (D7.3). */
+  withdrawListing(id: string): Observable<AgentListingBlock> {
+    return this.http.delete<AgentListingBlock>(`${this.baseUrl()}/${id}/listing`);
   }
 }

--- a/frontend/ai.client/src/app/agents/services/agent-listing.service.spec.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-listing.service.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { AgentListingService } from './agent-listing.service';
+import { AgentApiService } from './agent-api.service';
+import { AgentService } from './agent.service';
+import { AgentStoreService } from './agent-store.service';
+import { AgentCategory, AgentListingBlock } from '../models/store.model';
+
+function category(id: string): AgentCategory {
+  return { id, label: id, order: 0, enabled: true };
+}
+
+function listing(overrides: Partial<AgentListingBlock> = {}): AgentListingBlock {
+  return {
+    state: 'in_review',
+    category: 'Teaching',
+    publisherId: 'user-user-001',
+    ...overrides,
+  };
+}
+
+describe('AgentListingService', () => {
+  let service: AgentListingService;
+  let mockApi: {
+    getListingPreflight: ReturnType<typeof vi.fn>;
+    submitListing: ReturnType<typeof vi.fn>;
+    withdrawListing: ReturnType<typeof vi.fn>;
+  };
+  let mockAgents: { patchAgent: ReturnType<typeof vi.fn> };
+  let mockStore: { loadStoreFront: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockApi = {
+      getListingPreflight: vi.fn(),
+      submitListing: vi.fn(),
+      withdrawListing: vi.fn(),
+    };
+    mockAgents = { patchAgent: vi.fn() };
+    mockStore = { loadStoreFront: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AgentListingService,
+        { provide: AgentApiService, useValue: mockApi },
+        { provide: AgentService, useValue: mockAgents },
+        { provide: AgentStoreService, useValue: mockStore },
+      ],
+    });
+    service = TestBed.inject(AgentListingService);
+  });
+
+  describe('the kill-switch probe', () => {
+    it('starts unknown so no publication control renders before the answer', () => {
+      expect(service.available()).toBeNull();
+    });
+
+    it('marks the marketplace available and keeps the categories', async () => {
+      mockStore.loadStoreFront.mockResolvedValue({
+        featured: [],
+        categories: [category('Teaching'), category('Research')],
+      });
+
+      await service.loadCategories();
+
+      expect(service.available()).toBe(true);
+      expect(service.categories().map((c) => c.id)).toEqual(['Teaching', 'Research']);
+    });
+
+    it('marks the marketplace unavailable on a 404 without surfacing an error', async () => {
+      // AGENT_MARKETPLACE_ENABLED=false 404s the routes as a set; the surface should
+      // behave as if the feature does not exist rather than show a broken control.
+      mockStore.loadStoreFront.mockRejectedValue({ status: 404 });
+
+      await service.loadCategories();
+
+      expect(service.available()).toBe(false);
+      expect(service.categories()).toEqual([]);
+    });
+
+    it('hides the controls on a real outage too — submitting would fail as well', async () => {
+      mockStore.loadStoreFront.mockRejectedValue({ status: 500 });
+
+      await service.loadCategories();
+
+      expect(service.available()).toBe(false);
+    });
+
+    it('does not re-probe after a 404 — the kill switch does not flip mid-session', async () => {
+      mockStore.loadStoreFront.mockRejectedValue({ status: 404 });
+
+      await service.loadCategories();
+      await service.loadCategories();
+
+      expect(mockStore.loadStoreFront).toHaveBeenCalledTimes(1);
+    });
+
+    it('loads once per session unless forced', async () => {
+      mockStore.loadStoreFront.mockResolvedValue({ featured: [], categories: [category('Teaching')] });
+
+      await service.loadCategories();
+      await service.loadCategories();
+      expect(mockStore.loadStoreFront).toHaveBeenCalledTimes(1);
+
+      await service.loadCategories(true);
+      expect(mockStore.loadStoreFront).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries after a transient failure, since that was not a durable answer', async () => {
+      mockStore.loadStoreFront.mockRejectedValueOnce({ status: 500 });
+      await service.loadCategories();
+
+      mockStore.loadStoreFront.mockResolvedValue({ featured: [], categories: [category('IT')] });
+      await service.loadCategories();
+
+      expect(service.available()).toBe(true);
+    });
+  });
+
+  describe('submit', () => {
+    it('reflects the new listing on the author card without a reload', async () => {
+      const submitted = listing();
+      mockApi.submitListing.mockReturnValue(
+        of({ agentId: 'ast-001', listing: submitted, exposedSkills: [] }),
+      );
+
+      const response = await service.submit('ast-001', { category: 'Teaching' });
+
+      expect(mockApi.submitListing).toHaveBeenCalledWith('ast-001', { category: 'Teaching' });
+      expect(mockAgents.patchAgent).toHaveBeenCalledWith('ast-001', { listing: submitted });
+      expect(response.listing.state).toBe('in_review');
+    });
+
+    it('leaves the card alone when the submission is refused', async () => {
+      // A memory_space binding added since the preflight, for instance (D7.2).
+      mockApi.submitListing.mockReturnValue(throwError(() => ({ status: 400 })));
+
+      await expect(service.submit('ast-001', { category: 'Teaching' })).rejects.toBeTruthy();
+      expect(mockAgents.patchAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('withdraw', () => {
+    it('patches the card back to private', async () => {
+      const withdrawn = listing({ state: 'private' });
+      mockApi.withdrawListing.mockReturnValue(of(withdrawn));
+
+      const result = await service.withdraw('ast-001');
+
+      expect(result.state).toBe('private');
+      expect(mockAgents.patchAgent).toHaveBeenCalledWith('ast-001', { listing: withdrawn });
+    });
+  });
+
+  describe('preflight', () => {
+    it('returns the D7 answers verbatim — the dialog never re-derives them', async () => {
+      mockApi.getListingPreflight.mockReturnValue(
+        of({
+          agentId: 'ast-001',
+          exposedSkills: [{ ref: 'skill-a', label: 'Policy Citation Format' }],
+          blockReason: null,
+        }),
+      );
+
+      const preflight = await service.preflight('ast-001');
+
+      expect(preflight.exposedSkills).toHaveLength(1);
+      expect(preflight.blockReason).toBeNull();
+    });
+  });
+});

--- a/frontend/ai.client/src/app/agents/services/agent-listing.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-listing.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AgentApiService } from './agent-api.service';
+import { AgentService } from './agent.service';
+import { AgentStoreService } from './agent-store.service';
+import {
+  AgentCategory,
+  AgentListingBlock,
+  ListingPreflight,
+  ListingSubmissionResponse,
+  SubmitListingRequest,
+} from '../models/store.model';
+
+/**
+ * The author's half of the publication flow (D2, D7, D13).
+ *
+ * Phases 1–3 shipped `POST /agents/{id}/listing/submit`, `DELETE /agents/{id}/listing`
+ * and the whole admin review console — but nothing in the SPA called the author's two
+ * routes, so an agent could not reach the store without a hand-rolled request. This is
+ * the missing caller.
+ *
+ * `available` is the kill switch, observed rather than assumed: the marketplace routes
+ * 404 as a set when `AGENT_MARKETPLACE_ENABLED=false`, and the category load is the
+ * cheapest probe of that. Until it resolves, the value is `null` — "not known yet" —
+ * so the card shows no publication affordance rather than one that will error on click.
+ * Badges are unaffected: they render from `agent.listing`, which the list read already
+ * carries, and a listing that exists is worth naming whether or not new ones may be made.
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentListingService {
+  private api = inject(AgentApiService);
+  private agents = inject(AgentService);
+  private store = inject(AgentStoreService);
+
+  private _categories = signal<AgentCategory[]>([]);
+  private _available = signal<boolean | null>(null);
+
+  /**
+   * Whether the probe reached a durable answer. Success and a 404 both settle it — the
+   * kill switch does not flip mid-session — but a transient failure does not, so one
+   * bad request does not hide publication for the rest of the session.
+   */
+  private settled = false;
+
+  readonly categories = this._categories.asReadonly();
+  readonly available = this._available.asReadonly();
+
+  /**
+   * Load the category set the submit dialog offers, once per session.
+   *
+   * Only enabled categories come back — `store_front` filters them — which is the
+   * behaviour the picker wants: a disabled category still holds its existing listings
+   * but accepts no new ones, and offering it would produce a 400 on submit.
+   */
+  async loadCategories(force = false): Promise<AgentCategory[]> {
+    if (!force && this.settled) {
+      return this._categories();
+    }
+    try {
+      const front = await this.store.loadStoreFront();
+      this._categories.set(front.categories ?? []);
+      this._available.set(true);
+      this.settled = true;
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      // 404 is the kill switch behaving as designed (the routes act unmounted), and it
+      // is a durable answer. Any other failure is an outage: hide the control for now —
+      // submitting would fail too — but ask again rather than write the feature off.
+      if (status === 404) {
+        this.settled = true;
+      } else {
+        console.error('Error loading agent store categories:', err);
+      }
+      this._categories.set([]);
+      this._available.set(false);
+    }
+    return this._categories();
+  }
+
+  /** The D7 checks, without transitioning. Owner only. */
+  preflight(agentId: string): Promise<ListingPreflight> {
+    return firstValueFrom(this.api.getListingPreflight(agentId));
+  }
+
+  /** Submit for review, and reflect the new state on the author's card immediately. */
+  async submit(agentId: string, request: SubmitListingRequest): Promise<ListingSubmissionResponse> {
+    const response = await firstValueFrom(this.api.submitListing(agentId, request));
+    this.agents.patchAgent(agentId, { listing: response.listing });
+    return response;
+  }
+
+  /**
+   * Unpublish or withdraw (D7.3).
+   *
+   * A delisting, not a recall: it returns the listing to `private` and revokes nothing
+   * that already happened. The confirmation copy says so — see the caller.
+   */
+  async withdraw(agentId: string): Promise<AgentListingBlock> {
+    const listing = await firstValueFrom(this.api.withdrawListing(agentId));
+    this.agents.patchAgent(agentId, { listing });
+    return listing;
+  }
+}

--- a/frontend/ai.client/src/app/agents/services/agent.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent.service.ts
@@ -88,6 +88,20 @@ export class AgentService {
   }
 
   /**
+   * Merge a partial update into one cached agent, in place.
+   *
+   * For changes that happen outside the Designer's own write path — a marketplace
+   * submission or withdrawal, which returns a listing rather than a whole Agent. The
+   * alternative is reloading the list to observe one field, which discards nothing
+   * useful but flickers every card.
+   */
+  patchAgent(id: string, patch: Partial<Agent>): void {
+    this.agents.update((current) =>
+      current.map((a) => (a.agentId === id ? { ...a, ...patch } : a)),
+    );
+  }
+
+  /**
    * Fetch (and memoise) the RBAC-filtered bindable palette for a kind. Returns
    * `[]` on failure so a picker degrades to "nothing available" rather than
    * breaking the form. Pass `force` to bypass the cache after a mutation elsewhere.

--- a/frontend/ai.client/src/app/shared/utils/iso-date.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/iso-date.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseBackendIso, formatShortDate } from './iso-date';
+
+describe('parseBackendIso', () => {
+  it('parses a well-formed UTC timestamp', () => {
+    expect(parseBackendIso('2026-07-24T10:00:00Z')?.toISOString()).toBe('2026-07-24T10:00:00.000Z');
+  });
+
+  it('tolerates the backend form that carries both an offset and a Z', () => {
+    // `datetime.now(timezone.utc).isoformat() + "Z"` — invalid ISO 8601, already
+    // persisted across ~80 call sites, so consumers strip rather than wait for a sweep.
+    expect(parseBackendIso('2026-07-24T10:00:00.972451+00:00Z')?.toISOString()).toBe(
+      '2026-07-24T10:00:00.972Z',
+    );
+  });
+
+  it('preserves a real non-UTC offset', () => {
+    expect(parseBackendIso('2026-07-24T10:00:00-06:00')?.toISOString()).toBe(
+      '2026-07-24T16:00:00.000Z',
+    );
+  });
+
+  it('returns null rather than an Invalid Date', () => {
+    expect(parseBackendIso('not-a-date')).toBeNull();
+    expect(parseBackendIso(undefined)).toBeNull();
+    expect(parseBackendIso('')).toBeNull();
+  });
+});
+
+describe('formatShortDate', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('omits the year for a recent date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-25T00:00:00Z'));
+    expect(formatShortDate('2026-07-24T18:00:00Z')).not.toMatch(/2026/);
+  });
+
+  it('adds the year once a date is old enough to mislead', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-25T00:00:00Z'));
+    expect(formatShortDate('2025-01-10T10:00:00Z')).toMatch(/2025/);
+  });
+
+  it('renders nothing for an unparseable timestamp', () => {
+    expect(formatShortDate('not-a-date')).toBe('');
+  });
+});

--- a/frontend/ai.client/src/app/shared/utils/iso-date.ts
+++ b/frontend/ai.client/src/app/shared/utils/iso-date.ts
@@ -1,0 +1,34 @@
+/**
+ * Parsing helpers for backend timestamps.
+ *
+ * Much of the backend emits `datetime.now(timezone.utc).isoformat() + "Z"`, which
+ * produces `2026-07-25T05:34:23.972451+00:00Z` — an offset *and* a `Z`. That is not
+ * valid ISO 8601, and strict engines (Safari) refuse it outright while V8 returns
+ * `Invalid Date`. The pattern is spread across ~80 call sites and is already persisted
+ * in records, so consumers tolerate it rather than wait for a sweep.
+ */
+
+/** Parse a backend timestamp, stripping a redundant trailing `Z` after an offset. */
+export function parseBackendIso(iso: string | undefined | null): Date | null {
+  if (!iso) return null;
+  const date = new Date(iso.replace(/([+-]\d{2}:\d{2})Z$/, '$1'));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * "Jul 24" — a date the reader can act on, without a year they already know.
+ *
+ * Falls back to the year for anything older than ~10 months, so a stale record does
+ * not silently read as recent. Returns `''` when the timestamp is unparseable, which
+ * callers render as no date rather than as "Invalid Date".
+ */
+export function formatShortDate(iso: string | undefined | null): string {
+  const date = parseBackendIso(iso);
+  if (!date) return '';
+  const monthsOld = (Date.now() - date.getTime()) / (30 * 86_400_000);
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(monthsOld > 10 ? { year: 'numeric' } : {}),
+  });
+}


### PR DESCRIPTION
Closes the gap the Phasing table left open. Phases 1–3 (#731 · #732 · #733) shipped `POST /agents/{id}/listing/submit`, `DELETE /agents/{id}/listing` and the entire reviewer console — but nothing in the SPA called the author's two routes, so no Agent could reach the store without a hand-rolled request. This is the missing caller, plus one new endpoint the disclosure rule needs.

Spec: `docs/specs/agent-marketplace.md` — D2, D7, D13, and the "My Agents" bullet in the Frontend section. A `Phase 3.5` line was added to the Phasing table so this can't fall between phases again.

## Backend — one new route

`GET /agents/{id}/listing/preflight` runs the submit path's two checks without transitioning.

D7.1 asks the **dialog** to enumerate the skills publication would expose, but phase 1 could only answer in the submit *response* — i.e. after the author had already committed. Telling someone which of their skills just became world-readable after the fact is a weak form of informed consent.

`_memory_space_block` splits into a shared `_reason` half that both callers use, so the block the dialog shows and the block the write enforces cannot drift. Owner-only, like every other author path: skill exposure is a statement about the *owner's* publication, and it is not an editor's to see.

No index, no env var, no IAM — ships on `backend.yml` alone.

## SPA

- **Submit dialog** — category picker, optional note to the reviewer, the D7.1 skills listed by name (not counted), and D7.2 rendered as a disabled Submit carrying the backend's message, which names the space. The author learns an agent can't be published *before* filling in a category.
- **Listing-state badges** on the author's own cards — Draft / Private / In review / Changes requested / Published — with the reviewer's note inline and the D13 admin-edit trail ("An admin updated the category on Jul 24"). `adminEdits` was already on the list read; nothing new was needed server-side.
- **Withdraw / unpublish**, whose confirmation says plainly that it revokes nothing retroactively (D7.3): pins keep working, conversations underway keep running, and the direct link still resolves. It is a delisting, not a recall.

## Three things worth a reviewer's attention

**The listing-state vocabulary moved.** `ListingState`, `AdminEdit` and the badge label/class maps now live in `agents/models/store.model.ts`, and `admin/marketplace/models/marketplace.model.ts` re-exports them. Admin imports are unchanged. A reviewer and an author looking at the same listing must read the same word for it.

**`reviewNote` carries two voices.** Submission writes the *author's* note to the reviewer into that field; a review overwrites it with the *reviewer's* reason. So the badge attributes a note only in states a reviewer must have driven (`changes_requested`, `taken_down`, `published`); `private` is reachable from both `in_review` and `changes_requested` and stays deliberately neutral rather than guessing. I hit this live — after withdrawing, my own note was headed "Note from the reviewer."

**A pre-existing timestamp bug, worked around not fixed.** The backend emits `datetime.now(timezone.utc).isoformat() + "Z"` → `2026-07-25T05:51:41.928400+00:00Z`, which carries an offset *and* a `Z` and is invalid ISO 8601. That is ~80 call sites codebase-wide and already persisted in records; the admin review queue silently degrades every date to "recently" today because of it. D13's copy needs a real date, so this adds `shared/utils/iso-date.ts` following the existing tolerant-parse precedent in `sync-policy-control.component.ts`. **Sweeping the backend format is a worthwhile follow-up and is not attempted here.**

## Testing

Backend **5051 passed**, 3 skipped. SPA **1519 passed**. New coverage: a `TestPreflight` class pairing each case with its `TestMemorySpaceBlock` / `TestSkillDisclosure` counterpart (including that a preflight writes nothing), plus specs for the listing service, the status badge and the date util.

Verified live against dev-ai:

- the skill disclosure on a 1-skill agent
- the memory-space block naming "Oliver's Brain", with no Submit to click
- submit → **In review** badge + note, patched in place with no reload
- withdraw → **Private** + "Submit again", surviving a full page reload

Not exercised live: the `changes_requested` / `taken_down` reviewer-note states and a populated `adminEdits` trail — those need an admin review action, and are covered by unit tests. `adminEdits` was confirmed to arrive on the list read (as `[]`), so the trail renders as soon as an admin edits.

Note: this verification left a `private` listing block with a throwaway note on one "Untitled Agent" draft in dev-ai.

## Deploy

`backend.yml` + `frontend-deploy.yml`. No CDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)