### PR TITLE
feat(marketplace): phase 5 — pins and the curated store front

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -1,13 +1,13 @@
-"""Admin API routes for the Agent Marketplace (Phases 1-2).
+"""Admin API routes for the Agent Marketplace (Phases 1-2, 5).
 
 Mounted under ``/admin/agents`` per the CLAUDE.md route convention — admin CRUD lives at
 ``/admin/resource/``, never ``/resource/admin/``. Every route is ``Depends(require_admin)``
 (= ``require_app_roles("system_admin")``); D2 is explicit that a granular "marketplace
 curator" permission is a deliberate follow-up, so do not open a second permission axis here.
 
-Covers three of D10's seven surfaces — **Review queue**, **Listings** and **Categories**
-— plus the **Publishers** records they depend on. Store front, default pins and the
-reports queue are Phases 5, 6 and 8.
+Covers four of D10's seven surfaces — **Review queue**, **Listings**, **Categories** and
+**Store front** — plus the **Publishers** records they depend on. Default pins and the
+reports queue are Phases 6 and 8.
 """
 
 import logging
@@ -31,9 +31,11 @@ from apis.shared.assistants.categories import (
     get_category,
     put_category,
 )
+from apis.app_api.agent_designer.services.store_service import resolve_featured
 from apis.shared.assistants.models import (
     AdminListingPatchRequest,
     AdminListingsResponse,
+    AdminStoreFrontResponse,
     AgentCategoriesResponse,
     AgentCategory,
     AgentCategoryCreateRequest,
@@ -46,7 +48,13 @@ from apis.shared.assistants.models import (
     PublishersResponse,
     PublisherUpdateRequest,
     ReviewListingRequest,
+    StoreFrontUpdateRequest,
     TakedownRequest,
+)
+from apis.shared.assistants.storefront import (
+    MAX_FEATURED,
+    get_featured_ids,
+    put_featured_ids,
 )
 from apis.shared.assistants.publishers import (
     delete_publisher,
@@ -178,6 +186,67 @@ async def patch_agent_listing(
     except Exception as e:
         logger.error(f"Error patching agent listing: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to patch listing: {str(e)}")
+
+
+# ── store front (D10) ────────────────────────────────────────────────────────────────
+# The featured row deserves its own surface because **it is the only ranking lever that
+# exists**: ``GSI5_SK`` is ``created_at``, so everything below Featured is newest-first and
+# there is no popularity sort. Promotion is how a good Agent gets found.
+@router.get("/storefront", response_model=AdminStoreFrontResponse)
+async def get_store_front(admin: User = Depends(require_marketplace_admin)):
+    """The featured row, resolved in its configured order.
+
+    ``unavailable`` names configured ids that no longer resolve as published listings —
+    a taken-down or deleted Agent. They are reported rather than pruned, because a GET
+    that silently rewrote an admin's curation would also make a reversed takedown
+    permanently cost the Agent its slot.
+    """
+    try:
+        featured, unavailable = await resolve_featured(await get_featured_ids())
+        return AdminStoreFrontResponse(featured=featured, unavailable=unavailable)
+    except Exception as e:
+        logger.error(f"Error loading admin store front: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to load store front: {str(e)}")
+
+
+@router.put("/storefront", response_model=AdminStoreFrontResponse)
+async def put_store_front(
+    request: StoreFrontUpdateRequest, admin: User = Depends(require_marketplace_admin)
+):
+    """Replace the featured row, in order (D10).
+
+    A whole-list PUT: the row is short and reordering must be atomic, so the ordered array
+    is the record. Every id must resolve to a **published** listing — promoting something
+    the store cannot show would put a tile at the top of Discover that nobody can open —
+    and the refusal names the offending ids rather than reporting a count.
+    """
+    try:
+        if len(request.agent_ids) > MAX_FEATURED:
+            raise HTTPException(
+                status_code=400,
+                detail=f"The store front holds at most {MAX_FEATURED} agents.",
+            )
+
+        _rows, unavailable = await resolve_featured(request.agent_ids)
+        if unavailable:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Only published agents can be featured. These are not published: "
+                    + ", ".join(unavailable)
+                ),
+            )
+
+        saved = await put_featured_ids(request.agent_ids, updated_by=admin.user_id)
+        featured, still_unavailable = await resolve_featured(saved)
+        return AdminStoreFrontResponse(featured=featured, unavailable=still_unavailable)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error saving admin store front: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to save store front: {str(e)}")
 
 
 # ── categories (D10) ─────────────────────────────────────────────────────────────────

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -87,6 +87,12 @@ from apis.app_api.agent_designer.services.listing_service import (
     submit_listing,
     withdraw_listing,
 )
+from apis.app_api.agent_designer.services.pin_service import (
+    PinError,
+    list_pins,
+    pin_agent,
+    unpin_agent,
+)
 from apis.app_api.agent_designer.services.store_service import (
     browse_all,
     browse_category,
@@ -95,10 +101,12 @@ from apis.app_api.agent_designer.services.store_service import (
 from apis.shared.assistants.models import (
     AgentIconResponse,
     AgentListing,
+    AgentPinsResponse,
     AgentStoreFrontResponse,
     AgentStoreResponse,
     ListingPreflightResponse,
     ListingSubmissionResponse,
+    PinnedAgentResponse,
     SubmitListingRequest,
 )
 from apis.shared.auth.dependencies import get_current_user_from_session
@@ -245,8 +253,9 @@ async def list_agents_endpoint(
 async def agent_store_front_endpoint(current_user: User = Depends(require_marketplace_enabled)):
     """The browse header: the featured row plus the categories to render (D10).
 
