### PR TITLE
fix(observability): measure the cache TTL from the same-prefix predecessor

### DIFF
--- a/backend/src/apis/app_api/admin/costs/models.py
+++ b/backend/src/apis/app_api/admin/costs/models.py
@@ -122,6 +122,13 @@ class SessionCallRow(BaseModel):
     cost: float = 0.0
     cache_status: Optional[str] = Field(None, alias="cacheStatus")
     cache_gap_seconds: Optional[int] = Field(None, alias="cacheGapSeconds")
+    # Seconds since the last call with the SAME prefix, present only when that
+    # was an older call than the immediately previous one (#753). Its absence
+    # means the two coincide; its presence explains a status that would
+    # otherwise look inconsistent with `cacheGapSeconds`.
+    cache_prefix_gap_seconds: Optional[int] = Field(
+        None, alias="cachePrefixGapSeconds"
+    )
     wasted_usd: float = Field(0.0, alias="wastedUsd")
     prefix_fingerprints: Optional[PrefixFingerprints] = Field(
         None, alias="prefixFingerprints"

--- a/backend/src/apis/app_api/admin/costs/service.py
+++ b/backend/src/apis/app_api/admin/costs/service.py
@@ -370,6 +370,7 @@ class AdminCostService:
             wasted_usd += row_wasted
 
             gap_raw = record.get("cacheGapSeconds")
+            prefix_gap_raw = record.get("cachePrefixGapSeconds")
             calls.append(SessionCallRow(
                 timestamp=record.get("timestamp", ""),
                 message_id=record.get("messageId"),
@@ -381,6 +382,9 @@ class AdminCostService:
                 cost=cost,
                 cache_status=cache_status,
                 cache_gap_seconds=int(gap_raw) if gap_raw is not None else None,
+                cache_prefix_gap_seconds=(
+                    int(prefix_gap_raw) if prefix_gap_raw is not None else None
+                ),
                 wasted_usd=row_wasted,
                 prefix_fingerprints=(
                     PrefixFingerprints(**fingerprints_raw)

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -27,6 +27,15 @@ from .preview import is_preview_session
 
 logger = logging.getLogger(__name__)
 
+# How many recent call rows to read when looking for the predecessor whose cache
+# entry a call could have hit (#753). Wide enough to see past one interleaved
+# `@`-mention turn — including a tool-using one, which writes several rows — and
+# small enough to stay a single cheap GSI query. When the same-prefix predecessor
+# falls outside this window we classify conservatively as `miss_ttl_expired`
+# rather than guessing, so widening it can only ever recover under-reported
+# waste, never manufacture it.
+_CACHE_PREDECESSOR_LOOKBACK = 10
+
 
 def _convert_floats_to_decimal(obj: Any) -> Any:
     """
@@ -363,17 +372,27 @@ def _derive_cache_observability(
     timestamp: str,
     message_metadata: MessageMetadata,
 ) -> Dict[str, Any]:
-    """Classify this model call's prompt-cache outcome against the previous call.
+    """Classify this model call's prompt-cache outcome against its predecessor.
 
-    Queries the session's most recent existing ``C#`` cost row (one GSI read,
-    Limit=1) and derives:
+    Reads a small window of the session's most recent ``C#`` cost rows (one GSI
+    query) and derives:
 
     - ``cacheStatus``: first_write | hit | miss_ttl_expired | miss_avoidable
       | uncached (see ``apis.shared.observability.CacheStatus``).
     - ``cacheGapSeconds``: whole seconds since the previous call, when known.
+    - ``cachePrefixGapSeconds``: seconds since the last call with the *same*
+      prefix, when that is a different (older) call than the previous one.
     - ``wastedUsd``: for avoidable misses, the re-written previously-cached
       prefix priced at the cache-write premium over the cache-read rate,
       using this row's own pricingSnapshot.
+
+    ⚠️ The predecessor that decides ``miss_avoidable`` vs ``miss_ttl_expired``
+    is the last call with the **same toolConfig + system-prompt fingerprints**,
+    not simply the last call (#753). Those are the only entries this call could
+    have hit. Measuring the TTL against whatever ran most recently is wrong the
+    moment two prefixes interleave in one session — which is exactly what an
+    `@`-mention does — and it reported genuine TTL expiries as avoidable waste,
+    inflating the metric that exists to catch nondeterministic prefix assembly.
 
     The stream coordinator writes a turn's rows sequentially in call order,
     so within a multi-call turn each call sees its predecessor. Returns {}
@@ -401,8 +420,11 @@ def _derive_cache_observability(
 
         cache_read, cache_write = _extract_cache_usage(message_metadata)
 
-        # Most recent existing cost row for this session (GSI_SK = C#<timestamp>
-        # sorts chronologically; descending scan + Limit=1 = the previous call).
+        # Recent cost rows for this session, newest first (GSI_SK = C#<timestamp>
+        # sorts chronologically). We need a window rather than just the previous
+        # call: the TTL question is "was the entry this call could have HIT still
+        # alive", and that entry belongs to the most recent call with the *same
+        # prefix*, which is not always the call immediately before. See #753.
         response = table.query(
             IndexName="SessionLookupIndex",
             KeyConditionExpression=(
@@ -410,33 +432,76 @@ def _derive_cache_observability(
                 & Key("GSI_SK").begins_with("C#")
             ),
             ScanIndexForward=False,
-            Limit=1,
+            Limit=_CACHE_PREDECESSOR_LOOKBACK,
         )
-        prev_items = response.get("Items", [])
-        prev_row = _convert_decimal_to_float(prev_items[0]) if prev_items else None
+        prev_items = [_convert_decimal_to_float(item) for item in response.get("Items", [])]
+        prev_row = prev_items[0] if prev_items else None
 
-        gap_seconds: Optional[float] = None
-        prev_cached_prefix: Optional[int] = None
-        if prev_row:
-            prev_ts = prev_row.get("timestamp")
+        try:
+            current_dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except (ValueError, AttributeError, TypeError):
+            current_dt = None
+
+        def _gap_to(row: Optional[Dict[str, Any]]) -> Optional[float]:
+            if row is None or current_dt is None:
+                return None
             try:
-                current_dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-                prev_dt = datetime.fromisoformat(str(prev_ts).replace("Z", "+00:00"))
-                gap_seconds = (current_dt - prev_dt).total_seconds()
+                row_dt = datetime.fromisoformat(str(row.get("timestamp")).replace("Z", "+00:00"))
             except (ValueError, AttributeError, TypeError):
-                gap_seconds = None
+                return None
+            return (current_dt - row_dt).total_seconds()
 
-            prev_usage = prev_row.get("tokenUsage") or {}
-            prev_cached_prefix = int(
-                (prev_usage.get("cacheReadInputTokens") or 0)
-                + (prev_usage.get("cacheWriteInputTokens") or 0)
+        def _cached_prefix_of(row: Optional[Dict[str, Any]]) -> Optional[int]:
+            if row is None:
+                return None
+            usage = row.get("tokenUsage") or {}
+            return int(
+                (usage.get("cacheReadInputTokens") or 0)
+                + (usage.get("cacheWriteInputTokens") or 0)
             )
+
+        prev_gap_seconds = _gap_to(prev_row)
+
+        # The predecessor whose cache entry this call would actually have hit:
+        # the newest row sharing this call's toolConfig + system-prompt prefix.
+        # Both hashes are already persisted per row, so this costs no new data —
+        # only a wider read of rows we were already indexing.
+        own_prints = getattr(message_metadata, "prefixFingerprints", None) or {}
+        own_key = (own_prints.get("toolConfigHash"), own_prints.get("systemPromptHash"))
+        match_row: Optional[Dict[str, Any]] = None
+        comparable = all(part is not None for part in own_key)
+        if comparable:
+            for row in prev_items:  # already newest-first
+                row_prints = row.get("prefixFingerprints") or {}
+                if (row_prints.get("toolConfigHash"), row_prints.get("systemPromptHash")) == own_key:
+                    match_row = row
+                    break
+
+        if not comparable:
+            # No fingerprints on this call (hook disabled, or a non-Bedrock
+            # provider): fall back to the previous call, which is what this
+            # derivation did before #753.
+            classify_gap = prev_gap_seconds
+            prev_cached_prefix = _cached_prefix_of(prev_row)
+        elif match_row is not None:
+            classify_gap = _gap_to(match_row)
+            prev_cached_prefix = _cached_prefix_of(match_row)
+        else:
+            # This prefix has no predecessor inside the lookback window, so any
+            # entry for it is older than every row we just read. Pass None, which
+            # classifies as `miss_ttl_expired` rather than `miss_avoidable`.
+            # Deliberately the conservative direction: under-reporting waste
+            # keeps the metric trustworthy, whereas crying wolf is what made it
+            # useless. `prev_cached_prefix` still comes from the previous call so
+            # the below-threshold `first_write` guard keeps working.
+            classify_gap = None
+            prev_cached_prefix = _cached_prefix_of(prev_row)
 
         status = classify_cache_status(
             cache_read_tokens=cache_read,
             cache_write_tokens=cache_write,
             previous_call_exists=prev_row is not None,
-            gap_seconds=gap_seconds,
+            gap_seconds=classify_gap,
             previous_cached_prefix_tokens=prev_cached_prefix,
         )
         wasted_usd = compute_wasted_usd(
@@ -450,13 +515,28 @@ def _derive_cache_observability(
             "cacheStatus": status.value,
             "wastedUsd": round(wasted_usd, 6),
         }
-        if gap_seconds is not None and gap_seconds >= 0:
-            result["cacheGapSeconds"] = int(gap_seconds)
+        # `cacheGapSeconds` keeps its original meaning — seconds since the
+        # previous call — because the anatomy page and its consumers read it as
+        # a plain chronology. When the call that actually determined the verdict
+        # was a different, older one, `cachePrefixGapSeconds` records that gap
+        # too, so a status that looks inconsistent with the visible gap explains
+        # itself instead of reading as a bug.
+        if prev_gap_seconds is not None and prev_gap_seconds >= 0:
+            result["cacheGapSeconds"] = int(prev_gap_seconds)
+        if (
+            classify_gap is not None
+            and classify_gap >= 0
+            and classify_gap != prev_gap_seconds
+        ):
+            result["cachePrefixGapSeconds"] = int(classify_gap)
 
         if status is CacheStatus.MISS_AVOIDABLE:
             logger.warning(
-                "🔥 Avoidable prompt-cache miss: session=%s gap=%ss cacheWrite=%d wasted=$%.6f",
-                session_id, result.get("cacheGapSeconds"), cache_write, wasted_usd,
+                "🔥 Avoidable prompt-cache miss: session=%s gap=%ss prefix_gap=%ss "
+                "cacheWrite=%d wasted=$%.6f",
+                session_id, result.get("cacheGapSeconds"),
+                result.get("cachePrefixGapSeconds", result.get("cacheGapSeconds")),
+                cache_write, wasted_usd,
             )
         return result
 

--- a/backend/tests/shared/test_metadata_cache_derivation.py
+++ b/backend/tests/shared/test_metadata_cache_derivation.py
@@ -20,7 +20,7 @@ from apis.shared.sessions.models import (
 NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricing=True):
+def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricing=True, prints=None):
     pricing = None
     if with_pricing:
         pricing = PricingSnapshot(
@@ -30,7 +30,14 @@ def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricin
             cache_read_price_per_mtok=0.30,
             snapshot_at=NOW.isoformat(),
         )
+    extra = {}
+    if prints is not None:
+        extra["prefixFingerprints"] = {
+            "toolConfigHash": prints[0],
+            "systemPromptHash": prints[1],
+        }
     return MessageMetadata(
+        **extra,
         token_usage=TokenUsage(
             input_tokens=input_t,
             output_tokens=output_t,
@@ -63,15 +70,22 @@ class _FakeTable:
         return {}
 
 
-def _prev_row(seconds_ago, cache_read=0, cache_write=0):
+def _prev_row(seconds_ago, cache_read=0, cache_write=0, prints=None):
+    """A prior cost row. ``prints`` is (toolConfigHash, systemPromptHash)."""
     ts = (NOW - timedelta(seconds=seconds_ago)).isoformat()
-    return {
+    row = {
         "timestamp": ts,
         "tokenUsage": {
             "cacheReadInputTokens": Decimal(cache_read),
             "cacheWriteInputTokens": Decimal(cache_write),
         },
     }
+    if prints is not None:
+        row["prefixFingerprints"] = {
+            "toolConfigHash": prints[0],
+            "systemPromptHash": prints[1],
+        }
+    return row
 
 
 class TestDeriveCacheObservability:
@@ -132,12 +146,93 @@ class TestDeriveCacheObservability:
         assert result["wastedUsd"] == 0.0
         assert result["cacheGapSeconds"] == 30
 
-    def test_query_targets_previous_row_descending_limit_1(self):
+    def test_query_reads_a_descending_window_of_recent_rows(self):
+        """Newest-first, and wide enough to see past an interleaved mention turn.
+
+        Was ``Limit=1`` until #753: the predecessor that decides the TTL question
+        is the last call with the *same prefix*, which is not always the last
+        call, so one row is not enough to answer it.
+        """
         table = _FakeTable()
         self._derive(table, _metadata(cache_write=100))
         assert table.query_kwargs["IndexName"] == "SessionLookupIndex"
         assert table.query_kwargs["ScanIndexForward"] is False
-        assert table.query_kwargs["Limit"] == 1
+        assert table.query_kwargs["Limit"] == md._CACHE_PREDECESSOR_LOOKBACK
+        assert md._CACHE_PREDECESSOR_LOOKBACK > 1
+
+    # --- #753: the TTL clock runs from the same-prefix predecessor ---------
+
+    def test_interleaved_prefix_does_not_report_a_ttl_expiry_as_avoidable(self):
+        """The bug: an `@`-mention between two plain turns hid the real expiry.
+
+        Reproduces the measured dev case. The plain turn's own prefix was last
+        written 320s ago (expired); a mention ran 100s ago under a *different*
+        prefix. Classifying against "the previous call" saw 100s, called it
+        avoidable, and booked real dollars of waste that nothing could have
+        avoided.
+        """
+        table = _FakeTable([
+            _prev_row(seconds_ago=100, cache_write=4000, prints=("agentcfg", "agentsys")),
+            _prev_row(seconds_ago=320, cache_read=3000, cache_write=1000, prints=("basecfg", "basesys")),
+        ])
+        result = self._derive(
+            table, _metadata(cache_write=6000, prints=("basecfg", "basesys"))
+        )
+        assert result["cacheStatus"] == "miss_ttl_expired"
+        assert result["wastedUsd"] == 0.0
+        # The chronology stays honest: 100s since the previous call, but the
+        # entry that decided the verdict was 320s old.
+        assert result["cacheGapSeconds"] == 100
+        assert result["cachePrefixGapSeconds"] == 320
+
+    def test_same_prefix_within_ttl_is_still_avoidable(self):
+        """The fix must not suppress the bug class the metric exists for."""
+        table = _FakeTable([
+            _prev_row(seconds_ago=30, cache_write=4000, prints=("agentcfg", "agentsys")),
+            _prev_row(seconds_ago=60, cache_read=4000, cache_write=1000, prints=("basecfg", "basesys")),
+        ])
+        result = self._derive(
+            table, _metadata(cache_write=6000, prints=("basecfg", "basesys"))
+        )
+        assert result["cacheStatus"] == "miss_avoidable"
+        assert result["wastedUsd"] == round((5000 / 1_000_000) * 3.45, 6)
+        assert result["cachePrefixGapSeconds"] == 60
+
+    def test_no_same_prefix_predecessor_in_window_classifies_conservatively(self):
+        """An unseen predecessor is treated as expired, never as avoidable.
+
+        Under-reporting waste keeps the metric trustworthy; crying wolf is what
+        made it useless.
+        """
+        table = _FakeTable([
+            _prev_row(seconds_ago=10, cache_write=4000, prints=("othercfg", "othersys")),
+        ])
+        result = self._derive(
+            table, _metadata(cache_write=6000, prints=("basecfg", "basesys"))
+        )
+        assert result["cacheStatus"] == "miss_ttl_expired"
+        assert result["wastedUsd"] == 0.0
+
+    def test_prefix_gap_omitted_when_it_equals_the_previous_call_gap(self):
+        """No redundant field on the common path — same prefix, adjacent calls."""
+        table = _FakeTable([
+            _prev_row(seconds_ago=45, cache_read=4000, cache_write=1000, prints=("basecfg", "basesys")),
+        ])
+        result = self._derive(
+            table, _metadata(cache_write=6000, prints=("basecfg", "basesys"))
+        )
+        assert result["cacheStatus"] == "miss_avoidable"
+        assert result["cacheGapSeconds"] == 45
+        assert "cachePrefixGapSeconds" not in result
+
+    def test_calls_without_fingerprints_fall_back_to_previous_call(self):
+        """Hook disabled or a non-Bedrock provider: behave exactly as before #753."""
+        table = _FakeTable([
+            _prev_row(seconds_ago=60, cache_read=4000, cache_write=1000, prints=("basecfg", "basesys")),
+        ])
+        result = self._derive(table, _metadata(cache_write=6000))  # no prints
+        assert result["cacheStatus"] == "miss_avoidable"
+        assert result["cacheGapSeconds"] == 60
 
     def test_failure_returns_empty_never_raises(self):
         class _Boom:

--- a/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
+++ b/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
@@ -126,6 +126,14 @@ export interface SessionCallRow {
   cost: number;
   cacheStatus?: CacheStatus | null;
   cacheGapSeconds?: number | null;
+  /**
+   * Seconds since the last call with the SAME prefix, present only when that
+   * was an older call than the immediately previous one. Absent means the two
+   * coincide; present explains a status that would otherwise look inconsistent
+   * with `cacheGapSeconds` — e.g. a `miss_ttl_expired` sitting next to a short
+   * gap, because an `@`-mention ran in between under a different prefix.
+   */
+  cachePrefixGapSeconds?: number | null;
   wastedUsd: number;
   prefixFingerprints?: PrefixFingerprints | null;
 }

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
@@ -234,6 +234,17 @@ import {
                     </td>
                     <td class="whitespace-nowrap px-3 py-2 text-right tabular-nums">
                       {{ formatGap(row.call.cacheGapSeconds) }}
+                      @if (row.call.cachePrefixGapSeconds; as prefixGap) {
+                        <!-- The gap that decided the verdict, when a call with a
+                             different prefix ran in between (e.g. an @-mention).
+                             Without it, a miss_ttl_expired beside a short gap
+                             reads as a bug rather than as the correct answer. -->
+                        <span
+                          class="ml-1 text-xs text-gray-500 dark:text-gray-400"
+                          [title]="'Last call with the same prefix was ' + formatGap(prefixGap) + ' ago — that is the entry this call could have hit'"
+                          >({{ formatGap(prefixGap) }})</span
+                        >
+                      }
                     </td>
                     <td
                       class="whitespace-nowrap px-3 py-2 text-right tabular-nums"


### PR DESCRIPTION
Fixes #753.

## The bug

`classify_cache_status` decided `miss_avoidable` vs `miss_ttl_expired` from the gap to the **immediately-previous call row**. That is the wrong clock as soon as two prefixes interleave in one session — which is exactly what an `@`-mention does. The entry a call could have *hit* belongs to the last call with the **same prefix**, and that is not always the last call.

Measured on dev during the #741 verification:

| # | turn | time | status | gap | toolCfgHash |
|---|---|---|---|---|---|
| 2 | plain | 22:29:34 | `hit` | 27 | `4f53cda1` |
| 3 | mention | 22:30:16 | `miss_avoidable` | 41 | `98890bac` |
| 4 | plain | 22:34:42 | **`miss_avoidable`** | **266** | `4f53cda1` |

Row 4's gap of 266s is against row 3 — the *mention*, a different prefix. The entry it actually needed was row 2's, **308 seconds** earlier and already expired. The re-write was unavoidable, and $0.006256 was booked into `wastedUsd`.

Three of six rows in that trivial session were `miss_avoidable`; none were the nondeterministic-prefix bug the metric exists to catch. That ratio gets worse as mentions get used.

## The fix

The fingerprints needed to answer this correctly were **already on the row**. The lookup now reads a small window of recent rows rather than one, and classifies against the newest row sharing this call's `toolConfigHash` + `systemPromptHash`. No new data, no migration — just a wider read of rows already indexed.

Three behaviours worth reviewing specifically:

- **No same-prefix predecessor in the window → `miss_ttl_expired`, not `miss_avoidable`.** Deliberately the conservative direction. Under-reporting waste keeps the metric trustworthy; crying wolf is what made it useless. Widening `_CACHE_PREDECESSOR_LOOKBACK` can therefore only ever recover under-reported waste, never manufacture it.
- **Calls without fingerprints fall back to the previous call**, exactly as before, so nothing regresses where the fix cannot apply (hook disabled, non-Bedrock provider). Every pre-existing test in the file still passes unchanged, which is the evidence for that.
- **`previous_cached_prefix_tokens` still comes from the previous call when there is no match**, so the below-threshold `first_write` guard keeps working.

## The new field

`cacheGapSeconds` keeps its original meaning — plain chronology, which existing consumers read. `cachePrefixGapSeconds` is added **only when the deciding call was an older one**, so its absence means the two coincide.

Without it the anatomy page would show `miss_ttl_expired` next to a 266s gap and read as a bug. Surfaced through the admin costs API and rendered as a muted `(5m 20s)` beside the gap, with a tooltip explaining which entry it refers to.

## Tests

Five new, over the interleaved-prefix case:

- the measured dev scenario no longer reports an expiry as avoidable, and records both gaps
- **a same-prefix predecessor inside the TTL is still `miss_avoidable`** — the fix must not suppress the bug class the metric is for
- no predecessor in the window classifies conservatively
- the redundant field is omitted on the common path
- calls without fingerprints fall back to previous-call behaviour

Backend **5235 passed**, 3 skipped. Frontend **1565 passed** (137 files), `tsc --noEmit` clean.

## Not the same as the mention dimension

Still open on #741: turns classified **correctly** — a mention genuinely does change the prefix — that are nonetheless deliberate and want a dimension saying so. This PR fixes turns classified **incorrectly**. Fixing one does not fix the other.

## Deploy

`backend.yml` (app-api + inference-api) + `frontend-deploy.yml`. No CDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)