### PR TITLE
fix(agents): retire the unreachable `limits` runnability state

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/agent_detail.py
+++ b/backend/src/apis/app_api/agent_designer/services/agent_detail.py
@@ -21,13 +21,14 @@ empty list for that kind (the KB is welded to the Agent and is not user-configur
 A naive diff therefore marks every legacy Agent *blocked*. The KB is excluded from both
 reads instead — it is not a capability the viewer can lack.
 
-**2. ``limits`` requires an explicitly optional binding.** ``agent_binding_resolver`` is
-block-with-message for *every* kind it resolves — a missing model, tool, skill or memory
-space raises rather than degrading. So a gap only downgrades to "Runs with limits for
-you" when the binding declares ``config.optional == true``; anything else missing is
-``blocked``, because telling a user an Agent "runs with limits" when the next turn will
-raise would be a preview that lies. No surface writes ``optional`` yet — the flag is the
-seam for when the resolver grows a degrade path, not a live feature.
+**2. There are two states, not three.** ``agent_binding_resolver`` is block-with-message
+for *every* kind it resolves — a missing model, tool, skill or memory space raises rather
+than degrading — which is the Designer spec's D5 rule: "No **downgrade** on missing
+capability (block-only v1)". The Marketplace spec's D6 originally sketched a middle
+``limits`` state, gated on a binding declaring ``config.optional``; nothing ever wrote
+that flag, so it was unreachable, and building toward it would have contradicted D5. A
+preview offering an outcome the runtime cannot produce is a preview that lies. Removed in
+ #747. If downgrade is ever taken up as an opt-in, it starts at the resolver, not here.
 """
 
 import logging
@@ -71,11 +72,6 @@ _KIND_FALLBACK_LABELS = {
 
 def _fallback(kind: str) -> str:
     return _KIND_FALLBACK_LABELS.get(kind, "A capability")
-
-
-def _is_optional(binding) -> bool:
-    """Whether this binding degrades rather than blocks when the viewer lacks it."""
-    return (binding.config or {}).get("optional") is True
 
 
 def _binding_key(binding) -> str:
@@ -273,16 +269,16 @@ async def resolve_runnability(
 ) -> AgentRunnabilityResponse:
     """Diff the Agent's model + bindings against the viewer's own catalog (D6).
 
-    ``ready`` when nothing is missing, ``limits`` when only optional bindings are, and
-    ``blocked`` the moment something the run-time resolver would raise on is absent.
+    ``ready`` when nothing is missing, ``blocked`` the moment something the run-time
+    resolver would raise on is absent. There is no middle state — see note 2 above.
     """
     missing: List[MissingCapability] = []
     labels = await _labels_by_kind(
         assistant, user, tool_service=tool_service, memory_service=memory_service
     )
 
-    # The pinned model. Not a binding and never optional — ``agent_binding_resolver``
-    # blocks the turn outright when the invoker cannot access it.
+    # The pinned model. Not a binding — ``agent_binding_resolver`` blocks the turn
+    # outright when the invoker cannot access it, same as every other gated kind.
     if assistant.model_settings is not None:
         model_id = assistant.model_settings.model_id
         available_models = {item.ref for item in await list_bindable("model", user)}
@@ -291,7 +287,6 @@ async def resolve_runnability(
                 MissingCapability(
                     label=await _model_label(model_id) or _fallback("model"),
                     kind="model",
-                    optional=False,
                 )
             )
 
@@ -312,16 +307,10 @@ async def resolve_runnability(
             label = labels.get(kind, {}).get(key) or _fallback(kind)
             if any(m.kind == kind and m.label == label for m in missing):
                 continue
-            missing.append(
-                MissingCapability(label=label, kind=kind, optional=_is_optional(binding))
-            )
+            missing.append(MissingCapability(label=label, kind=kind))
 
-    if not missing:
-        state = "ready"
-    elif all(item.optional for item in missing):
-        state = "limits"
-    else:
-        state = "blocked"
+    # Any gap blocks. See ``RunnabilityState`` for why there is no middle state.
+    state = "ready" if not missing else "blocked"
 
     return AgentRunnabilityResponse(
         agent_id=assistant.assistant_id, state=state, missing=missing

--- a/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
@@ -53,7 +53,6 @@ from apis.app_api.agent_designer.services.agent_detail import (
     _binding_key,
     _fallback,
     _gated_bindings,
-    _is_optional,
     _labels_by_kind,
     _model_label,
 )
@@ -93,9 +92,6 @@ async def _diff_against_role(
                 MissingCapability(
                     label=await _model_label(model_id) or _fallback("model"),
                     kind="model",
-                    # The pinned model is never optional: the binding resolver blocks the
-                    # turn outright when the invoker cannot reach it.
-                    optional=False,
                 )
             )
 
@@ -116,16 +112,10 @@ async def _diff_against_role(
             label = labels.get(kind, {}).get(key) or _fallback(kind)
             if any(m.kind == kind and m.label == label for m in missing):
                 continue
-            missing.append(
-                MissingCapability(label=label, kind=kind, optional=_is_optional(binding))
-            )
+            missing.append(MissingCapability(label=label, kind=kind))
 
-    if not missing:
-        state = "ready"
-    elif all(item.optional for item in missing):
-        state = "limits"
-    else:
-        state = "blocked"
+    # Any gap blocks. See ``RunnabilityState`` for why there is no middle state.
+    state = "ready" if not missing else "blocked"
     return state, missing, notes
 
 

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -329,7 +329,16 @@ class AgentCapability(BaseModel):
     kind: str = Field(..., description="Binding kind (tool | skill | memory_space)")
 
 
-RunnabilityState = Literal["ready", "limits", "blocked"]
+# Two states, not three. The Marketplace spec's D6 sketched a middle "limits"
+# (degraded — runs, but something it declares is missing), and it was never
+# reachable: it required a binding to carry ``config.optional``, which no API
+# accepted and no Designer control set. It was also the wrong model to build
+# toward, because it contradicts the Designer spec's D5 — "No **downgrade** on
+# missing capability (block-only v1)" — which is the rule
+# ``agent_binding_resolver`` actually implements, raising for every kind. A
+# preview that offered a third outcome the runtime cannot produce would be a
+# preview that lies. Removed in #747; D6 records why.
+RunnabilityState = Literal["ready", "blocked"]
 
 
 class MissingCapability(BaseModel):
@@ -339,10 +348,6 @@ class MissingCapability(BaseModel):
 
     label: str = Field(..., description="Display name of the unavailable primitive")
     kind: str = Field(..., description="'model' or a binding kind")
-    optional: bool = Field(
-        False,
-        description="Whether the binding was declared optional; only optional gaps degrade to 'limits'",
-    )
 
 
 class AgentRunnabilityResponse(BaseModel):

--- a/backend/tests/routes/test_agent_detail.py
+++ b/backend/tests/routes/test_agent_detail.py
@@ -239,25 +239,6 @@ class TestRunnabilityRoute:
         assert resp.status_code == 200
         assert resp.json() == {"agentId": "ast-001", "state": "ready", "missing": []}
 
-    def test_limits_names_the_optional_binding(self, app, make_user, _flags_on):
-        mock_auth_user(app, make_user())
-        resp = self._call(
-            app,
-            result=AgentRunnabilityResponse(
-                agent_id="ast-001",
-                state="limits",
-                missing=[
-                    MissingCapability(label="Grants.gov Search", kind="tool", optional=True)
-                ],
-            ),
-        )
-
-        body = resp.json()
-        assert body["state"] == "limits"
-        assert body["missing"] == [
-            {"label": "Grants.gov Search", "kind": "tool", "optional": True}
-        ]
-
     def test_blocked_names_what_is_missing(self, app, make_user, _flags_on):
         mock_auth_user(app, make_user())
         resp = self._call(

--- a/backend/tests/shared/test_agent_runnability.py
+++ b/backend/tests/shared/test_agent_runnability.py
@@ -246,14 +246,18 @@ async def test_blocked_when_a_required_tool_is_not_in_the_viewers_catalog():
         )
 
     assert result.state == "blocked"
-    assert [(m.label, m.kind, m.optional) for m in result.missing] == [
-        ("Workday Query", "tool", False)
-    ]
+    assert [(m.label, m.kind) for m in result.missing] == [("Workday Query", "tool")]
 
 
 @pytest.mark.asyncio
-async def test_limits_when_only_an_optional_binding_is_missing():
-    """The one gap that degrades instead of blocking — see the module docstring."""
+async def test_a_binding_marked_optional_still_blocks():
+    """``config.optional`` is inert — there is no degraded state (#747).
+
+    Nothing ever wrote this flag, but a hand-edited or future record could carry it, and
+    it must not resurrect a middle state the runtime cannot honour: ``agent_binding_resolver``
+    raises for every kind, per the Designer spec's D5 block-only rule. Previewing
+    "runs with limits" here would promise a turn that is going to fail.
+    """
     agent = _agent(
         bindings=[
             AgentBinding(kind="tool", ref="document_search"),
@@ -270,12 +274,12 @@ async def test_limits_when_only_an_optional_binding_is_missing():
             ),
         )
 
-    assert result.state == "limits"
-    assert [(m.label, m.optional) for m in result.missing] == [("Grants.gov Search", True)]
+    assert result.state == "blocked"
+    assert [m.label for m in result.missing] == ["Grants.gov Search"]
 
 
 @pytest.mark.asyncio
-async def test_one_required_gap_outranks_any_number_of_optional_ones():
+async def test_every_gap_is_named_whether_or_not_it_claims_to_be_optional():
     agent = _agent(
         bindings=[
             AgentBinding(kind="tool", ref="grants_gov", config={"optional": True}),
@@ -297,7 +301,7 @@ async def test_one_required_gap_outranks_any_number_of_optional_ones():
 
 @pytest.mark.asyncio
 async def test_a_model_the_viewer_cannot_access_blocks_and_is_named():
-    """The pinned model is never optional — the run-time resolver raises outright."""
+    """The pinned model blocks like everything else — the resolver raises outright."""
     agent = _agent(model_settings=AgentModelConfig(model_id="claude-opus"))
     with patch(f"{MODULE}.list_bindable", side_effect=_catalog(model={})), _models(
         ("claude-opus", "Claude Opus 4.5")

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -157,8 +157,23 @@ the Agent's `modelConfig` + `bindings` against the viewer's own RBAC-filtered
 `GET /agents/bindable` results and renders one line under "What it can access":
 
 - **Ready to run for you**
-- **Runs with limits for you** — names the unavailable optional binding
 - **Not available to you** — names what is missing; the Start chat button is disabled
+
+⚠️ **REVISED — there were originally three states.** A middle *"Runs with limits for you"* named
+an unavailable **optional** binding. It was never reachable and has been removed (#747).
+
+Two reasons, and the second is the one that matters. First, it degraded only when a binding declared
+`config.optional == true`, and nothing ever wrote that flag — no API accepted it and the Designer
+had no control for it, so every gap resolved to blocked and the model was really two states already.
+Second, and decisive: building toward it would have contradicted `agent-designer.md` D5, whose
+Non-goals say *"No **downgrade** on missing capability (block-only v1)"* and call downgrade "a later
+opt-in". Block-only is what `agent_binding_resolver` actually implements — it raises for model, tool,
+skill and memory_space alike. A preview that offers an outcome the runtime cannot produce is a
+preview that lies, which is the same standard that put runnability on the detail page instead of the
+shelf in the first place.
+
+If downgrade is ever taken up, it starts at the resolver and this line grows back with it. It is not
+a preview-layer decision.
 
 **The cost, stated plainly:** with no badge on the shelf, a user only learns an Agent will not run
 after tapping into it. That is the accepted price of D4. It is mitigated by the fact that most store

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -179,8 +179,6 @@ export const MAX_ROLE_PINS = 25;
 export interface MissingCapability {
   label: string;
   kind: string;
-  /** Only an explicitly optional binding degrades to `limits` rather than blocking. */
-  optional: boolean;
 }
 
 /**
@@ -206,7 +204,8 @@ export interface RoleAgentPinRow {
   listingState?: ListingState | null;
   reachable: boolean;
   visibility: string;
-  state: 'ready' | 'limits' | 'blocked';
+  /** Two states, not three — see `RunnabilityState` in the agents feature (#747). */
+  state: 'ready' | 'blocked';
   missing: MissingCapability[];
   /** What the role-level check could not decide — a memory space resolves per person. */
   notes: string[];

--- a/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
@@ -321,8 +321,8 @@ interface StagedPin {
                         class="mt-2 ml-9 text-xs text-rose-700 dark:text-rose-300"
                         role="status"
                       >
-                        {{ pin.row.state === 'limits' ? 'Runs with limits for' : "Won't run for" }}
-                        this role — it does not grant {{ missingLabels(pin.row) }}.
+                        Won't run for this role — it does not grant
+                        {{ missingLabels(pin.row) }}.
                       </p>
                     }
                     @for (note of pin.row?.notes ?? []; track note) {

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -307,9 +307,7 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
                     [class]="
                       r.state === 'ready'
                         ? 'text-emerald-700 dark:text-emerald-400'
-                        : r.state === 'limits'
-                          ? 'text-amber-700 dark:text-amber-400'
-                          : 'text-rose-700 dark:text-rose-400'
+                        : 'text-rose-700 dark:text-rose-400'
                     "
                   >
                     <ng-icon [name]="availabilityIcon()" class="mt-1 size-4 shrink-0" aria-hidden="true" />
@@ -465,15 +463,13 @@ export class AgentDetailPage implements OnInit {
     switch (this.runnability()?.state) {
       case 'ready':
         return 'heroCheckCircle';
-      case 'limits':
-        return 'heroExclamationTriangle';
       default:
         return 'heroNoSymbol';
     }
   });
 
   /**
-   * D6's three lines, each naming what is unavailable rather than saying "something".
+   * D6's two lines, each naming what is unavailable rather than saying "something".
    * A user who cannot act on the sentence has been told nothing useful.
    */
   readonly availabilityText = computed(() => {
@@ -483,7 +479,7 @@ export class AgentDetailPage implements OnInit {
 
     const names = r.missing.map((m) => `“${m.label}”`).join(', ');
     const verb = r.missing.length === 1 ? "isn't" : "aren't";
-    const lead = r.state === 'limits' ? 'Runs with limits for you' : 'Not available to you';
+    const lead = 'Not available to you';
     return names ? `${lead} — ${names} ${verb} granted to your role.` : `${lead}.`;
   });
 

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -114,8 +114,15 @@ export interface Agent {
   userPermission?: UserPermission;
 }
 
-/** D6's three-way answer to "will this run for me?". */
-export type RunnabilityState = 'ready' | 'limits' | 'blocked';
+/**
+ * D6's answer to "will this run for me?" — two states, not three.
+ *
+ * A middle `'limits'` (runs, but degraded) was specced and removed in #747: it required a
+ * binding to declare `config.optional`, which nothing ever wrote, and it contradicted the
+ * Designer spec's D5 — "No downgrade on missing capability (block-only v1)" — which is the
+ * rule the runtime resolver actually implements. Any gap blocks.
+ */
+export type RunnabilityState = 'ready' | 'blocked';
 
 export interface MissingCapability {
   label: string;


### PR DESCRIPTION
Fixes #747. Resolved as **option 2 (delete the state)**.

## Why not option 1

The issue frames option 1 (let authors mark a binding optional) as "the only one that delivers what D6 promised". Two things make it bigger than it looks, and the second changed my recommendation:

1. **It is not a checkbox.** `agent_binding_resolver.py` raises for *every* kind — model, tool, skill, memory_space — and `optional` appears nowhere in it. Without teaching the resolver to skip optional bindings, the preview would still lie; it would just lie with a control attached.
2. **It contradicts an explicit non-goal.** `agent-designer.md` Non-goals: *"No **downgrade** on missing capability (block-only v1 — D5)"*, and D5 itself calls downgrade "a later opt-in". Block-only is the rule that actually shipped.

So the two specs disagreed. This settles them on the one the code implements. Whether an Agent may silently run degraded is a real product decision — worth taking deliberately, at the resolver, not backing into via a preview flag.

## What changed

| | Before | After |
|---|---|---|
| `RunnabilityState` | `ready \| limits \| blocked` | `ready \| blocked` |
| `MissingCapability.optional` | field, always `False` in practice | gone |
| `_is_optional` | read `config.optional`, written nowhere | gone |
| Detail page | 3-way colour + icon + lead sentence | 2-way |
| Admin default-pins | `state === 'limits' ? … : …` | one sentence |

Also updated the `agent_detail` module docstring, which explained the `optional` seam at length as though it were a live feature.

**D6 is revised, not quietly trimmed** — it records that there were three states, why the middle one went, and that if downgrade is ever taken up it starts at the resolver.

## One test worth calling out

`test_limits_when_only_an_optional_binding_is_missing` became **`test_a_binding_marked_optional_still_blocks`**. The flag is now *inert* rather than merely unused: nothing ever wrote it, but a hand-edited or future record could carry it, and it must not resurrect a state the runtime cannot honour. That's a regression worth pinning rather than a test worth deleting.

Two other tests were updated for the dropped field, and `test_limits_names_the_optional_binding` (a route test asserting the wire shape of a state that no longer exists) was removed.

## Testing

- Backend: **5298 passed, 6 skipped**
- SPA: **139 files / 1572 tests pass**
- No SPA spec referenced `'limits'`, so nothing was left asserting the removed branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)