### PR TITLE
feat(marketplace): problem reports (D15, phase 8)

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -5,9 +5,10 @@ Mounted under ``/admin/agents`` per the CLAUDE.md route convention — admin CRU
 (= ``require_app_roles("system_admin")``); D2 is explicit that a granular "marketplace
 curator" permission is a deliberate follow-up, so do not open a second permission axis here.
 
-Covers four of D10's seven surfaces — **Review queue**, **Listings**, **Categories** and
-**Store front** — plus the **Publishers** records they depend on. Default pins and the
-reports queue are Phases 6 and 8.
+Covers five of D10's seven surfaces — **Review queue**, **Reports**, **Listings**,
+**Categories** and **Store front** — plus the **Publishers** records they depend on.
+Default pins live under ``/admin/roles/`` because the AppRole record is the source of
+truth for a seed.
 """
 
 import logging
@@ -31,10 +32,20 @@ from apis.shared.assistants.categories import (
     get_category,
     put_category,
 )
+from apis.app_api.agent_designer.services.report_service import (
+    ReportError,
+    list_agent_report_history,
+    list_report_queue,
+    open_report_count,
+    triage_report,
+)
 from apis.app_api.agent_designer.services.store_service import resolve_featured
 from apis.shared.assistants.models import (
     AdminListingPatchRequest,
     AdminListingsResponse,
+    AdminQueueCountsResponse,
+    AdminReportRow,
+    AdminReportsResponse,
     AdminStoreFrontResponse,
     AgentCategoriesResponse,
     AgentCategory,
@@ -47,6 +58,7 @@ from apis.shared.assistants.models import (
     PublisherProfile,
     PublishersResponse,
     PublisherUpdateRequest,
+    ResolveReportRequest,
     ReviewListingRequest,
     StoreFrontUpdateRequest,
     TakedownRequest,
@@ -186,6 +198,103 @@ async def patch_agent_listing(
     except Exception as e:
         logger.error(f"Error patching agent listing: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to patch listing: {str(e)}")
+
+
+# ── problem reports (D15) ────────────────────────────────────────────────────────────
+# The second work stream beside submissions. Everything here is admin-only for a reason
+# stated once: **the reporter is visible to the admin and never to the author** (D15.2).
+# Admins need identity to spot a brigade or a grudge; authors need the substance, not the
+# name. Nothing in this section is reachable from a user-facing route.
+@router.get("/reports", response_model=AdminReportsResponse)
+async def list_agent_reports(admin: User = Depends(require_marketplace_admin)):
+    """The Reports queue: every open report, oldest first within severity (D15).
+
+    Reports are **triaged, never auto-forwarded to the author** (D15.1). Piping raw user
+    text straight to the person who built the thing is how one bad message ends a
+    volunteer's willingness to publish — and the author cannot act on "this is stupid"
+    anyway. When a report is actionable the reviewer uses the existing **request changes**
+    or **takedown** path, whose reason field is already the author-facing channel. Reports
+    are the *evidence* for that reason, not a substitute for it.
+    """
+    try:
+        rows, open_count = await list_report_queue()
+        return AdminReportsResponse(reports=rows, open_count=open_count)
+    except Exception as e:
+        logger.error(f"Error listing agent reports: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list reports: {str(e)}")
+
+
+@router.get("/queues", response_model=AdminQueueCountsResponse)
+async def get_queue_counts(admin: User = Depends(require_marketplace_admin)):
+    """The two counts D10 puts on the admin nav, without loading either queue.
+
+    Its own route because the badges have to be right on *every* admin page: making the
+    nav call ``/submissions`` and ``/reports`` to render two integers would put a table
+    scan and a full row projection behind every click in the console.
+
+    Fail-soft per half. A badge is orientation, not data — an unreachable count should
+    show as zero rather than break the shell around a page that works.
+    """
+    pending = 0
+    open_reports = 0
+    try:
+        _rows, pending = await list_admin_listings(state="in_review")
+    except Exception:
+        logger.warning("Failed to count pending submissions for the nav badge", exc_info=True)
+    try:
+        open_reports = await open_report_count()
+    except Exception:
+        logger.warning("Failed to count open reports for the nav badge", exc_info=True)
+    return AdminQueueCountsResponse(pending_count=pending, open_report_count=open_reports)
+
+
+@router.get("/{agent_id}/reports", response_model=AdminReportsResponse)
+async def list_agent_report_history_endpoint(
+    agent_id: str, admin: User = Depends(require_marketplace_admin)
+):
+    """Every report ever filed on one Agent, newest first.
+
+    The context a reviewer wants before deciding whether one complaint is a pattern. Note
+    the count returned here is this Agent's, not the queue's — it badges nothing.
+    """
+    try:
+        rows = await list_agent_report_history(agent_id)
+        return AdminReportsResponse(
+            reports=rows, open_count=len([r for r in rows if r.state == "open"])
+        )
+    except Exception as e:
+        logger.error(f"Error listing reports for agent {agent_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list reports: {str(e)}")
+
+
+@router.post("/{agent_id}/reports/{report_id}/resolve", response_model=AdminReportRow)
+async def resolve_agent_report(
+    agent_id: str,
+    report_id: str,
+    request: ResolveReportRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Resolve or dismiss a report (D15.5).
+
+    ⚠️ **This never changes ``listing.state``.** A report has its own tiny lifecycle —
+    ``open → resolved | dismissed`` — deliberately not a mirror of the listing state
+    machine, because a report is a note *about* an Agent, not a state *of* it. If one
+    warrants delisting, the admin uses ``POST /{agent_id}/takedown`` and that is a
+    separate, recorded act with its own author-facing reason.
+
+    The path carries ``agent_id`` because reports are child rows of the Agent — the spec's
+    ``/reports/{reportId}/resolve`` would need a second index to locate the parent, which
+    is exactly what D15's storage note declines to add.
+    """
+    try:
+        return await triage_report(
+            agent_id, report_id, admin, decision=request.decision, note=request.note
+        )
+    except ReportError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error resolving report {report_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to resolve report: {str(e)}")
 
 
 # ── store front (D10) ────────────────────────────────────────────────────────────────

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -93,6 +93,7 @@ from apis.app_api.agent_designer.services.pin_service import (
     pin_agent,
     unpin_agent,
 )
+from apis.app_api.agent_designer.services.report_service import ReportError, file_report
 from apis.app_api.agent_designer.services.store_service import (
     browse_all,
     browse_category,
@@ -108,6 +109,8 @@ from apis.shared.assistants.models import (
     ListingSubmissionResponse,
     PinnedAgentResponse,
     SubmitListingRequest,
+    SubmitReportRequest,
+    SubmitReportResponse,
 )
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
@@ -643,6 +646,45 @@ async def unpin_agent_endpoint(
     except Exception as e:
         logger.error(f"Error unpinning agent: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to unpin agent: {str(e)}")
+
+
+# ----------------------------------------------------------------- problem reports (D15)
+@router.post("/{agent_id}/report", response_model=SubmitReportResponse, status_code=201)
+async def report_agent_endpoint(
+    agent_id: str,
+    request: SubmitReportRequest,
+    current_user: User = Depends(require_marketplace_enabled),
+):
+    """Report a problem with a published Agent (D15).
+
+    **This is not a review, and the distinction is the whole design.** There are no stars,
+    no public comments and no visible counts: a report is a *private message to the
+    curator*, never shelf content, and nothing the reporter writes is ever rendered to
+    another browsing user. It is also never a ranking input — nothing here touches
+    ``usageCount`` or the store front, because the moment report volume influenced
+    placement, reporting would become a way to bury a competitor's Agent.
+
+    Reportable means **published** (D15.3): you may report what the store offered you.
+    A second report while the reporter's first is still open **updates** it rather than
+    stacking (D15.4), and the response says so — without that the queue is trivially
+    floodable and the count at the top of the nav stops meaning anything.
+    """
+    try:
+        report, replaced = await file_report(
+            agent_id, current_user, reason=request.reason, note=request.note
+        )
+        return SubmitReportResponse(
+            agent_id=agent_id,
+            reason=report.reason,
+            state=report.state,
+            created_at=report.created_at,
+            replaced_existing=replaced,
+        )
+    except ReportError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error reporting agent: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to report agent: {str(e)}")
 
 
 # ------------------------------------------------------------------------ icons (D5)

--- a/backend/src/apis/app_api/agent_designer/services/report_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/report_service.py
@@ -1,0 +1,206 @@
+"""Problem reports — the user's half and the admin queue (D15, Phase 8).
+
+Two surfaces over ``apis.shared.assistants.reports``, which owns the storage:
+
+* **A user reports a published Agent.** Gated on reachability *and* publication (D15.3):
+  you may report what the store offered you. Reporting a ``private`` or ``in_review``
+  Agent is not a thing — nobody outside the author was invited to it, and a takedown is
+  not available as a remedy for something that was never listed.
+
+* **An admin triages.** The reporter is visible here and nowhere else (D15.2), and a
+  decision writes only the report (D15.5).
+
+⚠️ **A report is not a permission signal and not a ranking input.** Nothing in this module
+touches ``usageCount``, the store front, or any ordering, and no count it produces is ever
+returned on a user-facing read. The moment report volume influences placement, reporting
+becomes a way to bury a competitor's Agent.
+"""
+
+import logging
+import os
+from typing import List, Optional, Tuple
+
+from apis.shared.assistants.icons import icon_url
+from apis.shared.assistants.models import (
+    REPORT_REASON_SEVERITY,
+    AdminReportRow,
+    AgentReport,
+    ReportReason,
+)
+from apis.shared.assistants.reports import (
+    count_open_reports,
+    list_open_reports,
+    list_reports_for_agent,
+    resolve_report,
+    submit_report,
+)
+from apis.shared.assistants.service import (
+    _get_assistant_cloud_without_ownership_check,
+    get_assistant_with_access_check,
+)
+from apis.shared.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+
+class ReportError(Exception):
+    """A report operation the caller may not perform, or that is not currently valid.
+
+    Mirrors ``ListingError``: ``status_code`` maps straight to the HTTP response.
+    """
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+async def file_report(
+    agent_id: str, user: User, *, reason: ReportReason, note: Optional[str]
+) -> Tuple[AgentReport, bool]:
+    """Record a user's problem report against a published Agent (D15).
+
+    Two gates, in this order, because they answer different questions:
+
+    1. **Can the caller reach it?** The same ``get_assistant_with_access_check`` the
+       detail page uses, so nothing here becomes a way to probe for Agents you cannot see.
+    2. **Is it published?** (D15.3) Checked *after*, and reported as a 400 rather than a
+       404 — the caller demonstrably could see the Agent, so pretending it does not exist
+       would be a confusing lie rather than a useful one.
+
+    Returns ``(report, replaced_existing)``; the second half is D15.4's one-open-report
+    rule surfacing so the UI can say "we updated your report" rather than implying a
+    second one is now queued.
+    """
+    assistant, _permission = await get_assistant_with_access_check(
+        assistant_id=agent_id, user_id=user.user_id, user_email=user.email
+    )
+    if not assistant:
+        raise ReportError(f"Agent not found: {agent_id}", status_code=404)
+
+    listing = assistant.listing
+    if listing is None or listing.state != "published":
+        raise ReportError(
+            "Only agents published in the store can be reported.", status_code=400
+        )
+
+    return await submit_report(
+        agent_id,
+        reporter_id=user.user_id,
+        reporter_name=_display_name(user),
+        reason=reason,
+        note=(note or "").strip() or None,
+    )
+
+
+def _display_name(user: User) -> str:
+    """The reporter as the admin queue should read them (D15.2).
+
+    Falls back through name → email → id rather than rendering an empty cell: an admin
+    triaging a possible brigade needs *something* to compare rows by.
+    """
+    return getattr(user, "name", None) or getattr(user, "email", None) or user.user_id
+
+
+async def list_report_queue() -> Tuple[List[AdminReportRow], int]:
+    """The admin Reports queue: open reports oldest-first, plus the nav badge count.
+
+    Each row is joined to its Agent so the admin can triage without a second fetch. An
+    Agent that no longer exists yields a row flagged ``agentMissing`` rather than being
+    dropped — a dropped row would be invisible *and* still counted, and the admin would
+    have no way to clear it.
+
+    Within the sweep, rows sort by ``(severity, createdAt)``: ``inappropriate`` should
+    page a human rather than wait its turn behind a stale-link complaint.
+    """
+    reports = await list_open_reports()
+    rows = [await _to_row(report) for report in reports]
+    rows.sort(key=lambda r: (REPORT_REASON_SEVERITY.get(r.reason, 99), r.created_at))
+    return rows, len(rows)
+
+
+async def list_agent_report_history(agent_id: str) -> List[AdminReportRow]:
+    """Every report on one Agent, newest first — the admin's per-agent history."""
+    return [await _to_row(report) for report in await list_reports_for_agent(agent_id)]
+
+
+async def triage_report(
+    agent_id: str, report_id: str, admin: User, *, decision: str, note: Optional[str]
+) -> AdminReportRow:
+    """Resolve or dismiss a report (D15.5).
+
+    ⚠️ This changes ``listing.state`` for nobody. A report is a note *about* an Agent, not
+    a state *of* it; if one warrants delisting, the admin uses the existing takedown path
+    and that is a separate, recorded act. Wiring the two together here would make the
+    queue's "Resolve" button quietly delist an Agent.
+    """
+    if decision not in ("resolve", "dismiss"):
+        raise ReportError(f"Unknown decision: {decision}", status_code=400)
+
+    state = "resolved" if decision == "resolve" else "dismissed"
+    try:
+        report = await resolve_report(
+            agent_id,
+            report_id,
+            state=state,
+            resolved_by=_display_name(admin),
+            note=(note or "").strip() or None,
+        )
+    except ValueError as e:
+        raise ReportError(str(e), status_code=404) from e
+
+    return await _to_row(report)
+
+
+async def _to_row(report: AgentReport) -> AdminReportRow:
+    """Join one report to its Agent for the console.
+
+    The Agent is read **without** an ownership or visibility check — deliberately. A
+    reviewer fails an ownership check by definition, and a report on an Agent whose author
+    has since made it ``PRIVATE`` is exactly the report an admin most needs to see. Same
+    reasoning as the listing service's admin load path.
+
+    A missing Agent yields a flagged row rather than an omitted one: a row that is dropped
+    from the queue but still counted by the badge is one an admin can neither see nor
+    clear.
+    """
+    base = dict(
+        report_id=report.report_id,
+        agent_id=report.agent_id,
+        reporter_id=report.reporter_id,
+        reporter_name=report.reporter_name,
+        reason=report.reason,
+        note=report.note,
+        state=report.state,
+        created_at=report.created_at,
+        resolved_at=report.resolved_at,
+        resolved_by=report.resolved_by,
+        resolution_note=report.resolution_note,
+    )
+
+    assistant = None
+    try:
+        table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+        if table_name:
+            assistant = await _get_assistant_cloud_without_ownership_check(
+                report.agent_id, table_name
+            )
+    except Exception:
+        logger.warning(f"Failed to load agent {report.agent_id} for report row", exc_info=True)
+
+    if assistant is None:
+        return AdminReportRow(**base, agent_name=report.agent_id, agent_missing=True)
+
+    return AdminReportRow(
+        **base,
+        agent_name=assistant.name,
+        emoji=assistant.emoji,
+        icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
+        owner_name=assistant.owner_name,
+        listing_state=assistant.listing.state if assistant.listing else None,
+    )
+
+
+async def open_report_count() -> int:
+    """The D10 nav badge. A COUNT query, never a projection of rows nobody renders."""
+    return await count_open_reports()

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -15,6 +15,24 @@ BindingKind = Literal["knowledge_base", "tool", "skill", "memory_space"]
 ListingState = Literal["private", "in_review", "published", "changes_requested", "taken_down"]
 PublisherKind = Literal["institution", "department", "individual"]
 
+# Agent Marketplace Phase 8 (D15): problem reports. A small fixed set so the queue can be
+# sorted by severity without reading every note — ``inappropriate`` is the one that should
+# page a human rather than wait for a sweep.
+ReportReason = Literal["inaccurate", "broken", "inappropriate", "other"]
+
+# Deliberately NOT a mirror of ``ListingState``: a report is a note *about* an Agent, not
+# a state *of* it. Resolving one never changes ``listing.state`` (D15.5) — if a report
+# warrants delisting, the admin takes the Agent down and that is a separate recorded act.
+ReportState = Literal["open", "resolved", "dismissed"]
+
+# Severity order for the queue sweep (D15). ``inappropriate`` first for the reason above.
+REPORT_REASON_SEVERITY: Dict[str, int] = {
+    "inappropriate": 0,
+    "broken": 1,
+    "inaccurate": 2,
+    "other": 3,
+}
+
 
 class AgentModelConfig(BaseModel):
     """Governed single-select model for an Agent (D3).
@@ -1024,6 +1042,173 @@ class AdminStoreFrontResponse(BaseModel):
             "Configured ids that are no longer published — surfaced rather than silently "
             "dropped, so an admin can see why the row is short and clear them"
         ),
+    )
+
+
+# ─────────────────────────────────────────────────────── Agent Marketplace (Phase 8)
+# Problem reports (D15). ⚠️ A report is a **private message to the curator**. Nothing in
+# this section is ever rendered to another browsing user, and no count derived from it may
+# reach ``usageCount``, the store front, or any ordering — the moment report volume
+# influences placement, reporting becomes a way to bury a competitor's Agent.
+class AgentReport(BaseModel):
+    """One problem report, stored as a child row of the Agent it concerns (D15).
+
+    ``extra="allow"`` mirrors ``AgentListing``: a field written by newer code survives a
+    read/write round trip through older code.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    report_id: str = Field(..., alias="reportId", description="Deterministic per (agent, reporter) — see reports.py")
+    agent_id: str = Field(..., alias="agentId", description="Agent this report concerns")
+    reporter_id: str = Field(
+        ...,
+        alias="reporterId",
+        description=(
+            "Who filed it. Visible to the admin and NEVER to the author (D15.2) — admins "
+            "need identity to spot a brigade or a grudge; authors need the substance."
+        ),
+    )
+    reporter_name: str = Field(..., alias="reporterName", description="Reporter display name, for the queue")
+    reason: ReportReason = Field(..., description="Fixed-set reason, so the queue sorts by severity")
+    note: Optional[str] = Field(None, description="The reporter's free text")
+    state: ReportState = Field("open", description="open → resolved | dismissed (D15.5)")
+    created_at: str = Field(..., alias="createdAt", description="ISO 8601; the GSI6 sort key while open")
+    updated_at: Optional[str] = Field(None, alias="updatedAt", description="ISO 8601 of the last write")
+    resolved_at: Optional[str] = Field(None, alias="resolvedAt", description="ISO 8601 of the triage decision")
+    resolved_by: Optional[str] = Field(None, alias="resolvedBy", description="Display name of the deciding admin")
+    resolution_note: Optional[str] = Field(
+        None,
+        alias="resolutionNote",
+        description=(
+            "The admin's own note. ⚠️ Never forwarded to the author (D15.1) — when a report "
+            "is actionable the admin uses request-changes or takedown, whose reason field is "
+            "the author-facing channel."
+        ),
+    )
+
+
+class SubmitReportRequest(BaseModel):
+    """A user reports a problem with a published Agent (D15)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    reason: ReportReason = Field(..., description="Why it is being reported")
+    note: Optional[str] = Field(
+        None, max_length=2000, description="What is wrong, in the reporter's words"
+    )
+
+
+class SubmitReportResponse(BaseModel):
+    """What the reporter is told back.
+
+    Deliberately thin. The reporter learns their report was recorded and whether it
+    *replaced* one they already had open (D15.4) — and nothing else. Queue position,
+    other reports, and every admin field are the curator's, not theirs.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent this report concerns")
+    reason: ReportReason = Field(..., description="The reason as recorded")
+    state: ReportState = Field(..., description="Always 'open' for a freshly filed report")
+    created_at: str = Field(..., alias="createdAt", description="When this report was filed")
+    replaced_existing: bool = Field(
+        False,
+        alias="replacedExisting",
+        description=(
+            "True when this updated the reporter's already-open report rather than adding "
+            "one (D15.4) — so the UI can say 'we updated your report' instead of implying a "
+            "second one is now queued."
+        ),
+    )
+
+
+class ResolveReportRequest(BaseModel):
+    """Admin triages a report: resolve it or dismiss it (D15.5)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    decision: Literal["resolve", "dismiss"] = Field(..., description="Triage outcome")
+    note: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="The admin's record of what they did. Never forwarded to the author (D15.1)",
+    )
+
+
+class AdminReportRow(BaseModel):
+    """One row in the admin Reports queue (D10/D15).
+
+    Carries the reporter (D15.2) and enough of the Agent to triage without a second
+    fetch. ``listingState`` is present but **never** written by this surface: resolving a
+    report does not change it (D15.5). It is here so an admin can see that the Agent they
+    are reading about has already been taken down by someone else.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    report_id: str = Field(..., alias="reportId", description="Report identifier, within its agent")
+    agent_id: str = Field(..., alias="agentId", description="Agent this report concerns")
+    agent_name: str = Field(..., alias="agentName", description="Agent display name at read time")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_url: Optional[str] = Field(None, alias="iconUrl", description="Where to render the icon from")
+    owner_name: Optional[str] = Field(
+        None, alias="ownerName", description="The author — who to talk to about behavior"
+    )
+    listing_state: Optional[ListingState] = Field(
+        None,
+        alias="listingState",
+        description="The Agent's publication state, read-only context; resolving never changes it (D15.5)",
+    )
+    agent_missing: bool = Field(
+        False,
+        alias="agentMissing",
+        description=(
+            "The Agent this report concerns no longer exists. Reports are deleted with "
+            "their Agent, so this is a repair affordance for a row orphaned by an older "
+            "delete path — the admin can still dismiss it."
+        ),
+    )
+    reporter_id: str = Field(..., alias="reporterId", description="Reporter user id (admin-only, D15.2)")
+    reporter_name: str = Field(..., alias="reporterName", description="Reporter display name (admin-only, D15.2)")
+    reason: ReportReason = Field(..., description="Fixed-set reason")
+    note: Optional[str] = Field(None, description="The reporter's free text")
+    state: ReportState = Field(..., description="open / resolved / dismissed")
+    created_at: str = Field(..., alias="createdAt", description="ISO 8601 when it was filed")
+    resolved_at: Optional[str] = Field(None, alias="resolvedAt", description="ISO 8601 of the decision")
+    resolved_by: Optional[str] = Field(None, alias="resolvedBy", description="Deciding admin's display name")
+    resolution_note: Optional[str] = Field(None, alias="resolutionNote", description="The admin's own note")
+
+
+class AdminReportsResponse(BaseModel):
+    """Rows for the admin Reports queue, plus the nav badge count (D10)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    reports: List[AdminReportRow] = Field(default_factory=list, description="Matching reports")
+    open_count: int = Field(
+        0,
+        alias="openCount",
+        description="Reports awaiting triage; badges the admin nav alongside submissions (D10)",
+    )
+
+
+class AdminQueueCountsResponse(BaseModel):
+    """The two numbers D10 puts on the admin nav, without loading either queue.
+
+    Exists because the badge has to be right on *every* admin page, and making the nav
+    fetch two full queues to render two integers would put a table scan behind every
+    click in the console.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pending_count: int = Field(
+        0, alias="pendingCount", description="Submissions awaiting review (D2)"
+    )
+    open_report_count: int = Field(
+        0, alias="openReportCount", description="Problem reports awaiting triage (D15)"
     )
 
 

--- a/backend/src/apis/shared/assistants/reports.py
+++ b/backend/src/apis/shared/assistants/reports.py
@@ -1,0 +1,359 @@
+"""Problem reports for the Agent Marketplace (D15, Phase 8).
+
+A report is a **private message to the curator**. It is never rendered to another browsing
+user, and nothing derived from it may reach ``usageCount``, the store front, or any
+ordering — the moment report volume influences placement, reporting becomes a way to bury
+a competitor's Agent. This module therefore has exactly two readers: the admin queue and
+the delete path that removes reports along with their Agent.
+
+Storage is child rows under the Agent on the **assistants** table, so a report is deleted
+with the Agent it concerns and never outlives it:
+
+    PK = AST#{agent_id}, SK = REPORT#{report_id}
+    { reporterId, reporterName, reason, note, state, createdAt,
+      resolvedAt?, resolvedBy?, resolutionNote? }
+
+Written only while ``state == "open"``, exactly as GSI5 is written only while published:
+
+    GSI6_PK = "REPORTS#OPEN"   GSI6_SK = CREATED#{created_at}
+
+Four things here are load-bearing:
+
+**1. ⚠️ The sort key is deterministic, not chronological.** The spec sketched
+``SK = REPORT#{created_at}#{report_id}``, but that is incompatible with its own D15.4
+instruction to enforce one-open-report-per-reporter "with a conditional write on a
+deterministic ``report_id``, not a second index": you cannot conditionally update a row
+whose key embeds the timestamp you are trying *not* to change without first reading it —
+which is the extra lookup D15.4 exists to avoid. So the key is
+``REPORT#{sha256(agent_id:reporter_id)}`` and the chronology lives in ``GSI6_SK``, which
+is the only place anything actually reads it. Nothing sorts by the table's sort key.
+
+**2. The one-open-report rule is enforced by three conditional writes and no read.**
+Create-if-absent, else update-if-open (preserving ``createdAt`` and the index keys, so a
+re-report does not jump the queue), else overwrite-if-closed with a fresh ``createdAt``.
+Each step is a condition on the item itself, so two taps racing cannot stack two reports
+or resurrect a resolved one.
+
+**3. Triage clears the index key rather than filtering on state.** A resolved report
+leaves the queue because it has no key, not because a reader remembered to exclude it —
+the same physics as the sparse directory index.
+
+**4. Per (agent, reporter), history is one deep.** Filing again after a resolution
+replaces the resolved row. An append-only archive was considered and declined: nothing
+reads it, and D15.1 already puts the durable record elsewhere — a report is the *evidence*
+for a request-changes or takedown, and that act is separately recorded on the listing.
+"""
+
+import hashlib
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from .models import AgentReport, ReportReason
+
+logger = logging.getLogger(__name__)
+
+_SK_PREFIX = "REPORT#"
+
+# The single open-queue partition (D15). One partition is correct here and would not be
+# for the directory: the queue is bounded by how fast admins work, it is read only by the
+# admin console, and it wants one chronological sweep rather than per-agent slices.
+_OPEN_PK = "REPORTS#OPEN"
+
+_GSI6_ATTRS = ("GSI6_PK", "GSI6_SK")
+
+# ``state`` is a DynamoDB reserved word; ``reason`` and ``note`` are aliased alongside it
+# rather than checked one by one against the reserved list, which grows.
+_NAMES = {"#st": "state", "#reason": "reason", "#note": "note"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat() + "Z"
+
+
+def _table():
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def report_id_for(agent_id: str, reporter_id: str) -> str:
+    """The deterministic report id for one reporter's report of one Agent (D15.4).
+
+    Hashed rather than the raw reporter id so the sort key is not itself a directory of
+    who has reported what — the reporter is admin-visible in the *item*, which is where
+    D15.2 puts them, not in a key that any query of the partition would enumerate. The
+    agent id is mixed in so the same reporter's ids do not correlate across Agents.
+    """
+    digest = hashlib.sha256(f"{agent_id}:{reporter_id}".encode()).hexdigest()
+    return digest[:16]
+
+
+def _key(agent_id: str, report_id: str) -> Dict[str, str]:
+    return {"PK": f"AST#{agent_id}", "SK": f"{_SK_PREFIX}{report_id}"}
+
+
+def _to_report(item: Dict[str, Any]) -> AgentReport:
+    """Project a raw item into ``AgentReport``, deriving the ids back out of the keys."""
+    return AgentReport.model_validate(
+        {
+            **{k: v for k, v in item.items() if k not in ("PK", "SK", *_GSI6_ATTRS)},
+            "reportId": str(item["SK"])[len(_SK_PREFIX) :],
+            "agentId": str(item["PK"])[len("AST#") :],
+        }
+    )
+
+
+async def submit_report(
+    agent_id: str,
+    *,
+    reporter_id: str,
+    reporter_name: str,
+    reason: ReportReason,
+    note: Optional[str],
+) -> Tuple[AgentReport, bool]:
+    """File a report, or update this reporter's already-open one (D15.4).
+
+    Returns ``(report, replaced_existing)``. ``replaced_existing`` is True only when an
+    *open* report was updated in place — that is the case the UI must not describe as a
+    second report having been queued.
+
+    Three conditional writes, no read, in the order the cases actually occur:
+
+    1. **Create** — condition ``attribute_not_exists(SK)``. The common path.
+    2. **Update while open** — condition ``state = open``. Keeps ``createdAt`` and the
+       index keys, so amending a report does not move it to the front of the sweep.
+    3. **Overwrite a closed one** — condition ``state <> open``, with a fresh
+       ``createdAt`` and the resolution fields cleared. The guard means this can never
+       clobber an open report that step 2 lost a race to.
+    """
+    from botocore.exceptions import ClientError
+
+    report_id = report_id_for(agent_id, reporter_id)
+    now = _now()
+    table = _table()
+
+    body: Dict[str, Any] = {
+        "reporterId": reporter_id,
+        "reporterName": reporter_name,
+        "reason": reason,
+        "state": "open",
+        "updatedAt": now,
+    }
+    if note:
+        body["note"] = note
+
+    def _built(created_at: str) -> AgentReport:
+        return AgentReport.model_validate(
+            {**body, "reportId": report_id, "agentId": agent_id, "createdAt": created_at}
+        )
+
+    # 1. Create.
+    try:
+        table.put_item(
+            Item={
+                **_key(agent_id, report_id),
+                **body,
+                "createdAt": now,
+                "GSI6_PK": _OPEN_PK,
+                "GSI6_SK": f"CREATED#{now}",
+            },
+            ConditionExpression="attribute_not_exists(SK)",
+        )
+        logger.info(f"🚩 {reporter_id} reported agent {agent_id} ({reason})")
+        return _built(now), False
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            logger.error(f"Failed to file report on {agent_id}: {e}")
+            raise
+
+    # 2. Update the reporter's open report in place, keeping its place in the queue.
+    set_parts = ["reporterName = :rname", "#reason = :reason", "#st = :open", "updatedAt = :now"]
+    values: Dict[str, Any] = {
+        ":rname": reporter_name,
+        ":reason": reason,
+        ":open": "open",
+        ":now": now,
+    }
+    remove_parts: List[str] = []
+    if note:
+        set_parts.append("#note = :note")
+        values[":note"] = note
+    else:
+        # An amended report with the text removed must not keep the old text.
+        remove_parts.append("#note")
+
+    expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        expression += " REMOVE " + ", ".join(remove_parts)
+
+    try:
+        response = table.update_item(
+            Key=_key(agent_id, report_id),
+            UpdateExpression=expression,
+            ExpressionAttributeNames=_NAMES,
+            ExpressionAttributeValues=values,
+            ConditionExpression="#st = :open",
+            ReturnValues="ALL_NEW",
+        )
+        logger.info(f"🚩 {reporter_id} updated their open report on agent {agent_id}")
+        return _to_report(response["Attributes"]), True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            logger.error(f"Failed to update report on {agent_id}: {e}")
+            raise
+
+    # 3. The existing report is resolved or dismissed — this is a genuinely new one.
+    table.put_item(
+        Item={
+            **_key(agent_id, report_id),
+            **body,
+            "createdAt": now,
+            "GSI6_PK": _OPEN_PK,
+            "GSI6_SK": f"CREATED#{now}",
+        },
+        ConditionExpression="#st <> :open",
+        ExpressionAttributeNames={"#st": "state"},
+        ExpressionAttributeValues={":open": "open"},
+    )
+    logger.info(f"🚩 {reporter_id} re-reported agent {agent_id} after an earlier resolution")
+    return _built(now), False
+
+
+async def resolve_report(
+    agent_id: str,
+    report_id: str,
+    *,
+    state: str,
+    resolved_by: str,
+    note: Optional[str],
+) -> AgentReport:
+    """Record a triage decision and drop the report out of the open queue (D15.5).
+
+    ⚠️ This writes **only** the report. It does not touch ``listing.state``: if a report
+    warrants delisting, the admin uses the takedown path and that is a separate, recorded
+    act. Tying the two together here would make "resolve" quietly mean "delist".
+
+    The ``REMOVE`` of the index keys is what takes it off the queue — not a state filter
+    on the read. Raises ``ValueError`` if the report no longer exists.
+    """
+    from botocore.exceptions import ClientError
+
+    now = _now()
+    set_parts = ["#st = :state", "resolvedAt = :now", "resolvedBy = :by", "updatedAt = :now"]
+    values: Dict[str, Any] = {":state": state, ":now": now, ":by": resolved_by}
+    remove_parts = list(_GSI6_ATTRS)
+
+    if note:
+        set_parts.append("resolutionNote = :note")
+        values[":note"] = note
+    else:
+        remove_parts.append("resolutionNote")
+
+    try:
+        response = _table().update_item(
+            Key=_key(agent_id, report_id),
+            UpdateExpression="SET " + ", ".join(set_parts) + " REMOVE " + ", ".join(remove_parts),
+            ExpressionAttributeNames={"#st": "state"},
+            ExpressionAttributeValues=values,
+            ConditionExpression="attribute_exists(SK)",
+            ReturnValues="ALL_NEW",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise ValueError(f"Report not found: {report_id}") from e
+        logger.error(f"Failed to resolve report {report_id} on {agent_id}: {e}")
+        raise
+
+    logger.info(f"🚩 {resolved_by} marked report {report_id} on {agent_id} as {state}")
+    return _to_report(response["Attributes"])
+
+
+async def list_open_reports(limit: int = 200) -> List[AgentReport]:
+    """The open queue, oldest first — a pure GSI6 query (D15).
+
+    Oldest-first because this is a work queue, not a feed: the report that has waited
+    longest is the one to triage next. It cannot return a resolved report, because a
+    resolved report has no key in this index.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    response = _table().query(
+        IndexName="AgentReportsIndex",
+        KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
+        ScanIndexForward=True,
+        Limit=limit,
+    )
+    return [_to_report(item) for item in response.get("Items", [])]
+
+
+async def count_open_reports() -> int:
+    """How many reports await triage — the D10 nav badge.
+
+    ``Select=COUNT`` so the badge never pays to project rows nobody renders.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    response = _table().query(
+        IndexName="AgentReportsIndex",
+        KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
+        Select="COUNT",
+    )
+    return int(response.get("Count", 0))
+
+
+async def list_reports_for_agent(agent_id: str) -> List[AgentReport]:
+    """Every report on one Agent, open or not.
+
+    Not a user-facing read and never joined into any Agent projection: it backs the
+    delete sweep, and the admin console's per-agent history.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    response = _table().query(
+        KeyConditionExpression=Key("PK").eq(f"AST#{agent_id}")
+        & Key("SK").begins_with(_SK_PREFIX)
+    )
+    reports = [_to_report(item) for item in response.get("Items", [])]
+    reports.sort(key=lambda r: r.created_at, reverse=True)
+    return reports
+
+
+async def delete_reports_for_agent(agent_id: str) -> int:
+    """Delete every report on an Agent. Called when the Agent itself is deleted.
+
+    Reports are child rows precisely so they never outlive what they concern — and an
+    orphaned *open* report would be worse than untidy: it keeps its sparse index key, so
+    it would sit in the admin queue forever pointing at an Agent nobody can open.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    table = _table()
+    response = table.query(
+        KeyConditionExpression=Key("PK").eq(f"AST#{agent_id}")
+        & Key("SK").begins_with(_SK_PREFIX),
+        ProjectionExpression="PK, SK",
+    )
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(f"AST#{agent_id}")
+            & Key("SK").begins_with(_SK_PREFIX),
+            ProjectionExpression="PK, SK",
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        items.extend(response.get("Items", []))
+
+    if not items:
+        return 0
+
+    with table.batch_writer() as batch:
+        for item in items:
+            batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
+
+    logger.info(f"🗑️ Deleted {len(items)} report(s) with agent {agent_id}")
+    return len(items)

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -902,6 +902,23 @@ async def _delete_assistant_cloud(assistant_id: str, table_name: str) -> bool:
         dynamodb = boto3.resource("dynamodb")
         table = dynamodb.Table(table_name)
 
+        # Child rows first. Marketplace problem reports (D15) live under this same
+        # partition precisely so they never outlive what they concern — and an orphaned
+        # *open* report is worse than untidy: it keeps its sparse GSI6 key, so it would
+        # sit in the admin queue forever pointing at an Agent nobody can open. Best
+        # effort, because failing to tidy up must not make the Agent undeletable; the
+        # queue projection flags a row whose Agent is gone so an admin can still clear it.
+        try:
+            from .reports import delete_reports_for_agent
+
+            await delete_reports_for_agent(assistant_id)
+        except Exception:
+            logger.warning(
+                f"Failed to delete reports for assistant {assistant_id}; "
+                "the admin queue will show them as orphaned",
+                exc_info=True,
+            )
+
         table.delete_item(Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"})
 
         logger.info(f"🗑️ Deleted assistant {assistant_id} from DynamoDB table {table_name}")

--- a/backend/tests/routes/test_agent_reports.py
+++ b/backend/tests/routes/test_agent_reports.py
@@ -1,0 +1,403 @@
+"""Agent Marketplace Phase 8 — the report routes (D15).
+
+Two surfaces, and the rules that make them different from every other pair of routes in
+the marketplace:
+
+* **The user's half** is gated on *publication*, not just access (D15.3) — you may report
+  what the store offered you — and one open report per reporter (D15.4), which is what
+  keeps the queue from being floodable and the nav count from becoming noise.
+
+* **The admin's half** is the only place the reporter is ever visible (D15.2), and it must
+  not be reachable from anywhere else. Several cases below exist purely to assert an
+  *absence*: no report content on a user-facing read, no listing change from a resolution,
+  no report count anywhere near the store.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.agents.routes import router as admin_router
+from apis.app_api.agent_designer.routes import router as agents_router
+from apis.shared.assistants.models import AgentListing, AgentReport, Assistant
+from apis.shared.auth import require_admin
+from tests.routes.conftest import mock_auth_user
+
+REPORT_SERVICE = "apis.app_api.agent_designer.services.report_service"
+AGENT_ROUTES = "apis.app_api.agent_designer.routes"
+
+AGENT = "ast-001"
+
+
+def _make_assistant(listing_state="published", **overrides) -> Assistant:
+    defaults = dict(
+        assistantId=AGENT,
+        ownerId="user-author",
+        ownerName="Ada Author",
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="SECRET SYSTEM PROMPT",
+        vectorIndexId="idx-001",
+        visibility="PUBLIC",
+        usageCount=0,
+        createdAt="2026-07-01T00:00:00Z",
+        updatedAt="2026-07-01T00:00:00Z",
+        status="COMPLETE",
+        emoji="📋",
+        tagline="Find and cite university policy",
+    )
+    if listing_state is not None:
+        defaults["listing"] = AgentListing(
+            state=listing_state, category="Administration", publisher_id="pub-registrar"
+        ).model_dump(by_alias=True)
+    defaults.update(overrides)
+    return Assistant.model_validate(defaults)
+
+
+def _report(**overrides) -> AgentReport:
+    defaults = dict(
+        reportId="rep-abc",
+        agentId=AGENT,
+        reporterId="user-001",
+        reporterName="Pat Reporter",
+        reason="broken",
+        note="It errors out",
+        state="open",
+        createdAt="2026-07-24T00:00:00Z",
+    )
+    defaults.update(overrides)
+    return AgentReport.model_validate(defaults)
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(agents_router)
+    _app.include_router(admin_router, prefix="/admin")
+    return _app
+
+
+@pytest.fixture(autouse=True)
+def _flags_on(monkeypatch):
+    monkeypatch.setenv("AGENTS_API_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "true")
+
+
+@pytest.fixture
+def client(app, make_user):
+    mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
+    app.dependency_overrides[require_admin] = lambda: make_user(
+        user_id="admin-1", email="admin@example.edu"
+    )
+    return TestClient(app)
+
+
+_UNSET = object()
+
+
+def _report_agent(client, *, assistant=_UNSET, body=None, submitted=None):
+    """POST the report with the storage layer stubbed at the service's own boundary.
+
+    ``assistant=None`` means "the access check denies", which is why the default is a
+    sentinel rather than ``None``.
+    """
+    resolved = _make_assistant() if assistant is _UNSET else assistant
+
+    with (
+        patch(
+            f"{REPORT_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(resolved, "viewer") if resolved else (None, None)),
+        ),
+        patch(
+            f"{REPORT_SERVICE}.submit_report",
+            AsyncMock(return_value=submitted or (_report(), False)),
+        ) as submit,
+    ):
+        response = client.post(
+            f"/agents/{AGENT}/report", json=body or {"reason": "broken", "note": "It errors out"}
+        )
+    return response, submit
+
+
+# ── reportable means published (D15.3) ───────────────────────────────────────────────
+def test_a_published_agent_can_be_reported(client):
+    response, submit = _report_agent(client)
+
+    assert response.status_code == 201
+    assert submit.await_count == 1
+    assert response.json()["state"] == "open"
+
+
+@pytest.mark.parametrize("state", ["private", "in_review", "changes_requested", "taken_down"])
+def test_an_unpublished_agent_cannot_be_reported(client, state):
+    """You may report what the store offered you — nothing else (D15.3).
+
+    A takedown is not available as a remedy for something that was never listed, so there
+    is no useful thing the queue could do with the report either.
+    """
+    response, submit = _report_agent(client, assistant=_make_assistant(listing_state=state))
+
+    assert response.status_code == 400
+    assert submit.await_count == 0, "nothing may reach storage for an unpublished agent"
+
+
+def test_an_agent_that_was_never_submitted_cannot_be_reported(client):
+    response, submit = _report_agent(client, assistant=_make_assistant(listing_state=None))
+
+    assert response.status_code == 400
+    assert submit.await_count == 0
+
+
+def test_an_agent_the_caller_cannot_reach_is_a_404(client):
+    """The access check runs first, so reporting is not a way to probe for agents."""
+    response, submit = _report_agent(client, assistant=None)
+
+    assert response.status_code == 404
+    assert submit.await_count == 0
+
+
+def test_an_unknown_reason_is_refused(client):
+    """The fixed set is what lets the queue sort by severity without reading every note."""
+    response, submit = _report_agent(client, body={"reason": "i-just-dont-like-it"})
+
+    assert response.status_code == 422
+    assert submit.await_count == 0
+
+
+# ── one open report per reporter (D15.4) ─────────────────────────────────────────────
+def test_a_replaced_report_says_so(client):
+    """The UI has to be able to say "we updated your report" rather than imply a second."""
+    response, _ = _report_agent(client, submitted=(_report(), True))
+
+    assert response.json()["replacedExisting"] is True
+
+
+def test_a_first_report_does_not_claim_to_have_replaced_anything(client):
+    response, _ = _report_agent(client, submitted=(_report(), False))
+
+    assert response.json()["replacedExisting"] is False
+
+
+# ── ⚠️ a report is private, and never a ranking input ────────────────────────────────
+def test_the_reporter_response_leaks_nothing_about_the_queue(client):
+    """A report is a private message to the curator, so the reporter learns only that it
+    landed. Queue position, other reports and every admin field would each be a way to
+    read a surface the reporter has no business in.
+    """
+    response, _ = _report_agent(client)
+
+    assert set(response.json()) == {
+        "agentId",
+        "reason",
+        "state",
+        "createdAt",
+        "replacedExisting",
+    }
+
+
+def test_reporting_does_not_touch_the_listing_or_usage_count(client):
+    """⚠️ The moment report volume influenced placement, reporting would become a way to
+    bury a competitor's agent. Nothing on the write path may reach the listing.
+    """
+    with (
+        patch(
+            f"{REPORT_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(), "viewer")),
+        ),
+        patch(f"{REPORT_SERVICE}.submit_report", AsyncMock(return_value=(_report(), False))),
+        patch(
+            "apis.shared.assistants.listing_repository.write_listing", AsyncMock()
+        ) as write_listing,
+    ):
+        client.post(f"/agents/{AGENT}/report", json={"reason": "inappropriate"})
+
+    assert write_listing.await_count == 0
+
+
+# ── the kill switch ──────────────────────────────────────────────────────────────────
+def test_reporting_is_404_when_the_marketplace_is_off(client, monkeypatch):
+    """404 rather than 403, so the surface reads as unmounted while the feature ships."""
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+
+    response, submit = _report_agent(client)
+
+    assert response.status_code == 404
+    assert submit.await_count == 0
+
+
+def test_the_admin_queue_is_404_when_the_marketplace_is_off(client, monkeypatch):
+    monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
+
+    assert client.get("/admin/agents/reports").status_code == 404
+
+
+# ── the admin queue (D10, D15.2) ─────────────────────────────────────────────────────
+def _queue(client, reports):
+    with (
+        patch(
+            f"{REPORT_SERVICE}.list_open_reports", AsyncMock(return_value=reports)
+        ),
+        patch(
+            f"{REPORT_SERVICE}._get_assistant_cloud_without_ownership_check",
+            AsyncMock(return_value=_make_assistant()),
+        ),
+    ):
+        return client.get("/admin/agents/reports")
+
+
+def test_the_queue_shows_the_reporter(client):
+    """D15.2 — admins need identity to spot a brigade or a grudge."""
+    response = _queue(client, [_report()])
+
+    row = response.json()["reports"][0]
+    assert row["reporterName"] == "Pat Reporter"
+    assert row["reporterId"] == "user-001"
+    assert row["note"] == "It errors out"
+
+
+def test_the_queue_leads_with_severity(client):
+    """`inappropriate` should page a human rather than wait behind a stale-link report."""
+    response = _queue(
+        client,
+        [
+            _report(reportId="rep-old", reason="other", createdAt="2026-07-01T00:00:00Z"),
+            _report(reportId="rep-bad", reason="inappropriate", createdAt="2026-07-24T00:00:00Z"),
+        ],
+    )
+
+    assert [r["reportId"] for r in response.json()["reports"]] == ["rep-bad", "rep-old"]
+
+
+def test_the_open_count_badges_the_nav(client):
+    response = _queue(client, [_report(reportId="a"), _report(reportId="b")])
+
+    assert response.json()["openCount"] == 2
+
+
+def test_a_report_whose_agent_is_gone_is_flagged_not_dropped(client):
+    """A row that is dropped but still counted is one an admin can neither see nor clear."""
+    with (
+        patch(f"{REPORT_SERVICE}.list_open_reports", AsyncMock(return_value=[_report()])),
+        patch(
+            f"{REPORT_SERVICE}._get_assistant_cloud_without_ownership_check",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        response = client.get("/admin/agents/reports")
+
+    row = response.json()["reports"][0]
+    assert row["agentMissing"] is True
+    assert row["agentName"] == AGENT
+
+
+def test_the_queue_requires_an_admin(app, make_user):
+    """The reporter is visible here; there is no non-admin view of this surface."""
+    mock_auth_user(app, make_user(user_id="user-001"))
+    response = TestClient(app).get("/admin/agents/reports")
+
+    assert response.status_code in (401, 403)
+
+
+# ── triage never delists (D15.5) ─────────────────────────────────────────────────────
+def _triage(client, decision="resolve", note="Asked the author for changes"):
+    with (
+        patch(
+            f"{REPORT_SERVICE}.resolve_report",
+            AsyncMock(
+                return_value=_report(
+                    state="resolved" if decision == "resolve" else "dismissed",
+                    resolvedBy="admin@example.edu",
+                    resolutionNote=note,
+                )
+            ),
+        ) as resolve,
+        patch(
+            f"{REPORT_SERVICE}._get_assistant_cloud_without_ownership_check",
+            AsyncMock(return_value=_make_assistant()),
+        ),
+        patch(
+            "apis.app_api.agent_designer.services.listing_service.takedown_listing", AsyncMock()
+        ) as takedown,
+        patch(
+            "apis.shared.assistants.listing_repository.write_listing", AsyncMock()
+        ) as write_listing,
+    ):
+        response = client.post(
+            f"/admin/agents/{AGENT}/reports/rep-abc/resolve",
+            json={"decision": decision, "note": note},
+        )
+    return response, resolve, takedown, write_listing
+
+
+@pytest.mark.parametrize("decision", ["resolve", "dismiss"])
+def test_triage_records_the_decision(client, decision):
+    response, resolve, _takedown, _write = _triage(client, decision=decision)
+
+    assert response.status_code == 200
+    assert resolve.await_args.kwargs["state"] == (
+        "resolved" if decision == "resolve" else "dismissed"
+    )
+
+
+@pytest.mark.parametrize("decision", ["resolve", "dismiss"])
+def test_triage_never_changes_the_listing(client, decision):
+    """⚠️ D15.5. A report is a note *about* an agent, not a state *of* it.
+
+    If this ever starts delisting, "Resolve" quietly becomes a takedown with no reason
+    recorded for the author — and an admin tidying the queue would be removing agents.
+    """
+    _response, _resolve_mock, takedown, write_listing = _triage(client, decision=decision)
+
+    assert takedown.await_count == 0
+    assert write_listing.await_count == 0
+
+
+def test_an_unknown_decision_is_refused(client):
+    response = client.post(
+        f"/admin/agents/{AGENT}/reports/rep-abc/resolve", json={"decision": "delist"}
+    )
+
+    assert response.status_code == 422
+
+
+def test_resolving_a_missing_report_is_a_404(client):
+    with patch(
+        f"{REPORT_SERVICE}.resolve_report", AsyncMock(side_effect=ValueError("Report not found"))
+    ):
+        response = client.post(
+            f"/admin/agents/{AGENT}/reports/nope/resolve", json={"decision": "resolve"}
+        )
+
+    assert response.status_code == 404
+
+
+# ── the nav counts ───────────────────────────────────────────────────────────────────
+def test_the_queue_counts_endpoint_returns_both(client):
+    with (
+        patch(
+            "apis.app_api.admin.agents.routes.list_admin_listings", AsyncMock(return_value=([], 3))
+        ),
+        patch("apis.app_api.admin.agents.routes.open_report_count", AsyncMock(return_value=5)),
+    ):
+        response = client.get("/admin/agents/queues")
+
+    assert response.json() == {"pendingCount": 3, "openReportCount": 5}
+
+
+def test_one_unreachable_count_does_not_break_the_other(client):
+    """A badge is orientation. An unreachable count shows zero rather than erroring the
+    shell around a page that works.
+    """
+    with (
+        patch(
+            "apis.app_api.admin.agents.routes.list_admin_listings",
+            AsyncMock(side_effect=RuntimeError("table gone")),
+        ),
+        patch("apis.app_api.admin.agents.routes.open_report_count", AsyncMock(return_value=5)),
+    ):
+        response = client.get("/admin/agents/queues")
+
+    assert response.status_code == 200
+    assert response.json() == {"pendingCount": 0, "openReportCount": 5}

--- a/backend/tests/shared/test_agent_reports.py
+++ b/backend/tests/shared/test_agent_reports.py
@@ -1,0 +1,263 @@
+"""Agent Marketplace Phase 8 — problem reports (D15).
+
+These run against a real (moto) table with the sparse GSI6, because the properties worth
+testing are all properties of the *keys*, not of the Python:
+
+* **The queue is sparse, not filtered.** A resolved report leaves the admin queue by
+  losing its index key. A test that asserted on a filtered list would still pass if
+  someone replaced the sparse write with a state filter — and would then miss the day a
+  reader forgot the filter.
+* **One open report per reporter (D15.4).** Enforced by three conditional writes on a
+  deterministic key. Every case below is a way that can silently become "stacks a second
+  report", which is the failure that makes the queue floodable and the nav count
+  meaningless.
+* **Reports are child rows that never outlive their Agent.** An orphaned *open* report
+  keeps its index key, so it would sit in the queue forever pointing at nothing.
+"""
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.reports import (
+    count_open_reports,
+    delete_reports_for_agent,
+    list_open_reports,
+    list_reports_for_agent,
+    report_id_for,
+    resolve_report,
+    submit_report,
+)
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT = "ast-001"
+REPORTER = "user-reporter"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI6_PK", "AttributeType": "S"},
+                {"AttributeName": "GSI6_SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "AgentReportsIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI6_PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI6_SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+async def _file(agent_id=AGENT, reporter=REPORTER, reason="broken", note="It errors out"):
+    return await submit_report(
+        agent_id,
+        reporter_id=reporter,
+        reporter_name=f"Name of {reporter}",
+        reason=reason,
+        note=note,
+    )
+
+
+# ── the stored shape ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_report_is_a_child_row_of_the_agent_it_concerns(table):
+    """PK is the Agent's, so the report is deleted with it and never outlives it."""
+    await _file()
+
+    item = table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report_id_for(AGENT, REPORTER)}"}
+    )["Item"]
+    assert item["reporterId"] == REPORTER
+    assert item["reason"] == "broken"
+    assert item["state"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_the_sort_key_does_not_carry_the_timestamp(table):
+    """The key has to be derivable from (agent, reporter) alone (D15.4).
+
+    The spec sketched ``REPORT#{created_at}#{report_id}``, which cannot be conditionally
+    updated without first reading it — the very lookup D15.4 exists to avoid. Chronology
+    lives in GSI6_SK instead, which is the only place anything reads it.
+    """
+    report, _ = await _file()
+
+    item = table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report_id_for(AGENT, REPORTER)}"}
+    )["Item"]
+    assert item["SK"] == f"REPORT#{report.report_id}"
+    assert report.created_at not in item["SK"]
+    assert item["GSI6_SK"] == f"CREATED#{report.created_at}"
+
+
+@pytest.mark.asyncio
+async def test_the_report_id_does_not_expose_the_reporter(table):
+    """The reporter is admin-visible in the *item* (D15.2), not enumerable from the key."""
+    assert REPORTER not in report_id_for(AGENT, REPORTER)
+
+
+@pytest.mark.asyncio
+async def test_the_same_reporter_gets_different_ids_on_different_agents(table):
+    assert report_id_for("ast-001", REPORTER) != report_id_for("ast-002", REPORTER)
+
+
+# ── one open report per reporter (D15.4) ─────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_second_report_while_the_first_is_open_updates_it(table):
+    first, replaced_first = await _file(reason="broken", note="It errors out")
+    second, replaced_second = await _file(reason="inappropriate", note="Worse than I thought")
+
+    assert replaced_first is False
+    assert replaced_second is True
+
+    reports = await list_reports_for_agent(AGENT)
+    assert len(reports) == 1, "a second submission must update, not stack"
+    assert reports[0].reason == "inappropriate"
+    assert reports[0].note == "Worse than I thought"
+
+
+@pytest.mark.asyncio
+async def test_updating_an_open_report_does_not_move_it_up_the_queue(table):
+    """``createdAt`` and the index key survive, so amending is not a way to jump ahead."""
+    first, _ = await _file()
+    second, _ = await _file(reason="other", note="amended")
+
+    assert second.created_at == first.created_at
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_note_on_an_amended_report_drops_the_old_text(table):
+    await _file(note="It errors out")
+    await _file(note=None)
+
+    assert (await list_reports_for_agent(AGENT))[0].note is None
+
+
+@pytest.mark.asyncio
+async def test_two_reporters_each_get_their_own_report(table):
+    await _file(reporter="user-a")
+    await _file(reporter="user-b")
+
+    assert len(await list_reports_for_agent(AGENT)) == 2
+    assert await count_open_reports() == 2
+
+
+@pytest.mark.asyncio
+async def test_reporting_again_after_a_resolution_files_a_new_report(table):
+    """The one-open rule is about *open* reports; a closed one is not a permanent gag."""
+    first, _ = await _file()
+    await resolve_report(
+        AGENT, first.report_id, state="resolved", resolved_by="Admin", note="Fixed"
+    )
+
+    fresh, replaced = await _file(reason="broken", note="It is back")
+
+    assert replaced is False, "a closed report must not be reported as merely amended"
+    assert fresh.state == "open"
+    assert fresh.created_at >= first.created_at
+
+    stored = (await list_reports_for_agent(AGENT))[0]
+    assert stored.state == "open"
+    assert stored.resolved_at is None, "a fresh report must not inherit the old verdict"
+    assert stored.resolution_note is None
+
+
+# ── the queue is sparse, not filtered ────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_an_open_report_is_in_the_queue(table):
+    await _file()
+    assert [r.report_id for r in await list_open_reports()] == [report_id_for(AGENT, REPORTER)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["resolved", "dismissed"])
+async def test_triage_removes_the_index_key_rather_than_filtering(table, state):
+    report, _ = await _file()
+    await resolve_report(AGENT, report.report_id, state=state, resolved_by="Admin", note=None)
+
+    assert await list_open_reports() == []
+    assert await count_open_reports() == 0
+
+    item = table.get_item(Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report.report_id}"})["Item"]
+    assert "GSI6_PK" not in item, "the report must leave the queue by losing its key"
+    assert "GSI6_SK" not in item
+    assert item["state"] == state
+
+
+@pytest.mark.asyncio
+async def test_triage_records_who_decided_and_what_they_wrote(table):
+    report, _ = await _file()
+    resolved = await resolve_report(
+        AGENT, report.report_id, state="resolved", resolved_by="Ada Admin", note="Asked for changes"
+    )
+
+    assert resolved.resolved_by == "Ada Admin"
+    assert resolved.resolution_note == "Asked for changes"
+    assert resolved.resolved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_resolving_a_report_that_is_gone_is_a_not_found(table):
+    with pytest.raises(ValueError):
+        await resolve_report(AGENT, "nope", state="resolved", resolved_by="Admin", note=None)
+
+
+@pytest.mark.asyncio
+async def test_the_queue_is_oldest_first(table):
+    """It is a work queue, not a feed: the report that has waited longest is next."""
+    await _file(reporter="user-a")
+    await _file(reporter="user-b")
+    await _file(reporter="user-c")
+
+    ordered = await list_open_reports()
+    assert [r.created_at for r in ordered] == sorted(r.created_at for r in ordered)
+
+
+# ── reports never outlive their Agent ────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_deleting_an_agent_clears_its_reports_from_the_queue(table):
+    await _file(reporter="user-a")
+    await _file(reporter="user-b")
+
+    assert await delete_reports_for_agent(AGENT) == 2
+    assert await list_reports_for_agent(AGENT) == []
+    assert await count_open_reports() == 0, "an orphaned open report would haunt the queue"
+
+
+@pytest.mark.asyncio
+async def test_deleting_reports_leaves_other_agents_alone(table):
+    await _file(agent_id="ast-001")
+    await _file(agent_id="ast-002")
+
+    await delete_reports_for_agent("ast-001")
+
+    assert len(await list_reports_for_agent("ast-002")) == 1
+    assert await count_open_reports() == 1
+
+
+@pytest.mark.asyncio
+async def test_deleting_reports_on_an_agent_with_none_is_a_no_op(table):
+    assert await delete_reports_for_agent("ast-never-reported") == 0

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -400,10 +400,15 @@ Child rows under the Agent, so a report is deleted with the Agent it concerns an
 outlives it:
 
 ```
-PK = AST#{agent_id}, SK = "REPORT#{created_at}#{report_id}"
+PK = AST#{agent_id}, SK = "REPORT#{report_id}"
 { reporterId, reporterName, reason, note, state, createdAt,
   resolvedAt?, resolvedBy?, resolutionNote? }
 ```
+
+⚠️ **As built, the sort key carries no timestamp.** It was drafted as
+`REPORT#{created_at}#{report_id}`, which cannot satisfy the D15.4 rule two paragraphs
+below — see the Phase 8 notes. `report_id` is `sha256(agent_id:reporter_id)[:16]`, and
+the chronology lives in `GSI6_SK`, which is where it is actually read.
 
 **Sparse open-report index (GSI6 on `rag-assistants`)**, written only while
 `state == 'open'`, exactly as GSI5 is written only while published:
@@ -509,7 +514,7 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `DELETE /agents/{id}/listing` | Author unpublishes. |
 | `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). Pinning is gated on the caller being able to *reach* the Agent, not on it being published. |
 | `POST /agents/{id}/report` | Report a problem with a published Agent (D15). One open report per reporter. |
-| `GET /admin/agents/reports` · `POST /admin/agents/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). |
+| `GET /admin/agents/reports` · `POST /admin/agents/{id}/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). Also `GET /admin/agents/{id}/reports` for one Agent's history and `GET /admin/agents/queues` for the two nav counts. |
 | `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes (D2). |
 | `GET /admin/agents/listings` · `POST /admin/agents/{id}/takedown` | Listings table; delist with a reason. |
 | `PATCH /admin/agents/{id}/listing` | Edit presentation only — `name`, `tagline`, `iconKey`, `category`, `publisherId` (D13). Rejects any behavior field. |
@@ -563,8 +568,8 @@ Phase 4  Icons: upload, S3, generated fallback, all four render sizes  ✅ shipp
 Phase 5  Pins: user pin state + Pinned tab + store front admin        ✅ shipped (PR #736)
 Phase 6  Default pins by role (D9) + the assignment-time runnability check
                                                                       ✅ shipped (PR #737)
-Phase 7  @-mention in the composer                                          ← in progress
-Phase 8  Problem reports (D15): report action + admin Reports queue   ← depends on 3
+Phase 7  @-mention in the composer                                    ✅ shipped (PR #738)
+Phase 8  Problem reports (D15): report action + admin Reports queue         ← in progress
 Later    Ranking + full-corpus search via the Registry catalog (F6b)
 ```
 
@@ -651,6 +656,53 @@ thread" in one sentence, and that sentence turned out to be the whole phase:
 - **Known edge, pre-existing:** `continue_truncated` skips the whole assistant block, so a
   "Continue" after a max_tokens truncation runs without the Agent — true for bound Agent
   conversations before this phase, and unchanged by it.
+
+**Phase 8 notes (as built).** Six, the first of which is a contradiction inside this spec
+and the fourth of which was a live trap:
+
+- **⚠️ The report's sort key is deterministic, not chronological — the data model above
+  and D15.4 could not both be satisfied.** The sketch says
+  `SK = REPORT#{created_at}#{report_id}`; D15.4 says enforce one-open-report-per-reporter
+  "with a conditional write on a deterministic `report_id` … the write already knows both
+  halves of the key". It does not: a key containing `created_at` cannot be conditionally
+  updated without first *reading* the row to learn the timestamp — which is the extra
+  lookup D15.4 exists to avoid. So the key is `REPORT#{sha256(agent_id:reporter_id)[:16]}`
+  and the chronology moved to `GSI6_SK`, which is the only place anything reads it (the
+  queue never sorts by the table's sort key). The reporter is hashed rather than embedded
+  so the sort key is not itself an enumerable directory of who reported what — D15.2 puts
+  the reporter in the *item*, where an admin reads it, not in a key any partition query
+  returns.
+- **The rule is three conditional writes and no read**: create-if-absent → else
+  update-if-open → else overwrite-if-closed. Amending an open report preserves `createdAt`
+  and the index key, so re-submitting is not a way to jump the queue; filing again *after*
+  a resolution starts a genuinely new report and clears the old verdict. Two taps racing
+  cannot stack two reports or resurrect a resolved one.
+- **Per (agent, reporter), history is one deep.** A new report replaces the resolved one
+  at that key. An append-only archive was considered and declined: nothing would read it,
+  and D15.1 already puts the durable record elsewhere — a report is the *evidence* for a
+  request-changes or takedown, and that act is separately recorded on the listing.
+- **⚠️ `_delete_assistant_cloud` deleted only the `METADATA` item.** Reports are child rows
+  precisely so they never outlive the Agent, but nothing swept them — and an orphaned
+  *open* report keeps its sparse GSI6 key, so it would have sat in the admin queue forever
+  pointing at an Agent nobody can open. The sweep now runs inside the shared delete (so
+  every delete path is covered, not just the Agent router's) and is best-effort: failing
+  to tidy up must not make an Agent undeletable. The queue therefore also *flags* a row
+  whose Agent is gone rather than dropping it — a row that is invisible but still counted
+  is one an admin can neither see nor clear.
+- **The nav badge needed a counts route.** `AdminListingsResponse.pendingCount` existed
+  since Phase 1 but badged nothing: the layout never read it, and it is only populated
+  once a queue page has loaded — a badge that appears *after* you visit the queue is not a
+  badge. D10 wants both counts visible from anywhere in the console, so `GET
+  /admin/agents/queues` returns the two integers and the layout fetches it on init. The
+  alternative — having the nav load both queues — would have put a table scan and a full
+  row projection behind every click in the admin console. It fails soft per half: a badge
+  is orientation, and an unreachable count shows zero rather than breaking the shell.
+- **Queue order is `(severity, oldest-first)`, and the owner is not excluded.** The spec
+  asks for a chronological sweep and separately says `inappropriate` "should page a human
+  rather than wait for a sweep"; sorting severity-first is how both hold. And D15's gate
+  is exactly publication — an author can report their own published Agent, because adding
+  an owner exception would be a rule the spec does not have, for a case that is at worst
+  a redundant queue item.
 
 **Phase 3.5 is a gap this table originally left open.** Phases 1–3 shipped the submit and withdraw
 endpoints and the entire reviewer console, but no phase owned the *author's* half of the surface —

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -3,8 +3,11 @@ import {
   ChangeDetectionStrategy,
   computed,
   inject,
+  OnInit,
+  Signal,
 } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { AdminMarketplaceService } from './marketplace/services/admin-marketplace.service';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -21,6 +24,7 @@ import {
   heroBars3,
   heroSparkles,
   heroInbox,
+  heroFlag,
   heroRectangleStack,
   heroStar,
   heroTag,
@@ -31,6 +35,12 @@ interface NavItem {
   label: string;
   icon: string;
   route: string;
+  /**
+   * A count that badges this entry (D10). A signal rather than a number so the badge is
+   * live — triaging the last report has to empty the badge without a reload, or the nav
+   * starts lying about work that is already done.
+   */
+  badge?: Signal<number>;
 }
 
 interface NavGroup {
@@ -58,6 +68,7 @@ interface NavGroup {
       heroBars3,
       heroSparkles,
       heroInbox,
+      heroFlag,
       heroRectangleStack,
       heroStar,
       heroTag,
@@ -100,7 +111,11 @@ interface NavGroup {
                 @for (group of navGroups(); track group.label) {
                   <optgroup [label]="group.label">
                     @for (item of group.items; track item.route) {
-                      <option [value]="item.route">{{ item.label }}</option>
+                      <!-- No badge element on mobile: an <option> renders text only, so
+                           the count goes inline or it is invisible here. -->
+                      <option [value]="item.route">
+                        {{ item.label }}{{ item.badge && item.badge() > 0 ? ' (' + item.badge() + ')' : '' }}
+                      </option>
                     }
                   </optgroup>
                 }
@@ -124,7 +139,17 @@ interface NavGroup {
                             class="group flex items-center gap-x-3 whitespace-nowrap rounded-md px-3 py-2 text-sm/6 font-medium text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white"
                           >
                             <ng-icon [name]="item.icon" class="size-5 shrink-0 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" />
-                            {{ item.label }}
+                            <span class="min-w-0 flex-1">{{ item.label }}</span>
+                            @if (item.badge; as badge) {
+                              @if (badge() > 0) {
+                                <span
+                                  class="inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs/5 font-semibold text-white dark:bg-blue-500"
+                                  [attr.aria-label]="badge() + ' waiting'"
+                                >
+                                  {{ badge() }}
+                                </span>
+                              }
+                            }
                           </a>
                         </li>
                       }
@@ -144,8 +169,9 @@ interface NavGroup {
     </div>
   `,
 })
-export class AdminLayout {
+export class AdminLayout implements OnInit {
   private router = inject(Router);
+  private marketplace = inject(AdminMarketplaceService);
 
   private readonly allNavGroups: NavGroup[] = [
     {
@@ -166,11 +192,26 @@ export class AdminLayout {
       ],
     },
     {
-      // Agent Marketplace. Five of D10's seven surfaces; the reports queue joins this
-      // group with Phase 8.
+      // Agent Marketplace. Six of D10's seven surfaces; Default Pins is the seventh and
+      // is listed here even though its route lives under Roles, because the AppRole
+      // record is the source of truth for a seed.
+      //
+      // Two entries carry counts (D10): work waiting should be *visible* rather than
+      // discovered by clicking into a queue to see whether it is empty.
       label: 'Agent Marketplace',
       items: [
-        { label: 'Review Queue', icon: 'heroInbox', route: '/admin/marketplace/review' },
+        {
+          label: 'Review Queue',
+          icon: 'heroInbox',
+          route: '/admin/marketplace/review',
+          badge: this.marketplace.pendingCount,
+        },
+        {
+          label: 'Reports',
+          icon: 'heroFlag',
+          route: '/admin/marketplace/reports',
+          badge: this.marketplace.openReportCount,
+        },
         { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
         { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front' },
         { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories' },
@@ -200,6 +241,19 @@ export class AdminLayout {
    * (SKILLS_ENABLED), so no client-side feature gate is needed here.
    */
   readonly navGroups = computed<NavGroup[]>(() => this.allNavGroups);
+
+  /**
+   * One small call for both badges, on every admin page.
+   *
+   * The counts have to be right wherever the admin is standing, not only once they open
+   * a queue — that is what makes the badge a prompt rather than a confirmation. It is a
+   * dedicated endpoint rather than two queue loads so this does not put a table scan and
+   * a full row projection behind every click in the console, and it swallows failures:
+   * a badge is orientation, and an unreachable count must not break the shell.
+   */
+  ngOnInit(): void {
+    void this.marketplace.refreshQueueCounts();
+  }
 
   onMobileNavChange(event: Event): void {
     const select = event.target as HTMLSelectElement;

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -85,11 +85,15 @@ export const adminRoutes: Routes = [
     path: 'skills/edit/:skillId',
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
-  // Agent Marketplace (docs/specs/agent-marketplace.md) — five of D10's seven admin
-  // surfaces. The reports queue arrives with Phase 8.
+  // Agent Marketplace (docs/specs/agent-marketplace.md) — six of D10's seven admin
+  // surfaces. Default pins live under Roles, because the AppRole record owns a seed.
   {
     path: 'marketplace/review',
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
+  },
+  {
+    path: 'marketplace/reports',
+    loadComponent: () => import('./marketplace/pages/reports.page').then(m => m.ReportsPage),
   },
   {
     path: 'marketplace/listings',

--- a/frontend/ai.client/src/app/admin/marketplace/components/resolve-report-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/resolve-report-dialog.component.ts
@@ -1,0 +1,159 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { AdminReportRow } from '../models/marketplace.model';
+
+export interface ResolveReportDialogData {
+  report: AdminReportRow;
+  decision: 'resolve' | 'dismiss';
+}
+
+/** The admin's note, or undefined if cancelled. An empty string is a valid submission. */
+export type ResolveReportDialogResult = { note?: string } | undefined;
+
+/**
+ * Close out a report (D15.5).
+ *
+ * The callout is load-bearing copy, and it is the mirror image of the takedown dialog's:
+ * closing a report **changes nothing about the agent**. An admin who believes "Resolve"
+ * delists will use it for something it does not do — and worse, will believe a problem
+ * has been acted on when only the queue has been tidied.
+ *
+ * The note is the admin's own record and is deliberately labelled as such. It is never
+ * forwarded to the author (D15.1): when a report is actionable, the author-facing channel
+ * is the reason field on request-changes or takedown, and piping a user's raw words to
+ * the person who built the thing is how one bad message ends a volunteer's willingness to
+ * publish.
+ */
+@Component({
+  selector: 'app-resolve-report-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="resolve-report-title"
+        aria-describedby="resolve-report-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2
+              id="resolve-report-title"
+              class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+            >
+              {{ isDismiss() ? 'Dismiss' : 'Resolve' }} this report?
+            </h2>
+            <p
+              id="resolve-report-description"
+              class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400"
+            >
+              {{ isDismiss() ? 'Dismissing' : 'Resolving' }} takes it off the queue and records
+              who decided. The reporter is not notified.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <div class="rounded-2xl bg-amber-50 px-4 py-3 dark:bg-amber-900/20">
+            <h3 class="text-sm/6 font-semibold text-amber-800 dark:text-amber-300">
+              This does not change the agent
+            </h3>
+            <p class="mt-1 text-sm/6 text-gray-700 dark:text-gray-300">
+              “{{ data.report.agentName }}” stays exactly as it is. If this report warrants
+              action, use <strong>Request changes</strong> or <strong>Take down</strong> on the
+              Listings table — that is the channel the author actually sees, and it is recorded
+              separately.
+            </p>
+          </div>
+
+          <label
+            for="resolution-note"
+            class="mt-4 block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            Your note <span class="font-normal text-gray-500">(optional, admin-only)</span>
+          </label>
+          <p class="mt-0.5 text-sm/6 text-gray-500 dark:text-gray-400">
+            What you did about it. Never sent to the author or the reporter.
+          </p>
+          <textarea
+            id="resolution-note"
+            rows="3"
+            maxlength="2000"
+            [value]="note()"
+            (input)="onNoteInput($event)"
+            [placeholder]="
+              isDismiss() ? 'Why this needs no action' : 'What you changed, or who you contacted'
+            "
+            class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+          ></textarea>
+        </div>
+
+        <div
+          class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="onSubmit()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ isDismiss() ? 'Dismiss report' : 'Resolve report' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class ResolveReportDialogComponent {
+  private dialogRef = inject<DialogRef<ResolveReportDialogResult>>(DialogRef);
+  readonly data = inject<ResolveReportDialogData>(DIALOG_DATA);
+
+  readonly note = signal('');
+
+  isDismiss(): boolean {
+    return this.data.decision === 'dismiss';
+  }
+
+  onNoteInput(event: Event): void {
+    this.note.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onSubmit(): void {
+    this.dialogRef.close({ note: this.note().trim() || undefined });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -185,3 +185,64 @@ export interface RoleAgentPinsUpdateRequest {
   pins: { agentId: string; locked: boolean }[];
 }
 
+
+// ── problem reports (D15, Phase 8) ─────────────────────────────────────────────────
+/**
+ * Why an agent was reported. A fixed set so the queue sorts by severity without anyone
+ * reading every note; `inappropriate` is the one that should page a human.
+ */
+export type ReportReason = 'inaccurate' | 'broken' | 'inappropriate' | 'other';
+
+/**
+ * A report's own tiny lifecycle. Deliberately **not** a mirror of `ListingState`: a
+ * report is a note *about* an agent, not a state *of* it, and resolving one never changes
+ * the listing (D15.5).
+ */
+export type ReportState = 'open' | 'resolved' | 'dismissed';
+
+/**
+ * One row in the admin Reports queue.
+ *
+ * ⚠️ `reporterId` / `reporterName` are **admin-only** (D15.2). Admins need identity to
+ * spot a brigade or a grudge; the author needs the substance and never the name. Nothing
+ * on this interface may be rendered on a user-facing surface.
+ */
+export interface AdminReportRow {
+  reportId: string;
+  agentId: string;
+  agentName: string;
+  emoji?: string;
+  iconUrl?: string;
+  ownerName?: string;
+  /** Context only — resolving a report never writes this (D15.5). */
+  listingState?: ListingState | null;
+  /** The agent is gone; the row is shown so the admin can still clear it. */
+  agentMissing: boolean;
+  reporterId: string;
+  reporterName: string;
+  reason: ReportReason;
+  note?: string;
+  state: ReportState;
+  createdAt: string;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  resolutionNote?: string;
+}
+
+export interface AdminReportsResponse {
+  reports: AdminReportRow[];
+  /** Awaiting triage — badges the admin nav alongside submissions (D10). */
+  openCount: number;
+}
+
+/** Resolve or dismiss. The note is the admin's record, never forwarded to the author. */
+export interface ResolveReportRequest {
+  decision: 'resolve' | 'dismiss';
+  note?: string;
+}
+
+/** The two integers D10 puts on the nav, fetched without loading either queue. */
+export interface AdminQueueCounts {
+  pendingCount: number;
+  openReportCount: number;
+}

--- a/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
@@ -1,0 +1,302 @@
+import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroCheck,
+  heroExclamationTriangle,
+  heroFlag,
+  heroNoSymbol,
+} from '@ng-icons/heroicons/outline';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminReportRow, ReportReason } from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import {
+  ResolveReportDialogComponent,
+  ResolveReportDialogData,
+  ResolveReportDialogResult,
+} from '../components/resolve-report-dialog.component';
+
+/**
+ * The Reports queue — user-submitted problem reports (D10, D15).
+ *
+ * The second work stream beside submissions, and deliberately shaped like it: a card
+ * list where each row is one decision. Three things about this surface are load-bearing.
+ *
+ * **The reporter is shown here and nowhere else (D15.2).** Admins need identity to spot a
+ * brigade or a grudge — three reports on one agent from one person reads very differently
+ * from three from three. The author never sees it.
+ *
+ * **Closing a report is not a takedown (D15.5).** Resolve and Dismiss write only the
+ * report. The row links to the agent so the reviewer can act on it properly if it
+ * warrants that, and the dialog says so explicitly — an admin who thinks "Resolve" delists
+ * will believe a problem has been handled when only the queue has been tidied.
+ *
+ * **Severity leads the sweep.** Rows arrive ordered `(severity, oldest-first)` from the
+ * server, so `inappropriate` sits at the top rather than waiting its turn behind a
+ * stale-link complaint. The page renders that order; it does not re-sort.
+ */
+@Component({
+  selector: 'app-marketplace-reports',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, RouterLink, AgentTileComponent, TooltipDirective],
+  providers: [provideIcons({ heroCheck, heroExclamationTriangle, heroFlag, heroNoSymbol })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Reports</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Problems users reported from an agent's page. These are private — they never
+            appear in the store, and the author is never told who reported them. Resolving one
+            records your decision; it does not change the agent.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading reports</span>
+          </div>
+        } @else if (reports().length === 0) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroFlag"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              Nothing reported
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Problems users report from an agent's page appear here.
+            </p>
+          </div>
+        } @else {
+          <ul class="flex flex-col gap-3">
+            @for (row of reports(); track row.reportId) {
+              <li
+                class="rounded-2xl border bg-white p-4 dark:bg-gray-800"
+                [class]="
+                  row.reason === 'inappropriate'
+                    ? 'border-rose-300 dark:border-rose-800'
+                    : 'border-gray-200 dark:border-gray-700'
+                "
+              >
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
+                  <app-agent-tile
+                    [agentId]="row.agentId"
+                    [iconUrl]="row.iconUrl"
+                    [emoji]="row.emoji"
+                  />
+
+                  <div class="min-w-0 flex-1">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <h2 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+                        {{ row.agentName }}
+                      </h2>
+                      <span
+                        class="inline-flex items-center rounded-full px-2 py-0.5 text-xs/5 font-semibold"
+                        [class]="reasonClass(row.reason)"
+                      >
+                        {{ reasonLabel(row.reason) }}
+                      </span>
+                      @if (row.agentMissing) {
+                        <span
+                          class="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs/5 font-semibold text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                          [appTooltip]="
+                            'This agent has been deleted. Reports are deleted with their agent, so this row was orphaned by an older delete — dismiss it to clear it.'
+                          "
+                          appTooltipPosition="top"
+                        >
+                          <ng-icon name="heroExclamationTriangle" class="size-3.5" aria-hidden="true" />
+                          Agent deleted
+                        </span>
+                      } @else if (row.listingState && row.listingState !== 'published') {
+                        <span
+                          class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs/5 font-semibold text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                          [appTooltip]="'Someone has already changed this listing'"
+                          appTooltipPosition="top"
+                        >
+                          {{ listingLabel(row.listingState) }}
+                        </span>
+                      }
+                    </div>
+
+                    <!--
+                      D15.2 — the reporter, admin-only. Shown next to the timestamp
+                      because the pattern an admin is looking for is "same person, again".
+                    -->
+                    <p class="mt-0.5 truncate text-sm/6 text-gray-500 dark:text-gray-400">
+                      Reported by {{ row.reporterName }} · {{ relativeTime(row.createdAt) }}
+                      @if (row.ownerName) {
+                        · author {{ row.ownerName }}
+                      }
+                    </p>
+
+                    @if (row.note) {
+                      <p
+                        class="mt-2 whitespace-pre-wrap rounded-2xl bg-gray-50 px-3 py-2 text-sm/6 text-gray-700 dark:bg-gray-900 dark:text-gray-300"
+                      >
+                        {{ row.note }}
+                      </p>
+                    }
+                  </div>
+
+                  <div class="flex shrink-0 flex-wrap gap-2">
+                    @if (!row.agentMissing) {
+                      <a
+                        [routerLink]="['/agents', row.agentId]"
+                        [appTooltip]="'Open this agent as a user sees it'"
+                        appTooltipPosition="top"
+                        class="inline-flex items-center rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                      >
+                        View agent
+                      </a>
+                    }
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.reportId"
+                      (click)="triage(row, 'dismiss')"
+                      [appTooltip]="'No action needed — takes it off the queue'"
+                      appTooltipPosition="top"
+                      class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      <ng-icon name="heroNoSymbol" class="size-4" aria-hidden="true" />
+                      Dismiss
+                    </button>
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.reportId"
+                      (click)="triage(row, 'resolve')"
+                      [appTooltip]="'Handled — records your decision, does not change the agent'"
+                      appTooltipPosition="top"
+                      class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    >
+                      <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+                      Resolve
+                    </button>
+                  </div>
+                </div>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class ReportsPage implements OnInit {
+  private service = inject(AdminMarketplaceService);
+  private dialog = inject(Dialog);
+
+  readonly reports = signal<AdminReportRow[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busyId = signal<string | null>(null);
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.reports.set(await this.service.loadReports());
+    } catch {
+      this.error.set(this.service.error() ?? 'Failed to load reports.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async triage(row: AdminReportRow, decision: 'resolve' | 'dismiss'): Promise<void> {
+    const ref = this.dialog.open<ResolveReportDialogResult, ResolveReportDialogData>(
+      ResolveReportDialogComponent,
+      { data: { report: row, decision } },
+    );
+    const result = await firstValueFrom(ref.closed);
+    if (!result) return;
+
+    this.busyId.set(row.reportId);
+    this.error.set(null);
+    try {
+      await this.service.resolveReport(row.agentId, row.reportId, { decision, note: result.note });
+      // Reload rather than splice: the decision clears the row's index key server-side, and
+      // a reload is the only way the nav badge count stays honest.
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(typeof detail === 'string' ? detail : 'Failed to record the decision.');
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+
+  /** What the reporter picked, in the reviewer's words. */
+  reasonLabel(reason: ReportReason): string {
+    switch (reason) {
+      case 'inaccurate':
+        return 'Wrong answers';
+      case 'broken':
+        return 'Not working';
+      case 'inappropriate':
+        return 'Inappropriate';
+      default:
+        return 'Other';
+    }
+  }
+
+  /** Only `inappropriate` gets colour — everything else is a queue item, not an alarm. */
+  reasonClass(reason: ReportReason): string {
+    return reason === 'inappropriate'
+      ? 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300'
+      : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+  }
+
+  listingLabel(state: string): string {
+    switch (state) {
+      case 'taken_down':
+        return 'Taken down';
+      case 'in_review':
+        return 'In review';
+      case 'changes_requested':
+        return 'Changes requested';
+      case 'private':
+        return 'Unpublished';
+      default:
+        return state;
+    }
+  }
+
+  /** Matches the Review queue's subtitle wording, so the two streams read alike. */
+  relativeTime(iso?: string): string {
+    if (!iso) return 'recently';
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return 'recently';
+
+    const days = Math.floor((Date.now() - then) / 86_400_000);
+    if (days <= 0) return 'today';
+    if (days === 1) return 'yesterday';
+    if (days < 7) return `${days} days ago`;
+    if (days < 14) return 'last week';
+    if (days < 60) return `${Math.floor(days / 7)} weeks ago`;
+    return `${Math.floor(days / 30)} months ago`;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -4,12 +4,16 @@ import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
   AdminListingRow,
+  AdminQueueCounts,
+  AdminReportRow,
+  AdminReportsResponse,
   AdminStoreFrontResponse,
   AgentCategory,
   AdminListingsResponse,
   ListingPatchRequest,
   ListingState,
   PublisherProfile,
+  ResolveReportRequest,
   ReviewListingRequest,
   RoleAgentPinsResponse,
   RoleAgentPinsUpdateRequest,
@@ -39,12 +43,16 @@ export class AdminMarketplaceService {
   private _loading = signal(false);
   private _error = signal<string | null>(null);
   private _pendingCount = signal(0);
+  private _openReportCount = signal(0);
 
   readonly loading = this._loading.asReadonly();
   readonly error = this._error.asReadonly();
 
   /** Submissions awaiting review — badges the nav so the queue stays visible (D2). */
   readonly pendingCount = this._pendingCount.asReadonly();
+
+  /** Problem reports awaiting triage — badges the nav alongside submissions (D10). */
+  readonly openReportCount = this._openReportCount.asReadonly();
 
   /** The Review queue: everything currently awaiting a decision. */
   async loadSubmissions(): Promise<AdminListingRow[]> {
@@ -88,6 +96,82 @@ export class AdminMarketplaceService {
   /** Edit presentation only; the backend 422s any behavior field. */
   async patchListing(agentId: string, patch: ListingPatchRequest): Promise<void> {
     await firstValueFrom(this.http.patch(`${this.baseUrl()}/${agentId}/listing`, patch));
+  }
+
+  // ── problem reports (D15) ─────────────────────────────────────────────────────
+  /**
+   * The Reports queue.
+   *
+   * ⚠️ Rows carry the reporter (D15.2) and are admin-only. Nothing fetched here may be
+   * rendered on a user-facing surface, and no count derived from it may reach the store
+   * front or any ordering — report volume influencing placement would make reporting a
+   * way to bury a competitor's agent.
+   */
+  async loadReports(): Promise<AdminReportRow[]> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const response = await firstValueFrom(
+        this.http.get<AdminReportsResponse>(`${this.baseUrl()}/reports`),
+      );
+      this._openReportCount.set(response.openCount ?? 0);
+      return response.reports ?? [];
+    } catch (err) {
+      this._error.set(this.messageFor(err, 'Failed to load reports'));
+      throw err;
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /** Every report ever filed on one agent — is this complaint a pattern? */
+  async loadAgentReports(agentId: string): Promise<AdminReportRow[]> {
+    const response = await firstValueFrom(
+      this.http.get<AdminReportsResponse>(
+        `${this.baseUrl()}/${encodeURIComponent(agentId)}/reports`,
+      ),
+    );
+    return response.reports ?? [];
+  }
+
+  /**
+   * Resolve or dismiss a report (D15.5).
+   *
+   * ⚠️ This never delists anything. A report is a note about an agent, not a state of it;
+   * if one warrants a takedown, that is `takedown()` above and a separately recorded act
+   * with its own author-facing reason.
+   */
+  async resolveReport(
+    agentId: string,
+    reportId: string,
+    request: ResolveReportRequest,
+  ): Promise<void> {
+    await firstValueFrom(
+      this.http.post(
+        `${this.baseUrl()}/${encodeURIComponent(agentId)}/reports/${encodeURIComponent(reportId)}/resolve`,
+        request,
+      ),
+    );
+  }
+
+  /**
+   * Refresh both nav badge counts (D10).
+   *
+   * Its own endpoint rather than two queue loads: the badges have to be right on every
+   * admin page, and fetching two full queues to render two integers would put a table
+   * scan behind every click in the console. Failures are swallowed — a badge is
+   * orientation, and an unreachable count must not error the shell around a working page.
+   */
+  async refreshQueueCounts(): Promise<void> {
+    try {
+      const counts = await firstValueFrom(
+        this.http.get<AdminQueueCounts>(`${this.baseUrl()}/queues`),
+      );
+      this._pendingCount.set(counts.pendingCount ?? 0);
+      this._openReportCount.set(counts.openReportCount ?? 0);
+    } catch {
+      // Leave whatever the last successful read said.
+    }
   }
 
   async loadPublishers(): Promise<PublisherProfile[]> {

--- a/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.ts
@@ -1,0 +1,187 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { ReportReason } from '../models/store.model';
+
+export interface ReportAgentDialogData {
+  agentName: string;
+  /** True when the user already has an open report on this agent, so the copy can say so. */
+  hasOpenReport?: boolean;
+}
+
+/** The reason + note, or undefined if cancelled. */
+export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | undefined;
+
+/**
+ * "Report a problem" (D15).
+ *
+ * The copy carries the one thing the user must not misread: **this is not a review**.
+ * There is no rating here and none is coming — a report is a private message to the
+ * people who curate the store, it never appears on the agent's page, and the author never
+ * learns who sent it. A user who thinks they are posting a public review will write a
+ * different (and less useful) thing than one who knows they are filing a ticket.
+ *
+ * The reason set is fixed so the queue can be triaged by severity without reading every
+ * note. The labels say what each one *means to the reader*, not what it is called in the
+ * enum — "It gives wrong answers" is answerable; "inaccurate" is a category.
+ */
+@Component({
+  selector: 'app-report-agent-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-title"
+        aria-describedby="report-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="report-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Report a problem with “{{ data.agentName }}”
+            </h2>
+            <p id="report-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              This goes privately to the people who curate the store. It is not a review —
+              it never appears on this agent's page, and the author is never told who sent it.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          @if (data.hasOpenReport) {
+            <!-- D15.4 surfaced before the user writes, not after: they are amending. -->
+            <div class="mb-4 rounded-2xl bg-amber-50 px-4 py-3 dark:bg-amber-900/20">
+              <p class="text-sm/6 text-gray-700 dark:text-gray-300">
+                You already have a report open on this agent. Sending this will
+                <strong>update</strong> it rather than adding a second one.
+              </p>
+            </div>
+          }
+
+          <fieldset>
+            <legend class="text-sm/6 font-medium text-gray-900 dark:text-white">
+              What's wrong?
+            </legend>
+            <div class="mt-2 flex flex-col gap-2">
+              @for (option of reasons; track option.value) {
+                <label
+                  class="flex cursor-pointer items-start gap-3 rounded-2xl border px-4 py-3 text-sm/6"
+                  [class]="
+                    reason() === option.value
+                      ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20'
+                      : 'border-gray-300 bg-white hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700'
+                  "
+                >
+                  <input
+                    type="radio"
+                    name="report-reason"
+                    class="mt-1 size-4 shrink-0 accent-blue-600"
+                    [value]="option.value"
+                    [checked]="reason() === option.value"
+                    (change)="reason.set(option.value)"
+                  />
+                  <span class="min-w-0">
+                    <span class="block font-medium text-gray-900 dark:text-white">
+                      {{ option.label }}
+                    </span>
+                    <span class="block text-gray-500 dark:text-gray-400">{{ option.hint }}</span>
+                  </span>
+                </label>
+              }
+            </div>
+          </fieldset>
+
+          <label
+            for="report-note"
+            class="mt-4 block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            Anything else? <span class="font-normal text-gray-500">(optional)</span>
+          </label>
+          <textarea
+            id="report-note"
+            rows="3"
+            maxlength="2000"
+            [value]="note()"
+            (input)="onNoteInput($event)"
+            placeholder="What did you ask, and what happened?"
+            class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+          ></textarea>
+        </div>
+
+        <div
+          class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            [disabled]="!reason()"
+            (click)="onSubmit()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {{ data.hasOpenReport ? 'Update report' : 'Send report' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class ReportAgentDialogComponent {
+  private dialogRef = inject<DialogRef<ReportAgentDialogResult>>(DialogRef);
+  readonly data = inject<ReportAgentDialogData>(DIALOG_DATA);
+
+  /** Ordered by how often they are the right answer, not by severity. */
+  readonly reasons: { value: ReportReason; label: string; hint: string }[] = [
+    { value: 'inaccurate', label: 'It gives wrong answers', hint: 'The information it returns is incorrect or out of date.' },
+    { value: 'broken', label: "It doesn't work", hint: 'It errors, hangs, or ignores what it is asked.' },
+    { value: 'inappropriate', label: 'It produced something inappropriate', hint: 'Offensive, unsafe, or content that should not be here.' },
+    { value: 'other', label: 'Something else', hint: 'Tell us below.' },
+  ];
+
+  readonly reason = signal<ReportReason | null>(null);
+  readonly note = signal('');
+
+  onNoteInput(event: Event): void {
+    this.note.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onSubmit(): void {
+    const reason = this.reason();
+    if (!reason) return;
+    this.dialogRef.close({ reason, note: this.note().trim() || undefined });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { Router } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -16,6 +17,7 @@ import {
   heroCheckBadge,
   heroCheckCircle,
   heroExclamationTriangle,
+  heroFlag,
   heroLockClosed,
   heroNoSymbol,
   heroPlus,
@@ -24,6 +26,11 @@ import { AgentApiService } from '../services/agent-api.service';
 import { AgentPinService } from '../services/agent-pin.service';
 import { Agent, AgentRunnability } from '../models/agent.model';
 import { AgentIconComponent } from '../components/agent-icon.component';
+import {
+  ReportAgentDialogComponent,
+  ReportAgentDialogData,
+  ReportAgentDialogResult,
+} from '../components/report-agent-dialog.component';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 
 /**
@@ -44,8 +51,15 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
  * an Agent they cannot run today, and hiding the button would leave them nothing to do
  * with the page.
  *
- * Not here yet, by phase: "Report a problem" (Phase 8). Rendering an affordance whose
- * backing lever does not exist is how a store starts lying.
+ * "Report a problem" (D15, Phase 8) is at the foot of the page, not beside those two, and
+ * that placement is the design: it is the exit, not an action the page is inviting. It
+ * renders only for a **published** agent (D15.3) — you may report what the store offered
+ * you; a private or in-review agent nobody outside the author was invited to has no
+ * takedown available as a remedy either.
+ *
+ * ⚠️ Nothing about reports is ever shown *here* to anyone else. No count, no other user's
+ * text, no badge. A report is a private message to the curator; the moment this page
+ * rendered report volume, reporting would become a way to bury a competitor's agent.
  */
 @Component({
   selector: 'app-agent-detail',
@@ -59,6 +73,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
       heroCheckBadge,
       heroCheckCircle,
       heroExclamationTriangle,
+      heroFlag,
       heroLockClosed,
       heroNoSymbol,
       heroPlus,
@@ -303,6 +318,41 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
               </section>
             </div>
           </div>
+
+          <!--
+            D15. At the foot of the page and styled as a quiet link, because it is the
+            exit rather than something the page is inviting. Published only (D15.3).
+          -->
+          @if (canReport()) {
+            <div class="mt-10 border-t border-gray-200 pt-5 dark:border-gray-700">
+              @if (reportConfirmation()) {
+                <p
+                  role="status"
+                  class="flex items-start gap-2 text-sm/6 text-emerald-700 dark:text-emerald-400"
+                >
+                  <ng-icon name="heroCheckCircle" class="mt-1 size-4 shrink-0" aria-hidden="true" />
+                  <span>{{ reportConfirmation() }}</span>
+                </p>
+              } @else {
+                <button
+                  type="button"
+                  (click)="onReport()"
+                  [disabled]="reportBusy()"
+                  [appTooltip]="reportTooltip()"
+                  appTooltipPosition="top"
+                  class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-white"
+                >
+                  <ng-icon name="heroFlag" class="size-4" aria-hidden="true" />
+                  Report a problem
+                </button>
+              }
+              @if (reportError()) {
+                <p role="alert" class="mt-2 text-sm/6 text-rose-700 dark:text-rose-400">
+                  {{ reportError() }}
+                </p>
+              }
+            </div>
+          }
         }
       </div>
     </div>
@@ -312,6 +362,7 @@ export class AgentDetailPage {
   private api = inject(AgentApiService);
   private pinService = inject(AgentPinService);
   private router = inject(Router);
+  private dialog = inject(Dialog);
 
   /** Bound from the `agents/:id` route via `withComponentInputBinding`. */
   readonly id = input.required<string>();
@@ -327,6 +378,19 @@ export class AgentDetailPage {
    * complaint about an action the user did not take.
    */
   readonly pinError = signal<string | null>(null);
+
+  readonly reportBusy = signal(false);
+  readonly reportError = signal<string | null>(null);
+  /**
+   * The acknowledgement, which replaces the control rather than sitting beside it.
+   *
+   * Session-local on purpose: there is no read endpoint for "have I reported this", and
+   * there should not be — that would hand every user a way to probe the queue. So the
+   * page can only remember what it did itself, and the *server* is what actually enforces
+   * one open report per reporter (D15.4).
+   */
+  readonly reportConfirmation = signal<string | null>(null);
+  private readonly hasOpenReport = signal(false);
 
   constructor() {
     void this.load();
@@ -446,6 +510,50 @@ export class AgentDetailPage {
       this.pinError.set(this.pinService.error());
     } finally {
       this.pinBusy.set(false);
+    }
+  }
+
+  /**
+   * D15.3 — reportable means published.
+   *
+   * Read off the listing block the detail response already carries, so there is no second
+   * request and no second copy of the rule; the server refuses an unpublished agent
+   * regardless, and this only decides whether to render a control that would be refused.
+   */
+  readonly canReport = computed(() => this.agent()?.listing?.state === 'published');
+
+  reportTooltip(): string {
+    return `Tell the store's curators about a problem with ${this.agent()?.name ?? 'this agent'} — privately`;
+  }
+
+  async onReport(): Promise<void> {
+    const agent = this.agent();
+    if (!agent) return;
+
+    const ref = this.dialog.open<ReportAgentDialogResult, ReportAgentDialogData>(
+      ReportAgentDialogComponent,
+      { data: { agentName: agent.name, hasOpenReport: this.hasOpenReport() } },
+    );
+    const result = await firstValueFrom(ref.closed);
+    if (!result) return;
+
+    this.reportBusy.set(true);
+    this.reportError.set(null);
+    try {
+      const response = await firstValueFrom(this.api.reportAgent(this.id(), result));
+      this.hasOpenReport.set(true);
+      // The wording follows `replacedExisting` (D15.4) rather than assuming: telling
+      // someone their report was "sent" when it amended an earlier one would leave them
+      // expecting two things in the queue.
+      this.reportConfirmation.set(
+        response.replacedExisting
+          ? 'Thanks — we updated the report you already had open on this agent.'
+          : "Thanks — this went privately to the store's curators.",
+      );
+    } catch (err) {
+      this.reportError.set(this.messageFor(err, 'Failed to send this report.'));
+    } finally {
+      this.reportBusy.set(false);
     }
   }
 

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -191,3 +191,37 @@ export interface CategoryShelf {
   category: AgentCategory;
   listings: AgentListing[];
 }
+
+// ── problem reports, the reporter's half (D15, Phase 8) ────────────────────────────
+/**
+ * Why an agent is being reported.
+ *
+ * A small fixed set so the admin queue can sort by severity without reading every note.
+ * `inappropriate` is the one meant to page a human rather than wait for a sweep.
+ */
+export type ReportReason = 'inaccurate' | 'broken' | 'inappropriate' | 'other';
+
+export interface SubmitReportRequest {
+  reason: ReportReason;
+  note?: string;
+}
+
+/**
+ * What the reporter is told back — deliberately thin.
+ *
+ * ⚠️ A report is a *private message to the curator*. It is never rendered to another
+ * browsing user and never feeds `usageCount`, the store front, or any ordering, so there
+ * is no count, no queue position and no admin field here to leak one.
+ */
+export interface SubmitReportResponse {
+  agentId: string;
+  reason: ReportReason;
+  state: 'open' | 'resolved' | 'dismissed';
+  createdAt: string;
+  /**
+   * True when this updated a report the user already had open (D15.4) rather than adding
+   * one — so the confirmation says "we updated your report" instead of implying a second
+   * one is now queued.
+   */
+  replacedExisting: boolean;
+}

--- a/frontend/ai.client/src/app/agents/services/agent-api.service.ts
+++ b/frontend/ai.client/src/app/agents/services/agent-api.service.ts
@@ -19,6 +19,8 @@ import {
   ListingPreflight,
   ListingSubmissionResponse,
   SubmitListingRequest,
+  SubmitReportRequest,
+  SubmitReportResponse,
 } from '../models/store.model';
 import {
   ShareAssistantRequest,
@@ -115,6 +117,19 @@ export class AgentApiService {
   /** Unpublish or withdraw. Returns the listing at `private`; revokes nothing (D7.3). */
   withdrawListing(id: string): Observable<AgentListingBlock> {
     return this.http.delete<AgentListingBlock>(`${this.baseUrl()}/${id}/listing`);
+  }
+
+  /**
+   * Report a problem with a published agent (D15).
+   *
+   * ⚠️ Not a review. There are no stars, no public comments and no visible counts — this
+   * posts a private message to the curator, and nothing the reporter writes is ever
+   * rendered to another browsing user. The server refuses anything not published (D15.3)
+   * and *updates* the reporter's already-open report rather than stacking a second one
+   * (D15.4), which the response reports back as `replacedExisting`.
+   */
+  reportAgent(id: string, request: SubmitReportRequest): Observable<SubmitReportResponse> {
+    return this.http.post<SubmitReportResponse>(`${this.baseUrl()}/${id}/report`, request);
   }
 
   /**

--- a/infrastructure/lib/constructs/rag/rag-data-construct.ts
+++ b/infrastructure/lib/constructs/rag/rag-data-construct.ts
@@ -176,6 +176,23 @@ export class RagDataConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // Sparse open-report index for user problem reports (D15, Phase 8). Reports are
+    // child rows of the Agent (PK = AST#{id}, SK = REPORT#{report_id}) so they are
+    // deleted with it; this index is written ONLY while state == "open", so a resolved
+    // or dismissed report leaves the admin queue by losing its key rather than by being
+    // filtered out — the same physics as AgentDirectoryIndex above.
+    //   GSI6_PK = "REPORTS#OPEN"   GSI6_SK = CREATED#{created_at}  (oldest-first sweep)
+    // One partition is correct here: the open queue is bounded by how fast admins work
+    // and is read only by the admin console, which wants one chronological sweep rather
+    // than per-agent slices. If it ever outgrows a hot partition, that is a product
+    // signal (nobody is triaging) before it is a capacity one.
+    this.assistantsTable.addGlobalSecondaryIndex({
+      indexName: 'AgentReportsIndex',
+      partitionKey: { name: 'GSI6_PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI6_SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // ── SSM publications (consumed by restore tooling, app-api/inference-api runtime) ──
     new ssm.StringParameter(this, 'RagAssistantsTableNameParameter', {
       parameterName: `/${config.projectPrefix}/rag/assistants-table-name`,


### PR DESCRIPTION
Phase 8 of the [Agent Marketplace](docs/specs/agent-marketplace.md). Users can report a problem with a published Agent from its detail page; the report lands in a new admin **Reports** queue beside submissions.

## ⚠️ Needs a `platform.yml` deploy, before `backend.yml`

The one infra change is the sparse **GSI6 `AgentReportsIndex`** on `rag-assistants`, which `RagDataConstruct` creates in **PlatformStack**. Deploy platform first or the queue query 400s on a missing index.

Nothing else is needed: reports are child rows on the existing table (no new table, no new env var), and `RagAssistantsTableAccess` already grants on `${ragAssistantsTable.tableArn}/index/*`, so the new index is covered the moment it exists. The `coreTables` loop is not involved — `rag-assistants` has its own statement.

## The four D15 rules, and where each is enforced

| Rule | Enforced by |
|---|---|
| A report is a **private message to the curator** — never shelf content, never a ranking input | `SubmitReportResponse` carries five fields and no queue state; nothing on the write path touches `usageCount` or the listing (asserted in tests) |
| **Reporter visible to the admin, never the author**; resolving never delists | `reporterId`/`reporterName` exist only on `AdminReportRow`; `triage_report` writes only the report (asserted for both decisions) |
| **One open report per reporter** — a second updates rather than stacks | Three conditional writes on a deterministic key, no read |
| **Reportable means published** | `file_report` checks reachability *then* `listing.state == "published"` |

## Two things the spec left contradictory or open

**The sketched sort key could not satisfy D15.4.** `REPORT#{created_at}#{report_id}` cannot be conditionally updated without first reading the row to learn the timestamp — the exact lookup D15.4's "the write already knows both halves of the key" exists to avoid. The key is now `REPORT#{sha256(agent_id:reporter_id)[:16]}` and the chronology moved to `GSI6_SK`, which is the only place anything reads it. The reporter is hashed so the sort key isn't an enumerable directory of who reported what.

**`_delete_assistant_cloud` deleted only the `METADATA` item.** Reports are child rows *precisely* so they never outlive the Agent, but nothing swept them — and an orphaned **open** report keeps its sparse index key, so it would have sat in the queue forever pointing at an Agent nobody can open. The sweep now runs inside the shared delete (covering every delete path, not just the Agent router's) and is best-effort, so a tidy-up failure can't make an Agent undeletable. The queue therefore also *flags* a row whose Agent is gone rather than dropping one it still counts.

Four more decisions are recorded in the spec's new **Phase 8 notes (as built)** block.

## Also: the nav badge now exists

`pendingCount` has shipped since Phase 1 but badged nothing — the layout never read it, and it only populates once a queue page loads. D10 wants both counts visible from anywhere in the console, so `GET /admin/agents/queues` returns the two integers and the layout fetches it on init, rather than having the nav load two full queues (a table scan behind every click). Fails soft per half.

## Verification

- `pytest tests/` — **5192 passed**, 0 failures (45 new: 18 persistence against a moto table with the real GSI, 27 route-level)
- `npm run test:ci` — **1546 passed** (135 files)
- `npm run build` (SPA) and `npm run build` (CDK) both clean

Branched from `develop` @ `29879f8c`; re-fetched before opening — `develop` has not moved, so this is already on top of it and phase 7 has not landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)