-    ``featured`` is empty until the store-front admin ships in Phase 5; the field is
-    present now so the SPA contract does not change when it fills in.
+    ``featured`` is the admin's curated order — the store's only ranking lever, since
+    everything below it is newest-first (see the spec's ranking caveat). Entries whose
+    listing is no longer published are dropped here rather than rendered as dead tiles.
     """
     try:
         featured, categories = await store_front()
@@ -281,6 +290,26 @@ async def agent_store_endpoint(
     except Exception as e:
         logger.error(f"Error browsing agent store: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to browse the store: {str(e)}")
+
+
+# ----------------------------------------------------------------------- pins (D8/D9)
+# Declared BEFORE ``/{agent_id}`` so the literal path is not captured by the path param.
+@router.get("/pins", response_model=AgentPinsResponse)
+async def list_agent_pins_endpoint(current_user: User = Depends(require_marketplace_enabled)):
+    """The caller's effective pin list (D9).
+
+    Phase 5 resolves the user's own pins. Role-seeded pins union in here in Phase 6
+    without changing the shape — ``source`` and ``locked`` are already on every row.
+
+    Rows the caller can no longer reach (deleted, or visibility narrowed) are omitted from
+    the response while the stored pin is left untouched: both conditions are reversible,
+    and a read is not the place to garbage-collect someone's shelf.
+    """
+    try:
+        return AgentPinsResponse(pins=await list_pins(current_user))
+    except Exception as e:
+        logger.error(f"Error listing agent pins: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list pinned agents: {str(e)}")
 
 
 # --------------------------------------------------------------------------- palette
@@ -576,6 +605,44 @@ async def withdraw_agent_listing_endpoint(
     except Exception as e:
         logger.error(f"Error withdrawing agent listing: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to withdraw agent listing: {str(e)}")
+
+
+@router.post("/{agent_id}/pin", response_model=PinnedAgentResponse, status_code=201)
+async def pin_agent_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """Add an Agent to the caller's own set (D8).
+
+    A pointer, never a fork: nothing is copied, so the Agent the user reaches tomorrow is
+    the one its author maintains. Pinning something already pinned is a no-op that returns
+    the existing row, and it clears any earlier dismissal of that Agent (D9.3).
+    """
+    try:
+        return await pin_agent(current_user, agent_id)
+    except PinError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error pinning agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to pin agent: {str(e)}")
+
+
+@router.delete("/{agent_id}/pin", status_code=204)
+async def unpin_agent_endpoint(
+    agent_id: str, current_user: User = Depends(require_marketplace_enabled)
+):
+    """Remove an Agent from the caller's own set, and remember the dismissal (D9.3).
+
+    The tombstone is the point: role-seeded pins (Phase 6) are resolved live, so without a
+    remembered dismissal a seeded pin would re-appear on the next request and the user
+    could never remove it.
+    """
+    try:
+        await unpin_agent(current_user, agent_id)
+    except PinError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error unpinning agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to unpin agent: {str(e)}")
 
 
 # ------------------------------------------------------------------------ icons (D5)

--- a/backend/src/apis/app_api/agent_designer/services/pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/pin_service.py
@@ -1,0 +1,165 @@
+"""Agent Marketplace Phase 5 — the pin read and write (D8, D9 user side).
+
+"Add to my agents" stores a pointer (D8). This module turns that pointer list back into
+something renderable, which is the whole of the work: the stored state is ids, and a shelf
+needs icon, name, tagline and publisher.
+
+Three rules are load-bearing:
+
+**1. The pin list is access-checked on every read.** A pin is a bookmark, not a grant.
+``get_assistant_with_access_check`` is the same gate the detail page uses, so an Agent
+that goes ``PUBLIC`` → ``PRIVATE`` disappears from every stranger's Pinned tab at once,
+and nothing here can hand a user a row they could not have reached by navigating. Denied
+rows are dropped from the *response*, never from the stored pin: visibility is reversible,
+and deleting someone's pin because an author toggled a setting for an afternoon would be a
+silent, unrecoverable edit to their shelf.
+
+**2. A pin survives a takedown.** D2 is explicit that delisting is not revocation —
+existing pins keep working and conversations underway keep running. So the projection here
+tolerates an Agent with no ``listing`` block at all, unlike the browse read, whose whole
+safety property is that it can only see published rows.
+
+**3. One read per pin, through the access check, rather than a batch read plus a second
+access path.** ``get_assistant_with_access_check`` already fetches the record, so batching
+the fetch would mean either re-reading each Agent anyway or restating the visibility rules
+here — a second copy of an access decision, which is how a resource ends up *listed* by one
+path and *denied* by another (the ``can_access_model`` divergence in CLAUDE.md's RBAC
+rule). A pin list is bounded by ``MAX_PINS`` and is normally a handful of ids; a duplicated
+access rule is unbounded in cost.
+"""
+
+import logging
+from typing import List, Optional
+
+from apis.shared.assistants.icons import icon_url
+from apis.shared.assistants.models import (
+    Assistant,
+    ListingPublisher,
+    PinnedAgentRef,
+    PinnedAgentResponse,
+    PublisherProfile,
+)
+from apis.shared.assistants.pins import (
+    PinLimitError,
+    add_pin,
+    get_pin_state,
+    remove_pin,
+)
+from apis.shared.assistants.publishers import list_publishers
+from apis.shared.assistants.service import get_assistant_with_access_check
+from apis.shared.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PinError", "list_pins", "pin_agent", "unpin_agent"]
+
+
+class PinError(Exception):
+    """A pin operation the caller should see as an HTTP status rather than a 500."""
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+def _pin_row(
+    assistant: Assistant, ref: Optional[PinnedAgentRef], publishers: dict
+) -> PinnedAgentResponse:
+    """Project a pinned Agent into the shelf shape.
+
+    The same narrow projection browse uses (D4) — no ``instructions``, no binding refs,
+    no owner id — plus ``source``/``locked``, which are constant in Phase 5 and become
+    meaningful when role-seeded pins land (D9).
+    """
+    listing = assistant.listing
+    profile: Optional[PublisherProfile] = (
+        publishers.get(listing.publisher_id) if listing else None
+    )
+    return PinnedAgentResponse(
+        agent_id=assistant.assistant_id,
+        name=assistant.name,
+        tagline=assistant.tagline,
+        emoji=assistant.emoji,
+        icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
+        publisher=(
+            ListingPublisher(label=profile.label, kind=profile.kind, verified=profile.verified)
+            if profile
+            else None
+        ),
+        category=(listing.category if listing else ""),
+        source="user",
+        locked=False,
+        pinned_at=ref.pinned_at if ref else None,
+    )
+
+
+async def list_pins(user: User) -> List[PinnedAgentResponse]:
+    """The user's effective pin list, in shelf order (D9).
+
+    Phase 5 resolves the user's own pins only. Phase 6 unions role-seeded pins in here —
+    ``(⋃ role pins) − dismissed ∪ own pins`` — which is why the dismissal tombstones are
+    already being written and why ``source``/``locked`` are already on the row.
+    """
+    state = await get_pin_state(user.user_id)
+    refs = sorted(state.pinned, key=lambda ref: ref.order)
+    if not refs:
+        return []
+
+    publishers = {p.id: p for p in await list_publishers()}
+
+    rows: List[PinnedAgentResponse] = []
+    for ref in refs:
+        try:
+            assistant, permission = await get_assistant_with_access_check(
+                ref.agent_id, user.user_id, user.email
+            )
+        except Exception:
+            logger.warning(f"Failed to resolve pinned agent {ref.agent_id}", exc_info=True)
+            continue
+
+        # Deleted since it was pinned, or no longer reachable by this user. Dropped from
+        # the response; the stored pin is left alone, because a read is not the place to
+        # garbage-collect writes and both conditions are reversible.
+        if assistant is None or permission is None:
+            continue
+
+        rows.append(_pin_row(assistant, ref, publishers))
+
+    return rows
+
+
+async def pin_agent(user: User, agent_id: str) -> PinnedAgentResponse:
+    """Pin an Agent for this user (D8).
+
+    Gated on the viewer being able to *reach* the Agent, not on it being published: an
+    author pinning their own draft, or a colleague pinning something shared with them, is
+    the same "keep this to hand" gesture the store's Add button performs, and the `@`
+    menu (D11) is scoped to exactly "your own and pinned Agents". Publication decides what
+    the store *offers*, not what a user may bookmark.
+    """
+    assistant, permission = await get_assistant_with_access_check(
+        agent_id, user.user_id, user.email
+    )
+    if assistant is None or permission is None:
+        # Not-found and access-denied deliberately collapse: telling a stranger that an id
+        # exists but is not theirs is a disclosure the store has no reason to make.
+        raise PinError(404, f"Agent not found: {agent_id}")
+
+    try:
+        state = await add_pin(user.user_id, agent_id)
+    except PinLimitError as e:
+        raise PinError(409, str(e)) from e
+
+    ref = next((r for r in state.pinned if r.agent_id == agent_id), None)
+    publishers = {p.id: p for p in await list_publishers()}
+    return _pin_row(assistant, ref, publishers)
+
+
+async def unpin_agent(user: User, agent_id: str) -> None:
+    """Unpin an Agent and record the dismissal (D9.3).
+
+    No existence check: unpinning a deleted Agent has to work, or a user whose pinned
+    Agent was removed is stuck with a row they cannot clear.
+    """
+    await remove_pin(user.user_id, agent_id)

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -20,7 +20,8 @@ from typing import List, Optional, Tuple
 
 from apis.shared.assistants.categories import ensure_seeded, list_categories
 from apis.shared.assistants.icons import icon_url
-from apis.shared.assistants.listing_repository import query_store
+from apis.shared.assistants.listing import is_published
+from apis.shared.assistants.listing_repository import batch_get_agents, query_store
 from apis.shared.assistants.models import (
     AgentCategory,
     AgentListingResponse,
@@ -29,6 +30,7 @@ from apis.shared.assistants.models import (
     PublisherProfile,
 )
 from apis.shared.assistants.publishers import list_publishers
+from apis.shared.assistants.storefront import get_featured_ids
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ logger = logging.getLogger(__name__)
 _MAX_FANOUT_CATEGORIES = 12
 
 
-def _to_listing_response(
+def to_listing_response(
     assistant: Assistant, publishers: dict
 ) -> Optional[AgentListingResponse]:
     """Project a stored agent into the shelf shape, or ``None`` if it cannot render."""
@@ -75,7 +77,7 @@ def _project(items: list, publishers: dict) -> List[AgentListingResponse]:
         except Exception:
             logger.warning("Skipping unparseable store row", exc_info=True)
             continue
-        projected = _to_listing_response(assistant, publishers)
+        projected = to_listing_response(assistant, publishers)
         if projected:
             responses.append(projected)
     return responses
@@ -122,12 +124,60 @@ async def browse_all(*, limit: int = 50) -> List[AgentListingResponse]:
     return [response for _created, response in merged[:limit]]
 
 
-async def store_front() -> Tuple[List[AgentListingResponse], List[AgentCategory]]:
-    """The browse header: the featured row and the categories to render.
+async def resolve_featured(
+    agent_ids: List[str],
+) -> Tuple[List[AgentListingResponse], List[str]]:
+    """Project the configured store-front ids into shelf rows, in the admin's order.
 
-    ``featured`` is empty until the store-front admin ships in Phase 5. Returning the
-    field now — rather than adding it later — keeps the SPA contract stable across that
-    phase, and an empty list renders as "no featured row" rather than as a broken one.
+    Returns ``(rows, unavailable_ids)``. An id is *unavailable* when the Agent was deleted
+    or its listing is no longer ``published`` — a takedown must drop it off the shelf, and
+    the sparse-index physics that guarantee this for browse do not apply to a hand-curated
+    id list, so the state check has to be explicit here.
+
+    The unavailable ids are returned rather than swallowed so the admin console can show
+    an admin why their row is short. Nothing on this path *writes*: a takedown that is
+    later reversed restores the Agent to its slot (see ``storefront``).
+    """
+    if not agent_ids:
+        return [], []
+
+    records = await batch_get_agents(agent_ids)
+    publishers = {p.id: p for p in await list_publishers()}
+
+    rows: List[AgentListingResponse] = []
+    unavailable: List[str] = []
+    for agent_id in agent_ids:
+        item = records.get(agent_id)
+        if not item:
+            unavailable.append(agent_id)
+            continue
+        try:
+            assistant = Assistant.model_validate(item)
+        except Exception:
+            logger.warning(f"Skipping unparseable featured agent {agent_id}", exc_info=True)
+            unavailable.append(agent_id)
+            continue
+        listing = assistant.listing
+        if not listing or not is_published(listing.state):
+            unavailable.append(agent_id)
+            continue
+        projected = to_listing_response(assistant, publishers)
+        if projected:
+            rows.append(projected)
+        else:
+            unavailable.append(agent_id)
+
+    return rows, unavailable
+
+
+async def store_front() -> Tuple[List[AgentListingResponse], List[AgentCategory]]:
+    """The browse header: the featured row and the categories to render (D10).
+
+    The featured row is the store's **only ranking lever** — everything below it is
+    newest-first — so it is a hand-curated ordered list rather than anything derived.
+    Entries that are no longer published are dropped silently here; the admin console is
+    where that gap is named.
     """
     categories = await ensure_seeded()
-    return [], [c for c in categories if c.enabled]
+    featured, _unavailable = await resolve_featured(await get_featured_ids())
+    return featured, [c for c in categories if c.enabled]

--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -23,7 +23,7 @@ import base64
 import json
 import logging
 import os
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .listing import gsi5_keys
 from .models import AgentListing
@@ -248,6 +248,51 @@ def _decode_cursor(cursor: str) -> Optional[Dict[str, Any]]:
     except Exception:
         logger.warning("Ignoring malformed store cursor")
         return None
+
+
+async def batch_get_agents(agent_ids: List[str]) -> Dict[str, dict]:
+    """Fetch Agent records by id, keyed by id (Phase 5).
+
+    The read behind the curated store front, which is an arbitrary set of ids rather than
+    a category partition — so neither the GSI5 query nor a scan fits, and this is a
+    ``BatchGetItem`` over the exact keys.
+
+    **A missing id is simply absent from the result**: a featured Agent that was deleted
+    should drop off the shelf, not error the whole page. Ordering is the caller's —
+    DynamoDB returns batches unordered, and the store front's order is the admin's.
+
+    Not used by the pin read, deliberately: pins resolve through
+    ``get_assistant_with_access_check`` so that a pinned Agent is subject to exactly one
+    access decision (see ``pin_service``).
+    """
+    if not agent_ids:
+        return {}
+
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+
+    resource = boto3.resource("dynamodb")
+    found: Dict[str, dict] = {}
+
+    # De-duplicated because BatchGetItem rejects duplicate keys outright, and both callers
+    # can hold one (a re-pin race, an admin pasting an id twice).
+    unique_ids = list(dict.fromkeys(agent_ids))
+    for start in range(0, len(unique_ids), 100):  # BatchGetItem caps at 100 keys
+        keys = [_key(agent_id) for agent_id in unique_ids[start : start + 100]]
+        request = {table_name: {"Keys": keys}}
+        while request:
+            response = resource.batch_get_item(RequestItems=request)
+            for item in response.get("Responses", {}).get(table_name, []):
+                parsed = from_ddb(item)
+                agent_id = parsed.get("assistantId")
+                if agent_id:
+                    found[str(agent_id)] = parsed
+            request = response.get("UnprocessedKeys") or None
+
+    return found
 
 
 async def list_by_state(state: Optional[str] = None) -> list:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -807,10 +807,107 @@ class AgentStoreFrontResponse(BaseModel):
 
     featured: List[AgentListingResponse] = Field(
         default_factory=list,
-        description="Curated store-front row; empty until the store-front admin ships in Phase 5",
+        description="Curated store-front row, in the admin's order (D10)",
     )
     categories: List[AgentCategory] = Field(
         default_factory=list, description="Enabled categories in browse order"
+    )
+
+
+# ─────────────────────────────────────────────────────── Agent Marketplace (Phase 5)
+class PinnedAgentRef(BaseModel):
+    """One entry in a user's own pin list — a pointer, never a copy (D8)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    order: int = Field(0, description="Position within the user's own pins, ascending")
+    pinned_at: Optional[str] = Field(None, alias="pinnedAt", description="ISO 8601 timestamp")
+
+
+class UserPinState(BaseModel):
+    """The whole per-user pin item (D9's user side).
+
+    ``dismissed`` is a tombstone list, and it is the single most important detail in the
+    pin design: role-seeded pins (Phase 6) are resolved live rather than materialized, so
+    without a tombstone a seed re-applies on the next resolution and the user can never
+    remove it. It is written from Phase 5 so the resolver that arrives with role pins has
+    a history to respect rather than starting from a blank slate.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pinned: List[PinnedAgentRef] = Field(default_factory=list, description="The user's own pins")
+    dismissed: List[str] = Field(
+        default_factory=list, description="Agent ids the user removed — the resolver MUST respect these (D9.3)"
+    )
+
+
+class PinnedAgentResponse(BaseModel):
+    """One row on the Pinned shelf.
+
+    The shelf projection (D4) plus the two fields that describe *why* it is pinned.
+    ``source`` and ``locked`` are always ``"user"``/``False`` in Phase 5 — role-seeded
+    pins are Phase 6 — and they are on the contract now so that phase adds rows rather
+    than changing the shape the SPA already renders.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    name: str = Field(..., description="Agent display name")
+    tagline: Optional[str] = Field(None, description="One-line subtitle (D4)")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_url: Optional[str] = Field(
+        None, alias="iconUrl", description="Square icon URL (D5); absent → the generated gradient"
+    )
+    publisher: Optional[ListingPublisher] = Field(None, description="Attribution (D12), display only")
+    category: str = Field("", description="Category id; empty when the agent carries no listing")
+    source: Literal["user", "role"] = Field(
+        "user", description="Whose pin this is — 'role' arrives with default pins (D9)"
+    )
+    locked: bool = Field(
+        False, description="A locked role pin cannot be dismissed (D9.4); always false in Phase 5"
+    )
+    pinned_at: Optional[str] = Field(None, alias="pinnedAt", description="ISO 8601 timestamp")
+
+
+class AgentPinsResponse(BaseModel):
+    """A user's effective pin list (D9)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pins: List[PinnedAgentResponse] = Field(default_factory=list, description="Resolved pins, in order")
+
+
+class StoreFrontUpdateRequest(BaseModel):
+    """Replace the featured row, in order (D10).
+
+    A whole-list PUT rather than per-item ``order`` fields: the row is short and
+    reordering has to be atomic, so the ordered array *is* the record.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_ids: List[str] = Field(
+        default_factory=list, alias="agentIds", description="Featured agent ids, in render order"
+    )
+
+
+class AdminStoreFrontResponse(BaseModel):
+    """The featured row as the admin console sees it (D10)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    featured: List[AgentListingResponse] = Field(
+        default_factory=list, description="Resolved featured rows, in the configured order"
+    )
+    unavailable: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Configured ids that are no longer published — surfaced rather than silently "
+            "dropped, so an admin can see why the row is short and clear them"
+        ),
     )
 
 

--- a/backend/src/apis/shared/assistants/pins.py
+++ b/backend/src/apis/shared/assistants/pins.py
@@ -1,0 +1,132 @@
+"""User pin state for the Agent Marketplace (D8, D9 user side — Phase 5).
+
+A pin is a **pointer, never a fork** (D8). Agents are addressable by id and already run
+for anyone with access, so there is nothing to install: "Add to my agents" stores an id.
+Forking would duplicate the record (version drift the moment the author updates) and
+re-owner the bindings, which silently breaks Skills v2 invoke-through in the confusing
+direction.
+
+Storage is one item per user on the **user-settings** table, following the established
+``USER#{id}`` + uppercase-semantic-SK convention (``SETTINGS``, ``TOOL_PREFERENCES``):
+
+    PK = USER#{user_id}, SK = "PINNED_AGENTS"
+    { pinned: [ { agentId, order, pinnedAt } ], dismissed: [ agentId, ... ] }
+
+Two properties worth stating because both are easy to erode:
+
+**1. ``dismissed`` is written from Phase 5, before anything reads it.** Role-seeded pins
+(D9, Phase 6) are resolved live rather than materialized, so a seeded pin the user removed
+would re-apply on the very next resolution without a tombstone. Recording the tombstone
+now means the resolver that arrives with role pins inherits a real history instead of
+treating every existing user as having dismissed nothing.
+
+**2. Pinning clears the tombstone; unpinning writes one.** They are two halves of one
+toggle. A user who pins an Agent they previously dismissed has changed their mind, and
+leaving the tombstone in place would make a future role seed for that Agent unreachable
+forever — the failure being tombstoned exists to prevent, inverted.
+
+The write is a read-modify-write on a single per-user item. Two taps racing can lose one
+of them; the cost is a pin the user re-taps, and the alternative (a set-typed attribute
+with atomic ADD/DELETE) cannot carry the per-entry ``order`` and ``pinnedAt`` the shelf
+sorts and renders by.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+from .models import PinnedAgentRef, UserPinState
+
+logger = logging.getLogger(__name__)
+
+_SK = "PINNED_AGENTS"
+
+# A user with hundreds of pins has a sidebar nobody can read, and the resolver reads one
+# Agent record per pin. Neither is a hard system limit; this is the point where the
+# feature has stopped being a shelf, and refusing is kinder than degrading silently.
+MAX_PINS = 100
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_USER_SETTINGS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_USER_SETTINGS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _key(user_id: str) -> dict:
+    return {"PK": f"USER#{user_id}", "SK": _SK}
+
+
+class PinLimitError(ValueError):
+    """Raised when a pin would take the user past ``MAX_PINS``."""
+
+
+async def get_pin_state(user_id: str) -> UserPinState:
+    """The user's raw pin item, or an empty state when they have never pinned anything."""
+    item = _table().get_item(Key=_key(user_id)).get("Item")
+    if not item:
+        return UserPinState()
+    return UserPinState.model_validate(
+        {"pinned": item.get("pinned", []), "dismissed": item.get("dismissed", [])}
+    )
+
+
+async def _put_pin_state(user_id: str, state: UserPinState) -> UserPinState:
+    _table().put_item(
+        Item={
+            **_key(user_id),
+            "pinned": [ref.model_dump(by_alias=True, exclude_none=True) for ref in state.pinned],
+            "dismissed": state.dismissed,
+            "updatedAt": _now(),
+        }
+    )
+    return state
+
+
+async def add_pin(user_id: str, agent_id: str) -> UserPinState:
+    """Pin an Agent for this user, and clear any dismissal of it.
+
+    Idempotent: pinning something already pinned keeps the original ``pinnedAt`` and
+    order, so a double tap does not reshuffle the shelf.
+    """
+    state = await get_pin_state(user_id)
+
+    if any(ref.agent_id == agent_id for ref in state.pinned):
+        if agent_id not in state.dismissed:
+            return state
+    elif len(state.pinned) >= MAX_PINS:
+        raise PinLimitError(
+            f"You have reached the limit of {MAX_PINS} pinned agents. Remove one to add another."
+        )
+    else:
+        next_order = max((ref.order for ref in state.pinned), default=-1) + 1
+        state.pinned.append(
+            PinnedAgentRef(agent_id=agent_id, order=next_order, pinned_at=_now())
+        )
+
+    state.dismissed = [pinned_id for pinned_id in state.dismissed if pinned_id != agent_id]
+    logger.info(f"📌 {user_id} pinned agent {agent_id}")
+    return await _put_pin_state(user_id, state)
+
+
+async def remove_pin(user_id: str, agent_id: str) -> UserPinState:
+    """Unpin an Agent and remember the dismissal (D9.3).
+
+    The tombstone is written even when the pin was the user's own rather than a role
+    seed: the two are indistinguishable to the user, and a dismissal that only counted
+    for seeded pins would let a role pin resurrect an Agent the user had already removed
+    by hand.
+    """
+    state = await get_pin_state(user_id)
+    state.pinned = [ref for ref in state.pinned if ref.agent_id != agent_id]
+    if agent_id not in state.dismissed:
+        state.dismissed.append(agent_id)
+    logger.info(f"📌 {user_id} unpinned agent {agent_id}")
+    return await _put_pin_state(user_id, state)

