### PR TITLE
feat(marketplace): mark published Agents whose behavior changed after approval

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -163,6 +163,13 @@ def _agent_response(assistant, *, permission: Optional[str] = None,
         # Dropped rather than blanked: every route here serves the model with
         # ``response_model_exclude_none``, so the key is simply absent for a viewer.
         view.pop("instructions", None)
+        # The drift baseline (#744) is a hash *of* the instructions, so it rides the same
+        # gate. On its own it is not reversible, but it would confirm a guessed prompt for
+        # anyone who could produce one — which is exactly what dropping ``instructions``
+        # above exists to prevent. Admins read it through the admin listings projection,
+        # never through here.
+        if isinstance(view.get("listing"), dict):
+            view["listing"].pop("approvedInstructionsHash", None)
     if permission is not None:
         view["userPermission"] = permission
     if is_shared_with_me is not None:

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -24,6 +24,7 @@ Three rules are enforced here and nowhere else:
 the rest. Publisher is a name on a shelf.
 """
 
+import hashlib
 import logging
 import os
 from datetime import datetime, timezone
@@ -364,16 +365,21 @@ async def review_listing(
             raise ListingError(f"Unknown publisher '{publisher_id}'.", status_code=400)
 
     now = _now()
-    listing = assistant.listing.model_copy(
-        update={
-            "state": target,
-            "category": category or assistant.listing.category,
-            "publisher_id": publisher_id or assistant.listing.publisher_id,
-            "reviewed_at": now,
-            "reviewed_by": admin.user_id,
-            "review_note": note or None,
-        }
-    )
+    changes = {
+        "state": target,
+        "category": category or assistant.listing.category,
+        "publisher_id": publisher_id or assistant.listing.publisher_id,
+        "reviewed_at": now,
+        "reviewed_by": admin.user_id,
+        "review_note": note or None,
+    }
+    # Approval — and only approval — establishes the behavior baseline the drift marker
+    # compares against (#744). ``request_changes`` deliberately leaves any existing hash
+    # alone: it does not publish anything, so it has no baseline to set, and clearing the
+    # previous one would blind the marker on a listing that is still live in the store.
+    if target == "published":
+        changes["approved_instructions_hash"] = _instructions_hash(assistant)
+    listing = assistant.listing.model_copy(update=changes)
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
     logger.info(f"⚖️ Agent {agent_id} review by {admin.user_id}: {decision} → {target}")
     return listing
@@ -492,6 +498,50 @@ async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminLi
     return rows, pending
 
 
+def _instructions_hash(assistant: Assistant) -> str:
+    """SHA-256 of an Agent's instructions — the drift marker's behavior baseline (#744).
+
+    Hashed rather than stored verbatim: the listing block is read on every admin table
+    load, and instructions run to thousands of tokens. We only ever need to answer "same
+    or not", never "what changed" — a diff view would read the live record anyway.
+    """
+    return hashlib.sha256((assistant.instructions or "").encode("utf-8")).hexdigest()
+
+
+def _drift(assistant: Assistant, listing: AgentListing) -> Optional[str]:
+    """Whether a published listing has drifted from what the reviewer approved (#744).
+
+    D2 deliberately does not re-review edits, and there is no versioning — an approved
+    author may rewrite instructions and the new behavior is live immediately. That is
+    defensible for an Agent someone *chose* to pin; it reads differently once an admin has
+    **locked** it into a role's sidebar (D9), because then the affected user cannot opt out
+    either. This marker does not add a gate; it gives the curator a reason to look.
+
+    Only ``published`` listings can drift. A draft or an in-review submission has no
+    approved state to differ from, and a taken-down one is already off the shelf.
+
+    ⚠️ **The timestamp fallback is deliberately the weaker claim.** ``updated_at`` bumps on
+    *every* write to the record, including an admin's own D13 presentation edit (which does
+    not touch ``reviewed_at``) and a harmless author rename. Reporting that as "behavior
+    changed" would have admins chasing their own typo fixes. It is reported as ``edited``
+    and must render as the softer signal. Listings approved since the hash shipped never
+    reach the fallback — ``review_listing`` writes the baseline on the way in.
+    """
+    if listing.state != "published":
+        return None
+
+    if listing.approved_instructions_hash:
+        return "instructions" if _instructions_hash(assistant) != listing.approved_instructions_hash else None
+
+    # Legacy listing, approved before the baseline existed. ``review_listing`` writes
+    # ``updated_at`` from the same ``now`` as ``reviewed_at``, so a freshly approved record
+    # compares equal and only a later write can exceed it. Both are ISO 8601 UTC, so the
+    # string comparison is chronological.
+    if listing.reviewed_at and assistant.updated_at > listing.reviewed_at:
+        return "edited"
+    return None
+
+
 def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> AdminListingRow:
     listing = assistant.listing
     if listing is None:  # callers filter; belt-and-braces rather than a stripped assert
@@ -512,5 +562,6 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         reviewed_at=listing.reviewed_at,
         review_note=listing.review_note,
         updated_at=assistant.updated_at,
+        drift=_drift(assistant, listing),
         admin_edits=listing.admin_edits,
     )

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -25,6 +25,19 @@ ReportReason = Literal["inaccurate", "broken", "inappropriate", "other"]
 # warrants delisting, the admin takes the Agent down and that is a separate recorded act.
 ReportState = Literal["open", "resolved", "dismissed"]
 
+# How much a published listing has drifted from what the reviewer approved. Absent (``None``)
+# means no drift detected, or the question does not apply because the listing is not published.
+#
+# **The two values are not the same claim, and the UI must not merge them.**
+# ``instructions`` is *measured*: the Agent's instructions hash differs from the one recorded
+# at approval, so behavior definitely changed. ``edited`` is *inferred*: the record was written
+# after the review timestamp, but we do not know what changed — it could be a rename, or an
+# admin's own D13 presentation edit, both harmless. Only listings approved before the hash
+# baseline shipped can report ``edited``; everything approved since resolves to ``instructions``
+# or nothing. Rendering the weak signal with the strong one's urgency is how a governance
+# marker gets learned-ignored.
+ListingDrift = Literal["instructions", "edited"]
+
 # Severity order for the queue sweep (D15). ``inappropriate`` first for the reason above.
 REPORT_REASON_SEVERITY: Dict[str, int] = {
     "inappropriate": 0,
@@ -116,6 +129,15 @@ class AgentListing(BaseModel):
         None,
         alias="reviewNote",
         description="Reviewer's reason; rendered on the author's own card so they never have to ask",
+    )
+    approved_instructions_hash: Optional[str] = Field(
+        None,
+        alias="approvedInstructionsHash",
+        description=(
+            "SHA-256 of the Agent's instructions as they read at approval — the baseline for "
+            "the post-approval drift marker. Absent on listings approved before the marker "
+            "shipped, which is why the read side falls back to a timestamp comparison."
+        ),
     )
     admin_edits: List[AdminEdit] = Field(
         default_factory=list, alias="adminEdits", description="Append-only log of admin presentation edits (D13)"
@@ -629,6 +651,14 @@ class AdminListingRow(BaseModel):
     reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
     review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
     updated_at: str = Field(..., alias="updatedAt", description="Audit trail for post-approval drift (D2)")
+    drift: Optional[ListingDrift] = Field(
+        None,
+        description=(
+            "Post-approval drift, derived server-side (see ``ListingDrift``): ``instructions`` "
+            "= measured behavior change, ``edited`` = record changed but cause unknown, absent "
+            "= no drift or not applicable. Derived rather than stored so it can never go stale."
+        ),
+    )
     admin_edits: List[AdminEdit] = Field(default_factory=list, alias="adminEdits", description="Admin edit log (D13)")
 
 

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -414,3 +414,148 @@ class TestAdminTables:
         assert [c["id"] for c in categories][0] == "Administration"
         # Ids double as the GSI5 partition suffix, so they must survive as written.
         assert all(c["id"] == c["label"] for c in categories)
+
+
+# ── #744 — post-approval drift ───────────────────────────────────────────────────────
+def _hash(instructions: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(instructions.encode("utf-8")).hexdigest()
+
+
+def _listing_rows(assistant):
+    """Patch the admin table read to return exactly this one agent."""
+    rows = [{"PK": "AST#ast-001", **assistant.model_dump(by_alias=True, exclude_none=True)}]
+    return (
+        patch(f"{SERVICE_MODULE}.list_by_state", new_callable=AsyncMock, return_value=rows),
+        patch(f"{SERVICE_MODULE}.list_publishers", new_callable=AsyncMock, return_value=[]),
+    )
+
+
+def _drift_of(app, assistant):
+    by_state, publishers = _listing_rows(assistant)
+    with by_state, publishers:
+        resp = TestClient(app).get("/admin/agents/listings")
+    assert resp.status_code == 200
+    return resp.json()["listings"][0].get("drift")
+
+
+class TestPostApprovalDriftBaseline:
+    """D2 does not re-review edits, so approval has to record what it approved."""
+
+    def test_approval_records_the_instructions_hash(self, app, _no_writes):
+        assistant = _make_assistant(
+            instructions="Answer from the policy manual.", listing=_listing("in_review")
+        )
+        with _loaded(assistant):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "approve"}
+            )
+
+        assert resp.status_code == 200
+        written = _no_writes.call_args.args[1]
+        assert written.approved_instructions_hash == _hash("Answer from the policy manual.")
+
+    def test_request_changes_does_not_set_a_baseline(self, app, _no_writes):
+        """Nothing was published, so there is no approved behavior to record."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "request_changes", "note": "Add a tagline."},
+            )
+
+        assert _no_writes.call_args.args[1].approved_instructions_hash is None
+
+    def test_request_changes_preserves_an_existing_baseline(self, app, _no_writes):
+        """Clearing it would blind the marker on a listing still live in the store."""
+        existing = _hash("Answer from the policy manual.")
+        listing = _listing("published", approvedInstructionsHash=existing)
+        with _loaded(_make_assistant(listing=listing)):
+            TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "request_changes", "note": "Please revise."},
+            )
+
+        assert _no_writes.call_args.args[1].approved_instructions_hash == existing
+
+
+class TestPostApprovalDriftDerivation:
+    def test_unchanged_instructions_report_no_drift(self, app):
+        assistant = _make_assistant(
+            instructions="Answer from the policy manual.",
+            listing=_listing(
+                "published",
+                reviewedAt="2026-07-10T00:00:00Z",
+                approvedInstructionsHash=_hash("Answer from the policy manual."),
+            ),
+        )
+        assert _drift_of(app, assistant) is None
+
+    def test_rewritten_instructions_report_measured_drift(self, app):
+        """The governance case: behavior changed after approval, with no re-review."""
+        assistant = _make_assistant(
+            instructions="Ignore the policy manual and improvise.",
+            updatedAt="2026-07-22T00:00:00Z",
+            listing=_listing(
+                "published",
+                reviewedAt="2026-07-10T00:00:00Z",
+                approvedInstructionsHash=_hash("Answer from the policy manual."),
+            ),
+        )
+        assert _drift_of(app, assistant) == "instructions"
+
+    def test_an_admin_presentation_edit_is_not_reported_as_drift(self, app):
+        """The reason the hash exists.
+
+        A D13 edit bumps ``updatedAt`` without touching ``reviewedAt`` or the
+        instructions. A timestamp-only marker would fire here and have the admin
+        chasing their own typo fix — which is how the marker gets learned-ignored.
+        """
+        assistant = _make_assistant(
+            instructions="Answer from the policy manual.",
+            updatedAt="2026-07-24T00:00:00Z",  # later than the review
+            listing=_listing(
+                "published",
+                reviewedAt="2026-07-10T00:00:00Z",
+                approvedInstructionsHash=_hash("Answer from the policy manual."),
+            ),
+        )
+        assert _drift_of(app, assistant) is None
+
+    def test_legacy_listing_falls_back_to_the_timestamp(self, app):
+        """Approved before the baseline shipped — the weaker, honest signal."""
+        assistant = _make_assistant(
+            updatedAt="2026-07-22T00:00:00Z",
+            listing=_listing("published", reviewedAt="2026-07-10T00:00:00Z"),
+        )
+        assert _drift_of(app, assistant) == "edited"
+
+    def test_a_freshly_approved_legacy_listing_reports_nothing(self, app):
+        """``review_listing`` writes ``updatedAt`` from the same clock as ``reviewedAt``,
+        so equal timestamps mean untouched — the fallback must not fire on every row."""
+        assistant = _make_assistant(
+            updatedAt="2026-07-10T00:00:00Z",
+            listing=_listing("published", reviewedAt="2026-07-10T00:00:00Z"),
+        )
+        assert _drift_of(app, assistant) is None
+
+    @pytest.mark.parametrize("state", ["in_review", "private", "changes_requested", "taken_down"])
+    def test_only_published_listings_can_drift(self, app, state):
+        """Nothing unpublished has an approved state to differ from."""
+        assistant = _make_assistant(
+            instructions="Totally different now.",
+            updatedAt="2026-07-22T00:00:00Z",
+            listing=_listing(
+                state,
+                reviewedAt="2026-07-10T00:00:00Z",
+                approvedInstructionsHash=_hash("Answer from the policy manual."),
+            ),
+        )
+        assert _drift_of(app, assistant) is None
+
+    def test_legacy_listing_never_reviewed_reports_nothing(self, app):
+        """No ``reviewedAt`` means nothing to compare against — not an alarm."""
+        assistant = _make_assistant(
+            updatedAt="2026-07-22T00:00:00Z", listing=_listing("published")
+        )
+        assert _drift_of(app, assistant) is None

