### PR TITLE
feat(marketplace): phase 4 — icons, upload through all four render sizes

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -20,7 +20,17 @@ Phase-4 concern when the Designer consumes it.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 
 from apis.app_api.agent_designer.services.bindable_catalog import (
     BINDABLE_KINDS,
@@ -65,6 +75,12 @@ from apis.shared.assistants.service import (
     update_assistant,
     update_share_permission,
 )
+from apis.app_api.agent_designer.services.icon_service import (
+    AgentIconError,
+    read_icon,
+    remove_icon,
+    upload_icon,
+)
 from apis.app_api.agent_designer.services.listing_service import (
     ListingError,
     preflight_listing,
@@ -77,6 +93,7 @@ from apis.app_api.agent_designer.services.store_service import (
     store_front,
 )
 from apis.shared.assistants.models import (
+    AgentIconResponse,
     AgentListing,
     AgentStoreFrontResponse,
     AgentStoreResponse,
@@ -559,3 +576,76 @@ async def withdraw_agent_listing_endpoint(
     except Exception as e:
         logger.error(f"Error withdrawing agent listing: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to withdraw agent listing: {str(e)}")
+
+
+# ------------------------------------------------------------------------ icons (D5)
+# Bytes to S3, key on the record, and one route that serves them back. The serve route
+# is what makes ``iconUrl`` a stable path instead of a presigned URL that changes on
+# every read — see ``apis.shared.assistants.icons.icon_url``.
+@router.post("/{agent_id}/icon", response_model=AgentIconResponse, response_model_exclude_none=True)
+async def upload_agent_icon_endpoint(
+    agent_id: str,
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_marketplace_enabled),
+):
+    """Upload the Agent's square icon (owner or editor).
+
+    512×512 PNG or JPEG, ≤ 400 KB (D5). The image is re-encoded server-side — that is
+    what normalizes the dimensions *and* strips EXIF, so an icon cropped from a phone
+    photo does not publish its GPS coordinates. Rejections carry the limit and the
+    supplied value, since "invalid image" sends an author back to the file picker with
+    nothing to change.
+    """
+    content = await file.read()
+    try:
+        return await upload_icon(agent_id, content, current_user)
+    except AgentIconError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error uploading agent icon: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to upload agent icon: {str(e)}")
+
+
+@router.delete("/{agent_id}/icon", response_model=AgentIconResponse, response_model_exclude_none=True)
+async def delete_agent_icon_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """Clear the icon, returning the Agent to its generated gradient (owner or editor)."""
+    try:
+        return await remove_icon(agent_id, current_user)
+    except AgentIconError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error removing agent icon: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to remove agent icon: {str(e)}")
+
+
+@router.get("/{agent_id}/icon")
+async def get_agent_icon_endpoint(
+    agent_id: str,
+    request: Request,
+    current_user: User = Depends(require_marketplace_enabled),
+):
+    """Serve the icon bytes.
+
+    The object is immutable — its key *is* its content digest — so this answers with a
+    one-year ``immutable`` cache directive and the digest as the ETag. A replacement
+    changes ``iconUrl``'s ``?v=``, which is what busts the cache; the ``If-None-Match``
+    304 below is for the same URL being asked for twice.
+
+    A missing icon is a 404 and the SPA falls through to the generated gradient, so a key
+    that outlived its object degrades to the designed default rather than a broken tile.
+    """
+    try:
+        data, content_type, version = await read_icon(agent_id, current_user)
+    except AgentIconError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error reading agent icon: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to read agent icon: {str(e)}")
+
+    etag = f'"{version}"'
+    headers = {"Cache-Control": "public, max-age=31536000, immutable", "ETag": etag}
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    return Response(content=data, media_type=content_type, headers=headers)

--- a/backend/src/apis/app_api/agent_designer/services/icon_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/icon_service.py
@@ -1,0 +1,166 @@
+"""Agent Marketplace Phase 4 — the icon upload / read / remove paths (D5).
+
+Authorization for an Agent's square icon, and the one place the three storage concerns
+meet: validation (``apis.shared.assistants.icons``), the object write (S3), and the
+``iconKey`` attribute write (``listing_repository.write_icon_key``).
+
+Two authorization rules, and they are deliberately different from each other:
+
+* **Writing an icon is editing the agent.** Owner *or* editor, matching ``PUT /agents/{id}``
+  — an icon is presentation, not behavior, and an editor who may rewrite the instructions
+  is not someone to stop at the avatar. (Admins reach the same field through D13's
+  ``PATCH /admin/agents/{id}/listing``, which is a separate path with its own audit trail.)
+* **Reading an icon follows the shelf, not the record.** A published agent's icon is
+  readable by any authenticated user, because the store read already hands that agent's
+  name, tagline and emoji to every browsing user — the icon is no new disclosure, and
+  gating it on the record's own access check would render a broken image on the shelf of
+  any published agent whose ``visibility`` is still PRIVATE.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Tuple
+
+from apis.shared.assistants.icons import (
+    IconError,
+    IconStoreError,
+    get_icon_store,
+    icon_url,
+    icon_version,
+    normalize_icon,
+)
+from apis.shared.assistants.listing_repository import write_icon_key
+from apis.shared.assistants.models import AgentIconResponse, Assistant
+from apis.shared.assistants.service import (
+    _get_assistant_cloud_without_ownership_check,
+    get_assistant_with_access_check,
+    resolve_assistant_permission,
+)
+from apis.shared.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+
+class AgentIconError(Exception):
+    """An icon operation the caller may not perform, or an image we cannot store.
+
+    ``status_code`` maps to the HTTP response: 403 authorization, 404 missing agent or
+    missing icon, 400 an image that fails the D5 limits, 503 storage unconfigured.
+    """
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+async def _load_for_write(agent_id: str, user: User) -> Assistant:
+    """Load an Agent the caller may edit (owner or editor), or raise."""
+    assistant, permission = await resolve_assistant_permission(
+        assistant_id=agent_id, user_id=user.user_id, user_email=user.email
+    )
+    if not assistant:
+        raise AgentIconError(f"Agent not found: {agent_id}", status_code=404)
+    if permission not in ("owner", "editor"):
+        raise AgentIconError(
+            "You do not have permission to change this agent's icon.", status_code=403
+        )
+    return assistant
+
+
+async def upload_icon(agent_id: str, content: bytes, user: User) -> AgentIconResponse:
+    """Validate, store and record a new icon; return the key and its URL.
+
+    The old object is deleted only *after* the record points at the new one, so a failure
+    anywhere in the middle leaves the agent with its previous icon rather than none. The
+    key is content-addressed, which makes re-uploading the same image idempotent — and
+    makes the delete a no-op in exactly that case, which is why it is skipped when the
+    key is unchanged.
+    """
+    assistant = await _load_for_write(agent_id, user)
+
+    try:
+        data, ext, content_type = normalize_icon(content)
+    except IconError as e:
+        raise AgentIconError(str(e), status_code=400) from e
+
+    store = get_icon_store()
+    try:
+        key = store.put(agent_id=agent_id, content=data, ext=ext, content_type=content_type)
+    except IconStoreError as e:
+        logger.error(f"Icon storage unavailable for agent {agent_id}: {e}")
+        raise AgentIconError("Icon storage is unavailable.", status_code=503) from e
+
+    previous = assistant.icon_key
+    await write_icon_key(agent_id, key, updated_at=_now())
+    if previous and previous != key:
+        store.delete(previous)
+
+    logger.info(f"🖼️ User {user.user_id} set the icon for agent {agent_id}")
+    return AgentIconResponse(agent_id=agent_id, icon_key=key, icon_url=icon_url(agent_id, key))
+
+
+async def remove_icon(agent_id: str, user: User) -> AgentIconResponse:
+    """Clear the icon, returning the agent to the generated gradient fallback (D5).
+
+    Not in the spec's API table, and it has to exist: ``PATCH /admin/.../listing`` can only
+    *replace* ``iconKey``, so without this an author who uploads an off-brand icon has no
+    way back to the default the store was designed around.
+    """
+    assistant = await _load_for_write(agent_id, user)
+    previous = assistant.icon_key
+
+    await write_icon_key(agent_id, None, updated_at=_now())
+    if previous:
+        get_icon_store().delete(previous)
+
+    logger.info(f"🖼️ User {user.user_id} removed the icon for agent {agent_id}")
+    return AgentIconResponse(agent_id=agent_id, icon_key=None, icon_url=None)
+
+
+async def read_icon(agent_id: str, user: User) -> Tuple[bytes, str, str]:
+    """Return ``(bytes, content_type, version)`` for an agent's icon.
+
+    Access follows the shelf: published → any authenticated user; otherwise the record's
+    own access check (see the module docstring). The ``version`` is the key's digest,
+    which the route serves as the ETag.
+    """
+    assistant = await _resolve_readable(agent_id, user)
+    if not assistant.icon_key:
+        raise AgentIconError("This agent has no icon.", status_code=404)
+
+    try:
+        data, content_type = get_icon_store().get(assistant.icon_key)
+    except IconStoreError as e:
+        # A key that outlived its object: 404 rather than 500, so the SPA's <img> error
+        # path drops to the generated fallback instead of showing a broken tile.
+        logger.warning(f"Icon object missing for agent {agent_id}: {e}")
+        raise AgentIconError("This agent has no icon.", status_code=404) from e
+
+    return data, content_type, icon_version(assistant.icon_key) or ""
+
+
+async def _resolve_readable(agent_id: str, user: User) -> Assistant:
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+
+    record = await _get_assistant_cloud_without_ownership_check(agent_id, table_name)
+    if not record:
+        raise AgentIconError(f"Agent not found: {agent_id}", status_code=404)
+    if record.listing and record.listing.state == "published":
+        return record
+
+    assistant, _permission = await get_assistant_with_access_check(
+        assistant_id=agent_id, user_id=user.user_id, user_email=user.email
+    )
+    if not assistant:
+        raise AgentIconError(
+            "Access denied: you do not have permission to access this agent", status_code=403
+        )
+    return assistant

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -31,6 +31,7 @@ from typing import List, Optional, Tuple
 
 from apis.shared.assistants.compat import effective_bindings
 from apis.shared.assistants.categories import ensure_seeded
+from apis.shared.assistants.icons import icon_url
 from apis.shared.assistants.listing import ListingTransitionError, assert_transition
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
 from apis.shared.assistants.models import (
@@ -501,6 +502,7 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         tagline=assistant.tagline,
         emoji=assistant.emoji,
         icon_key=assistant.icon_key,
+        icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
         owner_name=assistant.owner_name,
         publisher=publisher,
         category=listing.category,

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -19,6 +19,7 @@ import logging
 from typing import List, Optional, Tuple
 
 from apis.shared.assistants.categories import ensure_seeded, list_categories
+from apis.shared.assistants.icons import icon_url
 from apis.shared.assistants.listing_repository import query_store
 from apis.shared.assistants.models import (
     AgentCategory,
@@ -54,7 +55,9 @@ def _to_listing_response(
         name=assistant.name,
         tagline=assistant.tagline,
         emoji=assistant.emoji,
-        # icon_url stays absent until Phase 4; the SPA renders the generated fallback.
+        # Phase 4: the uploaded icon when there is one, the generated gradient when not —
+        # and the emoji above is what that gradient carries, so both always ship.
+        icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
         publisher=(
             ListingPublisher(label=profile.label, kind=profile.kind, verified=profile.verified)
             if profile

--- a/backend/src/apis/shared/assistants/compat.py
+++ b/backend/src/apis/shared/assistants/compat.py
@@ -23,6 +23,7 @@ must go to a child row (``AST#{id}/BINDING#…``), not inline here.
 
 from typing import List
 
+from apis.shared.assistants.icons import icon_url
 from apis.shared.assistants.models import AgentBinding, Assistant
 
 
@@ -79,5 +80,8 @@ def to_agent_view(assistant: Assistant) -> dict:
         # ``response_model_exclude_none``, so that payload is unchanged.
         "tagline": assistant.tagline,
         "iconKey": assistant.icon_key,
+        # Derived, never stored (Phase 4): the record holds the S3 key, the read shape
+        # holds where to fetch it from. ``None`` when unset → the SPA's generated gradient.
+        "iconUrl": icon_url(assistant.assistant_id, assistant.icon_key),
         "listing": assistant.listing.model_dump(by_alias=True) if assistant.listing else None,
     }

--- a/backend/src/apis/shared/assistants/icons.py
+++ b/backend/src/apis/shared/assistants/icons.py
@@ -1,0 +1,304 @@
+"""Square-icon storage for Agents (Marketplace Phase 4, D5).
+
+An Agent's identity in the store is a 512×512 square icon. The **bytes live in S3 and
+the record carries only the object key** — the same rule MCP App icons learned the hard
+way against the 400 KB DynamoDB item limit, except here the limit would be hit by design
+rather than by accident, since the icon ceiling *is* 400 KB.
+
+Storage
+-------
+Objects land in the existing assistants asset bucket
+(``S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME`` → ``{prefix}-rag-documents``), under the same
+``assistants/{agent_id}/`` prefix that assistant documents already use:
+
+    assistants/{agent_id}/icons/{sha256[:16]}.{png|jpg}
+
+The key is **content-addressed**, which buys two things: re-uploading the same image is a
+no-op rather than a new object, and the digest doubles as the cache version — the serve
+route hands it out as the ETag and the read shapes hang it off ``?v=`` so an icon can be
+cached ``immutable`` and still change the moment a new one is uploaded.
+
+Validation
+----------
+Everything a caller sends is untrusted, so the ``Content-Type`` header is ignored and the
+format is sniffed from the bytes. Beyond the D5 limits (PNG or JPEG, ≤ 400 KB, square),
+the image is **always re-encoded** even when it already measures 512×512. That is not
+redundant work: re-encoding is what strips EXIF, and an author uploading a phone photo as
+an icon would otherwise publish its GPS coordinates to the whole institution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+from typing import Optional, Tuple
+
+try:  # boto3 is absent in some local-dev setups
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - exercised only without boto3
+    boto3 = None
+    ClientError = Exception  # type: ignore[assignment, misc]
+
+logger = logging.getLogger(__name__)
+
+# D5 limits.
+ICON_MAX_BYTES = 400 * 1024
+ICON_SIZE = 512
+# Below this, upscaling to 512 produces a soft tile that reads worse than the generated
+# gradient it replaced — so we decline rather than accept a downgrade.
+ICON_MIN_SOURCE = 256
+# A hand-cropped square is often off by a pixel; a 4:3 photo is not.
+ICON_SQUARE_TOLERANCE_PX = 2
+
+_FORMAT_EXT = {"PNG": "png", "JPEG": "jpg"}
+_EXT_CONTENT_TYPE = {"png": "image/png", "jpg": "image/jpeg"}
+
+# AWS-managed (SSE-S3 / AES256) encryption, matching the bucket default.
+_SSE_ALGORITHM = "AES256"
+
+
+class IconError(ValueError):
+    """An icon the author cannot publish, with a message written for the author.
+
+    Every message names the limit *and* what was actually supplied, because "invalid
+    image" sends someone back to a file picker with nothing to change.
+    """
+
+
+class IconStoreError(RuntimeError):
+    """Storage is unavailable or the object could not be read/written."""
+
+
+# ── keys and URLs ────────────────────────────────────────────────────────────────────
+
+
+def build_icon_key(agent_id: str, digest: str, ext: str) -> str:
+    """``assistants/{agent_id}/icons/{digest}.{ext}`` — the content-addressed key."""
+    return f"assistants/{agent_id}/icons/{digest}.{ext}"
+
+
+def icon_version(icon_key: Optional[str]) -> Optional[str]:
+    """The cache version carried by a key: its digest segment.
+
+    Used as the ``?v=`` on ``iconUrl`` and as the ETag on the serve route, so a stored
+    icon can be cached ``immutable`` while a replacement busts it immediately.
+    """
+    if not icon_key:
+        return None
+    return icon_key.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+
+
+def icon_url(agent_id: str, icon_key: Optional[str]) -> Optional[str]:
+    """Resolve the read-shape ``iconUrl`` for a stored key, or ``None`` when unset.
+
+    A **relative app-api path**, not a presigned S3 URL and not a CloudFront path:
+
+    * Presigning would hand out a different string on every response, so a browsing user
+      re-downloads every shelf icon on every page view and the JSON stops being
+      cacheable — for an asset whose whole job is to be fetched repeatedly.
+    * A CloudFront path would need its own origin + behavior over the documents bucket,
+      which is a CDK deploy for something the existing same-origin ``/api/*`` behavior
+      already reaches. The URL shape here is a stable path, so adding that behavior later
+      is a pure infra change with no contract break.
+
+    Relative because the SPA prefixes ``config.appApiUrl()`` (``/api`` in prod), and the
+    container has no reliable knowledge of its own public origin.
+    """
+    version = icon_version(icon_key)
+    if not version:
+        return None
+    return f"/agents/{agent_id}/icon?v={version}"
+
+
+# ── validation / normalization ───────────────────────────────────────────────────────
+
+
+def normalize_icon(content: bytes) -> Tuple[bytes, str, str]:
+    """Validate and normalize an uploaded icon.
+
+    Returns ``(bytes, ext, content_type)`` for a 512×512, metadata-free PNG or JPEG.
+    Raises :class:`IconError` with an author-facing message on anything it declines.
+    """
+    from PIL import Image, UnidentifiedImageError  # lazy: keeps PIL off every importer
+
+    if not content:
+        raise IconError("The uploaded file is empty.")
+    if len(content) > ICON_MAX_BYTES:
+        raise IconError(
+            f"Icons must be {ICON_MAX_BYTES // 1024} KB or smaller "
+            f"(this one is {len(content) // 1024} KB)."
+        )
+
+    try:
+        image = Image.open(io.BytesIO(content))
+        source_format = image.format
+        image.load()
+    except (UnidentifiedImageError, OSError, ValueError) as e:
+        raise IconError("Icons must be a PNG or JPEG image.") from e
+
+    if source_format not in _FORMAT_EXT:
+        raise IconError(
+            f"Icons must be a PNG or JPEG image (this one is {source_format or 'an unknown format'})."
+        )
+
+    width, height = image.size
+    if abs(width - height) > ICON_SQUARE_TOLERANCE_PX:
+        raise IconError(f"Icons must be square (this one is {width}×{height}).")
+    if min(width, height) < ICON_MIN_SOURCE:
+        raise IconError(
+            f"Icons must be at least {ICON_MIN_SOURCE}×{ICON_MIN_SOURCE} "
+            f"(this one is {width}×{height})."
+        )
+
+    ext = _FORMAT_EXT[source_format]
+    # Re-encoding always happens — see the module docstring on EXIF. LANCZOS because a
+    # 28px tile is a 18× downscale of the stored icon and cheaper filters alias badly.
+    image = image.convert("RGBA" if ext == "png" else "RGB")
+    if (width, height) != (ICON_SIZE, ICON_SIZE):
+        image = image.resize((ICON_SIZE, ICON_SIZE), Image.Resampling.LANCZOS)
+
+    encoded = _encode_within_limit(image, ext)
+    if encoded is None:
+        raise IconError(
+            f"This icon could not be stored under {ICON_MAX_BYTES // 1024} KB. "
+            "Try a simpler image or fewer colors."
+        )
+    data, ext = encoded
+    return data, ext, _EXT_CONTENT_TYPE[ext]
+
+
+def _encode_within_limit(image, ext: str) -> Optional[Tuple[bytes, str]]:
+    """Encode at 512×512 under the size ceiling, degrading in defined steps.
+
+    A downscale to 512 almost always lands well under 400 KB; this ladder exists for the
+    input that arrives *already* 512×512 and near the ceiling, where re-encoding could
+    push it over. Each rung is deliberate rather than a retry loop: JPEG loses quality,
+    an opaque PNG becomes a JPEG, and a transparent PNG loses colors but keeps its alpha.
+    """
+    from PIL import Image
+
+    if ext == "jpg":
+        for quality in (92, 85, 78):
+            data = _save(image, "JPEG", quality=quality, optimize=True, progressive=True)
+            if len(data) <= ICON_MAX_BYTES:
+                return data, "jpg"
+        return None
+
+    data = _save(image, "PNG", optimize=True)
+    if len(data) <= ICON_MAX_BYTES:
+        return data, "png"
+
+    has_alpha = image.getchannel("A").getextrema()[0] < 255
+    if not has_alpha:
+        for quality in (92, 85):
+            data = _save(image.convert("RGB"), "JPEG", quality=quality, optimize=True)
+            if len(data) <= ICON_MAX_BYTES:
+                return data, "jpg"
+        return None
+
+    # FASTOCTREE, not the default MEDIANCUT: it is the only method Pillow will quantize
+    # an RGBA image with, and this rung exists precisely to keep the alpha.
+    quantized = image.quantize(colors=256, method=Image.Quantize.FASTOCTREE)
+    data = _save(quantized, "PNG", optimize=True)
+    return (data, "png") if len(data) <= ICON_MAX_BYTES else None
+
+
+def _save(image, fmt: str, **kwargs) -> bytes:
+    buffer = io.BytesIO()
+    image.save(buffer, format=fmt, **kwargs)
+    return buffer.getvalue()
+
+
+def content_digest(content: bytes) -> str:
+    """The 16-hex-char content address used in the key and as the cache version."""
+    return hashlib.sha256(content).hexdigest()[:16]
+
+
+# ── S3 ───────────────────────────────────────────────────────────────────────────────
+
+
+class AgentIconStore:
+    """Put / get / delete agent icons in the assistants asset bucket."""
+
+    def __init__(self, bucket_name: Optional[str] = None, s3_client: Optional[object] = None) -> None:
+        self.bucket_name = bucket_name or os.environ.get("S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME")
+        # Lazily constructed so importing this module never needs AWS credentials;
+        # tests inject a client.
+        self._s3 = s3_client
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.bucket_name) and boto3 is not None
+
+    def _client(self):
+        if self._s3 is None:
+            if boto3 is None:  # pragma: no cover - import-guarded above
+                raise IconStoreError("icon storage unavailable: boto3 is not installed")
+            self._s3 = boto3.client("s3")
+        return self._s3
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise IconStoreError(
+                "icon storage is not configured (S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME is unset)"
+            )
+
+    def put(self, *, agent_id: str, content: bytes, ext: str, content_type: str) -> str:
+        """Store normalized bytes and return the content-addressed key."""
+        self._require_enabled()
+        key = build_icon_key(agent_id, content_digest(content), ext)
+        try:
+            self._client().put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=content,
+                ContentType=content_type,
+                ServerSideEncryption=_SSE_ALGORITHM,
+                # The object is immutable by construction (the key is its digest), so the
+                # cache directive belongs on the object as much as on the serve response.
+                CacheControl="public, max-age=31536000, immutable",
+            )
+        except ClientError as e:  # pragma: no cover - network/permission path
+            logger.error(f"agent-icons: put failed for agent={agent_id} key={key}: {e}")
+            raise IconStoreError(f"failed to store icon for agent '{agent_id}'") from e
+
+        logger.info(f"🖼️ agent-icons: stored agent={agent_id} key={key} ({len(content)} bytes)")
+        return key
+
+    def get(self, icon_key: str) -> Tuple[bytes, str]:
+        """Return ``(bytes, content_type)`` for a stored icon."""
+        self._require_enabled()
+        try:
+            response = self._client().get_object(Bucket=self.bucket_name, Key=icon_key)
+            body = response["Body"].read()
+            return body, response.get("ContentType") or "application/octet-stream"
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("NoSuchKey", "404"):
+                raise IconStoreError(f"icon not found at key '{icon_key}'") from e
+            logger.error(f"agent-icons: get failed for key={icon_key}: {e}")
+            raise IconStoreError(f"failed to read icon at key '{icon_key}'") from e
+
+    def delete(self, icon_key: str) -> None:
+        """Best-effort delete. Never raises: a replaced icon's old object going missing
+        is not a reason to fail the upload that replaced it."""
+        if not self.enabled or not icon_key:
+            return
+        try:
+            self._client().delete_object(Bucket=self.bucket_name, Key=icon_key)
+        except ClientError as e:  # pragma: no cover - network/permission path
+            logger.warning(f"agent-icons: delete failed for key={icon_key}: {e}")
+
+
+_store: Optional[AgentIconStore] = None
+
+
+def get_icon_store() -> AgentIconStore:
+    """Process-wide store, bound on first use (the env is set by the time routes run)."""
+    global _store
+    if _store is None:
+        _store = AgentIconStore()
+    return _store

--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -155,6 +155,48 @@ async def clear_listing(agent_id: str) -> None:
         raise
 
 
+async def write_icon_key(agent_id: str, icon_key: Optional[str], *, updated_at: str) -> None:
+    """Set — or clear — the Agent record's ``iconKey`` (D5, Phase 4).
+
+    A direct attribute write rather than a ``service.update_assistant`` call, for two
+    reasons:
+
+    1. **Clearing has to REMOVE.** ``_update_assistant_cloud`` builds a SET-only
+       expression from ``model_dump(exclude_none=True)``, so ``icon_key=None`` there
+       means "leave it alone", never "remove it" — an author could set an icon and never
+       get back to the generated fallback.
+    2. **An icon is not a listing.** ``write_listing`` can carry a D13 admin edit to
+       ``iconKey``, but it requires a listing block; an author may icon an agent that has
+       never been submitted.
+
+    Raises ``ValueError`` if the agent no longer exists.
+    """
+    from botocore.exceptions import ClientError
+
+    values: Dict[str, Any] = {":updated_at": updated_at}
+    if icon_key:
+        expression = "SET iconKey = :icon_key, updatedAt = :updated_at"
+        values[":icon_key"] = icon_key
+    else:
+        expression = "SET updatedAt = :updated_at REMOVE iconKey"
+
+    try:
+        _table().update_item(
+            Key=_key(agent_id),
+            UpdateExpression=expression,
+            ExpressionAttributeValues=values,
+            ConditionExpression="attribute_exists(PK)",
+            ReturnValues="NONE",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise ValueError(f"Agent not found: {agent_id}") from e
+        logger.error(f"Failed to write iconKey for {agent_id}: {e}")
+        raise
+
+    logger.info(f"🖼️ iconKey for {agent_id} → {icon_key or 'cleared'}")
+
+
 async def query_store(
     category: str, *, limit: int = 50, cursor: Optional[str] = None
 ) -> Tuple[list, Optional[str]]:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -362,6 +362,15 @@ class AgentResponse(BaseModel):
     # so an unsubmitted agent's payload is byte-identical to before this shipped.
     tagline: Optional[str] = Field(None, description="Shelf subtitle (D4)")
     icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon (D5)")
+    icon_url: Optional[str] = Field(
+        None,
+        alias="iconUrl",
+        description=(
+            "Where to render the icon from (Phase 4). Derived from ``iconKey``, never stored: a "
+            "relative app-api path carrying the key's digest as ``?v=``, so it caches immutably "
+            "and busts the moment a new icon is uploaded. Absent → the generated gradient (D5)."
+        ),
+    )
     listing: Optional[AgentListing] = Field(None, description="Publication state (D2); absent = never submitted")
 
     # Marketplace Phase 3 — the detail read. Both are populated only by GET /agents/{id};
@@ -590,6 +599,9 @@ class AdminListingRow(BaseModel):
     tagline: Optional[str] = Field(None, description="Shelf subtitle")
     emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
     icon_key: Optional[str] = Field(None, alias="iconKey", description="S3 object key for the square icon")
+    icon_url: Optional[str] = Field(
+        None, alias="iconUrl", description="Where to render the icon from (Phase 4); absent → generated gradient"
+    )
     owner_name: str = Field(..., alias="ownerName", description="Author display name — who to talk to about behavior")
     publisher: Optional[PublisherProfile] = Field(None, description="Resolved attribution (D12), display only")
     category: str = Field(..., description="Category id")
@@ -753,10 +765,28 @@ class AgentListingResponse(BaseModel):
     icon_url: Optional[str] = Field(
         None,
         alias="iconUrl",
-        description="Square icon URL; absent until icons ship in Phase 4, then the SPA falls back to the generated gradient",
+        description="Square icon URL (D5); absent → the SPA renders the generated gradient",
     )
     publisher: Optional[ListingPublisher] = Field(None, description="Attribution (D12), display only")
     category: str = Field(..., description="Category id")
+
+
+class AgentIconResponse(BaseModel):
+    """The result of setting or clearing an Agent's square icon (D5, Phase 4).
+
+    Both fields are ``None`` after a remove, which is the signal the SPA needs to drop
+    back to the generated gradient without re-reading the agent.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    icon_key: Optional[str] = Field(
+        None, alias="iconKey", description="S3 object key now on the record; None after a remove"
+    )
+    icon_url: Optional[str] = Field(
+        None, alias="iconUrl", description="Where to render it from; None → the generated gradient"
+    )
 
 
 class AgentStoreResponse(BaseModel):

--- a/backend/tests/shared/test_agent_icons.py
+++ b/backend/tests/shared/test_agent_icons.py
@@ -1,0 +1,402 @@
+"""Agent Marketplace Phase 4 — icon validation, storage and the author paths (D5).
+
+Two things these are really testing, beyond the happy path:
+
+* **Every rejection is one an author can act on.** Each declined image asserts the limit
+  is named in the message, because the failure mode of an upload gate is not "it let
+  something through", it is "it said no and the author cannot tell why".
+* **The bytes never touch the record.** ``iconKey`` is a key; the object lives in S3. The
+  400 KB ceiling is a DynamoDB item-limit lesson (MCP App icons), so a test asserts the
+  stored attribute is a short key rather than anything resembling image data.
+"""
+
+import io
+
+import boto3
+import pytest
+from moto import mock_aws
+from PIL import Image
+
+from apis.app_api.agent_designer.services.icon_service import (
+    AgentIconError,
+    read_icon,
+    remove_icon,
+    upload_icon,
+)
+from apis.shared.assistants.icons import (
+    ICON_MAX_BYTES,
+    ICON_SIZE,
+    AgentIconStore,
+    IconError,
+    build_icon_key,
+    content_digest,
+    icon_url,
+    icon_version,
+    normalize_icon,
+)
+from apis.shared.assistants.listing_repository import write_listing
+from apis.shared.assistants.models import AgentListing
+from apis.shared.auth.models import User
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+BUCKET = "test-rag-documents"
+
+
+def _png(size=(512, 512), color=(30, 90, 180, 255), mode="RGBA") -> bytes:
+    buffer = io.BytesIO()
+    Image.new(mode, size, color[: 3 if mode == "RGB" else 4]).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _jpeg(size=(512, 512)) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", size, (200, 40, 40)).save(buffer, format="JPEG", quality=95)
+    return buffer.getvalue()
+
+
+def _noise_png(size=(512, 512)) -> bytes:
+    """An image that does not compress — the only realistic way to approach 400 KB."""
+    import random
+
+    rng = random.Random(7)
+    image = Image.new("RGB", size)
+    image.putdata([(rng.randrange(256), rng.randrange(256), rng.randrange(256)) for _ in range(size[0] * size[1])])
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# ── validation ───────────────────────────────────────────────────────────────────────
+def test_a_square_png_normalizes_to_512():
+    data, ext, content_type = normalize_icon(_png((640, 640)))
+
+    assert (ext, content_type) == ("png", "image/png")
+    assert Image.open(io.BytesIO(data)).size == (ICON_SIZE, ICON_SIZE)
+
+
+def test_a_square_jpeg_stays_a_jpeg():
+    data, ext, content_type = normalize_icon(_jpeg((1024, 1024)))
+
+    assert (ext, content_type) == ("jpg", "image/jpeg")
+    assert Image.open(io.BytesIO(data)).size == (ICON_SIZE, ICON_SIZE)
+
+
+def test_an_exactly_512_image_is_still_re_encoded():
+    """Re-encoding is what strips EXIF — an icon cropped from a phone photo would
+    otherwise carry its GPS coordinates into the store."""
+    buffer = io.BytesIO()
+    exif = Image.Exif()
+    exif[0x010E] = "location: somewhere private"
+    Image.new("RGB", (512, 512), (10, 10, 10)).save(buffer, format="JPEG", exif=exif)
+    source = buffer.getvalue()
+    assert b"location: somewhere private" in source
+
+    data, _ext, _ct = normalize_icon(source)
+
+    assert b"location: somewhere private" not in data
+
+
+def test_normalization_is_deterministic():
+    """Same image in, same digest out — the content-addressed key depends on it."""
+    source = _png((600, 600))
+    assert content_digest(normalize_icon(source)[0]) == content_digest(normalize_icon(source)[0])
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        (b"", "empty"),
+        (b"not an image at all", "PNG or JPEG"),
+        (_png((512, 384)), "square"),
+        (_png((128, 128)), "at least 256"),
+    ],
+)
+def test_declined_images_say_what_is_wrong(content, expected):
+    with pytest.raises(IconError) as excinfo:
+        normalize_icon(content)
+    assert expected in str(excinfo.value)
+
+
+def test_a_gif_is_declined_even_though_pillow_can_read_it():
+    buffer = io.BytesIO()
+    Image.new("P", (512, 512)).save(buffer, format="GIF")
+
+    with pytest.raises(IconError, match="PNG or JPEG"):
+        normalize_icon(buffer.getvalue())
+
+
+def test_oversized_uploads_are_declined_before_decoding():
+    with pytest.raises(IconError, match="400 KB or smaller"):
+        normalize_icon(b"\x89PNG\r\n\x1a\n" + b"\x00" * ICON_MAX_BYTES)
+
+
+def test_an_almost_square_image_is_accepted():
+    """A hand-cropped square is often a pixel or two out; a 4:3 photo is not."""
+    data, _ext, _ct = normalize_icon(_png((513, 512)))
+    assert Image.open(io.BytesIO(data)).size == (ICON_SIZE, ICON_SIZE)
+
+
+def test_the_encode_ladder_degrades_an_opaque_png_to_jpeg(monkeypatch):
+    """The rung that only an already-512, near-the-ceiling image reaches.
+
+    Driven through ``_encode_within_limit`` with a lowered ceiling because the natural
+    input — a 512² of pure noise — is ~770 KB and never gets past the upload gate. The
+    ladder is still what runs; only the number it is measured against moves.
+    """
+    import apis.shared.assistants.icons as icons_module
+
+    monkeypatch.setattr(icons_module, "ICON_MAX_BYTES", 300_000)
+    noise = Image.open(io.BytesIO(_noise_png())).convert("RGBA")
+
+    data, ext = icons_module._encode_within_limit(noise, "png")
+
+    assert ext == "jpg" and len(data) <= 300_000
+
+
+def test_the_encode_ladder_keeps_alpha_by_quantizing(monkeypatch):
+    """A transparent PNG cannot become a JPEG without losing its alpha, so it loses
+    colors instead."""
+    import apis.shared.assistants.icons as icons_module
+
+    monkeypatch.setattr(icons_module, "ICON_MAX_BYTES", 300_000)
+    noise = Image.open(io.BytesIO(_noise_png())).convert("RGBA")
+    noise.putalpha(Image.new("L", noise.size, 128))
+
+    result = icons_module._encode_within_limit(noise, "png")
+
+    assert result is not None
+    data, ext = result
+    assert ext == "png" and len(data) <= 300_000
+    assert Image.open(io.BytesIO(data)).convert("RGBA").getchannel("A").getextrema()[0] < 255
+
+
+# ── keys and URLs ────────────────────────────────────────────────────────────────────
+def test_the_key_carries_the_digest_and_the_url_carries_it_as_a_cache_version():
+    key = build_icon_key("ast-1", "0123456789abcdef", "png")
+
+    assert key == "assistants/ast-1/icons/0123456789abcdef.png"
+    assert icon_version(key) == "0123456789abcdef"
+    assert icon_url("ast-1", key) == "/agents/ast-1/icon?v=0123456789abcdef"
+
+
+def test_no_key_means_no_url():
+    """Absent is the signal for the generated gradient — never an empty string."""
+    assert icon_url("ast-1", None) is None
+    assert icon_version(None) is None
+
+
+# ── the author paths, end to end ─────────────────────────────────────────────────────
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    monkeypatch.setenv("S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME", BUCKET)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_PK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "AgentDirectoryIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI5_PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI5_SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+        # The store is a module-level singleton bound on first use; rebind it per test so
+        # it picks up this moto session rather than a previous one's client.
+        import apis.shared.assistants.icons as icons_module
+
+        monkeypatch.setattr(icons_module, "_store", AgentIconStore(bucket_name=BUCKET, s3_client=s3))
+        yield {"table": ddb.Table(TABLE), "s3": s3}
+
+
+def _seed(table, agent_id="ast-1", owner_id="user-author", **extra):
+    item = {
+        "PK": f"AST#{agent_id}",
+        "SK": "METADATA",
+        "assistantId": agent_id,
+        "ownerId": owner_id,
+        "ownerName": "Ada Author",
+        "name": "An Agent",
+        "description": "Description",
+        "instructions": "Instructions",
+        "vectorIndexId": "assistants-index",
+        "visibility": "PRIVATE",
+        "usageCount": 0,
+        "createdAt": "2026-07-01T00:00:00Z",
+        "updatedAt": "2026-07-01T00:00:00Z",
+        "status": "COMPLETE",
+        "emoji": "📋",
+    }
+    item.update(extra)
+    table.put_item(Item=item)
+    return item
+
+
+AUTHOR = User(user_id="user-author", name="Ada Author", email="ada@example.edu", roles=[])
+STRANGER = User(user_id="user-other", name="Otto Other", email="otto@example.edu", roles=[])
+
+
+@pytest.mark.asyncio
+async def test_upload_stores_the_key_on_the_record_and_the_bytes_in_s3(aws):
+    _seed(aws["table"])
+
+    response = await upload_icon("ast-1", _png(), AUTHOR)
+
+    item = aws["table"].get_item(Key={"PK": "AST#ast-1", "SK": "METADATA"})["Item"]
+    assert item["iconKey"] == response.icon_key
+    # The record carries a key, never an image. This is the 400 KB item-limit rule.
+    assert len(item["iconKey"]) < 100
+    assert item["iconKey"].startswith("assistants/ast-1/icons/")
+    assert response.icon_url == f"/agents/ast-1/icon?v={icon_version(response.icon_key)}"
+
+    stored = aws["s3"].get_object(Bucket=BUCKET, Key=response.icon_key)
+    assert Image.open(io.BytesIO(stored["Body"].read())).size == (ICON_SIZE, ICON_SIZE)
+
+
+@pytest.mark.asyncio
+async def test_replacing_an_icon_deletes_the_old_object(aws):
+    _seed(aws["table"])
+    first = await upload_icon("ast-1", _png(color=(10, 10, 10, 255)), AUTHOR)
+
+    second = await upload_icon("ast-1", _jpeg(), AUTHOR)
+
+    assert second.icon_key != first.icon_key
+    keys = {o["Key"] for o in aws["s3"].list_objects_v2(Bucket=BUCKET).get("Contents", [])}
+    assert keys == {second.icon_key}
+
+
+@pytest.mark.asyncio
+async def test_re_uploading_the_same_image_keeps_the_object(aws):
+    """The key is the content digest, so this is idempotent — and the delete of the
+    'previous' key must not remove the object the record still points at."""
+    _seed(aws["table"])
+    first = await upload_icon("ast-1", _png(), AUTHOR)
+
+    second = await upload_icon("ast-1", _png(), AUTHOR)
+
+    assert second.icon_key == first.icon_key
+    assert aws["s3"].get_object(Bucket=BUCKET, Key=second.icon_key)["ContentLength"] > 0
+
+
+@pytest.mark.asyncio
+async def test_remove_clears_the_attribute_so_the_gradient_comes_back(aws):
+    _seed(aws["table"])
+    uploaded = await upload_icon("ast-1", _png(), AUTHOR)
+
+    response = await remove_icon("ast-1", AUTHOR)
+
+    assert response.icon_key is None and response.icon_url is None
+    item = aws["table"].get_item(Key={"PK": "AST#ast-1", "SK": "METADATA"})["Item"]
+    # REMOVE, not an empty string: absent is what the read shapes mean by "no icon".
+    assert "iconKey" not in item
+    assert aws["s3"].list_objects_v2(Bucket=BUCKET).get("Contents", []) == []
+    assert uploaded.icon_key is not None
+
+
+@pytest.mark.asyncio
+async def test_a_stranger_cannot_set_an_icon(aws):
+    _seed(aws["table"])
+
+    with pytest.raises(AgentIconError) as excinfo:
+        await upload_icon("ast-1", _png(), STRANGER)
+
+    assert excinfo.value.status_code in (403, 404)
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_image_is_a_400_and_writes_nothing(aws):
+    _seed(aws["table"])
+
+    with pytest.raises(AgentIconError) as excinfo:
+        await upload_icon("ast-1", _png((512, 300)), AUTHOR)
+
+    assert excinfo.value.status_code == 400
+    item = aws["table"].get_item(Key={"PK": "AST#ast-1", "SK": "METADATA"})["Item"]
+    assert "iconKey" not in item
+    assert aws["s3"].list_objects_v2(Bucket=BUCKET).get("Contents", []) == []
+
+
+# ── the read gate ────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_published_agents_icon_is_readable_by_anyone(aws):
+    """The shelf already shows this agent's name, tagline and emoji to every browsing
+    user; gating the icon on the PRIVATE record would render a broken tile on the shelf."""
+    _seed(aws["table"])
+    await upload_icon("ast-1", _png(), AUTHOR)
+    await write_listing(
+        "ast-1",
+        AgentListing(state="published", category="Administration", publisher_id="pub-1"),
+        "2026-07-01T00:00:00Z",
+    )
+
+    data, content_type, version = await read_icon("ast-1", STRANGER)
+
+    assert content_type == "image/png"
+    assert Image.open(io.BytesIO(data)).size == (ICON_SIZE, ICON_SIZE)
+    assert version and len(version) == 16
+
+
+@pytest.mark.asyncio
+async def test_an_unpublished_private_agents_icon_is_not(aws):
+    _seed(aws["table"])
+    await upload_icon("ast-1", _png(), AUTHOR)
+
+    with pytest.raises(AgentIconError) as excinfo:
+        await read_icon("ast-1", STRANGER)
+
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_the_owner_reads_their_own_unpublished_icon(aws):
+    _seed(aws["table"])
+    await upload_icon("ast-1", _png(), AUTHOR)
+
+    data, _content_type, _version = await read_icon("ast-1", AUTHOR)
+    assert data
+
+
+@pytest.mark.asyncio
+async def test_a_key_that_outlived_its_object_is_a_404_not_a_500(aws):
+    """So the SPA's <img> error path drops to the generated gradient (the designed
+    default) rather than showing a broken tile."""
+    _seed(aws["table"])
+    uploaded = await upload_icon("ast-1", _png(), AUTHOR)
+    aws["s3"].delete_object(Bucket=BUCKET, Key=uploaded.icon_key)
+
+    with pytest.raises(AgentIconError) as excinfo:
+        await read_icon("ast-1", AUTHOR)
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_an_agent_with_no_icon_is_a_404(aws):
+    _seed(aws["table"])
+
+    with pytest.raises(AgentIconError) as excinfo:
+        await read_icon("ast-1", AUTHOR)
+
+    assert excinfo.value.status_code == 404

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -502,7 +502,9 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `GET /agents/store/front` | Featured order + categories for the browse header. |
 | `GET /agents/{id}` | Detail. Adds `listing`; gates `instructions`. |
 | `GET /agents/{id}/runnability` | Per-invoker capability preview (D6). |
-| `POST /agents/{id}/icon` | Upload a square icon (D5) → S3, returns `iconKey`. |
+| `POST /agents/{id}/icon` | Upload a square icon (D5) → S3, returns `iconKey` + `iconUrl`. Owner or editor. |
+| `DELETE /agents/{id}/icon` | Clear the icon, back to the generated gradient. Admin `PATCH` can only *replace* `iconKey`, so without this an author cannot undo an upload. |
+| `GET /agents/{id}/icon` | Serve the bytes, `immutable` + ETag. What makes `iconUrl` a stable path (`/agents/{id}/icon?v={digest}`) rather than a presigned URL that changes on every read and re-downloads every shelf icon. Readable by anyone when the listing is published — the shelf already shows that agent's name, tagline and emoji to every browsing user. |
 | `POST /agents/{id}/listing/submit` | Author submits. Runs D7 checks; 400 on a `memory_space` binding. |
 | `DELETE /agents/{id}/listing` | Author unpublishes. |
 | `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). |
@@ -552,12 +554,12 @@ Phase 0  This spec                                                          ✅ 
 Phase 1  listing block + state machine + sparse GSI5 + submit/review/takedown API
          + publisher profiles (D12) + admin Review queue & Listings
          + backfill (no listing block)                               ✅ shipped (PR #731)
-Phase 2  GET /agents/store + the Discover page + categories admin           ← in progress
+Phase 2  GET /agents/store + the Discover page + categories admin     ✅ shipped (PR #732)
 Phase 3  Detail page + runnability + the instructions gate            ✅ shipped (PR #733)
 Phase 3.5 Author Submit UI: submit dialog (category, note, D7 disclosures),
          listing-state badges + reviewer note + D13 edit trail on My Agents,
-         withdraw/unpublish, and GET /agents/{id}/listing/preflight
-Phase 4  Icons: upload, S3, generated fallback, all four render sizes
+         withdraw/unpublish, GET /agents/{id}/listing/preflight   ✅ shipped (PR #734)
+Phase 4  Icons: upload, S3, generated fallback, all four render sizes      ← in progress
 Phase 5  Pins: user pin state + Pinned tab + store front admin
 Phase 6  Default pins by role (D9) + the assignment-time runnability check
 Phase 7  @-mention in the composer

--- a/frontend/ai.client/src/app/admin/marketplace/components/agent-tile.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/agent-tile.component.ts
@@ -1,32 +1,36 @@
-import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, computed } from '@angular/core';
+import {
+  AgentIconComponent,
+  AgentIconSize,
+} from '../../../agents/components/agent-icon.component';
 
 /**
  * The small square that identifies an agent in the admin tables.
  *
- * Phase 1 renders the agent's emoji on a neutral tile. D5's real identity work — an
- * uploaded 512×512 icon plus a *generated gradient* fallback derived from the agent id,
- * at four render sizes — is Phase 4. Deliberately not approximating that here: a
- * throwaway gradient would be one more thing Phase 4 has to unpick, and nothing in
- * Phase 1 is user-visible.
+ * A thin adapter over `app-agent-icon` (Phase 4): the reviewer sees the same tile a
+ * browsing user will — the uploaded icon, or the generated gradient derived from the
+ * agent id. That matters for the two admin jobs that involve an icon: catching an
+ * off-brand one in the review queue, and judging a D13 icon swap against what the shelf
+ * actually renders.
  */
 @Component({
   selector: 'app-agent-tile',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AgentIconComponent],
   template: `
-    <span
-      class="flex shrink-0 items-center justify-center rounded-2xl bg-gray-100 dark:bg-gray-700"
-      [class]="sizeClass()"
-      aria-hidden="true"
-    >
-      {{ emoji() || '✦' }}
-    </span>
+    <app-agent-icon
+      [agentId]="agentId()"
+      [iconUrl]="iconUrl()"
+      [emoji]="emoji()"
+      [size]="iconSize()"
+    />
   `,
 })
 export class AgentTileComponent {
+  readonly agentId = input.required<string>();
   readonly emoji = input<string | undefined>();
+  readonly iconUrl = input<string | undefined>();
   readonly size = input<'sm' | 'md'>('md');
 
-  sizeClass(): string {
-    return this.size() === 'sm' ? 'size-7 text-sm' : 'size-10 text-xl';
-  }
+  readonly iconSize = computed<AgentIconSize>(() => (this.size() === 'sm' ? 28 : 40));
 }

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -49,6 +49,8 @@ export interface AdminListingRow {
   tagline?: string;
   emoji?: string;
   iconKey?: string;
+  /** Where to render the icon from (Phase 4); absent → the generated gradient. */
+  iconUrl?: string;
   /** The author — who to talk to about behavior. Distinct from `publisher`. */
   ownerName: string;
   publisher?: PublisherProfile | null;

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -126,7 +126,12 @@ import {
                   <tr class="border-t border-gray-200 dark:border-gray-700">
                     <td class="px-4 py-3">
                       <div class="flex items-center gap-3">
-                        <app-agent-tile [emoji]="row.emoji" size="sm" />
+                        <app-agent-tile
+                          [agentId]="row.agentId"
+                          [iconUrl]="row.iconUrl"
+                          [emoji]="row.emoji"
+                          size="sm"
+                        />
                         <div class="min-w-0">
                           <p class="truncate font-medium text-gray-900 dark:text-white">
                             {{ row.name }}

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -82,7 +82,7 @@ import {
               <li
                 class="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center dark:border-gray-700 dark:bg-gray-800"
               >
-                <app-agent-tile [emoji]="row.emoji" />
+                <app-agent-tile [agentId]="row.agentId" [iconUrl]="row.iconUrl" [emoji]="row.emoji" />
 
                 <div class="min-w-0 flex-1">
                   <h2 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -86,9 +86,12 @@
             <div class="group flex flex-col overflow-hidden rounded-2xl border border-gray-200/80 bg-white p-5 shadow-xs transition-all duration-200 hover:border-gray-300 hover:shadow-sm dark:border-gray-700/60 dark:bg-gray-800/80 dark:hover:border-gray-600">
               <!-- Head -->
               <button type="button" (click)="onEdit(agent)" class="flex items-start gap-3 text-left">
-                <div class="flex size-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-primary-500/15 to-secondary-500/15 text-xl">
-                  {{ agent.emoji || '🤖' }}
-                </div>
+                <app-agent-icon
+                  [agentId]="agent.agentId"
+                  [iconUrl]="agent.iconUrl"
+                  [emoji]="agent.emoji"
+                  [size]="52"
+                />
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2">
                     <h3 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">{{ agent.name }}</h3>
@@ -126,11 +129,20 @@
                 </div>
               }
 
-              <!-- Publication controls. Owner-only, and hidden entirely when the
-                   marketplace routes are unmounted, so nothing offers a dead click. -->
-              @if (marketplaceAvailable() && isOwner(agent)) {
+              <!-- Presentation + publication controls, hidden entirely when the
+                   marketplace routes are unmounted so nothing offers a dead click.
+                   Icon is owner-or-editor (presentation, D13); publishing is owner-only. -->
+              @if (marketplaceAvailable() && canEditIcon(agent)) {
                 <div class="mt-3 flex flex-wrap items-center gap-2">
-                  @if (canSubmit(agent)) {
+                  <!-- Presentation (D13): an editor may set the icon; only the owner publishes. -->
+                  <button
+                    type="button"
+                    (click)="onEditIcon(agent)"
+                    class="rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs/5 font-medium text-gray-700 transition hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    {{ agent.iconUrl ? 'Change icon' : 'Add icon' }}
+                  </button>
+                  @if (isOwner(agent) && canSubmit(agent)) {
                     <button
                       type="button"
                       (click)="onSubmitListing(agent)"
@@ -140,7 +152,7 @@
                       {{ submitLabel(agent) }}
                     </button>
                   }
-                  @if (isPublished(agent)) {
+                  @if (isOwner(agent) && isPublished(agent)) {
                     <button
                       type="button"
                       (click)="onViewInStore(agent)"
@@ -149,7 +161,7 @@
                       View in store
                     </button>
                   }
-                  @if (canWithdraw(agent)) {
+                  @if (isOwner(agent) && canWithdraw(agent)) {
                     <button
                       type="button"
                       (click)="onWithdrawListing(agent)"

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -23,6 +23,12 @@ import {
 import { ShareAssistantDialogComponent, ShareAssistantDialogData } from '../assistants/components/share-assistant-dialog.component';
 import { TooltipDirective } from '../components/tooltip/tooltip.directive';
 import { AgentsTabsComponent } from './components/agents-tabs.component';
+import { AgentIconComponent } from './components/agent-icon.component';
+import {
+  AgentIconDialogComponent,
+  AgentIconDialogData,
+  AgentIconDialogResult,
+} from './components/agent-icon-dialog.component';
 import { ListingStatusComponent } from './components/listing-status.component';
 import {
   SubmitListingDialogComponent,
@@ -48,7 +54,13 @@ import {
   templateUrl: './agents.page.html',
   styleUrl: './agents.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, TooltipDirective, AgentsTabsComponent, ListingStatusComponent],
+  imports: [
+    NgIcon,
+    TooltipDirective,
+    AgentsTabsComponent,
+    AgentIconComponent,
+    ListingStatusComponent,
+  ],
   providers: [
     provideIcons({
       heroPlus,
@@ -144,6 +156,16 @@ export class AgentsPage implements OnInit {
     return (agent.userPermission ?? 'owner') === 'owner';
   }
 
+  /**
+   * The icon is presentation, not behavior (D13), so an editor may set it — the same
+   * line `PUT /agents/{id}` draws, and the same one the backend enforces. Publishing
+   * stays owner-only above.
+   */
+  canEditIcon(agent: Agent): boolean {
+    const permission = agent.userPermission ?? 'owner';
+    return permission === 'owner' || permission === 'editor';
+  }
+
   private listingState(agent: Agent): ListingState | undefined {
     return agent.listing?.state;
   }
@@ -185,6 +207,32 @@ export class AgentsPage implements OnInit {
 
   onViewInStore(agent: Agent): void {
     this.router.navigate(['/agents', agent.agentId]);
+  }
+
+  /**
+   * Set, replace or remove the agent's icon (D5).
+   *
+   * The dialog returns the record's new icon state, and the card is patched from it
+   * rather than re-listing every agent: the URL carries the new content digest, so a
+   * replacement repaints immediately instead of showing the cached previous icon.
+   */
+  async onEditIcon(agent: Agent): Promise<void> {
+    this.listingError.set(null);
+    const dialogRef = this.dialog.open<AgentIconDialogResult>(AgentIconDialogComponent, {
+      data: {
+        agentId: agent.agentId,
+        agentName: agent.name,
+        emoji: agent.emoji,
+        iconUrl: agent.iconUrl,
+      } satisfies AgentIconDialogData,
+    });
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result) {
+      this.agentService.patchAgent(result.agentId, {
+        iconKey: result.iconKey,
+        iconUrl: result.iconUrl,
+      });
+    }
   }
 
   async onSubmitListing(agent: Agent): Promise<void> {

--- a/frontend/ai.client/src/app/agents/components/agent-icon-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-icon-dialog.component.ts
@@ -1,0 +1,310 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowUpTray, heroXMark } from '@ng-icons/heroicons/outline';
+import { firstValueFrom } from 'rxjs';
+import { AgentApiService } from '../services/agent-api.service';
+import { AgentIconResponse } from '../models/store.model';
+import { AgentIconComponent } from './agent-icon.component';
+
+export interface AgentIconDialogData {
+  agentId: string;
+  agentName: string;
+  emoji?: string;
+  /** The icon on the record now, if any. */
+  iconUrl?: string;
+}
+
+/** The record's new icon state, or `undefined` if cancelled. */
+export type AgentIconDialogResult = AgentIconResponse | undefined;
+
+/** Mirrors the server's D5 gate, so the common rejections never cost a round trip. */
+const MAX_BYTES = 400 * 1024;
+const MIN_SOURCE_PX = 256;
+const ACCEPTED = ['image/png', 'image/jpeg'];
+
+/**
+ * Upload, replace or remove an Agent's square icon (D5).
+ *
+ * The preview strip is the reason this is a dialog rather than a bare file input. An
+ * icon is authored at a size nobody browses at: it reads beautifully at 84px and turns
+ * to mud at 28px, where fine detail and thin type disappear into four hundred pixels.
+ * So all four store sizes render at their true pixel size, live, before the upload — the
+ * small ones are the ones worth looking at.
+ *
+ * Removing shows the same strip with the generated gradient, so "revert to default" is a
+ * thing the author can *see* rather than a thing they have to risk. Per D5 that gradient
+ * is the designed default, not an absence.
+ *
+ * Client-side checks mirror the server's and are not trusted by it: the server re-derives
+ * every one of them, and does the thing a browser cannot — re-encoding to strip EXIF, so
+ * an icon cropped from a phone photo does not publish its GPS coordinates.
+ */
+@Component({
+  selector: 'app-agent-icon-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AgentIconComponent, NgIcon],
+  providers: [provideIcons({ heroArrowUpTray, heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative flex max-h-[90vh] w-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="agent-icon-title"
+        aria-describedby="agent-icon-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2
+              id="agent-icon-title"
+              class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+            >
+              Icon
+            </h2>
+            <p
+              id="agent-icon-description"
+              class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400"
+            >
+              A square image for <span class="font-medium">{{ data.agentName }}</span> —
+              512×512 PNG or JPEG, up to 400 KB.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-6 py-4">
+          <!-- The preview strip: every size the store renders, at true scale. -->
+          <div
+            class="flex flex-wrap items-end gap-6 rounded-2xl border border-gray-200 bg-gray-50 px-5 py-5 dark:border-gray-700 dark:bg-gray-900/40"
+          >
+            @for (preview of previews; track preview.size) {
+              <div class="flex flex-col items-center gap-2">
+                <app-agent-icon
+                  [agentId]="data.agentId"
+                  [iconUrl]="previewUrl()"
+                  [emoji]="data.emoji"
+                  [size]="preview.size"
+                />
+                <span class="text-xs/5 text-gray-500 dark:text-gray-400">{{ preview.label }}</span>
+              </div>
+            }
+          </div>
+          <p class="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+            {{ previewUrl() ? previewCaption() : 'No icon yet — this is the default.' }}
+          </p>
+
+          <label
+            class="mt-5 flex cursor-pointer items-center justify-center gap-2 rounded-2xl border border-dashed border-gray-300 px-4 py-5 text-sm/6 font-medium text-gray-700 hover:border-blue-500 hover:text-blue-700 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:border-gray-600 dark:text-gray-200 dark:hover:border-blue-400 dark:hover:text-blue-300"
+          >
+            <ng-icon name="heroArrowUpTray" class="size-5" aria-hidden="true" />
+            {{ file() ? 'Choose a different image' : 'Choose an image' }}
+            <input
+              type="file"
+              class="sr-only"
+              accept="image/png,image/jpeg"
+              (change)="onFileChosen($event)"
+            />
+          </label>
+
+          @if (error(); as message) {
+            <p role="alert" class="mt-4 text-sm/6 text-rose-700 dark:text-rose-400">
+              {{ message }}
+            </p>
+          }
+        </div>
+
+        <div
+          class="flex items-center justify-between gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700"
+        >
+          @if (data.iconUrl) {
+            <button
+              type="button"
+              (click)="onRemove()"
+              [disabled]="busy()"
+              class="rounded-2xl px-3 py-2 text-sm/6 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+            >
+              Remove icon
+            </button>
+          } @else {
+            <span></span>
+          }
+          <div class="flex gap-2">
+            <button
+              type="button"
+              (click)="onCancel()"
+              class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              [disabled]="!canSave()"
+              (click)="onSave()"
+              class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {{ busy() ? 'Saving…' : 'Save icon' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class AgentIconDialogComponent implements OnDestroy {
+  private dialogRef = inject<DialogRef<AgentIconDialogResult>>(DialogRef);
+  private api = inject(AgentApiService);
+  readonly data = inject<AgentIconDialogData>(DIALOG_DATA);
+
+  /** 84 first because that is what an author designs for; the small ones follow. */
+  readonly previews = [
+    { size: 84 as const, label: '84 · detail' },
+    { size: 52 as const, label: '52 · card' },
+    { size: 40 as const, label: '40 · browse' },
+    { size: 28 as const, label: '28 · menu' },
+  ];
+
+  readonly file = signal<File | null>(null);
+  readonly localUrl = signal<string | null>(null);
+  readonly busy = signal(false);
+  readonly error = signal<string | null>(null);
+
+  /** The chosen file while there is one, otherwise whatever is on the record. */
+  readonly previewUrl = computed(() => this.localUrl() ?? this.data.iconUrl ?? undefined);
+  readonly previewCaption = computed(() =>
+    this.localUrl() ? 'Not saved yet.' : 'The icon on this agent now.',
+  );
+  readonly canSave = computed(() => !!this.file() && !this.busy());
+
+  async onFileChosen(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const chosen = input.files?.[0];
+    // Clear the input so re-picking the same file after a rejection still fires `change`.
+    input.value = '';
+    if (!chosen) return;
+
+    this.error.set(null);
+    const problem = await this.validate(chosen);
+    if (problem) {
+      this.error.set(problem);
+      return;
+    }
+    this.revokeLocal();
+    this.file.set(chosen);
+    this.localUrl.set(URL.createObjectURL(chosen));
+  }
+
+  async onSave(): Promise<void> {
+    const chosen = this.file();
+    if (!chosen) return;
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      const result = await firstValueFrom(this.api.uploadIcon(this.data.agentId, chosen));
+      this.dialogRef.close(result);
+    } catch (err) {
+      this.error.set(this.detail(err) ?? 'Could not save this icon.');
+      this.busy.set(false);
+    }
+  }
+
+  async onRemove(): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      const result = await firstValueFrom(this.api.removeIcon(this.data.agentId));
+      this.dialogRef.close(result);
+    } catch (err) {
+      this.error.set(this.detail(err) ?? 'Could not remove this icon.');
+      this.busy.set(false);
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+
+  ngOnDestroy(): void {
+    this.revokeLocal();
+  }
+
+  /**
+   * The server's own limits, checked here so the usual mistakes (a screenshot, a 4:3
+   * photo) are answered instantly. Anything this misses the server still refuses.
+   */
+  private async validate(file: File): Promise<string | null> {
+    if (!ACCEPTED.includes(file.type)) {
+      return 'Icons must be a PNG or JPEG image.';
+    }
+    if (file.size > MAX_BYTES) {
+      return `Icons must be 400 KB or smaller (this one is ${Math.round(file.size / 1024)} KB).`;
+    }
+    const size = await this.dimensions(file);
+    if (!size) {
+      return 'That file could not be read as an image.';
+    }
+    const { width, height } = size;
+    if (Math.abs(width - height) > 2) {
+      return `Icons must be square (this one is ${width}×${height}). Crop it first.`;
+    }
+    if (Math.min(width, height) < MIN_SOURCE_PX) {
+      return `Icons must be at least ${MIN_SOURCE_PX}×${MIN_SOURCE_PX} (this one is ${width}×${height}).`;
+    }
+    return null;
+  }
+
+  private dimensions(file: File): Promise<{ width: number; height: number } | null> {
+    return new Promise((resolve) => {
+      const url = URL.createObjectURL(file);
+      const image = new Image();
+      image.onload = () => {
+        resolve({ width: image.naturalWidth, height: image.naturalHeight });
+        URL.revokeObjectURL(url);
+      };
+      image.onerror = () => {
+        resolve(null);
+        URL.revokeObjectURL(url);
+      };
+      image.src = url;
+    });
+  }
+
+  private revokeLocal(): void {
+    const url = this.localUrl();
+    if (url) {
+      URL.revokeObjectURL(url);
+      this.localUrl.set(null);
+    }
+  }
+
+  private detail(err: unknown): string | null {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : null;
+  }
+}

--- a/frontend/ai.client/src/app/agents/components/agent-icon.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-icon.component.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { AgentIconComponent, gradientFor } from './agent-icon.component';
+import { ConfigService } from '../../services/config.service';
+
+describe('AgentIconComponent', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    TestBed.inject(ConfigService).appApiUrl.set('/api');
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  function create(inputs: {
+    agentId: string;
+    iconUrl?: string;
+    emoji?: string;
+    size?: 28 | 40 | 52 | 84;
+    alt?: string;
+  }) {
+    const fixture = TestBed.createComponent(AgentIconComponent);
+    fixture.componentRef.setInput('agentId', inputs.agentId);
+    if (inputs.iconUrl !== undefined) fixture.componentRef.setInput('iconUrl', inputs.iconUrl);
+    if (inputs.emoji !== undefined) fixture.componentRef.setInput('emoji', inputs.emoji);
+    if (inputs.size !== undefined) fixture.componentRef.setInput('size', inputs.size);
+    if (inputs.alt !== undefined) fixture.componentRef.setInput('alt', inputs.alt);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  // ── the generated fallback (D5) ────────────────────────────────────────────────
+  it('draws the generated gradient when there is no uploaded icon', () => {
+    const fixture = create({ agentId: 'ast-1', emoji: '📋' });
+
+    const tile: HTMLElement = fixture.nativeElement.querySelector('span');
+    expect(fixture.nativeElement.querySelector('img')).toBeNull();
+    expect(tile.style.backgroundImage).toContain('linear-gradient');
+    expect(fixture.nativeElement.textContent).toContain('📋');
+  });
+
+  it('falls back to a glyph when the agent has no emoji either', () => {
+    const fixture = create({ agentId: 'ast-1' });
+    expect(fixture.nativeElement.textContent).toContain('✦');
+  });
+
+  it('draws the same gradient for the same agent everywhere', () => {
+    // The store, My Agents and the chat header must not look like three agents.
+    const a = create({ agentId: 'ast-42', size: 84 });
+    const b = create({ agentId: 'ast-42', size: 28 });
+
+    const gradient = (fixture: ReturnType<typeof create>) =>
+      (fixture.nativeElement.querySelector('span') as HTMLElement).style.backgroundImage;
+    // The DOM re-serializes the hex pair as rgb(), so the rendered values are compared
+    // to each other and the pure function is pinned separately.
+    expect(gradient(a)).toBe(gradient(b));
+    expect(gradientFor('ast-42')).toBe(gradientFor('ast-42'));
+    expect(gradientFor('ast-42')).toMatch(/^linear-gradient\(135deg, #[0-9a-f]{6}, #[0-9a-f]{6}\)$/);
+  });
+
+  it('spreads different agents across the palette', () => {
+    const drawn = new Set(
+      Array.from({ length: 40 }, (_, i) => gradientFor(`ast-${i}`)),
+    );
+    // Not a distribution proof — a guard against a hash that collapses to one tile.
+    expect(drawn.size).toBeGreaterThan(5);
+  });
+
+  // ── the uploaded icon ──────────────────────────────────────────────────────────
+  it('prefixes the API base onto the relative path the read shape carries', () => {
+    const fixture = create({ agentId: 'ast-1', iconUrl: '/agents/ast-1/icon?v=abc123' });
+
+    const img: HTMLImageElement = fixture.nativeElement.querySelector('img');
+    expect(img.getAttribute('src')).toBe('/api/agents/ast-1/icon?v=abc123');
+  });
+
+  it('leaves an absolute URL alone, so the upload dialog can preview a local file', () => {
+    const fixture = create({ agentId: 'ast-1', iconUrl: 'blob:http://localhost/abcd' });
+
+    const img: HTMLImageElement = fixture.nativeElement.querySelector('img');
+    expect(img.getAttribute('src')).toBe('blob:http://localhost/abcd');
+  });
+
+  it('drops to the gradient when the image fails to load', () => {
+    // The backend answers 404 for a key that outlived its object; that path has to
+    // land on the designed default rather than a broken tile.
+    const fixture = create({ agentId: 'ast-1', iconUrl: '/agents/ast-1/icon?v=gone', emoji: '📋' });
+    const img: HTMLImageElement = fixture.nativeElement.querySelector('img');
+
+    img.dispatchEvent(new Event('error'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('img')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('📋');
+  });
+
+  it('re-attempts the load when the icon is replaced', () => {
+    const fixture = create({ agentId: 'ast-1', iconUrl: '/agents/ast-1/icon?v=gone' });
+    fixture.nativeElement.querySelector('img').dispatchEvent(new Event('error'));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('img')).toBeNull();
+
+    fixture.componentRef.setInput('iconUrl', '/agents/ast-1/icon?v=fresh');
+    fixture.detectChanges();
+
+    const img: HTMLImageElement = fixture.nativeElement.querySelector('img');
+    expect(img.getAttribute('src')).toBe('/api/agents/ast-1/icon?v=fresh');
+  });
+
+  // ── the four sizes (D5) ────────────────────────────────────────────────────────
+  it.each([
+    [28, 'size-7'],
+    [40, 'size-10'],
+    [52, 'size-13'],
+    [84, 'size-21'],
+  ] as const)('renders %ipx as %s', (size, expected) => {
+    const fixture = create({ agentId: 'ast-1', size });
+    const tile: HTMLElement = fixture.nativeElement.querySelector('span');
+    expect(tile.className).toContain(expected);
+  });
+
+  // ── accessibility ──────────────────────────────────────────────────────────────
+  it('is decorative by default, since rows already name the agent', () => {
+    const fixture = create({ agentId: 'ast-1' });
+    const tile: HTMLElement = fixture.nativeElement.querySelector('span');
+    expect(tile.getAttribute('aria-hidden')).toBe('true');
+    expect(tile.getAttribute('role')).toBeNull();
+  });
+
+  it('becomes an image with a label when given alt text', () => {
+    const fixture = create({ agentId: 'ast-1', alt: 'Policy Lookup' });
+    const tile: HTMLElement = fixture.nativeElement.querySelector('span');
+    expect(tile.getAttribute('role')).toBe('img');
+    expect(tile.getAttribute('aria-label')).toBe('Policy Lookup');
+    expect(tile.getAttribute('aria-hidden')).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/agents/components/agent-icon.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-icon.component.ts
@@ -1,0 +1,150 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  linkedSignal,
+} from '@angular/core';
+import { ConfigService } from '../../services/config.service';
+
+/** The four sizes the store renders an Agent at (D5). */
+export type AgentIconSize = 28 | 40 | 52 | 84;
+
+/**
+ * Per-size box, corner radius and glyph scale.
+ *
+ * Two ratios are held constant across the four sizes, and both had to be tuned rather
+ * than inherited from the type scale:
+ *
+ * * **Radius ~29% of the box.** A constant `rounded-2xl` reads as a circle at 28px and
+ *   as a barely-softened square at 84px, so the curve steps with the box.
+ * * **Glyph ~50% of the box.** Stepping the Tailwind text scale (`text-xl` → `text-4xl`)
+ *   grows the glyph more slowly than the tile, so the emoji drifts from 54% of a 28px
+ *   tile down to 43% of an 84px one — the same icon looking progressively emptier the
+ *   larger it gets.
+ */
+const SIZE_CLASSES: Record<AgentIconSize, string> = {
+  28: 'size-7 rounded-lg text-[15px]',
+  40: 'size-10 rounded-xl text-xl',
+  52: 'size-13 rounded-2xl text-[26px]',
+  84: 'size-21 rounded-[1.5rem] text-[42px]',
+};
+
+/**
+ * The generated fallback's palette (D5).
+ *
+ * A curated set of pairs rather than hue math on the hash. Free-running hue arithmetic
+ * reliably produces a handful of muddy or low-contrast tiles, and this is the *designed*
+ * default for most of the store — not a placeholder — so every draw has to look
+ * deliberate. All twelve are mid-to-dark and saturated, which keeps a white-ish emoji
+ * legible on them in both themes.
+ */
+const GRADIENTS: readonly (readonly [string, string])[] = [
+  ['#1f6feb', '#6f42c1'],
+  ['#0ea5e9', '#2563eb'],
+  ['#14b8a6', '#0e7490'],
+  ['#22c55e', '#15803d'],
+  ['#f59e0b', '#ea580c'],
+  ['#ef4444', '#b91c1c'],
+  ['#ec4899', '#be185d'],
+  ['#8b5cf6', '#4c1d95'],
+  ['#06b6d4', '#3b82f6'],
+  ['#84cc16', '#16a34a'],
+  ['#f97316', '#db2777'],
+  ['#64748b', '#334155'],
+];
+
+/**
+ * FNV-1a, 32-bit. Any stable hash would do; what matters is that it is computed the same
+ * way on every surface, so an Agent's tile is the same tile in the store, in My Agents
+ * and in the chat header. A per-surface hash would make the same Agent look like three.
+ */
+export function hashAgentId(agentId: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < agentId.length; i++) {
+    hash ^= agentId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** The gradient an Agent id deterministically draws. */
+export function gradientFor(agentId: string): string {
+  const [from, to] = GRADIENTS[hashAgentId(agentId) % GRADIENTS.length];
+  return `linear-gradient(135deg, ${from}, ${to})`;
+}
+
+/**
+ * An Agent's square identity, at one of the four store sizes (D5).
+ *
+ * Renders the uploaded icon when there is one and the **generated gradient** when there
+ * is not. The gradient is the designed default, not a placeholder to be replaced later:
+ * an app store where a third of the tiles are a bare emoji on grey reads as unfinished,
+ * and most Agents will never have an uploaded icon.
+ *
+ * `iconUrl` arrives from the API as a relative path (`/agents/{id}/icon?v=…`) so the
+ * container never has to know its own public origin; the API base is prefixed here.
+ * The `?v=` is the icon's content digest, which is what lets the response be cached
+ * `immutable` and still change the instant a new icon is uploaded.
+ *
+ * A load failure falls back to the gradient rather than showing a broken tile — the
+ * backend answers 404 for a key that outlived its object, and that path has to land
+ * somewhere composed.
+ */
+@Component({
+  selector: 'app-agent-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (src() && !failed()) {
+      <img
+        [src]="src()"
+        [alt]="alt()"
+        [class]="boxClasses()"
+        class="shrink-0 object-cover ring-1 ring-black/5 dark:ring-white/10"
+        loading="lazy"
+        decoding="async"
+        (error)="failed.set(true)"
+      />
+    } @else {
+      <span
+        [class]="boxClasses()"
+        [style.background-image]="gradient()"
+        class="flex shrink-0 items-center justify-center ring-1 ring-black/5 select-none dark:ring-white/10"
+        [attr.role]="alt() ? 'img' : null"
+        [attr.aria-label]="alt() || null"
+        [attr.aria-hidden]="alt() ? null : true"
+      >
+        <span class="leading-none drop-shadow-sm">{{ emoji() || '✦' }}</span>
+      </span>
+    }
+  `,
+})
+export class AgentIconComponent {
+  private config = inject(ConfigService);
+
+  readonly agentId = input.required<string>();
+  /** Relative API path from the read shape; absent → the generated gradient. */
+  readonly iconUrl = input<string | undefined>();
+  readonly emoji = input<string | undefined>();
+  readonly size = input<AgentIconSize>(40);
+  /** Empty (the default) marks the tile decorative, for rows that already name the agent. */
+  readonly alt = input<string>('');
+
+  readonly src = computed(() => {
+    const url = this.iconUrl();
+    if (!url) return null;
+    // Only a leading `/` marks an API path needing the base. Anything else is already
+    // absolute — including the `blob:` URL the upload dialog previews a local file with.
+    return url.startsWith('/') ? `${this.config.appApiUrl()}${url}` : url;
+  });
+
+  /** Reset on every new src, so replacing a broken icon re-attempts the load. */
+  readonly failed = linkedSignal<string | null, boolean>({
+    source: this.src,
+    computation: () => false,
+  });
+
+  readonly boxClasses = computed(() => SIZE_CLASSES[this.size()]);
+  readonly gradient = computed(() => gradientFor(this.agentId()));
+}

--- a/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
@@ -3,6 +3,7 @@ import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroCheckBadge } from '@ng-icons/heroicons/outline';
 import { AgentListing } from '../models/store.model';
+import { AgentIconComponent } from './agent-icon.component';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 
 /**
@@ -12,8 +13,8 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
  * runnability badge. A row's job is to make you tap; everything else lives on the detail
  * page and in admin reporting.
  *
- * The icon is the emoji on a neutral tile for now — D5's uploaded icon and generated
- * gradient fallback are Phase 4.
+ * The icon is `app-agent-icon` at 40px: the author's uploaded square when there is one,
+ * the generated gradient carrying the emoji when there is not (D5).
  *
  * The whole row routes to the detail page (Phase 3). A `+` add affordance sits beside it
  * in the mockup; that is Phase 5's pin, so the row has exactly one destination today.
@@ -21,19 +22,19 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 @Component({
   selector: 'app-agent-listing-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, RouterLink, TooltipDirective],
+  imports: [AgentIconComponent, NgIcon, RouterLink, TooltipDirective],
   providers: [provideIcons({ heroCheckBadge })],
   template: `
     <a
       [routerLink]="['/agents', listing().agentId]"
       class="flex w-full items-center gap-3 rounded-2xl px-3 py-2.5 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:hover:bg-gray-800"
     >
-      <span
-        class="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-xl dark:bg-gray-700"
-        aria-hidden="true"
-      >
-        {{ listing().emoji || '✦' }}
-      </span>
+      <app-agent-icon
+        [agentId]="listing().agentId"
+        [iconUrl]="listing().iconUrl"
+        [emoji]="listing().emoji"
+        [size]="40"
+      />
       <div class="min-w-0 flex-1">
         <p
           class="flex items-center gap-1.5 truncate text-sm/6 font-semibold text-gray-900 dark:text-white"

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -19,6 +19,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { AgentApiService } from '../services/agent-api.service';
 import { Agent, AgentRunnability } from '../models/agent.model';
+import { AgentIconComponent } from '../components/agent-icon.component';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 
 /**
@@ -33,15 +34,14 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
  * and settles into the sidebar when it arrives. Blocking the whole page on the slower
  * question would trade a fast page for a spinner.
  *
- * Not here yet, by phase: "Add to my agents" (pins, Phase 5), the uploaded icon and its
- * generated gradient fallback (Phase 4), and "Report a problem" (Phase 8). Rendering an
- * affordance whose backing lever does not exist is how a store starts lying, so the
- * header carries Start chat alone.
+ * Not here yet, by phase: "Add to my agents" (pins, Phase 5) and "Report a problem"
+ * (Phase 8). Rendering an affordance whose backing lever does not exist is how a store
+ * starts lying, so the header carries Start chat alone.
  */
 @Component({
   selector: 'app-agent-detail',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, TooltipDirective],
+  imports: [AgentIconComponent, NgIcon, TooltipDirective],
   providers: [
     provideIcons({
       heroArrowLeft,
@@ -81,12 +81,12 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
         } @else if (agent(); as a) {
           <!-- Identity -->
           <div class="flex flex-wrap items-start gap-5">
-            <span
-              class="flex size-21 shrink-0 items-center justify-center rounded-3xl bg-gray-100 text-4xl dark:bg-gray-700"
-              aria-hidden="true"
-            >
-              {{ a.emoji || '✦' }}
-            </span>
+            <app-agent-icon
+              [agentId]="a.agentId"
+              [iconUrl]="a.iconUrl"
+              [emoji]="a.emoji"
+              [size]="84"
+            />
             <div class="min-w-0 flex-1">
               <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">{{ a.name }}</h1>
               @if (a.tagline) {

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -93,6 +93,13 @@ export interface Agent {
   // Marketplace listing (Phase 1) + the detail read (Phase 3). All are absent on the
   // list route and on an agent that was never submitted.
   tagline?: string;
+  /** S3 object key for the uploaded square icon (D5); the bytes are never on the record. */
+  iconKey?: string;
+  /**
+   * Where to render the icon from (Phase 4) — a relative API path carrying the key's
+   * digest as `?v=`. Absent → `app-agent-icon` draws the generated gradient.
+   */
+  iconUrl?: string;
   listing?: AgentListingBlock;
   /** Resolved on `GET /agents/{id}` only. */
   capabilities?: AgentCapability[];

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -123,6 +123,18 @@ export interface AgentListing {
   category: string;
 }
 
+/**
+ * The result of setting or clearing an agent's square icon (D5).
+ *
+ * Both fields are absent after a remove, which is the signal to fall back to the
+ * generated gradient without re-reading the agent.
+ */
+export interface AgentIconResponse {
+  agentId: string;
+  iconKey?: string;
+  iconUrl?: string;
+}
+
 /** An admin-managed store category. `id` is immutable; `label` is what renders. */
 export interface AgentCategory {
   id: string;

--- a/frontend/ai.client/src/app/agents/services/agent-api.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-api.service.ts
@@ -14,6 +14,7 @@ import {
   UpdateAgentRequest,
 } from '../models/agent.model';
 import {
+  AgentIconResponse,
   AgentListingBlock,
   ListingPreflight,
   ListingSubmissionResponse,
@@ -114,5 +115,23 @@ export class AgentApiService {
   /** Unpublish or withdraw. Returns the listing at `private`; revokes nothing (D7.3). */
   withdrawListing(id: string): Observable<AgentListingBlock> {
     return this.http.delete<AgentListingBlock>(`${this.baseUrl()}/${id}/listing`);
+  }
+
+  /**
+   * Upload the agent's square icon (D5). Multipart, because the server has to see the
+   * bytes: it validates the format and dimensions and re-encodes to strip metadata, none
+   * of which a presigned direct-to-S3 upload could do.
+   *
+   * No explicit `Content-Type` — the browser has to set the multipart boundary itself.
+   */
+  uploadIcon(id: string, file: File): Observable<AgentIconResponse> {
+    const form = new FormData();
+    form.append('file', file);
+    return this.http.post<AgentIconResponse>(`${this.baseUrl()}/${id}/icon`, form);
+  }
+
+  /** Clear the icon, returning the agent to its generated gradient. */
+  removeIcon(id: string): Observable<AgentIconResponse> {
+    return this.http.delete<AgentIconResponse>(`${this.baseUrl()}/${id}/icon`);
   }
 }


### PR DESCRIPTION
Phase 4 of `docs/specs/agent-marketplace.md` (D5, plus the `POST /agents/{id}/icon` row of the APIs table). `iconKey` has been on the Agent record since phase 1 — declared, admin-PATCH-writable, projected by `compat.to_agent_view` — with nothing to populate it. This is the write path, the URL resolution that makes it renderable, and the generated fallback for the majority of agents that will never have one.

## Deploy

**`backend.yml` + `frontend-deploy.yml` only — no CDK deploy**, same as phases 2, 3 and 3.5.

It reuses the existing assistants asset bucket (`{prefix}-rag-documents`, reaching app-api as `S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME`), on which the app-api task role already holds `GetObject`/`PutObject`/`DeleteObject`/`ListBucket` (`app-api-iam-grants.ts:128`). The bucket is versioned with no lifecycle expiry, so icons do not age out. No new env var, index or IAM statement.

## `iconUrl` is a stable path, not a presigned URL

`iconUrl` resolves to `/agents/{id}/icon?v={digest}` — a relative app-api path — and a new `GET` route serves the bytes with `Cache-Control: public, max-age=31536000, immutable` and the digest as the ETag.

- **Not presigned.** A SigV4 URL is a different string on every response, so every browse re-downloads every shelf icon and the JSON itself stops being cacheable — for an asset whose whole job is to be fetched repeatedly. Presigned URLs also expire inside a long-lived SPA session.
- **Not CloudFront.** A `/agent-icons/*` behavior over the documents bucket needs a new origin + OAC + behavior, i.e. exactly the `platform.yml` deploy this phase otherwise avoids, when the existing same-origin `/api/*` behavior already reaches it. The URL is a stable path, so adding that behavior later is a pure infra change with no contract break.

Cookies work on both surfaces: prod is same-origin `/api`, and dev's `localhost:4200 → localhost:8000` is same-*site* (SameSite ignores port), so an `<img>` carries the session cookie.

## Storage

Bytes to `assistants/{agent_id}/icons/{sha256[:16]}.{png|jpg}` — the same `assistants/{id}/` prefix documents already use. **The key goes on the record, never the image**, per the MCP App icon lesson; here the 400 KB ceiling *is* the icon limit, so inlining would hit the DynamoDB item limit by design rather than by accident.

The key is content-addressed, which makes re-upload idempotent and gives the cache version away free — the digest is both the ETag and the `?v=`.

Validation always re-encodes, even at exactly 512×512. That is not redundant work: re-encoding is what strips EXIF, and an icon cropped from a phone photo would otherwise publish its GPS coordinates to the whole institution.

## Two authorization rules, deliberately different

- **Writing an icon is editing the agent** — owner or editor, matching `PUT /agents/{id}`. An icon is presentation (D13), and an editor who may rewrite the instructions is not someone to stop at the avatar. Publishing stays owner-only.
- **Reading one follows the shelf** — a published agent's icon is readable by any authenticated user, because the store read already hands that agent's name, tagline and emoji to every browsing user. Gating on the record instead would render a broken tile on the shelf of any published agent whose `visibility` is still PRIVATE.

## Beyond the spec's API table

`DELETE /agents/{id}/icon`. Admin `PATCH .../listing` can only *replace* `iconKey`, so without this an author who uploads an off-brand icon has no way back to the generated fallback the store is designed around. A missing S3 object answers 404 rather than 500, so a key that outlived its bytes degrades to that same fallback instead of a broken image.

## The generated fallback (D5) and the four sizes

The gradient is the designed default, not a placeholder: most agents will never have an uploaded icon, and a store where a third of the tiles are a bare emoji on grey reads as unfinished.

Twelve curated gradient pairs indexed by an FNV-1a hash of the agent id — not hue arithmetic on the hash, which reliably draws a few muddy or low-contrast tiles. The hash lives in one exported function, so the same agent is the same tile in the store, in My Agents and in the admin queue.

All four D5 sizes render live: **84** detail, **52** My Agents card, **40** browse row, **28** the admin tables' compact tile. The 28px sidebar and `@` menu D5 names are Phases 5 and 7 — the component is ready for them, but inventing those surfaces is not this phase's work. The admin tile becomes a thin adapter over the shared component, so a reviewer judges the icon the shelf will actually render.

The upload dialog previews all four sizes at true scale before upload, because an icon is authored at a size nobody browses at — it reads beautifully at 84px and turns to mud at 28px. Removing shows the same strip with the gradient, so "revert to the default" is something an author can see rather than risk.

## Two things the build found

- **Pillow only quantizes RGBA with `FASTOCTREE`** — the default MEDIANCUT raises — which silently broke the alpha-preserving rung of the encode ladder. Caught by the test written for that rung.
- **The glyph drifted as the tile grew.** Stepping the Tailwind text scale across the four sizes takes the emoji from 54% of a 28px tile down to 43% of an 84px one — the same icon looking progressively emptier the larger it gets. The component now pins ~50% glyph and ~29% radius explicitly, checked by rendering all twelve gradients at every size in light and dark.

## Testing

- **5080 backend tests pass** (26 new in `tests/shared/test_agent_icons.py`): validation and every rejection message, the encode ladder, key/URL derivation, and the author paths end to end through moto — including that the stored attribute is a short key rather than image data, that replacing deletes the old object while re-uploading the same image does not, and both branches of the read gate.
- **1533 SPA tests pass** (14 new): gradient determinism across surfaces, the API-base prefix vs. an absolute `blob:` URL, the img→gradient error path and its reset on replacement, the four size classes, and the decorative/labelled a11y modes.
- `ng build` clean; the four arbitrary Tailwind utilities (`size-13`, `size-21`, `text-[42px]`, `rounded-[1.5rem]`) verified present in the built CSS.

**Not verified live:** the icon routes do not exist on the dev backend until `backend.yml` runs, so the S3 round trip, the 304 and the published-agent read gate are proven by moto only.

Post-deploy smoke test (note `/agents` is system-admin-only in the sidenav; `/agents/discover` and `/agents/:id` work by direct URL for any signed-in user): Add icon on a My Agents card → the preview strip renders; a 4:3 image → rejected client-side with its dimensions named; upload → the card repaints at 52px with no reload; then check the browse row at 40px and the detail page at 84px.

## Known gap, not fixed here

An agent's icon object is not deleted when the agent is deleted. Assistant documents have the same gap today, so this is a pre-existing bucket-cleanup concern rather than something this PR introduces — flagged rather than half-fixed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)