--- a/backend/src/apis/shared/assistants/storefront.py
+++ b/backend/src/apis/shared/assistants/storefront.py
@@ -1,0 +1,86 @@
+"""The curated store front (Agent Marketplace D10, Phase 5).
+
+    PK = "AGENT_STOREFRONT", SK = "CONFIG"    { featured: [agentId, ...] }
+
+**A single item holding an ordered array**, deliberately unlike categories and publishers
+(which are per-item records with an ``order`` field, following ``UserMenuLink``). Two
+reasons: the list is short, and reordering has to be atomic — with per-item ``order``
+fields a drag that rewrites five rows is five writes and a half-applied order is
+reachable. Here the array *is* the order, and one ``put_item`` moves the whole row.
+
+⚠️ **This is the only ranking lever that exists.** ``GSI5_SK`` is ``created_at``, so
+everything below the featured row is newest-first; there is no popularity sort and v1
+deliberately does not approximate one. Promotion is therefore how a good Agent gets found,
+which is exactly why the ordering is admin-owned and explicit rather than derived.
+
+Membership is *not* self-healing here: an id whose listing was later taken down stays in
+the array until an admin removes it, and the read paths drop it from what they render.
+Pruning on read would quietly rewrite an admin's curation from a GET, and a takedown that
+is later reversed would have silently cost the Agent its slot.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+_PARTITION = "AGENT_STOREFRONT"
+_SK = "CONFIG"
+
+# The featured row is a shelf, not a second store. Ten is the point past which the row
+# stops reading as "these are the ones we stand behind".
+MAX_FEATURED = 10
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+async def get_featured_ids() -> List[str]:
+    """The featured agent ids, in render order. Empty when nothing has been promoted."""
+    item = _table().get_item(Key={"PK": _PARTITION, "SK": _SK}).get("Item")
+    if not item:
+        return []
+    return [str(agent_id) for agent_id in item.get("featured", [])]
+
+
+async def put_featured_ids(agent_ids: List[str], *, updated_by: str) -> List[str]:
+    """Replace the featured row.
+
+    De-duplicates while preserving first position — a double-add is an admin slip, not an
+    instruction to render the same tile twice — and enforces ``MAX_FEATURED``. The caller
+    is responsible for refusing ids that are not published; that check needs the listing
+    records and belongs in the service layer, not here.
+    """
+    deduped: List[str] = []
+    for agent_id in agent_ids:
+        if agent_id and agent_id not in deduped:
+            deduped.append(agent_id)
+
+    if len(deduped) > MAX_FEATURED:
+        raise ValueError(
+            f"The store front holds at most {MAX_FEATURED} agents; {len(deduped)} were given."
+        )
+
+    _table().put_item(
+        Item={
+            "PK": _PARTITION,
+            "SK": _SK,
+            "featured": deduped,
+            "updatedAt": _now(),
+            "updatedBy": updated_by,
+        }
+    )
+    logger.info(f"⭐ Store front set to {len(deduped)} agents by {updated_by}")
+    return deduped

--- a/backend/tests/routes/test_agent_pins.py
+++ b/backend/tests/routes/test_agent_pins.py
@@ -1,0 +1,313 @@
+"""Agent Marketplace Phase 5 — the pin routes and the store-front admin (D8, D9, D10).
+
+The cases that matter here are the ones where a pin could become something it is not:
+
+* a **grant** — a pin must never let a user reach an Agent they could not navigate to,
+  so the read is access-checked on every request and the write refuses what it cannot see;
+* a **fork** — the response is the shelf projection, carrying no ``instructions``;
+* a **ranking input** — only published agents can be featured, and the order is the
+  admin's array rather than anything derived.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.agents.routes import router as admin_router
+from apis.app_api.agent_designer.routes import router as agents_router
+from apis.shared.assistants.models import (
+    AgentListing,
+    AgentListingResponse,
+    Assistant,
+    PinnedAgentRef,
+    UserPinState,
+)
+from apis.shared.auth import require_admin
+from tests.routes.conftest import mock_auth_user
+
+PIN_SERVICE = "apis.app_api.agent_designer.services.pin_service"
+ADMIN_ROUTES = "apis.app_api.admin.agents.routes"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="SECRET SYSTEM PROMPT",
+        vectorIndexId="idx-001",
+        visibility="PUBLIC",
+        usageCount=0,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+        emoji="📋",
+        tagline="Find and cite university policy",
+        listing=AgentListing(
+            state="published", category="Administration", publisher_id="pub-registrar"
+        ).model_dump(by_alias=True),
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(agents_router)
+    _app.include_router(admin_router, prefix="/admin")
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def _flags_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+@pytest.fixture
+def client(app, make_user):
+    mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
+    app.dependency_overrides[require_admin] = lambda: make_user(user_id="admin-1")
+    return TestClient(app)
+
+
+# ── GET /agents/pins ─────────────────────────────────────────────────────────────────
+def test_pins_are_empty_for_a_user_who_has_never_pinned(client):
+    with patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=UserPinState())):
+        response = client.get("/agents/pins")
+
+    assert response.status_code == 200
+    assert response.json() == {"pins": []}
+
+
+def test_a_pin_row_is_the_shelf_projection(client):
+    state = UserPinState(pinned=[PinnedAgentRef(agent_id="ast-001", order=0, pinned_at="2026-07-25T00:00:00Z")])
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=state)),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(), "viewer")),
+        ),
+    ):
+        response = client.get("/agents/pins")
+
+    assert response.status_code == 200
+    row = response.json()["pins"][0]
+    assert row["agentId"] == "ast-001"
+    assert row["name"] == "Policy Lookup"
+    assert row["source"] == "user"
+    assert row["locked"] is False
+    # A pin is a pointer, not a copy — the row carries nothing about behavior.
+    for leaked in ("instructions", "description", "bindings", "ownerId"):
+        assert leaked not in row
+
+
+def test_pins_render_in_the_users_order(client):
+    state = UserPinState(
+        pinned=[
+            PinnedAgentRef(agent_id="ast-002", order=1),
+            PinnedAgentRef(agent_id="ast-001", order=0),
+        ]
+    )
+
+    async def _resolve(agent_id, _user_id, _email=None):
+        return _make_assistant(assistantId=agent_id, name=agent_id.upper()), "viewer"
+
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=state)),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(f"{PIN_SERVICE}.get_assistant_with_access_check", AsyncMock(side_effect=_resolve)),
+    ):
+        response = client.get("/agents/pins")
+
+    assert [row["agentId"] for row in response.json()["pins"]] == ["ast-001", "ast-002"]
+
+
+def test_an_unreachable_pin_is_omitted_but_not_deleted(client):
+    """A pin is a bookmark, not a grant — and visibility changes are reversible."""
+    state = UserPinState(pinned=[PinnedAgentRef(agent_id="ast-001", order=0)])
+    remove = AsyncMock()
+
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=state)),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check", AsyncMock(return_value=(None, None))
+        ),
+        patch(f"{PIN_SERVICE}.remove_pin", remove),
+    ):
+        response = client.get("/agents/pins")
+
+    assert response.json() == {"pins": []}
+    remove.assert_not_awaited()
+
+
+def test_a_pinned_agent_survives_its_takedown(client):
+    """D2: delisting is not revocation. A pin with no listing block still renders."""
+    state = UserPinState(pinned=[PinnedAgentRef(agent_id="ast-001", order=0)])
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=state)),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(listing=None), "viewer")),
+        ),
+    ):
+        response = client.get("/agents/pins")
+
+    row = response.json()["pins"][0]
+    assert row["agentId"] == "ast-001"
+    assert row["category"] == ""
+
+
+# ── POST / DELETE /agents/{id}/pin ───────────────────────────────────────────────────
+def test_pinning_returns_the_new_row(client):
+    add = AsyncMock(
+        return_value=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-001", order=0)])
+    )
+    with (
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(), "viewer")),
+        ),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(f"{PIN_SERVICE}.add_pin", add),
+    ):
+        response = client.post("/agents/ast-001/pin")
+
+    assert response.status_code == 201
+    assert response.json()["agentId"] == "ast-001"
+    add.assert_awaited_once_with("user-001", "ast-001")
+
+
+def test_pinning_an_agent_you_cannot_reach_is_a_404(client):
+    """Not-found and access-denied collapse: the store does not confirm ids exist."""
+    add = AsyncMock()
+    with (
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check", AsyncMock(return_value=(None, None))
+        ),
+        patch(f"{PIN_SERVICE}.add_pin", add),
+    ):
+        response = client.post("/agents/ast-secret/pin")
+
+    assert response.status_code == 404
+    add.assert_not_awaited()
+
+
+def test_pinning_past_the_ceiling_is_a_409(client):
+    from apis.shared.assistants.pins import PinLimitError
+
+    with (
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(), "viewer")),
+        ),
+        patch(f"{PIN_SERVICE}.add_pin", AsyncMock(side_effect=PinLimitError("Too many pins."))),
+    ):
+        response = client.post("/agents/ast-001/pin")
+
+    assert response.status_code == 409
+
+
+def test_unpinning_needs_no_existence_check(client):
+    """Otherwise a user whose pinned agent was deleted cannot clear the row."""
+    remove = AsyncMock(return_value=UserPinState(dismissed=["ast-gone"]))
+    with patch(f"{PIN_SERVICE}.remove_pin", remove):
+        response = client.delete("/agents/ast-gone/pin")
+
+    assert response.status_code == 204
+    remove.assert_awaited_once_with("user-001", "ast-gone")
+
+
+# ── the kill switch (D14) ────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "method,path",
+    [("get", "/agents/pins"), ("post", "/agents/ast-001/pin"), ("delete", "/agents/ast-001/pin")],
+)
+def test_pin_routes_404_when_the_marketplace_is_off(client, monkeypatch, method, path):
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+
+    assert getattr(client, method)(path).status_code == 404
+
+
+# ── admin store front (D10) ──────────────────────────────────────────────────────────
+def _listing_row(agent_id: str, name: str) -> AgentListingResponse:
+    return AgentListingResponse(
+        agent_id=agent_id, name=name, category="Administration", tagline="One line"
+    )
+
+
+def test_admin_store_front_reports_ids_that_no_longer_publish(client):
+    with (
+        patch(f"{ADMIN_ROUTES}.get_featured_ids", AsyncMock(return_value=["ast-a", "ast-gone"])),
+        patch(
+            f"{ADMIN_ROUTES}.resolve_featured",
+            AsyncMock(return_value=([_listing_row("ast-a", "Alpha")], ["ast-gone"])),
+        ),
+    ):
+        response = client.get("/admin/agents/storefront")
+
+    body = response.json()
+    assert [row["agentId"] for row in body["featured"]] == ["ast-a"]
+    assert body["unavailable"] == ["ast-gone"]
+
+
+def test_saving_the_store_front_keeps_the_submitted_order(client):
+    put = AsyncMock(side_effect=lambda ids, updated_by: ids)
+    rows = [_listing_row("ast-b", "Beta"), _listing_row("ast-a", "Alpha")]
+    with (
+        patch(f"{ADMIN_ROUTES}.resolve_featured", AsyncMock(return_value=(rows, []))),
+        patch(f"{ADMIN_ROUTES}.put_featured_ids", put),
+    ):
+        response = client.put("/admin/agents/storefront", json={"agentIds": ["ast-b", "ast-a"]})
+
+    assert response.status_code == 200
+    assert [row["agentId"] for row in response.json()["featured"]] == ["ast-b", "ast-a"]
+    put.assert_awaited_once_with(["ast-b", "ast-a"], updated_by="admin-1")
+
+
+def test_only_published_agents_can_be_featured(client):
+    """A featured tile nobody can open is worse than a short row."""
+    put = AsyncMock()
+    with (
+        patch(f"{ADMIN_ROUTES}.resolve_featured", AsyncMock(return_value=([], ["ast-draft"]))),
+        patch(f"{ADMIN_ROUTES}.put_featured_ids", put),
+    ):
+        response = client.put("/admin/agents/storefront", json={"agentIds": ["ast-draft"]})
+
+    assert response.status_code == 400
+    assert "ast-draft" in response.json()["detail"]
+    put.assert_not_awaited()
+
+
+def test_the_featured_row_has_a_ceiling(client):
+    from apis.shared.assistants.storefront import MAX_FEATURED
+
+    put = AsyncMock()
+    with patch(f"{ADMIN_ROUTES}.put_featured_ids", put):
+        response = client.put(
+            "/admin/agents/storefront",
+            json={"agentIds": [f"ast-{index}" for index in range(MAX_FEATURED + 1)]},
+        )
+
+    assert response.status_code == 400
+    put.assert_not_awaited()
+
+
+def test_clearing_the_store_front_is_allowed(client):
+    put = AsyncMock(return_value=[])
+    with (
+        patch(f"{ADMIN_ROUTES}.resolve_featured", AsyncMock(return_value=([], []))),
+        patch(f"{ADMIN_ROUTES}.put_featured_ids", put),
+    ):
+        response = client.put("/admin/agents/storefront", json={"agentIds": []})
+
+    assert response.status_code == 200
+    put.assert_awaited_once()

