### PR TITLE
feat(marketplace): @-mention hands one turn to an Agent (Phase 7, D11)

### DIFF
--- a/backend/src/apis/inference_api/chat/agent_binding_policy.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_policy.py
@@ -1,0 +1,41 @@
+"""Whether the Agent running a turn *binds* the conversation to itself.
+
+This sits in its own module for the same reason ``system_prompt_resolver`` does: the rule
+is three lines and the route that applies it is a thousand, so the only way it gets tested
+is if it lives somewhere a test can reach without an agent + invocation stack.
+
+Binding is what makes a conversation "an Agent conversation":
+
+* it is **validated** — a bound conversation refuses a second Agent, and refuses to be
+  bound at all once it has messages, because its history was produced under different
+  instructions, tools and skills;
+* it is **persisted** — ``preferences.assistant_id`` is what the SPA self-heals its
+  ``assistantId`` query param from, so a written binding survives reload forever.
+
+Two kinds of turn run an Agent without binding, and they must skip *both* halves together
+— validating without persisting would refuse the second mention in a thread, and
+persisting without validating would let a mention quietly annex the conversation:
+
+* **`@`-mention** (Marketplace D11) — the user handed this one turn to an Agent from the
+  composer. Mentioning inside a thread that already has messages is the normal case, not
+  the error case, and the next unmentioned message is plain chat again.
+* **preview** — the Agent/assistant editor's own scratch session, which persists nothing
+  by design.
+
+⚠️ This decides *binding*, never *authorization*. The Agent itself is still resolved
+through ``get_assistant_with_access_check`` on every turn, so a client that lies about
+``agent_mention`` gains nothing: the worst it can do is decline to save a binding it would
+otherwise have saved.
+"""
+
+from __future__ import annotations
+
+
+def binds_conversation(*, is_agent_mention: bool, is_preview: bool) -> bool:
+    """True when this turn's Agent should be validated against, and written to, the session.
+
+    Args:
+        is_agent_mention: The Agent was ``@``-mentioned for this turn only (D11).
+        is_preview: The session is an editor preview, which persists nothing.
+    """
+    return not is_agent_mention and not is_preview

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -102,6 +102,21 @@ class InvocationRequest(BaseModel):
     # AgentCore Runtime returns 424 when it sees a non-empty 'assistant_id' field,
     # likely trying to resolve it as an AWS Bedrock Agent ID.
     rag_assistant_id: Optional[str] = None
+    # Marketplace D11: this turn was handed to the Agent by an `@`-mention in
+    # the composer, rather than the whole conversation being bound to it.
+    #
+    # A mention borrows the Agent for ONE turn: the route skips the
+    # bind-once-per-session validation (a mention is legitimate in a thread
+    # that already has messages, and in a thread bound to a different Agent),
+    # and skips writing `preferences.assistant_id`, so the next plain turn is
+    # plain again. Everything else — access check, RAG, binding resolution,
+    # memory injection — is identical to a bound turn, because the same Agent
+    # is running with the same governance.
+    #
+    # ⚠️ It is the *client's* claim about intent, never an access decision:
+    # `get_assistant_with_access_check` still gates the Agent itself, so the
+    # worst a forged flag can do is decline to persist a binding.
+    agent_mention: Optional[bool] = None
     # When set, the route resumes a paused agent turn instead of starting a
     # new one. `message` is ignored in that case — the original prompt is
     # already in the agent's interrupt context.

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -53,6 +53,7 @@ from .app_context_dispatch import (
     merge_and_clear_pending_context,
 )
 from .app_tool_dispatch import AppToolCallError, dispatch_app_tool_call
