### PR TITLE
fix(spa): stop cross-file state leaks that made ng test flaky

### DIFF
--- a/frontend/ai.client/src/app/admin/costs/services/admin-cost-state.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/services/admin-cost-state.service.spec.ts
@@ -31,6 +31,11 @@ describe('AdminCostStateService', () => {
   });
 
   afterEach(() => {
+    // The export test spies on `document.createElement` and on
+    // `document.body.appendChild`/`removeChild`. Left in place they follow
+    // every spec that later shares this worker — `createElement` would hand
+    // back a plain object instead of an Element.
+    vi.restoreAllMocks();
     TestBed.resetTestingModule();
   });
 

--- a/frontend/ai.client/src/app/app.spec.ts
+++ b/frontend/ai.client/src/app/app.spec.ts
@@ -1,13 +1,32 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
+
+// These two load the root component through a runtime dynamic `import()`, so
+// vite's module runner transforms the App dependency graph on demand rather
+// than at build time. That measures ~4s on a developer machine — against
+// vitest's 5000ms default this leaves ~20% headroom, and any parallel load
+// (a busy CI runner, another suite on the same box) pushes it over, failing
+// as "Test timed out in 5000ms". The import is deliberately dynamic: this
+// spec having no static Angular imports is what originally surfaced the
+// JIT/PlatformLocation ordering bug that `src/test-setup.ts` guards against,
+// so raise the budget rather than hoisting the import to a static one.
+const IMPORT_TIMEOUT_MS = 30_000;
 
 describe('App', () => {
-  it('should export App component class', async () => {
-    const { App } = await import('./app');
-    expect(App).toBeDefined();
-  });
+  it(
+    'should export App component class',
+    async () => {
+      const { App } = await import('./app');
+      expect(App).toBeDefined();
+    },
+    IMPORT_TIMEOUT_MS,
+  );
 
-  it('should have newChat as a method', async () => {
-    const { App } = await import('./app');
-    expect(App.prototype.newChat).toBeDefined();
-  });
+  it(
+    'should have newChat as a method',
+    async () => {
+      const { App } = await import('./app');
+      expect(App.prototype.newChat).toBeDefined();
+    },
+    IMPORT_TIMEOUT_MS,
+  );
 });

--- a/frontend/ai.client/src/app/auth/admin.guard.spec.ts
+++ b/frontend/ai.client/src/app/auth/admin.guard.spec.ts
@@ -47,6 +47,9 @@ describe('adminGuard', () => {
   });
 
   afterEach(() => {
+    // Releases the `console.warn` spy installed above — an unrestored spy on a
+    // global follows every spec that later shares this worker.
+    vi.restoreAllMocks();
     TestBed.resetTestingModule();
   });
 