--- a/backend/tests/shared/test_agent_pins.py
+++ b/backend/tests/shared/test_agent_pins.py
@@ -1,0 +1,191 @@
+"""Agent Marketplace Phase 5 — user pin state (D8, D9 user side).
+
+Two things here are load-bearing beyond "does the write round-trip":
+
+* **The dismissal tombstone.** Role-seeded pins (Phase 6) resolve live, so an unpin that
+  does not remember itself is an unpin the next request undoes. It is written in Phase 5,
+  before anything reads it, so that resolver inherits a real history.
+* **Pin ↔ dismiss is one toggle.** Re-pinning must clear the tombstone, or a user who
+  changed their mind is permanently unreachable by a future role seed for that Agent.
+
+These go through a real (moto) table rather than mocking the item, because the shape of
+the stored item *is* the contract the Phase 6 resolver will read.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.pins import (
+    MAX_PINS,
+    PinLimitError,
+    add_pin,
+    get_pin_state,
+    remove_pin,
+)
+
+REGION = "us-east-1"
+TABLE = "test-user-settings"
+USER = "user-001"
+
+
+async def _pinned_ids(user_id: str = USER):
+    """The user's pinned ids in shelf order — what the pin read sorts by."""
+    state = await get_pin_state(user_id)
+    return [ref.agent_id for ref in sorted(state.pinned, key=lambda ref: ref.order)]
+
+
+async def _ref(agent_id: str, user_id: str = USER):
+    state = await get_pin_state(user_id)
+    return next((ref for ref in state.pinned if ref.agent_id == agent_id), None)
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_USER_SETTINGS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+# ── the stored shape ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_user_with_no_pins_reads_as_empty(table):
+    state = await get_pin_state(USER)
+    assert state.pinned == []
+    assert state.dismissed == []
+
+
+@pytest.mark.asyncio
+async def test_pin_writes_the_documented_item(table):
+    await add_pin(USER, "ast-001")
+
+    item = table.get_item(Key={"PK": f"USER#{USER}", "SK": "PINNED_AGENTS"})["Item"]
+    assert item["pinned"][0]["agentId"] == "ast-001"
+    assert "pinnedAt" in item["pinned"][0]
+    assert item["dismissed"] == []
+
+
+@pytest.mark.asyncio
+async def test_pins_keep_their_order(table):
+    for agent_id in ("ast-001", "ast-002", "ast-003"):
+        await add_pin(USER, agent_id)
+
+    assert await _pinned_ids() == ["ast-001", "ast-002", "ast-003"]
+
+
+@pytest.mark.asyncio
+async def test_pinning_twice_is_idempotent(table):
+    await add_pin(USER, "ast-001")
+    first = await _ref("ast-001")
+    await add_pin(USER, "ast-001")
+    second = await _ref("ast-001")
+
+    assert await _pinned_ids() == ["ast-001"]
+    # A double tap must not reshuffle the shelf or rewrite when it was pinned.
+    assert second.pinned_at == first.pinned_at
+    assert second.order == first.order
+
+
+# ── the tombstone (D9.3) ─────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_unpin_records_a_dismissal(table):
+    await add_pin(USER, "ast-001")
+    await remove_pin(USER, "ast-001")
+
+    state = await get_pin_state(USER)
+    assert state.pinned == []
+    assert state.dismissed == ["ast-001"]
+
+
+@pytest.mark.asyncio
+async def test_unpinning_something_never_pinned_still_tombstones(table):
+    """The Phase 6 case: dismissing a role-seeded pin the user never pinned themselves."""
+    await remove_pin(USER, "ast-seeded")
+
+    assert (await get_pin_state(USER)).dismissed == ["ast-seeded"]
+
+
+@pytest.mark.asyncio
+async def test_repinning_clears_the_tombstone(table):
+    """Otherwise a user who changed their mind is unreachable by a future role seed."""
+    await remove_pin(USER, "ast-001")
+    await add_pin(USER, "ast-001")
+
+    state = await get_pin_state(USER)
+    assert state.dismissed == []
+    assert [ref.agent_id for ref in state.pinned] == ["ast-001"]
+
+
+@pytest.mark.asyncio
+async def test_repinning_an_already_pinned_agent_still_clears_a_stale_tombstone(table):
+    """A pin and a tombstone must never coexist — the resolver would have to guess."""
+    await add_pin(USER, "ast-001")
+    table.update_item(
+        Key={"PK": f"USER#{USER}", "SK": "PINNED_AGENTS"},
+        UpdateExpression="SET dismissed = :d",
+        ExpressionAttributeValues={":d": ["ast-001"]},
+    )
+
+    await add_pin(USER, "ast-001")
+
+    state = await get_pin_state(USER)
+    assert state.dismissed == []
+    assert [ref.agent_id for ref in state.pinned] == ["ast-001"]
+
+
+@pytest.mark.asyncio
+async def test_dismissals_do_not_accumulate_duplicates(table):
+    await remove_pin(USER, "ast-001")
+    await remove_pin(USER, "ast-001")
+
+    assert (await get_pin_state(USER)).dismissed == ["ast-001"]
+
+
+# ── the ceiling ──────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_pinning_past_the_ceiling_is_refused_with_an_actionable_message(table):
+    for index in range(MAX_PINS):
+        await add_pin(USER, f"ast-{index:03d}")
+
+    with pytest.raises(PinLimitError) as excinfo:
+        await add_pin(USER, "ast-one-too-many")
+
+    assert str(MAX_PINS) in str(excinfo.value)
+    assert len((await get_pin_state(USER)).pinned) == MAX_PINS
+
+
+@pytest.mark.asyncio
+async def test_repinning_at_the_ceiling_is_not_refused(table):
+    """The limit is on growth. An idempotent re-pin adds nothing, so it cannot exceed it."""
+    for index in range(MAX_PINS):
+        await add_pin(USER, f"ast-{index:03d}")
+
+    await add_pin(USER, "ast-000")
+
+    assert len((await get_pin_state(USER)).pinned) == MAX_PINS
+
+
+@pytest.mark.asyncio
+async def test_pins_are_per_user(table):
+    await add_pin(USER, "ast-001")
+    await add_pin("user-002", "ast-002")
+
+    assert await _pinned_ids() == ["ast-001"]
+    assert await _pinned_ids("user-002") == ["ast-002"]