+from .agent_binding_policy import binds_conversation
 from .models import FileContent, InvocationRequest
 from .service import generate_conversation_title, get_agent
 from .system_prompt_resolver import (
@@ -1061,8 +1062,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # resume there is no interrupt to validate — the agent is rebuilt from the
     # resent params and re-entered with an empty prompt (assistant-prefill).
     is_continuation = bool(input_data.continue_truncated)
+    # Marketplace D11: the Agent was `@`-mentioned in the composer, so it runs
+    # this turn only — it does not bind the conversation. Only meaningful
+    # alongside `rag_assistant_id`; on its own it does nothing.
+    is_agent_mention = bool(input_data.agent_mention) and bool(input_data.rag_assistant_id)
     logger.info(
-        "Invocation request received (resume=%s, continue_truncated=%s)" % (is_resume, is_continuation)
+        "Invocation request received (resume=%s, continue_truncated=%s, agent_mention=%s)"
+        % (is_resume, is_continuation, is_agent_mention)
     )
     logger.info("Message received")
 
@@ -1406,7 +1412,18 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         # If it does, verify it's the same assistant (can't change assistants mid-session)
         # If it doesn't, verify session has no messages (can only attach to new sessions)
         # Skip validation for preview sessions (they don't persist state)
-        if not is_preview_session(input_data.session_id):
+        #
+        # Marketplace D11: an `@`-mention turn skips BOTH rules on purpose. It
+        # borrows the Agent for one turn without binding the conversation, so
+        # "you already have a different Agent" and "this thread already has
+        # messages" are the normal case rather than the error case. The Agent's
+        # own access check below is untouched — skipping this block relaxes
+        # *binding* semantics, never authorization. Rule in
+        # ``agent_binding_policy`` so it is testable without this stack.
+        if binds_conversation(
+            is_agent_mention=is_agent_mention,
+            is_preview=is_preview_session(input_data.session_id),
+        ):
             try:
                 existing_metadata = await get_session_metadata(input_data.session_id, user_id)
                 existing_assistant_id = existing_metadata.preferences.assistant_id if existing_metadata and existing_metadata.preferences else None
@@ -1442,7 +1459,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 logger.error("Error checking session state", exc_info=True)
                 # Continue anyway - better to allow than block on error
         else:
-            logger.info("Preview session - skipping session state validation")
+            logger.info(
+                "Turn does not bind the conversation (mention=%s) - skipping session state validation"
+                % is_agent_mention
+            )
 
         # 2. Load assistant with access check
         logger.info("Loading assistant with access check...")
@@ -1610,7 +1630,19 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
 
         # 6. Save assistant_id to session preferences (persist for future loads)
         # Skip persistence for preview sessions
-        if not is_preview_session(input_data.session_id):
+        #
+        # Marketplace D11: a mention turn deliberately writes nothing. Persisting
+        # here would silently convert the whole conversation to the Agent — the
+        # SPA self-heals its `assistantId` query param from these preferences on
+        # reload — so one `@` would bind the thread forever, which is the exact
+        # behavior the per-turn design rejects. Same predicate as the validation
+        # above, deliberately: validating without persisting would refuse the
+        # second mention in a thread, and persisting without validating would let
+        # a mention annex the conversation.
+        if binds_conversation(
+            is_agent_mention=is_agent_mention,
+            is_preview=is_preview_session(input_data.session_id),
+        ):
             try:
                 existing_metadata = await get_session_metadata(input_data.session_id, user_id)
                 if existing_metadata:
@@ -1662,7 +1694,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 logger.error("Failed to save assistant_id to session preferences", exc_info=True)
                 # Continue - not critical if metadata save fails
         else:
-            logger.info("Preview session - skipping assistant_id persistence")
+            logger.info(
+                "Turn does not bind the conversation (mention=%s) - skipping assistant_id persistence"
+                % is_agent_mention
+            )
 
     # Append active custom system prompt (if any). Gating rules + lookup live
     # in `system_prompt_resolver.py` so they can be unit-tested independently

--- a/backend/tests/apis/inference_api/test_agent_binding_policy.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_policy.py
@@ -1,0 +1,51 @@
+"""Agent Marketplace Phase 7 — does this turn's Agent bind the conversation? (D11)
+
+The rule is small; what it guards is not. Binding does two things that must move together:
+it *refuses* a second Agent (and any Agent at all once the thread has messages), and it
+*persists* ``preferences.assistant_id``, which the SPA self-heals its ``assistantId`` query
+param from on every later load.
+
+Split them and you get one of two bugs, both silent:
+
+* validate but don't persist → the first mention works, the second is refused as an
+  attempt to "change assistants mid-session";
+* persist but don't validate → one `@` annexes the whole conversation, and every later
+  message goes to the mentioned Agent whether the user wanted that or not.
+
+So both call sites in ``routes.py`` ask this one question.
+"""
+
+import pytest
+
+from apis.inference_api.chat.agent_binding_policy import binds_conversation
+
+
+@pytest.mark.parametrize(
+    "is_agent_mention,is_preview,expected",
+    [
+        # An ordinary Agent conversation: validated and persisted.
+        (False, False, True),
+        # A mention borrows the Agent for one turn (D11).
+        (True, False, False),
+        # An editor preview persists nothing by design.
+        (False, True, False),
+        # A mention inside a preview is still not a binding.
+        (True, True, False),
+    ],
+)
+def test_binding_matrix(is_agent_mention, is_preview, expected):
+    assert (
+        binds_conversation(is_agent_mention=is_agent_mention, is_preview=is_preview)
+        is expected
+    )
+
+
+def test_a_plain_agent_turn_is_the_only_thing_that_binds():
+    """Stated positively, because this is the case the two guards exist for."""
+    assert binds_conversation(is_agent_mention=False, is_preview=False) is True
+
+
+def test_a_mention_never_binds_however_it_is_combined():
+    """A mention is the user naming who answers *this* message — never a commitment."""
+    assert not binds_conversation(is_agent_mention=True, is_preview=False)
+    assert not binds_conversation(is_agent_mention=True, is_preview=True)

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -561,8 +561,9 @@ Phase 3.5 Author Submit UI: submit dialog (category, note, D7 disclosures),
          withdraw/unpublish, GET /agents/{id}/listing/preflight   ✅ shipped (PR #734)
 Phase 4  Icons: upload, S3, generated fallback, all four render sizes  ✅ shipped (PR #735)
 Phase 5  Pins: user pin state + Pinned tab + store front admin        ✅ shipped (PR #736)
-Phase 6  Default pins by role (D9) + the assignment-time runnability check  ← in progress
-Phase 7  @-mention in the composer
+Phase 6  Default pins by role (D9) + the assignment-time runnability check
+                                                                      ✅ shipped (PR #737)
+Phase 7  @-mention in the composer                                          ← in progress
 Phase 8  Problem reports (D15): report action + admin Reports queue   ← depends on 3
 Later    Ranking + full-corpus search via the Registry catalog (F6b)
 ```
@@ -618,6 +619,38 @@ is an ordered list, and a per-row toggle can express membership but not position
   D9.1 escape hatch — while `locked` still follows the role's flag. The removal warning lives on the
   console's **Save**, not on the row's `✕`: the editor is staged, and Save is the moment anything
   reaches other people.
+
+**Phase 7 notes (as built).** D11 said "hands **that turn** to the Agent … without leaving the
+thread" in one sentence, and that sentence turned out to be the whole phase:
+
+- **⚠️ The invocation path forbade it outright.** `chat/routes.py` 400s on both *"Cannot change
+  assistants mid-session"* and *"Assistants can only be attached to new sessions"*, and the SPA
+  treats the Agent as session-wide (URL query param → session preferences → self-heal on reload).
+  A mention is precisely the case both rules were written to reject. **Phil chose the per-turn
+  reading** over the two cheaper alternatives (mention opens a new thread; mention only on an
+  empty thread), because the store's other surfaces already cover those and neither is worth a
+  menu in the composer.
+- **One field, one flag.** The mention rides the existing `rag_assistant_id` with a new
+  `agent_mention: true` beside it, rather than a second id field — otherwise every downstream
+  step (RAG, binding resolution, memory injection, the resume snapshot) would need teaching about
+  a second way to name the Agent running the turn. The flag is a *binding* signal, never an
+  authorization one: `get_assistant_with_access_check` still gates the Agent, so a forged flag
+  buys nothing but a skipped write.
+- **Validation and persistence move together**, via `binds_conversation` in
+  `inference_api/chat/agent_binding_policy.py` (the `system_prompt_resolver` precedent — the rule
+  is three lines, the route is a thousand, so it lives where a test can reach it). Splitting them
+  gives two silent bugs: validate-only refuses the *second* mention in a thread; persist-only lets
+  one `@` annex the conversation.
+- **💰 A mention costs two prompt-cache prefix re-writes**, and this is a deliberate purchase. An
+  Agent turn swaps the system prompt and `toolConfig`, so the mention turn re-writes the cached
+  prefix and the next plain turn re-writes it back. At a 50k-token prefix and the $2.50/MTok
+  cache-write premium that is roughly $0.25 per mention round-trip. It is bounded (twice per
+  mention, never per turn) and it buys the thing the feature is for. If mentions ever become
+  common in long threads, the lever is to *bind* the conversation after a mention rather than to
+  make the swap cheaper.
+- **Known edge, pre-existing:** `continue_truncated` skips the whole assistant block, so a
+  "Continue" after a max_tokens truncation runs without the Agent — true for bound Agent
+  conversations before this phase, and unchanged by it.
 
 **Phase 3.5 is a gap this table originally left open.** Phases 1–3 shipped the submit and withdraw
 endpoints and the entire reviewer console, but no phase owned the *author's* half of the surface —

--- a/frontend/ai.client/src/app/agents/agent-form/components/agent-preview.component.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/components/agent-preview.component.ts
@@ -134,6 +134,8 @@ import { ModelService } from '../../../session/services/model/model.service';
               />
             </div>
             <div class="shrink-0 border-t border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+              <!-- No @-mention here (D11): the preview already runs the thing being
+                   edited, so handing its turn to another Agent would make it lie. -->
               <app-chat-input
                 [sessionId]="previewChatService.sessionId()"
                 [isChatLoading]="previewChatService.isLoading()"
@@ -141,6 +143,7 @@ import { ModelService } from '../../../session/services/model/model.service';
                 [showVoiceControl]="false"
                 [showSettingsControl]="false"
                 [autoFocus]="false"
+                [showAgentMentions]="false"
                 (messageSubmitted)="onMessageSubmitted($event)"
                 (messageCancelled)="onMessageCancelled()"
               />

--- a/frontend/ai.client/src/app/agents/services/agent-mention.service.spec.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-mention.service.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { AgentMentionService } from './agent-mention.service';
+import { AgentService } from './agent.service';
+import { AgentPinService } from './agent-pin.service';
+import { Agent } from '../models/agent.model';
+import { PinnedAgent } from '../models/store.model';
+
+function agent(partial: Partial<Agent> & { agentId: string; name: string }): Agent {
+  return {
+    ownerName: 'Ada Author',
+    description: '',
+    bindings: [],
+    visibility: 'PRIVATE',
+    tags: [],
+    starters: [],
+    usageCount: 0,
+    status: 'COMPLETE',
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    ...partial,
+  } as Agent;
+}
+
+function pin(partial: Partial<PinnedAgent> & { agentId: string; name: string }): PinnedAgent {
+  return {
+    category: 'Teaching',
+    source: 'user',
+    locked: false,
+    ...partial,
+  } as PinnedAgent;
+}
+
+/**
+ * The `@` menu's candidate list (Marketplace D11).
+ *
+ * Scope is the whole design here: your own Agents plus everything pinned, and *not* the
+ * store. The cases below are the ways that scope quietly widens or narrows — a draft
+ * becoming mentionable, an Agent appearing twice under two groups, or a role-seeded pin
+ * being filtered out, which would defeat the point of seeding a role in the first place.
+ */
+describe('AgentMentionService', () => {
+  let service: AgentMentionService;
+  let agents: ReturnType<typeof signal<Agent[]>>;
+  let pins: ReturnType<typeof signal<PinnedAgent[]>>;
+  let loadAgents: ReturnType<typeof vi.fn>;
+  let loadPins: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    agents = signal<Agent[]>([]);
+    pins = signal<PinnedAgent[]>([]);
+    loadAgents = vi.fn().mockResolvedValue(undefined);
+    loadPins = vi.fn().mockResolvedValue([]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AgentMentionService,
+        { provide: AgentService, useValue: { agents$: agents.asReadonly(), loadAgents } },
+        { provide: AgentPinService, useValue: { pins: pins.asReadonly(), load: loadPins } },
+      ],
+    });
+    service = TestBed.inject(AgentMentionService);
+  });
+
+  it('offers your own agents and your pins, own first', () => {
+    agents.set([agent({ agentId: 'ast-own', name: 'My Grader' })]);
+    pins.set([pin({ agentId: 'ast-pinned', name: 'Policy Lookup' })]);
+
+    expect(service.mentionable().map((entry) => [entry.agentId, entry.group])).toEqual([
+      ['ast-own', 'own'],
+      ['ast-pinned', 'pinned'],
+    ]);
+  });
+
+  it('lists an agent you own and also pinned exactly once', () => {
+    agents.set([agent({ agentId: 'ast-1', name: 'My Grader' })]);
+    pins.set([pin({ agentId: 'ast-1', name: 'My Grader' })]);
+
+    const rows = service.mentionable();
+    expect(rows).toHaveLength(1);
+    // The own row wins: it is the group that explains why you can edit it.
+    expect(rows[0].group).toBe('own');
+  });
+
+  it('includes role-seeded pins', () => {
+    // The whole payoff of seeding a role (D9): a member who has never opened the store
+    // still finds their department's agent by typing `@`.
+    pins.set([pin({ agentId: 'ast-seeded', name: 'Registrar Helper', source: 'role' })]);
+
+    expect(service.mentionable().map((entry) => entry.agentId)).toEqual(['ast-seeded']);
+  });
+
+  it('excludes drafts', () => {
+    agents.set([
+      agent({ agentId: 'ast-draft', name: 'Half Built', status: 'DRAFT' }),
+      agent({ agentId: 'ast-done', name: 'Finished' }),
+    ]);
+
+    expect(service.mentionable().map((entry) => entry.agentId)).toEqual(['ast-done']);
+  });
+
+  it('shows the publisher for a pin and the tagline for your own', () => {
+    agents.set([agent({ agentId: 'ast-own', name: 'Mine', tagline: 'Grades essays' })]);
+    pins.set([
+      pin({
+        agentId: 'ast-pin',
+        name: 'Theirs',
+        tagline: 'Finds policy',
+        publisher: { label: 'Registrar', kind: 'department', verified: true },
+      }),
+    ]);
+
+    expect(service.mentionable().map((entry) => entry.subtitle)).toEqual([
+      'Grades essays',
+      'Registrar',
+    ]);
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      agents.set([
+        agent({ agentId: 'ast-1', name: 'Policy Lookup', tagline: 'cites university policy' }),
+        agent({ agentId: 'ast-2', name: 'Grading Assistant', tagline: 'policy-free grading' }),
+      ]);
+    });
+
+    it('ranks a name prefix above a name substring above a subtitle match', () => {
+      agents.update((current) => [
+        ...current,
+        agent({ agentId: 'ast-3', name: 'Campus Policy Bot' }),
+      ]);
+
+      expect(service.search('policy').map((entry) => entry.agentId)).toEqual([
+        'ast-1', // name prefix
+        'ast-3', // name substring
+        'ast-2', // subtitle only
+      ]);
+    });
+
+    it('is case-insensitive', () => {
+      expect(service.search('POLICY')[0].agentId).toBe('ast-1');
+    });
+
+    it('returns everything for an empty query — typing `@` alone opens the whole menu', () => {
+      expect(service.search('')).toHaveLength(2);
+    });
+
+    it('returns nothing when nothing matches', () => {
+      expect(service.search('zzz')).toEqual([]);
+    });
+  });
+
+  it('warms both sources once, and survives one of them failing', async () => {
+    loadAgents.mockRejectedValueOnce(new Error('down'));
+
+    await service.load();
+    await service.load();
+
+    expect(loadAgents).toHaveBeenCalledTimes(1);
+    expect(loadPins).toHaveBeenCalledTimes(1);
+    // A composer affordance must not break because a list behind it did not load.
+    expect(service.mentionable()).toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/agents/services/agent-mention.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-mention.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { AgentService } from './agent.service';
+import { AgentPinService } from './agent-pin.service';
+
+/** One row in the `@` menu (D11). */
+export interface MentionableAgent {
+  agentId: string;
+  name: string;
+  /** Rendered as secondary text: the publisher for a pinned agent, else the tagline. */
+  subtitle?: string;
+  emoji?: string;
+  iconUrl?: string;
+  group: 'own' | 'pinned';
+}
+
+/** How many rows the menu shows at once. */
+const MAX_RESULTS = 8;
+
+/**
+ * The `@`-mention candidate list (Marketplace D11).
+ *
+ * **Scope is deliberately narrow: your own Agents plus everything pinned.** Making the menu
+ * search the whole store turns an autocomplete into a directory query — which is what the
+ * store page is for — and it puts every Agent's name in front of every user in a surface
+ * where they cannot evaluate it. The menu's last row is "Browse all agents →" instead.
+ *
+ * Pinned deliberately includes role-seeded pins (D9), which is the point of seeding a role:
+ * a member who has never visited the store still finds their department's Agent by typing
+ * `@`. That comes free — `AgentPinService.pins()` is already the resolved effective list.
+ *
+ * Both sources are **already loaded by other surfaces**, and both are session-cached, so the
+ * menu costs nothing on the keystroke path. A source that fails is simply absent: an `@`
+ * menu missing a group is still usable, and the composer must never fail because a list
+ * behind an optional affordance did not load.
+ */
+@Injectable({ providedIn: 'root' })
+export class AgentMentionService {
+  private agentService = inject(AgentService);
+  private pinService = inject(AgentPinService);
+
+  private loaded = false;
+  private _loading = signal(false);
+
+  readonly loading = this._loading.asReadonly();
+
+  /**
+   * Own Agents first, then pins that are not already listed as your own.
+   *
+   * Dedup keeps the *own* row: an author who pinned their own Agent should see it once,
+   * under the group that explains why they can edit it. Drafts are excluded — an Agent whose
+   * instructions and bindings are half-written should not be handed a turn.
+   */
+  readonly mentionable = computed<MentionableAgent[]>(() => {
+    const own = this.agentService
+      .agents$()
+      .filter((agent) => agent.status === 'COMPLETE')
+      .map<MentionableAgent>((agent) => ({
+        agentId: agent.agentId,
+        name: agent.name,
+        subtitle: agent.tagline || agent.description,
+        emoji: agent.emoji,
+        iconUrl: agent.iconUrl,
+        group: 'own',
+      }));
+
+    const ownIds = new Set(own.map((agent) => agent.agentId));
+    const pinned = this.pinService
+      .pins()
+      .filter((pin) => !ownIds.has(pin.agentId))
+      .map<MentionableAgent>((pin) => ({
+        agentId: pin.agentId,
+        name: pin.name,
+        subtitle: pin.publisher?.label || pin.tagline,
+        emoji: pin.emoji,
+        iconUrl: pin.iconUrl,
+        group: 'pinned',
+      }));
+
+    return [...own, ...pinned];
+  });
+
+  /**
+   * Warm both lists. Safe to call on every composer focus — each underlying service
+   * caches for the session, and a failure in one leaves the other's rows usable.
+   */
+  async load(): Promise<void> {
+    if (this.loaded) return;
+    this.loaded = true;
+    this._loading.set(true);
+    try {
+      await Promise.all([
+        // Drafts excluded at the source as well as in the projection: an agent that is
+        // still a draft is not a thing you can hand a turn to.
+        this.agentService.loadAgents(false).catch(() => undefined),
+        this.pinService.load().catch(() => undefined),
+      ]);
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Rows matching what the user has typed after the `@`.
+   *
+   * Name matches rank above subtitle matches, and a prefix above a substring, because the
+   * thing a person types after `@` is almost always the start of a name. Capped at
+   * {@link MAX_RESULTS} — a menu you have to scroll is a list, and the list has a page.
+   */
+  search(query: string): MentionableAgent[] {
+    const needle = query.trim().toLowerCase();
+    const all = this.mentionable();
+    if (!needle) return all.slice(0, MAX_RESULTS);
+
+    const scored = all
+      .map((agent) => ({ agent, score: this.score(agent, needle) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    return scored.slice(0, MAX_RESULTS).map((entry) => entry.agent);
+  }
+
+  private score(agent: MentionableAgent, needle: string): number {
+    const name = agent.name.toLowerCase();
+    if (name.startsWith(needle)) return 3;
+    if (name.includes(needle)) return 2;
+    if ((agent.subtitle ?? '').toLowerCase().includes(needle)) return 1;
+    return 0;
+  }
+}

--- a/frontend/ai.client/src/app/assistants/assistant-form/components/assistant-preview.component.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/components/assistant-preview.component.ts
@@ -65,6 +65,8 @@ import { AssistantCardComponent } from '../../components/assistant-card.componen
             </div>
             <!-- Chat input at bottom when showing card -->
             <div class="shrink-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+              <!-- No @-mention here (D11): the preview already runs the thing being
+                   edited, so handing its turn to another Agent would make it lie. -->
               <app-chat-input
                 [sessionId]="previewChatService.sessionId()"
                 [isChatLoading]="previewChatService.isLoading()"
@@ -72,6 +74,7 @@ import { AssistantCardComponent } from '../../components/assistant-card.componen
                 [showVoiceControl]="false"
                 [showSettingsControl]="false"
                 [autoFocus]="false"
+                [showAgentMentions]="false"
                 (messageSubmitted)="onMessageSubmitted($event)"
                 (messageCancelled)="onMessageCancelled()"
               />

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -130,7 +130,10 @@ export class ChatContainerComponent {
   }));
 
   // Output events
-  messageSubmitted = output<{ content: string; timestamp: Date; fileUploadIds?: string[] }>();
+  // `mentionAgentId` rides through untouched (Marketplace D11): the container is a
+  // layout shell, and dropping the field here would silently turn every `@`-mention
+  // back into a plain turn.
+  messageSubmitted = output<{ content: string; timestamp: Date; fileUploadIds?: string[]; mentionAgentId?: string }>();
   continueRequested = output<void>();
   messageCancelled = output<void>();
   fileAttached = output<File>();
@@ -199,7 +202,7 @@ export class ChatContainerComponent {
   }
 
   // Event handlers
-  onMessageSubmitted(event: { content: string; timestamp: Date; fileUploadIds?: string[] }) {
+  onMessageSubmitted(event: { content: string; timestamp: Date; fileUploadIds?: string[]; mentionAgentId?: string }) {
     this.messageSubmitted.emit(event);
 
     // Wait for DOM to update (user message to be added) then scroll to it

--- a/frontend/ai.client/src/app/session/components/chat-input/agent-mention-menu.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/agent-mention-menu.component.ts
@@ -1,0 +1,143 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowRight } from '@ng-icons/heroicons/outline';
+import { AgentIconComponent } from '../../../agents/components/agent-icon.component';
+import { MentionableAgent } from '../../../agents/services/agent-mention.service';
+
+/**
+ * The `@` menu over the composer (Marketplace D11).
+ *
+ * Renders what the user can hand a turn to — their own Agents and everything pinned —
+ * grouped, with the publisher (or tagline) as secondary text, and "Browse all agents →" as
+ * the last row. The store is deliberately *not* searchable from here; that row is the door
+ * to it.
+ *
+ * **Rows commit on `mousedown`, not `click`.** The composer's textarea must keep focus
+ * through the whole interaction — a `click` handler fires after `blur`, by which time the
+ * caret position this menu edits around is gone.
+ *
+ * Keyboard handling lives in the parent, not here, for the same reason: the textarea never
+ * gives up focus, so arrow keys and Enter arrive there. This component only renders the
+ * highlight it is told about (`activeIndex`) and exposes the ids that
+ * `aria-activedescendant` on the textarea points at.
+ */
+@Component({
+  selector: 'app-agent-mention-menu',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AgentIconComponent, NgIcon],
+  providers: [provideIcons({ heroArrowRight })],
+  template: `
+    <div
+      class="absolute bottom-full left-0 z-20 mb-2 w-full max-w-md overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800"
+    >
+      <ul
+        [id]="listboxId()"
+        role="listbox"
+        aria-label="Agents you can mention"
+        class="max-h-72 overflow-y-auto py-1"
+      >
+        @if (items().length === 0) {
+          <li class="px-4 py-3 text-sm/6 text-gray-500 dark:text-gray-400" role="presentation">
+            No agents match “{{ query() }}”.
+          </li>
+        }
+
+        @for (entry of grouped(); track entry.agent.agentId) {
+          @if (entry.heading) {
+            <li
+              class="px-4 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+              role="presentation"
+            >
+              {{ entry.heading }}
+            </li>
+          }
+          <li
+            [id]="optionId(entry.index)"
+            role="option"
+            [attr.aria-selected]="entry.index === activeIndex()"
+            (mousedown)="onPick($event, entry.agent)"
+            class="flex cursor-pointer items-center gap-3 px-4 py-2"
+            [class]="
+              entry.index === activeIndex()
+                ? 'bg-gray-100 dark:bg-gray-700'
+                : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+            "
+          >
+            <app-agent-icon
+              [agentId]="entry.agent.agentId"
+              [iconUrl]="entry.agent.iconUrl"
+              [emoji]="entry.agent.emoji"
+              [size]="28"
+            />
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                {{ entry.agent.name }}
+              </p>
+              @if (entry.agent.subtitle) {
+                <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                  {{ entry.agent.subtitle }}
+                </p>
+              }
+            </div>
+          </li>
+        }
+      </ul>
+
+      <button
+        type="button"
+        (mousedown)="onBrowseAll($event)"
+        class="flex w-full items-center justify-between gap-2 border-t border-gray-200 px-4 py-2.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700/50"
+      >
+        Browse all agents
+        <ng-icon name="heroArrowRight" class="size-4" aria-hidden="true" />
+      </button>
+    </div>
+  `,
+})
+export class AgentMentionMenuComponent {
+  readonly items = input.required<MentionableAgent[]>();
+  readonly activeIndex = input<number>(0);
+  readonly query = input<string>('');
+
+  readonly picked = output<MentionableAgent>();
+  readonly browseAll = output<void>();
+
+  readonly listboxId = () => 'agent-mention-listbox';
+
+  optionId(index: number): string {
+    return `agent-mention-option-${index}`;
+  }
+
+  /**
+   * Rows with their flat index and, on the first of each group, its heading.
+   *
+   * The index has to be the *flat* one because that is what the parent's arrow keys and
+   * `aria-activedescendant` count in; the headings are presentational and must not be
+   * separately navigable.
+   */
+  readonly grouped = computed(() => {
+    let lastGroup: string | null = null;
+    return this.items().map((agent, index) => {
+      const heading =
+        agent.group === lastGroup
+          ? null
+          : agent.group === 'own'
+            ? 'Your agents'
+            : 'Pinned';
+      lastGroup = agent.group;
+      return { agent, index, heading };
+    });
+  });
+
+  onPick(event: MouseEvent, agent: MentionableAgent): void {
+    // Keep the textarea focused: the parent edits around the caret this menu was
+    // opened from, and a blur would lose it.
+    event.preventDefault();
+    this.picked.emit(agent);
+  }
+
+  onBrowseAll(event: MouseEvent): void {
+    event.preventDefault();
+    this.browseAll.emit();
+  }
+}

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -46,6 +46,21 @@
       </div>
     }
 
+    <!--
+      Agent `@`-mention menu (Marketplace D11). Positioned against this container rather
+      than the caret: a composer is anchored to the bottom of the viewport, so "above the
+      input" is where the menu can always open without being clipped.
+    -->
+    @if (isMentionMenuOpen()) {
+      <app-agent-mention-menu
+        [items]="mentionResults()"
+        [activeIndex]="mentionActiveIndex()"
+        [query]="mentionQuery()"
+        (picked)="onMentionPicked($event)"
+        (browseAll)="onMentionBrowseAll()"
+      />
+    }
+
     <!-- Main Input Area -->
     <div class="relative">
       <label for="user-message" class="sr-only">How can I help you today?</label>
@@ -57,9 +72,18 @@
         [value]="userInput()"
         (input)="onTextareaInput($event)"
         (keydown)="onKeyDown($event)"
+        (keyup)="onTextareaCaretMove($event)"
+        (click)="onTextareaCaretMove($event)"
         (focus)="onFocus()"
         (blur)="onBlur()"
         placeholder="How can I help you today?"
+        role="combobox"
+        aria-autocomplete="list"
+        [attr.aria-expanded]="isMentionMenuOpen()"
+        [attr.aria-controls]="isMentionMenuOpen() ? 'agent-mention-listbox' : null"
+        [attr.aria-activedescendant]="
+          isMentionMenuOpen() ? 'agent-mention-option-' + mentionActiveIndex() : null
+        "
         class="block w-full resize-none bg-transparent px-6 py-4 text-base text-gray-900 placeholder:text-gray-500 dark:text-gray-100 dark:placeholder:text-gray-400 focus:outline-hidden overflow-y-auto"
         style="min-height: 60px; max-height: 200px;"
       ></textarea>
@@ -138,6 +162,29 @@
               <ng-icon name="heroMicrophone" class="size-5" aria-hidden="true" />
             }
           </button>
+          }
+
+          <!--
+            Mentioned-agent chip (D11). Says who is answering *this* message and gives
+            the only way back: the literal "@Name" in the text is what the user typed,
+            but the binding is this chip, so clearing it here is what un-mentions.
+          -->
+          @if (mentionedAgent(); as agent) {
+            <div
+              class="flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 pl-2.5 pr-1 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+              role="status"
+              [attr.aria-label]="'This message goes to ' + agent.name"
+            >
+              <span class="max-w-32 truncate">{{ agent.name }} answers this one</span>
+              <button
+                type="button"
+                (click)="clearMention()"
+                class="flex size-4 shrink-0 items-center justify-center rounded-full text-emerald-500 transition-colors hover:bg-emerald-200 hover:text-emerald-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-emerald-500 dark:text-emerald-400 dark:hover:bg-emerald-700 dark:hover:text-emerald-200"
+                aria-label="Send this message to the assistant instead"
+              >
+                <ng-icon name="heroXMark" class="size-3" aria-hidden="true" />
+              </button>
+            </div>
           }
 
           <!-- Active Conversation Mode Chip -->

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -11,6 +11,7 @@ import {
   ElementRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroPlus,
@@ -37,6 +38,11 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { ToolService } from '../../../services/tool/tool.service';
 import { VoiceChatService, type VoiceStatus } from '../../services/voice';
 import { SystemPromptsService } from '../../../services/system-prompts/system-prompts.service';
+import {
+  AgentMentionService,
+  MentionableAgent,
+} from '../../../agents/services/agent-mention.service';
+import { AgentMentionMenuComponent } from './agent-mention-menu.component';
 
 // Must stay in sync with the inline min-height/max-height on the textarea in
 // chat-input.component.html.
@@ -47,11 +53,22 @@ interface Message {
   content: string;
   timestamp: Date;
   fileUploadIds?: string[];
+  /**
+   * Marketplace D11: the Agent `@`-mentioned for **this turn only**. The conversation is
+   * not bound to it — the next message with no mention is plain chat again.
+   */
+  mentionAgentId?: string;
+}
+
+/** The `@…` the caret is currently sitting in, and where it starts in the text. */
+interface MentionToken {
+  query: string;
+  start: number;
 }
 
 @Component({
   selector: 'app-chat-input',
-  imports: [FormsModule, ModelDropdownComponent, NgIcon, QuotaWarningBannerComponent, StorageQuotaBannerComponent, TooltipDirective, FileCardComponent],
+  imports: [FormsModule, ModelDropdownComponent, NgIcon, QuotaWarningBannerComponent, StorageQuotaBannerComponent, TooltipDirective, FileCardComponent, AgentMentionMenuComponent],
   providers: [
     provideIcons({
       heroPlus,
@@ -73,6 +90,7 @@ export class ChatInputComponent {
   private readonly toolService = inject(ToolService);
   private readonly voiceChatService = inject(VoiceChatService);
   protected readonly systemPromptsService = inject(SystemPromptsService);
+  private readonly router = inject(Router);
 
   // Input: session ID for file uploads
   readonly sessionId = input<string | null>(null);
@@ -94,6 +112,11 @@ export class ChatInputComponent {
   // Input: auto-focus the textarea on load and session change (defaults to true).
   // Disabled where the input sits beside an editable form (e.g. assistant preview).
   readonly autoFocus = input<boolean>(true);
+
+  // Input: offer the `@`-mention menu (defaults to true). Off where handing the turn to
+  // another Agent makes no sense — the Agent editor's own preview, which is already
+  // running the Agent being edited.
+  readonly showAgentMentions = input<boolean>(true);
 
   private readonly messageInput = viewChild<ElementRef<HTMLTextAreaElement>>('messageInput');
 
@@ -173,6 +196,58 @@ export class ChatInputComponent {
     }
   });
 
+  // =========================================================================
+  // `@`-mention (Marketplace D11)
+  //
+  // Mentioning an Agent hands **that turn** to its model, tools and skills without
+  // leaving the thread. The conversation is not bound to it: the mention rides one
+  // request, and the next plain message is plain chat again.
+  //
+  // The menu opens on an `@` that starts a word and closes on anything that ends the
+  // token — whitespace, a second `@`, moving the caret away, or Escape. `mentionedAgent`
+  // survives the menu closing, because the *selection* is a property of the pending turn
+  // while the menu is a property of what is being typed right now.
+  // =========================================================================
+  private readonly mentionService = inject(AgentMentionService);
+
+  /** The Agent this turn will be handed to, once picked. Cleared on submit. */
+  readonly mentionedAgent = signal<MentionableAgent | null>(null);
+
+  /** The `@…` token under the caret, or null when the caret is not in one. */
+  private readonly mentionToken = signal<MentionToken | null>(null);
+
+  readonly mentionActiveIndex = signal(0);
+
+  readonly mentionResults = computed(() => {
+    const token = this.mentionToken();
+    return token ? this.mentionService.search(token.query) : [];
+  });
+
+  /**
+   * The menu opens only when there is something to offer, and only when the turn is not
+   * already spoken for.
+   *
+   * A user with no Agents — or an environment with the whole surface switched off, where
+   * both source calls 404 — must be able to type `@` in a sentence without a menu
+   * appearing to say it has nothing. Once the lists load, the token is still set and the
+   * menu pops in on its own.
+   *
+   * **One mention per turn.** D11 hands *the* turn to *an* Agent, so a second mention has
+   * nothing to mean. Suppressing the menu while one is pending also stops it re-opening
+   * when the caret lands back inside the `@Name` text already committed — names contain
+   * spaces, so that would otherwise happen constantly. The chip's `✕` is how you change
+   * your mind.
+   */
+  readonly isMentionMenuOpen = computed(
+    () =>
+      this.showAgentMentions() &&
+      this.mentionToken() !== null &&
+      this.mentionedAgent() === null &&
+      this.mentionService.mentionable().length > 0,
+  );
+
+  readonly mentionQuery = computed(() => this.mentionToken()?.query ?? '');
+
   constructor() {
     // Focus the textarea on first mount...
     afterNextRender(() => this.focusInput());
@@ -218,11 +293,15 @@ export class ChatInputComponent {
     this.messageSubmitted.emit({
       content,
       timestamp: new Date(),
-      fileUploadIds: fileUploadIds.length > 0 ? fileUploadIds : undefined
+      fileUploadIds: fileUploadIds.length > 0 ? fileUploadIds : undefined,
+      mentionAgentId: this.mentionedAgent()?.agentId,
     });
 
-    // Clear input and pending uploads
+    // Clear input and pending uploads. The mention clears with them: it belongs to the
+    // turn that was just sent, not to the composer (D11).
     this.userInput.set('');
+    this.mentionedAgent.set(null);
+    this.closeMentionMenu();
     this.resetTextareaHeight();
     this.fileUploadService.clearReadyUploads();
   }
@@ -301,6 +380,100 @@ export class ChatInputComponent {
     const textarea = event.target as HTMLTextAreaElement;
     this.userInput.set(textarea.value);
     this.autoResize(textarea);
+    this.syncMentionToken(textarea);
+  }
+
+  // ---------------------------------------------------------------- mentions (D11)
+
+  /**
+   * Recompute the `@…` token from the text before the caret.
+   *
+   * Matched rather than tracked: the caret can move by click, arrow key, undo or paste,
+   * and a state machine that only listens to typing gets out of step with all four. The
+   * token must start a word (`^` or whitespace) so an email address never opens the menu,
+   * and it ends at whitespace or a second `@`.
+   */
+  private syncMentionToken(textarea: HTMLTextAreaElement): void {
+    if (!this.showAgentMentions()) {
+      return;
+    }
+    const caret = textarea.selectionStart ?? textarea.value.length;
+    const before = textarea.value.slice(0, caret);
+    const match = /(?:^|\s)@([^\s@]*)$/.exec(before);
+
+    if (!match) {
+      this.mentionToken.set(null);
+      return;
+    }
+
+    void this.mentionService.load();
+    this.mentionToken.set({ query: match[1], start: caret - match[1].length - 1 });
+    this.mentionActiveIndex.set(0);
+  }
+
+  /** Caret moves that are not edits — a click or an arrow key — also open or close the menu. */
+  onTextareaCaretMove(event: Event): void {
+    this.syncMentionToken(event.target as HTMLTextAreaElement);
+  }
+
+  /**
+   * Commit a pick: replace the typed `@query` with the Agent's name and remember it for
+   * this turn.
+   *
+   * The literal `@Name` stays in the message text. It is what the user typed, it is what
+   * the thread will show them tomorrow when they wonder why one answer looks different,
+   * and the model reads it as the address it is.
+   */
+  onMentionPicked(agent: MentionableAgent): void {
+    const token = this.mentionToken();
+    const textarea = this.messageInput()?.nativeElement;
+    if (!token || !textarea) {
+      return;
+    }
+
+    const caret = textarea.selectionStart ?? textarea.value.length;
+    const replacement = `@${agent.name} `;
+    const next =
+      textarea.value.slice(0, token.start) + replacement + textarea.value.slice(caret);
+
+    this.userInput.set(next);
+    this.mentionedAgent.set(agent);
+    this.mentionToken.set(null);
+
+    // Write through to the element and restore the caret: the textarea is not bound to
+    // the signal (it uses `[value]` + an input handler), so the DOM is authoritative for
+    // the caret and would otherwise sit at the end of the replaced text.
+    textarea.value = next;
+    const caretAfter = token.start + replacement.length;
+    textarea.setSelectionRange(caretAfter, caretAfter);
+    textarea.focus();
+    this.autoResize(textarea);
+  }
+
+  /** Clear the pending mention; the turn goes back to plain chat. */
+  clearMention(): void {
+    this.mentionedAgent.set(null);
+    this.focusInput();
+  }
+
+  private closeMentionMenu(): void {
+    this.mentionToken.set(null);
+  }
+
+  private moveMentionSelection(delta: number): void {
+    const count = this.mentionResults().length;
+    if (count === 0) {
+      return;
+    }
+    const next = (this.mentionActiveIndex() + delta + count) % count;
+    this.mentionActiveIndex.set(next);
+  }
+
+  private commitActiveMention(): void {
+    const agent = this.mentionResults()[this.mentionActiveIndex()];
+    if (agent) {
+      this.onMentionPicked(agent);
+    }
   }
 
   /**
@@ -326,6 +499,34 @@ export class ChatInputComponent {
   }
 
   onKeyDown(event: KeyboardEvent) {
+    // The `@` menu owns the keyboard while it is open (D11). Enter must pick an Agent
+    // rather than send the half-typed message — a send that fires out from under an open
+    // menu is the single most annoying way to get an autocomplete wrong.
+    if (this.isMentionMenuOpen()) {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          this.moveMentionSelection(1);
+          return;
+        case 'ArrowUp':
+          event.preventDefault();
+          this.moveMentionSelection(-1);
+          return;
+        case 'Enter':
+        case 'Tab':
+          if (this.mentionResults().length > 0) {
+            event.preventDefault();
+            this.commitActiveMention();
+            return;
+          }
+          break;
+        case 'Escape':
+          event.preventDefault();
+          this.closeMentionMenu();
+          return;
+      }
+    }
+
     // Submit on Enter (without Shift)
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
@@ -335,10 +536,25 @@ export class ChatInputComponent {
 
   onFocus() {
     this.isFocused.set(true);
+    // Warm the `@` candidates before the first keystroke needs them — both sources are
+    // session-cached, so this costs one request per session and makes the menu instant.
+    if (this.showAgentMentions()) {
+      void this.mentionService.load();
+    }
   }
 
   onBlur() {
     this.isFocused.set(false);
+    // The menu's own rows commit on `mousedown` and preventDefault, so reaching here
+    // means the user went somewhere else entirely — close it. The *selected* Agent
+    // survives: it belongs to the pending turn, not to the menu.
+    this.closeMentionMenu();
+  }
+
+  /** The menu's last row: the store, which is where a search over everything belongs (D11). */
+  onMentionBrowseAll(): void {
+    this.closeMentionMenu();
+    void this.router.navigate(['/agents/discover']);
   }
 
   // =========================================================================

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.spec.ts
@@ -179,6 +179,45 @@ describe('ChatRequestService', () => {
     );
   });
 
+  // ── `@`-mention: one turn, not a binding (Marketplace D11) ──────────────────────
+  describe('agent mention', () => {
+    it('sends the mentioned agent with the flag that stops it binding the session', async () => {
+      await service.submitChatRequest('@Policy Lookup hi', 'session1', undefined, undefined, 'agent-9');
+
+      expect(mockChatHttpService.sendChatRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rag_assistant_id: 'agent-9',
+          agent_mention: true,
+        }),
+      );
+    });
+
+    it('a mention beats the conversation-bound assistant for that turn', async () => {
+      // The user just named who they want, in the composer, for this message.
+      await service.submitChatRequest('@Grader hi', 'session1', undefined, 'assistant1', 'agent-9');
+
+      const sent = mockChatHttpService.sendChatRequest.mock.calls[0][0];
+      expect(sent['rag_assistant_id']).toBe('agent-9');
+      expect(sent['agent_mention']).toBe(true);
+    });
+
+    it('leaves the URL bound to the conversation assistant, not the mention', async () => {
+      // Otherwise one `@` would convert the whole thread — the SPA reads this param as
+      // the session's assistant on every subsequent load.
+      await service.submitChatRequest('@Grader hi', null, undefined, 'assistant1', 'agent-9');
+
+      const navigation = mockRouter.navigate.mock.calls[0];
+      expect(navigation[1].queryParams).toEqual({ assistantId: 'assistant1' });
+    });
+
+    it('an unmentioned turn carries no flag at all', async () => {
+      await service.submitChatRequest('Hello', 'session1', undefined, 'assistant1');
+
+      const sent = mockChatHttpService.sendChatRequest.mock.calls[0][0];
+      expect('agent_mention' in sent).toBe(false);
+    });
+  });
+
   it('keys loading and viewed-session state to the submitted session', async () => {
     const chatState = TestBed.inject(ChatStateService) as any;
 

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -67,6 +67,7 @@ export class ChatRequestService implements OnDestroy {
     sessionId: string | null,
     fileUploadIds?: string[],
     assistantId?: string,
+    mentionAgentId?: string,
   ): Promise<void> {
     // Ensure conversation exists and get its ID
     // Update URL to reflect current conversation
@@ -124,6 +125,7 @@ export class ChatRequestService implements OnDestroy {
         sessionId,
         fileUploadIds,
         assistantId,
+        mentionAgentId,
       );
       await this.chatHttpService.sendChatRequest(requestObject);
     } catch (error) {
@@ -207,6 +209,7 @@ export class ChatRequestService implements OnDestroy {
     session_id: string,
     fileUploadIds?: string[],
     assistantId?: string,
+    mentionAgentId?: string,
   ) {
     const selectedModel = this.modelService.getSelectedModel();
 
@@ -255,7 +258,20 @@ export class ChatRequestService implements OnDestroy {
     // Add assistant ID if present
     // NOTE: Field name is 'rag_assistant_id' to avoid collision with AWS Bedrock
     // AgentCore Runtime's internal 'assistant_id' field handling (causes 424 error)
-    if (assistantId) {
+    //
+    // Marketplace D11: an `@`-mention wins for this one turn and rides the SAME field,
+    // with `agent_mention` telling the backend not to treat it as a binding — it skips
+    // the "one assistant per session" validation and does not write session preferences.
+    // Sending it as a *different* field would have meant teaching every downstream step
+    // (RAG, binding resolution, memory injection, the resume snapshot) about a second
+    // way to name the agent running the turn; the flag keeps one.
+    //
+    // A mention beats the bound assistant deliberately: the user just named who they
+    // want, in the composer, for this message.
+    if (mentionAgentId) {
+      requestObject['rag_assistant_id'] = mentionAgentId;
+      requestObject['agent_mention'] = true;
+    } else if (assistantId) {
       requestObject['rag_assistant_id'] = assistantId;
     } else {
       // Forward the active conversation mode for non-assistant turns. The

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -570,7 +570,7 @@ export class ConversationPage implements OnDestroy {
       });
   }
 
-  onMessageSubmitted(message: { content: string, timestamp: Date, fileUploadIds?: string[] }) {
+  onMessageSubmitted(message: { content: string, timestamp: Date, fileUploadIds?: string[], mentionAgentId?: string }) {
     // Use the effective session ID (route sessionId or staged sessionId)
     const sessionIdToUse = this.effectiveSessionId();
 
@@ -587,12 +587,16 @@ export class ConversationPage implements OnDestroy {
     // Loading state is set inside submitChatRequest once the (possibly
     // freshly generated) session id is known — it's per-session now.
 
-    // Submit the chat request with file upload IDs and assistant ID if present
+    // Submit the chat request with file upload IDs and assistant ID if present.
+    // A `@`-mention (Marketplace D11) rides alongside rather than replacing the bound
+    // assistant: it runs this one turn, the URL keeps whatever the conversation is bound
+    // to, and the next unmentioned message goes back to that.
     this.chatRequestService.submitChatRequest(
       message.content,
       sessionIdToUse,
       message.fileUploadIds,
-      assistantIdToUse
+      assistantIdToUse,
+      message.mentionAgentId
     ).catch((error) => {
       console.error('Error sending chat request:', error);
     });


### PR DESCRIPTION
Phase 7 of the [Agent Marketplace](docs/specs/agent-marketplace.md) (D11). Follows #737.

Typing `@` in the composer offers the user's own Agents plus everything pinned — including the role-seeded pins from phase 6 — grouped, with the publisher as secondary text and "Browse all agents →" as the last row. Picking one hands **that turn** to the Agent's model, tools and skills without leaving the thread.

## ⚠️ The invocation path forbade exactly this

`inference_api/chat/routes.py` 400s on both halves of what a mention is:

- `"Cannot change assistants mid-session. Start a new session to use a different assistant."`
- `"Assistants can only be attached to new sessions"` — any session that already has messages

And the SPA treats the Agent as session-wide: URL `assistantId` query param → `preferences.assistant_id` → self-heal back into the URL on reload.

So D11's one sentence was the whole phase. Three cheaper readings were on the table — mention opens a new thread, or mention only works on an empty thread — and both were declined: the store's Start-chat button already covers them, and neither is worth a menu in the composer.

## A mention is a turn-scoped Agent, not a binding

- **One field, one flag.** It rides the existing `rag_assistant_id` with a new `agent_mention: true` beside it, rather than a second id field. A second field would mean teaching every downstream step — RAG, binding resolution, memory injection, the resume snapshot — about a second way to name the Agent running the turn.
- **The flag is a *binding* signal, never an authorization one.** `get_assistant_with_access_check` still gates the Agent on every turn, so a client that forges the flag gains nothing but a skipped write.
- **Validation and persistence move together**, via `binds_conversation()` in the new `chat/agent_binding_policy.py`. That module exists for the reason `system_prompt_resolver.py` does: the rule is three lines, the route around it is a thousand, so it only gets tested if it lives where a test can reach it. Splitting the two guards gives two silent bugs — validate-only refuses the *second* mention in a thread, persist-only lets one `@` annex the conversation.

## 💰 Cost, stated rather than discovered later

An Agent turn swaps the system prompt and `toolConfig`, so a mention inside a plain thread re-writes the cached prefix on the mention turn and re-writes it back on the next plain turn. At a 50k-token prefix and CLAUDE.md's $2.50/MTok cache-write premium that is roughly **$0.25 per mention round-trip**.

Bounded — twice per mention, never per turn — and bought deliberately for the thing the feature is for. The spec records the arithmetic and the lever if it stops being worth it: *bind* the conversation after a mention, rather than trying to make the swap cheaper.

## Composer behaviour

- **One mention per turn.** A second has nothing to mean, and suppressing the menu while one is pending also stops it re-opening every time the caret lands back inside an already-committed `@Policy Lookup` — agent names contain spaces.
- **Rows commit on `mousedown`, not `click`** — a click fires after `blur`, by which point the caret the replacement is anchored to is gone.
- **The menu owns Enter, arrows and Escape while open**, so a send never fires out from under a half-typed name.
- **It stays shut when there is nothing to offer** — no agents, or the whole surface switched off and both source calls 404 — so `@` in an email address is just an `@`.
- The literal `@Name` stays in the message text: it is what the user typed, and it is what explains the odd-looking answer when they scroll back tomorrow.
- Off in the two editor previews, which already run the thing being edited.

## Deploy

`backend.yml` + `frontend-deploy.yml`. **No CDK** — one optional request field, no new route, table, index or env var. Note this phase ships the **inference-api image to the AgentCore Runtime** (`deploy-inference-api-code`), unlike phases 4–6 which were app-api only. The app-api BFF relays the request body verbatim, so it needed no change.

## Testing

- `tests/apis/inference_api` + `tests/routes` — 891 passed, including 6 new tests over the binding matrix
- SPA `npm test` — 1560 passed (14 new: the candidate list's scope rules, and the request shape)
- `ng build` + `tsc --noEmit` — clean

**Not done:** any live exercise of the path. It needs phase 6 *and* this merged and deployed to dev, and the acceptance test is the pair — mention an Agent mid-thread and it answers; send the next message with no `@` and you are back in plain chat. If that second turn still goes to the Agent, the `preferences` write leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)