### PR TITLE
docs(marketplace): a mention costs one prefix re-write, not two

### DIFF
--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -646,13 +646,38 @@ thread" in one sentence, and that sentence turned out to be the whole phase:
   is three lines, the route is a thousand, so it lives where a test can reach it). Splitting them
   gives two silent bugs: validate-only refuses the *second* mention in a thread; persist-only lets
   one `@` annex the conversation.
-- **💰 A mention costs two prompt-cache prefix re-writes**, and this is a deliberate purchase. An
-  Agent turn swaps the system prompt and `toolConfig`, so the mention turn re-writes the cached
-  prefix and the next plain turn re-writes it back. At a 50k-token prefix and the $2.50/MTok
-  cache-write premium that is roughly $0.25 per mention round-trip. It is bounded (twice per
-  mention, never per turn) and it buys the thing the feature is for. If mentions ever become
-  common in long threads, the lever is to *bind* the conversation after a mention rather than to
-  make the swap cheaper.
+- **💰 A mention costs ONE prompt-cache prefix re-write, not two** — measured, not predicted. The
+  Agent's bindings change `toolConfig`, which sits first in the prefix, so the mention turn
+  invalidates system and history behind it and genuinely re-writes the whole prefix. **The next
+  plain turn does not re-write it back**: the base `toolConfig` and system prompt revert
+  byte-identically and read from the still-live pre-mention entry, so the swap-back is a cache
+  *hit* that writes only the mention exchange as a delta.
+
+  Measured on dev (session `bf9481e7-62ec-4a14-817f-546a2953588d`, Sonnet 5, mention and
+  swap-back 28s apart):
+
+  | turn | status | cacheRead | cacheWrite |
+  |---|---|---|---|
+  | mention | `miss_avoidable` | 0 | 4301 |
+  | next plain turn | **`hit`** | 2720 | 138 |
+
+  At a 50k-token prefix and Sonnet 5's $2.30/MTok write premium (`$2.50` write less `$0.20`
+  read) that is roughly **$0.12 per mention**, about half what this section originally claimed.
+  Still bounded per mention rather than per turn, and it still buys the thing the feature is for.
+  If mentions ever become common in long threads, the lever is to *bind* the conversation after a
+  mention rather than to make the swap cheaper.
+
+  ⚠️ Two caveats worth keeping attached to the number. **The swap-back only hits inside the
+  ~5-minute cache TTL** — a slower reply re-writes the prefix regardless, and that cost is not
+  attributable to the mention. And **an Agent that pins its own model** (`modelConfig` →
+  `model_override`) is categorically more expensive: cache entries are per-model, so such a
+  mention can hit nothing and its write is never re-read.
+
+  The original estimate here was not merely conservative — it was measured once against a bug.
+  Before #741 was fixed the swap-back looked *cheaper* than this (write 71, not 138) because the
+  stale agent was silently omitting the mention exchange from the prefix. A cost number taken
+  from a broken run flattered us in one direction while the spec's prediction erred in the other.
+  Re-measure after any change to the invocation path rather than trusting either.
 - **Known edge, pre-existing:** `continue_truncated` skips the whole assistant block, so a
   "Continue" after a max_tokens truncation runs without the Agent — true for bound Agent
   conversations before this phase, and unchanged by it.


### PR DESCRIPTION
Corrects the phase 7 cost estimate in `docs/specs/agent-marketplace.md` with a measured number. Docs only — no code.

## What was wrong

The spec predicted **"two prompt-cache prefix re-writes ... roughly $0.25 per mention round-trip"** — the mention turn swaps the prefix, the next plain turn swaps it back.

The first half is right. The second is not.

## What actually happens

Measured on dev, session `bf9481e7-62ec-4a14-817f-546a2953588d` (Sonnet 5, mention and swap-back 28s apart, both well inside the TTL):

| turn | status | cacheRead | cacheWrite |
|---|---|---|---|
| mention | `miss_avoidable` | 0 | 4301 |
| next plain turn | **`hit`** | 2720 | 138 |

The **outbound** leg is a genuine full re-write: the Agent's bindings change `toolConfig`, which sits first in the prefix, so system and history behind it are invalidated too.

The **return** leg is a cache hit. Base `toolConfig` and system prompt revert byte-identically, so they read from the still-live pre-mention entry; only the mention exchange is written, as a delta.

At a 50k prefix and Sonnet 5's $2.30/MTok write premium ($2.50 write less $0.20 read) that is **~$0.12 per mention**, roughly half the original figure.

## Two caveats now recorded with the number

Both change it materially, and neither was in the original estimate:

- **The swap-back only hits inside the ~5-minute TTL.** A slower reply re-writes the prefix regardless, and that cost is not attributable to the mention.
- **An Agent that pins its own model** (`modelConfig` → `model_override`) is categorically more expensive — cache entries are per-model, so such a mention can hit nothing and its write is never re-read.

## ⚠️ Why the number was wrong twice

Worth reading even if you skip the rest. The **first** measurement of this was taken against #741, and it made the swap-back look *cheaper* than the truth — write **71**, not 138 — because the stale agent was silently omitting the mention exchange from the prefix. So a broken run flattered us in one direction while the spec's prediction erred in the other, and averaging two wrong numbers would have landed near the right one by luck.

The spec now says to re-measure after any invocation-path change rather than trusting either. That instruction is the durable part of this PR; the dollar figure is just today's value.

## Related

- #741 / #750 — the fork that made the first measurement unreliable
- The `miss_avoidable` on the mention row is a **deliberate** swap being booked as waste; the dimension that would distinguish it is tracked on #741.

## Deploy

None. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)