--- a/backend/tests/shared/test_agent_storefront.py
+++ b/backend/tests/shared/test_agent_storefront.py
@@ -1,0 +1,267 @@
+"""Agent Marketplace Phase 5 — the curated store front (D10).
+
+The featured row is the store's **only** ranking lever: browse is newest-first because
+``GSI5_SK`` is ``created_at``, and v1 deliberately ships no popularity sort. That makes two
+properties worth testing rather than assuming:
+
+* **Order is the admin's, exactly.** Not "roughly", not re-sorted by anything the read
+  path happens to know. The array is the ordering.
+* **Only published agents render.** The sparse-index physics that make this free for
+  browse do not apply to a hand-curated id list, so the state check is explicit — and a
+  taken-down agent must leave the shelf without an admin touching anything.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.agent_designer.services.store_service import resolve_featured, store_front
+from apis.shared.assistants.listing_repository import batch_get_agents, write_listing
+from apis.shared.assistants.models import AgentListing, PublisherProfile
+from apis.shared.assistants.publishers import put_publisher
+from apis.shared.assistants.storefront import (
+    MAX_FEATURED,
+    get_featured_ids,
+    put_featured_ids,
+)
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_PK", "AttributeType": "S"},
+                {"AttributeName": "GSI5_SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "AgentDirectoryIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI5_PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI5_SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+def _seed_agent(table, agent_id: str, *, name: str, created_at="2026-07-01T00:00:00Z"):
+    table.put_item(
+        Item={
+            "PK": f"AST#{agent_id}",
+            "SK": "METADATA",
+            "assistantId": agent_id,
+            "ownerId": "user-author",
+            "ownerName": "Ada Author",
+            "name": name,
+            "description": "A description the shelf must not show",
+            "instructions": "SECRET SYSTEM PROMPT",
+            "vectorIndexId": "assistants-index",
+            "visibility": "PUBLIC",
+            "usageCount": 0,
+            "createdAt": created_at,
+            "updatedAt": created_at,
+            "status": "COMPLETE",
+            "emoji": "📋",
+            "tagline": "One line",
+        }
+    )
+
+
+async def _publish(agent_id: str, category="Administration", created_at="2026-07-01T00:00:00Z"):
+    await write_listing(
+        agent_id,
+        AgentListing(state="published", category=category, publisher_id="pub-registrar"),
+        created_at,
+    )
+
+
+async def _unpublish(agent_id: str, state="taken_down", created_at="2026-07-01T00:00:00Z"):
+    await write_listing(
+        agent_id,
+        AgentListing(state=state, category="Administration", publisher_id="pub-registrar"),
+        created_at,
+    )
+
+
+# ── the config item ──────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_an_unset_store_front_is_empty(table):
+    assert await get_featured_ids() == []
+
+
+@pytest.mark.asyncio
+async def test_the_array_is_the_order(table):
+    await put_featured_ids(["ast-c", "ast-a", "ast-b"], updated_by="admin-1")
+
+    assert await get_featured_ids() == ["ast-c", "ast-a", "ast-b"]
+
+
+@pytest.mark.asyncio
+async def test_duplicates_collapse_to_their_first_position(table):
+    saved = await put_featured_ids(["ast-a", "ast-b", "ast-a"], updated_by="admin-1")
+
+    assert saved == ["ast-a", "ast-b"]
+
+
+@pytest.mark.asyncio
+async def test_the_row_has_a_ceiling(table):
+    with pytest.raises(ValueError):
+        await put_featured_ids(
+            [f"ast-{index}" for index in range(MAX_FEATURED + 1)], updated_by="admin-1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_later_put_replaces_the_whole_row(table):
+    await put_featured_ids(["ast-a", "ast-b"], updated_by="admin-1")
+    await put_featured_ids(["ast-c"], updated_by="admin-2")
+
+    assert await get_featured_ids() == ["ast-c"]
+
+
+# ── resolution ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_featured_rows_render_in_the_configured_order(table):
+    for agent_id, name in (("ast-a", "Alpha"), ("ast-b", "Beta"), ("ast-c", "Gamma")):
+        _seed_agent(table, agent_id, name=name)
+        await _publish(agent_id)
+
+    rows, unavailable = await resolve_featured(["ast-c", "ast-a", "ast-b"])
+
+    assert [row.name for row in rows] == ["Gamma", "Alpha", "Beta"]
+    assert unavailable == []
+
+
+@pytest.mark.asyncio
+async def test_a_featured_row_carries_no_behavior(table):
+    """The featured tile is a shelf row (D4), so it gets the same narrow projection."""
+    _seed_agent(table, "ast-a", name="Alpha")
+    await _publish("ast-a")
+
+    rows, _ = await resolve_featured(["ast-a"])
+    payload = rows[0].model_dump(by_alias=True)
+
+    for leaked in ("instructions", "description", "bindings", "ownerId", "ownerName"):
+        assert leaked not in payload
+
+
+@pytest.mark.asyncio
+async def test_the_publisher_is_resolved_for_a_featured_tile(table):
+    await put_publisher(
+        PublisherProfile(
+            id="pub-registrar", label="Office of the Registrar", kind="department", verified=True
+        )
+    )
+    _seed_agent(table, "ast-a", name="Alpha")
+    await _publish("ast-a")
+
+    rows, _ = await resolve_featured(["ast-a"])
+
+    assert rows[0].publisher.label == "Office of the Registrar"
+    assert rows[0].publisher.verified is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["taken_down", "private", "in_review", "changes_requested"])
+async def test_an_unpublished_agent_leaves_the_featured_row(table, state):
+    _seed_agent(table, "ast-a", name="Alpha")
+    await _publish("ast-a")
+    await _unpublish("ast-a", state=state)
+
+    rows, unavailable = await resolve_featured(["ast-a"])
+
+    assert rows == []
+    assert unavailable == ["ast-a"]
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_agent_is_reported_not_crashed_on(table):
+    rows, unavailable = await resolve_featured(["ast-gone"])
+
+    assert rows == []
+    assert unavailable == ["ast-gone"]
+
+
+@pytest.mark.asyncio
+async def test_an_agent_that_was_never_submitted_cannot_be_featured(table):
+    _seed_agent(table, "ast-a", name="Alpha")
+
+    rows, unavailable = await resolve_featured(["ast-a"])
+
+    assert rows == []
+    assert unavailable == ["ast-a"]
+
+
+@pytest.mark.asyncio
+async def test_a_takedown_empties_the_slot_without_rewriting_the_curation(table):
+    """Membership is not self-healing: a reversed takedown restores the slot."""
+    _seed_agent(table, "ast-a", name="Alpha")
+    await _publish("ast-a")
+    await put_featured_ids(["ast-a"], updated_by="admin-1")
+
+    await _unpublish("ast-a")
+    featured, _categories = await store_front()
+    assert featured == []
+    assert await get_featured_ids() == ["ast-a"]
+
+    await _publish("ast-a")
+    featured, _categories = await store_front()
+    assert [row.name for row in featured] == ["Alpha"]
+
+
+@pytest.mark.asyncio
+async def test_store_front_returns_the_featured_row_with_the_categories(table):
+    _seed_agent(table, "ast-a", name="Alpha")
+    await _publish("ast-a")
+    await put_featured_ids(["ast-a"], updated_by="admin-1")
+
+    featured, categories = await store_front()
+
+    assert [row.name for row in featured] == ["Alpha"]
+    assert categories, "the default category set should have been seeded"
+
+
+# ── the batch read ───────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_batch_get_skips_missing_ids(table):
+    _seed_agent(table, "ast-a", name="Alpha")
+
+    found = await batch_get_agents(["ast-a", "ast-missing"])
+
+    assert set(found) == {"ast-a"}
+
+
+@pytest.mark.asyncio
+async def test_batch_get_tolerates_duplicate_ids(table):
+    """BatchGetItem rejects duplicate keys outright, so de-duplication is not optional."""
+    _seed_agent(table, "ast-a", name="Alpha")
+
+    found = await batch_get_agents(["ast-a", "ast-a"])
+
+    assert set(found) == {"ast-a"}
+
+
+@pytest.mark.asyncio
+async def test_batch_get_of_nothing_does_not_call_dynamo(table):
+    assert await batch_get_agents([]) == {}

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -507,7 +507,7 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `GET /agents/{id}/icon` | Serve the bytes, `immutable` + ETag. What makes `iconUrl` a stable path (`/agents/{id}/icon?v={digest}`) rather than a presigned URL that changes on every read and re-downloads every shelf icon. Readable by anyone when the listing is published — the shelf already shows that agent's name, tagline and emoji to every browsing user. |
 | `POST /agents/{id}/listing/submit` | Author submits. Runs D7 checks; 400 on a `memory_space` binding. |
 | `DELETE /agents/{id}/listing` | Author unpublishes. |
-| `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). |
+| `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). Pinning is gated on the caller being able to *reach* the Agent, not on it being published. |
 | `POST /agents/{id}/report` | Report a problem with a published Agent (D15). One open report per reporter. |
 | `GET /admin/agents/reports` · `POST /admin/agents/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). |
 | `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes (D2). |
@@ -559,8 +559,8 @@ Phase 3  Detail page + runnability + the instructions gate            ✅ shippe
 Phase 3.5 Author Submit UI: submit dialog (category, note, D7 disclosures),
          listing-state badges + reviewer note + D13 edit trail on My Agents,
          withdraw/unpublish, GET /agents/{id}/listing/preflight   ✅ shipped (PR #734)
-Phase 4  Icons: upload, S3, generated fallback, all four render sizes      ← in progress
-Phase 5  Pins: user pin state + Pinned tab + store front admin
+Phase 4  Icons: upload, S3, generated fallback, all four render sizes  ✅ shipped (PR #735)
+Phase 5  Pins: user pin state + Pinned tab + store front admin              ← in progress
 Phase 6  Default pins by role (D9) + the assignment-time runnability check
 Phase 7  @-mention in the composer
 Phase 8  Problem reports (D15): report action + admin Reports queue   ← depends on 3
@@ -574,6 +574,22 @@ otherwise independent of 4–7 and can run alongside them.
 Phase 1 is the smallest thing that is independently useful: authors can submit, admins can approve
 and take down, and nothing is user-visible until Phase 2. Phases 4–7 are independent of each other
 and parallelizable once 1–3 land.
+
+**Phase 5 notes (as built).** Two decisions worth recording because the spec left them open:
+
+- **Pinning is gated on reachability, not on publication.** `POST /agents/{id}/pin` accepts anything
+  the caller could open (owner, editor, viewer), not only published listings. Publication decides
+  what the store *offers*; a pin is a bookmark, and D11 scopes the `@` menu to "your own and pinned
+  Agents", which presumes an author can pin their own unpublished work. The read applies the same
+  gate on every request, so a pin never becomes a grant.
+- **The featured row is not self-healing.** A taken-down Agent drops out of what the store and the
+  admin console *render*, but its id stays in `AGENT_STOREFRONT` until an admin saves the row. A GET
+  that pruned would rewrite an admin's curation as a side effect, and a reversed takedown would have
+  silently cost the Agent its slot. The admin surface names the stale ids instead
+  (`AdminStoreFrontResponse.unavailable`).
+
+Promotion lives on the **Store front** surface rather than as a star on the Listings table: the row
+is an ordered list, and a per-row toggle can express membership but not position.
 
 **Phase 3.5 is a gap this table originally left open.** Phases 1–3 shipped the submit and withdraw
 endpoints and the entire reviewer console, but no phase owned the *author's* half of the surface —

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -22,6 +22,7 @@ import {
   heroSparkles,
   heroInbox,
   heroRectangleStack,
+  heroStar,
   heroTag,
 } from '@ng-icons/heroicons/outline';
 
@@ -57,6 +58,7 @@ interface NavGroup {
       heroSparkles,
       heroInbox,
       heroRectangleStack,
+      heroStar,
       heroTag,
     }),
   ],
@@ -162,12 +164,13 @@ export class AdminLayout {
       ],
     },
     {
-      // Agent Marketplace. Three of D10's seven surfaces; store front, default pins and
-      // the reports queue join this group as their phases land.
+      // Agent Marketplace. Four of D10's seven surfaces; default pins and the reports
+      // queue join this group as their phases land.
       label: 'Agent Marketplace',
       items: [
         { label: 'Review Queue', icon: 'heroInbox', route: '/admin/marketplace/review' },
         { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
+        { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front' },
         { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories' },
       ],
     },

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -85,8 +85,8 @@ export const adminRoutes: Routes = [
     path: 'skills/edit/:skillId',
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
-  // Agent Marketplace (docs/specs/agent-marketplace.md) — three of D10's seven admin
-  // surfaces. Store front, default pins and the reports queue arrive in later phases.
+  // Agent Marketplace (docs/specs/agent-marketplace.md) — four of D10's seven admin
+  // surfaces. Default pins and the reports queue arrive in later phases.
   {
     path: 'marketplace/review',
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
@@ -98,6 +98,10 @@ export const adminRoutes: Routes = [
   {
     path: 'marketplace/categories',
     loadComponent: () => import('./marketplace/pages/categories.page').then(m => m.MarketplaceCategoriesPage),
+  },
+  {
+    path: 'marketplace/store-front',
+    loadComponent: () => import('./marketplace/pages/store-front.page').then(m => m.MarketplaceStoreFrontPage),
   },
   {
     path: 'marketplace',

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -1,13 +1,16 @@
 /**
- * Agent Marketplace admin types (Phase 1).
+ * Agent Marketplace admin types (Phases 1–2, 5).
  *
- * Mirrors the backend wire models in `apis/shared/assistants/models.py`. Phase 1 covers
- * two of the six admin surfaces — Review queue and Listings — plus the publisher profiles
- * they read. Store front, categories and default pins arrive in later phases.
+ * Mirrors the backend wire models in `apis/shared/assistants/models.py`. Four of D10's
+ * seven surfaces are covered — Review queue, Listings, Categories and Store front — plus
+ * the publisher profiles they read. Default pins and the reports queue arrive with their
+ * phases.
  */
 
 import {
   AdminEdit,
+  AdminStoreFrontResponse,
+  AgentListing,
   ListingState,
   LISTING_STATE_CLASSES,
   LISTING_STATE_LABELS,
@@ -21,6 +24,15 @@ import {
  */
 export type { AdminEdit, ListingState };
 export { LISTING_STATE_CLASSES, LISTING_STATE_LABELS };
+
+/**
+ * The store-front row is the *same* shelf shape Discover renders, deliberately: an admin
+ * curating the featured row should be looking at exactly the tile a user will see.
+ */
+export type { AdminStoreFrontResponse, AgentListing };
+
+/** The featured row holds at most this many agents — see `storefront.MAX_FEATURED`. */
+export const MAX_FEATURED = 10;
 
 export type PublisherKind = 'institution' | 'department' | 'individual';
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -32,9 +32,13 @@ import {
  * state badge because until the Discover page ships (Phase 2) this is the *only* view of
  * the marketplace, and an admin needs to see the ones that are not live too.
  *
- * Two mockup columns are deliberately absent because their levers do not exist yet: the
- * store-front star (Phase 5) and the inline category `<select>` (Phase 2's category CRUD).
- * Category is shown as text here rather than rendered as a control that cannot be honored.
+ * The mockup's inline category `<select>` is deliberately absent; category is shown as
+ * text rather than rendered as a control that cannot be honored here.
+ *
+ * Promotion to the store front is **not** a star on this table (Phase 5). The featured row
+ * is an ordered list, and a per-row toggle can express membership but not position — an
+ * admin promoting three agents from here would have no way to say which comes first. It
+ * lives on the Store Front surface, where the order is the thing being edited.
  */
 @Component({
   selector: 'app-marketplace-listings',

--- a/frontend/ai.client/src/app/admin/marketplace/pages/store-front.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/store-front.page.ts
@@ -1,0 +1,382 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowDown,
+  heroArrowUp,
+  heroStar,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import {
+  AdminListingRow,
+  AgentListing,
+  MAX_FEATURED,
+} from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+
+/**
+ * Store front — the Featured row, as an explicitly ordered list (D10).
+ *
+ * This surface exists because **it is the only ranking lever the store has.** Browse is
+ * newest-first (`GSI5_SK` is `created_at`) and v1 ships no popularity sort, so promotion
+ * is how a good Agent gets found. That makes the ordering something a person owns, not
+ * something the system infers — hence explicit slots with explicit move controls rather
+ * than drag-and-drop, which is hard to operate by keyboard and impossible to describe in
+ * a screen reader without a live region.
+ *
+ * The editor is **staged**: moves and removals change local order, and Save writes the
+ * whole array in one PUT. Reordering has to be atomic — a half-applied order is a store
+ * front nobody chose — and per-move autosave would make every mis-click a live change to
+ * the front page of the store.
+ *
+ * Only published agents may be featured, and that rule is enforced server-side: the PUT
+ * names any id that is not published rather than silently dropping it. `unavailable`
+ * carries the same news for ids that *were* published when they were promoted and have
+ * since been taken down.
+ */
+@Component({
+  selector: 'app-marketplace-store-front',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, AgentTileComponent, TooltipDirective],
+  providers: [provideIcons({ heroArrowDown, heroArrowUp, heroStar, heroXMark })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Store front</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            The featured row at the top of Discover, in order. Everything below it is
+            newest-first — there is no popularity ranking — so this is how a good agent
+            gets found. Up to {{ maxFeatured }} agents.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (unavailable().length) {
+          <div
+            role="status"
+            class="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            {{ unavailable().length }}
+            {{ unavailable().length === 1 ? 'featured agent is' : 'featured agents are' }}
+            no longer published, so
+            {{ unavailable().length === 1 ? 'its slot is' : 'their slots are' }}
+            empty on Discover. Saving this row clears
+            {{ unavailable().length === 1 ? 'it' : 'them' }}.
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading the store front</span>
+          </div>
+        } @else {
+          <!-- The row -->
+          <section class="mb-8">
+            <div class="mb-3 flex items-center justify-between gap-4">
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                Featured ({{ featured().length }}/{{ maxFeatured }})
+              </h2>
+              <div class="flex items-center gap-2">
+                @if (dirty()) {
+                  <button
+                    type="button"
+                    (click)="reload()"
+                    [disabled]="busy()"
+                    class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    Discard
+                  </button>
+                }
+                <button
+                  type="button"
+                  (click)="save()"
+                  [disabled]="!dirty() || busy()"
+                  class="rounded-2xl bg-blue-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {{ dirty() ? 'Save order' : 'Saved' }}
+                </button>
+              </div>
+            </div>
+
+            @if (featured().length === 0) {
+              <div
+                class="rounded-2xl border border-dashed border-gray-300 px-6 py-12 text-center dark:border-gray-600"
+              >
+                <ng-icon
+                  name="heroStar"
+                  class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+                <h3 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+                  Nothing featured
+                </h3>
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                  Discover renders no featured row until something is promoted below.
+                </p>
+              </div>
+            } @else {
+              <ol class="flex flex-col gap-2">
+                @for (row of featured(); track row.agentId; let i = $index) {
+                  <li
+                    class="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    <span
+                      class="w-6 shrink-0 text-center text-sm/6 font-semibold tabular-nums text-gray-400 dark:text-gray-500"
+                      aria-hidden="true"
+                    >
+                      {{ i + 1 }}
+                    </span>
+                    <app-agent-tile
+                      [agentId]="row.agentId"
+                      [iconUrl]="row.iconUrl"
+                      [emoji]="row.emoji"
+                      size="sm"
+                    />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                        {{ row.name }}
+                      </p>
+                      <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {{ row.tagline || row.publisher?.label || row.category }}
+                      </p>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        (click)="moveUp(i)"
+                        [disabled]="i === 0 || busy()"
+                        [appTooltip]="'Move up'"
+                        appTooltipPosition="top"
+                        class="rounded-2xl p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                      >
+                        <ng-icon name="heroArrowUp" class="size-5" aria-hidden="true" />
+                        <span class="sr-only">Move {{ row.name }} up</span>
+                      </button>
+                      <button
+                        type="button"
+                        (click)="moveDown(i)"
+                        [disabled]="i === featured().length - 1 || busy()"
+                        [appTooltip]="'Move down'"
+                        appTooltipPosition="top"
+                        class="rounded-2xl p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                      >
+                        <ng-icon name="heroArrowDown" class="size-5" aria-hidden="true" />
+                        <span class="sr-only">Move {{ row.name }} down</span>
+                      </button>
+                      <button
+                        type="button"
+                        (click)="remove(row.agentId)"
+                        [disabled]="busy()"
+                        [appTooltip]="'Remove from the featured row'"
+                        appTooltipPosition="top"
+                        class="rounded-2xl p-2 text-gray-500 hover:bg-rose-50 hover:text-rose-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-rose-900/20 dark:hover:text-rose-400"
+                      >
+                        <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+                        <span class="sr-only">Remove {{ row.name }}</span>
+                      </button>
+                    </div>
+                  </li>
+                }
+              </ol>
+            }
+          </section>
+
+          <!-- The candidates -->
+          <section>
+            <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">
+              Published agents
+            </h2>
+            <p class="mb-3 text-sm/6 text-gray-600 dark:text-gray-400">
+              Only published agents can be featured — a tile nobody can open is worse than
+              a short row.
+            </p>
+
+            @if (candidates().length === 0) {
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                Nothing else is published yet.
+              </p>
+            } @else {
+              <ul class="flex flex-col gap-2">
+                @for (row of candidates(); track row.agentId) {
+                  <li
+                    class="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    <app-agent-tile
+                      [agentId]="row.agentId"
+                      [iconUrl]="row.iconUrl"
+                      [emoji]="row.emoji"
+                      size="sm"
+                    />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                        {{ row.name }}
+                      </p>
+                      <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {{ row.tagline || row.category }}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      (click)="promote(row)"
+                      [disabled]="isFull() || busy()"
+                      [appTooltip]="
+                        isFull()
+                          ? 'The featured row is full — remove one first'
+                          : 'Add to the featured row'
+                      "
+                      appTooltipPosition="top"
+                      class="shrink-0 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      Feature
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
+          </section>
+        }
+      </div>
+    </div>
+  `,
+})
+export class MarketplaceStoreFrontPage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+
+  readonly maxFeatured = MAX_FEATURED;
+
+  readonly featured = signal<AgentListing[]>([]);
+  readonly published = signal<AdminListingRow[]>([]);
+  readonly unavailable = signal<string[]>([]);
+  readonly loading = signal(true);
+  readonly busy = signal(false);
+  readonly error = signal<string | null>(null);
+
+  /** The saved order, to compare against. Staging is what makes reordering atomic. */
+  private savedOrder = signal<string[]>([]);
+
+  private readonly order = computed(() => this.featured().map((row) => row.agentId));
+
+  readonly dirty = computed(
+    () => this.order().join(' ') !== this.savedOrder().join(' '),
+  );
+
+  readonly isFull = computed(() => this.featured().length >= MAX_FEATURED);
+
+  /** Published agents not already in the row — the only things that may be promoted. */
+  readonly candidates = computed(() => {
+    const already = new Set(this.order());
+    return this.published().filter((row) => !already.has(row.agentId));
+  });
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const [front, published] = await Promise.all([
+        this.service.loadStoreFront(),
+        this.service.loadListings('published'),
+      ]);
+      this.featured.set(front.featured ?? []);
+      this.unavailable.set(front.unavailable ?? []);
+      this.savedOrder.set((front.featured ?? []).map((row) => row.agentId));
+      this.published.set(published);
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load the store front.'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * Promote from the published list. The row is built from the admin row rather than
+   * re-fetched: the two shapes overlap on everything a tile renders, and Save round-trips
+   * the authoritative version back anyway.
+   */
+  promote(row: AdminListingRow): void {
+    if (this.isFull()) return;
+    this.featured.update((current) => [
+      ...current,
+      {
+        agentId: row.agentId,
+        name: row.name,
+        tagline: row.tagline,
+        emoji: row.emoji,
+        iconUrl: row.iconUrl,
+        publisher: row.publisher
+          ? {
+              label: row.publisher.label,
+              kind: row.publisher.kind,
+              verified: row.publisher.verified,
+            }
+          : null,
+        category: row.category,
+      },
+    ]);
+  }
+
+  remove(agentId: string): void {
+    this.featured.update((current) => current.filter((row) => row.agentId !== agentId));
+  }
+
+  moveUp(index: number): void {
+    this.swap(index, index - 1);
+  }
+
+  moveDown(index: number): void {
+    this.swap(index, index + 1);
+  }
+
+  private swap(from: number, to: number): void {
+    this.featured.update((current) => {
+      if (to < 0 || to >= current.length) return current;
+      const next = [...current];
+      [next[from], next[to]] = [next[to], next[from]];
+      return next;
+    });
+  }
+
+  async save(): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      const saved = await this.service.saveStoreFront(this.order());
+      this.featured.set(saved.featured ?? []);
+      this.unavailable.set(saved.unavailable ?? []);
+      this.savedOrder.set((saved.featured ?? []).map((row) => row.agentId));
+    } catch (err) {
+      // The refusal names the offending ids, so the server's message beats a generic one.
+      this.error.set(this.messageFor(err, 'Failed to save the store front.'));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
   AdminListingRow,
+  AdminStoreFrontResponse,
   AgentCategory,
   AdminListingsResponse,
   ListingPatchRequest,
@@ -21,7 +22,7 @@ interface CategoriesResponse {
 }
 
 /**
- * Admin surface for the Agent Marketplace (Phase 1).
+ * Admin surface for the Agent Marketplace (Phases 1–2, 5).
  *
  * Mirrors `AdminSkillService`: signal-backed state plus explicit reload, so the two
  * pages can share the pending count without either owning the other's fetch.
@@ -131,6 +132,26 @@ export class AdminMarketplaceService {
   async deleteCategory(categoryId: string): Promise<void> {
     await firstValueFrom(
       this.http.delete(`${this.baseUrl()}/categories/${encodeURIComponent(categoryId)}`),
+    );
+  }
+
+  /** The featured row, resolved in its configured order (D10). */
+  async loadStoreFront(): Promise<AdminStoreFrontResponse> {
+    return firstValueFrom(
+      this.http.get<AdminStoreFrontResponse>(`${this.baseUrl()}/storefront`),
+    );
+  }
+
+  /**
+   * Replace the featured row.
+   *
+   * A whole-list PUT because reordering has to be atomic — the ordered array *is* the
+   * record. The server refuses any id that is not published and names it, so the caller
+   * surfaces the message rather than pre-validating a copy of that rule.
+   */
+  async saveStoreFront(agentIds: string[]): Promise<AdminStoreFrontResponse> {
+    return firstValueFrom(
+      this.http.put<AdminStoreFrontResponse>(`${this.baseUrl()}/storefront`, { agentIds }),
     );
   }
 

--- a/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
@@ -1,71 +1,126 @@
-import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroCheckBadge } from '@ng-icons/heroicons/outline';
+import { heroCheck, heroCheckBadge, heroPlus } from '@ng-icons/heroicons/outline';
 import { AgentListing } from '../models/store.model';
 import { AgentIconComponent } from './agent-icon.component';
+import { AgentPinService } from '../services/agent-pin.service';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 
 /**
- * One shelf row: icon, name, one line (D4).
+ * One shelf row: icon, name, one line (D4), and the `＋` that pins it (D8).
  *
  * Deliberately carries no model chip, no tool/skill counts, no chat count and no
  * runnability badge. A row's job is to make you tap; everything else lives on the detail
  * page and in admin reporting.
  *
- * The icon is `app-agent-icon` at 40px: the author's uploaded square when there is one,
- * the generated gradient carrying the emoji when there is not (D5).
+ * The row has **two** destinations, which is why the anchor no longer wraps the whole
+ * thing: tapping the body opens the detail page, tapping `＋` pins without leaving the
+ * shelf. A button nested inside an anchor is invalid HTML and swallows its own activation
+ * in some browsers, so the two are siblings under a shared hover container.
  *
- * The whole row routes to the detail page (Phase 3). A `+` add affordance sits beside it
- * in the mockup; that is Phase 5's pin, so the row has exactly one destination today.
+ * Pinning is a pointer, never a fork (D8) — nothing is copied, and the Agent the user
+ * reaches tomorrow is the one its author maintains.
  */
 @Component({
   selector: 'app-agent-listing-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [AgentIconComponent, NgIcon, RouterLink, TooltipDirective],
-  providers: [provideIcons({ heroCheckBadge })],
+  providers: [provideIcons({ heroCheck, heroCheckBadge, heroPlus })],
   template: `
-    <a
-      [routerLink]="['/agents', listing().agentId]"
-      class="flex w-full items-center gap-3 rounded-2xl px-3 py-2.5 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:hover:bg-gray-800"
+    <div
+      class="group flex w-full items-center gap-1 rounded-2xl pr-2 hover:bg-gray-50 dark:hover:bg-gray-800"
     >
-      <app-agent-icon
-        [agentId]="listing().agentId"
-        [iconUrl]="listing().iconUrl"
-        [emoji]="listing().emoji"
-        [size]="40"
-      />
-      <div class="min-w-0 flex-1">
-        <p
-          class="flex items-center gap-1.5 truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >
-          {{ listing().name }}
-          @if (listing().publisher?.verified) {
-            <ng-icon
-              name="heroCheckBadge"
-              class="size-4 shrink-0 text-blue-600 dark:text-blue-400"
-              [appTooltip]="verifiedTooltip()"
-              appTooltipPosition="top"
-            />
-          }
-        </p>
-        <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
-          {{ subtitle() }}
-        </p>
-      </div>
-    </a>
+      <a
+        [routerLink]="['/agents', listing().agentId]"
+        class="flex min-w-0 flex-1 items-center gap-3 rounded-2xl px-3 py-2.5 text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      >
+        <app-agent-icon
+          [agentId]="listing().agentId"
+          [iconUrl]="listing().iconUrl"
+          [emoji]="listing().emoji"
+          [size]="40"
+        />
+        <div class="min-w-0 flex-1">
+          <p
+            class="flex items-center gap-1.5 truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+          >
+            {{ listing().name }}
+            @if (listing().publisher?.verified) {
+              <ng-icon
+                name="heroCheckBadge"
+                class="size-4 shrink-0 text-blue-600 dark:text-blue-400"
+                [appTooltip]="verifiedTooltip()"
+                appTooltipPosition="top"
+              />
+            }
+          </p>
+          <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
+            {{ subtitle() }}
+          </p>
+        </div>
+      </a>
+
+      <button
+        type="button"
+        (click)="onTogglePin()"
+        [disabled]="busy()"
+        [appTooltip]="pinTooltip()"
+        appTooltipPosition="top"
+        [attr.aria-pressed]="isPinned()"
+        class="grid size-8 shrink-0 place-items-center rounded-full text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-gray-700 dark:hover:text-white"
+        [class]="
+          isPinned()
+            ? 'text-emerald-600 dark:text-emerald-400'
+            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+        "
+      >
+        <ng-icon [name]="isPinned() ? 'heroCheck' : 'heroPlus'" class="size-5" />
+        <span class="sr-only">{{ pinTooltip() }}</span>
+      </button>
+    </div>
   `,
 })
 export class AgentListingRowComponent {
+  private pinService = inject(AgentPinService);
+
   readonly listing = input.required<AgentListing>();
+
+  readonly busy = signal(false);
 
   /** The tagline is the subtitle; the publisher is the fallback when there isn't one. */
   subtitle(): string {
     return this.listing().tagline || this.listing().publisher?.label || '';
   }
 
+  isPinned(): boolean {
+    return this.pinService.isPinned(this.listing().agentId);
+  }
+
+  /**
+   * The pinned state is a check rather than a filled `＋`, and the control stays visible
+   * once pinned: an affordance that vanishes on success leaves the user unsure whether
+   * anything happened, and there would be no way back.
+   */
+  pinTooltip(): string {
+    return this.isPinned()
+      ? `Remove ${this.listing().name} from your agents`
+      : `Add ${this.listing().name} to your agents`;
+  }
+
   verifiedTooltip(): string {
     const label = this.listing().publisher?.label ?? 'a university team';
     return `Published by ${label} — a verified university team`;
+  }
+
+  async onTogglePin(): Promise<void> {
+    this.busy.set(true);
+    try {
+      await this.pinService.toggle(this.listing().agentId);
+    } catch {
+      // The service holds the user-facing message and has already rolled back.
+    } finally {
+      this.busy.set(false);
+    }
   }
 }

--- a/frontend/ai.client/src/app/agents/components/agents-tabs.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agents-tabs.component.ts
@@ -4,8 +4,10 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
 /**
  * The `/agents` hub tab strip.
  *
- * Phase 2 has two tabs. **Pinned** joins in Phase 5 — deliberately not rendered now,
- * because a tab that leads to an empty page teaches people not to click tabs.
+ * Three tabs as of Phase 5: **Discover** (the store), **My Agents** (what you built) and
+ * **Pinned** (what you added). Pinned is rendered unconditionally rather than only when
+ * the user has pins — a tab that appears after the first pin is a tab nobody discovers,
+ * and its empty state is the one that explains what pinning is for.
  */
 @Component({
   selector: 'app-agents-tabs',
@@ -30,6 +32,13 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
         class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
       >
         My Agents
+      </a>
+      <a
+        routerLink="/agents/pinned"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        Pinned
       </a>
     </nav>
   `,

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -12,12 +12,15 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
   heroArrowRight,
+  heroCheck,
   heroCheckBadge,
   heroCheckCircle,
   heroExclamationTriangle,
   heroNoSymbol,
+  heroPlus,
 } from '@ng-icons/heroicons/outline';
 import { AgentApiService } from '../services/agent-api.service';
+import { AgentPinService } from '../services/agent-pin.service';
 import { Agent, AgentRunnability } from '../models/agent.model';
 import { AgentIconComponent } from '../components/agent-icon.component';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
@@ -34,9 +37,14 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
  * and settles into the sidebar when it arrives. Blocking the whole page on the slower
  * question would trade a fast page for a spinner.
  *
- * Not here yet, by phase: "Add to my agents" (pins, Phase 5) and "Report a problem"
- * (Phase 8). Rendering an affordance whose backing lever does not exist is how a store
- * starts lying, so the header carries Start chat alone.
+ * "Add to my agents" (D8, Phase 5) sits beside Start chat and is a **pin, never a fork**:
+ * it stores a pointer, so the Agent the user opens tomorrow is the one its author
+ * maintains. It is deliberately *not* gated on runnability — a user may reasonably keep
+ * an Agent they cannot run today, and hiding the button would leave them nothing to do
+ * with the page.
+ *
+ * Not here yet, by phase: "Report a problem" (Phase 8). Rendering an affordance whose
+ * backing lever does not exist is how a store starts lying.
  */
 @Component({
   selector: 'app-agent-detail',
@@ -46,10 +54,12 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
     provideIcons({
       heroArrowLeft,
       heroArrowRight,
+      heroCheck,
       heroCheckBadge,
       heroCheckCircle,
       heroExclamationTriangle,
       heroNoSymbol,
+      heroPlus,
     }),
   ],
   template: `
@@ -113,17 +123,49 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
                 }
               </p>
             </div>
-            <button
-              type="button"
-              (click)="onStartChat()"
-              [disabled]="isBlocked()"
-              [appTooltip]="startChatTooltip()"
-              appTooltipPosition="top"
-              class="rounded-full bg-blue-600 px-4 py-2 text-sm/6 font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-45 dark:bg-blue-500 dark:hover:bg-blue-400"
-            >
-              Start chat
-            </button>
+            <div class="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                (click)="onTogglePin()"
+                [disabled]="pinBusy()"
+                [appTooltip]="pinTooltip()"
+                appTooltipPosition="top"
+                [attr.aria-pressed]="isPinned()"
+                class="inline-flex items-center gap-1.5 rounded-full border px-4 py-2 text-sm/6 font-semibold disabled:cursor-not-allowed disabled:opacity-45"
+                [class]="
+                  isPinned()
+                    ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-900 dark:bg-emerald-900/20 dark:text-emerald-300'
+                    : 'border-gray-300 bg-white text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700'
+                "
+              >
+                <ng-icon
+                  [name]="isPinned() ? 'heroCheck' : 'heroPlus'"
+                  class="size-4"
+                  aria-hidden="true"
+                />
+                {{ isPinned() ? 'Added' : 'Add' }}
+              </button>
+              <button
+                type="button"
+                (click)="onStartChat()"
+                [disabled]="isBlocked()"
+                [appTooltip]="startChatTooltip()"
+                appTooltipPosition="top"
+                class="rounded-full bg-blue-600 px-4 py-2 text-sm/6 font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-45 dark:bg-blue-500 dark:hover:bg-blue-400"
+              >
+                Start chat
+              </button>
+            </div>
           </div>
+
+          @if (pinError()) {
+            <p
+              role="alert"
+              class="mt-3 text-sm/6 text-rose-700 dark:text-rose-400"
+            >
+              {{ pinError() }}
+            </p>
+          }
 
           <!--
             Hero: the @-mention prompt this agent answers to. Display-only — the
@@ -251,6 +293,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 })
 export class AgentDetailPage {
   private api = inject(AgentApiService);
+  private pinService = inject(AgentPinService);
   private router = inject(Router);
 
   /** Bound from the `agents/:id` route via `withComponentInputBinding`. */
@@ -260,9 +303,18 @@ export class AgentDetailPage {
   readonly runnability = signal<AgentRunnability | null>(null);
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
+  readonly pinBusy = signal(false);
+  /**
+   * Local rather than the service's signal: that one also carries list-load failures,
+   * and "failed to load your pinned agents" under the Add button would read as a
+   * complaint about an action the user did not take.
+   */
+  readonly pinError = signal<string | null>(null);
 
   constructor() {
     void this.load();
+    // Cached across the session, so arriving from a shelf row costs nothing.
+    void this.pinService.load();
   }
 
   private async load(): Promise<void> {
@@ -345,6 +397,30 @@ export class AgentDetailPage {
     const lead = r.state === 'limits' ? 'Runs with limits for you' : 'Not available to you';
     return names ? `${lead} — ${names} ${verb} granted to your role.` : `${lead}.`;
   });
+
+  isPinned(): boolean {
+    return this.pinService.isPinned(this.id());
+  }
+
+  pinTooltip(): string {
+    const name = this.agent()?.name ?? 'this agent';
+    return this.isPinned()
+      ? `Remove ${name} from your agents`
+      : `Add ${name} to your agents — a pointer, not a copy`;
+  }
+
+  async onTogglePin(): Promise<void> {
+    this.pinBusy.set(true);
+    this.pinError.set(null);
+    try {
+      await this.pinService.toggle(this.id());
+    } catch {
+      // The service has already rolled the list back and holds the message.
+      this.pinError.set(this.pinService.error());
+    } finally {
+      this.pinBusy.set(false);
+    }
+  }
 
   startChatTooltip(): string {
     return this.isBlocked()

--- a/frontend/ai.client/src/app/agents/discover/discover.page.ts
+++ b/frontend/ai.client/src/app/agents/discover/discover.page.ts
@@ -8,32 +8,46 @@ import {
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroMagnifyingGlass, heroSparkles } from '@ng-icons/heroicons/outline';
+import { RouterLink } from '@angular/router';
 import { AgentStoreService } from '../services/agent-store.service';
+import { AgentPinService } from '../services/agent-pin.service';
 import { AgentListing, CategoryShelf } from '../models/store.model';
 import { AgentsTabsComponent } from '../components/agents-tabs.component';
+import { AgentIconComponent } from '../components/agent-icon.component';
 import { AgentListingRowComponent } from '../components/agent-listing-row.component';
 
 /**
- * Discover — the browse surface over published Agents (D4, Phase 2).
+ * Discover — the browse surface over published Agents (D4, D10, Phases 2 and 5).
  *
  * Rows carry an icon, a name and one line, and nothing else: no model chip, no tool or
  * skill counts, no chat counts, no runnability badge. Those numbers are still collected
  * and still surfaced — on the detail page and in admin reporting — but a store row that
  * reports its own dependency list is a spec sheet, and it scans like one.
  *
+ * Above the shelves sit two rows that are not shelves. The **Pinned strip** is the
+ * user's own set, here because arriving at a store you have used before and seeing none
+ * of your own choices is disorienting. The **Featured row** is the admin's curation, and
+ * it is the store's *only* ranking lever — everything below it is newest-first, because
+ * `GSI5_SK` is `created_at` and v1 ships no popularity sort. Both are hidden when empty.
+ *
  * Search filters what has been loaded rather than issuing a query per keystroke. The
  * store is small enough that this is honest; a real full-corpus search arrives with the
  * Registry catalog, and pretending to have one now would mean silently missing results
  * past the first page.
- *
- * Not here yet, by phase: the featured row renders only once the store-front admin can
- * populate it (Phase 5), and rows are not yet clickable because the detail page is
- * Phase 3.
  */
+/** How many pins the strip shows before deferring to the Pinned tab. */
+const PINNED_STRIP_LIMIT = 8;
+
 @Component({
   selector: 'app-agent-discover',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, AgentsTabsComponent, AgentListingRowComponent],
+  imports: [
+    NgIcon,
+    RouterLink,
+    AgentsTabsComponent,
+    AgentIconComponent,
+    AgentListingRowComponent,
+  ],
   providers: [provideIcons({ heroMagnifyingGlass, heroSparkles })],
   template: `
     <div class="min-h-dvh">
@@ -70,6 +84,18 @@ import { AgentListingRowComponent } from '../components/agent-listing-row.compon
             class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
           >
             {{ error() }}
+          </div>
+        }
+
+        <!-- Separate from the store's own error: a row's add control failing is a
+             different event from the shelves failing to load, and a pin that silently
+             does nothing is the worst of the three outcomes. -->
+        @if (pinError()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ pinError() }}
           </div>
         }
 
@@ -116,6 +142,73 @@ import { AgentListingRowComponent } from '../components/agent-listing-row.compon
             </ul>
           </section>
         } @else {
+          @if (pinned().length) {
+            <section class="mb-8">
+              <div class="mb-3 flex items-baseline justify-between gap-4">
+                <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                  Your pinned agents
+                </h2>
+                <a
+                  routerLink="/agents/pinned"
+                  class="text-sm/6 font-medium text-blue-600 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400"
+                >
+                  See all
+                </a>
+              </div>
+              <ul class="flex flex-wrap gap-2">
+                @for (pin of pinnedStrip(); track pin.agentId) {
+                  <li>
+                    <a
+                      [routerLink]="['/agents', pin.agentId]"
+                      class="flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1.5 pl-1.5 pr-4 text-sm/6 font-medium text-gray-900 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+                    >
+                      <app-agent-icon
+                        [agentId]="pin.agentId"
+                        [iconUrl]="pin.iconUrl"
+                        [emoji]="pin.emoji"
+                        [size]="28"
+                      />
+                      {{ pin.name }}
+                    </a>
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+
+          @if (featured().length) {
+            <section class="mb-8">
+              <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">
+                Featured
+              </h2>
+              <ul class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                @for (listing of featured(); track listing.agentId) {
+                  <li>
+                    <a
+                      [routerLink]="['/agents', listing.agentId]"
+                      class="flex h-full items-start gap-3 rounded-2xl border border-gray-200 bg-white p-4 hover:border-gray-300 hover:shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
+                    >
+                      <app-agent-icon
+                        [agentId]="listing.agentId"
+                        [iconUrl]="listing.iconUrl"
+                        [emoji]="listing.emoji"
+                        [size]="52"
+                      />
+                      <div class="min-w-0 flex-1">
+                        <p class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+                          {{ listing.name }}
+                        </p>
+                        <p class="line-clamp-2 text-sm/6 text-gray-500 dark:text-gray-400">
+                          {{ listing.tagline || listing.publisher?.label || '' }}
+                        </p>
+                      </div>
+                    </a>
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+
           @for (shelf of shelves(); track shelf.category.id) {
             <section class="mb-8">
               <h2 class="mb-3 text-base/7 font-semibold text-gray-900 dark:text-white">
@@ -138,12 +231,17 @@ import { AgentListingRowComponent } from '../components/agent-listing-row.compon
 })
 export class AgentDiscoverPage implements OnInit {
   private store = inject(AgentStoreService);
+  private pinService = inject(AgentPinService);
 
   readonly shelves = signal<CategoryShelf[]>([]);
   readonly featured = signal<AgentListing[]>([]);
   readonly query = signal('');
   readonly loading = this.store.loading;
   readonly error = this.store.error;
+
+  readonly pinned = this.pinService.pins;
+  readonly pinError = this.pinService.error;
+  readonly pinnedStrip = computed(() => this.pinned().slice(0, PINNED_STRIP_LIMIT));
 
   /** Everything loaded, flattened — the corpus search filters over. */
   private readonly allListings = computed(() =>
@@ -166,6 +264,9 @@ export class AgentDiscoverPage implements OnInit {
 
   ngOnInit(): void {
     void this.load();
+    // Independent of the shelves: every row asks the pin service whether it is pinned,
+    // and a failure there must not keep the store from rendering.
+    void this.pinService.load();
   }
 
   async load(): Promise<void> {

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -150,9 +150,39 @@ export interface AgentStoreResponse {
 }
 
 export interface AgentStoreFrontResponse {
-  /** Curated row; empty until the store-front admin ships in Phase 5. */
+  /** The admin's curated row — the store's only ranking lever (D10). */
   featured: AgentListing[];
   categories: AgentCategory[];
+}
+
+/**
+ * One row on the Pinned shelf (D8, D9).
+ *
+ * The shelf projection plus the two fields that say *why* it is pinned. `source` is
+ * always `'user'` and `locked` always `false` in Phase 5 — role-seeded pins are Phase 6 —
+ * and both are on the contract now so that phase adds rows rather than changing a shape
+ * the SPA already renders.
+ */
+export interface PinnedAgent extends AgentListing {
+  source: 'user' | 'role';
+  /** A locked role pin cannot be removed; the control is hidden rather than disabled. */
+  locked: boolean;
+  pinnedAt?: string;
+}
+
+export interface AgentPinsResponse {
+  pins: PinnedAgent[];
+}
+
+/** The featured row as the admin console sees it (D10). */
+export interface AdminStoreFrontResponse {
+  featured: AgentListing[];
+  /**
+   * Configured ids that no longer resolve as published listings. Reported rather than
+   * pruned on read, so an admin can see why the row is short instead of watching a
+   * curation silently rewrite itself.
+   */
+  unavailable: string[];
 }
 
 /** A category plus the listings currently on its shelf, for the Discover sections. */

--- a/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
+++ b/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
@@ -1,0 +1,112 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroBookmark } from '@ng-icons/heroicons/outline';
+import { AgentPinService } from '../services/agent-pin.service';
+import { AgentsTabsComponent } from '../components/agents-tabs.component';
+import { AgentListingRowComponent } from '../components/agent-listing-row.component';
+
+/**
+ * Pinned — the Agents a user has added to their own set (D8, D9, Phase 5).
+ *
+ * The rows are the same shelf rows Discover renders, and their `＋` has already become a
+ * check, so removing one happens here without a second control to learn. That is the
+ * whole reason the pin toggle lives on the row rather than on the page: one gesture,
+ * everywhere it appears.
+ *
+ * Phase 6 adds role-seeded pins to this same list. It needs no new page — a seeded pin is
+ * a pin — but it does need this page to keep respecting `locked`, which is why the removal
+ * control is driven by the row's own state rather than by "is this page the Pinned tab".
+ *
+ * A pin whose Agent was deleted, or whose visibility narrowed, is simply absent: the
+ * server resolves the list against the viewer on every read, and it does not delete the
+ * underlying pin for either reason.
+ */
+@Component({
+  selector: 'app-agent-pinned',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AgentsTabsComponent, AgentListingRowComponent, NgIcon, RouterLink],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <app-agents-tabs />
+
+        <div class="mt-6 mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Pinned agents</h1>
+          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+            The agents you have added. Removing one here does not affect anyone else.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading pinned agents</span>
+          </div>
+        } @else if (isEmpty()) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroBookmark"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              Nothing pinned yet
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Add an agent from Discover and it will wait for you here.
+            </p>
+            <a
+              routerLink="/agents/discover"
+              class="mt-4 inline-flex rounded-full bg-blue-600 px-4 py-2 text-sm/6 font-semibold text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400"
+            >
+              Browse agents
+            </a>
+          </div>
+        } @else {
+          <ul class="grid gap-x-8 sm:grid-cols-2">
+            @for (pin of pins(); track pin.agentId) {
+              <li>
+                <app-agent-listing-row [listing]="pin" />
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class AgentPinnedPage implements OnInit {
+  private pinService = inject(AgentPinService);
+
+  readonly pins = this.pinService.pins;
+  readonly loading = this.pinService.loading;
+  readonly error = this.pinService.error;
+
+  readonly isEmpty = computed(() => this.pins().length === 0);
+
+  ngOnInit(): void {
+    // Forced: this is the page whose whole content is the list, so a stale session-cached
+    // answer is exactly the thing a user arrives here to check.
+    void this.pinService.load(true);
+  }
+}

--- a/frontend/ai.client/src/app/agents/services/agent-pin.service.spec.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-pin.service.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { AgentPinService } from './agent-pin.service';
+import { ConfigService } from '../../services/config.service';
+import { PinnedAgent } from '../models/store.model';
+
+function pin(agentId: string, name = agentId): PinnedAgent {
+  return {
+    agentId,
+    name,
+    category: 'Teaching',
+    source: 'user',
+    locked: false,
+  };
+}
+
+/**
+ * The pin service backs three surfaces at once (the Pinned tab, every Discover row's
+ * `＋`, the detail page's Add), so the cases that matter are the ones where those three
+ * could disagree: a cached load, an optimistic write, and a rollback.
+ */
+describe('AgentPinService', () => {
+  let service: AgentPinService;
+  let http: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    http = { get: vi.fn(), post: vi.fn(), delete: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AgentPinService,
+        { provide: HttpClient, useValue: http },
+        { provide: ConfigService, useValue: { appApiUrl: () => '/api' } },
+      ],
+    });
+    service = TestBed.inject(AgentPinService);
+  });
+
+  it('loads the effective pin list once per session', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001')] }));
+
+    await service.load();
+    await service.load();
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(service.pins().map((p) => p.agentId)).toEqual(['ast-001']);
+  });
+
+  it('re-reads when forced', async () => {
+    http.get.mockReturnValue(of({ pins: [] }));
+
+    await service.load();
+    await service.load(true);
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the store browsable when the pin read fails', async () => {
+    http.get.mockReturnValue(throwError(() => ({ error: { detail: 'nope' } })));
+
+    const pins = await service.load();
+
+    expect(pins).toEqual([]);
+    expect(service.error()).toBe('nope');
+  });
+
+  it('answers isPinned from the loaded set', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001')] }));
+    await service.load();
+
+    expect(service.isPinned('ast-001')).toBe(true);
+    expect(service.isPinned('ast-002')).toBe(false);
+  });
+
+  it('adds the server row rather than an optimistic guess', async () => {
+    const row = { ...pin('ast-001', 'Policy Lookup'), tagline: 'From the server' };
+    http.post.mockReturnValue(of(row));
+
+    await service.pin('ast-001');
+
+    expect(http.post).toHaveBeenCalledWith('/api/agents/ast-001/pin', {});
+    expect(service.pins()[0].tagline).toBe('From the server');
+  });
+
+  it('does not re-request a pin it already holds', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001')] }));
+    await service.load();
+
+    await service.pin('ast-001');
+
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('rolls the list back when a pin fails', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001')] }));
+    await service.load();
+    http.post.mockReturnValue(throwError(() => ({ error: { detail: 'Too many pins.' } })));
+
+    await expect(service.pin('ast-002')).rejects.toBeTruthy();
+
+    expect(service.pins().map((p) => p.agentId)).toEqual(['ast-001']);
+    expect(service.error()).toBe('Too many pins.');
+  });
+
+  it('removes optimistically', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001'), pin('ast-002')] }));
+    await service.load();
+    http.delete.mockReturnValue(of(null));
+
+    await service.unpin('ast-001');
+
+    expect(http.delete).toHaveBeenCalledWith('/api/agents/ast-001/pin');
+    expect(service.pins().map((p) => p.agentId)).toEqual(['ast-002']);
+  });
+
+  it('restores the row when a removal fails', async () => {
+    http.get.mockReturnValue(of({ pins: [pin('ast-001')] }));
+    await service.load();
+    http.delete.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    await expect(service.unpin('ast-001')).rejects.toBeTruthy();
+
+    expect(service.pins().map((p) => p.agentId)).toEqual(['ast-001']);
+  });
+
+  it('toggles in both directions', async () => {
+    http.get.mockReturnValue(of({ pins: [] }));
+    await service.load();
+    http.post.mockReturnValue(of(pin('ast-001')));
+    http.delete.mockReturnValue(of(null));
+
+    await service.toggle('ast-001');
+    expect(service.isPinned('ast-001')).toBe(true);
+
+    await service.toggle('ast-001');
+    expect(service.isPinned('ast-001')).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/agents/services/agent-pin.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-pin.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../services/config.service';
+import { AgentPinsResponse, PinnedAgent } from '../models/store.model';
+
+/**
+ * The user's pinned Agents (Marketplace D8, D9 user side — Phase 5).
+ *
+ * One session-wide list, because three surfaces need the same answer at once: the Pinned
+ * tab renders it, every Discover row asks "is this one pinned?", and the detail page's
+ * Add button is the same question for one id. A per-surface fetch would show a row as
+ * unpinned in one place and pinned in another within the same second.
+ *
+ * **Writes update the local list before the server answers**, and roll back on failure.
+ * A pin is a bookmark: the honest interaction is instant, and the cost of being wrong is
+ * a row that reappears with an error message rather than anything lost.
+ *
+ * `pinnedIds` is a `Set` rather than a scan of the array — it is read once per rendered
+ * row, and a store shelf renders a lot of rows.
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentPinService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/agents`);
+
+  private _pins = signal<PinnedAgent[]>([]);
+  private _loading = signal(false);
+  private _error = signal<string | null>(null);
+  private loaded = false;
+
+  readonly pins = this._pins.asReadonly();
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  readonly pinnedIds = computed(() => new Set(this._pins().map((pin) => pin.agentId)));
+
+  isPinned(agentId: string): boolean {
+    return this.pinnedIds().has(agentId);
+  }
+
+  /**
+   * Load the effective pin list, once per session unless forced.
+   *
+   * A failure leaves the list empty and the error set: pins are an enhancement to every
+   * surface that reads them, so a store that cannot answer "what is pinned?" still
+   * browses.
+   */
+  async load(force = false): Promise<PinnedAgent[]> {
+    if (this.loaded && !force) return this._pins();
+
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const response = await firstValueFrom(
+        this.http.get<AgentPinsResponse>(`${this.baseUrl()}/pins`),
+      );
+      this._pins.set(response.pins ?? []);
+      this.loaded = true;
+      return this._pins();
+    } catch (err) {
+      this._error.set(this.messageFor(err, 'Failed to load your pinned agents.'));
+      return [];
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /** Add an Agent to the user's own set. Idempotent server-side. */
+  async pin(agentId: string): Promise<void> {
+    if (this.isPinned(agentId)) return;
+    const previous = this._pins();
+    this._error.set(null);
+    try {
+      const row = await firstValueFrom(
+        this.http.post<PinnedAgent>(`${this.baseUrl()}/${agentId}/pin`, {}),
+      );
+      // Re-read rather than append the optimistic guess: the server row carries the
+      // resolved publisher and icon, which the caller may not have had.
+      this._pins.set([...previous.filter((pin) => pin.agentId !== agentId), row]);
+      this.loaded = true;
+    } catch (err) {
+      this._pins.set(previous);
+      this._error.set(this.messageFor(err, 'Failed to add that agent.'));
+      throw err;
+    }
+  }
+
+  /** Remove it, and remember the dismissal server-side (D9.3). */
+  async unpin(agentId: string): Promise<void> {
+    const previous = this._pins();
+    this._pins.set(previous.filter((pin) => pin.agentId !== agentId));
+    this._error.set(null);
+    try {
+      await firstValueFrom(this.http.delete(`${this.baseUrl()}/${agentId}/pin`));
+    } catch (err) {
+      this._pins.set(previous);
+      this._error.set(this.messageFor(err, 'Failed to remove that agent.'));
+      throw err;
+    }
+  }
+
+  /** Toggle, for the single control that both surfaces render. */
+  async toggle(agentId: string): Promise<void> {
+    return this.isPinned(agentId) ? this.unpin(agentId) : this.pin(agentId);
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -68,6 +68,13 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        // Marketplace Pinned tab (spec phase 5). Declared with the other literal
+        // `agents/*` paths, above `agents/:id`, for the same reason.
+        path: 'agents/pinned',
+        loadComponent: () => import('./agents/pinned/pinned.page').then(m => m.AgentPinnedPage),
+        canActivate: [authGuard],
+    },
+    {
         // Marketplace detail (spec phase 3). Declared AFTER `agents/discover` so the
         // literal path is not captured by `:id`, and after `agents/:id/edit` so the
         // deeper route still wins. `id` binds to the page's `input.required` via


### PR DESCRIPTION
Phase 5 of `docs/specs/agent-marketplace.md` — the user's own pin state (D8, D9's user half) and the Featured row admins own (D10). Phases 1–4 gave the store a shelf, a detail page and an identity; this gives a user somewhere to keep what they found and an admin the one lever that decides what gets found.

## Deploy

**`backend.yml` + `frontend-deploy.yml` only — no CDK deploy**, same as phases 2, 3, 3.5 and 4.

Both new records live on tables that already exist: the pin item on user-settings (`PK=USER#{id}, SK=PINNED_AGENTS` — `DYNAMODB_USER_SETTINGS_TABLE_NAME` is already on app-api and the task role already holds Get/Put/Update/Delete on that table, `app-api-iam-grants.ts:81`), and the store-front config on `rag-assistants` (`PK=AGENT_STOREFRONT, SK=CONFIG`, alongside the `AGENT_CATEGORIES` / `AGENT_PUBLISHERS` partitions phases 1–2 added). No new index, no new env var, no new IAM statement.

## Dismissal tombstones are written now, before anything reads them

The single most important detail in the pin design, and it is invisible until phase 6. Role-seeded pins resolve **live** rather than materializing (D9.1), so a seeded pin the user removed re-applies on the very next resolution unless the removal is remembered. `remove_pin` therefore writes a tombstone from day one — including for pins the user made themselves, which are indistinguishable to them.

Writing them now rather than with phase 6 means that resolver inherits a real history instead of treating every existing user as having dismissed nothing.

The corollary: **pin and dismiss are one toggle.** Re-pinning clears the tombstone, because a pin and a tombstone coexisting is a state the phase-6 resolver would have to guess about, and leaving a stale tombstone would make a future role seed for that agent unreachable forever — the exact failure tombstoning exists to prevent, inverted.

`source` and `locked` are already on every pin row, always `"user"`/`false` here, so phase 6 adds rows to the response rather than changing a shape the SPA renders.

## Pinning is gated on reachability, not on publication

`POST /agents/{id}/pin` accepts anything the caller could open — owner, editor or viewer — not only published listings. Publication decides what the store *offers*; a pin is a bookmark. D11 scopes the `@` menu to "your own and pinned Agents", which presumes an author can pin their own unpublished work.

The read applies the **same** gate on every request, through `get_assistant_with_access_check` — the one the detail page uses. So a pin can never hand someone an agent they could not have navigated to, and an agent that goes PUBLIC → PRIVATE leaves every stranger's Pinned tab at once.

Two things follow, both deliberate:

- **A denied or deleted row is dropped from the response, never from the stored pin.** Both conditions are reversible, and deleting someone's pin because an author toggled a setting for an afternoon is a silent, unrecoverable edit to their shelf.
- **One read per pin, through that gate, rather than a batch read plus a second access path.** `get_assistant_with_access_check` already fetches the record, so batching would mean either re-reading each agent anyway or restating the visibility rules in the pin service — a second copy of an access decision, which is how a resource ends up *listed* by one path and *denied* by another (the `can_access_model` divergence CLAUDE.md's RBAC rule calls out). Pin lists are bounded by `MAX_PINS`; a duplicated access rule is not.

A pin also survives a takedown, per D2 — delisting is not revocation — so the projection tolerates an agent with no `listing` block at all, unlike the browse read whose whole safety property is that it cannot see one.

## The store front is an ordered array, and it is not self-healing

`PK=AGENT_STOREFRONT, SK=CONFIG` holds `{ featured: [agentId, ...] }` — a single item, deliberately unlike categories and publishers (per-item records with an `order` field, following `UserMenuLink`). The row is short and reordering has to be atomic: with per-item `order`, a drag that rewrites five rows is five writes and a half-applied order is reachable. Here the array *is* the order.

Only published agents may be featured, enforced server-side, and the PUT names the offending ids rather than silently dropping them — a tile at the top of Discover that nobody can open is worse than a short row. The sparse-GSI5 physics that make this free for browse do not apply to a hand-curated id list, so the state check is explicit.

**Membership does not prune itself.** A taken-down agent leaves what Discover and the admin console render, but keeps its slot in the config until an admin saves the row; `AdminStoreFrontResponse.unavailable` names the stale ids so the admin can see why the row is short. A GET that pruned would rewrite an admin's curation as a side effect of reading it, and a takedown that is later reversed would have silently cost the agent its place.

Promotion lives on the **Store Front** surface rather than as a star on the Listings table: the row is an ordered list, and a per-row toggle can express membership but not position — an admin promoting three agents from the table would have no way to say which comes first.

## Frontend

- **Pinned tab** at `/agents/pinned`, rendering the same shelf rows Discover does. Their `＋` has already become a check, so removing one needs no second control to learn.
- **The add control on every shelf row.** The row now has two destinations, so the anchor no longer wraps the whole thing — a button nested inside an anchor is invalid HTML and swallows its own activation in some browsers. Unpinned, it appears on hover *or keyboard focus*; pinned, it stays visible, because an affordance that vanishes on success leaves you unsure anything happened and offers no way back.
- **Add on the detail page**, beside Start chat and deliberately *not* gated on runnability — a user may reasonably keep an agent they cannot run today.
- **Discover** grows the Featured row (the tiles) and a Pinned strip, both hidden when empty. Pin failures get their own alert: a row's add control failing is a different event from the shelves failing to load, and a pin that silently does nothing is the worst of the three outcomes.
- **Admin Store Front** — explicit slots with move-up/move-down and a staged Save. Not drag-and-drop: it is hard to operate by keyboard and impossible to narrate to a screen reader without a live region. Staged because reordering must be atomic and per-move autosave would make every mis-click a live change to the front page of the store.

Four of D10's seven admin surfaces are now built. Default pins and the reports queue arrive with phases 6 and 8.

## Ceilings

`MAX_PINS = 100` and `MAX_FEATURED = 10`. Neither is a system limit; both are the point where the feature has stopped being a shelf, and refusing with a message is kinder than degrading silently. The pin ceiling bounds growth only — an idempotent re-pin at the limit is not refused.

## Tests

- **Backend: 5133 passed**, 48 of them new across `test_agent_pins.py` (shared), `test_agent_storefront.py` and `test_agent_pins.py` (routes). The storage tests go through a real moto table rather than mocking the item, because the shape of the stored pin item *is* the contract the phase-6 resolver will read.
- **Frontend: 1543 passed**, 11 new `AgentPinService` specs covering the cached load, the optimistic write and both rollbacks — the three places where the Pinned tab, a Discover row and the detail button could disagree about the same agent. `npm run build` clean.

⚠️ `agent-form.page.spec.ts` (from #729, untouched here) times out intermittently in the **full** vitest run on a loaded machine — it passes alone and on a quiet full run. Seen both failing and passing across two identical runs on this branch; unrelated to pins.

## Not verified in a browser

`localhost:4200` talks to the deployed dev backend, which has neither `/agents/pins` nor `/admin/agents/storefront` until this ships, so a clickthrough would only show 404s. The real check is a dev smoke test after `backend.yml` lands: pin from a Discover row, confirm it appears in the Pinned tab and on the detail page as "Added", unpin, reload and confirm it stays gone — that last step is the tombstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
