### PR TITLE
feat(marketplace): default pins by role (Phase 6, D9)

### DIFF
--- a/backend/src/apis/app_api/admin/roles/agent_pins.py
+++ b/backend/src/apis/app_api/admin/roles/agent_pins.py
@@ -1,0 +1,124 @@
+"""Admin API for a role's default pinned Agents (Marketplace D9, D10 — Phase 6).
+
+Mounted under ``/admin/roles/{role_id}/agent-pins`` because **the AppRole record is the
+source of truth** (CLAUDE.md's RBAC rule). If an Agent-side "which roles pin this?" picker
+is ever added, it must write *through* to each role's pin items and derive the field back
+on read — the ``set_roles_for_skill`` pattern — never a role list persisted on the Agent,
+which would silently grant nothing.
+
+Two things this surface must keep saying out loud:
+
+**⚠️ ``default`` is a substitute, not a baseline (D9.6).** ``resolve_user_permissions``
+consults the ``default`` role only when the user matched *zero* AppRoles, and never merges
+it alongside a matched role. Pins seeded there reach only users who match nothing else — in
+prod, close to nobody. ``fallbackOnly`` on the response is what lets the console say so
+instead of letting an admin assume it means "everyone". ``unmapped`` is the same warning
+for any role that carries no ``jwtRoleMappings`` at all.
+
+**Removing a role pin unpins for everyone who had not pinned it themselves (D9.1).** Pins
+resolve live; there is no fan-out and no "new members only". The console's removal dialog
+has to say that plainly.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apis.app_api.admin.agents.routes import require_marketplace_admin
+from apis.app_api.agent_designer.services.role_pin_service import resolve_role_pins
+from apis.shared.assistants.models import (
+    RoleAgentPinsResponse,
+    RoleAgentPinsUpdateRequest,
+)
+from apis.shared.assistants.role_pins import list_role_pins, put_role_pins
+from apis.shared.auth import User
+from apis.shared.rbac.admin_service import get_app_role_admin_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/roles", tags=["admin-role-agent-pins"])
+
+
+async def _load_role(role_id: str):
+    role = await get_app_role_admin_service().get_role(role_id)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Role '{role_id}' not found"
+        )
+    return role
+
+
+async def _respond(role, admin: User) -> RoleAgentPinsResponse:
+    pins = await list_role_pins(role.role_id)
+    rows, unavailable = await resolve_role_pins(role, pins, admin)
+    return RoleAgentPinsResponse(
+        role_id=role.role_id,
+        role_label=role.display_name or role.role_id,
+        # D9.6 — computed here rather than hardcoded in the SPA, so the honest label
+        # travels with the data to any other surface that renders it.
+        fallback_only=role.role_id == "default",
+        unmapped=not role.jwt_role_mappings,
+        pins=rows,
+        unavailable=unavailable,
+    )
+
+
+@router.get("/{role_id}/agent-pins", response_model=RoleAgentPinsResponse)
+async def get_role_agent_pins(
+    role_id: str, admin: User = Depends(require_marketplace_admin)
+):
+    """This role's default pins, with the D9.5 assignment-time diff already applied.
+
+    Every row carries whether the role's members can *reach* the Agent and whether the
+    role grants what it binds. Rows whose Agent no longer exists are named in
+    ``unavailable`` rather than pruned — a read must not rewrite curation.
+    """
+    try:
+        return await _respond(await _load_role(role_id), admin)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error loading default pins for role {role_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to load default pins: {str(e)}")
+
+
+@router.put("/{role_id}/agent-pins", response_model=RoleAgentPinsResponse)
+async def put_role_agent_pins(
+    role_id: str,
+    request: RoleAgentPinsUpdateRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Replace this role's default pins, in order (D9).
+
+    A whole-list PUT: ``order`` belongs to the list, so a per-row save would let two edits
+    interleave into an order nobody chose.
+
+    **Warnings do not block the save.** An unreachable Agent or a capability the role does
+    not grant is reported on the response — an admin may legitimately seed something whose
+    author is about to publish it, and refusing would teach people to route around the
+    console. What *is* refused is a list that cannot mean what it says: past
+    ``MAX_ROLE_PINS``, or naming the same Agent twice.
+    """
+    try:
+        role = await _load_role(role_id)
+        await put_role_pins(role_id, request.pins, updated_by=admin.user_id)
+        logger.info(
+            f"Admin {admin.email} set {len(request.pins)} default pin(s) on role {role_id}",
+            extra={
+                "event": "role_agent_pins_updated",
+                "role_id": role_id,
+                "pin_count": len(request.pins),
+                "admin_user_id": admin.user_id,
+            },
+        )
+        # No cache to invalidate: pins are read live on every ``GET /agents/pins`` (D9.1),
+        # and they are deliberately absent from ``EffectivePermissions``, so nothing that
+        # the AppRole cache holds has changed.
+        return await _respond(role, admin)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error saving default pins for role {role_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to save default pins: {str(e)}")

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -870,6 +870,16 @@ from .roles.routes import router as roles_router
 
 router.include_router(roles_router)
 
+# ========== Include Role Default-Pins Subrouter (Marketplace D9) ==========
+# Its own module, mounted on the same ``/roles`` prefix: the AppRole record is the source
+# of truth for a default pin, but a pin is NOT a permission — keeping it out of the role
+# CRUD routes is the same separation the storage keeps (see ``assistants/role_pins.py``).
+# Every route depends on ``require_marketplace_admin``, so the surface 404s while the
+# marketplace kill switch is off.
+from .roles.agent_pins import router as role_agent_pins_router
+
+router.include_router(role_agent_pins_router)
+
 # ========== Include Tools Admin Subrouter ==========
 from .tools.routes import router as tools_router
 

--- a/backend/src/apis/app_api/agent_designer/services/pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/pin_service.py
@@ -1,4 +1,4 @@
-"""Agent Marketplace Phase 5 — the pin read and write (D8, D9 user side).
+"""Agent Marketplace Phases 5-6 — the pin read and write (D8, D9).
 
 "Add to my agents" stores a pointer (D8). This module turns that pointer list back into
 something renderable, which is the whole of the work: the stored state is ids, and a shelf
@@ -26,10 +26,20 @@ here — a second copy of an access decision, which is how a resource ends up *l
 path and *denied* by another (the ``can_access_model`` divergence in CLAUDE.md's RBAC
 rule). A pin list is bounded by ``MAX_PINS`` and is normally a handful of ids; a duplicated
 access rule is unbounded in cost.
+
+**4. Role-seeded pins are resolved live, per request (D9.1, Phase 6).** The effective list
+is *(⋃ role pins for the roles the caller matched) − dismissed(unlocked only) ∪ own pins*.
+Nothing is materialized per member, so removing a role pin removes it for everyone who had
+not independently pinned the Agent — and a user who *did* pin it has converted the seed to
+their own pin, which survives. The role ids come from ``resolve_user_permissions``, whose
+``app_roles`` is the list of roles that actually matched (including the ``default``
+substitution); the pins themselves are read by their own query, never from
+``EffectivePermissions``.
 """
 
 import logging
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 from apis.shared.assistants.icons import icon_url
 from apis.shared.assistants.models import (
@@ -46,8 +56,10 @@ from apis.shared.assistants.pins import (
     remove_pin,
 )
 from apis.shared.assistants.publishers import list_publishers
+from apis.shared.assistants.role_pins import list_pins_for_roles
 from apis.shared.assistants.service import get_assistant_with_access_check
 from apis.shared.auth.models import User
+from apis.shared.rbac.service import get_app_role_service
 
 logger = logging.getLogger(__name__)
 
@@ -63,14 +75,32 @@ class PinError(Exception):
         self.message = message
 
 
+@dataclass(frozen=True)
+class _Seed:
+    """A role pin as it applies to one user, after merging every role that seeds it."""
+
+    locked: bool
+    priority: int
+    order: int
+    created_at: Optional[str]
+
+
 def _pin_row(
-    assistant: Assistant, ref: Optional[PinnedAgentRef], publishers: dict
+    assistant: Assistant,
+    ref: Optional[PinnedAgentRef],
+    publishers: dict,
+    seed: Optional[_Seed] = None,
 ) -> PinnedAgentResponse:
     """Project a pinned Agent into the shelf shape.
 
     The same narrow projection browse uses (D4) — no ``instructions``, no binding refs,
-    no owner id — plus ``source``/``locked``, which are constant in Phase 5 and become
-    meaningful when role-seeded pins land (D9).
+    no owner id — plus ``source``/``locked``, which say *why* the row is on the shelf.
+
+    ``source`` is ``"user"`` whenever the caller has their own pin, even when a role also
+    seeds the Agent: that is the D9.1 escape hatch, and it is what survives the role pin
+    being removed. ``locked`` follows the *seed* regardless of source — a role that locks
+    an Agent has said its members keep it, and a user who separately pinned it has not
+    contradicted that.
     """
     listing = assistant.listing
     profile: Optional[PublisherProfile] = (
@@ -88,45 +118,131 @@ def _pin_row(
             else None
         ),
         category=(listing.category if listing else ""),
-        source="user",
-        locked=False,
-        pinned_at=ref.pinned_at if ref else None,
+        source="user" if ref is not None else "role",
+        locked=bool(seed and seed.locked),
+        pinned_at=(ref.pinned_at if ref else (seed.created_at if seed else None)),
     )
+
+
+async def _role_seeds(user: User) -> Dict[str, _Seed]:
+    """Every Agent seeded to this user by a role they hold (D9.1, D9.2).
+
+    ``resolve_user_permissions`` is used *only* for its ``app_roles`` — the roles that
+    actually matched, including the ``default`` substitution when nothing did. The pins
+    are then read by their own query. Nothing here reads or writes ``EffectivePermissions``:
+    a pin is not a permission, and folding one into that structure would put it on the
+    model call path.
+
+    **Pins from multiple roles merge, with no precedence rules (D9.2).** The union is what
+    a user holding both ``staff`` and ``faculty`` gets; the only per-Agent decisions are
+    that a lock from *any* role wins (the strictest claim is the honest one) and that the
+    ordering hints come from the highest-priority role that seeds it.
+    """
+    service = get_app_role_service()
+    try:
+        permissions = await service.resolve_user_permissions(user)
+    except Exception:
+        # A shelf that renders the user's own pins beats a shelf that fails to render.
+        logger.warning("Failed to resolve roles for default pins", exc_info=True)
+        return {}
+
+    role_ids = list(permissions.app_roles or [])
+    if not role_ids:
+        return {}
+
+    by_role = await list_pins_for_roles(role_ids)
+
+    seeds: Dict[str, _Seed] = {}
+    for role_id, pins in by_role.items():
+        if not pins:
+            continue
+        role = await service.get_role(role_id)
+        priority = role.priority if role else 0
+        for pin in pins:
+            current = seeds.get(pin.agent_id)
+            if current is None:
+                seeds[pin.agent_id] = _Seed(
+                    locked=pin.locked,
+                    priority=priority,
+                    order=pin.order,
+                    created_at=pin.created_at,
+                )
+                continue
+            wins = (priority, -pin.order) > (current.priority, -current.order)
+            seeds[pin.agent_id] = _Seed(
+                locked=current.locked or pin.locked,
+                priority=priority if wins else current.priority,
+                order=pin.order if wins else current.order,
+                created_at=(pin.created_at if wins else current.created_at),
+            )
+
+    return seeds
+
+
+def _shelf_key(
+    ref: Optional[PinnedAgentRef], seed: Optional[_Seed], name: str
+) -> Tuple[int, int, int, int, str]:
+    """``(locked desc, role priority desc, order asc, name asc)`` from the spec's Data model.
+
+    The extra term is where a pin with no role sits: a user's own pins have no role
+    priority to sort by, so they follow the seeded ones rather than being interleaved by a
+    priority they do not have. Within each group the stored ``order`` holds.
+    """
+    if seed is not None:
+        return (0 if seed.locked else 1, 0, -seed.priority, seed.order, name.lower())
+    return (1, 1, 0, ref.order if ref else 0, name.lower())
 
 
 async def list_pins(user: User) -> List[PinnedAgentResponse]:
     """The user's effective pin list, in shelf order (D9).
 
-    Phase 5 resolves the user's own pins only. Phase 6 unions role-seeded pins in here —
-    ``(⋃ role pins) − dismissed ∪ own pins`` — which is why the dismissal tombstones are
-    already being written and why ``source``/``locked`` are already on the row.
+    ``(⋃ role pins) − dismissed(unlocked only) ∪ own pins``. The tombstones are the point:
+    seeds resolve live, so without them a dismissed seed would re-apply on the very next
+    request and the user could never remove it. A *locked* seed ignores the tombstone by
+    design (D9.4) — that is the whole meaning of the flag.
     """
     state = await get_pin_state(user.user_id)
-    refs = sorted(state.pinned, key=lambda ref: ref.order)
-    if not refs:
+    own: Dict[str, PinnedAgentRef] = {ref.agent_id: ref for ref in state.pinned}
+    dismissed = set(state.dismissed)
+    seeds = await _role_seeds(user)
+
+    candidates: List[Tuple[str, Optional[PinnedAgentRef], Optional[_Seed]]] = []
+    for agent_id, seed in seeds.items():
+        ref = own.get(agent_id)
+        if ref is None and agent_id in dismissed and not seed.locked:
+            continue
+        candidates.append((agent_id, ref, seed))
+    for agent_id, ref in own.items():
+        if agent_id not in seeds:
+            candidates.append((agent_id, ref, None))
+
+    if not candidates:
         return []
 
     publishers = {p.id: p for p in await list_publishers()}
 
-    rows: List[PinnedAgentResponse] = []
-    for ref in refs:
+    rows: List[Tuple[Tuple[int, int, int, int, str], PinnedAgentResponse]] = []
+    for agent_id, ref, seed in candidates:
         try:
             assistant, permission = await get_assistant_with_access_check(
-                ref.agent_id, user.user_id, user.email
+                agent_id, user.user_id, user.email
             )
         except Exception:
-            logger.warning(f"Failed to resolve pinned agent {ref.agent_id}", exc_info=True)
+            logger.warning(f"Failed to resolve pinned agent {agent_id}", exc_info=True)
             continue
 
         # Deleted since it was pinned, or no longer reachable by this user. Dropped from
         # the response; the stored pin is left alone, because a read is not the place to
-        # garbage-collect writes and both conditions are reversible.
+        # garbage-collect writes and both conditions are reversible. A role seed the
+        # caller cannot reach drops here too — the pin never becomes a grant.
         if assistant is None or permission is None:
             continue
 
-        rows.append(_pin_row(assistant, ref, publishers))
+        row = _pin_row(assistant, ref, publishers, seed)
+        rows.append((_shelf_key(ref, seed, assistant.name), row))
 
-    return rows
+    rows.sort(key=lambda entry: entry[0])
+    return [row for _key, row in rows]
 
 
 async def pin_agent(user: User, agent_id: str) -> PinnedAgentResponse:
@@ -153,7 +269,11 @@ async def pin_agent(user: User, agent_id: str) -> PinnedAgentResponse:
 
     ref = next((r for r in state.pinned if r.agent_id == agent_id), None)
     publishers = {p.id: p for p in await list_publishers()}
-    return _pin_row(assistant, ref, publishers)
+    # The seed is resolved for the response row too: the SPA splices this row straight
+    # into its list, so a row that said ``locked: false`` about an Agent the caller's role
+    # has locked would offer a remove control until the next full read took it away.
+    seed = (await _role_seeds(user)).get(agent_id)
+    return _pin_row(assistant, ref, publishers, seed)
 
 
 async def unpin_agent(user: User, agent_id: str) -> None:
@@ -161,5 +281,14 @@ async def unpin_agent(user: User, agent_id: str) -> None:
 
     No existence check: unpinning a deleted Agent has to work, or a user whose pinned
     Agent was removed is stuck with a row they cannot clear.
+
+    **A locked role seed no-ops** (D9.4). The SPA hides the control, but the endpoint is
+    reachable directly, and writing the tombstone anyway would be worse than refusing: the
+    row would come back on the next read (a locked seed ignores tombstones) while the
+    stored dismissal quietly waited to take effect the day an admin unlocked the pin.
     """
+    seed = (await _role_seeds(user)).get(agent_id)
+    if seed is not None and seed.locked:
+        logger.info(f"📌 {user.user_id} tried to unpin locked role pin {agent_id}; ignored")
+        return
     await remove_pin(user.user_id, agent_id)

--- a/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
@@ -1,0 +1,193 @@
+"""Agent Marketplace Phase 6 — the admin side of default pins (D9, D10).
+
+Projects a role's stored pin ids into rows an admin can read, and answers the question
+D9.5 asks before a save: **will this Agent actually work for this role's members?**
+
+Two checks, deliberately separate, because they fail for different reasons and have
+different remedies:
+
+* **Reachability** — a ``PRIVATE`` Agent is visible to its owner alone and a ``SHARED``
+  one to its share list, so seeding either to a role hands most members a pin that
+  silently resolves to nothing (``list_pins`` access-checks every row on every read). The
+  remedy is the *author's*: publish it, or set it PUBLIC. This is not gated on the listing
+  being *published* — an Agent can be PUBLIC without ever having been submitted to the
+  store, and a role seed is a pin, not a shelf slot.
+
+* **Runnability against the role** — the Agent's pinned model and its tool/skill bindings
+  diffed against that role's own ``effective_permissions``, which
+  ``_compute_effective_permissions`` already denormalizes onto the AppRole record. Seeding
+  410 researchers an Agent that fails on their first message is the exact failure D9.5
+  exists to prevent. The remedy is the *admin's*: grant the capability, or seed something
+  else.
+
+Both **warn**; neither refuses. An admin can legitimately seed an Agent whose author is
+about to publish it, or whose missing tool is about to be granted, and a save that blocks
+on a condition the admin is mid-way through fixing teaches people to work around the
+console rather than through it.
+
+⚠️ The role-level diff is narrower than the per-user one on purpose. ``memory_space``
+resolves per person and cannot be decided for a role at all, so it is reported as a *note*
+rather than counted as present or missing — "ready" here must never claim to have checked
+something it could not.
+"""
+
+import logging
+from typing import List, Sequence, Set, Tuple
+
+from apis.shared.assistants.icons import icon_url
+from apis.shared.assistants.listing_repository import batch_get_agents
+from apis.shared.assistants.models import (
+    Assistant,
+    ListingPublisher,
+    MissingCapability,
+    RoleAgentPin,
+    RoleAgentPinRow,
+)
+from apis.shared.assistants.publishers import list_publishers
+from apis.shared.rbac.models import AppRole
+
+# Reused rather than re-derived: these are the same helpers the per-invoker runnability
+# preview (D6) uses, so the admin's assignment-time warning and the user's "will it run
+# for me?" line can never drift into disagreeing about what an Agent binds.
+from apis.app_api.agent_designer.services.agent_detail import (
+    _binding_key,
+    _fallback,
+    _gated_bindings,
+    _is_optional,
+    _labels_by_kind,
+    _model_label,
+)
+
+logger = logging.getLogger(__name__)
+
+# What a role's ``effective_permissions`` can actually decide. ``memory_space`` is absent
+# because a role does not grant memory spaces — people do, per space.
+_ROLE_GATED_KINDS = ("tool", "skill")
+
+_MEMORY_NOTE = (
+    "Binds a memory space, which is granted per person — this check cannot decide it for "
+    "a whole role."
+)
+
+
+def _grants(role: AppRole, axis: str) -> Set[str]:
+    perms = role.effective_permissions
+    return set(getattr(perms, axis, []) or [])
+
+
+def _granted(grants: Set[str], key: str) -> bool:
+    return "*" in grants or key in grants
+
+
+async def _diff_against_role(
+    assistant: Assistant, role: AppRole, admin_user
+) -> Tuple[str, List[MissingCapability], List[str]]:
+    """``(state, missing, notes)`` for one Agent against one role (D9.5)."""
+    missing: List[MissingCapability] = []
+    notes: List[str] = []
+
+    if assistant.model_settings is not None:
+        model_id = assistant.model_settings.model_id
+        if not _granted(_grants(role, "models"), model_id):
+            missing.append(
+                MissingCapability(
+                    label=await _model_label(model_id) or _fallback("model"),
+                    kind="model",
+                    # The pinned model is never optional: the binding resolver blocks the
+                    # turn outright when the invoker cannot reach it.
+                    optional=False,
+                )
+            )
+
+    bindings = _gated_bindings(assistant)
+    if any(binding.kind == "memory_space" for binding in bindings):
+        notes.append(_MEMORY_NOTE)
+
+    labels = await _labels_by_kind(assistant, admin_user)
+    for kind, axis in (("tool", "tools"), ("skill", "skills")):
+        of_kind = [b for b in bindings if b.kind == kind]
+        if not of_kind:
+            continue
+        grants = _grants(role, axis)
+        for binding in of_kind:
+            key = _binding_key(binding)
+            if _granted(grants, key):
+                continue
+            label = labels.get(kind, {}).get(key) or _fallback(kind)
+            if any(m.kind == kind and m.label == label for m in missing):
+                continue
+            missing.append(
+                MissingCapability(label=label, kind=kind, optional=_is_optional(binding))
+            )
+
+    if not missing:
+        state = "ready"
+    elif all(item.optional for item in missing):
+        state = "limits"
+    else:
+        state = "blocked"
+    return state, missing, notes
+
+
+async def resolve_role_pins(
+    role: AppRole, pins: Sequence[RoleAgentPin], admin_user
+) -> Tuple[List[RoleAgentPinRow], List[str]]:
+    """Project a role's stored pins into admin rows, in seed order.
+
+    Returns ``(rows, unavailable_ids)``. An id whose Agent no longer exists is *reported*,
+    never pruned on read: a GET that rewrote the seed list would make an accidental delete
+    of the wrong Agent look like the admin's own edit.
+    """
+    if not pins:
+        return [], []
+
+    agent_ids = [pin.agent_id for pin in pins]
+    records = await batch_get_agents(agent_ids)
+    publishers = {p.id: p for p in await list_publishers()}
+
+    rows: List[RoleAgentPinRow] = []
+    unavailable: List[str] = []
+    for pin in pins:
+        item = records.get(pin.agent_id)
+        if not item:
+            unavailable.append(pin.agent_id)
+            continue
+        try:
+            assistant = Assistant.model_validate(item)
+        except Exception:
+            logger.warning(f"Skipping unparseable pinned agent {pin.agent_id}", exc_info=True)
+            unavailable.append(pin.agent_id)
+            continue
+
+        listing = assistant.listing
+        profile = publishers.get(listing.publisher_id) if listing else None
+        state, missing, notes = await _diff_against_role(assistant, role, admin_user)
+        visibility = assistant.visibility or "PRIVATE"
+
+        rows.append(
+            RoleAgentPinRow(
+                agent_id=assistant.assistant_id,
+                name=assistant.name,
+                tagline=assistant.tagline,
+                emoji=assistant.emoji,
+                icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
+                publisher=(
+                    ListingPublisher(
+                        label=profile.label, kind=profile.kind, verified=profile.verified
+                    )
+                    if profile
+                    else None
+                ),
+                category=(listing.category if listing else ""),
+                order=pin.order,
+                locked=pin.locked,
+                listing_state=(listing.state if listing else None),
+                reachable=visibility == "PUBLIC",
+                visibility=visibility,
+                state=state,
+                missing=missing,
+                notes=notes,
+            )
+        )
+
+    return rows, unavailable

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -880,6 +880,122 @@ class AgentPinsResponse(BaseModel):
     pins: List[PinnedAgentResponse] = Field(default_factory=list, description="Resolved pins, in order")
 
 
+# ── role-seeded default pins (D9, Phase 6) ──────────────────────────────────────────
+# ⚠️ A pin is **not** a permission. These models never touch ``EffectivePermissions`` and
+# never enter ``_compute_effective_permissions``: role pins live in their own items, are
+# resolved by their own query, and do not inherit through ``inheritsFrom``. Folding them
+# into the permission payload would pollute a structure the model call path depends on.
+class RoleAgentPin(BaseModel):
+    """One default pin stored against an AppRole (``SK = AGENT_PIN#{agent_id}``)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    order: int = Field(0, description="Position within this role's seed list, ascending")
+    locked: bool = Field(
+        False,
+        description=(
+            "A locked seed cannot be dismissed (D9.4) — the remove control is hidden and "
+            "the dismissal endpoint no-ops. For the one Agent a role genuinely must keep."
+        ),
+    )
+    created_at: Optional[str] = Field(None, alias="createdAt", description="ISO 8601 timestamp")
+    created_by: Optional[str] = Field(None, alias="createdBy", description="Admin user id")
+
+
+class RoleAgentPinInput(BaseModel):
+    """One entry of a role's pin list as the admin console submits it."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    locked: bool = Field(False, description="Members cannot dismiss this one (D9.4)")
+
+
+class RoleAgentPinsUpdateRequest(BaseModel):
+    """Replace a role's default pins, in order (D9).
+
+    A whole-list PUT for the same reason as the store front: ``order`` is a property of
+    the list, not of any one row, so a half-applied reorder is an order nobody chose.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pins: List[RoleAgentPinInput] = Field(
+        default_factory=list, alias="pins", description="Seeded agents, in shelf order"
+    )
+
+
+class RoleAgentPinRow(BaseModel):
+    """One default pin as the admin console sees it: the shelf projection plus the D9.5 diff."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    name: str = Field(..., description="Agent display name")
+    tagline: Optional[str] = Field(None, description="Shelf subtitle")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_url: Optional[str] = Field(None, alias="iconUrl", description="Square icon URL (D5)")
+    publisher: Optional[ListingPublisher] = Field(None, description="Attribution (D12), display only")
+    category: str = Field("", description="Category id; empty when the agent carries no listing")
+    order: int = Field(0, description="Position in the seed list")
+    locked: bool = Field(False, description="Members cannot dismiss this one (D9.4)")
+    listing_state: Optional[ListingState] = Field(
+        None, alias="listingState", description="Publication state; absent when never submitted"
+    )
+    reachable: bool = Field(
+        True,
+        description=(
+            "Whether an ordinary member of the role could open this Agent at all. False for "
+            "a PRIVATE agent (owner only) — the seed would silently resolve to nothing."
+        ),
+    )
+    visibility: str = Field("PUBLIC", description="PRIVATE | SHARED | PUBLIC — why ``reachable`` reads as it does")
+    state: str = Field(
+        "ready", description="D9.5 assignment-time check against the ROLE's permissions: ready | limits | blocked"
+    )
+    missing: List[MissingCapability] = Field(
+        default_factory=list, description="Capabilities this role does not grant (D9.5)"
+    )
+    notes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "What the role-level check could not decide — a memory-space binding resolves "
+            "per person, so 'ready' here never claims to have checked it"
+        ),
+    )
+
+
+class RoleAgentPinsResponse(BaseModel):
+    """A role's default pins, plus the two facts that decide whether they reach anyone."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    role_id: str = Field(..., alias="roleId", description="AppRole identifier")
+    role_label: str = Field("", alias="roleLabel", description="Display name of the role")
+    fallback_only: bool = Field(
+        False,
+        alias="fallbackOnly",
+        description=(
+            "⚠️ D9.6 — the ``default`` role is consulted ONLY for users who matched zero "
+            "AppRoles, and is never merged alongside a matched role. Pins seeded here "
+            "reach nobody who holds any other role."
+        ),
+    )
+    unmapped: bool = Field(
+        False,
+        description="The role carries no jwtRoleMappings, so no user matches it at all",
+    )
+    pins: List[RoleAgentPinRow] = Field(default_factory=list, description="Seeded agents, in order")
+    unavailable: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Configured ids that no longer resolve to an Agent — reported rather than "
+            "pruned on read, so a GET never rewrites an admin's curation as a side effect"
+        ),
+    )
+
+
 class StoreFrontUpdateRequest(BaseModel):
     """Replace the featured row, in order (D10).
 

