### PR TITLE
fix(marketplace): the agent detail page never loaded its agent

### DIFF
--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -4,6 +4,7 @@ import {
   computed,
   inject,
   input,
+  OnInit,
   signal,
 } from '@angular/core';
 import { Router } from '@angular/router';
@@ -358,7 +359,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
     </div>
   `,
 })
-export class AgentDetailPage {
+export class AgentDetailPage implements OnInit {
   private api = inject(AgentApiService);
   private pinService = inject(AgentPinService);
   private router = inject(Router);
@@ -392,7 +393,14 @@ export class AgentDetailPage {
   readonly reportConfirmation = signal<string | null>(null);
   private readonly hasOpenReport = signal(false);
 
-  constructor() {
+  /**
+   * ``ngOnInit``, not the constructor: ``id`` is a required signal input bound by
+   * ``withComponentInputBinding()``, and the router sets it *after* construction.
+   * Reading it a moment too early throws NG0950, which ``load()``'s own try/catch
+   * then swallowed into "Failed to load this agent." — an error banner with no
+   * network request behind it, which is what this page did from phase 3 until now.
+   */
+  ngOnInit(): void {
     void this.load();
     // Cached across the session, so arriving from a shelf row costs nothing.
     void this.pinService.load();


### PR DESCRIPTION
## What

`AgentDetailPage` called `load()` from its **constructor**. `load()` reads `this.id()` — an `input.required<string>()` bound by `withComponentInputBinding()` — and the router sets that input *after* construction. The read threw NG0950 before `AgentApiService.getAgent()` was ever called.

The throw landed inside `load()`'s own `try/catch`, which turned it into `this.error.set('Failed to load this agent.')`. The page rendered a plausible error banner with **no HTTP request behind it**: no console error, no failed request in the network tab, nothing to grep for.

`/agents/:id` has been in this state since phase 3 (`66f38346`) — the detail page has never successfully loaded in a browser.

Fix: move both init calls to `ngOnInit`, which runs after input binding.

## How it was found

Running the phase 5–7 dev smoke test, where the detail page is the only surface carrying the pin control.

Before / after on dev, same URL: previously the error banner with zero requests to `:8000`; now `GET /agents/{id}` → 200, `GET /agents/{id}/runnability` → 200, and the page renders the hero band, details, "What it can access" and the runnability line.

The rest of that smoke test passed — the phase 5/6 pin acceptance path (pin → unpin → reload → seed role pin → tombstone beats seed → lock overrides) behaves exactly as specced.

## Test coverage

There is **no `agent-detail.page.spec.ts` at all**, which is why CI never caught this. A regression spec is tracked separately.

⚠️ For whoever writes it: the spec must set the input the way the router does — after creation, e.g. via `RouterTestingHarness` or `componentRef.setInput()` post-creation. Passing `id` at construction time reproduces neither the bug nor the fix, so a naive spec would pass against the broken code.

## Verification

- `npm test` (i.e. `ng test`) — **136 files, 1560 tests, all passing** on this branch
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- Verified live against dev through `localhost:4200`

Note on flakiness: a first run showed 6 failures in `agents/agent-form/agent-form.page.spec.ts` (5000ms timeouts); a re-run was fully green. That's the known load-dependent flake in that file, unrelated to this change.

## Deploy

`frontend-deploy.yml` only. No backend, no CDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
