### PR TITLE
fix(inference): one session is one conversation, whatever agent runs a turn

### DIFF
--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -118,6 +118,80 @@ def _is_paused_on_interrupt(agent: BaseAgent) -> bool:
     return bool(state is not None and getattr(state, "activated", False))
 
 
+def _adopt_session_conversation(agent: BaseAgent, session_id: str) -> None:
+    """Point a newly built agent at the conversation its session is already having.
+
+    The cache key varies with an agent's *configuration* — system prompt, tools,
+    model, skills — and that is correct: those genuinely need different ``Agent``
+    objects. The **conversation** is not configuration. One session is one
+    conversation, whichever agent happens to run a given turn.
+
+    Without this, an `@`-mention (Marketplace D11) forks the thread. The mention
+    turn misses the cache and builds a second agent, which restores history and
+    looks fine; the next plain turn reverts the key and cache-*hits* the original
+    instance, whose in-memory list still ends before the mention. ``initialize()``
+    never re-runs on a hit, so the stale list wins and the model answers "NOT IN
+    HISTORY" about a turn the user can see on screen (issue #741).
+
+    ⚠️ The list is shared **by reference, deliberately**. Copying would fix only
+    the direction that already works — the miss. The turn that goes stale is a
+    cache hit, where nothing runs at all and there is no opportunity to copy
+    anything. Aliasing is what makes the mention turn's appends visible to the
+    instance the *next* turn will hit. This holds because every site that rebinds
+    ``agent.messages`` lives inside ``TurnBasedSessionManager.initialize()``
+    (document stripping, content-block sanitizing, compaction slicing, pairing
+    repair) and so runs before we get here; after construction the list is only
+    appended to. A future compaction that rebinds mid-life would silently break
+    the alias — ``test_second_cache_key_for_a_session_shares_the_conversation``
+    is what catches that.
+
+    Re-restoring on a stale hit was the alternative and is worse: restored history
+    passes through the sanitizers and pairing repair while accumulated history does
+    not, so the same conversation can serialize differently depending on the path
+    that produced it — a prefix-byte change on an arbitrary turn, which is exactly
+    what the prompt-cache contract forbids. Aliasing never re-serializes anything.
+
+    Safe against concurrent turns because the single-flight session lease admits
+    one turn per session at a time. Cross-replica divergence is not our problem
+    either way — separate processes share no cache — but the length guard below
+    keeps us from *losing* history if a live instance ever trails what was
+    restored from Memory.
+    """
+    inner = getattr(agent, "agent", None)
+    if inner is None or not isinstance(getattr(inner, "messages", None), list):
+        return
+
+    live = None
+    for key, cached in _agent_cache.items():
+        if key[0] != session_id:
+            continue
+        cached_inner = getattr(cached, "agent", None)
+        if isinstance(getattr(cached_inner, "messages", None), list):
+            live = cached_inner  # newest wins — dict preserves insertion order
+
+    if live is None or live.messages is inner.messages:
+        return
+
+    # A restored list longer than the live one means that instance is behind
+    # (another replica wrote to Memory). Keep the longer history rather than
+    # aliasing to a shorter one. Note the reverse comparison would be wrong:
+    # compaction legitimately makes a restored list *shorter* than the live one.
+    if len(inner.messages) > len(live.messages):
+        logger.info(
+            "Session %s: restored history (%d) is ahead of the live instance (%d); "
+            "keeping the restored list",
+            scrub_log(session_id), len(inner.messages), len(live.messages),
+        )
+        return
+
+    logger.info(
+        "Session %s: adopting the in-flight conversation (%d message(s)) for a "
+        "newly built agent",
+        scrub_log(session_id), len(live.messages),
+    )
+    inner.messages = live.messages
+
+
 async def get_agent(
     session_id: str,
     user_id: Optional[str] = None,
@@ -252,6 +326,12 @@ async def get_agent(
     if resolved_agent_type != "voice":
         create_kwargs["accessible_skill_ids"] = accessible_skill_ids
     agent = create_agent(**create_kwargs)
+
+    # One session is one conversation, even when a turn runs under a different
+    # configuration (an `@`-mention, a different toolset). Runs before the
+    # extra_tools early return below, because an uncached agent still takes a
+    # turn in the thread and must not fork it. See #741.
+    _adopt_session_conversation(agent, session_id)
 
     # Stamp the type onto the construction snapshot so a paused turn can
     # resume on the same factory variant after cache eviction. A turn carrying

--- a/backend/tests/apis/inference_api/test_chat_service.py
+++ b/backend/tests/apis/inference_api/test_chat_service.py
@@ -251,3 +251,92 @@ async def test_chat_path_unaffected_by_skills_hash(mock_create_agent, mock_fresh
     assert a is a_again
     assert mock_create_agent.call_count == 1
     assert mock_create_agent.call_args.kwargs.get("accessible_skill_ids") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #741 — conversation continuity across cache keys
+# ---------------------------------------------------------------------------
+#
+# The cache key intentionally varies with the agent's *configuration* (system
+# prompt, tools, model, skills). The conversation is not configuration: one
+# session is one conversation, whichever agent ran a given turn.
+#
+# An `@`-mention (Marketplace D11) is the first path that changes agent identity
+# mid-thread, so it is the first to violate that: the mention turn misses the
+# cache and builds a second Agent, then the next plain turn reverts the key and
+# cache-HITs the original instance, whose in-memory `agent.messages` still ends
+# before the mention. `initialize()` never re-runs on a hit, so the stale list
+# wins silently and the model answers "NOT IN HISTORY" about a turn the user can
+# see on screen. Measured on dev session e5e8b259-1780-4179-8ebe-38c57d3709a5.
+
+
+def _fake_agent_with_messages(*, system_prompt=None, restored=None) -> MagicMock:
+    """Fake whose inner Strands agent carries a `messages` list, like the real one.
+
+    ``restored`` models what ``TurnBasedSessionManager.initialize()`` loads from
+    AgentCore Memory when a *fresh* instance is built — a copy, because each real
+    instance owns its own list. That detail is the whole bug: a cache **hit**
+    skips this entirely and keeps whatever the instance last saw.
+    """
+    inner = SimpleNamespace(
+        _interrupt_state=SimpleNamespace(activated=False),
+        messages=list(restored or []),
+    )
+    wrapper = MagicMock(spec=["agent", "_construction_snapshot"])
+    wrapper.agent = inner
+    wrapper._construction_snapshot = {"system_prompt": system_prompt}
+    return wrapper
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Issue #741: a second cache key for the same session forks the conversation. "
+        "Remove this marker with the fix — strict=True so it fails loudly once it passes."
+    ),
+)
+@pytest.mark.asyncio
+async def test_second_cache_key_for_a_session_shares_the_conversation(mock_freshness_hash):
+    """Turn 3 runs under a different config; turn 4 reverts and must still see turn 3.
+
+    Models the `@`-mention round trip: plain → plain → mention → plain, where the
+    mention swaps the system prompt (any cache-key component would do). ``store``
+    stands in for AgentCore Memory: every turn flushes into it, and every *freshly
+    built* agent restores from it. That is why the mention turn sees the earlier
+    history in production — it is a cache miss, so it restores. The plain turn
+    after it is a cache **hit**, restores nothing, and is therefore stale.
+
+    The assertion is deliberately about the *conversation*, not instance identity:
+    a fix may reuse one instance, hand the message list between instances, or
+    re-restore on a stale hit, and this test should pass either way.
+    """
+    store: list[dict] = []
+
+    def _turn(agent, *messages):
+        """Run a turn: the agent appends, and the session flushes to Memory."""
+        agent.agent.messages.extend(messages)
+        store.extend(messages)
+
+    with patch.object(service, "create_agent") as mock:
+        mock.side_effect = lambda **kwargs: _fake_agent_with_messages(
+            system_prompt=kwargs.get("system_prompt"), restored=store
+        )
+
+        plain = await service.get_agent(session_id="s", user_id="u")
+        _turn(plain, {"role": "user", "t": 1}, {"role": "assistant", "t": 2})
+
+        # The mention turn: same session, different configuration → cache miss,
+        # so it restores and legitimately sees the first exchange.
+        mentioned = await service.get_agent(
+            session_id="s", user_id="u", system_prompt="You are the mentioned Agent."
+        )
+        assert len(mentioned.agent.messages) == 2, "mention turn lost the prior history"
+        _turn(mentioned, {"role": "user", "t": 3}, {"role": "assistant", "t": 4})
+
+        # The next plain turn reverts the key → cache hit on the original
+        # instance, which never saw turns 3-4.
+        plain_again = await service.get_agent(session_id="s", user_id="u")
+
+    assert len(plain_again.agent.messages) == 4, (
+        "the plain turn cache-hit a stale instance and cannot see the mention exchange"
+    )

--- a/backend/tests/apis/inference_api/test_chat_service.py
+++ b/backend/tests/apis/inference_api/test_chat_service.py
@@ -288,13 +288,6 @@ def _fake_agent_with_messages(*, system_prompt=None, restored=None) -> MagicMock
     return wrapper
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Issue #741: a second cache key for the same session forks the conversation. "
-        "Remove this marker with the fix — strict=True so it fails loudly once it passes."
-    ),
-)
 @pytest.mark.asyncio
 async def test_second_cache_key_for_a_session_shares_the_conversation(mock_freshness_hash):
     """Turn 3 runs under a different config; turn 4 reverts and must still see turn 3.
@@ -340,3 +333,46 @@ async def test_second_cache_key_for_a_session_shares_the_conversation(mock_fresh
     assert len(plain_again.agent.messages) == 4, (
         "the plain turn cache-hit a stale instance and cannot see the mention exchange"
     )
+
+
+@pytest.mark.asyncio
+async def test_adoption_keeps_the_longer_history_when_the_live_instance_trails(
+    mock_freshness_hash,
+):
+    """A live instance behind what Memory restored must not drag the new agent back.
+
+    Separate runtime replicas share no cache, so this is not the mention case —
+    it is the guard against *losing* turns if a cached instance ever trails the
+    persisted conversation. Note the comparison only fires in this direction:
+    compaction legitimately makes a restored list shorter than the live one, so
+    "restored is shorter" is normal and must still adopt.
+    """
+    stale_live = [{"role": "user", "t": 1}]
+    restored = [{"role": "user", "t": 1}, {"role": "assistant", "t": 2}]
+
+    with patch.object(service, "create_agent") as mock:
+        mock.side_effect = lambda **kwargs: _fake_agent_with_messages(
+            system_prompt=kwargs.get("system_prompt"),
+            restored=stale_live if kwargs.get("system_prompt") is None else restored,
+        )
+        await service.get_agent(session_id="s", user_id="u")
+        ahead = await service.get_agent(
+            session_id="s", user_id="u", system_prompt="different config"
+        )
+
+    assert len(ahead.agent.messages) == 2, "adoption clobbered a longer restored history"
+
+
+@pytest.mark.asyncio
+async def test_adoption_does_not_reach_across_sessions(mock_freshness_hash):
+    """Sharing is scoped to one session id — never between two conversations."""
+    with patch.object(service, "create_agent") as mock:
+        mock.side_effect = lambda **kwargs: _fake_agent_with_messages(
+            system_prompt=kwargs.get("system_prompt")
+        )
+        a = await service.get_agent(session_id="s1", user_id="u")
+        a.agent.messages.extend([{"role": "user"}, {"role": "assistant"}])
+        b = await service.get_agent(session_id="s2", user_id="u")
+
+    assert b.agent.messages == [], "a different session adopted someone else's conversation"
+    assert a.agent.messages is not b.agent.messages


### PR DESCRIPTION
Fixes #741.

## The bug

An `@`-mention turn and the plain turns around it ran on **two different cached `Agent` instances**, and neither saw the other's messages. The user saw one continuous thread — the SPA renders from the persisted store — but the model was amnesiac in both directions.

Reproduced on dev (`e5e8b259-1780-4179-8ebe-38c57d3709a5`): after `@Docx Dogfood` answered a question, the next plain turn replied **`NOT IN HISTORY`** when asked to quote it back. A second mention likewise could not see the plain turns in between.

The prompt-cache fingerprints show it without any prompting: the swap-back turn's `historyHash` was byte-identical to the mention turn's, and it wrote 71 tokens — impossible if the mention exchange were in the prompt.

## Root cause

`_create_cache_key` includes the system prompt, tools, model and skills hashes. That is **correct** — those genuinely need different `Agent` objects. But the *conversation* is not configuration, and nothing said so.

- mention turn → different key → cache **miss** → new agent → `initialize()` restores history → looks fine
- next plain turn → key reverts → cache **hit** → `initialize()` never re-runs → in-memory list still ends before the mention → stale list wins, silently

Not mention-specific in principle; any mid-thread cache-key change forks the same way. It stayed latent because the SPA blocks mid-thread model switches. The `@`-mention is simply the first path that changes agent identity inside a live thread.

## The fix

`_adopt_session_conversation` points a newly built agent at the message list its session is already using.

⚠️ **Shared by reference, deliberately** — this is the part to review. Copying would fix only the direction that already works (the miss). The turn that goes stale is a cache *hit*, where nothing runs and there is nothing to copy. Aliasing is what makes the mention turn's appends visible to the instance the next turn will hit.

That holds because every site that rebinds `agent.messages` — document stripping, content-block sanitizing, compaction slicing, pairing repair — lives inside `TurnBasedSessionManager.initialize()` and therefore runs before adoption. After construction the list is only appended to. A future compaction that rebinds mid-life would break the alias, and `test_second_cache_key_for_a_session_shares_the_conversation` is what catches that.

## Why not re-restore on a stale hit

It was the obvious alternative and it is worse for a specific reason: restored history passes through the sanitizers and pairing repair, while accumulated in-memory history does not. So the same conversation can serialize **differently depending on the path that produced it** — a prefix byte change on an arbitrary turn, which is exactly what the prompt-cache contract in `CLAUDE.md` forbids ($2.50/MTok on a re-write). Aliasing re-serializes nothing, so the cached prefix is untouched. It also costs no extra Memory read per turn.

## Details worth a look

- Adoption runs **before** the `extra_tools` early return — an uncached agent still takes a turn in the thread and must not fork it.
- A length guard keeps a live instance that trails Memory from dragging a newer restored history backwards. ⚠️ The reverse comparison would be a bug: compaction legitimately makes a restored list *shorter* than the live one, so "restored is shorter" is normal and must still adopt.
- Concurrency is covered by the single-flight session lease (one turn per session at a time). Separate replicas share no cache, so cross-process behavior is unchanged either way.

## Tests

- `test_second_cache_key_for_a_session_shares_the_conversation` — the repro, committed first as a **strict xfail** (`ffee261b`) so the bug was pinned executably before the fix, then flipped. It asserts on the *conversation*, not instance identity, so it stays valid if the mechanism is ever changed.
- `test_adoption_keeps_the_longer_history_when_the_live_instance_trails` — the guard.
- `test_adoption_does_not_reach_across_sessions` — scoping.

**Full backend suite: 5230 passed, 3 skipped.**

## Follow-ups, not in this PR

- The **same fork exists in compaction state** — each agent builds its own `TurnBasedSessionManager`, so two instances for one session means two `compaction_state` objects persisting to the same DynamoDB row. Same root cause, separate blast radius; filed separately rather than widening this PR.
- The cost dashboard still books deliberate mention swaps as `miss_avoidable` waste with no dimension marking them (comment on #741).
- The spec's "two prompt-cache re-writes ≈ $0.25 per mention" should be **re-measured after this lands** — the cheap swap-back measured earlier was partly an artifact of this bug.

## Deploy

`backend.yml` — inference-api image → AgentCore Runtime. No CDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)