--- a/backend/src/apis/shared/assistants/role_pins.py
+++ b/backend/src/apis/shared/assistants/role_pins.py
@@ -1,0 +1,161 @@
+"""Role-seeded default pins for the Agent Marketplace (D9 role side — Phase 6).
+
+An admin assigns default pinned Agents per ``AppRole``, so a role's members start with a
+useful sidebar instead of an empty one. Storage mirrors the grant items on the **app-roles**
+table:
+
+    PK = ROLE#{role_id}, SK = AGENT_PIN#{agent_id}
+    { order: int, locked: bool, createdAt, createdBy }
+
+Four properties, each of which the rest of the feature leans on:
+
+**1. ⚠️ A pin is not a permission.** These items share a partition with ``TOOL_GRANT#`` /
+``MODEL_GRANT#`` / ``SKILL_GRANT#`` and nothing else. They are deliberately absent from
+``AppRole``, from ``EffectivePermissions`` and from ``_compute_effective_permissions``;
+they do not inherit through ``inheritsFrom``, and they are resolved by the query below
+rather than merged into the permission payload the model call path reads.
+
+**2. They live in their own module for that reason.** The obvious home was
+``AppRoleRepository``, which already owns this table — and that is exactly the coupling
+worth refusing. Keeping the pin read out of the repository that computes permissions makes
+"a pin is not a permission" a structural fact rather than a comment.
+
+**3. Resolution is live, never materialized (D9.1).** There is no fan-out job writing a
+row per member. Removing a role pin removes it for everyone in the role who has not
+independently pinned the Agent — a real capability loss, taken deliberately in exchange for
+an entire asynchronous subsystem and its backfill.
+
+**4. The write is a whole-list replace.** ``order`` is a property of the list, not of any
+one row, so per-item saves would let two edits interleave into an order nobody chose.
+``createdAt``/``createdBy`` survive the replace for ids that stay, so the audit trail
+records when an Agent was *seeded*, not when the list was last dragged around.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Dict, List, Sequence
+
+from boto3.dynamodb.conditions import Key
+
+from .models import RoleAgentPin, RoleAgentPinInput
+
+logger = logging.getLogger(__name__)
+
+_SK_PREFIX = "AGENT_PIN#"
+
+# A role that seeds 25 Agents has handed every one of its members a sidebar they did not
+# choose and cannot curate down without 25 gestures. The user-side ``MAX_PINS`` is 100
+# because that shelf is the user's own; this one is somebody else's, so it is stricter.
+MAX_ROLE_PINS = 25
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_APP_ROLES_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_APP_ROLES_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _to_pin(item: dict) -> RoleAgentPin:
+    return RoleAgentPin(
+        agent_id=str(item["SK"])[len(_SK_PREFIX) :],
+        order=int(item.get("order", 0)),
+        locked=bool(item.get("locked", False)),
+        created_at=item.get("createdAt"),
+        created_by=item.get("createdBy"),
+    )
+
+
+async def list_role_pins(role_id: str) -> List[RoleAgentPin]:
+    """This role's default pins, in seed order.
+
+    Sorted here rather than by the sort key: ``AGENT_PIN#{agent_id}`` orders by id, and the
+    admin's ordering is an attribute. Ties break on agent id so two pins written in the
+    same save resolve identically on every read.
+    """
+    response = _table().query(
+        KeyConditionExpression=Key("PK").eq(f"ROLE#{role_id}") & Key("SK").begins_with(_SK_PREFIX)
+    )
+    pins = [_to_pin(item) for item in response.get("Items", [])]
+    pins.sort(key=lambda pin: (pin.order, pin.agent_id))
+    return pins
+
+
+async def list_pins_for_roles(role_ids: Sequence[str]) -> Dict[str, List[RoleAgentPin]]:
+    """Default pins for several roles at once — one query per role.
+
+    A query per role rather than a scan: a user holds a handful of roles, the result is
+    cached upstream behind the AppRole cache TTL, and a table scan on every pin read would
+    grow with the number of roles in the institution rather than the number the caller holds.
+    """
+    result: Dict[str, List[RoleAgentPin]] = {}
+    for role_id in role_ids:
+        try:
+            result[role_id] = await list_role_pins(role_id)
+        except Exception:
+            # One unreadable role must not empty the whole shelf: the other roles' seeds
+            # and the user's own pins are still correct answers.
+            logger.warning(f"Failed to read default pins for role {role_id}", exc_info=True)
+            result[role_id] = []
+    return result
+
+
+async def put_role_pins(
+    role_id: str, pins: Sequence[RoleAgentPinInput], updated_by: str
+) -> List[RoleAgentPin]:
+    """Replace this role's default pins with ``pins``, in the order given.
+
+    Raises ``ValueError`` past ``MAX_ROLE_PINS`` or on a duplicated agent id — a duplicate
+    would collapse to one item on write and silently renumber everything after it.
+    """
+    agent_ids = [pin.agent_id for pin in pins]
+    if len(agent_ids) > MAX_ROLE_PINS:
+        raise ValueError(f"A role can seed at most {MAX_ROLE_PINS} agents.")
+    if len(set(agent_ids)) != len(agent_ids):
+        raise ValueError("The same agent cannot be pinned to a role twice.")
+
+    existing = {pin.agent_id: pin for pin in await list_role_pins(role_id)}
+    now = _now()
+    table = _table()
+
+    with table.batch_writer() as batch:
+        for agent_id in existing:
+            if agent_id not in agent_ids:
+                batch.delete_item(Key={"PK": f"ROLE#{role_id}", "SK": f"{_SK_PREFIX}{agent_id}"})
+        for order, pin in enumerate(pins):
+            prior = existing.get(pin.agent_id)
+            batch.put_item(
+                Item={
+                    "PK": f"ROLE#{role_id}",
+                    "SK": f"{_SK_PREFIX}{pin.agent_id}",
+                    "order": order,
+                    "locked": pin.locked,
+                    # Preserved across a reorder: this records when the Agent was seeded,
+                    # not when the list was last dragged.
+                    "createdAt": (prior.created_at if prior else None) or now,
+                    "createdBy": (prior.created_by if prior else None) or updated_by,
+                    "updatedAt": now,
+                }
+            )
+
+    logger.info(f"📌 {updated_by} set {len(agent_ids)} default pin(s) on role {role_id}")
+    return await list_role_pins(role_id)
+
+
+async def delete_role_pins(role_id: str) -> None:
+    """Drop every default pin for a role. Called when the role itself is deleted."""
+    table = _table()
+    pins = await list_role_pins(role_id)
+    if not pins:
+        return
+    with table.batch_writer() as batch:
+        for pin in pins:
+            batch.delete_item(Key={"PK": f"ROLE#{role_id}", "SK": f"{_SK_PREFIX}{pin.agent_id}"})
+    logger.info(f"📌 Deleted {len(pins)} default pin(s) with role {role_id}")

--- a/backend/src/apis/shared/rbac/repository.py
+++ b/backend/src/apis/shared/rbac/repository.py
@@ -190,8 +190,9 @@ class AppRoleRepository:
             if existing.is_system_role:
                 raise ValueError(f"Cannot delete system role '{role_id}'")
 
-            # Delete all mapping items
-            await self._delete_mapping_items(role_id)
+            # Delete all mapping items. A deleted role takes its default pins (D9) with
+            # it — unlike an update, where they must survive.
+            await self._delete_mapping_items(role_id, include_agent_pins=True)
 
             # Delete the role definition
             self._table.delete_item(
@@ -421,8 +422,24 @@ class AppRoleRepository:
 
         return items
 
-    async def _delete_mapping_items(self, role_id: str):
-        """Delete all mapping items for a role (JWT, tool, model mappings)."""
+    async def _delete_mapping_items(self, role_id: str, include_agent_pins: bool = False):
+        """Delete a role's mapping items (JWT, tool, model, skill grants).
+
+        ⚠️ **Deletes by prefix, not "everything that is not DEFINITION".** ``update_role``
+        rebuilds the mapping items from the ``AppRole`` record, so anything under this
+        partition that the record does not carry would be wiped by every role edit and
+        never rewritten. Default agent pins (``AGENT_PIN#``, D9) are exactly that: they
+        share the partition with the grants but are deliberately not part of ``AppRole``,
+        because a pin is not a permission. Any future per-role item that is not
+        reconstructible from ``_build_role_items`` needs the same protection.
+
+        ``include_agent_pins`` is set only by ``delete_role``, where the role — and so
+        everything hanging off it — is going away.
+        """
+        prefixes = ("JWT_MAPPING#", "TOOL_GRANT#", "MODEL_GRANT#", "SKILL_GRANT#")
+        if include_agent_pins:
+            prefixes = prefixes + ("AGENT_PIN#",)
+
         try:
             # Query all items with this role's PK
             response = self._table.query(
@@ -430,10 +447,9 @@ class AppRoleRepository:
                 ExpressionAttributeValues={":pk": f"ROLE#{role_id}"},
             )
 
-            # Delete each item except the DEFINITION (which will be updated)
             with self._table.batch_writer() as batch:
                 for item in response.get("Items", []):
-                    if item["SK"] != "DEFINITION":
+                    if str(item["SK"]).startswith(prefixes):
                         batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
 
         except ClientError as e:

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -122,6 +122,17 @@ class AppRoleService:
 
         return permissions
 
+    async def get_role(self, role_id: str) -> Optional[AppRole]:
+        """A role record, through the same cache the permission resolution uses.
+
+        Public because the Marketplace's default pins (D9) need a role's ``priority`` and
+        ``displayName`` to order and label a resolved shelf, and re-reading DynamoDB per
+        pin read would drop a cache the request path already warmed. It returns the record,
+        not a permission decision — pins are resolved by their own query and never enter
+        ``UserEffectivePermissions``.
+        """
+        return await self._get_role_with_cache(role_id)
+
     async def _get_role_with_cache(self, role_id: str) -> Optional[AppRole]:
         """Get role from cache or database."""
         cached = await self.cache.get_role(role_id)

--- a/backend/tests/routes/test_role_agent_pins.py
+++ b/backend/tests/routes/test_role_agent_pins.py
@@ -1,0 +1,513 @@
+"""Agent Marketplace Phase 6 — default pins by role (D9).
+
+Two surfaces, one rule each that the feature turns on:
+
+* **The user's shelf** — ``(⋃ role pins) − dismissed(unlocked only) ∪ own pins``, resolved
+  live. Every case below is a way that formula can quietly stop holding: a dismissal that
+  the resolver forgets (the seed comes back and can never be removed), a lock that a
+  dismissal defeats, a role pin that outranks the user's own conversion of it, or a seed
+  that reaches someone who could not otherwise open the Agent — which would make a pin a
+  grant.
+
+* **The admin console** — the D9.5 assignment-time diff, and the two labels that keep an
+  admin from seeding nobody: ``default`` reaches only users who matched *zero* roles, and
+  a role with no JWT mappings matches nobody at all.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.roles.agent_pins import router as role_pins_router
+from apis.app_api.agent_designer.routes import router as agents_router
+from apis.shared.assistants.models import (
+    AgentListing,
+    Assistant,
+    PinnedAgentRef,
+    RoleAgentPin,
+    UserPinState,
+)
+from apis.shared.auth import require_admin
+from apis.shared.rbac.models import AppRole, EffectivePermissions, UserEffectivePermissions
+from tests.routes.conftest import mock_auth_user
+
+PIN_SERVICE = "apis.app_api.agent_designer.services.pin_service"
+ROLE_PIN_SERVICE = "apis.app_api.agent_designer.services.role_pin_service"
+ADMIN_ROUTES = "apis.app_api.admin.roles.agent_pins"
+
+
+def _make_assistant(**overrides) -> Assistant:
+    defaults = dict(
+        assistantId="ast-001",
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="SECRET SYSTEM PROMPT",
+        vectorIndexId="idx-001",
+        visibility="PUBLIC",
+        usageCount=0,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+        emoji="📋",
+        tagline="Find and cite university policy",
+        listing=AgentListing(
+            state="published", category="Administration", publisher_id="pub-registrar"
+        ).model_dump(by_alias=True),
+    )
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+def _role(role_id: str, priority: int = 0, **overrides) -> AppRole:
+    return AppRole(
+        role_id=role_id,
+        display_name=overrides.pop("display_name", role_id.title()),
+        description="",
+        jwt_role_mappings=overrides.pop("jwt_role_mappings", [role_id.title()]),
+        priority=priority,
+        effective_permissions=overrides.pop(
+            "effective_permissions", EffectivePermissions(tools=["*"], models=["*"], skills=["*"])
+        ),
+        **overrides,
+    )
+
+
+def _seed(agent_id: str, order: int = 0, locked: bool = False) -> RoleAgentPin:
+    return RoleAgentPin(
+        agent_id=agent_id, order=order, locked=locked, created_at="2026-07-20T00:00:00Z"
+    )
+
+
+def _role_service(roles):
+    """A stand-in AppRoleService that reports ``roles`` as the caller's matched roles."""
+    service = MagicMock()
+    service.resolve_user_permissions = AsyncMock(
+        return_value=UserEffectivePermissions(
+            user_id="user-001",
+            app_roles=[role.role_id for role in roles],
+            tools=[],
+            models=[],
+            quota_tier=None,
+            resolved_at="2026-07-25T00:00:00Z",
+        )
+    )
+    by_id = {role.role_id: role for role in roles}
+    service.get_role = AsyncMock(side_effect=lambda role_id: by_id.get(role_id))
+    return service
+
+
+def _shelf(client, *, state=None, seeds=None, roles=None, assistants=None):
+    """Call ``GET /agents/pins`` with the role side stubbed at the service boundary."""
+    roles = roles if roles is not None else [_role("faculty")]
+
+    async def _resolve(agent_id, _user_id, _email=None):
+        if assistants is not None and agent_id not in assistants:
+            return None, None
+        override = (assistants or {}).get(agent_id, {})
+        return _make_assistant(assistantId=agent_id, **override), "viewer"
+
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=state or UserPinState())),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(f"{PIN_SERVICE}.get_assistant_with_access_check", AsyncMock(side_effect=_resolve)),
+        patch(f"{PIN_SERVICE}.get_app_role_service", lambda: _role_service(roles)),
+        patch(f"{PIN_SERVICE}.list_pins_for_roles", AsyncMock(return_value=seeds or {})),
+    ):
+        return client.get("/agents/pins")
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(agents_router)
+    _app.include_router(role_pins_router, prefix="/admin")
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def _flags_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+@pytest.fixture
+def client(app, make_user):
+    mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
+    app.dependency_overrides[require_admin] = lambda: make_user(user_id="admin-1")
+    return TestClient(app)
+
+
+# ── the resolver: (⋃ role pins) − dismissed(unlocked only) ∪ own pins ────────────────
+def test_a_role_seed_lands_on_the_shelf(client):
+    response = _shelf(client, seeds={"faculty": [_seed("ast-seeded")]})
+
+    assert response.status_code == 200
+    row = response.json()["pins"][0]
+    assert row["agentId"] == "ast-seeded"
+    assert row["source"] == "role"
+    assert row["locked"] is False
+    # Still the shelf projection — a seed is a pin, not a richer object.
+    for leaked in ("instructions", "description", "bindings", "ownerId"):
+        assert leaked not in row
+
+
+def test_a_dismissed_seed_stays_gone(client):
+    """The tombstone is the whole reason live resolution is safe (D9.3)."""
+    response = _shelf(
+        client,
+        state=UserPinState(dismissed=["ast-seeded"]),
+        seeds={"faculty": [_seed("ast-seeded")]},
+    )
+
+    assert response.json() == {"pins": []}
+
+
+def test_a_locked_seed_ignores_the_dismissal(client):
+    """D9.4: locked means the role's members keep it, tombstone or not."""
+    response = _shelf(
+        client,
+        state=UserPinState(dismissed=["ast-locked"]),
+        seeds={"faculty": [_seed("ast-locked", locked=True)]},
+    )
+
+    row = response.json()["pins"][0]
+    assert row["agentId"] == "ast-locked"
+    assert row["locked"] is True
+
+
+def test_pinning_a_seeded_agent_converts_it_to_your_own(client):
+    """The D9.1 escape hatch: this is what survives the role pin being removed."""
+    response = _shelf(
+        client,
+        state=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-seeded", order=0)]),
+        seeds={"faculty": [_seed("ast-seeded")]},
+    )
+
+    rows = response.json()["pins"]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "user"
+
+
+def test_a_lock_survives_the_user_pinning_it_themselves(client):
+    """Owning a copy of the pin is not a contradiction of the role's lock."""
+    response = _shelf(
+        client,
+        state=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-locked", order=0)]),
+        seeds={"faculty": [_seed("ast-locked", locked=True)]},
+    )
+
+    assert response.json()["pins"][0]["locked"] is True
+
+
+def test_pins_from_several_roles_merge(client):
+    """D9.2: the union, with no precedence rules."""
+    response = _shelf(
+        client,
+        seeds={"faculty": [_seed("ast-a")], "staff": [_seed("ast-b")]},
+        roles=[_role("faculty"), _role("staff")],
+    )
+
+    assert {row["agentId"] for row in response.json()["pins"]} == {"ast-a", "ast-b"}
+
+
+def test_a_lock_from_any_role_wins(client):
+    """The strictest claim is the honest one — otherwise a lock is a coin toss."""
+    response = _shelf(
+        client,
+        seeds={"faculty": [_seed("ast-a")], "staff": [_seed("ast-a", locked=True)]},
+        roles=[_role("faculty"), _role("staff")],
+    )
+
+    rows = response.json()["pins"]
+    assert len(rows) == 1
+    assert rows[0]["locked"] is True
+
+
+def test_shelf_order_is_locked_then_priority_then_own(client):
+    response = _shelf(
+        client,
+        state=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-own", order=0)]),
+        seeds={
+            "faculty": [_seed("ast-high")],
+            "staff": [_seed("ast-low"), _seed("ast-locked", order=1, locked=True)],
+        },
+        roles=[_role("faculty", priority=50), _role("staff", priority=10)],
+    )
+
+    assert [row["agentId"] for row in response.json()["pins"]] == [
+        "ast-locked",
+        "ast-high",
+        "ast-low",
+        "ast-own",
+    ]
+
+
+def test_a_seed_the_user_cannot_reach_is_not_a_grant(client):
+    """The access check runs on every row, seeded or not."""
+    response = _shelf(
+        client,
+        seeds={"faculty": [_seed("ast-private"), _seed("ast-open", order=1)]},
+        assistants={"ast-open": {}},
+    )
+
+    assert [row["agentId"] for row in response.json()["pins"]] == ["ast-open"]
+
+
+def test_the_shelf_still_renders_when_roles_cannot_be_resolved(client):
+    """A pin list is an enhancement to three surfaces; it must degrade, not fail."""
+    service = MagicMock()
+    service.resolve_user_permissions = AsyncMock(side_effect=RuntimeError("dynamo down"))
+
+    with (
+        patch(
+            f"{PIN_SERVICE}.get_pin_state",
+            AsyncMock(return_value=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-own")])),
+        ),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(assistantId="ast-own"), "viewer")),
+        ),
+        patch(f"{PIN_SERVICE}.get_app_role_service", lambda: service),
+    ):
+        response = client.get("/agents/pins")
+
+    assert [row["agentId"] for row in response.json()["pins"]] == ["ast-own"]
+
+
+# ── POST /agents/{id}/pin against a seed ─────────────────────────────────────────────
+def test_pinning_something_your_role_locked_returns_a_locked_row(client):
+    """The SPA splices this row into its list — a `locked: false` here offers a remove
+    control that the next full read would take away."""
+    with (
+        patch(
+            f"{PIN_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(assistantId="ast-locked"), "viewer")),
+        ),
+        patch(f"{PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+        patch(
+            f"{PIN_SERVICE}.add_pin",
+            AsyncMock(return_value=UserPinState(pinned=[PinnedAgentRef(agent_id="ast-locked")])),
+        ),
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=UserPinState())),
+        patch(f"{PIN_SERVICE}.get_app_role_service", lambda: _role_service([_role("faculty")])),
+        patch(
+            f"{PIN_SERVICE}.list_pins_for_roles",
+            AsyncMock(return_value={"faculty": [_seed("ast-locked", locked=True)]}),
+        ),
+    ):
+        response = client.post("/agents/ast-locked/pin")
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source"] == "user"
+    assert body["locked"] is True
+
+
+# ── DELETE /agents/{id}/pin against a locked seed ────────────────────────────────────
+def test_unpinning_a_locked_seed_no_ops(client):
+    """D9.4. Writing the tombstone anyway would arm a dismissal for the day it unlocks."""
+    remove = AsyncMock()
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=UserPinState())),
+        patch(f"{PIN_SERVICE}.get_app_role_service", lambda: _role_service([_role("faculty")])),
+        patch(
+            f"{PIN_SERVICE}.list_pins_for_roles",
+            AsyncMock(return_value={"faculty": [_seed("ast-locked", locked=True)]}),
+        ),
+        patch(f"{PIN_SERVICE}.remove_pin", remove),
+    ):
+        response = client.delete("/agents/ast-locked/pin")
+
+    assert response.status_code == 204
+    remove.assert_not_awaited()
+
+
+def test_unpinning_an_unlocked_seed_tombstones_it(client):
+    remove = AsyncMock()
+    with (
+        patch(f"{PIN_SERVICE}.get_pin_state", AsyncMock(return_value=UserPinState())),
+        patch(f"{PIN_SERVICE}.get_app_role_service", lambda: _role_service([_role("faculty")])),
+        patch(
+            f"{PIN_SERVICE}.list_pins_for_roles",
+            AsyncMock(return_value={"faculty": [_seed("ast-seeded")]}),
+        ),
+        patch(f"{PIN_SERVICE}.remove_pin", remove),
+    ):
+        response = client.delete("/agents/ast-seeded/pin")
+
+    assert response.status_code == 204
+    remove.assert_awaited_once_with("user-001", "ast-seeded")
+
+
+# ── the admin console ────────────────────────────────────────────────────────────────
+def _admin_get(client, role, pins, agents):
+    with (
+        patch(f"{ADMIN_ROUTES}.get_app_role_admin_service", lambda: _admin_service(role)),
+        patch(f"{ADMIN_ROUTES}.list_role_pins", AsyncMock(return_value=pins)),
+        patch(f"{ROLE_PIN_SERVICE}.batch_get_agents", AsyncMock(return_value=agents)),
+        patch(f"{ROLE_PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+    ):
+        return client.get(f"/admin/roles/{role.role_id if role else 'nope'}/agent-pins")
+
+
+def _admin_service(role):
+    service = MagicMock()
+    service.get_role = AsyncMock(return_value=role)
+    return service
+
+
+def test_an_unknown_role_is_a_404(client):
+    with patch(f"{ADMIN_ROUTES}.get_app_role_admin_service", lambda: _admin_service(None)):
+        response = client.get("/admin/roles/ghost/agent-pins")
+
+    assert response.status_code == 404
+
+
+def test_the_default_role_is_labelled_as_a_substitute(client):
+    """⚠️ D9.6 — seeding ``default`` reaches only users who matched zero roles."""
+    response = _admin_get(client, _role("default", jwt_role_mappings=[]), [], {})
+
+    body = response.json()
+    assert body["fallbackOnly"] is True
+    assert body["unmapped"] is True
+
+
+def test_a_mapped_role_is_not_labelled_as_a_substitute(client):
+    response = _admin_get(client, _role("faculty"), [], {})
+
+    body = response.json()
+    assert body["fallbackOnly"] is False
+    assert body["unmapped"] is False
+
+
+def test_a_row_names_what_the_role_cannot_reach(client):
+    """D9.5: seeding 410 researchers an Agent that fails on their first message."""
+    agent = _make_assistant(
+        assistantId="ast-001",
+        modelConfig={"modelId": "anthropic.claude-opus-5"},
+        bindings=[{"kind": "tool", "ref": "web_search", "config": {}}],
+    ).model_dump(by_alias=True)
+    role = _role(
+        "student",
+        effective_permissions=EffectivePermissions(tools=[], models=[], skills=[]),
+    )
+
+    with patch(f"{ROLE_PIN_SERVICE}._model_label", AsyncMock(return_value="Claude Opus 5")):
+        response = _admin_get(client, role, [_seed("ast-001")], {"ast-001": agent})
+
+    row = response.json()["pins"][0]
+    assert row["state"] == "blocked"
+    assert {item["kind"] for item in row["missing"]} == {"model", "tool"}
+    # Never the raw ref — a capability label is rendered content.
+    assert any(item["label"] == "Claude Opus 5" for item in row["missing"])
+
+
+def test_a_role_that_grants_everything_reads_as_ready(client):
+    agent = _make_assistant(
+        assistantId="ast-001",
+        modelConfig={"modelId": "anthropic.claude-opus-5"},
+        bindings=[{"kind": "tool", "ref": "web_search", "config": {}}],
+    ).model_dump(by_alias=True)
+
+    response = _admin_get(client, _role("faculty"), [_seed("ast-001")], {"ast-001": agent})
+
+    row = response.json()["pins"][0]
+    assert row["state"] == "ready"
+    assert row["missing"] == []
+
+
+def test_a_memory_space_binding_is_a_note_not_a_verdict(client):
+    """A role does not grant memory spaces, so 'ready' must not claim to have checked one."""
+    agent = _make_assistant(
+        assistantId="ast-001",
+        bindings=[{"kind": "memory_space", "ref": "space-1", "config": {}}],
+    ).model_dump(by_alias=True)
+
+    response = _admin_get(client, _role("faculty"), [_seed("ast-001")], {"ast-001": agent})
+
+    row = response.json()["pins"][0]
+    assert row["notes"]
+    assert all(item["kind"] != "memory_space" for item in row["missing"])
+
+
+def test_a_private_agent_is_flagged_as_unreachable(client):
+    """The seed would resolve to nothing for every member: the read access-checks each row."""
+    agent = _make_assistant(assistantId="ast-001", visibility="PRIVATE").model_dump(by_alias=True)
+
+    response = _admin_get(client, _role("faculty"), [_seed("ast-001")], {"ast-001": agent})
+
+    row = response.json()["pins"][0]
+    assert row["reachable"] is False
+    assert row["visibility"] == "PRIVATE"
+
+
+def test_a_deleted_agent_is_reported_rather_than_pruned(client):
+    """A GET that rewrote the seed list would disguise an accidental delete as an edit."""
+    response = _admin_get(client, _role("faculty"), [_seed("ast-gone")], {})
+
+    body = response.json()
+    assert body["pins"] == []
+    assert body["unavailable"] == ["ast-gone"]
+
+
+def test_saving_replaces_the_list_in_order(client):
+    save = AsyncMock()
+    with (
+        patch(f"{ADMIN_ROUTES}.get_app_role_admin_service", lambda: _admin_service(_role("faculty"))),
+        patch(f"{ADMIN_ROUTES}.put_role_pins", save),
+        patch(f"{ADMIN_ROUTES}.list_role_pins", AsyncMock(return_value=[])),
+        patch(f"{ROLE_PIN_SERVICE}.batch_get_agents", AsyncMock(return_value={})),
+        patch(f"{ROLE_PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+    ):
+        response = client.put(
+            "/admin/roles/faculty/agent-pins",
+            json={"pins": [{"agentId": "ast-002"}, {"agentId": "ast-001", "locked": True}]},
+        )
+
+    assert response.status_code == 200
+    saved = save.await_args.args[1]
+    assert [pin.agent_id for pin in saved] == ["ast-002", "ast-001"]
+    assert [pin.locked for pin in saved] == [False, True]
+
+
+def test_a_refused_list_is_a_400_with_the_reason(client):
+    with (
+        patch(f"{ADMIN_ROUTES}.get_app_role_admin_service", lambda: _admin_service(_role("faculty"))),
+        patch(
+            f"{ADMIN_ROUTES}.put_role_pins",
+            AsyncMock(side_effect=ValueError("The same agent cannot be pinned to a role twice.")),
+        ),
+    ):
+        response = client.put(
+            "/admin/roles/faculty/agent-pins",
+            json={"pins": [{"agentId": "ast-001"}, {"agentId": "ast-001"}]},
+        )
+
+    assert response.status_code == 400
+    assert "twice" in response.json()["detail"]
+
+
+def test_a_warning_does_not_block_the_save(client):
+    """An admin may seed something whose author is about to publish it."""
+    agent = _make_assistant(assistantId="ast-001", visibility="PRIVATE").model_dump(by_alias=True)
+    save = AsyncMock()
+
+    with (
+        patch(f"{ADMIN_ROUTES}.get_app_role_admin_service", lambda: _admin_service(_role("faculty"))),
+        patch(f"{ADMIN_ROUTES}.put_role_pins", save),
+        patch(f"{ADMIN_ROUTES}.list_role_pins", AsyncMock(return_value=[_seed("ast-001")])),
+        patch(f"{ROLE_PIN_SERVICE}.batch_get_agents", AsyncMock(return_value={"ast-001": agent})),
+        patch(f"{ROLE_PIN_SERVICE}.list_publishers", AsyncMock(return_value=[])),
+    ):
+        response = client.put(
+            "/admin/roles/faculty/agent-pins", json={"pins": [{"agentId": "ast-001"}]}
+        )
+
+    assert response.status_code == 200
+    save.assert_awaited_once()
+    assert response.json()["pins"][0]["reachable"] is False

--- a/backend/tests/shared/test_role_agent_pins.py
+++ b/backend/tests/shared/test_role_agent_pins.py
@@ -1,0 +1,197 @@
+"""Agent Marketplace Phase 6 — role-seeded default pins, storage side (D9).
+
+Through a real (moto) table, because the stored shape *is* the contract: the resolver on
+the user side reads these items on every pin request, and the RBAC repository writes and
+deletes in the same partition.
+
+The case worth the whole file is ``test_updating_a_role_preserves_its_default_pins``.
+``AppRoleRepository.update_role`` rebuilds a role's mapping items by deleting them first,
+and it used to delete *everything* under ``PK=ROLE#{id}`` except the definition. Pins are
+deliberately not part of the ``AppRole`` record — a pin is not a permission — so nothing
+would have rewritten them: every edit to a role's name or grants would silently empty its
+seed list.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.models import RoleAgentPinInput
+from apis.shared.assistants.role_pins import (
+    MAX_ROLE_PINS,
+    delete_role_pins,
+    list_pins_for_roles,
+    list_role_pins,
+    put_role_pins,
+)
+from apis.shared.rbac.models import AppRole
+from apis.shared.rbac.repository import AppRoleRepository
+
+REGION = "us-east-1"
+TABLE = "test-app-roles"
+ADMIN = "admin-1"
+
+
+def _inputs(*specs):
+    """``("ast-001", True)`` or just ``"ast-001"`` → pin inputs, in order."""
+    out = []
+    for spec in specs:
+        agent_id, locked = spec if isinstance(spec, tuple) else (spec, False)
+        out.append(RoleAgentPinInput(agent_id=agent_id, locked=locked))
+    return out
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_APP_ROLES_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+# ── the stored shape ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_role_with_no_pins_reads_as_empty(table):
+    assert await list_role_pins("faculty") == []
+
+
+@pytest.mark.asyncio
+async def test_pins_are_stored_beside_the_grant_items(table):
+    await put_role_pins("faculty", _inputs("ast-001"), updated_by=ADMIN)
+
+    item = table.get_item(Key={"PK": "ROLE#faculty", "SK": "AGENT_PIN#ast-001"})["Item"]
+    assert item["order"] == 0
+    assert item["locked"] is False
+    assert item["createdBy"] == ADMIN
+    assert "createdAt" in item
+
+
+@pytest.mark.asyncio
+async def test_the_saved_order_is_the_list_order(table):
+    await put_role_pins("faculty", _inputs("ast-003", "ast-001", "ast-002"), updated_by=ADMIN)
+
+    pins = await list_role_pins("faculty")
+    assert [pin.agent_id for pin in pins] == ["ast-003", "ast-001", "ast-002"]
+    assert [pin.order for pin in pins] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_saving_replaces_the_whole_list(table):
+    await put_role_pins("faculty", _inputs("ast-001", "ast-002"), updated_by=ADMIN)
+    await put_role_pins("faculty", _inputs("ast-002"), updated_by=ADMIN)
+
+    assert [pin.agent_id for pin in await list_role_pins("faculty")] == ["ast-002"]
+
+
+@pytest.mark.asyncio
+async def test_reordering_keeps_when_an_agent_was_seeded(table):
+    """``createdAt`` records the seed, not the last drag — otherwise the audit trail lies."""
+    await put_role_pins("faculty", _inputs("ast-001", "ast-002"), updated_by=ADMIN)
+    original = {pin.agent_id: pin.created_at for pin in await list_role_pins("faculty")}
+
+    await put_role_pins("faculty", _inputs("ast-002", "ast-001"), updated_by="admin-2")
+
+    after = {pin.agent_id: pin for pin in await list_role_pins("faculty")}
+    assert after["ast-001"].created_at == original["ast-001"]
+    assert after["ast-001"].created_by == ADMIN
+    assert after["ast-002"].order == 0
+
+
+@pytest.mark.asyncio
+async def test_lock_round_trips(table):
+    await put_role_pins("faculty", _inputs(("ast-001", True), "ast-002"), updated_by=ADMIN)
+
+    pins = {pin.agent_id: pin.locked for pin in await list_role_pins("faculty")}
+    assert pins == {"ast-001": True, "ast-002": False}
+
+
+@pytest.mark.asyncio
+async def test_pins_are_per_role(table):
+    await put_role_pins("faculty", _inputs("ast-001"), updated_by=ADMIN)
+    await put_role_pins("staff", _inputs("ast-002"), updated_by=ADMIN)
+
+    by_role = await list_pins_for_roles(["faculty", "staff", "student"])
+    assert [pin.agent_id for pin in by_role["faculty"]] == ["ast-001"]
+    assert [pin.agent_id for pin in by_role["staff"]] == ["ast-002"]
+    assert by_role["student"] == []
+
+
+# ── refusals ─────────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_past_the_ceiling_is_refused(table):
+    too_many = _inputs(*[f"ast-{index:03d}" for index in range(MAX_ROLE_PINS + 1)])
+
+    with pytest.raises(ValueError) as excinfo:
+        await put_role_pins("faculty", too_many, updated_by=ADMIN)
+
+    assert str(MAX_ROLE_PINS) in str(excinfo.value)
+    assert await list_role_pins("faculty") == []
+
+
+@pytest.mark.asyncio
+async def test_the_same_agent_twice_is_refused(table):
+    """A duplicate would collapse to one item on write and renumber everything after it."""
+    with pytest.raises(ValueError):
+        await put_role_pins("faculty", _inputs("ast-001", "ast-001"), updated_by=ADMIN)
+
+
+# ── the partition it shares with the grants ──────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_updating_a_role_preserves_its_default_pins(table):
+    """The trap: ``update_role`` rebuilds mapping items, and a pin is not one of them."""
+    repository = AppRoleRepository(table_name=TABLE)
+    role = AppRole(
+        role_id="faculty",
+        display_name="Faculty",
+        description="Teaching staff",
+        jwt_role_mappings=["Faculty"],
+        granted_tools=["web_search"],
+    )
+    await repository.create_role(role)
+    await put_role_pins("faculty", _inputs("ast-001", "ast-002"), updated_by=ADMIN)
+
+    role.display_name = "Faculty (renamed)"
+    role.granted_tools = ["web_search", "calculator"]
+    await repository.update_role(role)
+
+    assert [pin.agent_id for pin in await list_role_pins("faculty")] == ["ast-001", "ast-002"]
+    # And the grants it *does* own were still rebuilt.
+    assert (await repository.get_role("faculty")).granted_tools == ["web_search", "calculator"]
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_role_takes_its_default_pins_with_it(table):
+    repository = AppRoleRepository(table_name=TABLE)
+    await repository.create_role(
+        AppRole(role_id="temp", display_name="Temp", description="", jwt_role_mappings=["Temp"])
+    )
+    await put_role_pins("temp", _inputs("ast-001"), updated_by=ADMIN)
+
+    await repository.delete_role("temp")
+
+    assert await list_role_pins("temp") == []
+
+
+@pytest.mark.asyncio
+async def test_delete_role_pins_clears_the_list(table):
+    await put_role_pins("faculty", _inputs("ast-001", "ast-002"), updated_by=ADMIN)
+
+    await delete_role_pins("faculty")
+
+    assert await list_role_pins("faculty") == []

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -560,8 +560,8 @@ Phase 3.5 Author Submit UI: submit dialog (category, note, D7 disclosures),
          listing-state badges + reviewer note + D13 edit trail on My Agents,
          withdraw/unpublish, GET /agents/{id}/listing/preflight   ✅ shipped (PR #734)
 Phase 4  Icons: upload, S3, generated fallback, all four render sizes  ✅ shipped (PR #735)
-Phase 5  Pins: user pin state + Pinned tab + store front admin              ← in progress
-Phase 6  Default pins by role (D9) + the assignment-time runnability check
+Phase 5  Pins: user pin state + Pinned tab + store front admin        ✅ shipped (PR #736)
+Phase 6  Default pins by role (D9) + the assignment-time runnability check  ← in progress
 Phase 7  @-mention in the composer
 Phase 8  Problem reports (D15): report action + admin Reports queue   ← depends on 3
 Later    Ranking + full-corpus search via the Registry catalog (F6b)
@@ -590,6 +590,34 @@ and parallelizable once 1–3 land.
 
 Promotion lives on the **Store front** surface rather than as a star on the Listings table: the row
 is an ordered list, and a per-row toggle can express membership but not position.
+
+**Phase 6 notes (as built).** Four, the first of which was a live trap:
+
+- **⚠️ `AppRoleRepository._delete_mapping_items` deleted every non-`DEFINITION` item under
+  `PK=ROLE#{id}`, and `update_role` calls it before rebuilding.** Pins are deliberately not part of
+  the `AppRole` record — a pin is not a permission — so nothing would have rewritten them: any edit
+  to a role's name, priority or grants would have silently emptied its seed list. It now deletes by
+  *prefix* (`JWT_MAPPING#`/`TOOL_GRANT#`/`MODEL_GRANT#`/`SKILL_GRANT#`), with `AGENT_PIN#` added only
+  for `delete_role`, where the role itself is going away. Any future per-role item that is not
+  reconstructible from `_build_role_items` needs the same protection.
+- **Role pins live in `assistants/role_pins.py`, not in `AppRoleRepository`.** The repository already
+  owns that table, and that is exactly the coupling worth refusing: keeping the pin read out of the
+  module that computes permissions makes "a pin is not a permission" structural rather than a comment.
+  The resolver reads `resolve_user_permissions` for its `app_roles` list *only* — the matched role
+  ids, including the `default` substitution — and queries the pins itself.
+- **Two separate checks on the admin row, because they have different owners.** *Reachability* is
+  visibility (`PRIVATE`/`SHARED` → the seed resolves to nothing for members; the author fixes it) and
+  *runnability* is the D9.5 diff against the role's `effective_permissions` (the admin fixes it).
+  Both **warn**; neither blocks the save, since an admin may legitimately seed something whose author
+  is mid-publish. `memory_space` is reported as a *note*, never as present or missing: a role does not
+  grant memory spaces, so "ready" must not claim to have checked one. `MAX_ROLE_PINS = 25` — stricter
+  than the user's own `MAX_PINS = 100`, because this shelf is somebody else's.
+- **Where a user's own pins sort.** The spec's `(locked desc, role priority desc, order asc, name asc)`
+  has no answer for a pin with no role, so own-only pins follow the seeded ones, ordered by their own
+  `order`. An own pin that a role *also* seeds sorts as the seed and reads as `source: "user"` — the
+  D9.1 escape hatch — while `locked` still follows the role's flag. The removal warning lives on the
+  console's **Save**, not on the row's `✕`: the editor is staged, and Save is the moment anything
+  reaches other people.
 
 **Phase 3.5 is a gap this table originally left open.** Phases 1–3 shipped the submit and withdraw
 endpoints and the entire reviewer console, but no phase owned the *author's* half of the surface —

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -24,6 +24,7 @@ import {
   heroRectangleStack,
   heroStar,
   heroTag,
+  heroBookmark,
 } from '@ng-icons/heroicons/outline';
 
 interface NavItem {
@@ -60,6 +61,7 @@ interface NavGroup {
       heroRectangleStack,
       heroStar,
       heroTag,
+      heroBookmark,
     }),
   ],
   host: { class: 'block' },
@@ -164,14 +166,15 @@ export class AdminLayout {
       ],
     },
     {
-      // Agent Marketplace. Four of D10's seven surfaces; default pins and the reports
-      // queue join this group as their phases land.
+      // Agent Marketplace. Five of D10's seven surfaces; the reports queue joins this
+      // group with Phase 8.
       label: 'Agent Marketplace',
       items: [
         { label: 'Review Queue', icon: 'heroInbox', route: '/admin/marketplace/review' },
         { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
         { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front' },
         { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories' },
+        { label: 'Default Pins', icon: 'heroBookmark', route: '/admin/marketplace/default-pins' },
       ],
     },
     {

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -85,8 +85,8 @@ export const adminRoutes: Routes = [
     path: 'skills/edit/:skillId',
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
-  // Agent Marketplace (docs/specs/agent-marketplace.md) — four of D10's seven admin
-  // surfaces. Default pins and the reports queue arrive in later phases.
+  // Agent Marketplace (docs/specs/agent-marketplace.md) — five of D10's seven admin
+  // surfaces. The reports queue arrives with Phase 8.
   {
     path: 'marketplace/review',
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
@@ -102,6 +102,10 @@ export const adminRoutes: Routes = [
   {
     path: 'marketplace/store-front',
     loadComponent: () => import('./marketplace/pages/store-front.page').then(m => m.MarketplaceStoreFrontPage),
+  },
+  {
+    path: 'marketplace/default-pins',
+    loadComponent: () => import('./marketplace/pages/default-pins.page').then(m => m.MarketplaceDefaultPinsPage),
   },
   {
     path: 'marketplace',

--- a/frontend/ai.client/src/app/admin/marketplace/components/role-pin-save-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/role-pin-save-dialog.component.ts
@@ -1,0 +1,126 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+
+export interface RolePinSaveDialogData {
+  roleLabel: string;
+  /** Agent names this save takes off the role's seed list. */
+  removed: string[];
+}
+
+/** `true` to save, `undefined` if cancelled. */
+export type RolePinSaveDialogResult = true | undefined;
+
+/**
+ * Confirms a save that removes seeded agents (D9.1).
+ *
+ * The copy is load-bearing and comes straight from the spec: role pins resolve live, so
+ * removing one **unpins for everyone in this role who has not pinned it themselves**.
+ * There is no "apply to new members only" — live resolution makes that unrepresentable,
+ * and it was dropped on purpose. An admin who believes removal only affects future
+ * members will use this control for something it does not do.
+ *
+ * It appears on Save rather than on the row's `✕`, because the editor is staged: the row
+ * control changes a local list, and the moment anything reaches other people is this one.
+ */
+@Component({
+  selector: 'app-role-pin-save-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="role-pin-save-title"
+        aria-describedby="role-pin-save-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2
+              id="role-pin-save-title"
+              class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+            >
+              Remove
+              {{ data.removed.length === 1 ? 'a default pin' : data.removed.length + ' default pins' }}
+              from {{ data.roleLabel }}?
+            </h2>
+            <p
+              id="role-pin-save-description"
+              class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400"
+            >
+              This unpins for everyone in this role who has not pinned it themselves.
+              Anyone who added it to their own agents keeps it.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <ul class="flex flex-col gap-1">
+            @for (name of data.removed; track name) {
+              <li class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ name }}</li>
+            }
+          </ul>
+          <div class="mt-4 rounded-2xl bg-amber-50 px-4 py-3 dark:bg-amber-900/20">
+            <p class="text-sm/6 text-gray-700 dark:text-gray-300">
+              Default pins resolve live — there is no "new members only". Removing one takes
+              effect for current members on their next page load.
+            </p>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="onConfirm()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Save changes
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class RolePinSaveDialogComponent {
+  private dialogRef = inject<DialogRef<RolePinSaveDialogResult>>(DialogRef);
+  readonly data = inject<RolePinSaveDialogData>(DIALOG_DATA);
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -1,10 +1,10 @@
 /**
- * Agent Marketplace admin types (Phases 1–2, 5).
+ * Agent Marketplace admin types (Phases 1–2, 5–6).
  *
- * Mirrors the backend wire models in `apis/shared/assistants/models.py`. Four of D10's
- * seven surfaces are covered — Review queue, Listings, Categories and Store front — plus
- * the publisher profiles they read. Default pins and the reports queue arrive with their
- * phases.
+ * Mirrors the backend wire models in `apis/shared/assistants/models.py`. Five of D10's
+ * seven surfaces are covered — Review queue, Listings, Categories, Store front and
+ * Default pins — plus the publisher profiles they read. The reports queue arrives with
+ * Phase 8.
  */
 
 import {
@@ -119,5 +119,69 @@ export interface AgentCategory {
   enabled: boolean;
   createdAt?: string;
   updatedAt?: string;
+}
+
+// ── default pins by role (D9, Phase 6) ─────────────────────────────────────────────
+
+/** A role seeds at most this many agents — see `role_pins.MAX_ROLE_PINS`. */
+export const MAX_ROLE_PINS = 25;
+
+/** One capability the role does not grant, named rather than counted (D9.5). */
+export interface MissingCapability {
+  label: string;
+  kind: string;
+  /** Only an explicitly optional binding degrades to `limits` rather than blocking. */
+  optional: boolean;
+}
+
+/**
+ * One seeded agent as the admin console sees it: the shelf row plus the two checks that
+ * decide whether the seed will do anything for this role's members.
+ *
+ * `reachable` is about *visibility* — a PRIVATE agent resolves to nothing for everyone
+ * but its owner, because the user-side read access-checks every row. `state` is about
+ * *capability* — the agent's model and bindings diffed against this role's granted
+ * permissions. They fail for different reasons and have different people to fix them.
+ */
+export interface RoleAgentPinRow {
+  agentId: string;
+  name: string;
+  tagline?: string;
+  emoji?: string;
+  iconUrl?: string;
+  publisher?: { label: string; kind: PublisherKind; verified: boolean } | null;
+  category: string;
+  order: number;
+  /** A locked seed cannot be dismissed by a member (D9.4). */
+  locked: boolean;
+  listingState?: ListingState | null;
+  reachable: boolean;
+  visibility: string;
+  state: 'ready' | 'limits' | 'blocked';
+  missing: MissingCapability[];
+  /** What the role-level check could not decide — a memory space resolves per person. */
+  notes: string[];
+}
+
+export interface RoleAgentPinsResponse {
+  roleId: string;
+  roleLabel: string;
+  /**
+   * ⚠️ D9.6 — `default` is consulted only for users who matched *zero* AppRoles and is
+   * never merged alongside a matched role. Pins seeded there reach nobody who holds any
+   * other role, which is why the console labels the chip rather than letting an admin
+   * assume it means "everyone".
+   */
+  fallbackOnly: boolean;
+  /** The role has no JWT mappings, so no user matches it at all. */
+  unmapped: boolean;
+  pins: RoleAgentPinRow[];
+  /** Seeded ids whose agent no longer exists — reported, never pruned on read. */
+  unavailable: string[];
+}
+
+/** Replace a role's seed list, in order. `order` belongs to the list, not to a row. */
+export interface RoleAgentPinsUpdateRequest {
+  pins: { agentId: string; locked: boolean }[];
 }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
@@ -1,0 +1,599 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowDown,
+  heroArrowUp,
+  heroBookmark,
+  heroLockClosed,
+  heroLockOpen,
+  heroXMark,
+} from '@ng-icons/heroicons/outline';
+import { firstValueFrom } from 'rxjs';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { AppRolesService } from '../../roles/services/app-roles.service';
+import { AppRole } from '../../roles/models/app-role.model';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import {
+  AdminListingRow,
+  MAX_ROLE_PINS,
+  RoleAgentPinRow,
+} from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+import {
+  RolePinSaveDialogComponent,
+  RolePinSaveDialogResult,
+} from '../components/role-pin-save-dialog.component';
+
+/** A staged row: the resolved server row, plus the lock the admin is editing. */
+interface StagedPin {
+  row: RoleAgentPinRow | null;
+  agentId: string;
+  name: string;
+  tagline?: string;
+  emoji?: string;
+  iconUrl?: string;
+  locked: boolean;
+}
+
+/**
+ * Default pins by role — the seventh of D10's admin surfaces (D9).
+ *
+ * A role's members start with a useful sidebar instead of an empty one. Three things this
+ * page has to keep saying out loud, because each is a way an admin ends up doing something
+ * other than what they intended:
+ *
+ * 1. **Removal is not "new members only."** Pins resolve live, so removing one unpins for
+ *    everyone in the role who has not pinned it themselves. The mockup's "apply to new
+ *    members only" option is unrepresentable and was dropped deliberately — the save
+ *    dialog carries the real consequence.
+ * 2. **⚠️ `default` is a substitute, not a baseline.** It is consulted only for users who
+ *    matched *zero* roles. An admin who reads that chip as "everyone" seeds nobody, which
+ *    is why the banner says so in the role's own words rather than in a tooltip.
+ * 3. **A seed can be inert for two different reasons.** The agent may be unreachable
+ *    (PRIVATE — nobody but its owner resolves it) or unrunnable (the role does not grant
+ *    its model or a bound tool, D9.5). They have different fixes and different owners, so
+ *    the row names which one it is rather than showing one generic warning.
+ *
+ * The editor is **staged**, like the store front: order and locks change locally and Save
+ * writes the whole list in one PUT. Reordering has to be atomic, and per-row autosave
+ * would make every mis-click a live change to somebody else's sidebar.
+ */
+@Component({
+  selector: 'app-marketplace-default-pins',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, AgentTileComponent, TooltipDirective],
+  providers: [
+    provideIcons({
+      heroArrowDown,
+      heroArrowUp,
+      heroBookmark,
+      heroLockClosed,
+      heroLockOpen,
+      heroXMark,
+    }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Default pins</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Agents every member of a role starts with. Pins resolve live — there is no
+            copy per person — so adding or removing one takes effect on the next page load.
+            Up to {{ maxPins }} per role.
+          </p>
+        </div>
+
+        <!-- Role picker -->
+        <div class="mb-6">
+          <label
+            for="role-picker"
+            class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            Role
+          </label>
+          <select
+            id="role-picker"
+            [value]="roleId()"
+            (change)="onRoleChange($event)"
+            class="mt-2 block w-full max-w-sm rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            @for (role of roles(); track role.roleId) {
+              <option [value]="role.roleId">
+                {{ role.displayName || role.roleId }}
+              </option>
+            }
+          </select>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        <!-- ⚠️ D9.6: the two ways a seed list reaches nobody. -->
+        @if (fallbackOnly()) {
+          <div
+            role="status"
+            class="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            <span class="font-semibold">Fallback only.</span>
+            The <code class="font-mono">default</code> role applies to users who match no
+            other role — it is never merged alongside one. Pins seeded here do not reach
+            anyone who holds faculty, staff, student or any other role. To reach everyone,
+            seed each role.
+          </div>
+        } @else if (unmapped()) {
+          <div
+            role="status"
+            class="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            <span class="font-semibold">No members.</span>
+            This role has no identity-provider mappings, so nobody currently matches it.
+            Pins seeded here will apply once a mapping is added.
+          </div>
+        }
+
+        @if (unavailable().length) {
+          <div
+            role="status"
+            class="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            {{ unavailable().length }}
+            seeded
+            {{ unavailable().length === 1 ? 'agent no longer exists' : 'agents no longer exist' }}.
+            Saving this list clears
+            {{ unavailable().length === 1 ? 'it' : 'them' }}.
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading default pins</span>
+          </div>
+        } @else {
+          <!-- The seed list -->
+          <section class="mb-8">
+            <div class="mb-3 flex items-center justify-between gap-4">
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                Seeded for {{ roleLabel() }} ({{ staged().length }}/{{ maxPins }})
+              </h2>
+              <div class="flex items-center gap-2">
+                @if (dirty()) {
+                  <button
+                    type="button"
+                    (click)="reloadPins()"
+                    [disabled]="busy()"
+                    class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    Discard
+                  </button>
+                }
+                <button
+                  type="button"
+                  (click)="save()"
+                  [disabled]="!dirty() || busy()"
+                  class="rounded-2xl bg-blue-600 px-4 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {{ dirty() ? 'Save pins' : 'Saved' }}
+                </button>
+              </div>
+            </div>
+
+            @if (staged().length === 0) {
+              <div
+                class="rounded-2xl border border-dashed border-gray-300 px-6 py-12 text-center dark:border-gray-600"
+              >
+                <ng-icon
+                  name="heroBookmark"
+                  class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+                <h3 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+                  Nothing seeded
+                </h3>
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                  Members of this role start with an empty Pinned tab.
+                </p>
+              </div>
+            } @else {
+              <ol class="flex flex-col gap-2">
+                @for (pin of staged(); track pin.agentId; let i = $index) {
+                  <li
+                    class="rounded-2xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    <div class="flex items-center gap-3">
+                      <span
+                        class="w-6 shrink-0 text-center text-sm/6 font-semibold tabular-nums text-gray-400 dark:text-gray-500"
+                        aria-hidden="true"
+                      >
+                        {{ i + 1 }}
+                      </span>
+                      <app-agent-tile
+                        [agentId]="pin.agentId"
+                        [iconUrl]="pin.iconUrl"
+                        [emoji]="pin.emoji"
+                        size="sm"
+                      />
+                      <div class="min-w-0 flex-1">
+                        <p
+                          class="truncate text-sm/6 font-medium text-gray-900 dark:text-white"
+                        >
+                          {{ pin.name }}
+                        </p>
+                        <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                          {{ pin.tagline }}
+                        </p>
+                      </div>
+                      <div class="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          (click)="toggleLock(pin.agentId)"
+                          [disabled]="busy()"
+                          [appTooltip]="
+                            pin.locked
+                              ? 'Locked — members cannot remove this. Click to unlock.'
+                              : 'Members can remove this. Click to lock it in place.'
+                          "
+                          appTooltipPosition="top"
+                          [attr.aria-pressed]="pin.locked"
+                          class="rounded-2xl p-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                          [class]="
+                            pin.locked
+                              ? 'text-amber-600 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-900/20'
+                              : 'text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'
+                          "
+                        >
+                          <ng-icon
+                            [name]="pin.locked ? 'heroLockClosed' : 'heroLockOpen'"
+                            class="size-5"
+                            aria-hidden="true"
+                          />
+                          <span class="sr-only">
+                            {{ pin.locked ? 'Unlock' : 'Lock' }} {{ pin.name }}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          (click)="moveUp(i)"
+                          [disabled]="i === 0 || busy()"
+                          [appTooltip]="'Move up'"
+                          appTooltipPosition="top"
+                          class="rounded-2xl p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                        >
+                          <ng-icon name="heroArrowUp" class="size-5" aria-hidden="true" />
+                          <span class="sr-only">Move {{ pin.name }} up</span>
+                        </button>
+                        <button
+                          type="button"
+                          (click)="moveDown(i)"
+                          [disabled]="i === staged().length - 1 || busy()"
+                          [appTooltip]="'Move down'"
+                          appTooltipPosition="top"
+                          class="rounded-2xl p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                        >
+                          <ng-icon name="heroArrowDown" class="size-5" aria-hidden="true" />
+                          <span class="sr-only">Move {{ pin.name }} down</span>
+                        </button>
+                        <button
+                          type="button"
+                          (click)="remove(pin.agentId)"
+                          [disabled]="busy()"
+                          [appTooltip]="'Remove from this role'"
+                          appTooltipPosition="top"
+                          class="rounded-2xl p-2 text-gray-500 hover:bg-rose-50 hover:text-rose-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-rose-900/20 dark:hover:text-rose-400"
+                        >
+                          <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+                          <span class="sr-only">Remove {{ pin.name }}</span>
+                        </button>
+                      </div>
+                    </div>
+
+                    <!-- D9.5, and the reachability check beside it. Two different fixes. -->
+                    @if (pin.row && !pin.row.reachable) {
+                      <p
+                        class="mt-2 ml-9 text-xs text-amber-700 dark:text-amber-300"
+                        role="status"
+                      >
+                        Not visible to this role — it is
+                        {{ pin.row.visibility === 'SHARED' ? 'shared with named people' : 'private to its owner' }},
+                        so the pin resolves to nothing for members. Its author has to
+                        publish it or make it public.
+                      </p>
+                    }
+                    @if (pin.row && pin.row.missing.length) {
+                      <p
+                        class="mt-2 ml-9 text-xs text-rose-700 dark:text-rose-300"
+                        role="status"
+                      >
+                        {{ pin.row.state === 'limits' ? 'Runs with limits for' : "Won't run for" }}
+                        this role — it does not grant {{ missingLabels(pin.row) }}.
+                      </p>
+                    }
+                    @for (note of pin.row?.notes ?? []; track note) {
+                      <p class="mt-2 ml-9 text-xs text-gray-500 dark:text-gray-400">
+                        {{ note }}
+                      </p>
+                    }
+                  </li>
+                }
+              </ol>
+            }
+          </section>
+
+          <!-- The candidates -->
+          <section>
+            <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">
+              Agents in the store
+            </h2>
+            <p class="mb-3 text-sm/6 text-gray-600 dark:text-gray-400">
+              Everything that has been submitted to the store. Seeding an agent that is not
+              published still works — it is a pin, not a shelf slot — but members can only
+              open one they could reach on their own.
+            </p>
+
+            @if (candidates().length === 0) {
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                Nothing left to add.
+              </p>
+            } @else {
+              <ul class="flex flex-col gap-2">
+                @for (row of candidates(); track row.agentId) {
+                  <li
+                    class="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    <app-agent-tile
+                      [agentId]="row.agentId"
+                      [iconUrl]="row.iconUrl"
+                      [emoji]="row.emoji"
+                      size="sm"
+                    />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                        {{ row.name }}
+                      </p>
+                      <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {{ row.tagline || row.category }}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      (click)="add(row)"
+                      [disabled]="isFull() || busy()"
+                      [appTooltip]="
+                        isFull()
+                          ? 'This role is at the limit — remove one first'
+                          : 'Seed this agent to the role'
+                      "
+                      appTooltipPosition="top"
+                      class="shrink-0 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      Add
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
+          </section>
+        }
+      </div>
+    </div>
+  `,
+})
+export class MarketplaceDefaultPinsPage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+  private rolesService = inject(AppRolesService);
+  private dialog = inject(Dialog);
+
+  readonly maxPins = MAX_ROLE_PINS;
+
+  readonly roles = signal<AppRole[]>([]);
+  readonly roleId = signal('');
+  readonly roleLabel = signal('');
+  readonly fallbackOnly = signal(false);
+  readonly unmapped = signal(false);
+  readonly unavailable = signal<string[]>([]);
+  readonly staged = signal<StagedPin[]>([]);
+  readonly listings = signal<AdminListingRow[]>([]);
+  readonly loading = signal(true);
+  readonly busy = signal(false);
+  readonly error = signal<string | null>(null);
+
+  /** The saved list, to compare against — staging is what makes the reorder atomic. */
+  private saved = signal<string>('');
+
+  /** The rows as the server last resolved them, so a removal can be named, not id'd. */
+  private savedPins = signal<RoleAgentPinRow[]>([]);
+
+  private readonly fingerprint = computed(() =>
+    this.staged()
+      .map((pin) => `${pin.agentId}:${pin.locked}`)
+      .join(' '),
+  );
+
+  readonly dirty = computed(() => this.fingerprint() !== this.saved());
+
+  readonly isFull = computed(() => this.staged().length >= MAX_ROLE_PINS);
+
+  readonly candidates = computed(() => {
+    const already = new Set(this.staged().map((pin) => pin.agentId));
+    return this.listings().filter((row) => !already.has(row.agentId));
+  });
+
+  ngOnInit(): void {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const [roleList, listings] = await Promise.all([
+        this.rolesService.fetchRoles(),
+        this.service.loadListings(),
+      ]);
+      // Highest priority first, matching how the shelf orders seeds from several roles.
+      const roles = [...(roleList.roles ?? [])].sort(
+        (a, b) => b.priority - a.priority || a.roleId.localeCompare(b.roleId),
+      );
+      this.roles.set(roles);
+      this.listings.set(listings);
+      if (roles.length && !this.roleId()) {
+        this.roleId.set(roles[0].roleId);
+      }
+      await this.reloadPins();
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load default pins.'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async reloadPins(): Promise<void> {
+    const roleId = this.roleId();
+    if (!roleId) return;
+    this.error.set(null);
+    try {
+      const response = await this.service.loadRolePins(roleId);
+      this.roleLabel.set(response.roleLabel || roleId);
+      this.fallbackOnly.set(response.fallbackOnly);
+      this.unmapped.set(response.unmapped);
+      this.unavailable.set(response.unavailable ?? []);
+      this.savedPins.set(response.pins ?? []);
+      this.staged.set(
+        (response.pins ?? []).map((row) => ({
+          row,
+          agentId: row.agentId,
+          name: row.name,
+          tagline: row.tagline,
+          emoji: row.emoji,
+          iconUrl: row.iconUrl,
+          locked: row.locked,
+        })),
+      );
+      this.saved.set(this.fingerprint());
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load default pins.'));
+    }
+  }
+
+  async onRoleChange(event: Event): Promise<void> {
+    this.roleId.set((event.target as HTMLSelectElement).value);
+    await this.reloadPins();
+  }
+
+  /**
+   * Seed from the listings table. The staged row carries no `row`, so it renders without
+   * warnings until Save round-trips the authoritative diff back — the alternative would
+   * be a second copy of the D9.5 rules in the browser, which is exactly how a resource
+   * ends up listed by one path and denied by another.
+   */
+  add(row: AdminListingRow): void {
+    if (this.isFull()) return;
+    this.staged.update((current) => [
+      ...current,
+      {
+        row: null,
+        agentId: row.agentId,
+        name: row.name,
+        tagline: row.tagline,
+        emoji: row.emoji,
+        iconUrl: row.iconUrl,
+        locked: false,
+      },
+    ]);
+  }
+
+  remove(agentId: string): void {
+    this.staged.update((current) => current.filter((pin) => pin.agentId !== agentId));
+  }
+
+  toggleLock(agentId: string): void {
+    this.staged.update((current) =>
+      current.map((pin) =>
+        pin.agentId === agentId ? { ...pin, locked: !pin.locked } : pin,
+      ),
+    );
+  }
+
+  moveUp(index: number): void {
+    this.swap(index, index - 1);
+  }
+
+  moveDown(index: number): void {
+    this.swap(index, index + 1);
+  }
+
+  private swap(from: number, to: number): void {
+    this.staged.update((current) => {
+      if (to < 0 || to >= current.length) return current;
+      const next = [...current];
+      [next[from], next[to]] = [next[to], next[from]];
+      return next;
+    });
+  }
+
+  missingLabels(row: RoleAgentPinRow): string {
+    return row.missing.map((item) => item.label).join(', ');
+  }
+
+  /**
+   * Save the whole list.
+   *
+   * A save that *removes* seeds is confirmed first, because that is the one that reaches
+   * other people: role pins resolve live, so removing one unpins for everyone in the role
+   * who has not pinned it themselves (D9.1).
+   */
+  async save(): Promise<void> {
+    const removed = this.removedNames();
+    if (removed.length) {
+      const ref = this.dialog.open<RolePinSaveDialogResult>(RolePinSaveDialogComponent, {
+        data: { roleLabel: this.roleLabel(), removed },
+      });
+      const confirmed = await firstValueFrom(ref.closed);
+      if (!confirmed) return;
+    }
+
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      await this.service.saveRolePins(this.roleId(), {
+        pins: this.staged().map((pin) => ({ agentId: pin.agentId, locked: pin.locked })),
+      });
+      await this.reloadPins();
+    } catch (err) {
+      // The refusal names the offending list, so the server's message beats a generic one.
+      this.error.set(this.messageFor(err, 'Failed to save the default pins.'));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /** Names, not ids — the dialog is read by a person deciding whether to unpin for a cohort. */
+  private removedNames(): string[] {
+    const stagedIds = new Set(this.staged().map((pin) => pin.agentId));
+    return this.savedPins()
+      .filter((row) => !stagedIds.has(row.agentId))
+      .map((row) => row.name);
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -11,6 +11,8 @@ import {
   ListingState,
   PublisherProfile,
   ReviewListingRequest,
+  RoleAgentPinsResponse,
+  RoleAgentPinsUpdateRequest,
 } from '../models/marketplace.model';
 
 interface PublishersResponse {
@@ -152,6 +154,40 @@ export class AdminMarketplaceService {
   async saveStoreFront(agentIds: string[]): Promise<AdminStoreFrontResponse> {
     return firstValueFrom(
       this.http.put<AdminStoreFrontResponse>(`${this.baseUrl()}/storefront`, { agentIds }),
+    );
+  }
+
+  /**
+   * A role's default pins (D9).
+   *
+   * Under `/admin/roles/` because the AppRole record is the source of truth for a seed —
+   * the same rule that makes a role-side grant the only thing an access check reads. The
+   * response carries the D9.5 diff already applied, so nothing here re-derives it.
+   */
+  async loadRolePins(roleId: string): Promise<RoleAgentPinsResponse> {
+    return firstValueFrom(
+      this.http.get<RoleAgentPinsResponse>(
+        `${this.config.appApiUrl()}/admin/roles/${encodeURIComponent(roleId)}/agent-pins`,
+      ),
+    );
+  }
+
+  /**
+   * Replace a role's default pins, in order.
+   *
+   * Warnings on the returned rows do not block the save — an admin may seed an agent
+   * whose author is about to publish it. What the server refuses is a list that cannot
+   * mean what it says: past the ceiling, or the same agent twice.
+   */
+  async saveRolePins(
+    roleId: string,
+    request: RoleAgentPinsUpdateRequest,
+  ): Promise<RoleAgentPinsResponse> {
+    return firstValueFrom(
+      this.http.put<RoleAgentPinsResponse>(
+        `${this.config.appApiUrl()}/admin/roles/${encodeURIComponent(roleId)}/agent-pins`,
+        request,
+      ),
     );
   }
 

--- a/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-listing-row.component.ts
@@ -1,7 +1,12 @@
 import { Component, ChangeDetectionStrategy, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroCheck, heroCheckBadge, heroPlus } from '@ng-icons/heroicons/outline';
+import {
+  heroCheck,
+  heroCheckBadge,
+  heroLockClosed,
+  heroPlus,
+} from '@ng-icons/heroicons/outline';
 import { AgentListing } from '../models/store.model';
 import { AgentIconComponent } from './agent-icon.component';
 import { AgentPinService } from '../services/agent-pin.service';
@@ -26,7 +31,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
   selector: 'app-agent-listing-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [AgentIconComponent, NgIcon, RouterLink, TooltipDirective],
-  providers: [provideIcons({ heroCheck, heroCheckBadge, heroPlus })],
+  providers: [provideIcons({ heroCheck, heroCheckBadge, heroLockClosed, heroPlus })],
   template: `
     <div
       class="group flex w-full items-center gap-1 rounded-2xl pr-2 hover:bg-gray-50 dark:hover:bg-gray-800"
@@ -61,6 +66,20 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
         </div>
       </a>
 
+      @if (isLocked()) {
+        <!--
+          A locked role pin (D9.4): the control is *absent*, not disabled. A disabled
+          toggle invites a click and then refuses it; a lock says who decided.
+        -->
+        <span
+          class="grid size-8 shrink-0 place-items-center rounded-full text-gray-400 dark:text-gray-500"
+          [appTooltip]="lockTooltip()"
+          appTooltipPosition="top"
+        >
+          <ng-icon name="heroLockClosed" class="size-5" aria-hidden="true" />
+          <span class="sr-only">{{ lockTooltip() }}</span>
+        </span>
+      } @else {
       <button
         type="button"
         (click)="onTogglePin()"
@@ -78,6 +97,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
         <ng-icon [name]="isPinned() ? 'heroCheck' : 'heroPlus'" class="size-5" />
         <span class="sr-only">{{ pinTooltip() }}</span>
       </button>
+      }
     </div>
   `,
 })
@@ -95,6 +115,15 @@ export class AgentListingRowComponent {
 
   isPinned(): boolean {
     return this.pinService.isPinned(this.listing().agentId);
+  }
+
+  /** Locked by a role (D9.4) — the row keeps it and offers no way to remove it. */
+  isLocked(): boolean {
+    return this.pinService.isLocked(this.listing().agentId);
+  }
+
+  lockTooltip(): string {
+    return `${this.listing().name} is pinned for your role and can't be removed`;
   }
 
   /**

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -16,6 +16,7 @@ import {
   heroCheckBadge,
   heroCheckCircle,
   heroExclamationTriangle,
+  heroLockClosed,
   heroNoSymbol,
   heroPlus,
 } from '@ng-icons/heroicons/outline';
@@ -58,6 +59,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
       heroCheckBadge,
       heroCheckCircle,
       heroExclamationTriangle,
+      heroLockClosed,
       heroNoSymbol,
       heroPlus,
     }),
@@ -124,6 +126,20 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
               </p>
             </div>
             <div class="flex shrink-0 items-center gap-2">
+              @if (isLocked()) {
+                <!--
+                  A locked role pin (D9.4): it stays on this user's shelf, so the control
+                  says who decided rather than offering an action that would be refused.
+                -->
+                <span
+                  class="inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-gray-50 px-4 py-2 text-sm/6 font-semibold text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                  [appTooltip]="lockTooltip()"
+                  appTooltipPosition="top"
+                >
+                  <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
+                  Added by your role
+                </span>
+              } @else {
               <button
                 type="button"
                 (click)="onTogglePin()"
@@ -145,6 +161,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
                 />
                 {{ isPinned() ? 'Added' : 'Add' }}
               </button>
+              }
               <button
                 type="button"
                 (click)="onStartChat()"
@@ -400,6 +417,16 @@ export class AgentDetailPage {
 
   isPinned(): boolean {
     return this.pinService.isPinned(this.id());
+  }
+
+  /** Pinned for the viewer's role and locked (D9.4) — there is no un-pinned state to offer. */
+  isLocked(): boolean {
+    return this.pinService.isLocked(this.id());
+  }
+
+  lockTooltip(): string {
+    const name = this.agent()?.name ?? 'This agent';
+    return `${name} is pinned for your role and can't be removed`;
   }
 
   pinTooltip(): string {

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -159,9 +159,10 @@ export interface AgentStoreFrontResponse {
  * One row on the Pinned shelf (D8, D9).
  *
  * The shelf projection plus the two fields that say *why* it is pinned. `source` is
- * always `'user'` and `locked` always `false` in Phase 5 — role-seeded pins are Phase 6 —
- * and both are on the contract now so that phase adds rows rather than changing a shape
- * the SPA already renders.
+ * `'user'` whenever the viewer has their own pin — even when a role also seeds the same
+ * agent, because that own pin is what survives the role pin being removed. `locked`
+ * follows the *role's* seed regardless of source: a role that locks an agent has said its
+ * members keep it.
  */
 export interface PinnedAgent extends AgentListing {
   source: 'user' | 'role';

--- a/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
+++ b/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
@@ -13,16 +13,18 @@ import { AgentsTabsComponent } from '../components/agents-tabs.component';
 import { AgentListingRowComponent } from '../components/agent-listing-row.component';
 
 /**
- * Pinned — the Agents a user has added to their own set (D8, D9, Phase 5).
+ * Pinned — the Agents a user has added to their own set, plus the ones their role seeds
+ * (D8, D9, Phases 5–6).
  *
  * The rows are the same shelf rows Discover renders, and their `＋` has already become a
  * check, so removing one happens here without a second control to learn. That is the
  * whole reason the pin toggle lives on the row rather than on the page: one gesture,
- * everywhere it appears.
+ * everywhere it appears — including on a role-seeded row, which a user removes exactly
+ * like their own (the dismissal is remembered, so it stays gone).
  *
- * Phase 6 adds role-seeded pins to this same list. It needs no new page — a seeded pin is
- * a pin — but it does need this page to keep respecting `locked`, which is why the removal
- * control is driven by the row's own state rather than by "is this page the Pinned tab".
+ * The one exception is a **locked** seed (D9.4): the row hides the control rather than
+ * disabling it. That is driven by the row's own state rather than by "is this page the
+ * Pinned tab", so it holds on Discover too.
  *
  * A pin whose Agent was deleted, or whose visibility narrowed, is simply absent: the
  * server resolves the list against the viewer on every read, and it does not delete the
@@ -40,7 +42,8 @@ import { AgentListingRowComponent } from '../components/agent-listing-row.compon
         <div class="mt-6 mb-6">
           <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Pinned agents</h1>
           <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-            The agents you have added. Removing one here does not affect anyone else.
+            The agents you have added, plus any your role starts you with. Removing one
+            here does not affect anyone else.
           </p>
         </div>
 

--- a/frontend/ai.client/src/app/agents/services/agent-pin.service.spec.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-pin.service.spec.ts
@@ -138,4 +138,41 @@ describe('AgentPinService', () => {
     await service.toggle('ast-001');
     expect(service.isPinned('ast-001')).toBe(false);
   });
+
+  // ── role-seeded pins (D9, Phase 6) ─────────────────────────────────────────────
+  it('reports a locked role pin as locked', async () => {
+    http.get.mockReturnValue(
+      of({ pins: [{ ...pin('ast-locked'), source: 'role', locked: true }, pin('ast-own')] }),
+    );
+
+    await service.load();
+
+    expect(service.isLocked('ast-locked')).toBe(true);
+    expect(service.isLocked('ast-own')).toBe(false);
+  });
+
+  it('refuses to toggle a locked role pin', async () => {
+    // The server no-ops the DELETE too (D9.4); refusing here keeps the row from
+    // flickering out and back on the next read.
+    http.get.mockReturnValue(
+      of({ pins: [{ ...pin('ast-locked'), source: 'role', locked: true }] }),
+    );
+    await service.load();
+
+    await service.toggle('ast-locked');
+
+    expect(http.delete).not.toHaveBeenCalled();
+    expect(service.isPinned('ast-locked')).toBe(true);
+  });
+
+  it('lets an unlocked role pin be dismissed like any other', async () => {
+    http.get.mockReturnValue(of({ pins: [{ ...pin('ast-seeded'), source: 'role' }] }));
+    await service.load();
+    http.delete.mockReturnValue(of(null));
+
+    await service.toggle('ast-seeded');
+
+    expect(http.delete).toHaveBeenCalledWith('/api/agents/ast-seeded/pin');
+    expect(service.isPinned('ast-seeded')).toBe(false);
+  });
 });

--- a/frontend/ai.client/src/app/agents/services/agent-pin.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-pin.service.ts
@@ -37,8 +37,22 @@ export class AgentPinService {
 
   readonly pinnedIds = computed(() => new Set(this._pins().map((pin) => pin.agentId)));
 
+  /**
+   * Pins a role has locked (D9.4) — the remove control is hidden for these, not disabled.
+   *
+   * A `Set` for the same reason as `pinnedIds`: every rendered shelf row asks.
+   */
+  readonly lockedIds = computed(
+    () => new Set(this._pins().filter((pin) => pin.locked).map((pin) => pin.agentId)),
+  );
+
   isPinned(agentId: string): boolean {
     return this.pinnedIds().has(agentId);
+  }
+
+  /** A locked role pin cannot be dismissed; the server no-ops the attempt as well. */
+  isLocked(agentId: string): boolean {
+    return this.lockedIds().has(agentId);
   }
 
   /**
@@ -104,6 +118,9 @@ export class AgentPinService {
 
   /** Toggle, for the single control that both surfaces render. */
   async toggle(agentId: string): Promise<void> {
+    // A locked seed has no un-pinned state to toggle to. The server ignores the call
+    // too; refusing here keeps the list from flickering out and back on the next read.
+    if (this.isLocked(agentId)) return;
     return this.isPinned(agentId) ? this.unpin(agentId) : this.pin(agentId);
   }
 


### PR DESCRIPTION
Phase 6 of the [Agent Marketplace](docs/specs/agent-marketplace.md) (D9). Follows #736.

An admin seeds default pinned Agents per `AppRole`, so a role's members start with a useful sidebar instead of an empty one. The effective shelf is now

```
(⋃ role pins) − dismissed(unlocked only) ∪ own pins
```

resolved **per request** (D9.1). No fan-out job, no materialized copy per member — which is why Phase 5 wrote the dismissal tombstones before anything read them, and why `source`/`locked` were already on the row. This phase adds rows, not a new shape.

## ⚠️ A live trap this fixes

`AppRoleRepository._delete_mapping_items` deleted **every** non-`DEFINITION` item under `PK=ROLE#{id}`, and `update_role` calls it before rebuilding the mapping items from the `AppRole` record — which deliberately does not carry pins, because a pin is not a permission. Any edit to a role's name, priority or grants would have silently emptied its seed list, with nothing to rewrite it.

It now deletes by **prefix** (`JWT_MAPPING#`/`TOOL_GRANT#`/`MODEL_GRANT#`/`SKILL_GRANT#`), with `AGENT_PIN#` included only for `delete_role`, where the role itself is going away. `test_updating_a_role_preserves_its_default_pins` is the regression. Any future per-role item that is not reconstructible from `_build_role_items` needs the same protection.

## A pin is not a permission

Storage mirrors the grant items (`PK=ROLE#{role_id}, SK=AGENT_PIN#{agent_id}`) but lives in its own module, `apis/shared/assistants/role_pins.py`, rather than on `AppRoleRepository`. The repository already owns that table, and that is exactly the coupling worth refusing: keeping the pin read out of the module that computes permissions makes the rule structural rather than a comment. Pins stay out of `EffectivePermissions` and `_compute_effective_permissions`, do not inherit through `inheritsFrom`, and never reach the model call path. The resolver reads `resolve_user_permissions()` for its `app_roles` list *only* — the roles that actually matched, including the `default` substitution — and queries the pins itself.

## The admin console (D10's seventh surface)

`GET`/`PUT /admin/roles/{roleId}/agent-pins`, under `/admin/roles/` because the AppRole record is the source of truth (CLAUDE.md's RBAC rule). Two **independent** checks per row, because they fail for different reasons and have different people to fix them:

- **Reachability** — a `PRIVATE` agent resolves to nothing for everyone but its owner (the user-side read access-checks every row), so the seed is inert. The *author* fixes it.
- **Runnability (D9.5)** — the agent's pinned model and tool/skill bindings diffed against that role's own `effective_permissions`. Seeding 410 researchers an agent that fails on their first message is the exact failure this prevents. The *admin* fixes it.

Both **warn**; neither blocks the save — an admin may legitimately seed something whose author is mid-publish, and refusing teaches people to route around the console. What is refused is a list that cannot mean what it says: past `MAX_ROLE_PINS` (25), or the same agent twice.

`memory_space` is reported as a **note**, never as present or missing: a role does not grant memory spaces, so `ready` must never claim to have checked one.

**⚠️ `default` is labelled as the substitute it is** (D9.6) — it is consulted only for users who matched *zero* roles, so pins seeded there reach nobody who holds any other role. A second banner covers a role with no JWT mappings. And the save dialog says plainly that removing a seed **unpins for everyone in this role who has not pinned it themselves**; there is no "new members only", and live resolution makes that unrepresentable on purpose.

## User side

Locked seeds (D9.4) hide the remove control rather than disabling it — on Discover, on Pinned and on the detail page — and `DELETE /agents/{id}/pin` no-ops on one, rather than arming a tombstone for the day an admin unlocks the pin. An own pin that a role also seeds reads as `source: "user"` (the D9.1 escape hatch, which survives the role pin's removal) while `locked` still follows the role's flag.

## Deploy

`backend.yml` + `frontend-deploy.yml` only — **no CDK**. Verified rather than assumed: the pin items sit on the existing app-roles table with no new index and no new env var, and app-api's task role already holds `Query`/`BatchWriteItem` on that ARN (`app-api-iam-grants.ts`, `coreTables`).

## Testing

- `pytest tests/` — 5170 passed, 3 skipped
- SPA `npm test` — 1546 passed
- `ng build` + `tsc --noEmit` — clean
- New: 12 storage tests (moto, incl. the role-update guard) and 24 route tests covering every way the resolver formula can quietly stop holding — a forgotten dismissal, a lock a dismissal defeats, a seed the caller cannot reach, and the multi-role merge.

**Not yet done:** the live dev smoke test. The acceptance path is pin → unpin → reload (gone) → seed that same agent to your role in `/admin/marketplace/default-pins` → reload Pinned, where it **must not come back** — the tombstone beating a live seed is what the whole design rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)