--- a/backend/tests/routes/test_agent_detail.py
+++ b/backend/tests/routes/test_agent_detail.py
@@ -297,3 +297,51 @@ class TestRunnabilityRoute:
         mock_auth_user(app, make_user())
 
         assert self._call(app).status_code == 404
+
+
+# ── #744 — the drift baseline rides the instructions gate ────────────────────────────
+class TestApprovedInstructionsHashIsGated:
+    """A hash *of* the instructions is subject to the same gate as the instructions.
+
+    It is not reversible on its own, but it would confirm a guessed prompt for anyone who
+    could produce one — which is exactly what dropping ``instructions`` for a viewer
+    exists to prevent. Admins read the baseline through the admin listings projection.
+    """
+
+    def _published(self):
+        from apis.shared.assistants.models import AgentListing
+
+        listing = AgentListing.model_validate(
+            {
+                "state": "published",
+                "category": "Administration",
+                "publisherId": "pub-registrar",
+                "approvedInstructionsHash": "deadbeef",
+            }
+        )
+        return _make_assistant(listing=listing)
+
+    @pytest.mark.parametrize("permission", ["owner", "editor"])
+    def test_owner_and_editor_still_see_the_baseline(self, app, make_user, _flags_on, permission):
+        mock_auth_user(app, make_user())
+        body = _get_agent(app, permission, agent=self._published()).json()
+
+        assert body["listing"]["approvedInstructionsHash"] == "deadbeef"
+
+    def test_a_viewer_never_sees_the_baseline(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        body = _get_agent(app, "viewer", agent=self._published()).json()
+
+        # Guard premise: if this ever stops holding, the test below proves nothing.
+        assert "instructions" not in body
+        assert "approvedInstructionsHash" not in body["listing"]
+        # A gate, not a truncation — the rest of the listing is public shelf data.
+        assert body["listing"]["state"] == "published"
+        assert body["listing"]["category"] == "Administration"
+
+    def test_the_hash_appears_nowhere_in_a_viewers_payload(self, app, make_user, _flags_on):
+        """Guards the whole response, not one key — the same shape as the prompt guard."""
+        mock_auth_user(app, make_user())
+        resp = _get_agent(app, "viewer", agent=self._published())
+
+        assert "deadbeef" not in resp.text

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -82,8 +82,36 @@ pending count badges the admin nav so the work stays visible to the people who a
 
 **Review gates the listing, not subsequent edits.** An approved author can revise instructions
 freely afterward. Re-review on every edit would make iteration miserable; the accepted risk is that a
-listing can drift from what was approved. Mitigation is an audit trail (`updatedAt` surfaced in the
-admin listings table), not a gate. Revisit if it is ever abused.
+listing can drift from what was approved. Mitigation is visibility, not a gate.
+
+⚠️ **That risk got sharper when D9 added locked pins, and the mitigation had to get sharper with
+it.** "No re-review on edit" is entirely defensible for an Agent someone *chose* to pin. It reads
+differently once an admin has pinned it *for* them and removed the opt-out: the author rewrites the
+instructions, the new behavior is live immediately for every member of the role, and the affected
+user cannot even dismiss it. Each of these decisions was reasonable alone; none was evaluated against
+the others.
+
+So approval records a **SHA-256 of the instructions it approved** (`listing.approvedInstructionsHash`),
+and the admin Listings table marks any published listing whose current instructions no longer match.
+This is still not a gate — it is the curator's reason to look.
+
+The marker reports **two distinct claims and must never merge them**:
+
+| Value | Means | Basis |
+|---|---|---|
+| `instructions` | Behavior definitely changed after approval | Measured — hash mismatch |
+| `edited` | The record changed after review; cause unknown | Inferred — `updatedAt` > `reviewedAt` |
+
+The inferred value exists only for listings approved before the hash shipped — which is precisely the
+already-published, possibly-locked back catalogue this decision is about, so a hash-only marker would
+have been blind exactly where it mattered. It is deliberately the weaker signal: `updatedAt` bumps on
+every write, including an admin's own D13 presentation edit and a harmless author rename. Reporting
+those as "behavior changed" would have admins chasing their own typo fixes, and a governance marker
+that cries wolf is one that gets learned-ignored. Everything approved since resolves to `instructions`
+or to nothing.
+
+Still deliberately absent: versioning, changelogs, and re-queueing on edit. Revisit if the marker
+shows this is actually being abused rather than merely possible.
 
 ## D3 — `listing` is separate from `visibility`
 
@@ -771,6 +799,8 @@ rather than restating the checks.
 - **No popularity ranking.** Newest-first plus a curated front, honestly labeled.
 - **No cross-tenant or external publishing.** The store is institution-scoped.
 - **No agent versioning or changelogs.** A published Agent is a live pointer; updates are immediate.
+  This composes with "no re-review on edit" (D2) and locked pins (D9) into a real governance gap —
+  see D2 for the drift marker that closes most of it without building versioning.
 
 ## Resolved
 

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -26,6 +26,45 @@ export type { AdminEdit, ListingState };
 export { LISTING_STATE_CLASSES, LISTING_STATE_LABELS };
 
 /**
+ * How far a published listing has drifted from what the reviewer approved (#744).
+ *
+ * Unlike `ListingState` this is admin-only vocabulary — it answers a curator's question
+ * ("has this changed under me?"), not an author's, so it is defined here rather than in
+ * the shared store model.
+ *
+ * **These are two different claims and are styled differently on purpose.**
+ * `'instructions'` is measured: the instructions hash differs from the one recorded at
+ * approval, so behavior definitely changed — that is the governance signal D2's "no
+ * re-review on edit" non-goal leaves uncovered, and it is worth an admin's attention.
+ * `'edited'` is inferred from timestamps on listings approved before the hash baseline
+ * existed; the cause is unknown and is just as likely to be a rename or an admin's own
+ * D13 presentation edit. Rendering the weak one as urgently as the strong one is how the
+ * whole marker gets learned-ignored, so it stays visually quieter.
+ */
+export type ListingDrift = 'instructions' | 'edited';
+
+export const LISTING_DRIFT_LABELS: Record<ListingDrift, string> = {
+  instructions: 'Instructions changed',
+  edited: 'Edited since review',
+};
+
+export const LISTING_DRIFT_CLASSES: Record<ListingDrift, string> = {
+  instructions: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  edited: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+};
+
+/** The hover explanation for each marker — the label alone does not say what to do. */
+export const LISTING_DRIFT_TOOLTIPS: Record<ListingDrift, string> = {
+  instructions:
+    "This agent's instructions differ from the version that was approved. Its behavior " +
+    'has changed since review, and any locked role pins cannot be opted out of.',
+  edited:
+    'This listing was edited after it was reviewed, but it predates change tracking, so ' +
+    'we cannot tell whether its behavior changed. It may only be a rename or a ' +
+    'presentation fix.',
+};
+
+/**
  * The store-front row is the *same* shelf shape Discover renders, deliberately: an admin
  * curating the featured row should be looking at exactly the tile a user will see.
  */
@@ -73,6 +112,16 @@ export interface AdminListingRow {
   reviewedAt?: string;
   reviewNote?: string;
   updatedAt: string;
+  /**
+   * Post-approval drift, derived server-side (#744). Only ever set on a published listing.
+   *
+   * The two values are different claims and must not render alike. `'instructions'` is
+   * *measured* — the instructions hash differs from the one recorded at approval, so
+   * behavior definitely changed. `'edited'` is *inferred* — the record was written after
+   * the review, but the cause is unknown and may be an admin's own presentation edit.
+   * Only listings approved before the hash baseline shipped can report `'edited'`.
+   */
+  drift?: ListingDrift;
   adminEdits: AdminEdit[];
 }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { MarketplaceListingsPage } from './listings.page';
+import { AdminListingRow, ListingDrift } from '../models/marketplace.model';
+
+/**
+ * The post-approval drift marker (#744).
+ *
+ * `drift` is derived server-side and covered there; what these assert is the part the
+ * backend cannot enforce — that the **two signals stay visually distinct**. `'instructions'`
+ * is measured and `'edited'` is a guess, and if a later edit renders them alike the marker
+ * stops carrying the distinction it exists to carry.
+ */
+describe('MarketplaceListingsPage — post-approval drift marker', () => {
+  let mockService: any;
+
+  function row(overrides: Partial<AdminListingRow> = {}): AdminListingRow {
+    return {
+      agentId: 'ast-001',
+      name: 'Policy Lookup',
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      state: 'published',
+      usageCount: 12,
+      updatedAt: '2026-07-22T00:00:00Z',
+      adminEdits: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: signal<string | null>(null),
+      loadListings: vi.fn().mockResolvedValue([]),
+      takedown: vi.fn().mockResolvedValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: { open: vi.fn() } },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function renderWith(rows: AdminListingRow[]): Promise<ComponentFixture<MarketplaceListingsPage>> {
+    mockService.loadListings.mockResolvedValue(rows);
+    const fixture = TestBed.createComponent(MarketplaceListingsPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function badgeText(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  function driftBadge(fixture: ComponentFixture<unknown>, label: string): HTMLElement | undefined {
+    const spans = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('span'),
+    ) as HTMLElement[];
+    return spans.find((s) => s.textContent?.trim() === label);
+  }
+
+  it('renders no drift badge on a listing that has not drifted', async () => {
+    const fixture = await renderWith([row()]);
+    expect(badgeText(fixture)).not.toContain('Instructions changed');
+    expect(badgeText(fixture)).not.toContain('Edited since review');
+  });
+
+  it('names a measured instructions change', async () => {
+    const fixture = await renderWith([row({ drift: 'instructions' })]);
+    expect(driftBadge(fixture, 'Instructions changed')).toBeDefined();
+  });
+
+  it('names an inferred edit differently from a measured change', async () => {
+    const fixture = await renderWith([row({ drift: 'edited' })]);
+    expect(driftBadge(fixture, 'Edited since review')).toBeDefined();
+    expect(badgeText(fixture)).not.toContain('Instructions changed');
+  });
+
+  it('styles the measured signal more urgently than the inferred one', async () => {
+    // The whole point of keeping two values: if these ever render identically, the weak
+    // signal inherits the strong one's urgency and admins learn to ignore both.
+    const measured = await renderWith([row({ drift: 'instructions' })]);
+    const measuredClass = driftBadge(measured, 'Instructions changed')!.className;
+
+    const inferred = await renderWith([row({ drift: 'edited' })]);
+    const inferredClass = driftBadge(inferred, 'Edited since review')!.className;
+
+    expect(measuredClass).not.toBe(inferredClass);
+    expect(measuredClass).toContain('amber');
+    expect(inferredClass).not.toContain('amber');
+  });
+
+  it('carries an icon only on the measured signal', async () => {
+    const measured = await renderWith([row({ drift: 'instructions' })]);
+    expect(driftBadge(measured, 'Instructions changed')!.querySelector('ng-icon')).toBeTruthy();
+
+    const inferred = await renderWith([row({ drift: 'edited' })]);
+    expect(driftBadge(inferred, 'Edited since review')!.querySelector('ng-icon')).toBeNull();
+  });
+
+  it('explains each marker on hover, since the label alone does not say what to do', async () => {
+    for (const drift of ['instructions', 'edited'] as ListingDrift[]) {
+      const fixture = await renderWith([row({ drift })]);
+      const label = drift === 'instructions' ? 'Instructions changed' : 'Edited since review';
+      // The tooltip directive is bound; its text lives on the component's lookup table.
+      expect(driftBadge(fixture, label)).toBeDefined();
+    }
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -9,11 +9,18 @@ import {
 import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroRectangleStack, heroCheckBadge } from '@ng-icons/heroicons/outline';
+import {
+  heroRectangleStack,
+  heroCheckBadge,
+  heroExclamationTriangle,
+} from '@ng-icons/heroicons/outline';
 import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import {
   AdminListingRow,
+  LISTING_DRIFT_CLASSES,
+  LISTING_DRIFT_LABELS,
+  LISTING_DRIFT_TOOLTIPS,
   LISTING_STATE_CLASSES,
   LISTING_STATE_LABELS,
   ListingState,
@@ -44,7 +51,9 @@ import {
   selector: 'app-marketplace-listings',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, AgentTileComponent, TooltipDirective],
-  providers: [provideIcons({ heroRectangleStack, heroCheckBadge })],
+  providers: [
+    provideIcons({ heroRectangleStack, heroCheckBadge, heroExclamationTriangle }),
+  ],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
@@ -165,12 +174,40 @@ import {
                     </td>
                     <td class="px-4 py-3 text-gray-600 dark:text-gray-300">{{ row.category }}</td>
                     <td class="px-4 py-3">
-                      <span
-                        class="inline-flex rounded-lg px-2 py-0.5 text-xs font-semibold"
-                        [class]="stateClasses[row.state]"
-                      >
-                        {{ stateLabels[row.state] }}
-                      </span>
+                      <div class="flex flex-col items-start gap-1">
+                        <span
+                          class="inline-flex rounded-lg px-2 py-0.5 text-xs font-semibold"
+                          [class]="stateClasses[row.state]"
+                        >
+                          {{ stateLabels[row.state] }}
+                        </span>
+                        <!--
+                          Post-approval drift (#744). Sits under the state badge rather than
+                          in its own column: it only ever applies to published rows, so a
+                          column would be mostly empty and would push the table wider.
+                        -->
+                        @if (row.drift; as drift) {
+                          <span
+                            class="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium"
+                            [class]="driftClasses[drift]"
+                            [appTooltip]="driftTooltips[drift]"
+                            appTooltipPosition="top"
+                          >
+                            <!--
+                              The icon is only on the measured signal. The inferred one is
+                              a maybe, and a warning triangle would overstate it.
+                            -->
+                            @if (drift === 'instructions') {
+                              <ng-icon
+                                name="heroExclamationTriangle"
+                                class="size-3.5"
+                                aria-hidden="true"
+                              />
+                            }
+                            {{ driftLabels[drift] }}
+                          </span>
+                        }
+                      </div>
                     </td>
                     <td class="px-4 py-3 text-right tabular-nums text-gray-600 dark:text-gray-300">
                       {{ row.usageCount.toLocaleString() }}
@@ -216,6 +253,9 @@ export class MarketplaceListingsPage implements OnInit {
   ];
   readonly stateLabels = LISTING_STATE_LABELS;
   readonly stateClasses = LISTING_STATE_CLASSES;
+  readonly driftLabels = LISTING_DRIFT_LABELS;
+  readonly driftClasses = LISTING_DRIFT_CLASSES;
+  readonly driftTooltips = LISTING_DRIFT_TOOLTIPS;
 
   ngOnInit(): void {
     void this.reload();


### PR DESCRIPTION
Closes #744.

## The gap

Three individually-reasonable v1 non-goals compose into a hole none of them was evaluated against:

| Decision | Where |
|---|---|
| No re-review on edit | D2 / Non-goals |
| No agent versioning or changelogs | Non-goals |
| Admins can **lock** a role-seeded pin so members cannot remove it | D9 / phase 6 |

An admin locks an Agent into every member of a role's sidebar → the author rewrites its instructions → the new behavior is live immediately, for everyone, with no re-review, no version history, and no notification. The affected user cannot opt out either: a locked pin overrides their own dismissal, by design.

## The fix

Approval records a SHA-256 of the instructions it approved (`listing.approvedInstructionsHash`), and the admin Listings table marks any published listing whose current instructions no longer match. **Not a gate** — the curator's reason to look.

The marker reports two claims and deliberately keeps them apart:

| Value | Means | Basis | Renders as |
|---|---|---|---|
| `instructions` | Behavior definitely changed | Measured — hash mismatch | Amber + warning icon |
| `edited` | Record changed, cause unknown | Inferred — `updatedAt` > `reviewedAt` | Neutral gray, no icon |

## Why not the timestamp alone, as the issue proposed

The issue called option 2 a pure read, and it is — but it is not sufficient on its own. An admin's **own D13 presentation edit** bumps `updatedAt` without touching `reviewedAt`, so a timestamp-only marker fires on the admin's own typo fix. A governance marker that cries wolf is one that gets learned-ignored.

The hash alone had the opposite problem: it would be blind on every listing approved before it shipped — precisely the already-published, possibly-locked back catalogue this issue is about. Hence both, with the inferred one explicitly weaker in wording and styling. Everything approved from now on resolves to `instructions` or to nothing.

## Security note

The baseline is a hash *of* the instructions, so it rides the same viewer gate. `_agent_response` already drops `instructions` for anyone below editor; it now drops the hash with it. Not reversible on its own, but it would confirm a guessed prompt for anyone who could produce one — which is what that gate exists to prevent. The admin listings projection is unaffected.

## Testing

Both new suites were verified to **discriminate**, not just pass:

- With a timestamp-only derivation, `test_an_admin_presentation_edit_is_not_reported_as_drift` fails with `assert 'edited' is None` — the exact false positive being designed out.
- Without the viewer gate, both hash-exposure tests fail while the owner/editor cases keep passing.

Coverage: baseline written on approve and only on approve; `request_changes` neither sets nor clears it; measured vs inferred vs none; the freshly-approved equality boundary (approval writes `updatedAt` from the same clock as `reviewedAt`, so equal means untouched); every non-published state; never-reviewed listings. Frontend specs assert the two signals stay visually distinct, since that is the part the backend cannot enforce.

- Backend: full suite **5248 passed, 3 skipped**
- SPA: **138 files / 1574 tests pass** (6 new)

⚠️ Unrelated pre-existing flake: the SPA suite intermittently fails one randomly-chosen spec file per run. If CI shows a single unrelated red file, re-run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)