### PR TITLE
feat(marketplace): GA the Agent store — the nav gate was the only closed door

### DIFF
--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -105,8 +105,11 @@ def agents_enabled() -> bool:
     Designer UI → binding reflection); now complete, it defaults on.
 
     Gates *feature existence* per environment; *who* may use a specific agent is the
-    identity-based access check already enforced by the assistant service, and the SPA
-    nav is separately preview-gated (system-admin) until Assistants are deprecated.
+    identity-based access check already enforced by the assistant service. This flag is
+    now the **only** control on the surface: the SPA nav was preview-gated to system
+    admins until the marketplace went GA, and that condition came off with D14 (the nav
+    entry is gated on this flag alone). See ``agent_marketplace_enabled`` for why there
+    is no RBAC capability on this axis.
     """
     return os.environ.get("AGENTS_API_ENABLED", "").strip().lower() != "false"
 
@@ -124,13 +127,19 @@ def agent_marketplace_enabled() -> bool:
     App-api only. The marketplace adds no inference-api routes — publication is a
     catalog concern, and the inference API stays inference-only.
 
-    NOTE on the spec's D14: it also calls for an ``agent-marketplace`` RBAC *capability*
-    that 404s the routes for ungranted roles, "mirroring the ``skills`` gate from Skills
-    v2 PR-5". That gate no longer exists — it was removed because a capability id cannot
-    be granted from the admin roles UI (see ``skills_enabled`` above and
-    ``AppRoleService.resolve_user_permissions``), so copying it would ship a gate nobody
-    can open. Phase 1 is admin routes plus two author routes with no user-facing surface,
-    which ``require_admin`` and the per-agent ownership checks already cover. Revisit when
-    Phase 2 makes Discover user-visible and a real "who sees the store" control is needed.
+    **This flag is the only lever, and the store is GA.** D14 originally paired it with an
+    ``agent-marketplace`` RBAC *capability* that would 404 the routes for ungranted roles,
+    "mirroring the ``skills`` gate from Skills v2 PR-5". That gate no longer exists — it was
+    removed because a capability id cannot be granted from the admin roles UI (see
+    ``skills_enabled`` above and ``AppRoleService.resolve_user_permissions``), so copying it
+    would ship a gate nobody can open. D14 has since been revised to drop the capability
+    outright rather than defer it: per-role rollout of a feature *surface* needs a grantable
+    axis this codebase does not have, and inventing one is not in this epic's scope.
+
+    The interim state it left behind was worse than either end state. One template condition
+    (``@if (showAgents() && isAdmin())``) hid the nav entry while ``/agents/discover``,
+    ``/agents/{id}``, the composer ``@``-mention menu and role-seeded pins were all reachable
+    by any authenticated user — the only closed door was the one we controlled. The nav gate
+    is now this flag alone.
     """
     return os.environ.get("AGENT_MARKETPLACE_ENABLED", "").strip().lower() != "false"

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -299,12 +299,34 @@ would silently break an Agent its author still maintains.
 Admin edits to presentation are **recorded and shown to the author** on their My Agents card ("An
 admin updated the category on Jul 24"). Editing someone's listing quietly is how you lose authors.
 
-## D14 — Ship gated, GA by grant
+## D14 — Ship gated, GA by kill switch
 
-House pattern: kill switch `AGENT_MARKETPLACE_ENABLED` (**default on**, `=false` disables — per the
-feature-flag convention) plus an RBAC capability `agent-marketplace` that 404s the routes for
-ungranted roles, mirroring the `skills` gate from Skills v2 PR-5. Note D9's `default`-role trap
-applies here too: granting the capability to `default` does **not** reach everyone.
+**REVISED.** The kill switch `AGENT_MARKETPLACE_ENABLED` (**default on**, `=false` disables — per
+the feature-flag convention) is the **only** lever. There is no `agent-marketplace` RBAC capability,
+and the sidenav entry is gated on the API surface alone (`showAgents()`), not on `isAdmin()`.
+
+This decision originally called for the kill switch *plus* an RBAC capability that 404s the routes
+for ungranted roles, "mirroring the `skills` gate from Skills v2 PR-5". Two things were wrong with
+that:
+
+**The capability axis does not work.** The admin roles UI builds its `grantedTools` control from the
+tool catalog with no free-text entry, so a feature-capability id cannot be granted from the UI at
+all — only by hand-writing DynamoDB items. That is precisely why the `skills` gate was removed and
+why `scheduled-runs` 403'd in prod and was dropped (see `AppRoleService.resolve_user_permissions`).
+Building it a third time ships a gate nobody can open. Per-role rollout of a *feature surface* needs
+a grantable capability axis that does not exist yet; it is not in this epic's scope.
+
+**"Gated" was not true anyway.** Until this revision the de-facto gate was one template condition,
+`@if (showAgents() && isAdmin())`, on the nav entry. `/agents/discover`, `/agents/:id` and
+`/agents/pinned` carried `authGuard` only, the composer `@`-menu had no admin check at all, and a
+role-seeded pin (D9) pushed Agents into a member's **Pinned** tab unprompted — working as designed.
+The marketplace was reachable by any authenticated user through three doors while hidden behind the
+one door we controlled. Half-revealed is worse than either end state: nobody could answer "who can
+see this?" without reading four files, and the honest answer was "more people than the nav suggests".
+
+So the store is GA. D9's `default`-role trap still applies to everything that *is* role-scoped here
+(seeded pins): granting to `default` does **not** reach everyone, because that role is consulted
+only when a user matches zero AppRoles.
 
 ---
 

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -46,8 +46,23 @@
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
         </a>
 
-        <!-- Agents (Agent Designer — preview: system-admin only, plus the accessibility probe) -->
-        @if (showAgents() && isAdmin()) {
+        <!--
+            Agents (Agent Designer + Marketplace).
+
+            Gated on the API surface alone (D14): `showAgents()` is "the /agents list call did
+            not 404", i.e. the AGENTS_API_ENABLED / AGENT_MARKETPLACE_ENABLED kill switches.
+            The former `&& isAdmin()` came off when the marketplace went GA — it hid the nav
+            entry while `/agents/discover`, `/agents/:id`, the composer `@`-menu and
+            role-seeded pins were all reachable by any authenticated user, so the one entry
+            point we controlled was the only one that was closed. There is deliberately no
+            RBAC capability behind this: a capability id cannot be granted from the admin
+            roles UI (see `AppRoleService.resolve_user_permissions`), which is what made the
+            `skills` and `scheduled-runs` gates inoperable.
+
+            The Preview badge stays until Assistant deprecation (#746) lands — until then the
+            sidenav ships both nouns, and the badge is what says which one is still moving.
+        -->
+        @if (showAgents()) {
             <a
                 routerLink="/agents"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { signal } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideLocationMocks } from '@angular/common/testing';
+import { Router, provideRouter } from '@angular/router';
+import { Component, input, output, signal } from '@angular/core';
 import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
@@ -146,5 +147,114 @@ describe('Sidenav', () => {
 
     mockAgentService.accessible$.set(true);
     expect(component.showAgents()).toBe(true);
+  });
+});
+
+/**
+ * Template-level gating (marketplace D14).
+ *
+ * These render the real template rather than reading the computed, because the bug they
+ * guard against lives *only* in the template: `showAgents()` was already true for every
+ * user while `@if (showAgents() && isAdmin())` hid the entry anyway. A spec that asserts
+ * the computed passes against both the gated and the GA'd code, so it proves nothing.
+ *
+ * The child components are stubbed — this is a spec about one `@if`, and pulling
+ * `SessionList` / `UserDropdownComponent` in would drag their dependency graphs with them.
+ */
+describe('Sidenav — Agents nav entry gating (D14)', () => {
+  @Component({ selector: 'app-session-list', template: '' })
+  class SessionListStub {}
+
+  @Component({ selector: 'app-user-dropdown', template: '' })
+  class UserDropdownStub {
+    readonly user = input<unknown>();
+    readonly isAdmin = input<boolean>(false);
+    readonly logout = output<void>();
+  }
+
+  let mockUserService: any;
+  let mockAgentService: any;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockUserService = {
+      hasAnyRole: vi.fn().mockReturnValue(false),
+      currentUser: signal({ user_id: 'u1', email: 'u1@example.com' }),
+      isAdmin: signal(false),
+    };
+    mockAgentService = {
+      accessible$: signal<boolean | null>(true),
+      loadAgents: vi.fn().mockResolvedValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        provideLocationMocks(),
+        {
+          provide: SessionService,
+          useValue: {
+            currentSession: signal({ sessionId: 's1', userId: 'u1', title: 'T', status: 'active' as const, createdAt: '', lastMessageAt: '', messageCount: 0 }),
+            hasCurrentSession: signal(true),
+          },
+        },
+        { provide: BffSessionService, useValue: { logout: vi.fn() } },
+        {
+          provide: SidenavService,
+          useValue: { isCollapsed: signal(false), close: vi.fn(), toggleCollapsed: vi.fn() },
+        },
+        { provide: UserService, useValue: mockUserService },
+        {
+          provide: MemorySpaceService,
+          useValue: { accessible$: signal<boolean | null>(false), loadSpaces: vi.fn().mockResolvedValue(undefined) },
+        },
+        { provide: AgentService, useValue: mockAgentService },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function renderSidenav() {
+    const { Sidenav } = await import('./sidenav');
+    const { SessionList } = await import('./components/session-list/session-list');
+    const { UserDropdownComponent } = await import('../topnav/components/user-dropdown.component');
+
+    TestBed.overrideComponent(Sidenav, {
+      remove: { imports: [SessionList, UserDropdownComponent] },
+      add: { imports: [SessionListStub, UserDropdownStub] },
+    });
+
+    const fixture = TestBed.createComponent(Sidenav);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function agentsNavLink(fixture: ComponentFixture<unknown>): HTMLAnchorElement | undefined {
+    const anchors = fixture.nativeElement.querySelectorAll('a[href="/agents"]');
+    return anchors.length ? (anchors[0] as HTMLAnchorElement) : undefined;
+  }
+
+  it('renders the Agents nav entry for a NON-admin once the surface is reachable', async () => {
+    mockUserService.isAdmin.set(false);
+    const fixture = await renderSidenav();
+
+    // Fails against the pre-GA `@if (showAgents() && isAdmin())`.
+    expect(agentsNavLink(fixture)).toBeDefined();
+    expect(agentsNavLink(fixture)!.textContent).toContain('Agents');
+  });
+
+  it('renders the Agents nav entry for an admin', async () => {
+    mockUserService.isAdmin.set(true);
+    const fixture = await renderSidenav();
+    expect(agentsNavLink(fixture)).toBeDefined();
+  });
+
+  it('still hides the Agents nav entry when the surface 404s, regardless of role', async () => {
+    mockAgentService.accessible$.set(false);
+    const fixture = await renderSidenav();
+    expect(agentsNavLink(fixture)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #745.

## The decision

D14 called for the kill switch `AGENT_MARKETPLACE_ENABLED` **plus** an `agent-marketplace` RBAC capability that 404s the routes for ungranted roles, "mirroring the `skills` gate from Skills v2 PR-5". This PR revises D14 to drop the capability outright rather than defer it, and GAs the store.

**The capability axis does not work.** The admin roles UI builds its `grantedTools` control from the tool catalog with no free-text entry, so a feature-capability id cannot be granted from the UI at all — only by hand-writing DynamoDB items. That is why the `skills` gate was removed and why `scheduled-runs` 403'd in prod and was dropped (see `AppRoleService.resolve_user_permissions`). Building it a third time ships a gate nobody can open. Per-role rollout of a feature *surface* needs a grantable axis this codebase does not have, and inventing one is not in this epic's scope.

**"Gated" was not true anyway.** The de-facto gate was one template condition on the nav entry:

| Door | Gate before this PR |
|---|---|
| Sidenav entry | `showAgents() && isAdmin()` — the only real gate |
| `/agents/discover`, `/agents/:id`, `/agents/pinned` | `authGuard` only |
| Composer `@`-mention menu | none — `showAgentMentions` defaults `true` |
| Role-seeded pins (D9) | none — working as designed |

The store was reachable by any authenticated user through three doors while hidden behind the one we controlled. Half-revealed is worse than either end state: nobody could answer "who can see this?" without reading four files, and the honest answer was "more people than the nav suggests".

## Changes

- `sidenav.html` — `@if (showAgents() && isAdmin())` → `@if (showAgents())`
- `agent-marketplace.md` — D14 rewritten to record the revision and its reasoning
- `feature_flags.py` — `agents_enabled` claimed the nav was "separately preview-gated (system-admin)", now false; the `agent_marketplace_enabled` D14 note said "revisit when Phase 2 makes Discover user-visible", and Phase 2 has shipped, so it is resolved rather than pending
- `sidenav.spec.ts` — 3 regression specs

**The amber Preview badge stays.** Until Assistant deprecation (#746) lands the sidenav ships both nouns, and the badge is what says which one is still moving.

## Testing

The regression specs render the real template rather than reading `showAgents()`. The bug lived **only** in the `@if` — `showAgents()` was already `true` for every user — so a spec asserting the computed passes against both the gated and the GA'd code and proves nothing. Verified by restoring the old condition: exactly one test failed (`expected undefined to be defined`), and only that one.

- SPA: 137 files / 1568 tests pass
- Backend: 23 related tests pass (`-k "feature_flag or marketplace"`)

⚠️ Unrelated: the SPA suite has a **pre-existing nondeterministic flake** — each run fails exactly one randomly-chosen spec file (observed `agent-form`, `agent-detail`, `session.service`), reproduced twice on a clean `develop` tree with no local changes. Not introduced here; being tracked separately. If CI shows a single unrelated red file, re-run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)