--- a/frontend/ai.client/src/app/auth/session.service.spec.ts
+++ b/frontend/ai.client/src/app/auth/session.service.spec.ts
@@ -29,6 +29,31 @@ describe('SessionService', () => {
   // jsdom enforces `__Host-` cookie prefix rules (Secure required, no
   // http://localhost), so a real `document.cookie` write is silently
   // rejected. Install a minimal one-cookie shim per-test.
+  //
+  // This spec replaces two process globals — `document.cookie` and
+  // `window.location`. The builder runs vitest with `isolate: false`, so
+  // anything left installed here follows every spec that later lands in the
+  // same worker. Snapshot the real descriptors up front and put them back in
+  // `afterEach`.
+  const realCookieDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+  const realLocationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+
+  const restoreGlobals = () => {
+    if (realCookieDescriptor) {
+      Object.defineProperty(document, 'cookie', realCookieDescriptor);
+    } else {
+      // `cookie` lives on Document.prototype; dropping our own property
+      // re-exposes the real accessor.
+      delete (document as unknown as Record<string, unknown>)['cookie'];
+    }
+
+    if (realLocationDescriptor) {
+      Object.defineProperty(window, 'location', realLocationDescriptor);
+    } else {
+      delete (window as unknown as Record<string, unknown>)['location'];
+    }
+  };
+
   let cookieStore = '';
   const installCookieShim = () => {
     cookieStore = '';
@@ -85,6 +110,7 @@ describe('SessionService', () => {
   afterEach(() => {
     httpMock.verify();
     clearCsrfCookie();
+    restoreGlobals();
     TestBed.resetTestingModule();
     vi.restoreAllMocks();
   });

--- a/frontend/ai.client/src/app/global-hygiene.spec.ts
+++ b/frontend/ai.client/src/app/global-hygiene.spec.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+//
+// Canary for cross-file global pollution.
+//
+// The unit-test builder runs vitest with `isolate: false`, so every spec file
+// assigned to a worker shares one jsdom. A spec that replaces a global and
+// never puts it back corrupts whichever unrelated spec happens to run next in
+// that worker — which is timing-dependent, so it surfaces as one randomly
+// chosen spec file failing per run.
+//
+// This file asserts the shared jsdom is intact at the moment it runs. It only
+// covers whatever executed before it in its worker, so it is a sampling check,
+// not a proof: a green run does not mean no spec pollutes, but a red run means
+// one definitely does. Treat a failure here as "some other spec leaked", not as
+// a bug in this file.
+import { describe, expect, it } from 'vitest';
+
+describe('global hygiene', () => {
+  it('window.location is the real jsdom Location', () => {
+    expect(Object.prototype.toString.call(window.location)).toBe('[object Location]');
+    expect(typeof window.location.assign).toBe('function');
+  });
+
+  it('document.cookie is the real jsdom accessor, not a shim', () => {
+    expect(Object.getOwnPropertyDescriptor(document, 'cookie')).toBeUndefined();
+  });
+
+  it('storage globals are the real jsdom Storage', () => {
+    expect(Object.prototype.toString.call(sessionStorage)).toBe('[object Storage]');
+    expect(Object.prototype.toString.call(localStorage)).toBe('[object Storage]');
+  });
+
+  it('document.createElement returns real Elements', () => {
+    expect(document.createElement('div')).toBeInstanceOf(HTMLElement);
+  });
+
+  it('timers are real', () => {
+    // A spec that leaves `vi.useFakeTimers()` installed freezes the clock for
+    // every later spec in the worker; anything that awaits a real timer then
+    // dies with "Test timed out in 5000ms".
+    const before = Date.now();
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(Date.now()).toBeGreaterThanOrEqual(before);
+        resolve();
+      }, 1);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/services/sidenav/sidenav.service.spec.ts
+++ b/frontend/ai.client/src/app/services/sidenav/sidenav.service.spec.ts
@@ -15,6 +15,7 @@ describe('SidenavService', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     TestBed.resetTestingModule();
   });
 

--- a/frontend/ai.client/src/app/services/toast/toast.service.spec.ts
+++ b/frontend/ai.client/src/app/services/toast/toast.service.spec.ts
@@ -15,6 +15,7 @@ describe('ToastService', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     TestBed.resetTestingModule();
   });
 

--- a/frontend/ai.client/src/app/session/components/citation-display/citation-display.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/citation-display/citation-display.component.spec.ts
@@ -17,6 +17,15 @@ describe('CitationDisplayComponent', () => {
     fixture.detectChanges();
   });
 
+  // Several tests below install fake timers — some in a nested `beforeEach`,
+  // some inline inside an `it`. `vi.restoreAllMocks()` does not restore timers,
+  // so reset them here for every test in the file. The builder runs vitest with
+  // `isolate: false`; a frozen clock left behind here times out whichever
+  // unrelated spec lands next in the same worker.
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -117,6 +126,7 @@ describe('CitationDisplayComponent', () => {
 
     afterEach(() => {
     TestBed.resetTestingModule();
+      vi.useRealTimers();
       vi.restoreAllMocks();
     });
 

--- a/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
@@ -54,6 +54,9 @@ describe('ModelService', () => {
 
   afterEach(() => {
     httpMock.match(() => true);
+    // `restoreAllMocks` does not undo `stubGlobal` — without this the fake
+    // sessionStorage leaks into every later spec in the same worker.
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
     TestBed.resetTestingModule();
   });

--- a/frontend/ai.client/src/test-setup.ts
+++ b/frontend/ai.client/src/test-setup.ts
@@ -13,3 +13,30 @@
 // compiler, but '@angular/compiler' is not available". This import makes the
 // compiler's presence an explicit invariant. See angular/angular-cli#31993.
 import '@angular/compiler';
+
+// Per-test teardown of process-global state.
+//
+// The unit-test builder runs vitest with `isolate: false` (hardcoded in
+// @angular/build's vitest runner), so every spec file assigned to a worker
+// shares one module registry, one jsdom, and one timer implementation. Worker
+// assignment is timing-dependent, so a spec that leaves a global mutated
+// breaks whichever unrelated spec happens to land after it — surfacing as
+// exactly one randomly-chosen spec file failing per run.
+//
+// The concrete case this was written for: a spec called `vi.useFakeTimers()`
+// in `beforeEach` and never restored them (`vi.restoreAllMocks()` does NOT
+// restore timers, and neither does `vi.resetAllMocks()`). Every later spec in
+// that worker then ran with a frozen clock, and the first one to `await`
+// anything real-timer-driven — a `RouterTestingHarness` navigation, an
+// `HttpTestingController` round-trip — died with "Test timed out in 5000ms".
+//
+// Resetting here rather than only in the offending specs keeps the invariant
+// enforced for specs added later. Individual specs are still expected to clean
+// up after themselves; this is the backstop, not the primary contract.
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});


### PR DESCRIPTION
## Problem

On any `ng test` run, exactly one randomly-chosen spec file failed; the next run passed it and failed a different one instead. Observed across 5 consecutive runs on a clean `develop` tree, so not caused by any in-flight change:

| run | victim |
|---|---|
| A | `agent-form.page.spec.ts` — 6 tests |
| B | all pass |
| C | `agent-detail.page.spec.ts` — 5 tests |
| D | `session.service.spec.ts` — 2 tests |
| E | all pass |

As-is this produces spurious CI failures on unrelated PRs.

## Root cause

`@angular/build:unit-test` **hardcodes `isolate: false`** in its vitest runner (`runners/vitest/plugins.js`, `projectDefaults`). Every spec file assigned to a worker shares one module registry, one jsdom, and one timer implementation. Worker assignment is timing-dependent, so *which* specs share state changes run to run — hence the random victim.

The trigger was **leaked fake timers**. `vi.restoreAllMocks()` restores neither fake timers nor `vi.stubGlobal`, and several specs relied on it for both. A spec left the clock frozen, and the next spec in that worker to `await` anything real-timer-driven — a `RouterTestingHarness` navigation, an `HttpTestingController` round-trip — died with `Test timed out in 5000ms`. That timeout, rather than an assertion failure, is how every observed victim presented.

Bisected down to a minimal pair: **`sidenav.service.spec.ts` immediately before `agent-detail.page.spec.ts`** reproduces it on its own.

## Changes

Fixed at the source in seven specs:

| spec | leak |
|---|---|
| `sidenav`, `toast`, `citation-display` | fake timers never restored |
| `model.service` | `stubGlobal` needs `unstubAllGlobals`, not `restoreAllMocks` |
| `session.service` | `window.location` + `document.cookie` replaced, never put back |
| `admin-cost-state`, `admin.guard` | unrestored spies on `document.createElement` / `console.warn` |

Plus a backstop `afterEach` in `src/test-setup.ts` (`useRealTimers` + `unstubAllGlobals` + `unstubAllEnvs`) so a spec added later can't reintroduce the class of bug, and `src/app/global-hygiene.spec.ts` as a canary asserting the shared jsdom is intact.

A global `vi.restoreAllMocks()` was **deliberately not** added to the backstop — it would reset `vi.fn()` implementations and break specs that build mocks outside `beforeEach`.

## Second, unrelated flake fixed

Found while verifying: `app.spec.ts` loads the root component through a runtime dynamic `import()`, which measures **~4.0s against vitest's 5000ms default** — ~20% headroom, so any parallel load pushes it over. Raised to 30s, matching the existing precedent in `shared-view.page.spec.ts` (already bumped to 15s for the same reason). Those two plus `topnav` (1.4s) are the only tests over 1s.

## Verification

Note that bisecting with `--include` **masks** this bug — subsetting changes the builder's bundling, and a minimal polluter→victim pair passes under `--include` while failing in the full suite. The harness used here always builds the full spec set and varies only execution order (single worker, custom `sequence.sequencer` via `--runner-config`). It reproduced your runs A, C and D exactly, under seeds 13, 1 and 3/5.

- 16 seeded orderings, including all four that previously failed — green
- 5 plain `ng test --watch=false` runs — green
- 3 runs under 8 CPU hogs on 10 cores (the condition that broke `app.spec.ts`) — green
- `tsc --noEmit -p tsconfig.spec.json` clean

The source fixes were also verified with the backstop disabled, which is how the two `spyOn` leakers were found rather than silently masked.

Test-only change — spec files aren't part of the app build, so the SPA bundle is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)